### PR TITLE
Initial support for running Rails on FIPS-certified systems

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -133,7 +133,7 @@ module ActionDispatch
         end
 
         def generate_strong_etag(validators)
-          %("#{Digest::MD5.hexdigest(ActiveSupport::Cache.expand_cache_key(validators))}")
+          %("#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key(validators))}")
         end
 
         def cache_control_segments

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -464,7 +464,7 @@ module ActionController
     end
 
     def test_stale_with_etag
-      @request.if_none_match = %(W/"#{Digest::MD5.hexdigest('123')}")
+      @request.if_none_match = %(W/"#{ActiveSupport::Digest.hexdigest('123')}")
       get :with_stale
       assert_equal 304, response.status.to_i
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -592,7 +592,7 @@ class EtagRenderTest < ActionController::TestCase
     end
 
     def strong_etag(record)
-      %("#{Digest::MD5.hexdigest(ActiveSupport::Cache.expand_cache_key(record))}")
+      %("#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key(record))}")
     end
 end
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -89,7 +89,7 @@ module ActionView
       end
 
       def digest(finder, stack = [])
-        Digest::MD5.hexdigest("#{template.source}-#{dependency_digest(finder, stack)}")
+        ActiveSupport::Digest.hexdigest("#{template.source}-#{dependency_digest(finder, stack)}")
       end
 
       def dependency_digest(finder, stack)

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module CollectionCacheKey
     def collection_cache_key(collection = all, timestamp_column = :updated_at) # :nodoc:
-      query_signature = Digest::MD5.hexdigest(collection.to_sql)
+      query_signature = ActiveSupport::Digest.hexdigest(collection.to_sql)
       key = "#{collection.model_name.cache_key}/query-#{query_signature}"
 
       if collection.loaded?

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
       /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
-      assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
+      assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
     end
@@ -37,7 +37,7 @@ module ActiveRecord
 
       /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
-      assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
+      assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
     end
@@ -50,7 +50,7 @@ module ActiveRecord
 
       /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
-      assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
+      assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
     end
@@ -68,7 +68,7 @@ module ActiveRecord
 
       /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
-      assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
+      assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduced `ActiveSupport::Digest` that allows to specify hash function implementation
+    and defaults to `Digest::MD5`.
+
+    Replaced calls to `::Digest::MD5.hexdigest` with calls to `ActiveSupport::Digest.hexdigest`.
+
+    *Dmitri Dolguikh*
+ 
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
 *   No changes.

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -53,6 +53,7 @@ module ActiveSupport
     autoload :Callbacks
     autoload :Configurable
     autoload :Deprecation
+    autoload :Digest
     autoload :Gzip
     autoload :Inflector
     autoload :JSON

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -121,7 +121,7 @@ module ActiveSupport
           fname = URI.encode_www_form_component(key)
 
           if fname.size > FILEPATH_MAX_SIZE
-            fname = Digest::MD5.hexdigest(key)
+            fname = ActiveSupport::Digest.hexdigest(key)
           end
 
           hash = Zlib.adler32(fname)

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -7,7 +7,6 @@ rescue LoadError => e
   raise e
 end
 
-require "digest/md5"
 require "active_support/core_ext/marshal"
 require "active_support/core_ext/array/extract_options"
 
@@ -183,7 +182,7 @@ module ActiveSupport
           key = super.dup
           key = key.force_encoding(Encoding::ASCII_8BIT)
           key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-          key = "#{key[0, 213]}:md5:#{Digest::MD5.hexdigest(key)}" if key.size > 250
+          key = "#{key[0, 213]}:md5:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
           key
         end
 

--- a/activesupport/lib/active_support/digest.rb
+++ b/activesupport/lib/active_support/digest.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  class Digest #:nodoc:
+    class <<self
+      def hash_digest_class
+        @hash_digest_class || ::Digest::MD5
+      end
+
+      def hash_digest_class=(klass)
+        raise ArgumentError, "#{klass} is expected to implement hexdigest class method" unless klass.respond_to?(:hexdigest)
+        @hash_digest_class = klass
+      end
+
+      def hexdigest(arg)
+        new.hexdigest(arg)
+      end
+    end
+
+    def initialize(digest_class: nil)
+      @digest_class = digest_class || self.class.hash_digest_class
+    end
+
+    def hexdigest(arg)
+      @digest_class.hexdigest(arg).truncate(32)
+    end
+  end
+end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -66,5 +66,12 @@ module ActiveSupport
         ActiveSupport.send(k, v) if ActiveSupport.respond_to? k
       end
     end
+
+    initializer "active_support.set_hash_digest_class" do |app|
+      if app.config.active_support.respond_to?(:use_hash_digest_class) && app.config.active_support.use_hash_digest_class
+        ActiveSupport::Digest.hash_digest_class =
+          app.config.active_support.use_hash_digest_class
+      end
+    end
   end
 end

--- a/activesupport/test/digest_test.rb
+++ b/activesupport/test/digest_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "openssl"
+
+class DigestTest < ActiveSupport::TestCase
+  class InvalidDigest; end
+  def test_with_default_hash_digest_class
+    assert_equal ::Digest::MD5.hexdigest("hello friend"), ActiveSupport::Digest.hexdigest("hello friend")
+  end
+
+  def test_with_custom_hash_digest_class
+    original_hash_digest_class = ActiveSupport::Digest.hash_digest_class
+
+    ActiveSupport::Digest.hash_digest_class = ::Digest::SHA1
+    digest = ActiveSupport::Digest.hexdigest("hello friend")
+
+    assert_equal 32, digest.length
+    assert_equal ::Digest::SHA1.hexdigest("hello friend").truncate(32), digest
+  ensure
+    ActiveSupport::Digest.hash_digest_class = original_hash_digest_class
+  end
+
+  def test_should_raise_argument_error_if_custom_digest_is_missing_hexdigest_method
+    assert_raises(ArgumentError) { ActiveSupport::Digest.hash_digest_class = InvalidDigest }
+  end
+end


### PR DESCRIPTION
This PR introduces initial support for running Rails on system in FIPS mode. These systems do not have access to commonly used hash functions and MD5 in particular. Attempts to calculate MD5 hashes using openssl on a linux system will result in termination of the Rails process.

This PR allows to switch from MD5 hashes to SHA512 hashes by setting ```config.active_support.use_fips_approved_hash_function``` setting to true. 