### PR TITLE
ActiveStorage: Call `attachment.destroy` before calling `blob.purge_later`

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -18,14 +18,14 @@ class ActiveStorage::Attachment < ActiveRecord::Base
 
   # Synchronously purges the blob (deletes it from the configured service) and destroys the attachment.
   def purge
-    blob.purge
     destroy
+    blob.purge
   end
 
   # Destroys the attachment and asynchronously purges the blob (deletes it from the configured service).
   def purge_later
-    blob.purge_later
     destroy
+    blob.purge_later
   end
 
   private


### PR DESCRIPTION
When I destroyed an object has `has_one_attached` and an error happened, blob is only destroyed to be retried. It means everything will be rollbacked when there is an error, but `PurgeJob` is still alive and it will be done finally. A blob will be purged asynchronously, but an object and an attachment is purged synchronously.

This problem causes an object has an attachment, but it doesn't have a blob.
So I think they will be destroyed at first, then blob will. (or [retry_on](https://github.com/rails/rails/blob/f7e3c686685fb89e67293440d24356f93fa34847/activestorage/app/jobs/active_storage/purge_job.rb#L6) will be removed for now?)

I'm sorry, I'm not sure this way is ok..
Anyway, thank you for modern approach of uploading files!

Sample repo: https://github.com/rono23/sample-rails