### PR TITLE
Suppress `warning: BigDecimal.new is deprecated` in Active Model

### DIFF
--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -33,7 +33,7 @@ module ActiveModel
 
       assert_equal 2, data.integer_field
       assert_equal "Rails FTW", data.string_field
-      assert_equal BigDecimal.new("12.3"), data.decimal_field
+      assert_equal BigDecimal("12.3"), data.decimal_field
       assert_equal "default string", data.string_with_default
       assert_equal Date.new(2016, 1, 1), data.date_field
       assert_equal false, data.boolean_field

--- a/activemodel/test/cases/type/decimal_test.rb
+++ b/activemodel/test/cases/type/decimal_test.rb
@@ -7,22 +7,22 @@ module ActiveModel
     class DecimalTest < ActiveModel::TestCase
       def test_type_cast_decimal
         type = Decimal.new
-        assert_equal BigDecimal.new("0"), type.cast(BigDecimal.new("0"))
-        assert_equal BigDecimal.new("123"), type.cast(123.0)
-        assert_equal BigDecimal.new("1"), type.cast(:"1")
+        assert_equal BigDecimal("0"), type.cast(BigDecimal("0"))
+        assert_equal BigDecimal("123"), type.cast(123.0)
+        assert_equal BigDecimal("1"), type.cast(:"1")
       end
 
       def test_type_cast_decimal_from_invalid_string
         type = Decimal.new
         assert_nil type.cast("")
-        assert_equal BigDecimal.new("1"), type.cast("1ignore")
-        assert_equal BigDecimal.new("0"), type.cast("bad1")
-        assert_equal BigDecimal.new("0"), type.cast("bad")
+        assert_equal BigDecimal("1"), type.cast("1ignore")
+        assert_equal BigDecimal("0"), type.cast("bad1")
+        assert_equal BigDecimal("0"), type.cast("bad")
       end
 
       def test_type_cast_decimal_from_float_with_large_precision
         type = Decimal.new(precision: ::Float::DIG + 2)
-        assert_equal BigDecimal.new("123.0"), type.cast(123.0)
+        assert_equal BigDecimal("123.0"), type.cast(123.0)
       end
 
       def test_type_cast_from_float_with_unspecified_precision
@@ -48,7 +48,7 @@ module ActiveModel
       def test_type_cast_decimal_from_object_responding_to_d
         value = Object.new
         def value.to_d
-          BigDecimal.new("1")
+          BigDecimal("1")
         end
         type = Decimal.new
         assert_equal BigDecimal("1"), type.cast(value)

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -20,7 +20,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   INTEGER_STRINGS = %w(0 +0 -0 10 +10 -10 0090 -090)
   FLOATS = [0.0, 10.0, 10.5, -10.5, -0.0001] + FLOAT_STRINGS
   INTEGERS = [0, 10, -10] + INTEGER_STRINGS
-  BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal.new(bd) }
+  BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal(bd) }
   JUNK = ["not a number", "42 not a number", "0xdeadbeef", "0xinvalidhex", "0Xdeadbeef", "00-1", "--3", "+-3", "+3-1", "-+019.0", "12.12.13.12", "123\nnot a number"]
   INFINITY = [1.0 / 0.0]
 
@@ -81,10 +81,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_greater_than_using_differing_numeric_types
-    Topic.validates_numericality_of :approved, greater_than: BigDecimal.new("97.18")
+    Topic.validates_numericality_of :approved, greater_than: BigDecimal("97.18")
 
-    invalid!([-97.18, BigDecimal.new("97.18"), BigDecimal("-97.18")], "must be greater than 97.18")
-    valid!([97.19, 98, BigDecimal.new("98"), BigDecimal.new("97.19")])
+    invalid!([-97.18, BigDecimal("97.18"), BigDecimal("-97.18")], "must be greater than 97.18")
+    valid!([97.19, 98, BigDecimal("98"), BigDecimal("97.19")])
   end
 
   def test_validates_numericality_with_greater_than_using_string_value
@@ -102,10 +102,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_greater_than_or_equal_using_differing_numeric_types
-    Topic.validates_numericality_of :approved, greater_than_or_equal_to: BigDecimal.new("97.18")
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: BigDecimal("97.18")
 
-    invalid!([-97.18, 97.17, 97, BigDecimal.new("97.17"), BigDecimal.new("-97.18")], "must be greater than or equal to 97.18")
-    valid!([97.18, 98, BigDecimal.new("97.19")])
+    invalid!([-97.18, 97.17, 97, BigDecimal("97.17"), BigDecimal("-97.18")], "must be greater than or equal to 97.18")
+    valid!([97.18, 98, BigDecimal("97.19")])
   end
 
   def test_validates_numericality_with_greater_than_or_equal_using_string_value
@@ -123,10 +123,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_equal_to_using_differing_numeric_types
-    Topic.validates_numericality_of :approved, equal_to: BigDecimal.new("97.18")
+    Topic.validates_numericality_of :approved, equal_to: BigDecimal("97.18")
 
     invalid!([-97.18], "must be equal to 97.18")
-    valid!([BigDecimal.new("97.18")])
+    valid!([BigDecimal("97.18")])
   end
 
   def test_validates_numericality_with_equal_to_using_string_value
@@ -144,10 +144,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_less_than_using_differing_numeric_types
-    Topic.validates_numericality_of :approved, less_than: BigDecimal.new("97.18")
+    Topic.validates_numericality_of :approved, less_than: BigDecimal("97.18")
 
-    invalid!([97.18, BigDecimal.new("97.18")], "must be less than 97.18")
-    valid!([-97.0, 97.0, -97, 97, BigDecimal.new("-97"), BigDecimal.new("97")])
+    invalid!([97.18, BigDecimal("97.18")], "must be less than 97.18")
+    valid!([-97.0, 97.0, -97, 97, BigDecimal("-97"), BigDecimal("97")])
   end
 
   def test_validates_numericality_with_less_than_using_string_value
@@ -165,10 +165,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_numericality_with_less_than_or_equal_to_using_differing_numeric_types
-    Topic.validates_numericality_of :approved, less_than_or_equal_to: BigDecimal.new("97.18")
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: BigDecimal("97.18")
 
     invalid!([97.19, 98], "must be less than or equal to 97.18")
-    valid!([-97.18, BigDecimal.new("-97.18"), BigDecimal.new("97.18")])
+    valid!([-97.18, BigDecimal("-97.18"), BigDecimal("97.18")])
   end
 
   def test_validates_numericality_with_less_than_or_equal_using_string_value


### PR DESCRIPTION
### Summary

`BigDecimal.new` has been deprecated in BigDecimal 1.3.3
 which will be a default for Ruby 2.5.

Refer ruby/bigdecimal@5337373

* This commit has been made as follows:

```ruby
$ cd activemodel/
$ git grep -l BigDecimal.new | grep \.rb | xargs sed -i -e "s/BigDecimal.new/BigDecimal/g"
```

* This commit has been tested with these Ruby versions:

```
ruby 2.5.0dev (2017-12-15 trunk 61262) [x86_64-linux]
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
```
