### PR TITLE
Accept block as fallback_location for redirect_back

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Accept block as fallback_location for redirect_back.
+
+    *Max Melentiev*
+
 *   Introduce a new error page to when the implict render page is accessed in the browser.
 
     Now instead of showing an error page that with exception and backtraces we now show only

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -71,15 +71,16 @@ module ActionController
     # The referrer information is pulled from the HTTP +Referer+ (sic) header on
     # the request. This is an optional header and its presence on the request is
     # subject to browser security settings and user preferences. If the request
-    # is missing this header, the <tt>fallback_location</tt> will be used.
+    # is missing this header, the <tt>fallback_location</tt> or value of block will be used.
     #
-    #   redirect_back fallback_location: { action: "show", id: 5 }
-    #   redirect_back fallback_location: @post
+    #   redirect_back { { action: "show", id: 5 } }
+    #   redirect_back { @post }
+    #   redirect_back { posts_url }
     #   redirect_back fallback_location: "http://www.rubyonrails.org"
     #   redirect_back fallback_location: "/images/screenshot.jpg"
-    #   redirect_back fallback_location: posts_url
-    #   redirect_back fallback_location: proc { edit_post_url(@post) }
     #   redirect_back fallback_location: '/', allow_other_host: false
+    #   redirect_back fallback_location: { action: "show", id: 5 }
+    #   redirect_back fallback_location: proc { edit_post_url(@post) }
     #
     # ==== Options
     # * <tt>:fallback_location</tt> - The default fallback location that will be used on missing +Referer+ header.
@@ -87,7 +88,9 @@ module ActionController
     #
     # All other options that can be passed to <tt>redirect_to</tt> are accepted as
     # options and the behavior is identical.
-    def redirect_back(fallback_location:, allow_other_host: true, **args)
+    def redirect_back(fallback_location: nil, allow_other_host: true, **args, &block)
+      fallback_location ||= block
+      raise ArgumentErrorm, "fallback_location or block is required" unless fallback_location
       referer = request.headers["Referer"]
       redirect_to_referer = referer && (allow_other_host || _url_host_allowed?(referer))
       redirect_to redirect_to_referer ? referer : fallback_location, **args

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -66,6 +66,10 @@ class RedirectController < ActionController::Base
     redirect_back(fallback_location: "/things/stuff", status: 307, allow_other_host: false)
   end
 
+  def redirect_back_with_block
+    redirect_back { "/things/stuff" }
+  end
+
   def host_redirect
     redirect_to action: "other_host", only_path: false, host: "other.test.host"
   end
@@ -278,6 +282,19 @@ class RedirectTest < ActionController::TestCase
 
     assert_response 307
     assert_equal referer, redirect_to_url
+  end
+
+  def test_redirect_back_with_block
+    referer = "http://www.example.com/coming/from"
+    @request.env["HTTP_REFERER"] = referer
+
+    get :redirect_back_with_block
+    assert_equal referer, redirect_to_url
+  end
+
+  def test_redirect_back_with_block_with_no_referer
+    get :redirect_back_with_block
+    assert_equal "http://test.host/things/stuff", redirect_to_url
   end
 
   def test_redirect_to_record


### PR DESCRIPTION
Passing proc as `fallback_location` to `redirect_back` should be preferred as it is lazy-eveluated. This pr makes it more convenient and compact:

```ruby
redirect_back { some_path }
# instead of
redirect_back fallback_location: -> { some_path }
```

`fallback_location` is still supported.

I'll add tests, changelog if proposed changes are OK.