### PR TITLE
Use weak references in descendants tracker

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use weak references in descendants tracker to allow anonymous subclasses to
+    be garbage collected.
+
+    *Edgars Beigarts*
+
 *   Update `ActiveSupport::Notifications::Instrumenter#instrument` to make
     passing a block optional. This will let users use
     `ActiveSupport::Notifications` messaging features outside of

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "weakref"
+
 module ActiveSupport
   # This module provides an internal implementation to track descendants
   # which is faster than iterating through ObjectSpace.
@@ -8,7 +10,8 @@ module ActiveSupport
 
     class << self
       def direct_descendants(klass)
-        @@direct_descendants[klass] || []
+        descendants = @@direct_descendants[klass]
+        descendants ? descendants.to_a : []
       end
 
       def descendants(klass)
@@ -34,15 +37,17 @@ module ActiveSupport
       # This is the only method that is not thread safe, but is only ever called
       # during the eager loading phase.
       def store_inherited(klass, descendant)
-        (@@direct_descendants[klass] ||= []) << descendant
+        (@@direct_descendants[klass] ||= DescendantsArray.new) << descendant
       end
 
       private
 
         def accumulate_descendants(klass, acc)
           if direct_descendants = @@direct_descendants[klass]
-            acc.concat(direct_descendants)
-            direct_descendants.each { |direct_descendant| accumulate_descendants(direct_descendant, acc) }
+            direct_descendants.each do |direct_descendant|
+              acc << direct_descendant
+              accumulate_descendants(direct_descendant, acc)
+            end
           end
         end
     end
@@ -58,6 +63,47 @@ module ActiveSupport
 
     def descendants
       DescendantsTracker.descendants(self)
+    end
+
+    # DescendantsArray is an array that contains weak references to classes.
+    class DescendantsArray # :nodoc:
+      include Enumerable
+
+      def initialize
+        @refs = []
+      end
+
+      def initialize_copy(orig)
+        @refs = @refs.dup
+      end
+
+      def <<(klass)
+        cleanup!
+        @refs << WeakRef.new(klass)
+      end
+
+      def each
+        @refs.each do |ref|
+          yield ref.__getobj__
+        rescue WeakRef::RefError
+        end
+      end
+
+      def refs_size
+        @refs.size
+      end
+
+      def cleanup!
+        @refs.delete_if { |ref| !ref.weakref_alive? }
+      end
+
+      def reject!
+        @refs.reject! do |ref|
+          yield ref.__getobj__
+        rescue WeakRef::RefError
+          true
+        end
+      end
     end
   end
 end

--- a/activesupport/test/descendants_tracker_test_cases.rb
+++ b/activesupport/test/descendants_tracker_test_cases.rb
@@ -27,6 +27,15 @@ module DescendantsTrackerTestCases
     assert_equal_sets [], Child2.descendants
   end
 
+  def test_descendants_with_garbage_collected_classes
+    1.times do
+      child_klass = Class.new(Parent)
+      assert_equal_sets [Child1, Grandchild1, Grandchild2, Child2, child_klass], Parent.descendants
+    end
+    GC.start
+    assert_equal_sets [Child1, Grandchild1, Grandchild2, Child2], Parent.descendants
+  end
+
   def test_direct_descendants
     assert_equal_sets [Child1, Child2], Parent.direct_descendants
     assert_equal_sets [Grandchild1, Grandchild2], Child1.direct_descendants


### PR DESCRIPTION
This PR will make descendants tracker use weak references ~~and weak map~~, so that unused subclasses (unused anonymous subclasses) can be garbage collected, for more details you can see #31395. /cc @matthewd

Ideally we would need `WeekKeyMap` and `WeekSet/WeekArray`~~, but the `ref` gem only provides `WeekKeyMap`~~.

Fixes #31395.

Benchmark results:

```
Original:
              Parent    352.629k (± 6.2%) i/s -      1.774M in   5.052777s
               Child    661.191k (± 6.6%) i/s -      3.329M in   5.062953s
          Grandchild      1.834M (± 5.0%) i/s -      9.151M in   5.001540s

           Class.new    348.889k (±29.5%) i/s -      1.443M in   5.070915s

Weak map (ref gem):
              Parent    131.917k (± 4.9%) i/s -    664.962k in   5.054227s
               Child    212.329k (±12.9%) i/s -      1.058M in   5.081918s
          Grandchild    848.726k (±14.1%) i/s -      4.152M in   5.013853s

           Class.new     75.910k (±29.9%) i/s -    280.782k in   5.172886s

Weak ref array:
              Parent    261.569k (± 6.5%) i/s -      1.314M in   5.045141s
               Child    510.892k (± 4.6%) i/s -      2.581M in   5.064146s
          Grandchild      1.813M (± 4.8%) i/s -      9.048M in   5.002708s

           Class.new      3.376k (±186.0%) i/s -      6.182k in   5.028783s
```

~~According to this class creation would be 4.5x times slower and `.descendants` calls would be 2.6x times slower. The performance could be improved by writing `WeekSet` and maybe improving `WeekKeyMap`.~~

Benchmark examples:
- https://gist.github.com/2bf37ac7b1b2ed1f57dc63e5682655db
- https://gist.github.com/c160f9cf698b5d5e31685deeb50b5cb3
