### PR TITLE
Refactor AM::AttributeMethods + AR::AttributeMethods using module builders

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -34,6 +34,7 @@ module ActiveModel
   autoload :Attributes
   autoload :AttributeAssignment
   autoload :AttributeMethods
+  autoload :AttributeMethodsBuilder
   autoload :BlockValidator, "active_model/validator"
   autoload :Callbacks
   autoload :Conversion

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -66,7 +66,7 @@ module ActiveModel
     included do
       class_attribute :attribute_aliases, instance_writer: false, default: {}
       class_attribute :attribute_methods_builders, instance_writer: false, default: []
-      _attribute_methods_builder
+      include AttributeMethodsBuilder::AttributeMissingMethods
     end
 
     module ClassMethods
@@ -240,6 +240,7 @@ module ActiveModel
       #     end
       #   end
       def define_attribute_methods(*attr_names)
+        attribute_methods_builder
         attribute_methods_builders.each do |builder|
           builder.define_attribute_methods(*(attr_names.flatten))
         end
@@ -327,5 +328,10 @@ module ActiveModel
           attribute_methods_builders.any? { |builder| builder.method_defined?(method_name) }
         end
     end
+
+    private
+      def _read_attribute(attr)
+        __send__(attr)
+      end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -328,10 +328,5 @@ module ActiveModel
           attribute_methods_builders.any? { |builder| builder.method_defined?(method_name) }
         end
     end
-
-    private
-      def _read_attribute(attr)
-        __send__(attr)
-      end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "concurrent/map"
-
 module ActiveModel
   # Raised when an attribute is not defined.
   #
@@ -65,12 +63,10 @@ module ActiveModel
   module AttributeMethods
     extend ActiveSupport::Concern
 
-    NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
-    CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
-
     included do
       class_attribute :attribute_aliases, instance_writer: false, default: {}
-      class_attribute :attribute_method_matchers, instance_writer: false, default: [ ClassMethods::AttributeMethodMatcher.new ]
+      class_attribute :attribute_methods_builders, instance_writer: false, default: []
+      _attribute_methods_builder
     end
 
     module ClassMethods
@@ -106,8 +102,7 @@ module ActiveModel
       #   person.clear_name
       #   person.name          # => nil
       def attribute_method_prefix(*prefixes)
-        self.attribute_method_matchers += prefixes.map! { |prefix| AttributeMethodMatcher.new prefix: prefix }
-        undefine_attribute_methods
+        attribute_methods_builder.prefix(*prefixes)
       end
 
       # Declares a method available for all attributes with the given suffix.
@@ -141,8 +136,7 @@ module ActiveModel
       #   person.name          # => "Bob"
       #   person.name_short?   # => true
       def attribute_method_suffix(*suffixes)
-        self.attribute_method_matchers += suffixes.map! { |suffix| AttributeMethodMatcher.new suffix: suffix }
-        undefine_attribute_methods
+        attribute_methods_builder.suffix(*suffixes)
       end
 
       # Declares a method available for all attributes with the given prefix
@@ -177,8 +171,7 @@ module ActiveModel
       #   person.reset_name_to_default!
       #   person.name                         # => 'Default Name'
       def attribute_method_affix(*affixes)
-        self.attribute_method_matchers += affixes.map! { |affix| AttributeMethodMatcher.new prefix: affix[:prefix], suffix: affix[:suffix] }
-        undefine_attribute_methods
+        attribute_methods_builder.affix(*affixes)
       end
 
       # Allows you to make aliases for attributes.
@@ -207,10 +200,8 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
-        attribute_method_matchers.each do |matcher|
-          matcher_new = matcher.method_name(new_name).to_s
-          matcher_old = matcher.method_name(old_name).to_s
-          define_proxy_call false, self, matcher_new, matcher_old
+        attribute_methods_builders.each do |builder|
+          builder.alias_attribute(new_name, old_name)
         end
       end
 
@@ -249,7 +240,9 @@ module ActiveModel
       #     end
       #   end
       def define_attribute_methods(*attr_names)
-        attr_names.flatten.each { |attr_name| define_attribute_method(attr_name) }
+        attribute_methods_builders.each do |builder|
+          builder.define_attribute_methods(*(attr_names.flatten))
+        end
       end
 
       # Declares an attribute that should be prefixed and suffixed by
@@ -281,22 +274,7 @@ module ActiveModel
       #   person.name = 'Bob'
       #   person.name        # => "Bob"
       #   person.name_short? # => true
-      def define_attribute_method(attr_name)
-        attribute_method_matchers.each do |matcher|
-          method_name = matcher.method_name(attr_name)
-
-          unless instance_method_already_implemented?(method_name)
-            generate_method = "define_method_#{matcher.method_missing_target}"
-
-            if respond_to?(generate_method, true)
-              send(generate_method, attr_name.to_s)
-            else
-              define_proxy_call true, generated_attribute_methods, method_name, matcher.method_missing_target, attr_name.to_s
-            end
-          end
-        end
-        attribute_method_matchers_cache.clear
-      end
+      alias_method :define_attribute_method, :define_attribute_methods
 
       # Removes all the previously dynamically defined methods from the class.
       #
@@ -322,157 +300,32 @@ module ActiveModel
       #
       #   person.name_short? # => NoMethodError
       def undefine_attribute_methods
-        generated_attribute_methods.module_eval do
-          instance_methods.each { |m| undef_method(m) }
-        end
-        attribute_method_matchers_cache.clear
+        attribute_methods_builders.each(&:undefine_attribute_methods)
+      end
+
+      def attribute_methods_builder_class
+        AttributeMethodsBuilder
       end
 
       private
-        def generated_attribute_methods
-          @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
+        def _attribute_methods_builder
+          @attribute_methods_builder ||=
+            attribute_methods_builder_class.new.tap do |builder|
+              self.attribute_methods_builders += [builder]
+              builder.apply(self)
+            end
+        end
+
+        # Note: method_missing overrides are only defined once the builder is
+        # first used, to avoid unnecessarily increasing execution time of
+        # +respond_to?+ in case the builder has no matchers on it.
+        def attribute_methods_builder
+          _attribute_methods_builder.tap(&:define_method_missing)
         end
 
         def instance_method_already_implemented?(method_name)
-          generated_attribute_methods.method_defined?(method_name)
-        end
-
-        # The methods +method_missing+ and +respond_to?+ of this module are
-        # invoked often in a typical rails, both of which invoke the method
-        # +matched_attribute_method+. The latter method iterates through an
-        # array doing regular expression matches, which results in a lot of
-        # object creations. Most of the time it returns a +nil+ match. As the
-        # match result is always the same given a +method_name+, this cache is
-        # used to alleviate the GC, which ultimately also speeds up the app
-        # significantly (in our case our test suite finishes 10% faster with
-        # this cache).
-        def attribute_method_matchers_cache
-          @attribute_method_matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
-        end
-
-        def attribute_method_matchers_matching(method_name)
-          attribute_method_matchers_cache.compute_if_absent(method_name) do
-            # Must try to match prefixes/suffixes first, or else the matcher with no prefix/suffix
-            # will match every time.
-            matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
-            matchers.map { |method| method.match(method_name) }.compact
-          end
-        end
-
-        # Define a method `name` in `mod` that dispatches to `send`
-        # using the given `extra` args. This falls back on `define_method`
-        # and `send` if the given names cannot be compiled.
-        def define_proxy_call(include_private, mod, name, send, *extra)
-          defn = if NAME_COMPILABLE_REGEXP.match?(name)
-            "def #{name}(*args)"
-          else
-            "define_method(:'#{name}') do |*args|"
-          end
-
-          extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
-
-          target = if CALL_COMPILABLE_REGEXP.match?(send)
-            "#{"self." unless include_private}#{send}(#{extra})"
-          else
-            "send(:'#{send}', #{extra})"
-          end
-
-          mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            #{defn}
-              #{target}
-            end
-          RUBY
-        end
-
-        class AttributeMethodMatcher #:nodoc:
-          attr_reader :prefix, :suffix, :method_missing_target
-
-          AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)
-
-          def initialize(options = {})
-            @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
-            @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
-            @method_missing_target = "#{@prefix}attribute#{@suffix}"
-            @method_name = "#{prefix}%s#{suffix}"
-          end
-
-          def match(method_name)
-            if @regex =~ method_name
-              AttributeMethodMatch.new(method_missing_target, $1, method_name)
-            end
-          end
-
-          def method_name(attr_name)
-            @method_name % attr_name
-          end
-
-          def plain?
-            prefix.empty? && suffix.empty?
-          end
+          attribute_methods_builders.any? { |builder| builder.method_defined?(method_name) }
         end
     end
-
-    # Allows access to the object attributes, which are held in the hash
-    # returned by <tt>attributes</tt>, as though they were first-class
-    # methods. So a +Person+ class with a +name+ attribute can for example use
-    # <tt>Person#name</tt> and <tt>Person#name=</tt> and never directly use
-    # the attributes hash -- except for multiple assignments with
-    # <tt>ActiveRecord::Base#attributes=</tt>.
-    #
-    # It's also possible to instantiate related objects, so a <tt>Client</tt>
-    # class belonging to the +clients+ table with a +master_id+ foreign key
-    # can instantiate master through <tt>Client#master</tt>.
-    def method_missing(method, *args, &block)
-      if respond_to_without_attributes?(method, true)
-        super
-      else
-        match = matched_attribute_method(method.to_s)
-        match ? attribute_missing(match, *args, &block) : super
-      end
-    end
-
-    # +attribute_missing+ is like +method_missing+, but for attributes. When
-    # +method_missing+ is called we check to see if there is a matching
-    # attribute method. If so, we tell +attribute_missing+ to dispatch the
-    # attribute. This method can be overloaded to customize the behavior.
-    def attribute_missing(match, *args, &block)
-      __send__(match.target, match.attr_name, *args, &block)
-    end
-
-    # A +Person+ instance with a +name+ attribute can ask
-    # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,
-    # and <tt>person.respond_to?(:name?)</tt> which will all return +true+.
-    alias :respond_to_without_attributes? :respond_to?
-    def respond_to?(method, include_private_methods = false)
-      if super
-        true
-      elsif !include_private_methods && super(method, true)
-        # If we're here then we haven't found among non-private methods
-        # but found among all methods. Which means that the given method is private.
-        false
-      else
-        !matched_attribute_method(method.to_s).nil?
-      end
-    end
-
-    private
-      def attribute_method?(attr_name)
-        respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
-      end
-
-      # Returns a struct representing the matching attribute method.
-      # The struct's attributes are prefix, base and suffix.
-      def matched_attribute_method(method_name)
-        matches = self.class.send(:attribute_method_matchers_matching, method_name)
-        matches.detect { |match| attribute_method?(match.attr_name) }
-      end
-
-      def missing_attribute(attr_name, stack)
-        raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
-      end
-
-      def _read_attribute(attr)
-        __send__(attr)
-      end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -54,6 +54,11 @@ module ActiveModel
     end
 
     def included(model_class)
+      # Strictly-speaking this is not necessary, since AM::AttributeMethods
+      # includes the module, and AR::AttributeMethods includes
+      # AM::AttributeMethods. However, since this class depends on methods in
+      # it, we should ensure that it is included into any module that includes
+      # instances of the builder.
       model_class.include AttributeMissingMethods
     end
 
@@ -255,10 +260,6 @@ module ActiveModel
 
           def missing_attribute(attr_name, stack)
             raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
-          end
-
-          def _read_attribute(attr)
-            __send__(attr)
           end
       end
   end

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -261,6 +261,10 @@ module ActiveModel
           def missing_attribute(attr_name, stack)
             raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
           end
+
+          def _read_attribute(attr)
+            __send__(attr)
+          end
       end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+require "concurrent/map"
+
+module ActiveModel
+  # == Active \Model \Attribute \Methods\ Builder
+  #
+  # Module builder to define attribute methods on a class. Used by
+  # <tt>ActiveModel::AttributeMethods</tt> to add prefixes and suffixes to
+  # models.
+  #
+  # The builder can also be used on its own:
+  #
+  #   class Person
+  #     mod = ActiveModel::AttributeMethodsBuidler.new
+  #
+  #     include mod
+  #
+  #     mod.affix prefix: 'reset_', suffix: '_to_default!'
+  #     mod.suffix '_contrived?'
+  #     mod.prefix 'clear_'
+  #     mod.define_attribute_methods :name
+  #
+  #     attr_accessor :name
+  #
+  #     def attributes
+  #       { 'name' => @name }
+  #     end
+  #
+  #     private
+  #
+  #     def attribute_contrived?(attr)
+  #       true
+  #     end
+  #
+  #     def clear_attribute(attr)
+  #       send("#{attr}=", nil)
+  #     end
+  #
+  #     def reset_attribute_to_default!(attr)
+  #       send("#{attr}=", 'Default Name')
+  #     end
+  #   end
+  #
+  class AttributeMethodsBuilder < Module
+    NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
+    CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
+
+    attr_accessor :matchers
+
+    def initialize
+      @matchers = [AttributeMethodMatcher.new]
+      @method_names = Set.new
+    end
+
+    def included(model_class)
+      model_class.include AttributeMissingMethods
+    end
+
+    def prefix(*prefixes)
+      self.matchers += prefixes.map! { |prefix| AttributeMethodMatcher.new prefix: prefix }
+      undefine_attribute_methods
+    end
+
+    # See ActiveModel::AttributeMethods#suffix
+    def suffix(*suffixes)
+      self.matchers += suffixes.map! { |suffix| AttributeMethodMatcher.new suffix: suffix }
+      undefine_attribute_methods
+    end
+
+    # See ActiveModel::AttributeMethods#affix
+    def affix(*affixes)
+      self.matchers += affixes.map! { |affix| AttributeMethodMatcher.new prefix: affix[:prefix], suffix: affix[:suffix] }
+      undefine_attribute_methods
+    end
+
+    # See ActiveModel::AttributeMethods#define_attribute_methods
+    def define_attribute_methods(*attr_names)
+      attr_names.each { |attr_name| define_attribute_method(attr_name) }
+      define_method_missing
+    end
+
+    # See ActiveModel::AttributeMethods#define_attribute_method
+    def define_attribute_method(attr_name)
+      matchers.each do |matcher|
+        method_name = matcher.method_name(attr_name)
+        @method_names << method_name.to_sym
+
+        unless instance_method_already_implemented?(method_name)
+          generate_method = "define_method_#{matcher.method_missing_target}"
+
+          if respond_to?(generate_method, true)
+            send(generate_method, attr_name.to_s)
+          else
+            define_proxy_call true, method_name, matcher.method_missing_target, attr_name.to_s
+          end
+        end
+      end
+      matchers_cache.clear
+    end
+
+    # See ActiveModel::AttributeMethods#undefine_attribute_method
+    def undefine_attribute_methods
+      (@method_names & instance_methods(false)).each(&method(:undef_method))
+      @method_names.clear
+      matchers_cache.clear
+    end
+
+    # See ActiveModel::AttributeMethods#alias_attribute
+    def alias_attribute(new_name, old_name)
+      matchers.each do |matcher|
+        define_proxy_call false, matcher.method_name(new_name), matcher.method_name(old_name)
+      end
+    end
+
+    # Check if method name matches any of our attribute method matchers.
+    def match(method_name)
+      return [] if method_name == "attributes"
+      matchers_cache.compute_if_absent(method_name) do
+        # Must try to match prefixes/suffixes first, or else the matcher with no prefix/suffix
+        # will match every time.
+        matchers.partition(&:plain?).reverse.flatten(1).map do |matcher|
+          matcher.match(method_name)
+        end.compact
+      end
+    end
+
+    # Includes self into class. Can be overridden to do something different,
+    # see ActiveRecord::AttributeMethodsBuilder.
+    def apply(klass)
+      klass.include self
+    end
+
+    # Defines +method_missing+ and +respond_to+ to respond to attribute method
+    # calls that match our matchers.
+    def define_method_missing
+      return false if method_defined?(:method_missing)
+      builder = self
+
+      # Allows access to the object attributes, which are held in the hash
+      # returned by <tt>attributes</tt>, as though they were first-class
+      # methods. So a +Person+ class with a +name+ attribute can for example use
+      # <tt>Person#name</tt> and <tt>Person#name=</tt> and never directly use
+      # the attributes hash -- except for multiple assignments with
+      # <tt>ActiveRecord::Base#attributes=</tt>.
+      #
+      # It's also possible to instantiate related objects, so a <tt>Client</tt>
+      # class belonging to the +clients+ table with a +master_id+ foreign key
+      # can instantiate master through <tt>Client#master</tt>.
+      define_method :method_missing do |method_name, *arguments, &method_block|
+        match = builder.match(method_name.to_s).find { |m| attribute_method?(m.attr_name) }
+        if match && !respond_to_without_attributes?(method_name, true)
+          attribute_missing(match, *arguments, &method_block)
+        else
+          super(method_name, *arguments, &method_block)
+        end
+      end
+
+      define_method :respond_to? do |method_name, include_private_methods = false|
+        return true if super(method_name, include_private_methods)
+
+        if builder.match(method_name.to_s).find { |m| attribute_method?(m.attr_name) }
+          !respond_to_without_attributes?(method_name, true)
+        else
+          false
+        end
+      end
+    end
+
+    private
+
+      # The methods +method_missing+ and +respond_to?+ of this module are
+      # invoked often in a typical rails, both of which invoke the method
+      # +matched_attribute_method+. The latter method iterates through an
+      # array doing regular expression matches, which results in a lot of
+      # object creations. Most of the time it returns a +nil+ match. As the
+      # match result is always the same given a +method_name+, this cache is
+      # used to alleviate the GC, which ultimately also speeds up the app
+      # significantly (in our case our test suite finishes 10% faster with
+      # this cache).
+      def matchers_cache
+        @matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
+      end
+
+      def define_proxy_call(include_private, name, send, *extra)
+        defn = if NAME_COMPILABLE_REGEXP.match?(name)
+          "def #{name}(*args)"
+        else
+          "define_method(:'#{name}') do |*args|"
+        end
+
+        extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
+
+        target = if CALL_COMPILABLE_REGEXP.match?(send)
+          "#{"self." unless include_private}#{send}(#{extra})"
+        else
+          "send(:'#{send}', #{extra})"
+        end
+
+        module_eval <<-RUBY, __FILE__, __LINE__ + 1
+          #{defn}
+            #{target}
+          end
+        RUBY
+      end
+
+      def instance_method_already_implemented?(method_name)
+        method_defined?(method_name)
+      end
+
+      class AttributeMethodMatcher #:nodoc:
+        attr_reader :prefix, :suffix, :method_missing_target
+
+        AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)
+
+        def initialize(options = {})
+          @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
+          @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
+          @method_missing_target = "#{@prefix}attribute#{@suffix}"
+          @method_name = "#{prefix}%s#{suffix}"
+        end
+
+        def match(method_name)
+          if @regex =~ method_name
+            AttributeMethodMatch.new(method_missing_target, $1, method_name)
+          end
+        end
+
+        def method_name(attr_name)
+          @method_name % attr_name
+        end
+
+        def plain?
+          prefix.empty? && suffix.empty?
+        end
+      end
+
+      module AttributeMissingMethods
+        # +attribute_missing+ is like +method_missing+, but for attributes. When
+        # +method_missing+ is called we check to see if there is a matching
+        # attribute method. If so, we tell +attribute_missing+ to dispatch the
+        # attribute. This method can be overloaded to customize the behavior.
+        def attribute_missing(match, *args, &block)
+          __send__(match.target, match.attr_name, *args, &block)
+        end
+
+        # A +Person+ instance with a +name+ attribute can ask
+        # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,
+        # and <tt>person.respond_to?(:name?)</tt> which will all return +true+.
+        alias :respond_to_without_attributes? :respond_to?
+
+        private
+          def attribute_method?(attr_name)
+            respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
+          end
+
+          def missing_attribute(attr_name, stack)
+            raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
+          end
+
+          def _read_attribute(attr)
+            __send__(attr)
+          end
+      end
+  end
+end

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -12,15 +12,12 @@ module ActiveModel
     def initialize
       @matchers = [AttributeMethodMatcher.new]
       @method_names = Set.new
-    end
-
-    def included(model_class)
       # Strictly-speaking this is not necessary, since AM::AttributeMethods
       # includes the module, and AR::AttributeMethods includes
       # AM::AttributeMethods. However, since this class depends on methods in
       # it, we should ensure that it is included into any module that includes
       # instances of the builder.
-      model_class.include AttributeMissingMethods
+      include AttributeMissingMethods
     end
 
     def prefix(*prefixes)

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -3,46 +3,7 @@
 require "concurrent/map"
 
 module ActiveModel
-  # == Active \Model \Attribute \Methods\ Builder
-  #
-  # Module builder to define attribute methods on a class. Used by
-  # <tt>ActiveModel::AttributeMethods</tt> to add prefixes and suffixes to
-  # models.
-  #
-  # The builder can also be used on its own:
-  #
-  #   class Person
-  #     mod = ActiveModel::AttributeMethodsBuilder.new
-  #
-  #     include mod
-  #
-  #     mod.affix prefix: 'reset_', suffix: '_to_default!'
-  #     mod.suffix '_contrived?'
-  #     mod.prefix 'clear_'
-  #     mod.define_attribute_methods :name
-  #
-  #     attr_accessor :name
-  #
-  #     def attributes
-  #       { 'name' => @name }
-  #     end
-  #
-  #     private
-  #
-  #     def attribute_contrived?(attr)
-  #       true
-  #     end
-  #
-  #     def clear_attribute(attr)
-  #       send("#{attr}=", nil)
-  #     end
-  #
-  #     def reset_attribute_to_default!(attr)
-  #       send("#{attr}=", 'Default Name')
-  #     end
-  #   end
-  #
-  class AttributeMethodsBuilder < Module
+  class AttributeMethodsBuilder < Module # :nodoc:
     NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
 
@@ -67,24 +28,20 @@ module ActiveModel
       undefine_attribute_methods
     end
 
-    # See ActiveModel::AttributeMethods#suffix
     def suffix(*suffixes)
       self.matchers += suffixes.map! { |suffix| AttributeMethodMatcher.new suffix: suffix }
       undefine_attribute_methods
     end
 
-    # See ActiveModel::AttributeMethods#affix
     def affix(*affixes)
       self.matchers += affixes.map! { |affix| AttributeMethodMatcher.new prefix: affix[:prefix], suffix: affix[:suffix] }
       undefine_attribute_methods
     end
 
-    # See ActiveModel::AttributeMethods#define_attribute_methods
     def define_attribute_methods(*attr_names)
       attr_names.each { |attr_name| define_attribute_method(attr_name) }
     end
 
-    # See ActiveModel::AttributeMethods#define_attribute_method
     def define_attribute_method(attr_name)
       matchers.each do |matcher|
         method_name = matcher.method_name(attr_name)
@@ -103,14 +60,12 @@ module ActiveModel
       matchers_cache.clear
     end
 
-    # See ActiveModel::AttributeMethods#undefine_attribute_method
     def undefine_attribute_methods
       (@method_names & instance_methods(false)).each(&method(:undef_method))
       @method_names.clear
       matchers_cache.clear
     end
 
-    # See ActiveModel::AttributeMethods#alias_attribute
     def alias_attribute(new_name, old_name)
       matchers.each do |matcher|
         define_proxy_call false, matcher.method_name(new_name), matcher.method_name(old_name)

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -116,7 +116,7 @@ module ActiveModel
         return true if super(method_name, include_private_methods)
 
         if builder.match(method_name.to_s).find { |m| attribute_method?(m.attr_name) }
-          !respond_to_without_attributes?(method_name, true)
+          include_private_methods || !respond_to_without_attributes?(method_name, true)
         else
           false
         end

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -77,7 +77,6 @@ module ActiveModel
     # See ActiveModel::AttributeMethods#define_attribute_methods
     def define_attribute_methods(*attr_names)
       attr_names.each { |attr_name| define_attribute_method(attr_name) }
-      define_method_missing
     end
 
     # See ActiveModel::AttributeMethods#define_attribute_method

--- a/activemodel/lib/active_model/attribute_methods_builder.rb
+++ b/activemodel/lib/active_model/attribute_methods_builder.rb
@@ -12,7 +12,7 @@ module ActiveModel
   # The builder can also be used on its own:
   #
   #   class Person
-  #     mod = ActiveModel::AttributeMethodsBuidler.new
+  #     mod = ActiveModel::AttributeMethodsBuilder.new
   #
   #     include mod
   #

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -100,9 +100,9 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_raises(NoMethodError) { ModelWithoutAttributesMethod.new.foo }
   end
 
-  test "unrelated classes should not share attribute method matchers" do
-    assert_not_equal ModelWithAttributes.send(:attribute_method_matchers),
-                     ModelWithAttributes2.send(:attribute_method_matchers)
+  test "unrelated classes should not share attribute method builders" do
+    assert_not_equal ModelWithAttributes.send(:attribute_methods_builders),
+                     ModelWithAttributes2.send(:attribute_methods_builders)
   end
 
   test "#define_attribute_method generates attribute method" do
@@ -117,15 +117,19 @@ class AttributeMethodsTest < ActiveModel::TestCase
   end
 
   test "#define_attribute_method does not generate attribute method if already defined in attribute module" do
-    klass = Class.new(ModelWithAttributes)
-    klass.send(:generated_attribute_methods).module_eval do
-      def foo
-        "<3"
+    begin
+      klass = Class.new(ModelWithAttributes)
+      klass.send(:attribute_methods_builder).module_eval do
+        def foo
+          "<3"
+        end
       end
-    end
-    klass.define_attribute_method(:foo)
+      klass.define_attribute_method(:foo)
 
-    assert_equal "<3", klass.new.foo
+      assert_equal "<3", klass.new.foo
+    ensure
+      klass.undefine_attribute_methods
+    end
   end
 
   test "#define_attribute_method generates a method that is already defined on the host" do

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -84,6 +84,7 @@ module ActiveRecord
     autoload :Associations
     autoload :AttributeAssignment
     autoload :AttributeMethods
+    autoload :AttributeMethodsBuilder
     autoload :AutosaveAssociation
 
     autoload :LegacyYamlAdapter

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -40,7 +40,13 @@ module ActiveRecord
 
       def inherited(child_class) #:nodoc:
         if (self == Base || abstract_class?) && !child_class.abstract_class?
-          builder = attribute_methods_builder.dup
+          # When a non-abstract class inherits from ActiveRecord::Base or an
+          # abstract class, we duplicate its attributes methods builder and
+          # include it, in order to get any prefixes/suffixes/affixes that have
+          # been defined on it. We use _attribute_methods_builder here to avoid
+          # defining method_missing/respond_to on the inherited builder, which
+          # would be unnecessary since we define them on the duplicated module.
+          builder = _attribute_methods_builder.dup
           child_class.attribute_methods_builders = [builder]
           child_class.include builder
         end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -9,7 +9,6 @@ module ActiveRecord
     include ActiveModel::AttributeMethods
 
     included do
-      @attribute_methods_builder = nil
       _attribute_methods_builder
       include Read
       include Write

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -5,49 +5,6 @@ module ActiveRecord
     module Read
       extend ActiveSupport::Concern
 
-      module ClassMethods # :nodoc:
-        private
-
-          # We want to generate the methods via module_eval rather than
-          # define_method, because define_method is slower on dispatch.
-          # Evaluating many similar methods may use more memory as the instruction
-          # sequences are duplicated and cached (in MRI).  define_method may
-          # be slower on dispatch, but if you're careful about the closure
-          # created, then define_method will consume much less memory.
-          #
-          # But sometimes the database might return columns with
-          # characters that are not allowed in normal method names (like
-          # 'my_column(omg)'. So to work around this we first define with
-          # the __temp__ identifier, and then use alias method to rename
-          # it to what we want.
-          #
-          # We are also defining a constant to hold the frozen string of
-          # the attribute name. Using a constant means that we do not have
-          # to allocate an object on each call to the attribute method.
-          # Making it frozen means that it doesn't get duped when used to
-          # key the @attributes in read_attribute.
-          def define_method_attribute(name)
-            safe_name = name.unpack("h*".freeze).first
-            temp_method = "__temp__#{safe_name}"
-
-            ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
-            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
-
-            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-              def #{temp_method}
-                #{sync_with_transaction_state}
-                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-                _read_attribute(name) { |n| missing_attribute(n, caller) }
-              end
-            STR
-
-            generated_attribute_methods.module_eval do
-              alias_method name, temp_method
-              undef_method temp_method
-            end
-          end
-      end
-
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -9,26 +9,6 @@ module ActiveRecord
         attribute_method_suffix "="
       end
 
-      module ClassMethods # :nodoc:
-        private
-
-          def define_method_attribute=(name)
-            safe_name = name.unpack("h*".freeze).first
-            ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
-            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
-
-            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-              def __temp__#{safe_name}=(value)
-                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-                #{sync_with_transaction_state}
-                _write_attribute(name, value)
-              end
-              alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
-              undef_method :__temp__#{safe_name}=
-            STR
-          end
-      end
-
       # Updates the attribute identified by <tt>attr_name</tt> with the
       # specified +value+. Empty strings for Integer and Float columns are
       # turned into +nil+.

--- a/activerecord/lib/active_record/attribute_methods_builder.rb
+++ b/activerecord/lib/active_record/attribute_methods_builder.rb
@@ -3,13 +3,7 @@
 require "mutex_m"
 
 module ActiveRecord
-  # == Active \Record \Attribute \Methods\ Builder
-  #
-  # Module builder to define ActiveRecord attribute methods. Used by
-  # <tt>ActiveRecord::AttributeMethods</tt> to add prefixes and suffixes to
-  # models, and define attribute methods.
-  #
-  class AttributeMethodsBuilder < ActiveModel::AttributeMethodsBuilder
+  class AttributeMethodsBuilder < ActiveModel::AttributeMethodsBuilder # :nodoc
     include Mutex_m
 
     attr_accessor :model_class

--- a/activerecord/lib/active_record/attribute_methods_builder.rb
+++ b/activerecord/lib/active_record/attribute_methods_builder.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "mutex_m"
+
+module ActiveRecord
+
+  # == Active \Record \Attribute \Methods\ Builder
+  #
+  # Module builder to define ActiveRecord attribute methods. Used by
+  # <tt>ActiveRecord::AttributeMethods</tt> to add prefixes and suffixes to
+  # models, and define attribute methods.
+  #
+  class AttributeMethodsBuilder < ActiveModel::AttributeMethodsBuilder
+    include Mutex_m
+
+    attr_accessor :model_class
+
+    def initialize(*)
+      super
+      @attribute_methods_generated = false
+    end
+
+    def included(model_class)
+      super
+      @model_class = model_class
+    end
+
+    # Generates all the attribute related methods for columns in the database
+    # accessors, mutators and query methods.
+    def define_attribute_methods(*attr_names)
+      return false if @attribute_methods_generated
+      # Use a mutex; we don't want two threads simultaneously trying to define
+      # attribute methods.
+      synchronize do
+        return false if @attribute_methods_generated
+        super(*attr_names)
+        @attribute_methods_generated = true
+      end
+    end
+
+    def undefine_attribute_methods
+      synchronize do
+        super if defined?(@attribute_methods_defined) && @attribute_methods_defined
+        @attribute_methods_generated = false
+      end
+    end
+
+    def apply(klass)
+      super unless klass == Base
+    end
+
+    private
+
+      # We want to generate the methods via module_eval rather than
+      # define_method, because define_method is slower on dispatch.
+      # Evaluating many similar methods may use more memory as the instruction
+      # sequences are duplicated and cached (in MRI).  define_method may
+      # be slower on dispatch, but if you're careful about the closure
+      # created, then define_method will consume much less memory.
+      #
+      # But sometimes the database might return columns with
+      # characters that are not allowed in normal method names (like
+      # 'my_column(omg)'. So to work around this we first define with
+      # the __temp__ identifier, and then use alias method to rename
+      # it to what we want.
+      #
+      # We are also defining a constant to hold the frozen string of
+      # the attribute name. Using a constant means that we do not have
+      # to allocate an object on each call to the attribute method.
+      # Making it frozen means that it doesn't get duped when used to
+      # key the @attributes in read_attribute.
+      def define_method_attribute(name)
+        safe_name = name.unpack("h*".freeze).first
+        temp_method = "__temp__#{safe_name}"
+
+        ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+
+        module_eval <<-STR, __FILE__, __LINE__ + 1
+          def #{temp_method}
+            name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+            sync_with_transaction_state if name == self.class.primary_key
+            _read_attribute(name) { |n| missing_attribute(n, caller) }
+          end
+        STR
+
+        alias_method name, temp_method
+        undef_method temp_method
+      end
+
+      def define_method_attribute=(name)
+        safe_name = name.unpack("h*".freeze).first
+        ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+
+        module_eval <<-STR, __FILE__, __LINE__ + 1
+          def __temp__#{safe_name}=(value)
+            name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+            sync_with_transaction_state if name == self.class.primary_key
+            _write_attribute(name, value)
+          end
+          alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
+          undef_method :__temp__#{safe_name}=
+        STR
+      end
+
+      def instance_method_already_implemented?(method_name)
+        @model_class && @model_class.instance_method_already_implemented?(method_name)
+      end
+  end
+end

--- a/activerecord/lib/active_record/attribute_methods_builder.rb
+++ b/activerecord/lib/active_record/attribute_methods_builder.rb
@@ -39,7 +39,7 @@ module ActiveRecord
     end
 
     def apply(klass)
-      super unless klass == Base
+      super unless klass == Base || klass.abstract_class?
     end
 
     private

--- a/activerecord/lib/active_record/attribute_methods_builder.rb
+++ b/activerecord/lib/active_record/attribute_methods_builder.rb
@@ -3,7 +3,6 @@
 require "mutex_m"
 
 module ActiveRecord
-
   # == Active \Record \Attribute \Methods\ Builder
   #
   # Module builder to define ActiveRecord attribute methods. Used by

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -144,6 +144,7 @@ module ActiveRecord
       def inherited(child_class) # :nodoc:
         # initialize cache at class definition for thread safety
         child_class.initialize_find_by_cache
+        child_class.initialize_generated_modules
         super
       end
 

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
           def self.superclass; Base; end
           def self.base_class; self; end
           def self.decorate_matching_attribute_types(*); end
+          def self.abstract_class?; false; end
 
           include ActiveRecord::DefineCallbacks
           include ActiveRecord::AttributeMethods


### PR DESCRIPTION
( This is a "lite" version of #30895 )

r? @matthewd

@matthewd This is in response to [your comment](https://github.com/rails/rails/pull/30895#issuecomment-336690267). This implementation does not add any more modules than would currently be added, so that issue is gone.

I've basically implemented what [I described](https://github.com/rails/rails/pull/30895#issuecomment-336752791) later in that thread.

## Summary

This is a large and substantial refactor of two core modules, `ActiveModel::AttributeMethods` and `ActiveRecord::AttributeMethods`. The inspiration for this PR is [this blog post](http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern) on the module builder pattern which I wrote a few months ago.

There are a few issues motivating this refactor, the main one being that `AR::AttributeMethods` and `AM::AttributeMethods` are heavily coupled, in such a way that (among other things) it makes it impossible to use them (or any other dependent modules like AM/AR Dirty) alongside each other. This is like a straightjacket on AR::Core models since it means you lose any flexibility that AM::AttributeMethods tries to give you.

I came face to face with this coupling when I first tried to make a change to `AM::AttributeMethods` in #30895, changing some private methods, and found that `AR::AttributeMethods` completely blew up because it depended on `generated_attribute_methods` being defined.

The other (related) motivation is to make these modules more encapsulated. Currently, both modules define many methods on the including class in order to "bootstrap" dynamic method definition, e.g. `define_proxy_call`, `matched_attribute_method`, `generated_attribute_methods`, `attribute_method_matchers_matching`, `attribute_method_matchers_cache`, etc. They also depend on class attributes like `attribute_method_matchers`.

## Outline

Within the constraints of the current API, this PR attempts to overcome these issues by extracting much of the "method-defining" logic into two module builders, `ActiveModel::AttributeMethodsBuilder` and `ActiveRecord::AttributeMethodsBuilder`. These classes each subclass `Module` so they can define modules themselves, and since they contain all the logic they need to define methods on themselves (including their own matchers), they avoiding the coupling mentioned above. Also since the AR module builder is a *subclass* of the AM module builder, the relationship between the two of them is clearer (instead of overriding class methods on the model class, we override class methods on the module builder class).

By defining these builders and keeping the core functionality encapsulated within them, they become much more versatile. If they are used in isolation (using `AM::AttributeMethodsBuilder.new` etc), you can actually define ActiveModel attribute methods alongside ActiveRecord attribute methods on the same model. And you can also go further and define your own attribute methods builder that subclasses either of these classes.

Here's an example of how you could define attribute methods *without* including `ActiveModel::AttributeMethods` into a class, by including an instance of `ActiveModel::AttributeMethodsBuilder` like this:

```ruby
class Person
  mod = ActiveModel::AttributeMethodsBuilder.new

  include mod

  mod.affix prefix: 'reset_', suffix: '_to_default!'
  mod.suffix '_contrived?'
  mod.prefix 'clear_'
  mod.define_attribute_methods :name

  attr_accessor :name

  def attributes
    { 'name' => @name }
  end

  private

  def attribute_contrived?(attr)
    true
  end

  def clear_attribute(attr)
    send("#{attr}=", nil)
  end

  def reset_attribute_to_default!(attr)
    send("#{attr}=", 'Default Name')
  end
end
```

This usage does not put any class methods or any class attributes onto the including class (everything needed is defined on the module instance `mod`).

In order to satisfy existing specs and usage, I left the class attribute `attribute_aliases` and defined a new `attribute_method_builders` (and method `attribute_method_builder`), but these are really "sugar" to maintain the current API; the core code is all encapsulated in the module builders.

## Other considerations

There's a lot more here, I'm happy to go through the changes and explain whatever needs to be explained.

I am aware that any impact on performance will rule out any change like this, which is why I closed #30895. This time around I have been careful to check that there is no performance impact (that I can detect at any rate).

I have only tested locally against MRI ruby, but it is possible that other implementations may be impacted since I change one `def` into a `define_method` (for the `respond_to` override). I'm happy to discuss this part of the code.

The other main concern was the number of modules added in #30895. This PR does not grow the number of modules so this should not be a concern this time around.