### PR TITLE
Remove stale comment about `ActiveRecord::SchemaDumper.ignore_tables` [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -399,7 +399,7 @@ by adding the following to your `application.rb` file:
 
 The schema dumper adds one additional configuration option:
 
-* `ActiveRecord::SchemaDumper.ignore_tables` accepts an array of tables that should _not_ be included in any generated schema file. This setting is ignored unless `config.active_record.schema_format == :ruby`.
+* `ActiveRecord::SchemaDumper.ignore_tables` accepts an array of tables that should _not_ be included in any generated schema file.
 
 ### Configuring Action Controller
 


### PR DESCRIPTION
Ignoring tables when dumping structure was introduced for `:sql` format here https://github.com/rails/rails/pull/29077. So comment was no longer valid from than time