### PR TITLE
Execute `JsonAttributeTest` only if `supports_json?` returns `true`

### DIFF
--- a/activerecord/test/cases/json_attribute_test.rb
+++ b/activerecord/test/cases/json_attribute_test.rb
@@ -3,33 +3,35 @@
 require "cases/helper"
 require "cases/json_shared_test_cases"
 
-class JsonAttributeTest < ActiveRecord::TestCase
-  include JSONSharedTestCases
-  self.use_transactional_tests = false
+if ActiveRecord::Base.connection.supports_json?
+  class JsonAttributeTest < ActiveRecord::TestCase
+    include JSONSharedTestCases
+    self.use_transactional_tests = false
 
-  class JsonDataTypeOnText < ActiveRecord::Base
-    self.table_name = "json_data_type"
+    class JsonDataTypeOnText < ActiveRecord::Base
+      self.table_name = "json_data_type"
 
-    attribute :payload,  :json
-    attribute :settings, :json
+      attribute :payload,  :json
+      attribute :settings, :json
 
-    store_accessor :settings, :resolution
+      store_accessor :settings, :resolution
+    end
+
+    def setup
+      super
+      @connection.create_table("json_data_type") do |t|
+        t.text "payload"
+        t.text "settings"
+      end
+    end
+
+    private
+      def column_type
+        :text
+      end
+
+      def klass
+        JsonDataTypeOnText
+      end
   end
-
-  def setup
-    super
-    @connection.create_table("json_data_type") do |t|
-      t.text "payload"
-      t.text "settings"
-    end
-  end
-
-  private
-    def column_type
-      :text
-    end
-
-    def klass
-      JsonDataTypeOnText
-    end
 end


### PR DESCRIPTION
### Summary
Oracle enhanced adapter does not fully support JSON datatype then `supports_json?` returns `false`.
I wanted to skip known failures and errors when tested with Oracle enhanced adapter.

### Steps to reproduce:
```ruby
$ cd rails/activerecord
$ bundle install
$ ARCONN=oracle bin/test test/cases/json_attribute_test.rb
```

### Result without this commit:
```ruby
$ ARCONN=oracle bin/test test/cases/json_attribute_test.rb
... snip ...
24 runs, 42 assertions, 5 failures, 6 errors, 0 skips
```

### Result with this commit:

```ruby
$ ARCONN=oracle bin/test test/cases/json_attribute_test.rb
Using oracle
Run options: --seed 57084

# Running:



Finished in 0.001110s, 0.0000 runs/s, 0.0000 assertions/s.

0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
$
```