### PR TITLE
[ci skip] Update instrumentation guide for ActiveStorage

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -543,6 +543,13 @@ Active Storage
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
+### service_delete_prefixed.active_storage
+
+| Key          | Value               |
+| ------------ | ------------------- |
+| `:prefix`    | Key prefix          |
+| `:service`   | Name of the service |
+
 ### service_exist.active_storage
 
 | Key          | Value                       |


### PR DESCRIPTION
### Summary

* Added `service_delete_prefixed.active_storage` which is using in [`ActiveStorage::Service#delete_prefixed`](https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/service/azure_storage_service.rb#L55-L67).