### PR TITLE
implement "truncate" for migrations against sqlite3 adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Implement `truncate` for migrations against sqlite3 adapter
+
+    *Joe Francis*
+
 *   Add support for PostgreSQL operator classes to `add_index`.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -281,6 +281,10 @@ module ActiveRecord
         exec_query "DROP INDEX #{quote_column_name(index_name)}"
       end
 
+      def truncate(table_name, name = nil)
+        execute "DELETE FROM #{quote_table_name(table_name)}", name
+      end
+
       # Renames a table.
       #
       # Example:

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -28,6 +28,17 @@ module ActiveRecord
         end
       end
 
+      def test_truncate
+        rows = ActiveRecord::Base.connection.exec_query("select count(*) from comments")
+        count = rows.first.values.first
+        assert_operator count, :>, 0
+
+        ActiveRecord::Base.connection.truncate("comments")
+        rows = ActiveRecord::Base.connection.exec_query("select count(*) from comments")
+        count = rows.first.values.first
+        assert_equal 0, count
+      end
+
       unless in_memory_db?
         def test_connect_with_url
           original_connection = ActiveRecord::Base.remove_connection


### PR DESCRIPTION
Migrations that request a `truncate` against the sqlite3 adapter currently throw a `NotImplementedError.`  This PR implements this method and adds a test to verify that it's working.

In sqlite, "DELETE FROM [table]" is the correct syntax to implement this.  SQLite has a "Truncate Optimization" that, in most cases, treats that query as a truncation rather than a normal delete.  See, [SQLite docs](https://sqlite.org/lang_delete.html) under "The Truncate Optimization"

SQLite cannot apply this optimization when triggers exist, but it will still delete the rows.  That seems like acceptable behavior, and better than a  `NotImplementedError.` (edit: incorrectly said foreign keys, not triggers, originally)