### PR TITLE
[ci skip] Fix documentation for deprecation method_wrappers

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -8,9 +8,7 @@ module ActiveSupport
     module MethodWrapper
       # Declare that a method has been deprecated.
       #
-      #   module Fred
-      #     extend self
-      #
+      #   class Fred
       #     def aaa; end
       #     def bbb; end
       #     def ccc; end
@@ -22,15 +20,15 @@ module ActiveSupport
       #   ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
       #   # => Fred
       #
-      #   Fred.aaa
+      #   Fred.new.aaa
       #   # DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.1. (called from irb_binding at (irb):10)
       #   # => nil
       #
-      #   Fred.bbb
+      #   Fred.new.bbb
       #   # DEPRECATION WARNING: bbb is deprecated and will be removed from Rails 5.1 (use zzz instead). (called from irb_binding at (irb):11)
       #   # => nil
       #
-      #   Fred.ccc
+      #   Fred.new.ccc
       #   # DEPRECATION WARNING: ccc is deprecated and will be removed from Rails 5.1 (use Bar#ccc instead). (called from irb_binding at (irb):12)
       #   # => nil
       #
@@ -39,7 +37,7 @@ module ActiveSupport
       #   ActiveSupport::Deprecation.deprecate_methods(Fred, ddd: :zzz, deprecator: custom_deprecator)
       #   # => [:ddd]
       #
-      #   Fred.ddd
+      #   Fred.new.ddd
       #   DEPRECATION WARNING: ddd is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):15)
       #   # => nil
       #
@@ -48,7 +46,7 @@ module ActiveSupport
       #   custom_deprecator.deprecate_methods(Fred, eee: :zzz)
       #   # => [:eee]
       #
-      #   Fred.eee
+      #   Fred.new.eee
       #   DEPRECATION WARNING: eee is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):18)
       #   # => nil
       def deprecate_methods(target_module, *method_names)


### PR DESCRIPTION
Seems like version with class methods doesn't work (and seems like it's correct, because of module prepending and `define_method` creates instance methods).

```ruby
require "active_support/deprecation.rb"

module Fred
  extend self

  def aaa; end
  def bbb; end
  def ccc; end
  def ddd; end
  def eee; end
end

ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
Fred.aaa
Fred.bbb
Fred.ccc
```

-> nothing


vs

```ruby
require "active_support/deprecation.rb"

class Fred
  def aaa; end
  def bbb; end
  def ccc; end
  def ddd; end
  def eee; end
end

ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
Fred.new.aaa
Fred.new.bbb
Fred.new.ccc
```

-> 

```
DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.2 (called from <main> at deprications.rb:15)
DEPRECATION WARNING: bbb is deprecated and will be removed from Rails 5.2 (use zzz instead) (called from <main> at deprications.rb:16)
DEPRECATION WARNING: ccc is deprecated and will be removed from Rails 5.2 (use Bar#ccc instead) (called from <main> at deprications.rb:17)
```
