### PR TITLE
Fix to wrap array literal active job arguments

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -31,14 +31,14 @@ module ActiveJob
     # as-is. Arrays/Hashes are serialized element by element.
     # All other types are serialized using GlobalID.
     def serialize(arguments)
-      arguments.map { |argument| serialize_argument(argument) }
+      Array(arguments).map { |argument| serialize_argument(argument) }
     end
 
     # Deserializes a set of arguments. Whitelisted types are returned
     # as-is. Arrays/Hashes are deserialized element by element.
     # All other types are deserialized using GlobalID.
     def deserialize(arguments)
-      arguments.map { |argument| deserialize_argument(argument) }
+      Array(arguments).map { |argument| deserialize_argument(argument) }
     rescue
       raise DeserializationError
     end


### PR DESCRIPTION
### Summary
ActiveJob argument serializer/deserializer expects array object, but when I execute job with hash argument, the argument converted to array object via `Enumerable#map` method.

example:
```rb
ActiveJob::Base.execute(job_class: 'MyJob', arguments: {arg_1: 'foo'})
```

I think it should not to be converted to array.
so, I fix it to wrap array literal for hash object arguments.