### PR TITLE
[ci skip] update links

### DIFF
--- a/guides/source/credits.html.erb
+++ b/guides/source/credits.html.erb
@@ -12,11 +12,11 @@ Ruby on Rails Guides: Credits
 <h3 class="section">Rails Guides Reviewers</h3>
 
 <%= author('Vijay Dev', 'vijaydev', 'vijaydev.jpg') do %>
-  Vijayakumar, found as Vijay Dev on the web, is a web applications developer and an open source enthusiast who lives in Chennai, India. He started using Rails in 2009 and began actively contributing to Rails documentation in late 2010. He <a href="https://twitter.com/vijay_dev">tweets</a> a lot and also <a href="http://vijaydev.wordpress.com">blogs</a>.
+  Vijayakumar, found as Vijay Dev on the web, is a web applications developer and an open source enthusiast who lives in Chennai, India. He started using Rails in 2009 and began actively contributing to Rails documentation in late 2010. He <a href="https://twitter.com/vijay_dev">tweets</a> a lot and also <a href="https://vijaydev.wordpress.com">blogs</a>.
 <% end %>
 
 <%= author('Xavier Noria', 'fxn', 'fxn.png') do %>
-  Xavier Noria has been into Ruby on Rails since 2005. He is a Rails core team member and enjoys combining his passion for Rails and his past life as a proofreader of math textbooks. Xavier is currently an independent Ruby on Rails consultant. Oh, he also <a href="http://twitter.com/fxn">tweets</a> and can be found everywhere as &quot;fxn&quot;.
+  Xavier Noria has been into Ruby on Rails since 2005. He is a Rails core team member and enjoys combining his passion for Rails and his past life as a proofreader of math textbooks. Xavier is currently an independent Ruby on Rails consultant. Oh, he also <a href="https://twitter.com/fxn">tweets</a> and can be found everywhere as &quot;fxn&quot;.
 <% end %>
 
 <h3 class="section">Rails Guides Designers</h3>
@@ -28,7 +28,7 @@ Ruby on Rails Guides: Credits
 <h3 class="section">Rails Guides Authors</h3>
 
 <%= author('Ryan Bigg', 'radar', 'radar.png') do %>
-  Ryan Bigg works as a Rails developer at <a href="http://marketplacer.com">Marketplacer</a> and has been working with Rails since 2006. He's the author of <a href="https://leanpub.com/multi-tenancy-rails">Multi Tenancy With Rails</a> and co-author of <a href="http://manning.com/bigg2">Rails 4 in Action</a>. He's written many gems which can be seen on <a href="https://github.com/radar">his GitHub page</a> and he also tweets prolifically as <a href="http://twitter.com/ryanbigg">@ryanbigg</a>.
+  Ryan Bigg works as the Junior Engineering Program Lead at <a href="https://www.cultureamp.com/">Culture Amp</a> and has been working with Rails since 2006. He's the author of <a href="https://leanpub.com/multi-tenancy-rails">Multi Tenancy With Rails</a> and co-author of <a href="http://manning.com/bigg2">Rails 4 in Action</a>. He's written many gems which can be seen on <a href="https://github.com/radar">his GitHub page</a> and he also tweets prolifically as <a href="https://twitter.com/ryanbigg">@ryanbigg</a>.
 <% end %>
 
 <%= author('Oscar Del Ben', 'oscardelben', 'oscardelben.jpg') do %>
@@ -36,27 +36,27 @@ Oscar Del Ben is a software engineer at <a href="http://www.businessinsider.com/
   <% end %>
 
 <%= author('Frederick Cheung', 'fcheung') do %>
-  Frederick Cheung is Chief Wizard at Texperts where he has been using Rails since 2006. He is based in Cambridge (UK) and when not consuming fine ales he blogs at <a href="http://www.spacevatican.org">spacevatican.org</a>.
+  Frederick Cheung is Chief Wizard at Texperts where he has been using Rails since 2006. He is based in Cambridge (UK) and when not consuming fine ales he blogs at <a href="https://www.spacevatican.org">spacevatican.org</a>.
 <% end %>
 
 <%= author('Tore Darell', 'toretore') do %>
-  Tore Darell is an independent developer based in Menton, France who specialises in cruft-free web applications using Ruby, Rails and unobtrusive JavaScript. You can follow him on <a href="http://twitter.com/toretore">Twitter</a>.
+  Tore Darell is an independent developer based in Menton, France who specialises in cruft-free web applications using Ruby, Rails and unobtrusive JavaScript. You can follow him on <a href="https://twitter.com/toretore">Twitter</a>.
 <% end %>
 
 <%= author('Jeff Dean', 'zilkey') do %>
-  Jeff Dean is a software engineer with <a href="http://pivotallabs.com">Pivotal Labs</a>.
+  Jeff Dean is a software engineer with <a href="https://pivotal.io/labs">Pivotal Labs</a>.
 <% end %>
 
 <%= author('Mike Gunderloy', 'mgunderloy') do %>
-  Mike Gunderloy is a consultant with <a href="http://www.actionrails.com">ActionRails</a>. He brings 25 years of experience in a variety of languages to bear on his current work with Rails. His near-daily links and other blogging can be found at <a href="http://afreshcup.com">A Fresh Cup</a> and he <a href="http://twitter.com/MikeG1">twitters</a> too much.
+  Mike Gunderloy is a consultant with ActionRails. He brings 25 years of experience in a variety of languages to bear on his current work with Rails. His near-daily links and other blogging can be found at <a href="https://afreshcup.com">A Fresh Cup</a> and he <a href="https://twitter.com/MikeG1">twitters</a> too much.
 <% end %>
 
 <%= author('Mikel Lindsaar', 'raasdnil') do %>
-  Mikel Lindsaar has been working with Rails since 2006 and is the author of the Ruby <a href="https://github.com/mikel/mail">Mail gem</a> and core contributor (he helped re-write Action Mailer's API). Mikel is the founder of <a href="http://rubyx.com/">RubyX</a>, has a <a href="http://lindsaar.net/">blog</a> and <a href="http://twitter.com/raasdnil">tweets</a>.
+  Mikel Lindsaar has been working with Rails since 2006 and is the author of the Ruby <a href="https://github.com/mikel/mail">Mail gem</a> and core contributor (he helped re-write Action Mailer's API). Mikel is the founder of <a href="https://reinteractive.com">RubyX</a>, has a <a href="http://lindsaar.net/">blog</a> and <a href="https://twitter.com/raasdnil">tweets</a>.
 <% end %>
 
 <%= author('Cássio Marques', 'cmarques') do %>
-  Cássio Marques is a Brazilian software developer working with different programming languages such as Ruby, JavaScript, CPP and Java, as an independent consultant. He blogs at <a href="http://cassiomarques.wordpress.com">/* CODIFICANDO */</a>, which is mainly written in Portuguese, but will soon get a new section for posts with English translation.
+  Cássio Marques is a Brazilian software developer working with different programming languages such as Ruby, JavaScript, CPP and Java, as an independent consultant. He blogs at <a href="https://cassiomarques.wordpress.com">/* CODIFICANDO */</a>, which is mainly written in Portuguese, but will soon get a new section for posts with English translation.
 <% end %>
 
 <%= author('James Miller', 'bensie') do %>
@@ -64,17 +64,17 @@ Oscar Del Ben is a software engineer at <a href="http://www.businessinsider.com/
 <% end %>
 
 <%= author('Pratik Naik', 'lifo') do %>
-  Pratik Naik is a Ruby on Rails developer at <a href="https://basecamp.com/">Basecamp</a> and maintains a blog at <a href="http://m.onkey.org">has_many :bugs, :through =&gt; :rails</a>. He also has a semi-active <a href="http://twitter.com/lifo">twitter account</a>.
+  Pratik Naik is a Ruby on Rails developer at <a href="https://basecamp.com/">Basecamp</a> and maintains a blog at <a href="http://m.onkey.org">has_many :bugs, :through =&gt; :rails</a>. He also has a semi-active <a href="https://twitter.com/lifo">twitter account</a>.
 <% end %>
 
 <%= author('Emilio Tagua', 'miloops') do %>
-  Emilio Tagua &mdash;a.k.a. miloops&mdash; is an Argentinian entrepreneur, developer, open source contributor and Rails evangelist. Cofounder of <a href="http://eventioz.com">Eventioz</a>. He has been using Rails since 2006 and contributing since early 2008. Can be found at gmail, twitter, freenode, everywhere as &quot;miloops&quot;.
+  Emilio Tagua &mdash;a.k.a. miloops&mdash; is an Argentinian entrepreneur, developer, open source contributor and Rails evangelist. Cofounder of Eventioz. He has been using Rails since 2006 and contributing since early 2008. Can be found at gmail, twitter, freenode, everywhere as &quot;miloops&quot;.
 <% end %>
 
 <%= author('Heiko Webers', 'hawe') do %>
-  Heiko Webers is the founder of <a href="http://www.bauland42.de">bauland42</a>, a German web application security consulting and development company focused on Ruby on Rails. He blogs at the <a href="http://www.rorsecurity.info">Ruby on Rails Security Project</a>. After 10 years of desktop application development, Heiko has rarely looked back.
+  Heiko Webers is the founder of <a href="http://www.bauland42.de">bauland42</a>, a German web application security consulting and development company focused on Ruby on Rails. He blogs at the <a href="https://www.rorsecurity.info">Ruby on Rails Security Project</a>. After 10 years of desktop application development, Heiko has rarely looked back.
 <% end %>
 
 <%= author('Akshay Surve', 'startupjockey', 'akshaysurve.jpg') do %>
-  Akshay Surve is the Founder at <a href="http://www.deltax.com">DeltaX</a>, hackathon specialist, a midnight code junkie and occasionally writes prose. You can connect with him on <a href="https://twitter.com/akshaysurve">Twitter</a>, <a href="http://www.linkedin.com/in/akshaysurve">Linkedin</a>, <a href="http://www.akshaysurve.com/">Personal Blog</a> or <a href="http://www.quora.com/Akshay-Surve">Quora</a>.
+  Akshay Surve is the Founder at <a href="http://www.deltax.com">DeltaX</a>, hackathon specialist, a midnight code junkie and occasionally writes prose. You can connect with him on <a href="https://twitter.com/akshaysurve">Twitter</a>, <a href="https://www.linkedin.com/in/akshaysurve">Linkedin</a>, <a href="http://www.akshaysurve.com/">Personal Blog</a> or <a href="https://www.quora.com/Akshay-Surve">Quora</a>.
 <% end %>


### PR DESCRIPTION
### Summary

- `http` to `https`:  Each `url` tested and then changed `http` to `https` where links works with `https`

- For Twitter, Github, LinkedIn changed to `https` where applicable

Following Domain are not working and Its for sale:

http://eventioz.com
http://www.actionrails.com 

Changes:

`http://pivotallabs.com` which redirect to `https://pivotal.io/labs`
'http://rubyx.com` which redirect to `https://reinteractive.com`