### PR TITLE
[ci skip] Added puts to fix output code

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/indent.rb
+++ b/activesupport/lib/active_support/core_ext/string/indent.rb
@@ -12,7 +12,7 @@ class String
 
   # Indents the lines in the receiver:
   #
-  #   <<EOS.indent(2)
+  #   puts <<EOS.indent(2)
   #   def some_method
   #     some_code
   #   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1253,7 +1253,7 @@ NOTE: Defined in `active_support/core_ext/string/strip.rb`.
 Indents the lines in the receiver:
 
 ```ruby
-<<EOS.indent(2)
+puts <<EOS.indent(2)
 def some_method
   some_code
 end


### PR DESCRIPTION
The previous code output as follows.

```ruby
 <<EOS.indent(2)
def some_method
  some_code
end
EOS
# =>  "  def some_method\n    some_code\n  end\n" 
```



