### PR TITLE
Quote colum_names when building select:

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1041,7 +1041,7 @@ module ActiveRecord
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
         elsif @klass.ignored_columns.any?
-          arel.project(*arel_columns(@klass.column_names))
+          arel.project(*arel_columns(@klass.column_names.map(&:to_sym)))
         else
           arel.project(table[Arel.star])
         end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1495,4 +1495,12 @@ class BasicsTest < ActiveRecord::TestCase
     # regular column
     assert query.include?("name")
   end
+
+  test "column names are quoted when using #from clause and model has ignored columns" do
+    refute_empty Developer.ignored_columns
+    query = Developer.from("`developers`").to_sql
+    quoted_id = Developer.connection.quote_table_name("id")
+
+    assert_match(/SELECT #{quoted_id}.* FROM `developers`/, query)
+  end
 end


### PR DESCRIPTION
Quote colum_names when building select:

- #30980 introduced a change to not use `Arel.star` when model have ignored columns, a query used to look like `SELECT *. FROM developers` whereas now it would like `SELECT column1, column2 FROM developers`
  - If a column has the same name has a reserved database specific keyword (such as key, where ...) then the query would fail because the names aren't quoted
- Quoting almost always happen unless we use a `from` clause in the query https://github.com/rails/rails/blob/9965b98dc0d58a86e10b4343bb6e15e01661a8c3/activerecord/lib/active_record/relation/query_methods.rb#L1052
- This PR cast all columns name to symbols in order for the quoting logic to be picked up https://github.com/rails/rails/blob/9965b98dc0d58a86e10b4343bb6e15e01661a8c3/activerecord/lib/active_record/relation/query_methods.rb#L1054-L1055
- A reproduction script can be found here https://gist.github.com/Edouard-chin/f56d464a0adcb76962afc1a9134a1536

