### PR TITLE
Move system test dependencies to test group

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -41,13 +41,6 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  <%- if depends_on_system_test? -%>
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.15'
-  gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
-  <%- end -%>
 end
 
 group :development do
@@ -70,6 +63,16 @@ group :development do
 <% end -%>
 <% end -%>
 end
+
+<%- if depends_on_system_test? -%>
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem 'capybara', '~> 2.15'
+  gem 'selenium-webdriver'
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
+end
+<%- end -%>
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
### Summary

This PR moves system test dependencies to the `test` group so they are not installed in the `development` group.