### PR TITLE
`webpack` is assigned but never used in webpack.config.js

### DIFF
--- a/activestorage/webpack.config.js
+++ b/activestorage/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require("webpack")
 const path = require("path")
 
 module.exports = {


### PR DESCRIPTION
### Summary

* Removed `webpack` const, so it is assigned but never used in `webpack.config.js`.
* After it removed, it can run `yarn build` and generate a file `app/assets/javascripts/activestorage.js`.