### PR TITLE
Fix example of using `composed_of`

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       # the database).
       #
       #   class Customer < ActiveRecord::Base
-      #     composed_of :balance, class_name: "Money", mapping: %w(amount currency)
+      #     composed_of :balance, class_name: "Money", mapping: [ %w(balance_amount amount), %w(balance_currency currency) ]
       #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
       #   end
       #


### PR DESCRIPTION
- Fix mapping of attributes in the example

See also https://github.com/rails/rails/blob/23226d04f921b79f0077ba38c5a5a923b6d43f89/activerecord/lib/active_record/aggregations.rb#L176-L183