### PR TITLE
Clarify accessor API for CSP

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -119,6 +119,8 @@ module ActionDispatch #:nodoc:
       define_method(name) do |*sources|
         if sources.first
           @directives[directive] = apply_mappings(sources)
+        elsif sources.first.nil?
+          @directives[directive]
         else
           @directives.delete(directive)
         end
@@ -128,6 +130,8 @@ module ActionDispatch #:nodoc:
     def block_all_mixed_content(enabled = true)
       if enabled
         @directives["block-all-mixed-content"] = true
+      elsif enabled.nil?
+        @directives["block-all-mixed-content"]
       else
         @directives.delete("block-all-mixed-content")
       end
@@ -136,6 +140,8 @@ module ActionDispatch #:nodoc:
     def plugin_types(*types)
       if types.first
         @directives["plugin-types"] = types
+      elsif types.first.nil?
+        @directives["plugin-types"]
       else
         @directives.delete("plugin-types")
       end
@@ -148,16 +154,20 @@ module ActionDispatch #:nodoc:
     def require_sri_for(*types)
       if types.first
         @directives["require-sri-for"] = types
+      elsif types.first.nil?
+        @directives["require-sri-for"]
       else
         @directives.delete("require-sri-for")
       end
     end
 
     def sandbox(*values)
-      if values.empty?
+      if true === values.first
         @directives["sandbox"] = true
       elsif values.first
         @directives["sandbox"] = values
+      elsif values.first.nil?
+        @directives["sandbox"]
       else
         @directives.delete("sandbox")
       end
@@ -166,6 +176,8 @@ module ActionDispatch #:nodoc:
     def upgrade_insecure_requests(enabled = true)
       if enabled
         @directives["upgrade-insecure-requests"] = true
+      elsif enabled.nil?
+        @directives["upgrade-insecure-requests"]
       else
         @directives.delete("upgrade-insecure-requests")
       end

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -217,12 +217,12 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
   def test_accessors
     @policy.sandbox true
     assert_equal true, @policy.sandbox
-    @policy.script_src 'I', 'II'
-    assert_equal ['I', 'II'], @policy.script_src
+    @policy.script_src "I", "II"
+    assert_equal ["I", "II"], @policy.script_src
   end
 
   def test_accessors_do_not_delete
-    @policy.script_src 'I', 'II'
+    @policy.script_src "I", "II"
     assert_equal "script-src I II;", @policy.build
     @policy.script_src
     assert_equal "script-src I II;", @policy.build
@@ -231,7 +231,7 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
   end
 
   def test_clear_directives
-    @policy.script_src 'I', 'II'
+    @policy.script_src "I", "II"
     assert_equal "script-src I II;", @policy.build
     @policy.script_src false
     assert_equal ";", @policy.build

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -136,7 +136,7 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.plugin_types "application/x-shockwave-flash"
     assert_match %r{plugin-types application/x-shockwave-flash;}, @policy.build
 
-    @policy.sandbox
+    @policy.sandbox true
     assert_match %r{sandbox;}, @policy.build
 
     @policy.sandbox "allow-scripts", "allow-modals"
@@ -172,7 +172,7 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.require_sri_for "script", "style"
     assert_match %r{require-sri-for script style;}, @policy.build
 
-    @policy.require_sri_for
+    @policy.require_sri_for false
     assert_no_match %r{require-sri-for}, @policy.build
 
     @policy.upgrade_insecure_requests
@@ -212,6 +212,29 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     end
 
     assert_equal "Invalid content security policy source: [:self]", exception.message
+  end
+
+  def test_accessors
+    @policy.sandbox true
+    assert_equal true, @policy.sandbox
+    @policy.script_src 'I', 'II'
+    assert_equal ['I', 'II'], @policy.script_src
+  end
+
+  def test_accessors_do_not_delete
+    @policy.script_src 'I', 'II'
+    assert_equal "script-src I II;", @policy.build
+    @policy.script_src
+    assert_equal "script-src I II;", @policy.build
+    @policy.script_src nil
+    assert_equal "script-src I II;", @policy.build
+  end
+
+  def test_clear_directives
+    @policy.script_src 'I', 'II'
+    assert_equal "script-src I II;", @policy.build
+    @policy.script_src false
+    assert_equal ";", @policy.build
   end
 
   def test_missing_context_for_dynamic_source


### PR DESCRIPTION
### Summary

Calling any of the "directive" methods (e.g. `script_src`) of `ActionDispatch::ContentSecurityPolicy` without an argument will clear the associated directive in the CSP. This seems a clear violation of the principle of least surprise in the CSP API.

This change rationalises the directives API so that an explicit `false` argument is required in order to clear the directive associated with each method. Calling a "directive" method without arguments acquires thereby the ordinary semantic of an accessor.
