### PR TITLE
Use Puma 3.11 in newly generated applications

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -192,7 +192,7 @@ module Rails
       def webserver_gemfile_entry # :doc:
         return [] if options[:skip_puma]
         comment = "Use Puma as the app server"
-        GemfileEntry.new("puma", "~> 3.7", comment)
+        GemfileEntry.new("puma", "~> 3.11", comment)
       end
 
       def include_all_railties? # :doc:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -457,7 +457,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_defaults_to_puma_version
     run_generator [destination_root]
-    assert_gem "puma", "'~> 3.7'"
+    assert_gem "puma", "'~> 3.11'"
   end
 
   def test_generator_if_skip_puma_is_given


### PR DESCRIPTION
In order to use early hints, need to use Puma 3.11.0 or higher.
So, I think that should specify that version in newly generated applications.

Ref: https://github.com/puma/puma/commit/f6f3892f4d82638fb7a2a57d993641b1486ee88a
