### PR TITLE
Avoid raising ArgumentError when #blank?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -120,6 +120,8 @@ class String
     # strings we can speed up this method (~3.5x) with an empty? call. The
     # penalty for the rest of strings is marginal.
     empty? || BLANK_RE.match?(self)
+  rescue ArgumentError
+    dup.force_encoding(Encoding::ASCII_8BIT).strip.empty?
   end
 end
 

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -24,6 +24,13 @@ class BlankTest < ActiveSupport::TestCase
     NOT.each   { |v| assert_equal false, v.blank?, "#{v.inspect} should not be blank" }
   end
 
+  def test_blank_with_invalid_encoding
+    v = "\xff".encode(Encoding::UTF_8)
+    assert_equal false, v.blank?, "#{v.inspect} should not be blank"
+    v = "\xff".dup.force_encoding(Encoding::ASCII_8BIT)
+    assert_equal false, v.blank?, "#{v.inspect} should not be blank"
+  end
+
   def test_present
     BLANK.each { |v| assert_equal false, v.present?, "#{v.inspect} should not be present" }
     NOT.each   { |v| assert_equal true, v.present?,  "#{v.inspect} should be present" }


### PR DESCRIPTION
Avoid raising ArgumentError when #blank? is applied to strings with invalid encodings.