### PR TITLE
Add `assert_in_epsilon` to Testing guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -319,6 +319,8 @@ specify to make your test failure messages clearer.
 | `assert_not_includes( collection, obj, [msg] )`                  | Ensures that `obj` is not in `collection`.|
 | `assert_in_delta( expected, actual, [delta], [msg] )`            | Ensures that the numbers `expected` and `actual` are within `delta` of each other.|
 | `assert_not_in_delta( expected, actual, [delta], [msg] )`        | Ensures that the numbers `expected` and `actual` are not within `delta` of each other.|
+| `assert_in_epsilon ( expected, actual, [epsilon], [msg] )`       | Ensures that the numbers `expected` and `actual` have a relative error less than `epsilon`.|
+| `assert_not_in_epsilon ( expected, actual, [epsilon], [msg] )`   | Ensures that the numbers `expected` and `actual` don't have a relative error less than `epsilon`.|
 | `assert_throws( symbol, [msg] ) { block }`                       | Ensures that the given block throws the symbol.|
 | `assert_raises( exception1, exception2, ... ) { block }`         | Ensures that the given block raises one of the given exceptions.|
 | `assert_instance_of( class, obj, [msg] )`                        | Ensures that `obj` is an instance of `class`.|


### PR DESCRIPTION
### Summary

I found `assert_in_epsilon` is not be in [2.4 Available Assertions](http://edgeguides.rubyonrails.org/testing.html#available-assertions).
So I Added them.

#### MiniTest::Assertions#assert_in_epsilon:

https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L204-L210

### Screenshot

I've confirmed a html document generated by `bundle exec rake guides:generate:html`:

![image](https://user-images.githubusercontent.com/15371677/33637820-7135336a-da66-11e7-8228-466de8a83a3a.png)
