### PR TITLE
Flush idle database connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -105,6 +105,7 @@ module ActiveRecord
         @logger              = logger
         @config              = config
         @pool                = nil
+        @idle_since          = Concurrent.monotonic_time
         @schema_cache        = SchemaCache.new self
         @quoted_column_names, @quoted_table_names = {}, {}
         @visitor = arel_visitor
@@ -164,6 +165,7 @@ module ActiveRecord
               "Current thread: #{Thread.current}."
           end
 
+          @idle_since = Concurrent.monotonic_time
           @owner = nil
         else
           raise ActiveRecordError, "Cannot expire connection, it is not currently leased."
@@ -181,6 +183,12 @@ module ActiveRecord
         else
           raise ActiveRecordError, "Cannot steal connection, it is not currently leased."
         end
+      end
+
+      # Seconds since this connection was returned to the pool
+      def seconds_idle # :nodoc:
+        return 0 if in_use?
+        Concurrent.monotonic_time - @idle_since
       end
 
       def unprepared_statement

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -140,6 +140,6 @@ module ActiveRecord
     end
 
     delegate :clear_active_connections!, :clear_reloadable_connections!,
-      :clear_all_connections!, to: :connection_handler
+      :clear_all_connections!, :flush_idle_connections!, to: :connection_handler
   end
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -177,7 +177,16 @@ end_warning
     initializer "active_record.clear_active_connections" do
       config.after_initialize do
         ActiveSupport.on_load(:active_record) do
+          # Ideally the application doesn't connect to the database during boot,
+          # but sometimes it does. In case it did, we want to empty out the
+          # connection pools so that a non-database-using process (e.g. a master
+          # process in a forking server model) doesn't retain a needless
+          # connection. If it was needed, the incremental cost of reestablishing
+          # this connection is trivial: the rest of the pool would need to be
+          # populated anyway.
+
           clear_active_connections!
+          flush_idle_connections!
         end
       end
     end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -156,6 +156,53 @@ module ActiveRecord
         @pool.connections.each { |conn| conn.close if conn.in_use? }
       end
 
+      def test_flush
+        idle_conn = @pool.checkout
+        recent_conn = @pool.checkout
+        active_conn = @pool.checkout
+
+        @pool.checkin idle_conn
+        @pool.checkin recent_conn
+
+        assert_equal 3, @pool.connections.length
+
+        def idle_conn.seconds_idle
+          1000
+        end
+
+        @pool.flush(30)
+
+        assert_equal 2, @pool.connections.length
+
+        assert_equal [recent_conn, active_conn].sort_by(&:__id__), @pool.connections.sort_by(&:__id__)
+      ensure
+        @pool.checkin active_conn
+      end
+
+      def test_flush_bang
+        idle_conn = @pool.checkout
+        recent_conn = @pool.checkout
+        active_conn = @pool.checkout
+        _dead_conn = Thread.new { @pool.checkout }.join
+
+        @pool.checkin idle_conn
+        @pool.checkin recent_conn
+
+        assert_equal 4, @pool.connections.length
+
+        def idle_conn.seconds_idle
+          1000
+        end
+
+        @pool.flush!
+
+        assert_equal 1, @pool.connections.length
+
+        assert_equal [active_conn].sort_by(&:__id__), @pool.connections.sort_by(&:__id__)
+      ensure
+        @pool.checkin active_conn
+      end
+
       def test_remove_connection
         conn = @pool.checkout
         assert conn.in_use?

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -18,6 +18,7 @@ module ActiveRecord
 
       class FakePool
         attr_reader :reaped
+        attr_reader :flushed
 
         def initialize
           @reaped = false
@@ -25,6 +26,10 @@ module ActiveRecord
 
         def reap
           @reaped = true
+        end
+
+        def flush
+          @flushed = true
         end
       end
 
@@ -47,6 +52,7 @@ module ActiveRecord
           Thread.pass
         end
         assert fp.reaped
+        assert fp.flushed
       end
 
       def test_pool_has_reaper


### PR DESCRIPTION
After #28742, this seems to be a plausible much simpler take on #23815.

This is actually two features:

1. What it says on the tin: allow the connection pool to shrink (down to zero, at the moment -- do we want to default to keeping one?) when it's not seeing enough activity to justify keeping those it has. 
2. The `on_load` hook, which ensures a Puma master process doesn't keep a connection open just because it needed one during boot. (Slightly related to #31173, but separate: that one's about being safer if we do keep the connection; this is about not keeping the connection at all if we don't need it.)