### PR TITLE
Add headless browser support in api docs [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -69,6 +69,9 @@ module ActionDispatch
   # size of the browser screen. These two options are not applicable for
   # headless drivers and will be silently ignored if passed.
   #
+  # Headless browsers such as headless Chrome and headless Firefox are also supported.
+  # You can use these browsers by setting the +:using+ argument to +:headless_chrome+ or +:headless_firefox+.
+  #
   # To use a headless driver, like Poltergeist, update your Gemfile to use
   # Poltergeist instead of Selenium and then declare the driver name in the
   # +application_system_test_case.rb+ file. In this case, you would leave out


### PR DESCRIPTION
I noticed headless firefox support was added. Its mentioned in the guide that you can use headless firefox and headless chrome, but it's not as clear in the api docs. There is a mention of the use of these in the end of system_test_case.rb, but maybe it could deserve more explanation in the api documentation?

 