### PR TITLE
Correct render method's response header's content type for option(:bo…

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -285,7 +285,7 @@ the response. Using `:plain` or `:html` might be more appropriate most of the
 time.
 
 NOTE: Unless overridden, your response returned from this render option will be
-`text/html`, as that is the default content type of Action Dispatch response.
+`text/plain`, as that is the default content type of Action Dispatch response.
 
 #### Options for `render`
 


### PR DESCRIPTION
…dy) from text/html to text/plain. [ci skip]

### Summary
On calling `render` method with `:body` option, content-type of the response header is `text/plain`.
Example provided in the [gist](https://gist.github.com/avneetmalhotra/f212166ce236dd11fae15156b0fd3415)
So changing the response header's content-type from `text/html` to `text/plain`.