### PR TITLE
[WIP] Adding ActiveStorage previewer for text files using the ImageMagick

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -5,6 +5,7 @@ require "active_storage"
 
 require "active_storage/previewer/pdf_previewer"
 require "active_storage/previewer/video_previewer"
+require "active_storage/previewer/text_previewer"
 
 require "active_storage/analyzer/image_analyzer"
 require "active_storage/analyzer/video_analyzer"
@@ -14,7 +15,7 @@ module ActiveStorage
     isolate_namespace ActiveStorage
 
     config.active_storage = ActiveSupport::OrderedOptions.new
-    config.active_storage.previewers = [ ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
+    config.active_storage.previewers = [ ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer, ActiveStorage::Previewer::TextPreviewer ]
     config.active_storage.analyzers  = [ ActiveStorage::Analyzer::ImageAnalyzer, ActiveStorage::Analyzer::VideoAnalyzer ]
 
     config.eager_load_namespaces << ActiveStorage

--- a/activestorage/lib/active_storage/previewer/text_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/text_previewer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  class Previewer::TextPreviewer < Previewer
+    def self.accept?(blob)
+      blob.text?
+    end
+
+    def preview
+      download_blob_to_tempfile do |input|
+        draw_text_preview_from input do |output|
+          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+        end
+      end
+    end
+
+    private
+      def draw_text_preview_from(file, &block)
+        draw "convert", "-size", "300x300", "xc:white", "-pointsize", "18",
+          "-draw", "text 10 28 '#{ escape file.read }'", "png:-", &block
+      end
+
+      def escape(string)
+        string.gsub("'", "\\'")
+      end
+  end
+end

--- a/activestorage/test/fixtures/files/code.js
+++ b/activestorage/test/fixtures/files/code.js
@@ -1,0 +1,11 @@
+import { start } from "./ujs"
+import { DirectUpload } from "./direct_upload"
+export { start, DirectUpload }
+
+function autostart() {
+  if (window.ActiveStorage) {
+    start()
+  }
+}
+
+setTimeout(autostart, 1)

--- a/activestorage/test/previewer/text_previewer_test.rb
+++ b/activestorage/test/previewer/text_previewer_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/previewer/text_previewer"
+
+class ActiveStorage::Previewer::TextPreviewerTest < ActiveSupport::TestCase
+  setup do
+    @blob = create_file_blob(filename: "code.js", content_type: "text/javascript")
+  end
+
+  test "previewing a text file" do
+    ActiveStorage::Previewer::TextPreviewer.new(@blob).preview do |attachable|
+      assert_equal "image/png", attachable[:content_type]
+      assert_equal "code.png", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 300, image.width
+      assert_equal 300, image.height
+    end
+  end
+end


### PR DESCRIPTION
Produces an image, showing the first few lines of the text file on a blank canvas.
E.g.:
![preview](https://user-images.githubusercontent.com/8790491/33384701-b2e91be8-d51e-11e7-9691-9dd8254b1582.png)