### PR TITLE
Only preload misses on multifetch cache

### DIFF
--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "active_record_unit"
+require "active_record/railties/collection_cache_association_loading"
+
+ActionView::PartialRenderer.prepend(ActiveRecord::Railties::CollectionCacheAssociationLoading)
+
+class MultifetchCacheTest < ActiveRecordTestCase
+  fixtures :topics, :replies
+
+  def setup
+    view_paths = ActionController::Base.view_paths
+
+    @view = Class.new(ActionView::Base) do
+      def view_cache_dependencies
+        []
+      end
+
+      def combined_fragment_cache_key(key)
+        [ :views, key ]
+      end
+    end.new(view_paths, {})
+  end
+
+  def test_only_preloading_for_records_that_miss_the_cache
+    @view.render partial: "test/partial", collection: [topics(:rails)], cached: true
+
+    @topics = Topic.preload(:replies)
+
+    @view.render partial: "test/partial", collection: @topics, cached: true
+
+    assert_not @topics.detect { |topic| topic.id == topics(:rails).id }.replies.loaded?
+    assert     @topics.detect { |topic| topic.id != topics(:rails).id }.replies.loaded?
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -157,6 +157,14 @@ end_warning
       end
     end
 
+    initializer "active_record.collection_cache_association_loading" do
+      require "active_record/railties/collection_cache_association_loading"
+      ActiveSupport.on_load(:action_view) do
+        ActionView::PartialRenderer.prepend(ActiveRecord::Railties::CollectionCacheAssociationLoading)
+      end
+    end
+
+
     initializer "active_record.set_reloader_hooks" do
       ActiveSupport.on_load(:active_record) do
         ActiveSupport::Reloader.before_class_unload do

--- a/activerecord/lib/active_record/railties/collection_cache_association_loading.rb
+++ b/activerecord/lib/active_record/railties/collection_cache_association_loading.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Railties # :nodoc:
+    module CollectionCacheAssociationLoading #:nodoc:
+      def setup(context, options, block)
+        @relation = relation_from_options(options)
+
+        super
+      end
+
+      def relation_from_options(cached: nil, partial: nil, collection: nil, **_)
+        return unless cached
+
+        relation = partial if partial.is_a?(ActiveRecord::Relation)
+        relation ||= collection if collection.is_a?(ActiveRecord::Relation)
+
+        if relation && !relation.loaded?
+          relation.skip_preloading!
+        end
+      end
+
+      def collection_without_template
+        @relation.preload_associations(@collection) if @relation
+        super
+      end
+
+      def collection_with_template
+        @relation.preload_associations(@collection) if @relation
+        super
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -8,7 +8,8 @@ module ActiveRecord
                             :extending, :unscope]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering,
-                            :reverse_order, :distinct, :create_with, :skip_query_cache]
+                            :reverse_order, :distinct, :create_with, :skip_query_cache,
+                            :skip_preloading]
     CLAUSE_METHODS = [:where, :having, :from]
     INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :group, :having]
 
@@ -546,6 +547,16 @@ module ActiveRecord
       ActiveRecord::Associations::AliasTracker.create(connection, table.name, joins)
     end
 
+    def preload_associations(records)
+      preload = preload_values
+      preload += includes_values unless eager_loading?
+      preloader = nil
+      preload.each do |associations|
+        preloader ||= build_preloader
+        preloader.preload records, associations
+      end
+    end
+
     protected
 
       def load_records(records)
@@ -575,13 +586,7 @@ module ActiveRecord
               klass.find_by_sql(arel, &block).freeze
             end
 
-          preload = preload_values
-          preload += includes_values unless eager_loading?
-          preloader = nil
-          preload.each do |associations|
-            preloader ||= build_preloader
-            preloader.preload @records, associations
-          end
+          preload_associations(@records) unless skip_preloading_value
 
           @records.each(&:readonly!) if readonly_value
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -899,6 +899,11 @@ module ActiveRecord
       self
     end
 
+    def skip_preloading! # :nodoc:
+      self.skip_preloading_value = true
+      self
+    end
+
     # Returns the Arel object associated with the relation.
     def arel(aliases = nil) # :nodoc:
       @arel ||= build_arel(aliases)

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       assert_equal [], relation.extending_values
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with, :skip_query_cache]).each do |method|
+    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :skip_preloading]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")
@@ -135,6 +135,11 @@ module ActiveRecord
     test "skip_query_cache!" do
       relation.skip_query_cache!
       assert relation.skip_query_cache_value
+    end
+
+    test "skip_preloading!" do
+      relation.skip_preloading!
+      assert relation.skip_preloading_value
     end
 
     private


### PR DESCRIPTION
### Summary

When rendering a collection with `cached: true` for an `ActiveRecord::Relation` that has `preload` values, the preload would normally only be required for rendering the partial when it misses the cache and nor required for generating the cache key.

Currently, we have to chose between using preload, which loads unused `ActiveRecord` instances when the have a high cache hit rate, or not preloading the associations, which can result in `N + 1` queries when there are a large number of cache misses. 

This PR attempts to optimise this be only preloading the associations for the records that miss the cache.

An example application to demonstrate this behaviour is at https://github.com/lsylvester/multifetch-demo. An example from the log demonstrating this behaviour is:

```
  Rendering categories/index.html.erb within layouts/application
  Category Load (0.1ms)  SELECT "categories".* FROM "categories"
  Product Load (0.4ms)  SELECT "products".* FROM "products" WHERE "products"."category_id" IN (?, ?, ?, ?)  [["category_id", 4], ["category_id", 5], ["category_id", 8], ["category_id", 9]]
  Rendered collection of categories/_category.html.erb [18 / 22 cache hits] (57.9ms)
```

Without this change, we would either so a query for each of the categories that miss the cache, or have to load products for every category.

### Concerns and Further Work

There may be instances where we want to preload the associations for generation of cache keys, or we may want to have all of the associations loaded because the collection is used in other contexts other than the current rendering.

Currently there is no API to support this, but it is possible to acheive the load behaviour by calling `load` on the association before it is passed to the `render` call.

I am looking for feedback on:

- Is preloading associations only for models that miss the cache reasonable default behaviour? Or should this be explicitly opted into when calling render?
- If it is default behaviour, is calling `load` on the relation before rendering a suffient API for opting out, or should an additional option to the render call be added.

If it is ok to be default behaviour then I assume that I would need to add some application config to control this behavour to prevent breaking existing application and to provide deprication warnings.

I am also not sure about the structure of this code is it is very tightly connected to both ActionView and ActiveRecord, so any feedback in that area is welcome.

