### PR TITLE
Address `warning: instance variable @hash_digest_class not initialized`

### DIFF
--- a/activesupport/lib/active_support/digest.rb
+++ b/activesupport/lib/active_support/digest.rb
@@ -4,7 +4,7 @@ module ActiveSupport
   class Digest #:nodoc:
     class <<self
       def hash_digest_class
-        @hash_digest_class || ::Digest::MD5
+        @hash_digest_class ||= ::Digest::MD5
       end
 
       def hash_digest_class=(klass)


### PR DESCRIPTION
### Summary
This pull request addresses this warning:

```ruby
$ cd activesupport
$ bundle exec rake test
... snip ...
/path/to/rails/activesupport/lib/active_support/digest.rb:7:
warning: instance variable @hash_digest_class not initialized
``
