### PR TITLE
Extended API for CSP

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -125,6 +125,13 @@ module ActionDispatch #:nodoc:
       end
     end
 
+    def merge!(other)
+      other.directives.each do |directive, sources|
+        @directives[directive] =
+          directives.fetch(directive, []) + sources.deep_dup
+      end
+    end
+
     def block_all_mixed_content(enabled = true)
       if enabled
         @directives["block-all-mixed-content"] = true

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -123,6 +123,10 @@ module ActionDispatch #:nodoc:
           @directives.delete(directive)
         end
       end
+
+      define_method("#{name}_append") do |*sources|
+        public_send(name, *public_send(name), *sources)
+      end
     end
 
     def merge!(other)

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -238,16 +238,16 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @other = @policy.dup
     @expected = @policy.dup
 
-    @policy.script_src 'I', 'II', 'III'
-    @policy.style_src 'IV'
-    @policy.connect_src 'V', 'VI'
+    @policy.script_src "I", "II", "III"
+    @policy.style_src "IV"
+    @policy.connect_src "V", "VI"
 
-    @other.script_src 'one', 'two', 'three'
-    @other.style_src 'four', 'five'
+    @other.script_src "one", "two", "three"
+    @other.style_src "four", "five"
 
-    @expected.script_src 'I', 'II', 'III', 'one', 'two', 'three'
-    @expected.style_src 'IV', 'four', 'five'
-    @expected.connect_src 'V', 'VI'
+    @expected.script_src "I", "II", "III", "one", "two", "three"
+    @expected.style_src "IV", "four", "five"
+    @expected.connect_src "V", "VI"
 
     assert_not_equal @other.build, @policy.build
     assert_not_equal @expected.build, @policy.build
@@ -258,14 +258,14 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
   def test_append_directives
     @expected = @policy.dup
 
-    @policy.script_src 'I', 'II'
+    @policy.script_src "I", "II"
     assert_not_equal @expected.build, @policy.build
 
-    @expected.script_src 'I', 'II', 'three', 'four'
-    @expected.style_src 'five'
+    @expected.script_src "I", "II", "three", "four"
+    @expected.style_src "five"
 
-    @policy.script_src_append 'three', 'four'
-    @policy.style_src_append 'five'
+    @policy.script_src_append "three", "four"
+    @policy.style_src_append "five"
     assert_equal @expected.build, @policy.build
   end
 end

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -233,6 +233,27 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
 
     assert_match %r{\AUnexpected content security policy source:}, exception.message
   end
+
+  def test_merge!
+    @other = @policy.dup
+    @expected = @policy.dup
+
+    @policy.script_src 'I', 'II', 'III'
+    @policy.style_src 'IV'
+    @policy.connect_src 'V', 'VI'
+
+    @other.script_src 'one', 'two', 'three'
+    @other.style_src 'four', 'five'
+
+    @expected.script_src 'I', 'II', 'III', 'one', 'two', 'three'
+    @expected.style_src 'IV', 'four', 'five'
+    @expected.connect_src 'V', 'VI'
+
+    assert_not_equal @other.build, @policy.build
+    assert_not_equal @expected.build, @policy.build
+    @policy.merge!(@other)
+    assert_equal @expected.build, @policy.build
+  end
 end
 
 class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -254,6 +254,20 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.merge!(@other)
     assert_equal @expected.build, @policy.build
   end
+
+  def test_append_directives
+    @expected = @policy.dup
+
+    @policy.script_src 'I', 'II'
+    assert_not_equal @expected.build, @policy.build
+
+    @expected.script_src 'I', 'II', 'three', 'four'
+    @expected.style_src 'five'
+
+    @policy.script_src_append 'three', 'four'
+    @policy.style_src_append 'five'
+    assert_equal @expected.build, @policy.build
+  end
 end
 
 class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
### Summary

To `ActionDispatch::ContentSecurityPolicy`, add `merge!` and `*_append` (e.g. `script_src_append`) public methods. This enhanced API allows for simpler code when extending the "base" application CSP &mdash; for example, in a controller callback.

### More information

Perhaps `merge!` is not the most appropriate method name; after all, this behaves very differently from `Hash#merge!`...

The `*_append` method names are not particularly elegant; it would be far nicer to be able to append to a directive like this:

```ruby
policy.script_src += ['more', 'sources', 'here']
policy.script_src << 'another one'
```

Appending to an existing directive is also potentially problematical for at least the following reasons.

* If the directive already contains `'none'`, then it is not clear what the appended directive value should be
* It is not clear how &mdash; if at all &mdash; duplication should be handled when appending to an existing directive

Both of these concerns also apply in the case of "merging" two or more CSPs.