### PR TITLE
Add ability to add specify column null and default values from cli

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -467,8 +467,6 @@ the first time (i.e. on the date the migration is applied).
 Some adapters may support additional options; see the adapter specific API docs
 for further information.
 
-NOTE: `null` and `default` cannot be specified via command line.
-
 ### Foreign Keys
 
 While it's not required you might want to add foreign key constraints to

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -21,11 +21,12 @@ module Rails
           # could set it to :string
           has_index, type = type, nil if INDEX_OPTIONS.include?(type)
 
-          type, attr_options = *parse_type_and_options(type)
-          type = type.to_sym if type
+          attr_options = type ? parse_options(type) : {}
 
-          if type && reference?(type)
-            if UNIQ_INDEX_OPTIONS.include?(has_index)
+          if type
+            type = type.gsub(/\{.*}/, "").to_sym
+
+            if reference?(type) && UNIQ_INDEX_OPTIONS.include?(has_index)
               attr_options[:index] = { unique: true }
             end
           end
@@ -41,16 +42,10 @@ module Rails
 
         # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
         # when declaring options curly brackets should be used
-        def parse_type_and_options(type_with_options)
-          return unless type_with_options
-
+        def parse_options(type_with_options)
           options = parse_null_options(type_with_options)
           options = options.merge parse_default_options(type_with_options)
-          options = options.merge type_options(type_with_options)
-
-          type = type_with_options.gsub(/\{.*}/, "")
-
-          return type, options
+          options.merge type_options(type_with_options)
         end
 
         def parse_null_options(type)

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -41,19 +41,42 @@ module Rails
 
         # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
         # when declaring options curly brackets should be used
-        def parse_type_and_options(type)
+        def parse_type_and_options(type_with_options)
+          return unless type_with_options
+
+          options = parse_null_options(type_with_options)
+          options = options.merge parse_default_options(type_with_options)
+          options = options.merge type_options(type_with_options)
+
+          type = type_with_options.gsub(/\{.*}/, "")
+
+          return type, options
+        end
+
+        def parse_null_options(type)
+          matchdata = type.match(/null=(true|false)/)
+          return {} unless matchdata
+
+          null_value = "true" == matchdata.captures.first
+          { null:  null_value }
+        end
+
+        def parse_default_options(type)
+          matchdata = type.match(/default=([^,}]+)/)
+          matchdata ? { default:  matchdata.captures.first } : {}
+        end
+
+        def type_options(type)
           case type
-          when /(string|text|binary|integer)\{(\d+)\}/
-            return $1, limit: $2.to_i
-          when /decimal\{(\d+)[,.-](\d+)\}/
-            return :decimal, precision: $1.to_i, scale: $2.to_i
-          when /(references|belongs_to)\{(.+)\}/
-            type = $1
+          when /(string|text|binary|integer)\{(\d+)/
+            { limit: $2.to_i }
+          when /decimal\{(\d+)[,.-](\d+)/
+            { precision: $1.to_i, scale: $2.to_i }
+          when /(references|belongs_to)\{([^},]+)/
             provided_options = $2.split(/[,.-]/)
-            options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
-            return type, options
+            Hash[provided_options.map { |opt| [opt.to_sym, true] }]
           else
-            return type, {}
+            {}
           end
         end
       end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -151,4 +151,30 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert att.has_index?
     assert att.required?
   end
+
+  def test_parse_not_null_attribute
+    att = Rails::Generators::GeneratedAttribute.parse("name:string{null=false}")
+
+    assert_equal "name", att.name
+    assert_equal :string, att.type
+    refute att.attr_options[:null]
+  end
+
+  def test_parse_attribute_with_default
+    att = Rails::Generators::GeneratedAttribute.parse("count:integer{default=0}")
+
+    assert_equal "count", att.name
+    assert_equal :integer, att.type
+    assert_equal "0", att.attr_options[:default]
+  end
+
+  def test_parse_attribute_with_every_extra_option
+    att = Rails::Generators::GeneratedAttribute.parse("count:integer{1, default=0, null=false}:index")
+
+    assert_equal "count", att.name
+    assert_equal :integer, att.type
+    refute att.attr_options[:null]
+    assert_equal 1, att.attr_options[:limit]
+    assert_equal "0", att.attr_options[:default]
+  end
 end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -169,7 +169,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   end
 
   def test_parse_attribute_with_every_extra_option
-    att = Rails::Generators::GeneratedAttribute.parse("count:integer{1, default=0, null=false}:index")
+    att = Rails::Generators::GeneratedAttribute.parse("count:integer{1,default=0,null=false}:index")
 
     assert_equal "count", att.name
     assert_equal :integer, att.type

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -176,15 +176,25 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_add_migration_with_attributes_index_declaration_and_attribute_options
-    run_generator ["product", "title:string{40}:index", "content:string{255}", "price:decimal{5,2}:index", "discount:decimal{5,2}:uniq", "supplier:references{polymorphic}"]
+    columns = [
+      "title:string{40, null=false}:index",
+      "content:string{255}",
+      "price:decimal{5,2,default=0}:index",
+      "discount:decimal{5,2}:uniq",
+      "supplier:references{polymorphic}",
+      "manufacturer:belongs_to{required}"
+    ]
+
+    run_generator ["product", *columns]
 
     assert_migration "db/migrate/create_products.rb" do |content|
       assert_method :change, content do |up|
         assert_match(/create_table :products/, up)
-        assert_match(/t.string :title, limit: 40/, up)
+        assert_match(/t.string :title, limit: 40, null: false/, up)
         assert_match(/t.string :content, limit: 255/, up)
-        assert_match(/t.decimal :price, precision: 5, scale: 2/, up)
+        assert_match(/t.decimal :price, precision: 5, scale: 2, default: "0"/, up)
         assert_match(/t.references :supplier, polymorphic: true/, up)
+        assert_match(/t.belongs_to :manufacturer, null: false, foreign_key: true/, up)
       end
       assert_match(/add_index :products, :title/, content)
       assert_match(/add_index :products, :price/, content)


### PR DESCRIPTION
This PR adds ability to specify null and default values when generating migrations from command 
line.

I've implemented syntax like in a code below, using #15583 issue as a reference

```bash
rails g migration createPosts title:string{null=false} comments_count:integer{null=false,default=0}:index type:integer{1,default=1} 
```

P.S. I also removed note from ruby guides, but there are probably other API docs I need to change