### PR TITLE
Removed "private" generators from command list.

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -218,6 +218,9 @@ module Rails
         rails.delete("app")
         rails.delete("plugin")
         rails.delete("encrypted_secrets")
+        rails.delete("encrypted_file")
+        rails.delete("encryption_key_file")
+        rails.delete("master_key")
         rails.delete("credentials")
 
         hidden_namespaces.each { |n| groups.delete(n.to_s) }

--- a/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
@@ -5,23 +5,7 @@ require "active_support/encrypted_file"
 
 module Rails
   module Generators
-    class EncryptedFileGenerator < Base
-      def add_encrypted_file(file_path, key_path)
-        unless File.exist?(file_path)
-          say "Adding #{file_path} to store encrypted content."
-          say ""
-          say "The following content has been encrypted with the encryption key:"
-          say ""
-          say template, :on_green
-          say ""
-
-          add_encrypted_file_silently(file_path, key_path)
-
-          say "You can edit encrypted file with `bin/rails encrypted:edit #{file_path}`."
-          say ""
-        end
-      end
-
+    class EncryptedFileGenerator < Base # :nodoc:
       def add_encrypted_file_silently(file_path, key_path, template = encrypted_file_template)
         unless File.exist?(file_path)
           setup = { content_path: file_path, key_path: key_path, env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true }

--- a/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
@@ -6,7 +6,7 @@ require "active_support/encrypted_file"
 
 module Rails
   module Generators
-    class EncryptionKeyFileGenerator < Base
+    class EncryptionKeyFileGenerator < Base # :nodoc:
       def add_key_file(key_path)
         key_path = Pathname.new(key_path)
 


### PR DESCRIPTION
Appropriate way to handle encrypted command is by `bin/rails credentials` and
`bin/rails encrypted`

It was displayed on `bin/rails generate` command:
```
Please choose a generator below.

Rails:
  application_record
  assets
  channel
  controller
  encrypted_file
  encryption_key_file
  generator
  ...
```

`encryption_key_file` is shared by 2 commands, thus hide it.
`encrypted_file` was not used in any other place, thus inline it where needed.

r? @kaspth 