### PR TITLE
Preserve original method visibility when deprecating a method

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -60,6 +60,13 @@ module ActiveSupport
               deprecator.deprecation_warning(method_name, options[method_name])
               super(*args, &block)
             end
+
+            case
+            when target_module.protected_method_defined?(method_name)
+              protected method_name
+            when target_module.private_method_defined?(method_name)
+              private method_name
+            end
           end
         end
 

--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -8,6 +8,16 @@ class MethodWrappersTest < ActiveSupport::TestCase
     @klass = Class.new do
       def new_method; "abc" end
       alias_method :old_method, :new_method
+
+      protected
+
+        def new_protected_method; "abc" end
+        alias_method :old_protected_method, :new_protected_method
+
+      private
+
+        def new_private_method; "abc" end
+        alias_method :old_private_method, :new_private_method
     end
   end
 
@@ -32,5 +42,17 @@ class MethodWrappersTest < ActiveSupport::TestCase
     deprecator.deprecate_methods(@klass, old_method: :new_method)
 
     assert_deprecated(warning, deprecator) { assert_equal "abc", @klass.new.old_method }
+  end
+
+  def test_deprecate_methods_protected_method
+    ActiveSupport::Deprecation.deprecate_methods(@klass, old_protected_method: :new_protected_method)
+
+    assert(@klass.protected_method_defined?(:old_protected_method))
+  end
+
+  def test_deprecate_methods_private_method
+    ActiveSupport::Deprecation.deprecate_methods(@klass, old_private_method: :new_private_method)
+
+    assert(@klass.private_method_defined?(:old_private_method))
   end
 end


### PR DESCRIPTION
### Summary

This commit fixes `deprecate` so that it preserves method visibility (like it
did previously when it was utilizing `alias_method_chain`).

### Other Information

When Module#prepend replaced alias_method_chain in a982a42 it caused deprecated
methods to always become public.

`alias_method_chain` had this bit of code:
https://github.com/rails/rails/blob/v5.0.6/activesupport/lib/active_support/core_ext/module/aliasing.rb#L40-L47
which preserved method visibility.

Without this fix, a workaround would be:

```ruby
class C
  private

  def new_method
  end

  def old_method
  end
  deprecate :old_method, :new_method
  # workaround:
  instance_method(:old_method).owner.send(:private, :old_method)
end
```

Because the visibility needs to be fixed on the Module prepended by
MethodWrapper.

I originally noticed this issue while writing https://github.com/solidusio/solidus/pull/2449.