### PR TITLE
Fix sqlite migrations with custom primary keys

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -360,6 +360,24 @@ module ActiveRecord
         end
       end
 
+      class Barcode < ActiveRecord::Base
+      end
+
+      def test_existing_records_have_custom_primary_key
+        connection = Barcode.connection
+        connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true) do |t|
+          t.text :other_attr
+        end
+        code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
+        Barcode.create! code: code, other_attr: "xxx"
+
+        connection.change_table "barcodes" do |t|
+          connection.remove_column("barcodes", "other_attr")
+        end
+
+        assert_equal code, Barcode.first.id
+      end
+
       def test_supports_extensions
         assert_not @conn.supports_extensions?, "does not support extensions"
       end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/31201

Previously, if a record was created with a custom primary key, that
table could not be migrated using sqlite. While attempting to copy the
table, the type of the primary key was ignored, generating a `DataTypeMismatch` error.

Once that was corrected, copying the indexes would fail because custom
primary keys are autoindexed by sqlite by default, so copying those fields
would create a duplicate index.

To correct that, this skips copying the index if the index name begins
with "sqlite_". This is a reserved word that indicates that the
index is an internal schema object. SQLite prohibits applications from
creating objects whose names begin with "sqlite_", so this string should
be safe to use as a check.

ref https://www.sqlite.org/fileformat2.html#intschema
