### PR TITLE
Ignore `NoDatabaseError` when loading schema cache

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1053,7 +1053,15 @@ module ActiveRecord
         end
       end
 
-      def current_version(connection = Base.connection)
+      def current_version(connection = nil)
+        if connection.nil?
+          begin
+            connection = Base.connection
+          rescue ActiveRecord::NoDatabaseError
+            return nil
+          end
+        end
+
         get_all_versions(connection).max || 0
       end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -90,12 +90,15 @@ module ActiveRecord
             filename = File.join(app.config.paths["db"].first, "schema_cache.yml")
 
             if File.file?(filename)
+              current_version = ActiveRecord::Migrator.current_version
+              next if current_version.nil?
+
               cache = YAML.load(File.read(filename))
-              if cache.version == ActiveRecord::Migrator.current_version
+              if cache.version == current_version
                 connection.schema_cache = cache
                 connection_pool.schema_cache = cache.dup
               else
-                warn "Ignoring db/schema_cache.yml because it has expired. The current schema version is #{ActiveRecord::Migrator.current_version}, but the one in the cache is #{cache.version}."
+                warn "Ignoring db/schema_cache.yml because it has expired. The current schema version is #{current_version}, but the one in the cache is #{cache.version}."
               end
             end
           end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -98,6 +98,20 @@ module ApplicationTests
         end
       end
 
+      test "db:create works when schema cache exists and database does not exist" do
+        use_postgresql
+
+        begin
+          rails %w(db:create db:migrate db:schema:cache:dump)
+
+          rails "db:drop"
+          rails "db:create"
+          assert_equal 0, $?.exitstatus
+        ensure
+          rails "db:drop" rescue nil
+        end
+      end
+
       test "db:drop failure because database does not exist" do
         output = rails("db:drop:_unsafe", "--trace")
         assert_match(/does not exist/, output)

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -381,6 +381,21 @@ module TestHelpers
 
       $:.reject! { |path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
+
+    def use_postgresql
+      File.open("#{app_path}/config/database.yml", "w") do |f|
+        f.puts <<-YAML
+        default: &default
+          adapter: postgresql
+          pool: 5
+          database: railties_test
+        development:
+          <<: *default
+        test:
+          <<: *default
+        YAML
+      end
+    end
   end
 end
 


### PR DESCRIPTION
When loading schema cache, fetch current migration version.
However, if database does not exist, connection acquisition will cause an error. This is a problem when create database.
When databas is not yet, schema cache is unnecessary, so fixed it to ignore errors.

Context: https://github.com/rails/rails/pull/31135#issuecomment-348404326