### PR TITLE
Add headless firefox driver to System Tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add headless firefox support to System Tests.
+
+    *bogdanvlviv*
+
 *   Changed the default system test screenshot output from `inline` to `simple`.
 
     `inline` works well for iTerm2 but not everyone uses iTerm2. Some terminals like

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -121,11 +121,15 @@ module ActionDispatch
     #
     #   driven_by :poltergeist
     #
-    #   driven_by :selenium, using: :firefox
+    #   driven_by :selenium, screen_size: [800, 800]
+    #
+    #   driven_by :selenium, using: :chrome
     #
     #   driven_by :selenium, using: :headless_chrome
     #
-    #   driven_by :selenium, screen_size: [800, 800]
+    #   driven_by :selenium, using: :firefox
+    #
+    #   driven_by :selenium, using: :headless_firefox
     def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {})
       self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -38,13 +38,24 @@ module ActionDispatch
             browser_options.args << "--disable-gpu"
 
             @options.merge(options: browser_options)
+          elsif @browser == :headless_firefox
+            browser_options = Selenium::WebDriver::Firefox::Options.new
+            browser_options.args << "-headless"
+
+            @options.merge(options: browser_options)
           else
             @options
           end
         end
 
         def browser
-          @browser == :headless_chrome ? :chrome : @browser
+          if @browser == :headless_chrome
+            :chrome
+          elsif @browser == :headless_firefox
+            :firefox
+          else
+            @browser
+          end
         end
 
         def register_selenium(app)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -453,3 +453,7 @@ end
 class DrivenBySeleniumWithHeadlessChrome < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome
 end
+
+class DrivenBySeleniumWithHeadlessFirefox < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_firefox
+end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -25,6 +25,14 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
+  test "initializing the driver with a headless firefox" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_firefox, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
+    assert_equal :selenium, driver.instance_variable_get(:@name)
+    assert_equal :headless_firefox, driver.instance_variable_get(:@browser)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
+  end
+
   test "initializing the driver with a poltergeist" do
     driver = ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
     assert_equal :poltergeist, driver.instance_variable_get(:@name)

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -28,6 +28,12 @@ class SetDriverToSeleniumHeadlessChromeTest < DrivenBySeleniumWithHeadlessChrome
   end
 end
 
+class SetDriverToSeleniumHeadlessFirefoxTest < DrivenBySeleniumWithHeadlessFirefox
+  test "uses selenium headless firefox" do
+    assert_equal :selenium, Capybara.current_driver
+  end
+end
+
 class SetHostTest < DrivenByRackTest
   test "sets default host" do
     assert_equal "http://127.0.0.1", Capybara.app_host

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -673,7 +673,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 end
 ```
 
-If you want to use a headless browser, you could use Headless Chrome by adding `headless_chrome` in the `:using` argument.
+If you want to use a headless browser, you could use Headless Chrome or Headless Firefox by adding
+`headless_chrome` or `headless_firefox` in the `:using` argument.
 
 ```ruby
 require "test_helper"


### PR DESCRIPTION
[Firefox supports headless mode](https://hacks.mozilla.org/2017/12/using-headless-mode-in-firefox/)  starting with version 56.
This PR adds headless firefox support to System Tests.

r? @eileencodes