### PR TITLE
[ci skip] Make `Todo` classes inherit `ApplicationRecord`

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -22,7 +22,7 @@ class Module
   #
   # == Using comments:
   #
-  #   class Todo
+  #   class Todo < ApplicationRecord
   #     # Other todo implementation
   #     # ...
   #
@@ -42,7 +42,7 @@ class Module
   #
   # Noisy syntax.
   #
-  #   class Todo
+  #   class Todo < ApplicationRecord
   #     # Other todo implementation
   #     # ...
   #
@@ -70,7 +70,7 @@ class Module
   # increased overhead can be a reasonable tradeoff even if it reduces our
   # at-a-glance perception of how things work.
   #
-  #   class Todo
+  #   class Todo < ApplicationRecord
   #     # Other todo implementation
   #     # ...
   #
@@ -82,7 +82,7 @@ class Module
   # By quieting the mix-in noise, we arrive at a natural, low-ceremony way to
   # separate bite-sized concerns.
   #
-  #   class Todo
+  #   class Todo < ApplicationRecord
   #     # Other todo implementation
   #     # ...
   #
@@ -101,7 +101,7 @@ class Module
   #   end
   #
   #   Todo.ancestors
-  #   # => [Todo, Todo::EventTracking, Object]
+  #   # => [Todo, Todo::EventTracking, ApplicationRecord, Object]
   #
   # This small step has some wonderful ripple effects. We can
   # * grok the behavior of our class in one glance,


### PR DESCRIPTION
### Summary

Example codes that use `has_many` or `before_create` in `Module::Concerning` look like active record models 😕 

So I've made them inherit `ApplicationRecord`.