### PR TITLE
Run Active Storage migrations in new apps

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -18,6 +18,7 @@ require "active_storage/analyzer/null_analyzer"
 class ActiveStorage::Blob < ActiveRecord::Base
   class UnpreviewableError < StandardError; end
   class UnrepresentableError < StandardError; end
+  class MissingTableError < StandardError; end
 
   self.table_name = "active_storage_blobs"
 
@@ -55,6 +56,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # then the +io+ is uploaded, then the blob is saved. This is done this way to avoid uploading (which may take
     # time), while having an open database transaction.
     def create_after_upload!(io:, filename:, content_type: nil, metadata: nil)
+      raise_if_table_missing!
       build_after_upload(io: io, filename: filename, content_type: content_type, metadata: metadata).tap(&:save!)
     end
 
@@ -64,8 +66,18 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # Once the form using the direct upload is submitted, the blob can be associated with the right record using
     # the signed ID.
     def create_before_direct_upload!(filename:, byte_size:, checksum:, content_type: nil, metadata: nil)
+      raise_if_table_missing!
       create! filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, metadata: metadata
     end
+
+    private
+
+      def raise_if_table_missing!
+        unless table_exists?
+          raise(MissingTableError, "Could not find table '#{table_name}'. " \
+            "To resolve this issue run: bin/rails active_storage:install")
+        end
+      end
   end
 
 

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -8,6 +8,7 @@ module ActiveStorage
   # Abstract base class for the concrete ActiveStorage::Attached::One and ActiveStorage::Attached::Many
   # classes that both provide proxy access to the blob association for a record.
   class Attached
+    class MissingTableError < StandardError; end
     attr_reader :name, :record, :dependent
 
     def initialize(name, record, dependent:)
@@ -30,6 +31,13 @@ module ActiveStorage
           ActiveStorage::Blob.find_signed(attachable)
         else
           nil
+        end
+      end
+
+      def raise_if_table_missing!
+        unless ActiveStorage::Attachment.table_exists?
+          raise(MissingTableError, "Could not find table '#{ActiveStorage::Attachment.table_name}'. " \
+            "To resolve this issue run: bin/rails active_storage:install")
         end
       end
   end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -9,6 +9,7 @@ module ActiveStorage
     #
     # All methods called on this proxy object that aren't listed here will automatically be delegated to +attachments+.
     def attachments
+      raise_if_table_missing!
       record.public_send("#{name}_attachments")
     end
 

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -10,6 +10,7 @@ module ActiveStorage
     # You don't have to call this method to access the attachment's methods as
     # they are all available at the model level.
     def attachment
+      raise_if_table_missing!
       record.public_send("#{name}_attachment")
     end
 

--- a/activestorage/test/models/attachment_missing_table_test.rb
+++ b/activestorage/test/models/attachment_missing_table_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::AttachmentMissingTableTest < ActiveSupport::TestCase
+  setup do
+    ActiveRecord::Migrator.down File.expand_path("../../db/migrate", __dir__)
+    ActiveRecord::Base.clear_cache!
+    @user = User.create!(name: "DHH")
+  end
+
+  teardown do
+    ActiveRecord::Migrator.migrate File.expand_path("../../db/migrate", __dir__)
+    ActiveRecord::Base.clear_cache!
+  end
+
+  test "attach a blob when Active Storage tables have not been setup" do
+    assert_raise ActiveStorage::Attached::MissingTableError do
+      @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+    end
+  end
+
+  test "attach many blobs when Active Storage tables have not been setup" do
+    assert_raise ActiveStorage::Attached::MissingTableError do
+      @user.highlights.attach(
+        { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" },
+        { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" }
+      )
+    end
+  end
+end

--- a/activestorage/test/models/blob_missing_table_test.rb
+++ b/activestorage/test/models/blob_missing_table_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "database/setup"
 
-class ActiveStorage::MissingTableTest < ActiveSupport::TestCase
+class ActiveStorage::BlobMissingTableTest < ActiveSupport::TestCase
   setup do
     ActiveRecord::Migrator.down File.expand_path("../../db/migrate", __dir__)
     ActiveRecord::Base.clear_cache!

--- a/activestorage/test/models/missing_table_test.rb
+++ b/activestorage/test/models/missing_table_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::MissingTableTest < ActiveSupport::TestCase
+  setup do
+    ActiveRecord::Migrator.down File.expand_path("../../db/migrate", __dir__)
+    ActiveRecord::Base.clear_cache!
+  end
+
+  teardown do
+    ActiveRecord::Migrator.migrate File.expand_path("../../db/migrate", __dir__)
+    ActiveRecord::Base.clear_cache!
+  end
+
+  test "creating a blob (after upload) when Active Storage tables have not been setup" do
+    assert_raise ActiveStorage::Blob::MissingTableError do
+      create_file_blob
+    end
+  end
+
+  test "creating a blob (before direct upload) when Active Storage tables have not been setup" do
+    assert_raise ActiveStorage::Blob::MissingTableError do
+      data = "Hello world!"
+      create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest(data)
+    end
+  end
+end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -41,9 +41,6 @@ application to Rails 5.2, run `rails active_storage:install` to generate a
 migration that creates these tables. Use `rails db:migrate` to run the
 migration.
 
-You need not run `rails active_storage:install` in a new Rails 5.2 application:
-the migration is generated automatically.
-
 Declare Active Storage services in `config/storage.yml`. For each service your
 application uses, provide a name and the requisite configuration. The example
 below declares three services named `local`, `test`, and `s3`:

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -456,16 +456,6 @@ module Rails
         end
       end
 
-      def run_active_storage
-        unless skip_active_storage?
-          if bundle_install?
-            rails_command "active_storage:install", capture: options[:quiet]
-          else
-            log("Active Storage installation was skipped. Please run `bin/rails active_storage:install` to install Active Storage files.")
-          end
-        end
-      end
-
       def empty_directory_with_keep_file(destination, config = {})
         empty_directory(destination, config)
         keep_file(destination)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -463,7 +463,6 @@ module Rails
 
       public_task :apply_rails_template, :run_bundle
       public_task :run_webpack, :generate_spring_binstubs
-      public_task :run_active_storage
 
       def run_after_bundle_callbacks
         @after_bundle_callbacks.each(&:call)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -854,7 +854,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       template
     end
 
-    sequence = ["git init", "install", "exec spring binstub --all", "active_storage:install", "echo ran after_bundle"]
+    sequence = ["git init", "install", "exec spring binstub --all", "echo ran after_bundle"]
     @sequence_step ||= 0
     ensure_bundler_first = -> command, options = nil do
       assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
@@ -871,7 +871,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       end
     end
 
-    assert_equal 5, @sequence_step
+    assert_equal 4, @sequence_step
   end
 
   def test_gitignore


### PR DESCRIPTION
In previous versions of Rails, running `rails new app_name; cd app_name; rails server`
was all it took to see something up and running in your browser at localhost:3000.

This had a great impact on newcomers, who would get excited about having something
up and running so quickly.

With Rails 5.2.0.beta2, this has changed: opening the browser now shows an
`ActiveRecord::PendingMigrationError` and a very "technical" page that asks to run
migrations.

The reason is that the last step of `rails new` is now `rails  active_storage:install`
which copies migration <timestamp>_create_active_storage_tables.active_storage.rb
from active_storage.

This commit ensures that those migrations are also executed when they are
added to the app.
