### PR TITLE
Fix protected environments with symbols

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -87,19 +87,6 @@ module ActiveRecord
     # Sets the name of the internal metadata table.
 
     ##
-    # :singleton-method: protected_environments
-    # :call-seq: protected_environments
-    #
-    # The array of names of environments where destructive actions should be prohibited. By default,
-    # the value is <tt>["production"]</tt>.
-
-    ##
-    # :singleton-method: protected_environments=
-    # :call-seq: protected_environments=(environments)
-    #
-    # Sets an array of names of environments where destructive actions should be prohibited.
-
-    ##
     # :singleton-method: pluralize_table_names
     # :call-seq: pluralize_table_names
     #
@@ -122,9 +109,9 @@ module ActiveRecord
       class_attribute :table_name_suffix, instance_writer: false, default: ""
       class_attribute :schema_migrations_table_name, instance_accessor: false, default: "schema_migrations"
       class_attribute :internal_metadata_table_name, instance_accessor: false, default: "ar_internal_metadata"
-      class_attribute :protected_environments, instance_accessor: false, default: [ "production" ]
       class_attribute :pluralize_table_names, instance_writer: false, default: true
 
+      self.protected_environments = ["production"]
       self.inheritance_column = "type"
       self.ignored_columns = [].freeze
 
@@ -236,6 +223,21 @@ module ActiveRecord
 
       def full_table_name_suffix #:nodoc:
         (parents.detect { |p| p.respond_to?(:table_name_suffix) } || self).table_name_suffix
+      end
+
+      # The array of names of environments where destructive actions should be prohibited. By default,
+      # the value is <tt>["production"]</tt>.
+      def protected_environments
+        if defined?(@protected_environments)
+          @protected_environments
+        else
+          superclass.protected_environments
+        end
+      end
+
+      # Sets an array of names of environments where destructive actions should be prohibited.
+      def protected_environments=(environments)
+        @protected_environments = environments.map(&:to_s)
       end
 
       # Defines the name of the table column which will store the class name on single-table

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1503,4 +1503,16 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_match(/SELECT #{quoted_id}.* FROM `developers`/, query)
   end
+
+  test "protected environments by default is an array with production" do
+    assert_equal ["production"], ActiveRecord::Base.protected_environments
+  end
+
+  def test_protected_environments_are_stored_as_an_array_of_string
+    previous_protected_environments = ActiveRecord::Base.protected_environments
+    ActiveRecord::Base.protected_environments = [:staging, "production"]
+    assert_equal ["staging", "production"], ActiveRecord::Base.protected_environments
+  ensure
+    ActiveRecord::Base.protected_environments = previous_protected_environments
+  end
 end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -30,13 +30,30 @@ module ActiveRecord
     def test_raises_an_error_when_called_with_protected_environment
       ActiveRecord::Migrator.stubs(:current_version).returns(1)
 
-      protected_environments = ActiveRecord::Base.protected_environments.dup
+      protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Migrator.current_environment
       assert_not_includes protected_environments, current_env
       # Assert no error
       ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
 
-      ActiveRecord::Base.protected_environments << current_env
+      ActiveRecord::Base.protected_environments = [current_env]
+      assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+      end
+    ensure
+      ActiveRecord::Base.protected_environments = protected_environments
+    end
+
+    def test_raises_an_error_when_called_with_protected_environment_which_name_is_a_symbol
+      ActiveRecord::Migrator.stubs(:current_version).returns(1)
+
+      protected_environments = ActiveRecord::Base.protected_environments
+      current_env            = ActiveRecord::Migrator.current_environment
+      assert_not_includes protected_environments, current_env
+      # Assert no error
+      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+      ActiveRecord::Base.protected_environments = [current_env.to_sym]
       assert_raise(ActiveRecord::ProtectedEnvironmentError) do
         ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -322,6 +322,10 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.active_record.schema_migrations_table_name` lets you set a string to be used as the name of the schema migrations table.
 
+* `config.active_record.internal_metadata_table_name` lets you set a string to be used as the name of the internal metadata table.
+
+* `config.active_record.protected_environments` lets you set an array of names of environments where destructive actions should be prohibited.
+
 * `config.active_record.pluralize_table_names` specifies whether Rails will look for singular or plural table names in the database. If set to `true` (the default), then the Customer class will use the `customers` table. If set to false, then the Customer class will use the `customer` table.
 
 * `config.active_record.default_timezone` determines whether to use `Time.local` (if set to `:local`) or `Time.utc` (if set to `:utc`) when pulling dates and times from the database. The default is `:utc`.


### PR DESCRIPTION
- Convert protected_environments to an array of strings 
  It will prevent ignoring environments name of which is a `Symbol`
  ```
  config.active_record.protected_environments = ['staging', :production]
  ```
- Update 'Configuring Rails Applications' guide
  - Add mention about `config.active_record.internal_metadata_table_name`
  - Add mention about `config.active_record.protected_environments`