### PR TITLE
Backport fix sqlite migrations with custom primary keys to 5-1-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -437,10 +437,11 @@ module ActiveRecord
 
         def copy_table(from, to, options = {})
           from_primary_key = primary_key(from)
+          from_primary_key_column = columns(from).select { |column| column.name == from_primary_key }.first
           options[:id] = false
           create_table(to, options) do |definition|
             @definition = definition
-            @definition.primary_key(from_primary_key) if from_primary_key.present?
+            @definition.primary_key(from_primary_key, from_primary_key_column.type) if from_primary_key.present?
             columns(from).each do |column|
               column_name = options[:rename] ?
                 (options[:rename][column.name] ||
@@ -464,6 +465,9 @@ module ActiveRecord
         def copy_table_indexes(from, to, rename = {})
           indexes(from).each do |index|
             name = index.name
+            # indexes sqlite creates for internal use start with `sqlite_` and
+            # don't need to be copied
+            next if name.starts_with?("sqlite_")
             if to == "a#{from}"
               name = "t#{name}"
             elsif from == "a#{to}"

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -366,6 +366,24 @@ module ActiveRecord
         end
       end
 
+      class Barcode < ActiveRecord::Base
+      end
+
+      def test_existing_records_have_custom_primary_key
+        connection = Barcode.connection
+        connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true) do |t|
+          t.text :other_attr
+        end
+        code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
+        Barcode.create! code: code, other_attr: "xxx"
+
+        connection.change_table "barcodes" do |t|
+          connection.remove_column("barcodes", "other_attr")
+        end
+
+        assert_equal code, Barcode.first.id
+      end
+
       def test_supports_extensions
         assert_not @conn.supports_extensions?, "does not support extensions"
       end


### PR DESCRIPTION
This backports bbacd60 which allows a record created with a custom primary key to be migrated using sqlite. Previously, while attempting to copy the table, the type of the primary key was ignored, creating a `DataTypeMismatch` error. 

This also skips copying an index if the index name begins
with "sqlite_".  Previously, copying the index for custom primary keys
would fail because they are autoindexed by sqlite, so attempting to copy them
created a duplicate index. "sqlite_" is a reserved word that indicates that the
index is an internal schema object. SQLite prohibits applications from
creating objects whose names begin with "sqlite_", so this string should
be safe to use as a check.
ref https://www.sqlite.org/fileformat2.html#intschema

cc @eileencodes 