### PR TITLE
Fix active_storage installation failure when in engine

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -3,6 +3,10 @@
 namespace :active_storage do
   desc "Copy over the migration needed to the application"
   task install: :environment do
-    Rake::Task["active_storage:install:migrations"].invoke
+    if Rake::Task.task_defined?("active_storage:install:migrations")
+      Rake::Task["active_storage:install:migrations"].invoke
+    else
+      Rake::Task["app:active_storage:install:migrations"].invoke
+    end
   end
 end


### PR DESCRIPTION
### Summary

When developing an engine, `active_storage:install` task should be invoked for an app instead of an engine (as `bin/rails -T` says) :

```
rails app:active_storage:install             # Copy over the migration needed to the application
```

However, when you invoke the above task, you'll get:

```
rails aborted!
Don't know how to build task 'active_storage:install:migrations' (see --tasks)
```

This error occurs because, in `activestorage/lib/tasks/activestorage.rake`, `active_storage:install:migrations` is invoked instead of `app:active_storage:install:migrations`.

So I have added a check if in engine by checking `ENGINE_PATH` and invoke `app:active_storage:install:migrations` appropriately, I am still not sure if checking `ENGINE_PATH` is the best way to do it though.