### PR TITLE
Suppress `warning: BigDecimal.new is deprecated` in activerecord

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       #   store_listing = StoreListing.new(price_in_cents: '10.1')
       #
       #   # before
-      #   store_listing.price_in_cents # => BigDecimal.new(10.1)
+      #   store_listing.price_in_cents # => BigDecimal(10.1)
       #
       #   class StoreListing < ActiveRecord::Base
       #     attribute :price_in_cents, :integer

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/decimal.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/decimal.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       module OID # :nodoc:
         class Decimal < Type::Decimal # :nodoc:
           def infinity(options = {})
-            BigDecimal.new("Infinity") * (options[:negative] ? -1 : 1)
+            BigDecimal("Infinity") * (options[:negative] ? -1 : 1)
           end
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -44,6 +44,6 @@ class PostgresqlDomainTest < ActiveRecord::PostgreSQLTestCase
     record.price = "34.15"
     record.save!
 
-    assert_equal BigDecimal.new("34.15"), record.reload.price
+    assert_equal BigDecimal("34.15"), record.reload.price
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -33,8 +33,8 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_default
-    assert_equal BigDecimal.new("150.55"), PostgresqlMoney.column_defaults["depth"]
-    assert_equal BigDecimal.new("150.55"), PostgresqlMoney.new.depth
+    assert_equal BigDecimal("150.55"), PostgresqlMoney.column_defaults["depth"]
+    assert_equal BigDecimal("150.55"), PostgresqlMoney.new.depth
   end
 
   def test_money_values
@@ -65,7 +65,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     money = PostgresqlMoney.create(wealth: "987.65".dup)
     assert_equal 987.65, money.wealth
 
-    new_value = BigDecimal.new("123.45")
+    new_value = BigDecimal("123.45")
     money.wealth = new_value
     money.save!
     money.reload

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -134,10 +134,10 @@ _SQL
     end
 
     def test_numrange_values
-      assert_equal BigDecimal.new("0.1")..BigDecimal.new("0.2"), @first_range.num_range
-      assert_equal BigDecimal.new("0.1")...BigDecimal.new("0.2"), @second_range.num_range
-      assert_equal BigDecimal.new("0.1")...BigDecimal.new("Infinity"), @third_range.num_range
-      assert_equal BigDecimal.new("-Infinity")...BigDecimal.new("Infinity"), @fourth_range.num_range
+      assert_equal BigDecimal("0.1")..BigDecimal("0.2"), @first_range.num_range
+      assert_equal BigDecimal("0.1")...BigDecimal("0.2"), @second_range.num_range
+      assert_equal BigDecimal("0.1")...BigDecimal("Infinity"), @third_range.num_range
+      assert_equal BigDecimal("-Infinity")...BigDecimal("Infinity"), @fourth_range.num_range
       assert_nil @empty_range.num_range
     end
 
@@ -285,14 +285,14 @@ _SQL
 
     def test_create_numrange
       assert_equal_round_trip(@new_range, :num_range,
-                              BigDecimal.new("0.5")...BigDecimal.new("1"))
+                              BigDecimal("0.5")...BigDecimal("1"))
     end
 
     def test_update_numrange
       assert_equal_round_trip(@first_range, :num_range,
-                              BigDecimal.new("0.5")...BigDecimal.new("1"))
+                              BigDecimal("0.5")...BigDecimal("1"))
       assert_nil_round_trip(@first_range, :num_range,
-                            BigDecimal.new("0.5")...BigDecimal.new("0.5"))
+                            BigDecimal("0.5")...BigDecimal("0.5"))
     end
 
     def test_create_daterange

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -566,7 +566,7 @@ class DefaultsUsingMultipleSchemasAndDomainTest < ActiveRecord::PostgreSQLTestCa
   end
 
   def test_decimal_defaults_in_new_schema_when_overriding_domain
-    assert_equal BigDecimal.new("3.14159265358979323846"), Default.new.decimal_col, "Default of decimal column was not correctly parsed"
+    assert_equal BigDecimal("3.14159265358979323846"), Default.new.decimal_col, "Default of decimal column was not correctly parsed"
   end
 
   def test_bpchar_defaults_in_new_schema_when_overriding_domain

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -38,7 +38,7 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
   end
 
   def test_type_cast_bigdecimal
-    bd = BigDecimal.new "10.0"
+    bd = BigDecimal "10.0"
     assert_equal bd.to_f, @conn.type_cast(bd)
   end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
     test "nonexistent attribute" do
       data = OverloadedType.new(non_existent_decimal: 1)
 
-      assert_equal BigDecimal.new(1), data.non_existent_decimal
+      assert_equal BigDecimal(1), data.non_existent_decimal
       assert_raise ActiveRecord::UnknownAttributeError do
         UnoverloadedType.new(non_existent_decimal: 1)
       end

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -53,7 +53,7 @@ class DefaultNumbersTest < ActiveRecord::TestCase
 
   def test_default_decimal_number
     record = DefaultNumber.new
-    assert_equal BigDecimal.new("2.78"), record.decimal_number
+    assert_equal BigDecimal("2.78"), record.decimal_number
     assert_equal "2.78", record.decimal_number_before_type_cast
   end
 end

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -80,7 +80,7 @@ module ActiveRecord
           TestModel.delete_all
 
           # Now use the Rails insertion
-          TestModel.create wealth: BigDecimal.new("12345678901234567890.0123456789")
+          TestModel.create wealth: BigDecimal("12345678901234567890.0123456789")
 
           # SELECT
           row = TestModel.first
@@ -146,7 +146,7 @@ module ActiveRecord
 
           TestModel.create first_name: "bob", last_name: "bobsen",
             bio: "I was born ....", age: 18, height: 1.78,
-            wealth: BigDecimal.new("12345678901234567890.0123456789"),
+            wealth: BigDecimal("12345678901234567890.0123456789"),
             birthday: 18.years.ago, favorite_day: 10.days.ago,
             moment_of_truth: "1782-10-10 21:40:18", male: true
 
@@ -159,7 +159,7 @@ module ActiveRecord
           # Test for 30 significant digits (beyond the 16 of float), 10 of them
           # after the decimal place.
 
-          assert_equal BigDecimal.new("0012345678901234567890.0123456789"), bob.wealth
+          assert_equal BigDecimal("0012345678901234567890.0123456789"), bob.wealth
 
           assert_equal true, bob.male?
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       end
 
       def test_quote_bigdecimal
-        bigdec = BigDecimal.new((1 << 100).to_s)
+        bigdec = BigDecimal((1 << 100).to_s)
         assert_equal bigdec.to_s("F"), @quoter.quote(bigdec)
       end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -265,7 +265,7 @@ module ActiveRecord
     end
 
     def test_where_with_decimal_for_string_column
-      count = Post.where(title: BigDecimal.new(0)).count
+      count = Post.where(title: BigDecimal(0)).count
       assert_equal 0, count
     end
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -175,12 +175,12 @@ class ValidationsTest < ActiveRecord::TestCase
         ActiveModel::Name.new(self, nil, "Topic")
       end
       attribute :wibble, :decimal, scale: 2, precision: 9
-      validates_numericality_of :wibble, greater_than_or_equal_to: BigDecimal.new("97.18")
+      validates_numericality_of :wibble, greater_than_or_equal_to: BigDecimal("97.18")
     end
 
     assert_not klass.new(wibble: "97.179").valid?
     assert_not klass.new(wibble: 97.179).valid?
-    assert_not klass.new(wibble: BigDecimal.new("97.179")).valid?
+    assert_not klass.new(wibble: BigDecimal("97.179")).valid?
   end
 
   def test_acceptance_validator_doesnt_require_db_connection


### PR DESCRIPTION
### Summary

`BigDecimal.new` has been deprecated in BigDecimal 1.3.3
 which will be a default for Ruby 2.5.

Refer https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

```
$ cd rails/activerecord/
$ git grep -l BigDecimal.new | grep \.rb | xargs sed -i -e "s/BigDecimal.new/BigDecimal/g"
```

- Changes made only to Active Record. Will apply the same change to
other module once this commit is merged.

- The following deprecation has not been addressed because it has been
reported at `ActiveRecord::Result.new`. `ActiveRecord::Result.ancestors`
did not show `BigDecimal`.

* Not addressed

```ruby
/path/to/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:34:
warning: BigDecimal.new is deprecated
```

* database_statements.rb:34

```ruby
ActiveRecord::Result.new(result.fields, result.to_a) if result
```

* ActiveRecord::Result.ancestors

```ruby
[ActiveRecord::Result,
 Enumerable,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 Metaclass::ObjectMethods,
 Mocha::ObjectMethods,
 PP::ObjectMixin,
 ActiveSupport::Dependencies::Loadable,
 ActiveSupport::Tryable,
 JSON::Ext::Generator::GeneratorMethods::Object,
 Kernel,
 BasicObject]
```

### Other Information

This commit has been tested with these Ruby and BigDecimal versions

- ruby 2.5 and bigdecimal 1.3.3

```
$ ruby -v
ruby 2.5.0dev (2017-12-14 trunk 61217) [x86_64-linux]
$ gem list |grep bigdecimal
bigdecimal (default: 1.3.3, default: 1.3.2)
```

- ruby 2.4 and bigdecimal 1.3.0

```
$ ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux-gnu]
$ gem list |grep bigdecimal
bigdecimal (default: 1.3.0)
```

- ruby 2.3 and bigdecimal 1.2.8

```
$ ruby -v
ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
$ gem list |grep -i bigdecimal
bigdecimal (1.2.8)
```

- ruby 2.2 and bigdecimal 1.2.6
```
$ ruby -v
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
$ gem list |grep bigdecimal
bigdecimal (1.2.6)
```