### PR TITLE
[ci skip] Fix Active Support Changelog about :race_condition_ttl

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -67,7 +67,7 @@
     config.cache_store = :redis_cache_store
 
     # Supports all common cache store options (:namespace, :compress,
-    # :compress_threshold, :expires_in, :race_condition_tool) and all
+    # :compress_threshold, :expires_in, :race_condition_ttl) and all
     # Redis options.
     cache_password = Rails.application.secrets.redis_cache_password
     config.cache_store = :redis_cache_store, driver: :hiredis,


### PR DESCRIPTION
I was reading the changelog and noticed with this. I don't know if this was on purpose to arrange the line length but it should have been called as `:race_condition_ttl` since the option itself is called as `:race_condition_ttl`.

\cc @jeremy 