### PR TITLE
Considering nil confirmation value in validates_confirmation_of a no valid case

### DIFF
--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -9,11 +9,10 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        unless (confirmed = record.send("#{attribute}_confirmation")).nil?
-          unless confirmation_value_equal?(record, attribute, value, confirmed)
-            human_attribute_name = record.class.human_attribute_name(attribute)
-            record.errors.add(:"#{attribute}_confirmation", :confirmation, options.except(:case_sensitive).merge!(attribute: human_attribute_name))
-          end
+        confirmed = record.send("#{attribute}_confirmation")
+        unless confirmation_value_equal?(record, attribute, value, confirmed)
+          human_attribute_name = record.class.human_attribute_name(attribute)
+          record.errors.add(:"#{attribute}_confirmation", :confirmation, options.except(:case_sensitive).merge!(attribute: human_attribute_name))
         end
       end
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -80,7 +80,9 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "create a new user with validation and a nil password confirmation" do
     @user.password = "password"
     @user.password_confirmation = nil
-    assert @user.valid?(:create), "user should be valid"
+    assert !@user.valid?(:create), "user should be invalid"
+    assert_equal 1, @user.errors.count
+    assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
   end
 
   test "create a new user with validation and an incorrect password confirmation" do
@@ -149,7 +151,9 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "updating an existing user with validation and a nil password confirmation" do
     @existing_user.password = "password"
     @existing_user.password_confirmation = nil
-    assert @existing_user.valid?(:update), "user should be valid"
+    assert @existing_user.invalid?(:update), "user should be invalid"
+    assert_equal 1, @existing_user.errors.count
+    assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
   end
 
   test "updating an existing user with validation and an incorrect password confirmation" do

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -21,7 +21,7 @@ class ConfirmationValidationTest < ActiveModel::TestCase
 
     t.title_confirmation = nil
     t.title = "Parallel Lives"
-    assert t.valid?
+    assert t.invalid?
 
     t.title_confirmation = "Parallel Lives"
     assert t.valid?
@@ -37,11 +37,21 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     assert t.valid?
   end
 
+  def test_validates_confirmation_for_nil_value
+    Topic.validates_confirmation_of(:title)
+
+    t = Topic.new(title: "title", "title_confirmation" => nil)
+    assert t.invalid?
+
+    t.title_confirmation = "title"
+    assert t.valid?
+  end
+
   def test_validates_confirmation_of_with_boolean_attribute
     Topic.validates_confirmation_of(:approved)
 
     t = Topic.new(approved: true, approved_confirmation: nil)
-    assert t.valid?
+    assert t.invalid?
 
     t.approved_confirmation = false
     assert t.invalid?


### PR DESCRIPTION
### Summary

Changing validate_each method to include nil values in the validation.
Test added to ensure the functionality.