### PR TITLE
Use `:string` instead of `:text` for `JsonAttributeTest`

### DIFF
--- a/activerecord/test/cases/json_attribute_test.rb
+++ b/activerecord/test/cases/json_attribute_test.rb
@@ -19,14 +19,14 @@ class JsonAttributeTest < ActiveRecord::TestCase
   def setup
     super
     @connection.create_table("json_data_type") do |t|
-      t.text "payload"
-      t.text "settings"
+      t.string "payload"
+      t.string "settings"
     end
   end
 
   private
     def column_type
-      :text
+      :string
     end
 
     def klass

--- a/activerecord/test/cases/json_attribute_test.rb
+++ b/activerecord/test/cases/json_attribute_test.rb
@@ -3,35 +3,33 @@
 require "cases/helper"
 require "cases/json_shared_test_cases"
 
-if ActiveRecord::Base.connection.supports_json?
-  class JsonAttributeTest < ActiveRecord::TestCase
-    include JSONSharedTestCases
-    self.use_transactional_tests = false
+class JsonAttributeTest < ActiveRecord::TestCase
+  include JSONSharedTestCases
+  self.use_transactional_tests = false
 
-    class JsonDataTypeOnText < ActiveRecord::Base
-      self.table_name = "json_data_type"
+  class JsonDataTypeOnText < ActiveRecord::Base
+    self.table_name = "json_data_type"
 
-      attribute :payload,  :json
-      attribute :settings, :json
+    attribute :payload,  :json
+    attribute :settings, :json
 
-      store_accessor :settings, :resolution
-    end
-
-    def setup
-      super
-      @connection.create_table("json_data_type") do |t|
-        t.text "payload"
-        t.text "settings"
-      end
-    end
-
-    private
-      def column_type
-        :text
-      end
-
-      def klass
-        JsonDataTypeOnText
-      end
+    store_accessor :settings, :resolution
   end
+
+  def setup
+    super
+    @connection.create_table("json_data_type") do |t|
+      t.text "payload"
+      t.text "settings"
+    end
+  end
+
+  private
+    def column_type
+      :text
+    end
+
+    def klass
+      JsonDataTypeOnText
+    end
 end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -23,7 +23,7 @@ module JSONSharedTestCases
   def test_column
     column = klass.columns_hash["payload"]
     assert_equal column_type, column.type
-    assert_equal column_type.to_s, column.sql_type
+    assert_type_match column_type, column.sql_type
 
     type = klass.type_for_attribute("payload")
     assert_not type.binary?
@@ -36,7 +36,7 @@ module JSONSharedTestCases
     klass.reset_column_information
     column = klass.columns_hash["users"]
     assert_equal column_type, column.type
-    assert_equal column_type.to_s, column.sql_type
+    assert_type_match column_type, column.sql_type
   end
 
   def test_schema_dumping
@@ -252,5 +252,10 @@ module JSONSharedTestCases
   private
     def klass
       JsonDataType
+    end
+
+    def assert_type_match(type, sql_type)
+      native_type = ActiveRecord::Base.connection.native_database_types[type][:name]
+      assert_match %r(\A#{native_type}\b), sql_type
     end
 end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -66,26 +66,26 @@ module JSONSharedTestCases
   end
 
   def test_rewrite
-    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k":"v"}')|)
+    @connection.execute(insert_statement_per_database('{"k":"v"}'))
     x = klass.first
     x.payload = { '"a\'' => "b" }
     assert x.save!
   end
 
   def test_select
-    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k":"v"}')|)
+    @connection.execute(insert_statement_per_database('{"k":"v"}'))
     x = klass.first
     assert_equal({ "k" => "v" }, x.payload)
   end
 
   def test_select_multikey
-    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|)
+    @connection.execute(insert_statement_per_database('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}'))
     x = klass.first
     assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
   end
 
   def test_null_json
-    @connection.execute("insert into json_data_type (payload) VALUES(null)")
+    @connection.execute(insert_statement_per_database("null"))
     x = klass.first
     assert_nil(x.payload)
   end
@@ -107,13 +107,13 @@ module JSONSharedTestCases
   end
 
   def test_select_array_json_value
-    @connection.execute(%q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|)
+    @connection.execute(insert_statement_per_database('["v0",{"k1":"v1"}]'))
     x = klass.first
     assert_equal(["v0", { "k1" => "v1" }], x.payload)
   end
 
   def test_rewrite_array_json_value
-    @connection.execute(%q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|)
+    @connection.execute(insert_statement_per_database('["v0",{"k1":"v1"}]'))
     x = klass.first
     x.payload = ["v1", { "k2" => "v2" }, "v3"]
     assert x.save!
@@ -257,5 +257,13 @@ module JSONSharedTestCases
     def assert_type_match(type, sql_type)
       native_type = ActiveRecord::Base.connection.native_database_types[type][:name]
       assert_match %r(\A#{native_type}\b), sql_type
+    end
+
+    def insert_statement_per_database(values)
+      if current_adapter?(:OracleAdapter)
+        "insert into json_data_type (id, payload) VALUES (json_data_type_seq.nextval, '#{values}')"
+      else
+        "insert into json_data_type (payload) VALUES ('#{values}')"
+      end
     end
 end


### PR DESCRIPTION
Since CLOB data type has many limitations in Oracle SELECT WHERE clause.

`JsonAttributeTest` is a test for JSON *attribute* (`attribute :payload, :json` on text column), not for JSON *data type*. So it should pass the test regardless of `supports_json?`.

I think that the oracle enhanced failure is due to CLOB data type limitations.

@yahonda Can you confirm the test result on this branch?