### PR TITLE
Fix conflicts `counter_cache` with `touch: true` by optimistic locking.

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -49,9 +49,9 @@ module ActiveRecord
         def update_counters(by)
           if require_counter_update? && foreign_key_present?
             if target && !stale_target?
-              target.increment!(reflection.counter_cache_column, by)
+              target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              klass.update_counters(target_id, reflection.counter_cache_column => by)
+              klass.update_counters(target_id, reflection.counter_cache_column => by, touch: reflection.options[:touch])
             end
           end
         end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -114,9 +114,13 @@ module ActiveRecord::Associations::Builder # :nodoc:
         BelongsTo.touch_record(record, record.send(changes_method), foreign_key, n, touch, belongs_to_touch_method)
       }}
 
-      model.after_save    callback.(:saved_changes), if: :saved_changes?
-      model.after_touch   callback.(:changes_to_save)
-      model.after_destroy callback.(:changes_to_save)
+      unless reflection.counter_cache_column
+        model.after_create callback.(:saved_changes), if: :saved_changes?
+        model.after_destroy callback.(:changes_to_save)
+      end
+
+      model.after_update callback.(:saved_changes), if: :saved_changes?
+      model.after_touch callback.(:changes_to_save)
     end
 
     def self.add_default_callbacks(model, reflection)

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Wheel < ActiveRecord::Base
-  belongs_to :wheelable, polymorphic: true, counter_cache: true
+  belongs_to :wheelable, polymorphic: true, counter_cache: true, touch: true
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define do
   create_table :cars, force: true do |t|
     t.string  :name
     t.integer :engines_count
-    t.integer :wheels_count
+    t.integer :wheels_count, default: 0
     t.column :lock_version, :integer, null: false, default: 0
     t.timestamps null: false
   end
@@ -964,6 +964,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :wheels, force: true do |t|
+    t.integer :size
     t.references :wheelable, polymorphic: true
   end
 


### PR DESCRIPTION
```
# create_table :posts do |t|
#   t.integer :comments_count, default: 0
#   t.integer :lock_version
#   t.timestamps
# end
class Post < ApplicationRecord
end

# create_table :comments do |t|
#   t.belongs_to :post
# end
class Comment < ApplicationRecord
  belongs_to :post, touch: true, counter_cache: true
end
```

Before:
```
post = Post.create!
# => begin transaction
     INSERT INTO "posts" ("created_at", "updated_at", "lock_version")
     VALUES ("2017-12-11 21:27:11.387397", "2017-12-11 21:27:11.387397", 0)
     commit transaction

comment = Comment.create!(post: post)
# => begin transaction
     INSERT INTO "comments" ("post_id") VALUES (1)

     UPDATE "posts" SET "comments_count" = COALESCE("comments_count", 0) + 1,
     "lock_version" = COALESCE("lock_version", 0) + 1 WHERE "posts"."id" = 1

     UPDATE "posts" SET "updated_at" = '2017-12-11 21:27:11.398330',
     "lock_version" = 1 WHERE "posts"."id" = 1 AND "posts"."lock_version" = 0
     rollback transaction
# => ActiveRecord::StaleObjectError: Attempted to touch a stale object: Post.

Comment.take.destroy!
# => begin transaction
     DELETE FROM "comments" WHERE "comments"."id" = 1

     UPDATE "posts" SET "comments_count" = COALESCE("comments_count", 0) - 1,
     "lock_version" = COALESCE("lock_version", 0) + 1 WHERE "posts"."id" = 1

     UPDATE "posts" SET "updated_at" = '2017-12-11 21:42:47.785901',
     "lock_version" = 1 WHERE "posts"."id" = 1 AND "posts"."lock_version" = 0
     rollback transaction
# => ActiveRecord::StaleObjectError: Attempted to touch a stale object: Post.
```

After:
```
post = Post.create!
# => begin transaction
     INSERT INTO "posts" ("created_at", "updated_at", "lock_version")
     VALUES ("2017-12-11 21:27:11.387397", "2017-12-11 21:27:11.387397", 0)
     commit transaction

comment = Comment.create!(post: post)
# => begin transaction
     INSERT INTO "comments" ("post_id") VALUES (1)

     UPDATE "posts" SET "comments_count" = COALESCE("comments_count", 0) + 1,
     "lock_version" = COALESCE("lock_version", 0) + 1,
     "updated_at" = '2017-12-11 21:37:09.802642' WHERE "posts"."id" = 1
     commit transaction

comment.destroy!
# => begin transaction
     DELETE FROM "comments" WHERE "comments"."id" = 1

     UPDATE "posts" SET "comments_count" = COALESCE("comments_count", 0) - 1,
     "lock_version" = COALESCE("lock_version", 0) + 1,
     "updated_at" = '2017-12-11 21:39:02.685520' WHERE "posts"."id" = 1
     commit transaction
```

Fixes #31199.
