### PR TITLE
Add options to ActiveRecord::Relation#explain

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add options support for `ActiveRecord::Relation.explain`
+    This adds support for MySQL and PostgreSQL specific EXPLAIN flags.
+
+     Examples:
+
+        # PostgreSQL
+        User.where(temper: "evil").explain(format: :xml)
+        User.where(temper: "evil").explain(verbose: :true, format: :json)
+        User.where(temper: "evil").explain(analyze: true, timing: false)
+
+
+        # MySQL
+        Spaceship.where(planet: "Mars").explain(extended: true, format: :json)
+
+    *Andrey Deryabin*
+
 *   Use `count(:all)` in `HasManyAssociation#count_records` to prevent invalid
     SQL queries for association counting.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -201,7 +201,7 @@ module ActiveRecord
       # DATABASE STATEMENTS ======================================
       #++
 
-      def explain(arel, binds = [])
+      def explain(arel, binds = [], _options = {})
         sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
         SQLite3::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", []))
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -180,13 +180,40 @@ module ActiveRecord
     # returns the result as a string. The string is formatted imitating the
     # ones printed by the database shell.
     #
+    # ==== Parameters
+    #
+    # * +options+ - A hash of EXPLAIN paratemers depend on your database.
+    #
+    # ==== Examples
+    #   # Postgres:
+    #
+    #   Person.where(rating: 4).explain
+    #   # returns a pretty formatted result of an EXPLAIN.
+    #
+    #   Person.where(rating: 4).explain(format: :json)
+    #   # returns an array of JSON of an EXPLAIN as a string
+    #
+    #   Person.where(rating: 4).explain(analyze: :true, format: :xml)
+    #   # returns an array of XML of an EXPLAIN ANALYZE as a string
+    #
+    #   # MySQL:
+    #
+    #   Person.where(rating: 4).explain
+    #   # returns a pretty formatted result of an EXPLAIN.
+    #
+    #   Person.where(rating: 4).explain(format: :json)
+    #   # returns an array of JSON of an EXPLAIN as a string
+    #
+    #   Person.where(rating: 4).explain(extended: true)
+    #   # returns pretty formatted result of an EXPLAIN EXTENDED
+    #
     # Note that this method actually runs the queries, since the results of some
     # are needed by the next ones when eager loading is going on.
     #
     # Please see further details in the
     # {Active Record Query Interface guide}[http://guides.rubyonrails.org/active_record_querying.html#running-explain].
-    def explain
-      exec_explain(collecting_queries_for_explain { exec_queries })
+    def explain(options = {})
+      exec_explain(collecting_queries_for_explain { exec_queries }, options)
     end
 
     # Converts relation objects to Array.

--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -3,9 +3,12 @@
 require "cases/helper"
 require "models/author"
 require "models/post"
+require "models/comment"
 
 class Mysql2ExplainTest < ActiveRecord::Mysql2TestCase
   fixtures :authors
+  fixtures :posts
+  fixtures :comments
 
   def test_explain_for_one_query
     explain = Author.where(id: 1).explain
@@ -19,5 +22,23 @@ class Mysql2ExplainTest < ActiveRecord::Mysql2TestCase
     assert_match %r(authors |.* const), explain
     assert_match %(EXPLAIN for: SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
     assert_match %r(posts |.* ALL), explain
+  end
+
+  def test_explain_with_json_format
+    explain = Author.where(id: 1).explain(format: :json)
+    json = JSON.load(explain[0])
+    assert_equal "authors", json["query_block"]["table"]["table_name"]
+  end
+
+  def test_explain_with_json_format_and_eager_loading
+    explain = Author.where(id: 1).includes(posts: [:comments]).explain(format: :json)
+    json = JSON.load(explain[2])
+    assert_equal "comments", json["query_block"]["table"]["table_name"]
+  end
+
+  def test_explain_with_traditional_format
+    explain = Author.where(id: 1).explain(format: :traditional)
+    assert_match %(EXPLAIN for: SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
+    assert_match %r(authors |.* const), explain
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -3,9 +3,12 @@
 require "cases/helper"
 require "models/author"
 require "models/post"
+require "models/comment"
 
 class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
   fixtures :authors
+  fixtures :posts
+  fixtures :comments
 
   def test_explain_for_one_query
     explain = Author.where(id: 1).explain
@@ -18,5 +21,37 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %r(EXPLAIN for: SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\$1 \[\["author_id", 1\]\]|1)), explain
+  end
+
+  def test_explain_with_json_format_option
+    explain = Author.where(id: 1).explain(format: :json)
+    assert_match "authors", JSON.parse(explain[0])[0]["Plan"]["Relation Name"]
+  end
+
+  def test_explain_with_json_format_and_eager_loading
+    explain = Author.where(id: 1).includes(posts: [:comments]).explain(format: :json)
+    json = JSON.load(explain[2])[0]
+    assert_equal "comments", json["Plan"]["Relation Name"]
+  end
+
+  def test_explain_with_yaml_format_option
+    explain = Author.where(id: 1).explain(format: :yaml)
+    assert_equal "authors", YAML.load(explain[0])[0]["Plan"]["Alias"]
+  end
+
+  def test_explain_with_xml_format_option
+    explain = Author.where(id: 1).explain(format: :xml)
+    xml = ActiveSupport::XmlMini.parse(explain[0])
+    assert_equal({ "__content__" => "authors" }, xml["explain"]["Query"]["Plan"]["Relation-Name"])
+  end
+
+  def test_explain_with_verbose_option
+    explain = Author.where(id: 1).explain(format: :xml, verbose: true)
+    assert_match %(<Output>), explain[0]
+  end
+
+  def test_explain_with_analyze_option
+    explain = Author.where(id: 1).explain(format: :xml, analyze: true)
+    assert_match %r{(<Execution-Time>)|(<Total-Runtime>)}, explain[0]
   end
 end


### PR DESCRIPTION
Support database specific options for ANALYZE requests.

### Summary
`EXPLAIN` displays the execution plan for the supplied statement and supports very useful options according to [documentation](https://www.postgresql.org/docs/9.4/static/sql-explain.html) like `ANALYZE`. For example, usage `EXPLAIN ANALYZE`displays timing information.

Another option is a `FORMAT`. It specifies the output format. 

Current implementation `ActiveRecord::Relation#explain` does not support any options. 
I've implemented support for PostgreSQL's options (`ANALYZE`, `VERBOSE`, `BUFFERS`, `TIMING` and `FORMAT`). 

`FORMAT` supports `TEXT`, `XML`, `JSON`, or `YAML`. 

MySQL [supports](https://dev.mysql.com/doc/refman/5.7/en/explain.html) support `EXTENDED`, `PARTITIONS ` and `FORMAT` options.


### Examples

#### PostgreSQL
```ruby
JSON.load(Author.where(id: 1).explain(format: :json)[0])

# [{"Plan"=>{"Node Type"=>"Index Scan", "Parallel Aware"=>false, "Scan Direction"=>"Forward", "Index Name"=>"authors_pkey", "Relation Name"=>"authors", "Alias"=>"authors", "Startup Cost"=>0.15, "Total Cost"=>8.17, "Plan Rows"=>1, "Plan Width"=>120, "Index Cond"=>"(id = '1'::bigint)"}}]

Author.where(id: 1).explain(analyze: true)
#                                                        QUERY PLAN
# ------------------------------------------------------------------------------------------------------------------------
#  Index Scan using authors_pkey on authors  (cost=0.15..8.17 rows=1 width=120) (actual time=0.005..0.005 rows=1 loops=1)
#    Index Cond: (id = '1'::bigint)
#  Planning time: 0.059 ms
#  Execution time: 0.015 ms
# (4 rows)

puts Author.where(id: 1).includes(posts: [:comments]).explain(format: :json)
[
  {
    "Plan": {
      "Node Type": "Index Scan",
      "Parallel Aware": false,
      "Scan Direction": "Forward",
      "Index Name": "authors_pkey",
      "Relation Name": "authors",
      "Alias": "authors",
      "Startup Cost": 0.15,
      "Total Cost": 8.17,
      "Plan Rows": 1,
      "Plan Width": 120,
      "Index Cond": "(id = '1'::bigint)"
    }
  }
]
[
  {
    "Plan": {
      "Node Type": "Bitmap Heap Scan",
      "Parallel Aware": false,
      "Relation Name": "posts",
      "Alias": "posts",
      "Startup Cost": 4.16,
      "Total Cost": 9.50,
      "Plan Rows": 2,
      "Plan Width": 136,
      "Recheck Cond": "(author_id = '1'::bigint)",
      "Plans": [
        {
          "Node Type": "Bitmap Index Scan",
          "Parent Relationship": "Outer",
          "Parallel Aware": false,
          "Index Name": "index_posts_on_author_id",
          "Startup Cost": 0.00,
          "Total Cost": 4.16,
          "Plan Rows": 2,
          "Plan Width": 0,
          "Index Cond": "(author_id = '1'::bigint)"
        }
      ]
    }
  }
]
[
  {
    "Plan": {
      "Node Type": "Seq Scan",
      "Parallel Aware": false,
      "Relation Name": "comments",
      "Alias": "comments",
      "Startup Cost": 0.00,
      "Total Cost": 15.36,
      "Plan Rows": 8,
      "Plan Width": 216,
      "Filter": "(post_id = ANY ('{1,2,4,5,6}'::integer[]))"
    }
  }
]
```

#### MySQL
```ruby
JSON.load(Author.where(id: 1).explain(format: :json)[0])
# {"query_block"=>{"select_id"=>1, "cost_info"=>{"query_cost"=>"1.00"}, "table"=>{"table_name"=>"authors", "access_type"=>"const", "possible_keys"=>["PRIMARY"], "key"=>"PRIMARY", "used_key_parts"=>["id"], "key_length"=>"8", "ref"=>["const"], "rows_examined_per_scan"=>1, "rows_produced_per_join"=>1, "filtered"=>"100.00", "cost_info"=>{"read_cost"=>"0.00", "eval_cost"=>"0.20", "prefix_cost"=>"0.00", "data_read_per_join"=>"2K"}, "used_columns"=>["id", "name", "author_address_id", "author_address_extra_id", "organization_id", "owned_essay_id"]}}}
```
