### PR TITLE
Fix example code in ActiveJob::Core [ci skip]

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -97,17 +97,23 @@ module ActiveJob
     # ==== Examples
     #
     #    class DeliverWebhookJob < ActiveJob::Base
+    #      attr_writer :attempt_number
+    #
+    #      def attempt_number
+    #        @attempt_number ||= 0
+    #      end
+    #
     #      def serialize
-    #        super.merge('attempt_number' => (@attempt_number || 0) + 1)
+    #        super.merge('attempt_number' => attempt_number + 1)
     #      end
     #
     #      def deserialize(job_data)
     #        super
-    #        @attempt_number = job_data['attempt_number']
+    #        self.attempt_number = job_data['attempt_number']
     #      end
     #
-    #      rescue_from(TimeoutError) do |exception|
-    #        raise exception if @attempt_number > 5
+    #      rescue_from(Timeout::Error) do |exception|
+    #        raise exception if attempt_number > 5
     #        retry_job(wait: 10)
     #      end
     #    end


### PR DESCRIPTION
1) It seems that it raise error on example code in `ActiveJob::Core`.

Before:

```ruby
class DeliverWebhookJob < ActiveJob::Base
  def serialize
    super.merge('attempt_number' => (@attempt_number || 0) + 1)
  end

  def deserialize(job_data)
    super
    @attempt_number = job_data['attempt_number']
  end

  rescue_from(Timeout::Error) do |exception|
    raise exception if @attempt_number > 5
    retry_job(wait: 10)
  end

  def perform
    raise Timeout::Error
  end
end
```

Then it run `DeliverWebhookJob.perform_now` in `rails console`. And raise error:

NoMethodError: undefined method \`>' for nil:NilClass
from /app/jobs/deliver_webhook_job.rb:12:in `block in <class:DeliverWebhookJob>'

So I thought it's necessary to fix it.

After:

```ruby
class DeliverWebhookJob < ActiveJob::Base
  attr_writer :attempt_number

  def attempt_number
    @attempt_number ||= 0
  end

  def serialize
    super.merge('attempt_number' => attempt_number + 1)
  end

  def deserialize(job_data)
    super
    self.attempt_number = job_data['attempt_number']
  end

  rescue_from(Timeout::Error) do |exception|
    raise exception if attempt_number > 5
    retry_job(wait: 10)
  end

  def perform
    raise Timeout::Error
  end
end
```

Then it run `DeliverWebhookJob.perform_now` in `rails console`. And it does'nt raise error NoMethodError.

2) Use `Timeout::Error` instead of `TimeoutError` (`TimeoutError` is deprecated).