### PR TITLE
Prevent race condition when resetting time stubs

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/module/redefine_method"
 require "active_support/core_ext/string/strip" # for strip_heredoc
 require "active_support/core_ext/time/calculations"
 require "concurrent/map"
@@ -43,7 +44,7 @@ module ActiveSupport
 
         def unstub_object(stub)
           singleton_class = stub.object.singleton_class
-          singleton_class.send :undef_method, stub.method_name
+          singleton_class.send :silence_redefinition_of_method, stub.method_name
           singleton_class.send :alias_method, stub.method_name, stub.original_method
           singleton_class.send :undef_method, stub.original_method
         end


### PR DESCRIPTION
If the current thread is preempted after the stub has been removed but before the original method has been restored, then the other thread will get a `NoMethodError` when it tries to call the method.

Using `silence_redefinition_of_method` instead of `undef_method` ensures that either the stub or the original method is always in place.

See https://github.com/rails/rails/pull/29233, which fixed several similar method redefinition race conditions.