### PR TITLE
Fix CSP copy boolean directives

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -175,13 +175,7 @@ module ActionDispatch #:nodoc:
 
     private
       def copy_directives(directives)
-        directives.transform_values do |sources|
-          if sources.is_a?(Array)
-            sources.map(&:dup)
-          else
-            sources
-          end
-        end
+        directives.transform_values { |sources| sources.deep_dup }
       end
 
       def apply_mappings(sources)

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -175,7 +175,7 @@ module ActionDispatch #:nodoc:
 
     private
       def copy_directives(directives)
-        directives.transform_values { |sources| sources.deep_dup }
+        directives.transform_values(&:deep_dup)
       end
 
       def apply_mappings(sources)

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -110,7 +110,7 @@ module ActionDispatch #:nodoc:
     end
 
     def initialize_copy(other)
-      @directives = copy_directives(other.directives)
+      @directives = other.directives.deep_dup
     end
 
     DIRECTIVES.each do |name, directive|
@@ -174,10 +174,6 @@ module ActionDispatch #:nodoc:
     end
 
     private
-      def copy_directives(directives)
-        directives.transform_values(&:deep_dup)
-      end
-
       def apply_mappings(sources)
         sources.map do |source|
           case source

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -175,7 +175,13 @@ module ActionDispatch #:nodoc:
 
     private
       def copy_directives(directives)
-        directives.transform_values { |sources| sources.map(&:dup) }
+        directives.transform_values do |sources|
+          if sources.is_a?(Array)
+            sources.map(&:dup)
+          else
+            sources
+          end
+        end
       end
 
       def apply_mappings(sources)

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -14,6 +14,15 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_equal "script-src 'self';", @policy.build
   end
 
+  def test_dup
+    @policy.img_src :self
+    @policy.block_all_mixed_content
+    @policy.upgrade_insecure_requests
+    @policy.sandbox
+    copied = @policy.dup
+    assert_equal copied.build, @policy.build
+  end
+
   def test_mappings
     @policy.script_src :data
     assert_equal "script-src data:;", @policy.build


### PR DESCRIPTION
### Summary

Copying a CSP instance fails if the instance contains Boolean directives; specifically, this affects the `block_all_mixed_content`, `upgrade_insecure_requests` and `sandbox` directives.
