### PR TITLE
Set `MYSQL=mariadb` explicitly to run CI with MariaDB at 5-0-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     # Latest compiled version in http://rubies.travis-ci.org
     - rvm: 2.3.3
       env:
-        - "GEM=ar:mysql2"
+        - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.2
     - rvm: jruby-9.1.7.0


### PR DESCRIPTION
### Summary

This pull request aims to address `5-0-stable` CI failure.
https://travis-ci.org/rails/rails/jobs/314848740

```ruby
Error:
ActiveRecord::Migration::ColumnsTest#test_remove_column_with_multi_column_index:
ActiveRecord::StatementInvalid: Mysql2::Error: Key column 'hat_size' doesn't exist in table: ALTER TABLE `test_models` DROP `hat_size`
```

I think it would address the error above. Since https://github.com/rails/rails/commit/55bcd2f62b5302cfa5a2214c8bba68718c710088 has been backported to 5-0-stable branch.  I have no other idea how to address it.

