### PR TITLE
Suppress `warning: BigDecimal.new is deprecated` in Active Job

### DIFF
--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -12,7 +12,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   [ nil, 1, 1.0, 1_000_000_000_000_000_000_000,
-    "a", true, false, BigDecimal.new(5),
+    "a", true, false, BigDecimal(5),
     [ 1, "a" ],
     { "a" => 1 }
   ].each do |arg|


### PR DESCRIPTION

### Summary

`BigDecimal.new` has been deprecated in BigDecimal 1.3.3
 which will be a default for Ruby 2.5.

Refer ruby/bigdecimal@5337373

* This commit suppresses this warning:

```ruby
$ bundle exec ruby -w -Itest test/cases/argument_serialization_test.rb
Using inline
test/cases/argument_serialization_test.rb:15: warning: BigDecimal.new is deprecated
Run options: --seed 40402

.......................

Finished in 0.042038s, 547.1180 runs/s, 927.7219 assertions/s.
23 runs, 39 assertions, 0 failures, 0 errors, 0 skips
$
```

* This commit has been made as follows:
```
cd activejob/
git grep -l BigDecimal.new | grep \.rb | xargs sed -i -e "s/BigDecimal.new/BigDecimal/g"
```

* This commit has been tested with these Ruby versions:

```
ruby 2.5.0dev (2017-12-15 trunk 61262) [x86_64-linux]
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
ruby 2.3.5p376 (2017-09-14 revision 59905) [x86_64-linux]
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
```
