### PR TITLE
Fix issue with `button_to`'s `to_form_params`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix issue with `button_to`'s `to_form_params`
+
+    `button_to` was throwing exception when invoked with `params` hash that
+    contains symbol and string keys. The reason for the exception was that
+    `to_form_params` was comparing the given symbol and string keys.
+
+    The issue is fixed by turning all keys to strings inside
+    `to_form_params` before comparing them.
+
+    *Georgi Georgiev*
+
 *   Mark arrays of translations as trusted safe by using the `_html` suffix.
 
     Example:

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -634,7 +634,7 @@ module ActionView
         # suitable for use as the names and values of form input fields:
         #
         #   to_form_params(name: 'David', nationality: 'Danish')
-        #   # => [{name: :name, value: 'David'}, {name: 'nationality', value: 'Danish'}]
+        #   # => [{name: 'name', value: 'David'}, {name: 'nationality', value: 'Danish'}]
         #
         #   to_form_params(country: { name: 'Denmark' })
         #   # => [{name: 'country[name]', value: 'Denmark'}]
@@ -666,7 +666,7 @@ module ActionView
               params.push(*to_form_params(value, array_prefix))
             end
           else
-            params << { name: namespace, value: attribute.to_param }
+            params << { name: namespace.to_s, value: attribute.to_param }
           end
 
           params.sort_by { |pair| pair[:name] }

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -77,8 +77,15 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_to_form_params_with_hash
     assert_equal(
-      [{ name: :name, value: "David" }, { name: :nationality, value: "Danish" }],
+      [{ name: "name", value: "David" }, { name: "nationality", value: "Danish" }],
       to_form_params(name: "David", nationality: "Danish")
+    )
+  end
+
+  def test_to_form_params_with_hash_having_symbol_and_string_keys
+    assert_equal(
+      [{ name: "name", value: "David" }, { name: "nationality", value: "Danish" }],
+      to_form_params("name" => "David", :nationality => "Danish")
     )
   end
 


### PR DESCRIPTION
### Summary

I've encountered an exception while using the `button_to` helper. The code goes like this: 

```ruby
button_to "Submit", clients_path, method: :post, 
           params: { name: "Georgi", user: { email: "georgi@example.com" } }
```

And it's expected that it will generate a form with hidden fields:
```html
<input type="hidden" name="name" value="Georgi" />
<input type="hidden" name="user[email]" value="georgi@example.com" />
```
But instead it raises: 
```ruby
ArgumentError: comparison of Symbol with String failed 
```
This happens because when the names for the hidden fields are extracted the name param is mapped to 
```ruby
{ name: :name, value: "Georgi" } 
```
and the user param is mapped to 
```ruby
{ name: "user[email]", value: "georgi@example.com" }
``` 
and after that these hashes are sorted by name, which triggers a comparison between `:name` and `"user[email]"` and so an exception is raised.

The same exception is also raised if we give a params hash with symbol and string key, for example:
```ruby
button_to "Submit", clients_path, method: :post, 
           params: { :name => "Georgi", "email" => "georgi@example.com" }
```
The most unintrusive fix a can think of is to turn all hidden field names to string in the comparison block. 