### PR TITLE
Remove field ids from scaffold form

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -15,15 +15,15 @@
   <div class="field">
 <% if attribute.password_digest? -%>
     <%%= form.label :password %>
-    <%%= form.password_field :password, id: :<%= field_id(:password) %> %>
+    <%%= form.password_field :password %>
   </div>
 
   <div class="field">
     <%%= form.label :password_confirmation %>
-    <%%= form.password_field :password_confirmation, id: :<%= field_id(:password_confirmation) %> %>
+    <%%= form.password_field :password_confirmation %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, id: :<%= field_id(attribute.column_name) %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>
 <% end -%>
   </div>
 

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -114,10 +114,6 @@ module Rails
           "new_#{singular_route_name}_url"
         end
 
-        def field_id(attribute_name)
-          [singular_table_name, attribute_name].join("_")
-        end
-
         def singular_table_name # :doc:
           @singular_table_name ||= (pluralize_table_names? ? table_name.singularize : table_name)
         end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -471,8 +471,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/accounts/_form.html.erb" do |content|
-      assert_match(/^\W{4}<%= form\.text_field :name, id: :account_name %>/, content)
-      assert_match(/^\W{4}<%= form\.text_field :currency_id, id: :account_currency_id %>/, content)
+      assert_match(/^\W{4}<%= form\.text_field :name %>/, content)
+      assert_match(/^\W{4}<%= form\.text_field :currency_id %>/, content)
     end
   end
 
@@ -495,8 +495,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/users/_form.html.erb" do |content|
-      assert_match(/<%= form\.password_field :password, id: :user_password %>/, content)
-      assert_match(/<%= form\.password_field :password_confirmation, id: :user_password_confirmation %>/, content)
+      assert_match(/<%= form\.password_field :password %>/, content)
+      assert_match(/<%= form\.password_field :password_confirmation %>/, content)
     end
 
     assert_file "app/views/users/index.html.erb" do |content|


### PR DESCRIPTION
This was added with 27f103fc7e3260efe0b8dde66bf5354f2202ee32 for link labels and fields.
However, `form_with` changed to generates ids by default with d3893ec38ec61282c2598b01a298124356d6b35a.
So I think that adding an explicit ids is unnecessary.
