### PR TITLE
Rubocop style: Missing magic comment

### DIFF
--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/encrypted_file"
 
 module Rails


### PR DESCRIPTION
### Summary
This PR applies frozen_string_literal magic comment

