### PR TITLE
Fix loop-backs in cyclic autosave associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix loop-backs in cyclic associations with `autosave: true`.
+
+    Added autosaving flag that is set during autosave callbacks.
+    The flag is used to avoid loop-backs in autosaved associations.
+
+    *Robertas Godelis*
+    
 *   Dump the schema or structure of a database when calling db:migrate:name
 
     In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -594,6 +594,7 @@ module ActiveRecord
         @_start_transaction_state = nil
         @transaction_state        = nil
         @strict_loading           = false
+        @autosaving               = false
 
         self.class.define_attribute_methods
       end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -31,8 +31,17 @@ class ShipWithoutNestedAttributes < ActiveRecord::Base
   validates :name, presence: true, if: -> { true }
 end
 
+class ShipWithAutosavedPrisoners < ActiveRecord::Base
+  self.table_name = "ships"
+  has_many :prisoners, inverse_of: :ship, foreign_key: :ship_id, autosave: true
+
+  validates :name, presence: true
+end
+
 class Prisoner < ActiveRecord::Base
   belongs_to :ship, autosave: true, class_name: "ShipWithoutNestedAttributes", inverse_of: :prisoners
+
+  validates :name, presence: true
 end
 
 class FamousShip < ActiveRecord::Base

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -862,6 +862,7 @@ ActiveRecord::Schema.define do
 
   create_table :prisoners, force: true do |t|
     t.belongs_to :ship
+    t.string :name
   end
 
   create_table :sinks, force: true do |t|


### PR DESCRIPTION
### Summary

Having a cyclic autosave association results in inverse saves and validations when saving the root model. This might result in duplicate callbacks and/or validations.

e.g.
```
class AutosavedParent
  has_many :autosaved_childs, autosave: true, inverse_of: :autosaved_parent
end

class AutosavedChild
  belongs_to :autosaved_parent, autosave: true, inverse_of: :autosaved_childs
end

parent = AutosavedParent.new
parent.autosaved_childs.build
parent.save
```

Saving an instance of AutosavedParent autosaves the AutosavedChild, which
in turn, validates and autosaves the instance of AutosavedParent again.

I've added a flag that marks whether a record is autosaving. It's set whenever the root model validates or autosaves associations. Having this, we can check the flag and see whether we need to autosave or validate a given model in the child association.