### PR TITLE
Add basic support for check constraints to database migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add basic support for CHECK constraints to database migrations.
+
+    Usage:
+
+    ```ruby
+    add_check_constraint :products, "price > 0", name: "price_check"
+    remove_check_constraint :products, name: "price_check"
+    ```
+
+    *fatkodima*
+
 *   Add `ActiveRecord::Base.strict_loading_by_default` and `ActiveRecord::Base.strict_loading_by_default=`
     to enable/disable strict_loading mode by default for a model. The configuration's value is
     inheritable by subclasses, but they can override that value and it will not impact parent class.

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -17,6 +17,7 @@ module ActiveRecord
       autoload :ColumnDefinition
       autoload :ChangeColumnDefinition
       autoload :ForeignKeyDefinition
+      autoload :CheckConstraintDefinition
       autoload :TableDefinition
       autoload :Table
       autoload :AlterTable

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -338,6 +338,11 @@ module ActiveRecord
       end
       deprecate :supports_foreign_keys_in_create?
 
+      # Does this adapter support creating check constraints?
+      def supports_check_constraints?
+        false
+      end
+
       # Does this adapter support views?
       def supports_views?
         false

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -11,6 +11,10 @@ module ActiveRecord
             "DROP FOREIGN KEY #{name}"
           end
 
+          def visit_DropCheckConstraint(name)
+            "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{name}"
+          end
+
           def visit_AddColumnDefinition(o)
             add_column_position!(super, column_options(o.column))
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -166,6 +166,10 @@ module ActiveRecord
         true
       end
 
+      def supports_check_constraints?
+        true
+      end
+
       def supports_validate_constraints?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -136,6 +136,10 @@ module ActiveRecord
         true
       end
 
+      def supports_check_constraints?
+        true
+      end
+
       def supports_views?
         true
       end
@@ -361,7 +365,12 @@ module ActiveRecord
             options[:null] == false && options[:default].nil?
         end
 
-        def alter_table(table_name, foreign_keys = foreign_keys(table_name), **options)
+        def alter_table(
+          table_name,
+          foreign_keys = foreign_keys(table_name),
+          check_constraints = check_constraints(table_name),
+          **options
+        )
           altered_table_name = "a#{table_name}"
 
           caller = lambda do |definition|
@@ -372,6 +381,10 @@ module ActiveRecord
               end
               to_table = strip_table_name_prefix_and_suffix(fk.to_table)
               definition.foreign_key(to_table, **fk.options)
+            end
+
+            check_constraints.each do |chk|
+              definition.check_constraint(chk.expression, **chk.options)
             end
 
             yield definition if block_given?

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -8,6 +8,7 @@ module ActiveRecord
     #
     # * add_column
     # * add_foreign_key
+    # * add_check_constraint
     # * add_index
     # * add_reference
     # * add_timestamps
@@ -25,6 +26,7 @@ module ActiveRecord
     # * remove_column (must supply a type)
     # * remove_columns (must specify at least one column name or more)
     # * remove_foreign_key (must supply a second table)
+    # * remove_check_constraint
     # * remove_index
     # * remove_reference
     # * remove_timestamps
@@ -39,7 +41,8 @@ module ActiveRecord
         :drop_join_table, :drop_table, :execute_block, :enable_extension, :disable_extension,
         :change_column, :execute, :remove_columns, :change_column_null,
         :add_foreign_key, :remove_foreign_key,
-        :change_column_comment, :change_table_comment
+        :change_column_comment, :change_table_comment,
+        :add_check_constraint, :remove_check_constraint
       ]
       include JoinTable
 
@@ -136,6 +139,7 @@ module ActiveRecord
               add_timestamps:    :remove_timestamps,
               add_reference:     :remove_reference,
               add_foreign_key:   :remove_foreign_key,
+              add_check_constraint: :remove_check_constraint,
               enable_extension:  :disable_extension
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
@@ -263,6 +267,11 @@ module ActiveRecord
           end
 
           [:change_table_comment, [table, from: options[:to], to: options[:from]]]
+        end
+
+        def invert_remove_check_constraint(args)
+          raise ActiveRecord::IrreversibleMigration, "remove_check_constraint is only reversible if given an expression." if args.size < 2
+          super
         end
 
         def respond_to_missing?(method, _)

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -345,6 +345,20 @@ module ActiveRecord
           assert_equal :delete_me, t.name
         end
       end
+
+      def test_check_constraint_creates_check_constraint
+        with_change_table do |t|
+          @connection.expect :add_check_constraint, nil, [:delete_me, "price > discounted_price", name: "price_check"]
+          t.check_constraint "price > discounted_price", name: "price_check"
+        end
+      end
+
+      def test_remove_check_constraint_removes_check_constraint
+        with_change_table do |t|
+          @connection.expect :remove_check_constraint, nil, [:delete_me, name: "price_check"]
+          t.remove_check_constraint name: "price_check"
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+if ActiveRecord::Base.connection.supports_check_constraints?
+  module ActiveRecord
+    class Migration
+      class CheckConstraintTest < ActiveRecord::TestCase
+        include SchemaDumpingHelper
+
+        class Trade < ActiveRecord::Base
+        end
+
+        setup do
+          @connection = ActiveRecord::Base.connection
+          @connection.create_table "trades", force: true do |t|
+            t.integer :price
+            t.integer :quantity
+          end
+        end
+
+        teardown do
+          @connection.drop_table "trades", if_exists: true
+        end
+
+        def test_check_constraints
+          check_constraints = @connection.check_constraints("products")
+          assert_equal 1, check_constraints.size
+
+          constraint = check_constraints.first
+          assert_equal "products", constraint.table_name
+          assert_equal "products_price_check", constraint.name
+
+          if current_adapter?(:Mysql2Adapter)
+            assert_equal "`price` > `discounted_price`", constraint.expression
+          else
+            assert_equal "price > discounted_price", constraint.expression
+          end
+        end
+
+        def test_add_check_constraint
+          @connection.add_check_constraint :trades, "quantity > 0"
+
+          check_constraints = @connection.check_constraints("trades")
+          assert_equal 1, check_constraints.size
+
+          constraint = check_constraints.first
+          assert_equal "trades", constraint.table_name
+          assert_equal "chk_rails_2189e9f96c", constraint.name
+
+          if current_adapter?(:Mysql2Adapter)
+            assert_equal "`quantity` > 0", constraint.expression
+          else
+            assert_equal "quantity > 0", constraint.expression
+          end
+        end
+
+        def test_added_check_constraint_ensures_valid_values
+          @connection.add_check_constraint :trades, "quantity > 0", name: "quantity_check"
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            Trade.create(quantity: -1)
+          end
+        end
+
+        def test_remove_check_constraint
+          @connection.add_check_constraint :trades, "price > 0", name: "price_check"
+          @connection.add_check_constraint :trades, "quantity > 0", name: "quantity_check"
+
+          assert_equal 2, @connection.check_constraints("trades").size
+          @connection.remove_check_constraint :trades, name: "quantity_check"
+          assert_equal 1, @connection.check_constraints("trades").size
+
+          constraint = @connection.check_constraints("trades").first
+          assert_equal "trades", constraint.table_name
+          assert_equal "price_check", constraint.name
+
+          if current_adapter?(:Mysql2Adapter)
+            assert_equal "`price` > 0", constraint.expression
+          else
+            assert_equal "price > 0", constraint.expression
+          end
+        end
+
+        def test_remove_non_existing_check_constraint
+          assert_raises(ArgumentError) do
+            @connection.remove_check_constraint :trades, name: "nonexistent"
+          end
+        end
+      end
+    end
+  end
+else
+  module ActiveRecord
+    class Migration
+      class NoForeignKeySupportTest < ActiveRecord::TestCase
+        setup do
+          @connection = ActiveRecord::Base.connection
+        end
+
+        def test_add_check_constraint_should_be_noop
+          @connection.add_check_constraint :products, "discounted_price > 0", name: "discounted_price_check"
+        end
+
+        def test_remove_check_constraint_should_be_noop
+          @connection.remove_check_constraint :products, name: "price_check"
+        end
+
+        def test_check_constraints_should_raise_not_implemented
+          assert_raises(NotImplementedError) do
+            @connection.check_constraints("products")
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -421,6 +421,17 @@ module ActiveRecord
           end
         end
       end
+
+      def test_invert_remove_check_constraint
+        enable = @recorder.inverse_of :remove_check_constraint, [:dogs, "speed > 0", name: "speed_check"]
+        assert_equal [:add_check_constraint, [:dogs, "speed > 0", name: "speed_check"], nil], enable
+      end
+
+      def test_invert_remove_check_constraint_without_expression
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :remove_check_constraint, [:dogs]
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -200,6 +200,17 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  if ActiveRecord::Base.connection.supports_check_constraints?
+    def test_schema_dumps_check_constraints
+      constraint_definition = dump_table_schema("products").split(/\n/).grep(/t.check_constraint.*products_price_check/).first.strip
+      if current_adapter?(:Mysql2Adapter)
+        assert_equal 't.check_constraint "`price` > `discounted_price`", name: "products_price_check"', constraint_definition
+      else
+        assert_equal 't.check_constraint "price > discounted_price", name: "products_price_check"', constraint_definition
+      end
+    end
+  end
+
   def test_schema_dump_should_honor_nonstandard_primary_keys
     output = standard_dump
     match = output.match(%r{create_table "movies"(.*)do})

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -767,8 +767,12 @@ ActiveRecord::Schema.define do
   create_table :products, force: true do |t|
     t.references :collection
     t.references :type
-    t.string     :name
+    t.string :name
+    t.decimal :price
+    t.decimal :discounted_price
   end
+
+  add_check_constraint :products, "price > discounted_price", name: "products_price_check"
 
   create_table :product_types, force: true do |t|
     t.string :name

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -725,10 +725,6 @@ of `create_table` and `reversible`, replacing `create_table`
 by `drop_table`, and finally replacing `up` by `down` and vice-versa.
 This is all taken care of by `revert`.
 
-NOTE: If you want to add check constraints like in the examples above,
-you will have to use `structure.sql` as dump method. See
-[Schema Dumping and You](#schema-dumping-and-you).
-
 Running Migrations
 ------------------
 
@@ -970,7 +966,7 @@ database and expressing its structure using `create_table`, `add_index`, and so
 on.
 
 `db/schema.rb` cannot express everything your database may support such as
-triggers, sequences, stored procedures, check constraints, etc. While migrations
+triggers, sequences, stored procedures, etc. While migrations
 may use `execute` to create database constructs that are not supported by the
 Ruby migration DSL, these constructs may not be able to be reconstituted by the
 schema dumper. If you are using features like these, you should set the schema


### PR DESCRIPTION
This patch adds basic support for adding and removing check constraints using the migration DSL:
```
create_table :distributors do |t|
  t.string :zipcode
  t.check_constraint "zipchk", "char_length(zipcode) = 5"   
end

remove_check_constraint :distributors, "zipchk"
```

Check constraints are dumped inside `create_table` sections to `schema.rb`.

`add_check_constraint` and `remove_check_constraint` are both reversible.

### Considerations
- Maybe remove the `_constraint` part from new methods names? Seems a little redundant
- Add additional options, such as `NO INHERIT`(PostgreSQL)?

Related https://github.com/rails/rails/issues/23083.