### PR TITLE
Fix secrets command deprecation message

### DIFF
--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -56,7 +56,7 @@ module Rails
       private
         def deprecate_in_favor_of_credentials_and_exit
           say "Encrypted secrets is deprecated in favor of credentials. Run:"
-          say "bin/rails credentials --help"
+          say "bin/rails credentials:help"
 
           exit 1
         end


### PR DESCRIPTION
```
$ bin/rails --version       
Rails 5.2.0.beta2

$ bin/rails secrets:setup     
Encrypted secrets is deprecated in favor of credentials. Run:
bin/rails credentials --help

$ bin/rails credentials --help
rails [-f rakefile] {options} targets...

Options are ...
        --backtrace=[OUT]            Enable full backtrace.  OUT can be stderr (default) or stdout.
...

$ bin/rails credentials:help  
Usage:
  bin/rails credentials [options]
...
```