### PR TITLE
Include reference key type exception for SQLite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -833,14 +833,15 @@ module ActiveRecord
         indexes(table_name).detect { |i| i.name == index_name }
       end
 
-      # Adds a reference. The reference column is a bigint by default,
+      # Adds a reference. The reference column is a bigint by default on most adapters,
       # the <tt>:type</tt> option can be used to specify a different type.
       # Optionally adds a +_type+ column, if <tt>:polymorphic</tt> option is provided.
       # #add_reference and #add_belongs_to are acceptable.
       #
       # The +options+ hash can include the following keys:
       # [<tt>:type</tt>]
-      #   The reference column type. Defaults to +:bigint+.
+      #   The reference column type. Defaults to +:bigint+ except for SQLite,
+      #   where it defaults to +:integer+ as big integer is not supported.
       # [<tt>:index</tt>]
       #   Add an appropriate index. Defaults to true.
       #   See #add_index for usage of this option.


### PR DESCRIPTION
### Summary

Before, all primary keys had type integer by default and the documentation reflected that. After #26266 MySQL and PostgreSQL started using `:bigint` as default type, while SQLite continued using `:integer` as big integer is not supported.

At #31007 documentation was updated to `:bigint`, but this wasn't accurate because SQLite doesn't support it. This patch reflects this exception.