### PR TITLE
Update content_security_policy.rb.tt [ci_skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -9,6 +9,9 @@ Rails.application.config.content_security_policy do |p|
   p.object_src  :none
   p.script_src  :self, :https
   p.style_src   :self, :https, :unsafe_inline
+  
+  # Whitelist Action Cable web socket connection
+  # p.connect_src :self, :https, 'ws://localhost:3000'
 
   # Specify URI for violation reports
   # p.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
### Summary

Related to #31309 

Providing an example of configuration for Action Cable

@pixeltrix Since you are the author of the template file can you please take a look.
My concern is that it is required for Action Cable to work but maybe we should add this is not exclusive to Action Cable, `connect-src` has a wider impact.