### PR TITLE
Change the system tests to set Puma as default server only when the user haven't specified manually another server.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Changed the system tests to set Puma as default server only when the
+    user haven't specified manually another server.
+
+    *Guillermo Iguaran*
+
 *   Add secure `X-Download-Options` and `X-Permitted-Cross-Domain-Policies` to
     default headers set.
 

--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         end
 
         def set_server
-          Capybara.server = :puma, { Silent: self.class.silence_puma }
+          Capybara.server = :puma, { Silent: self.class.silence_puma } if Capybara.server == Capybara.servers[:default]
         end
 
         def set_port

--- a/actionpack/test/dispatch/system_testing/server_test.rb
+++ b/actionpack/test/dispatch/system_testing/server_test.rb
@@ -6,10 +6,27 @@ require "action_dispatch/system_testing/server"
 
 class ServerTest < ActiveSupport::TestCase
   setup do
-    ActionDispatch::SystemTesting::Server.new.run
+    @old_capybara_server = Capybara.server
   end
 
   test "port is always included" do
+    ActionDispatch::SystemTesting::Server.new.run
     assert Capybara.always_include_port, "expected Capybara.always_include_port to be true"
+  end
+
+  test "server is changed from `default` to `puma`" do
+    Capybara.server = :default
+    ActionDispatch::SystemTesting::Server.new.run
+    refute_equal Capybara.server, Capybara.servers[:default]
+  end
+
+  test "server is not changed to `puma` when is different than default" do
+    Capybara.server = :webrick
+    ActionDispatch::SystemTesting::Server.new.run
+    assert_equal Capybara.server, Capybara.servers[:webrick]
+  end
+
+  teardown do
+    Capybara.server = @old_capybara_server
   end
 end


### PR DESCRIPTION
In our app we are configuring a custom server for Capybara in this way:

```ruby
Capybara.register_server(:unicorn) do |app, port, host|
  Unicorn::HttpServer.new(app, listeners: "#{host}:#{port}", logger: Logger.new(nil)).start.join
end

Capybara.server = :unicorn
```

But System Tests are overriding the `Capybara.server` to `:puma` so our configuration isn't taking effect.

With this change, the Capybara.server is set only if the user hasn't customized it manually (so it's other than `:default`).