### PR TITLE
Remove alias for cloning relations

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
 
         if collection.has_limit_or_offset?
-          query = collection.spawn
+          query = collection.clone
           query.select_values = [column]
           subquery_alias = "subquery_for_cache_key"
           subquery_column = "#{subquery_alias}.#{timestamp_column}"

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -56,7 +56,7 @@ module ActiveRecord
     end
 
     def or(other)
-      other.spawn
+      other.clone
     end
 
     private

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -184,7 +184,7 @@ module ActiveRecord
         relation.pluck(*column_names)
       else
         enforce_raw_sql_whitelist(column_names)
-        relation = spawn
+        relation = clone
         relation.select_values = column_names.map { |cn|
           @klass.has_attribute?(cn) || @klass.attribute_alias?(cn) ? arel_attribute(cn) : cn
         }
@@ -253,7 +253,7 @@ module ActiveRecord
           # Shortcut when limit is zero.
           return 0 if limit_value == 0
 
-          query_builder = build_count_subquery(spawn, column_name, distinct)
+          query_builder = build_count_subquery(clone, column_name, distinct)
         else
           # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
           relation = unscope(:order).distinct!(false)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -113,7 +113,7 @@ module ActiveRecord
     # the actual table name.
     def includes(*args)
       check_if_method_has_arguments!(:includes, args)
-      spawn.includes!(*args)
+      clone.includes!(*args)
     end
 
     def includes!(*args) # :nodoc:
@@ -132,7 +132,7 @@ module ActiveRecord
     #   # "users"."id"
     def eager_load(*args)
       check_if_method_has_arguments!(:eager_load, args)
-      spawn.eager_load!(*args)
+      clone.eager_load!(*args)
     end
 
     def eager_load!(*args) # :nodoc:
@@ -146,7 +146,7 @@ module ActiveRecord
     #   # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" IN (1, 2, 3)
     def preload(*args)
       check_if_method_has_arguments!(:preload, args)
-      spawn.preload!(*args)
+      clone.preload!(*args)
     end
 
     def preload!(*args) # :nodoc:
@@ -166,7 +166,7 @@ module ActiveRecord
     #   # Query now knows the string references posts, so adds a JOIN
     def references(*table_names)
       check_if_method_has_arguments!(:references, table_names)
-      spawn.references!(*table_names)
+      clone.references!(*table_names)
     end
 
     def references!(*table_names) # :nodoc:
@@ -227,7 +227,7 @@ module ActiveRecord
       end
 
       raise ArgumentError, "Call `select' with at least one field" if fields.empty?
-      spawn._select!(*fields)
+      clone._select!(*fields)
     end
 
     def _select!(*fields) # :nodoc:
@@ -261,7 +261,7 @@ module ActiveRecord
     #   # => [#<User id: 1, first_name: "Bill">, #<User id: 2, first_name: "Earl">, #<User id: 3, first_name: "Beto">]
     def group(*args)
       check_if_method_has_arguments!(:group, args)
-      spawn.group!(*args)
+      clone.group!(*args)
     end
 
     def group!(*args) # :nodoc:
@@ -292,7 +292,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" ORDER BY name DESC, email
     def order(*args)
       check_if_method_has_arguments!(:order, args)
-      spawn.order!(*args)
+      clone.order!(*args)
     end
 
     # Same as #order but operates on relation in-place instead of copying.
@@ -314,7 +314,7 @@ module ActiveRecord
     # generates a query with 'ORDER BY id ASC, name ASC'.
     def reorder(*args)
       check_if_method_has_arguments!(:reorder, args)
-      spawn.reorder!(*args)
+      clone.reorder!(*args)
     end
 
     # Same as #reorder but operates on relation in-place instead of copying.
@@ -365,7 +365,7 @@ module ActiveRecord
     #
     def unscope(*args)
       check_if_method_has_arguments!(:unscope, args)
-      spawn.unscope!(*args)
+      clone.unscope!(*args)
     end
 
     def unscope!(*args) # :nodoc:
@@ -427,7 +427,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id
     def joins(*args)
       check_if_method_has_arguments!(:joins, args)
-      spawn.joins!(*args)
+      clone.joins!(*args)
     end
 
     def joins!(*args) # :nodoc:
@@ -448,7 +448,7 @@ module ActiveRecord
       args.compact!
       args.flatten!
 
-      spawn.left_outer_joins!(*args)
+      clone.left_outer_joins!(*args)
     end
     alias :left_joins :left_outer_joins
 
@@ -578,11 +578,11 @@ module ActiveRecord
     # the current relation.
     def where(opts = :chain, *rest)
       if :chain == opts
-        WhereChain.new(spawn)
+        WhereChain.new(clone)
       elsif opts.blank?
         self
       else
-        spawn.where!(opts, *rest)
+        clone.where!(opts, *rest)
       end
     end
 
@@ -625,7 +625,7 @@ module ActiveRecord
         raise ArgumentError, "You have passed #{other.class.name} object to #or. Pass an ActiveRecord::Relation object instead."
       end
 
-      spawn.or!(other)
+      clone.or!(other)
     end
 
     def or!(other) # :nodoc:
@@ -647,7 +647,7 @@ module ActiveRecord
     #
     #   Order.having('SUM(price) > 30').group('user_id')
     def having(opts, *rest)
-      opts.blank? ? self : spawn.having!(opts, *rest)
+      opts.blank? ? self : clone.having!(opts, *rest)
     end
 
     def having!(opts, *rest) # :nodoc:
@@ -664,7 +664,7 @@ module ActiveRecord
     #
     #   User.limit(10).limit(20) # generated SQL has 'LIMIT 20'
     def limit(value)
-      spawn.limit!(value)
+      clone.limit!(value)
     end
 
     def limit!(value) # :nodoc:
@@ -680,7 +680,7 @@ module ActiveRecord
     #
     #   User.offset(10).order("name ASC")
     def offset(value)
-      spawn.offset!(value)
+      clone.offset!(value)
     end
 
     def offset!(value) # :nodoc:
@@ -691,7 +691,7 @@ module ActiveRecord
     # Specifies locking settings (default to +true+). For more information
     # on locking, please see ActiveRecord::Locking.
     def lock(locks = true)
-      spawn.lock!(locks)
+      clone.lock!(locks)
     end
 
     def lock!(locks = true) # :nodoc:
@@ -734,7 +734,7 @@ module ActiveRecord
     #   end
     #
     def none
-      spawn.none!
+      clone.none!
     end
 
     def none! # :nodoc:
@@ -748,7 +748,7 @@ module ActiveRecord
     #   users.first.save
     #   => ActiveRecord::ReadOnlyRecord: User is marked as readonly
     def readonly(value = true)
-      spawn.readonly!(value)
+      clone.readonly!(value)
     end
 
     def readonly!(value = true) # :nodoc:
@@ -770,7 +770,7 @@ module ActiveRecord
     #   users = users.create_with(nil)
     #   users.new.name # => 'Oscar'
     def create_with(value)
-      spawn.create_with!(value)
+      clone.create_with!(value)
     end
 
     def create_with!(value) # :nodoc:
@@ -798,7 +798,7 @@ module ActiveRecord
     #   # SELECT a.title FROM (SELECT * FROM topics WHERE approved = 't') a
     #
     def from(value, subquery_name = nil)
-      spawn.from!(value, subquery_name)
+      clone.from!(value, subquery_name)
     end
 
     def from!(value, subquery_name = nil) # :nodoc:
@@ -817,7 +817,7 @@ module ActiveRecord
     #   User.select(:name).distinct.distinct(false)
     #   # You can also remove the uniqueness
     def distinct(value = true)
-      spawn.distinct!(value)
+      clone.distinct!(value)
     end
 
     # Like #distinct, but modifies relation in place.
@@ -864,7 +864,7 @@ module ActiveRecord
     #   end
     def extending(*modules, &block)
       if modules.any? || block
-        spawn.extending!(*modules, &block)
+        clone.extending!(*modules, &block)
       else
         self
       end
@@ -884,7 +884,7 @@ module ActiveRecord
     #
     #   User.order('name ASC').reverse_order # generated SQL has 'ORDER BY name DESC'
     def reverse_order
-      spawn.reverse_order!
+      clone.reverse_order!
     end
 
     def reverse_order! # :nodoc:

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -6,11 +6,6 @@ require "active_record/relation/merger"
 
 module ActiveRecord
   module SpawnMethods
-    # This is overridden by Associations::CollectionProxy
-    def spawn #:nodoc:
-      clone
-    end
-
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.
     # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
     #
@@ -32,7 +27,7 @@ module ActiveRecord
       if other.is_a?(Array)
         records & other
       elsif other
-        spawn.merge!(other)
+        clone.merge!(other)
       else
         raise ArgumentError, "invalid argument: #{other.inspect}."
       end


### PR DESCRIPTION
Remove `Relation::SpawnMethods#spawn`, introduced in
https://github.com/rails/rails/commit/c86a32d7451c5d901620ac58630460915292f88b
to be overridden by `Associations::CollectionProxy`.
This is no longer true, and the comment is now inaccurate.
Also, the method could be confused with `Kernel#spawn`.

Since this is a public method, do I need to deprecate it instead of removing it?