### PR TITLE
Enhance add_reference on sqlite3 to create foreign keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Enhance add_reference so that sqlite3 creates foreign keys
+
+   *Joe Francis*
+
 *   Add support for PostgreSQL operator classes to `add_index`.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -52,7 +52,7 @@ module ActiveRecord
         options[:primary_key]
       end
 
-      [:limit, :precision, :scale, :default, :null, :collation, :comment].each do |option_name|
+      [:limit, :precision, :scale, :default, :null, :collation, :comment, :references].each do |option_name|
         module_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{option_name}
             options[:#{option_name}]
@@ -176,6 +176,9 @@ module ActiveRecord
         end
 
         def columns
+          if options[:add_reference]
+            options[:references] = "#{foreign_table_name}(id)"
+          end
           result = [[column_name, type, options]]
           if polymorphic
             result.unshift(["#{name}_type", :string, polymorphic_options])
@@ -356,7 +359,6 @@ module ActiveRecord
         name = name.to_s
         type = type.to_sym if type
         options = options.dup
-
         if @columns_hash[name] && @columns_hash[name].primary_key?
           raise ArgumentError, "you can't redefine the primary key column '#{name}'. To define a custom primary key, pass { id: false } to create_table."
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -5,6 +5,12 @@ module ActiveRecord
     module SQLite3
       class SchemaCreation < AbstractAdapter::SchemaCreation # :nodoc:
         private
+          def visit_AddColumnDefinition(o)
+            sql = "ADD #{accept(o.column)}"
+            sql += " REFERENCES #{o.column.references}" if o.column.references
+            sql.dup
+          end
+
           def add_column_options!(sql, options)
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -350,6 +350,9 @@ module ActiveRecord
       end
 
       def add_reference(table_name, ref_name, **options) # :nodoc:
+        if supports_foreign_keys_in_create? && options[:foreign_key]
+          options[:add_reference] = true
+        end
         super(table_name, ref_name, type: :integer, **options)
       end
       alias :add_belongs_to :add_reference

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -28,6 +28,13 @@ module ActiveRecord
             super
           end
         end
+
+        def add_reference(table_name, ref_name, **options)
+          if adapter_name == "SQLite"
+            options.delete(:foreign_key)
+          end
+          super
+        end
       end
 
       class V5_0 < V5_1

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -75,6 +75,24 @@ module ActiveRecord
         connection.drop_table :more_testings rescue nil
       end
 
+      if current_adapter?(:SQLite3Adapter)
+        def test_add_reference_does_not_add_foreign_key
+          migration = Class.new(ActiveRecord::Migration[5.1]) {
+            def migrate(x)
+              create_table :referenced
+              create_table :testing_references
+              add_reference :testing_references, :referenced, foreign_key: true
+            end
+
+          }.new
+          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          assert connection.foreign_keys(:testing_references).size.zero?
+        ensure
+          connection.drop_table :testing_references rescue nil
+          connection.drop_table :referenced rescue nil
+        end
+      end
+
       def test_timestamps_have_null_constraints_if_not_present_in_migration_of_create_table
         migration = Class.new(ActiveRecord::Migration[4.2]) {
           def migrate(x)

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -34,6 +34,8 @@ module ActiveRecord
         assert_difference "connection.foreign_keys(:#{table_name}).count" do
           add_reference table_name, :taggable, foreign_key: true
         end
+      ensure
+        connection.drop_table :taggables rescue nil
       end
 
       def test_creates_reference_type_column

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -27,6 +27,12 @@ module ActiveRecord
         assert_not column_exists?(table_name, :taggable_type, :string)
       end
 
+      def test_creates_foreign_key
+        assert_difference "connection.foreign_keys(:#{table_name}).count" do
+          add_reference table_name, :taggable, foreign_key: true
+        end
+      end
+
       def test_creates_reference_type_column
         add_reference table_name, :taggable, polymorphic: true
         assert column_exists?(table_name, :taggable_type, :string)

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -28,6 +28,9 @@ module ActiveRecord
       end
 
       def test_creates_foreign_key
+        connection.create_table :taggables do |t|
+          t.timestamps null: true
+        end
         assert_difference "connection.foreign_keys(:#{table_name}).count" do
           add_reference table_name, :taggable, foreign_key: true
         end


### PR DESCRIPTION
Currently, add_reference on sqlite3 does not add the new column correctly to be a foreign key (failing test in first commit).  

SQLite is able to add foreign keys in a way that matches add_reference, so I've taken a shot at implementing that.  

There may be a better way to accomplish this, but I'll offer this as a working start.  Thanks!
