### PR TITLE
Return `nil` instead of `false` if raise `Azure::Core::Http::HTTPError`

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -46,7 +46,7 @@ module ActiveStorage
         begin
           blobs.delete_blob(container, key)
         rescue Azure::Core::Http::HTTPError
-          false
+          # Ignore files already deleted
         end
       end
     end


### PR DESCRIPTION
### Summary

* If it raise error `Azure::Core::Http::HTTPError`, return `nil` instead of `false` in
  `ActiveStorage::Service::AzureStorageService#delete`.

* Other services behave as same as this.

    * [ActiveStorage::Service::DiskService#delete](https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/service/disk_service.rb#L41-L49)
    * [ActiveStorage::Service::GCSService#delete](https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/service/gcs_service.rb#L46-L54)