### PR TITLE
Use released `resque-scheduler` instead of master version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "bootsnap", ">= 1.1.0", require: false
 # Active Job.
 group :job do
   gem "resque", require: false
-  gem "resque-scheduler", github: "resque/resque-scheduler", require: false
+  gem "resque-scheduler", require: false
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,16 +24,6 @@ GIT
       websocket
 
 GIT
-  remote: https://github.com/resque/resque-scheduler.git
-  revision: 284b862dd63967da1cf3a7e6abd9d2052067c8be
-  specs:
-    resque-scheduler (4.3.0)
-      mono_logger (~> 1.0)
-      redis (>= 3.3, < 5)
-      resque (~> 1.26)
-      rufus-scheduler (~> 3.2)
-
-GIT
   remote: https://github.com/robin850/sdoc.git
   revision: 0e340352f3ab2f196c8a8743f83c2ee286e4f71c
   branch: upgrade
@@ -393,6 +383,11 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-scheduler (4.3.1)
+      mono_logger (~> 1.0)
+      redis (>= 3.3, < 5)
+      resque (~> 1.26)
+      rufus-scheduler (~> 3.2)
     retriable (3.1.1)
     rubocop (0.51.0)
       parallel (~> 1.10)
@@ -543,7 +538,7 @@ DEPENDENCIES
   redis (~> 4.0)
   redis-namespace
   resque
-  resque-scheduler!
+  resque-scheduler
   rubocop (>= 0.47)
   sass-rails
   sdoc!


### PR DESCRIPTION
The v4.3.1 has already released that includes Redis 4.0 support.
https://github.com/resque/resque-scheduler/blob/master/CHANGELOG.md#431---2017-11-20