### PR TITLE
Duration created with no parts will have a default seconds part eqaul to 0

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -194,7 +194,6 @@ module ActiveSupport
         end
 
         parts[:seconds] = remainder
-        parts.reject! { |k, v| v.zero? }
 
         new(value, parts)
       end
@@ -211,6 +210,7 @@ module ActiveSupport
     def initialize(value, parts) #:nodoc:
       @value, @parts = value, parts.to_h
       @parts.default = 0
+      @parts.reject! { |k, v| v.zero? }
     end
 
     def coerce(other) #:nodoc:
@@ -370,6 +370,8 @@ module ActiveSupport
     alias :before :ago
 
     def inspect #:nodoc:
+      return "0 seconds" if parts.empty?
+
       parts.
         reduce(::Hash.new(0)) { |h, (l, r)| h[l] += r; h }.
         sort_by { |unit,  _ | PARTS.index(unit) }.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -71,6 +71,8 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "7 days",                          7.days.inspect
     assert_equal "1 week",                          1.week.inspect
     assert_equal "2 weeks",                         1.fortnight.inspect
+    assert_equal "0 seconds",                       (10 % 5.seconds).inspect
+    assert_equal "10 minutes",                      (10.minutes + 0.seconds).inspect
   end
 
   def test_inspect_locale


### PR DESCRIPTION
Added a default value to seconds part with parts are empty.
Fixes #31302 