### PR TITLE
Keep current Code Climate behavior before upgrade

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,25 @@
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+
 engines:
   rubocop:
     enabled: true


### PR DESCRIPTION
### Summary

This PR means that Code Climate will continue to run the same analysis on Rails as it always has on your pull requests.

**If you do not merge these changes**, when Code Climate migrates Rails to our new analysis (very soon), Code Climate will continue to run Rubocop, but it will ALSO run Code Climate's new maintainability checks.

You may want this ... you may not. Just want to make sure you knew how to tweak or disable if you so desire.

### Other Information

- [How to tweak the maintainability checks](https://docs.codeclimate.com/docs/advanced-configuration)
- [Blog post: Code Climate's New 10 Point Technical Debt Assessment](https://codeclimate.com/blog/10-point-technical-debt-assessment)
- [Blog post: A new, clearer way to understand code quality](https://codeclimate.com/blog/a-new-clearer-way-to-understand-code-quality)
