### PR TITLE
Fix postgresql's count with subquery.

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -391,6 +391,11 @@ module ActiveRecord
       end
 
       def build_count_subquery(relation, column_name, distinct)
+        # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
+        if column_name == :all && relation.select_values.present?
+          relation.unscope!(:order)
+        end
+
         relation.select_values = [
           if column_name == :all
             distinct ? table[Arel.star] : Arel.sql(FinderMethods::ONE_AS_ONE)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -260,6 +260,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 3, Account.joins(:firm).distinct.order(:firm_id).limit(3).offset(2).count
   end
 
+  def test_distinct_joins_count_all_with_custom_order_and_limit_and_offset
+    subquery = "(SELECT COUNT(DISTINCT a.id) FROM accounts a GROUP BY companies.id)"
+    order = Arel.sql("#{subquery} DESC")
+    assert_equal 3, Account.joins(:firm).select("*", subquery).distinct.order(order).limit(3).offset(2).count(:all)
+  end
+
   def test_distinct_count_with_group_by_and_order_and_limit
     assert_equal({ 6 => 2 }, Account.group(:firm_id).distinct.order("1 DESC").limit(1).count)
   end


### PR DESCRIPTION
Without this change, #count for relation which use subquery for order
clause fails on PostgresQL.

```
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", path: "/Users/yskkin/projects/rails"
  gem "pg"
  gem "kaminari"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "test")
#ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.timestamps
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
    t.integer :status
    t.timestamps
  end
end

class Post < ActiveRecord::Base
  has_many :comments

  def self.find_by_comment_status
    subquery = "(SELECT COUNT(DISTINCT c.id) FROM comments c GROUP BY posts.id)"

    left_joins(:comments)
      .select(subquery)
      .merge(Comment.approved)
      .reorder(subquery + " DESC")
      .distinct
  end
end

class Comment < ActiveRecord::Base
  belongs_to :post
  enum status: %i[review approved rejected]
end

class BugTest < Minitest::Test
  def test_size_with_offset
    post = Post.create!
    Comment.new(status: :approved, post: post).save!

    Post.find_by_comment_status.offset(0).count(:all)
  end
end
```
