### PR TITLE
Provide instant feedback when booting Rails

### DIFF
--- a/activestorage/test/dummy/config/boot.rb
+++ b/activestorage/test/dummy/config/boot.rb
@@ -5,3 +5,7 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)
+
+if %w[s server c console].any? { |a| ARGV.include?(a) }
+  puts "=> Booting Rails"
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -2,3 +2,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+
+if %w[s server c console].any? { |a| ARGV.include?(a) }
+  puts "=> Booting Rails"
+end


### PR DESCRIPTION
Before:
![2017-12-13 16_46_35](https://user-images.githubusercontent.com/65950/33964140-721041fc-e025-11e7-9b25-9d839ce92977.gif)

After:
![2017-12-13 16_47_47](https://user-images.githubusercontent.com/65950/33964151-79e12f86-e025-11e7-93e9-7a75c70d408f.gif)

I've noticed during pair/mob programming sessions with peers that
despite the speed boosts provided by Bootsnap and Spring, there is a
noticeable latency between firing a bin/rails server command and any
feedback being provided to the console. Depending on the size of the
application this lack of feedback can make it seem like something is
wrong when Rails is simply busy initializing.

This change may seem gratuitous but by just printing one line to STDOUT
we're giving a clear signal to the Rails user that their command has
been received and that Rails is indeed booting. It almost imperciptibly
makes Rails feel more responsive.

Sure the code doesn't look very fancy but there's no other appropriate
place I could think of putting it than boot.rb.