### PR TITLE
Add possibility to set custom `Rails.application.credentials` object.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add possibility to set custom `Rails.application.credentials` object.
+    In multi environment application one can set custom file by:
+
+    ```
+    config.before_initialize do
+      self.credentials = encrypted("config/custom-credentials.yml.enc")
+    end
+    ```
+
+    *Wojciech Wnętrzak*
+
+
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
 *   No changes.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -118,6 +118,7 @@ module Rails
     attr_accessor :assets, :sandbox
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders, :reloader, :executor
+    attr_writer :credentials
 
     delegate :default_url_options, :default_url_options=, to: :routes
 

--- a/railties/test/application/credentials_test.rb
+++ b/railties/test/application/credentials_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class CredentialsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    setup :build_app
+    teardown :teardown_app
+
+    test "sets custom application credentials" do
+      Dir.chdir(app_path) do
+        File.write("config/master.key", ActiveSupport::EncryptedFile.generate_key)
+
+        file = ActiveSupport::EncryptedFile.new(
+          content_path: "config/custom-credentials.yml.enc",
+          key_path: "config/master.key",
+          env_key: "RAILS_MASTER_KEY"
+        )
+
+        file.write("aws_access_key_id: secret-key")
+      end
+
+      add_to_config <<-RUBY
+        config.before_initialize do
+          self.credentials = encrypted("config/custom-credentials.yml.enc")
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      assert_equal "secret-key", Rails.application.credentials.aws_access_key_id
+    end
+  end
+end


### PR DESCRIPTION
In multi environment application one can set custom file by:

```
config.before_initialize do
  self.credentials = encrypted("config/custom-credentials.yml.enc")
end
```

The last missing part of `credentials` feature ;-)

r? @kaspth