### PR TITLE
Fix typo in test error message

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -310,7 +310,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       case command
       when "active_storage:install"
         @binstub_called += 1
-        assert_equal 1, @binstub_called, "active_storage:install expected to be called once, but was called #{@install_called} times."
+        assert_equal 1, @binstub_called, "active_storage:install expected to be called once, but was called #{@binstub_called} times"
       end
     end
 


### PR DESCRIPTION
With the current code, a failing test shows this error, which is missing
the number of times called and has two periods at the end.

```
/railties$ be ruby -Itest test/generators/app_generator_test.rb -n test_active_storage_install

Failure:
AppGeneratorTest#test_active_storage_install [test/generators/app_generator_test.rb:313]:
active_storage:install expected to be called once, but was called  times..
Expected: 1
  Actual: 2
```

After the fix, the error message looks correct:

```
/railties$ be ruby -Itest test/generators/app_generator_test.rb -n test_active_storage_install

Failure:
AppGeneratorTest#test_active_storage_install [test/generators/app_generator_test.rb:313]:
active_storage:install expected to be called once, but was called 2 times.
Expected: 1
  Actual: 2
```

This was probably just a typo introduced in #31084 (@y-yagi)