### PR TITLE
Inverse instance should not be reloaded during autosave if called in validation

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -436,6 +436,9 @@ module ActiveRecord
             if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
               unless reflection.through_reflection
                 record[reflection.foreign_key] = key
+                if inverse_reflection = reflection.inverse_of
+                  record.association(inverse_reflection.name).loaded!
+                end
               end
 
               saved = record.save(validate: !autosave)

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -672,6 +672,16 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_equal old_inversed_man.object_id, new_inversed_man.object_id
   end
 
+  def test_inversed_instance_should_not_be_reloaded_after_stale_state_changed_with_validation
+    face = Face.new man: Man.new
+
+    old_inversed_man = face.man
+    face.save!
+    new_inversed_man = face.man
+
+    assert_equal old_inversed_man.object_id, new_inversed_man.object_id
+  end
+
   def test_should_not_try_to_set_inverse_instances_when_the_inverse_is_a_has_many
     i = interests(:llama_wrangling)
     m = i.polymorphic_man

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -8,4 +8,8 @@ class Face < ActiveRecord::Base
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, class_name: "Man", inverse_of: :horrible_face
   belongs_to :horrible_polymorphic_man, polymorphic: true, inverse_of: :horrible_polymorphic_face
+
+  validate do
+    man
+  end
 end


### PR DESCRIPTION
Fix for https://github.com/rails/rails/issues/31090


Record saved in save_has_one_association already will make a call to association.loaded! from  save_belongs_to_association( as before_save callback), but this allow owner object to reload if called from record's validation.


