### PR TITLE
Mention about Ruby 2.4 Unicode case mappings in `mb_chars` example [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -12,9 +12,11 @@ class String
   # class. If the proxy class doesn't respond to a certain method, it's forwarded to the encapsulated string.
   #
   #   >> "ǉ".upcase
-  #   => "Ǉ"
+  #   => "ǉ"
   #   >> "ǉ".mb_chars.upcase.to_s
   #   => "Ǉ"
+  #
+  # NOTE: An above example is useful for pre Ruby 2.4. Ruby 2.4 supports Unicode case mappings.
   #
   # == Method chaining
   #


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2016/09/08/ruby-2-4-0-preview2-released/