### PR TITLE
Reset cache before test

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -298,6 +298,8 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
     assert_not column.null
     assert_equal :string, column.type
     assert_equal 42, column.limit
+  ensure
+    Barcode.reset_column_information
   end
 
   test "schema dump primary key includes type and options" do


### PR DESCRIPTION
Currently, `test_copy_table_with_composite_primary_keys` test fails depending on execution order. The reproduction step is as follows.

```
$ ARCONN=sqlite3_mem bin/test -w -n "/^(?:CalculationsTest#(?:test_#skip_query_cache\\!_for_a_simple_calculation)|PrimaryKeyAnyTypeTest#(?:test_any_type_primary_key)|ActiveRecord::ConnectionAdapters::SQLite3AdapterTest#(?:test_copy_table_with_composite_primary_keys))$/" --seed 41545
```

The column info is cached by `PrimaryKeyAnyTypeTest#test_any_type_primary_key`, and the test seems to have failed due to the influence.
Therefore, added a reset to fix.

Related: https://travis-ci.org/rails/rails/jobs/313730163#L1788
