### PR TITLE
RedisCacheStore - Fix Default Error Handler

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -47,9 +47,11 @@ module ActiveSupport
         reconnect_attempts: 0,
       }
 
-      DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) {
-        logger.error { "RedisCacheStore: #{method} failed, returned #{returning.inspect}: #{e.class}: #{e.message}" } if logger
-      }
+      DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) do
+        if logger
+          logger.error { "RedisCacheStore: #{method} failed, returned #{returning.inspect}: #{exception.class}: #{exception.message}" }
+        end
+      end
 
       DELETE_GLOB_LUA = "for i, name in ipairs(redis.call('KEYS', ARGV[1])) do redis.call('DEL', name); end"
       private_constant :DELETE_GLOB_LUA


### PR DESCRIPTION
### Summary

Hello!

I noticed that there was a bug in `ActiveSupport::Cache::RedisCacheStore`'s `DEFAULT_ERROR_HANDLER` definition with respect to an invalid reference to the local variable `e`.

From the code, it's clear that this callback was supposed to reference the `exception` parameter to correctly log the error message.

I refactored the lambda into a `do/end` block to reduce line length - please let me know if this violates any internal code style conventions!

Thanks!
