### PR TITLE
Add global configuration for exception raising when skipped callback not defined

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -64,7 +64,13 @@ module ActiveSupport
 
     included do
       extend ActiveSupport::DescendantsTracker
+      include ActiveSupport::Configurable
+
       class_attribute :__callbacks, instance_writer: false, default: {}
+
+      config_accessor :skip_callback_raise_exception_if_not_defined do
+        true
+      end
     end
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around]
@@ -697,7 +703,7 @@ module ActiveSupport
             filters.each do |filter|
               callback = chain.find { |c| c.matches?(type, filter) }
 
-              if !callback && options[:raise]
+              if !callback && options[:raise] && skip_callback_raise_exception_if_not_defined
                 raise ArgumentError, "#{type.to_s.capitalize} #{name} callback #{filter.inspect} has not been defined"
               end
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -1171,6 +1171,18 @@ module CallbacksTest
       klass.new.run
       assert_equal 1, calls.length
     end
+
+    def test_skip_without_raise_globally
+      calls = []
+      klass = build_class(:bar)
+      klass.skip_callback_raise_exception_if_not_defined = false
+
+      klass.class_eval { define_method(:bar) { calls << klass } }
+      klass.skip :qux
+      klass.skip :foo
+      klass.new.run
+      assert_equal 1, calls.length
+    end
   end
 
   class NotSupportedStringConditionalTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

After Rails 5 if we use `skip_XXX_callback :foo` before `foo` is being
set as a callback, we'll get an argument error. The only way to avoid
this is to pass `raise: false` to the `skip_XXX_callback` call like

```ruby
skip_before_callback :foo, raise: false
```
 which can be very annoying if there're many of the skip calls.

So I added a new config for ActiveSupport::Callback, called
`skip_callback_raise_exception_if_not_defined` (name can be improved I think). It's purpose is to let
users config if they want the exception get raised globally instead of
passing options in every skip callback call. And the default value is
true so the current behavior will remain the same.

Sample usage:

```ruby
# config/environments/development.rb

# Add this line then any `skip_XXX_callback` in controllers won't raise exception when the callback is not defined.
config.action_controller.skip_callback_raise_exception_if_not_defined = false
```