### PR TITLE
Speed up travis by only installing packages when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ addons:
     sources:
       - sourceline: "ppa:mc3man/trusty-media"
       - sourceline: "ppa:ubuntuhandbook1/apps"
-    packages:
-      - ffmpeg
-      - mupdf
-      - mupdf-tools
 
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
@@ -42,6 +38,7 @@ before_script:
   # Decodes to e.g. `export VARIABLE=VALUE`
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9YTAzNTM0M2YtZTkyMi00MGIzLWFhM2MtMDZiM2VhNjM1YzQ4")
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXJ1YnlvbnJhaWxz")
+  - if [[ $GEM = *ast*  ]] ; then sudo apt-get update && sudo apt-get -y install ffmpeg mupdf mupdf-tools ; fi
 
 script: 'ci/travis.rb'
 


### PR DESCRIPTION
It appears that Travis is spending several minutes per build job installing ffmpeg and mupdf, but only uses them on activestorage builds (4 of 46 builds).  Only installing them on builds where needed should speed up Travis quite a bit.

Work in progress for now - I will update with stats after this build is green.