### PR TITLE
Suppress expected exceptions by `report_on_exception` = `false` in mysql2 test

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/transaction_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test.rb
@@ -13,6 +13,7 @@ module ActiveRecord
 
     setup do
       @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
+      Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
 
       @connection = ActiveRecord::Base.connection
       @connection.clear_cache!
@@ -31,6 +32,7 @@ module ActiveRecord
       @connection.drop_table "samples", if_exists: true
 
       Thread.abort_on_exception = @abort
+      Thread.report_on_exception = @original_report_on_exception if Thread.respond_to?(:report_on_exception)
     end
 
     test "raises Deadlocked when a deadlock is encountered" do


### PR DESCRIPTION
### Summary

Follow up #31428 to address similar exceptions with mysql2 adapter
This pull request suppresses this expected trace.

```ruby
$ ruby -v
ruby 2.5.0dev (2017-12-15 trunk 61262) [x86_64-linux]
$ cd rails/activerecord
$ ARCONN=mysql2 bundle exec ruby -Itest test/cases/adapters/mysql2/transaction_test.rb
Using mysql2
Run options: --seed 45921

# Running:

#<Thread:0x0000555666eead88@test/cases/adapters/mysql2/transaction_test.rb:43 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        58: from test/cases/adapters/mysql2/transaction_test.rb:44:in `block (3 levels) in <class:Mysql2TransactionTest>'
        57: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        56: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `transaction'
        55: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:227:in `within_new_transaction'
        54: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
        53: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:230:in `block in within_new_transaction'
        52: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `block in transaction'
        51: from test/cases/adapters/mysql2/transaction_test.rb:47:in `block (4 levels) in <class:Mysql2TransactionTest>'
        50: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:418:in `update'
        49: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:383:in `with_transaction_returning_status'
        48: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        47: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:252:in `transaction'
        46: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:386:in `block in with_transaction_returning_status'
        45: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:420:in `block in update'
        44: from /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:44:in `save'
        43: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:309:in `save'
        42: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:325:in `rollback_active_record_state!'
        41: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:310:in `block in save'
        40: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:383:in `with_transaction_returning_status'
        39: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
        38: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:252:in `transaction'
        37: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:386:in `block in with_transaction_returning_status'
        36: from /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:310:in `block (2 levels) in save'
        35: from /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:46:in `save'
        34: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:264:in `save'
        33: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `create_or_update'
        32: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:816:in `_run_save_callbacks'
        31: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:98:in `run_callbacks'
        30: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:338:in `block in create_or_update'
        29: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:701:in `create_or_update'
        28: from /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:107:in `_update_record'
        27: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:346:in `_update_record'
        26: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:816:in `_run_update_callbacks'
        25: from /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:132:in `run_callbacks'
        24: from /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:346:in `block in _update_record'
        23: from /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:133:in `_update_record'
        22: from /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:81:in `_update_record'
        21: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:713:in `_update_record'
        20: from /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:197:in `_update_record'
        19: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:21:in `update'
        18: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:157:in `update'
        17: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:45:in `exec_delete'
        16: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:196:in `execute_and_free'
        15: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:28:in `execute'
        14: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:185:in `execute'
        13: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:561:in `log'
        12: from /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
        11: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:570:in `block in log'
        10: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
         9: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `block (2 levels) in log'
         8: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:186:in `block in execute'
         7: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
         6: from /home/yahonda/git/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
         5: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
         4: from /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:187:in `block (2 levels) in execute'
         3: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/mysql2-0.4.9/lib/mysql2/client.rb:119:in `query'
         2: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/mysql2-0.4.9/lib/mysql2/client.rb:119:in `handle_interrupt'
         1: from /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/mysql2-0.4.9/lib/mysql2/client.rb:120:in `block in query'
/home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/mysql2-0.4.9/lib/mysql2/client.rb:120:in `_query': Mysql2::Error: Deadlock found when trying to get lock; try restarting transaction: UPDATE `samples` SET `value` = 1 WHERE `samples`.`id` = 2 (ActiveRecord::Deadlocked)
.. ..

Finished in 2.668103s, 1.4992 runs/s, 1.4992 assertions/s.
4 runs, 4 assertions, 0 failures, 0 errors, 0 skips
$
```

This exception is also reported at https://travis-ci.org/rails/rails/jobs/316552949