### PR TITLE
Drop the before_fork/on_worker_boot advice

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -26,31 +26,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory. If you use this option
-# you need to make sure to reconnect any threads in the `on_worker_boot`
-# block.
+# process behavior so workers use less memory.
 #
 # preload_app!
-
-# If you are preloading your application and using Active Record, it's
-# recommended that you close any connections to the database before workers
-# are forked to prevent connection leakage.
-#
-# before_fork do
-#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-# end
-
-# The code in the `on_worker_boot` will be called if you are using
-# clustered mode by specifying a number of `workers`. After each worker
-# process is booted, this block will be run. If you are using the `preload_app!`
-# option, you will want to use this block to reconnect to any threads
-# or connections that may have been created at application boot, as Ruby
-# cannot share connections between processes.
-#
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-#
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
It's no longer required for Active Record, and other common libraries (dalli, redis-rb) all seem to be fork-proof too.

I was going to drop the more obscure `before_fork` but keep `on_worker_boot`... but I couldn't come up with a way to describe when it's necessary or what to do, nor a plausible example. (Not because it's hard to describe the problem it fixes, but because the "except for all common libraries" exception makes it sound silly and confusing.)

Maybe we can just drop it entirely. If most people don't need it, it seems fine to treat it like any other Puma config option that exists but isn't promoted in the generated file.

Alternatively, does anyone have any other good examples of widely-seen code that apps need in one or both of these? [CodeTriage says no](https://github.com/codetriage/codetriage/blob/31fbf635e69b399b9889b038fdd99c50601e6a33/config/puma.rb); [Discourse does a lot](https://github.com/discourse/discourse/blob/db68434db14682faa5b527ae862e399c859dbdd8/config/unicorn.conf.rb), but nothing that strikes me as needing general promotion.

cc @schneems @nateberkopec 

(this is follow-on from #31221 and #31173, which remove the need for AR connection management)