### PR TITLE
Suppress `warning: BigDecimal.new is deprecated` in Active Support

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -108,8 +108,8 @@ require "bigdecimal"
 class BigDecimal
   # BigDecimals are duplicable:
   #
-  #   BigDecimal.new("1.2").duplicable? # => true
-  #   BigDecimal.new("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  #   BigDecimal("1.2").duplicable? # => true
+  #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
   def duplicable?
     true
   end

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -36,7 +36,7 @@ module ActiveSupport
           return 0 if number.zero?
           digits = digit_count(number)
           multiplier = 10**(digits - precision)
-          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+          (number / BigDecimal(multiplier.to_f.to_s)).round * multiplier
         end
 
         def convert_to_decimal(number)

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -90,7 +90,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_hash_elements
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object>', xml.first(30)
@@ -173,7 +173,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_instruct
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: false, indent: 0)
 
     assert_match(/^<\?xml [^>]*/, xml)
@@ -183,7 +183,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_block
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: true, indent: 0) do |builder|
       builder.count 2
     end

--- a/activesupport/test/core_ext/bigdecimal_test.rb
+++ b/activesupport/test/core_ext/bigdecimal_test.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/big_decimal"
 
 class BigDecimalTest < ActiveSupport::TestCase
   def test_to_s
-    bd = BigDecimal.new "0.01"
+    bd = BigDecimal "0.01"
     assert_equal "0.01", bd.to_s
     assert_equal "+0.01", bd.to_s("+F")
     assert_equal "+0.0 1", bd.to_s("+1F")

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -8,16 +8,16 @@ require "active_support/core_ext/numeric/time"
 class DuplicableTest < ActiveSupport::TestCase
   if RUBY_VERSION >= "2.5.0"
     RAISE_DUP = [method(:puts)]
-    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
+    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
   elsif RUBY_VERSION >= "2.4.1"
     RAISE_DUP = [method(:puts), Complex(1), Rational(1)]
-    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3]
+    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3]
   elsif RUBY_VERSION >= "2.4.0"  # Due to 2.4.0 bug. This elsif cannot be removed unless we drop 2.4.0 support...
     RAISE_DUP = [method(:puts), Complex(1), Rational(1), "symbol_from_string".to_sym]
-    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3]
   else
     RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts), Complex(1), Rational(1)]
-    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56")]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56")]
   end
 
   def test_duplicable


### PR DESCRIPTION
### Summary

`BigDecimal.new` has been deprecated in BigDecimal 1.3.3
 which will be a default for Ruby 2.5.

Refer
https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

* This commit has been made as follows:

```ruby
$ cd activesupport/
$ git grep -l BigDecimal.new | grep \.rb | xargs sed -i -e "s/BigDecimal.new/BigDecimal/g"
$ git checkout -f test/xml_mini_test.rb
```

### Other Information

* This warning has not been addressed
```ruby
/path/to/rails/activesupport/test/xml_mini_test.rb:117: warning:
BigDecimal.new is deprecated
```
Because it would cause these syntax errors:

```ruby
$ bin/test test/xml_mini_test.rb
Traceback (most recent call last):
        7: from bin/test:5:in `<main>'
        6: from bin/test:5:in `require_relative'
        5: from /home/yahonda/git/rails/tools/test.rb:26:in `<top (required)>'
        4: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:39:in `run'
        3: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `load_tests'
        2: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `each'
        1: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
/home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:51:in `require': /home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:117: syntax error, unexpected '(', expecting ')' (SyntaxError)
...  @xml.to_tag(:b, ::BigDecimal("1.2"), @options)
...                              ^
/home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:117: syntax error, unexpected ')', expecting keyword_end
....to_tag(:b, ::BigDecimal("1.2"), @options)
...                              ^
/home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:355: syntax error, unexpected keyword_end, expecting end-of-input
$
```

* This commit has been tested with these Ruby versions:

```
ruby 2.5.0dev (2017-12-15 trunk 61262) [x86_64-linux]
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
```

