### PR TITLE
`create_fixtures` doesn't work since at least a94220b

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -29,10 +29,6 @@ if defined?(ActiveRecord::Base)
   end
 
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-
-  def create_fixtures(*fixture_set_names, &block)
-    FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, {}, &block)
-  end
 end
 
 # :enddoc:


### PR DESCRIPTION
`create_fixtures` doesn't work since at least a94220b66c9e4890007f66b092b25f8a64a19d31

- The namespacing should be `ActiveRecord::FixtureSet`
- I might be missing something but I'm not sure why `create_fixtures` is useful for nowaday (unless for testing rails internal /shrug) and since it's been that long it wasn't working I think it should be fine to just fire it

