### PR TITLE
Add Expression Indexes support for SQLite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add Expression Indexes support for SQLite.
+
+    *fatkodima*
+
 *   Fix relation merger issue with `left_outer_joins`.
 
     *Mehmet Emin İNAÇ*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -119,6 +119,10 @@ module ActiveRecord
         sqlite_version >= "3.8.0"
       end
 
+      def supports_expression_index?
+        sqlite_version >= "3.9.0"
+      end
+
       def requires_reloading?
         true
       end
@@ -449,7 +453,7 @@ module ActiveRecord
             end
 
             to_column_names = columns(to).map(&:name)
-            columns = index.columns.map { |c| rename[c] || c }.select do |column|
+            columns = Array(index.columns).map { |c| rename[c] || c }.select do |column|
               to_column_names.include?(column)
             end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -345,6 +345,15 @@ module ActiveRecord
         end
       end
 
+      def test_expression_index
+        with_example_table do
+          @conn.add_index "ex", "id % 10, abs(number)", name: "expression", where: "id > 1000"
+          index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+          assert_equal "id % 10, abs(number)", index.columns
+          assert_equal "id > 1000", index.where
+        end
+      end
+
       def test_primary_key
         with_example_table do
           assert_equal "id", @conn.primary_key("ex")


### PR DESCRIPTION
This PR adds support for Expression Indexes for SQLite (before only for PostgreSQL was implemented).

Example:
```
    create_table :users do |t|
      t.string :name
      t.index "lower(name)"
    end
```