### PR TITLE
Suppress expected exceptions by `report_on_exception` = `false`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
 
     setup do
       @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
+      Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
 
       @connection = ActiveRecord::Base.connection
 
@@ -31,6 +32,7 @@ module ActiveRecord
       @connection.drop_table "samples", if_exists: true
 
       Thread.abort_on_exception = @abort
+      Thread.report_on_exception = @original_report_on_exception if Thread.respond_to?(:report_on_exception)
     end
 
     test "raises SerializationFailure when a serialization failure occurs" do

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -469,6 +469,7 @@ module ActiveRecord
       end
 
       def test_non_bang_disconnect_and_clear_reloadable_connections_throw_exception_if_threads_dont_return_their_conns
+        Thread.report_on_exception, original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
         @pool.checkout_timeout = 0.001 # no need to delay test suite by waiting the whole full default timeout
         [:disconnect, :clear_reloadable_connections].each do |group_action_method|
           @pool.with_connection do |connection|
@@ -477,6 +478,8 @@ module ActiveRecord
             end
           end
         end
+      ensure
+        Thread.report_on_exception = original_report_on_exception if Thread.respond_to?(:report_on_exception)
       end
 
       def test_disconnect_and_clear_reloadable_connections_attempt_to_wait_for_threads_to_return_their_conns


### PR DESCRIPTION
### Summary
This pull request suppress expected exceptions by `report_on_exception` = `false` in Ruby 2.5.

* Ruby 2.4 introduces `report_on_exception` to control if it reports exceptions in thread,
this default value has been `false` in Ruby 2.4.

Refer https://www.ruby-lang.org/en/news/2016/11/09/ruby-2-4-0-preview3-released/

* Ruby 2.5 changes `report_on_exception` default value to `true`
since this commit https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=61183&view=revision

This pull request suppresses expected exceptions by setting `report_on_exception` = `false`
it also supports Ruby 2.3 which does not have`report_on_exception`.

### Other Information

This pull request suppresses these traces.

```ruby
$ ruby -v
ruby 2.5.0dev (2017-12-13 trunk 61211) [x86_64-linux]
$ bin/test test/cases/connection_pool_test.rb:471
Using sqlite3
Run options: --seed 12498

Traceback (most recent call last):
        13: from /home/yahonda/git/rails/activerecord/test/cases/connection_pool_test.rb:476:in `block (4 levels) in test_non_bang_disconnect_and_clear_reloadable_connections_throw_exception_if_threads_dont_return_their_conns'
        12: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:431:in `disconnect'
        11: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:674:in `with_exclusively_acquired_all_connections'
        10: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:751:in `with_new_connections_blocked'
         9: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:675:in `block in with_exclusively_acquired_all_connections'
         8: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:689:in `attempt_to_checkout_all_existing_connections'
         7: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:256:in `with_a_bias_for'
         6: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:690:in `block in attempt_to_checkout_all_existing_connections'
         5: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:690:in `loop'
         4: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:691:in `block (2 levels) in attempt_to_checkout_all_existing_connections'
         3: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
         2: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:695:in `block (3 levels) in attempt_to_checkout_all_existing_connections'
         1: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:726:in `checkout_for_exclusive_access'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:743:in `rescue in checkout_for_exclusive_access': could not obtain ownership of all database connections in 0.001933456 seconds (#<ActiveRecord::ConnectionAdapters::SQLi
te3Adapter:0x000056484eba0058> is owned by #<Thread:0x000056484cff4cf0 sleep_forever>) (ActiveRecord::ExclusiveConnectionTimeoutError)
Traceback (most recent call last):
        13: from /home/yahonda/git/rails/activerecord/test/cases/connection_pool_test.rb:476:in `block (4 levels) in test_non_bang_disconnect_and_clear_reloadable_connections_throw_exception_if_threads_dont_return_their_conns'
        12: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:479:in `clear_reloadable_connections'
        11: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:674:in `with_exclusively_acquired_all_connections'
        10: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:751:in `with_new_connections_blocked'
         9: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:675:in `block in with_exclusively_acquired_all_connections'
         8: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:689:in `attempt_to_checkout_all_existing_connections'
         7: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:256:in `with_a_bias_for'
         6: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:690:in `block in attempt_to_checkout_all_existing_connections'
         5: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:690:in `loop'
         4: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:691:in `block (2 levels) in attempt_to_checkout_all_existing_connections'
         3: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
         2: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:695:in `block (3 levels) in attempt_to_checkout_all_existing_connections'
         1: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:726:in `checkout_for_exclusive_access'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:743:in `rescue in checkout_for_exclusive_access': could not obtain ownership of all database connections in 0.001960085 seconds (#<ActiveRecord::ConnectionAdapters::SQLi
te3Adapter:0x000056484eba0058> is owned by #<Thread:0x000056484cff4cf0 sleep_forever>) (ActiveRecord::ExclusiveConnectionTimeoutError)
.

Finished in 0.045047s, 22.1993 runs/s, 44.3986 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/transaction_test.rb
Using postgresql
Run options: --seed 35950

Traceback (most recent call last):
        54: from /home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:74:in `block (4 levels) in <class:PostgresqlTransactionTest>'
        53: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        52: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `transaction'
        51: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:227:in `within_new_transaction'
        50: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
        49: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:230:in `block in within_new_transaction'
        48: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `block in transaction'
        47: from /home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:77:in `block (5 levels) in <class:PostgresqlTransactionTest>'
        46: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:418:in `update'
        45: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:383:in `with_transaction_returning_status'
        44: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        43: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:252:in `transaction'
        42: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:386:in `block in with_transaction_returning_status'
        41: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:420:in `block in update'
        40: from /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:44:in `save'
        39: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `save'
        38: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:325:in `rollback_active_record_state!'
        37: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:310:in `block in save'
        36: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:383:in `with_transaction_returning_status'
        35: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        34: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:252:in `transaction'
        33: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:386:in `block in with_transaction_returning_status'
        32: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:310:in `block (2 levels) in save'
        31: from /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:46:in `save'
        30: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:264:in `save'
        29: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `create_or_update'
        28: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:816:in `_run_save_callbacks'
        27: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:98:in `run_callbacks'
        26: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `block in create_or_update'
        25: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:701:in `create_or_update'
        24: from /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:107:in `_update_record'
        23: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:346:in `_update_record'
        22: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:816:in `_run_update_callbacks'
        21: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:132:in `run_callbacks'
        20: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:346:in `block in _update_record'
        19: from /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:133:in `_update_record'
        18: from /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:81:in `_update_record'
        17: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:713:in `_update_record'
        16: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:197:in `_update_record'
        15: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:21:in `update'
        14: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:157:in `update'
        13: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:94:in `exec_delete'
        12: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:582:in `execute_and_clear'
        11: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:593:in `exec_no_cache'
        10: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:561:in `log'
         9: from /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
         8: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:570:in `block in log'
         7: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
         6: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `block (2 levels) in log'
         5: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:594:in `block in exec_no_cache'
         4: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
         3: from /home/yahonda/git/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
         2: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
         1: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:595:in `block (2 levels) in exec_no_cache'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:595:in `async_exec': PG::TRDeadlockDetected: ERROR:  deadlock detected (ActiveRecord::Deadlocked)
DETAIL:  Process 17363 waits for ShareLock on transaction 1736550; blocked by process 17359.
Process 17359 waits for ShareLock on transaction 1736551; blocked by process 17363.
HINT:  See server log for query details.
CONTEXT:  while updating tuple (0,2) in relation "samples"
: UPDATE "samples" SET "value" = $1 WHERE "samples"."id" = $2
...#<Thread:0x000055a79fd8df50@/home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:41 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        24: from /home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:42:in `block (3 levels) in <class:PostgresqlTransactionTest>'
        23: from /home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:183:in `with_warning_suppression'
        22: from /home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/transaction_test.rb:43:in `block (4 levels) in <class:PostgresqlTransactionTest>'
        21: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        20: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `transaction'
        19: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:227:in `within_new_transaction'
        18: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
        17: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:243:in `block in within_new_transaction'
        16: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:204:in `commit_transaction'
        15: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
        14: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:213:in `block in commit_transaction'
        13: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:176:in `commit'
        12: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:143:in `commit_db_transaction'
        11: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:73:in `execute'
        10: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:561:in `log'
         9: from /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
         8: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:570:in `block in log'
         7: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
         6: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `block (2 levels) in log'
         5: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:74:in `block in execute'
         4: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
         3: from /home/yahonda/git/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
         2: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
         1: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `block (2 levels) in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `async_exec': PG::TRSerializationFailure: ERROR:  could not serialize access due to read/write dependencies among transactions (ActiveRecord::SerializationFa
ilure)
DETAIL:  Reason code: Canceled on identification as a pivot, during commit attempt.
HINT:  The transaction might succeed if retried.
: COMMIT
..

Finished in 1.729983s, 2.8902 runs/s, 2.8902 assertions/s.

5 runs, 5 assertions, 0 failures, 0 errors, 0 skips
$
```


This pull request has been tested with these ruby versions.

```
ruby 2.5.0dev (2017-12-14 trunk 61214) [x86_64-linux]
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
```
