### PR TITLE
Revert "only install ffmpeg and mupdf on activestorage builds"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ addons:
     sources:
       - sourceline: "ppa:mc3man/trusty-media"
       - sourceline: "ppa:ubuntuhandbook1/apps"
+    packages:
+      - ffmpeg
+      - mupdf
+      - mupdf-tools
 
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
@@ -38,7 +42,6 @@ before_script:
   # Decodes to e.g. `export VARIABLE=VALUE`
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9YTAzNTM0M2YtZTkyMi00MGIzLWFhM2MtMDZiM2VhNjM1YzQ4")
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXJ1YnlvbnJhaWxz")
-  - if [[ $GEM = *ast*  ]] ; then sudo apt-get update && sudo apt-get -y install ffmpeg mupdf mupdf-tools ; fi
 
 script: 'ci/travis.rb'
 


### PR DESCRIPTION
### Summary
This pull request reverts 6ec0ed67d9afcc666ad0424b10e9903f63e60714 changed based on the discussion https://github.com/rails/rails/issues/31369#issuecomment-351082441

### Other Information

At first, I attempt to revert 7544cf7603959f25100b21f70b5e70354bed7e45 but it is a merge commit then reverted the original commit 6ec0ed67d9afcc666ad0424b10e9903f63e60714

```ruby
$ git revert 7544cf7603959f25100b21f70b5e70354bed7e45
error: commit 7544cf7603959f25100b21f70b5e70354bed7e45 is a merge but no -m option was given.
fatal: revert failed
$ git revert 6ec0ed67d9afcc666ad0424b10e9903f63e60714
[revert_31339_to_address_31369 9111fc9f30] Revert "only install ffmpeg and mupdf on activestorage builds"
 1 file changed, 4 insertions(+), 1 deletion(-)
$
```
cc @eileencodes 