### PR TITLE
Rename `TransactionTimeout` to more descriptive `LockWaitTimeout`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -190,7 +190,7 @@
 
     *Jeremy Green*
 
-*   Add new error class `TransactionTimeout` which will be raised
+*   Add new error class `LockWaitTimeout` which will be raised
     when lock wait timeout exceeded.
 
     *Gabriel Courtemanche*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -660,7 +660,7 @@ module ActiveRecord
           when ER_LOCK_DEADLOCK
             Deadlocked.new(message)
           when ER_LOCK_WAIT_TIMEOUT
-            TransactionTimeout.new(message)
+            LockWaitTimeout.new(message)
           when ER_QUERY_TIMEOUT
             StatementTimeout.new(message)
           else

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -413,7 +413,7 @@ module ActiveRecord
           when DEADLOCK_DETECTED
             Deadlocked.new(message)
           when LOCK_NOT_AVAILABLE
-            TransactionTimeout.new(message)
+            LockWaitTimeout.new(message)
           when QUERY_CANCELED
             StatementTimeout.new(message)
           else

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -335,8 +335,8 @@ module ActiveRecord
   class IrreversibleOrderError < ActiveRecordError
   end
 
-  # TransactionTimeout will be raised when lock wait timeout exceeded.
-  class TransactionTimeout < StatementInvalid
+  # LockWaitTimeout will be raised when lock wait timeout exceeded.
+  class LockWaitTimeout < StatementInvalid
   end
 
   # StatementTimeout will be raised when statement timeout exceeded.

--- a/activerecord/test/cases/adapters/mysql2/transaction_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test.rb
@@ -60,8 +60,8 @@ module ActiveRecord
       end
     end
 
-    test "raises TransactionTimeout when lock wait timeout exceeded" do
-      assert_raises(ActiveRecord::TransactionTimeout) do
+    test "raises LockWaitTimeout when lock wait timeout exceeded" do
+      assert_raises(ActiveRecord::LockWaitTimeout) do
         s = Sample.create!(value: 1)
         latch1 = Concurrent::CountDownLatch.new
         latch2 = Concurrent::CountDownLatch.new

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -91,9 +91,9 @@ module ActiveRecord
       end
     end
 
-    test "raises TransactionTimeout when lock wait timeout exceeded" do
+    test "raises LockWaitTimeout when lock wait timeout exceeded" do
       skip unless ActiveRecord::Base.connection.postgresql_version >= 90300
-      assert_raises(ActiveRecord::TransactionTimeout) do
+      assert_raises(ActiveRecord::LockWaitTimeout) do
         s = Sample.create!(value: 1)
         latch1 = Concurrent::CountDownLatch.new
         latch2 = Concurrent::CountDownLatch.new


### PR DESCRIPTION
Since #31129, new error class `StatementTimeout` has been added.
`TransactionTimeout` is caused by the timeout shorter than
`StatementTimeout`, but its name is too generic. I think that it should
be a name that understands the difference with `StatementTimeout`.