### PR TITLE
Fix URL helpers with permitted parameters.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -316,7 +316,7 @@ module ActionDispatch
                   when Hash
                     args.pop
                   when ActionController::Parameters
-                    args.pop.to_h
+                    args.pop.to_h.symbolize_keys
                   end
                 helper.call self, args, options
               end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -316,7 +316,7 @@ module ActionDispatch
                   when Hash
                     args.pop
                   when ActionController::Parameters
-                    args.pop.to_h.symbolize_keys
+                    args.pop.to_h
                   end
                 helper.call self, args, options
               end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3644,11 +3644,13 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_passing_action_parameters_to_url_helpers_is_allowed_if_parameters_are_permitted
     draw do
       root to: "projects#index"
+      resources :items
     end
     params = ActionController::Parameters.new(id: "1")
     params.permit!
 
     assert_equal "/?id=1", root_path(params)
+    assert_equal "/items/1", item_path(params)
   end
 
   def test_dynamic_controller_segments_are_deprecated

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3641,7 +3641,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_passing_action_parameters_to_url_helpers_is_allowed_if_parameters_are_permitted
+  def test_passing_action_parameters_to_url_helpers_is_allowed_for_query_if_parameters_are_permitted
     draw do
       root to: "projects#index"
       resources :items
@@ -3650,7 +3650,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     params.permit!
 
     assert_equal "/?id=1", root_path(params)
-    assert_equal "/items/1", item_path(params)
+    assert_raises(ActionController::UrlGenerationError) do
+      item_path(params)
+    end
   end
 
   def test_dynamic_controller_segments_are_deprecated


### PR DESCRIPTION
This fixes a issue demonstrated by following script.
This is first time for me to contribute code. 
I appreciate any feedback. Thank you ❤️ 

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails"
end

require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  secrets.secret_token    = "secret_token"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    resources :items
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: "Home"
  end
end

require "minitest/autorun"
require "rack/test"

class BugTest < Minitest::Test
  include Rack::Test::Methods

  def test_returns_success
    params = ActionController::Parameters.new(id: 1)
    params.permit!
    puts app.routes.url_helpers.item_path(id: 1)
    assert "/items/1" == app.routes.url_helpers.item_path(params)
  end

  private
    def app
      Rails.application
    end
end
```

Fixes #30450


