### PR TITLE
Suppress `warning: BigDecimal.new is deprecated`

### DIFF
--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -59,7 +59,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
 
   test "key: permitted scalar values" do
     values  = ["a", :a, nil]
-    values += [0, 1.0, 2**128, BigDecimal.new(1)]
+    values += [0, 1.0, 2**128, BigDecimal(1)]
     values += [true, false]
     values += [Date.today, Time.now, DateTime.now]
     values += [STDOUT, StringIO.new, ActionDispatch::Http::UploadedFile.new(tempfile: __FILE__),

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -747,19 +747,19 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
-    @post.secret = BigDecimal.new(0)
+    @post.secret = BigDecimal(0)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
-    @post.secret = BigDecimal.new(1)
+    @post.secret = BigDecimal(1)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
-    @post.secret = BigDecimal.new(2.2, 1)
+    @post.secret = BigDecimal(2.2, 1)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -316,18 +316,18 @@ class TagHelperTest < ActionView::TestCase
   def test_data_attributes
     ["data", :data].each { |data|
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
-        tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+        tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
-        tag.a(data: { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+        tag.a(data: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
     }
   end
 
   def test_aria_attributes
     ["aria", :aria].each { |aria|
       assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-        tag("a", aria => { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+        tag("a", aria => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
       assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-        tag.a(aria: { a_float: 3.14, a_big_decimal: BigDecimal.new("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+        tag.a(aria: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
     }
   end
 

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -12,7 +12,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   [ nil, 1, 1.0, 1_000_000_000_000_000_000_000,
-    "a", true, false, BigDecimal.new(5),
+    "a", true, false, BigDecimal(5),
     [ 1, "a" ],
     { "a" => 1 }
   ].each do |arg|

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -108,8 +108,8 @@ require "bigdecimal"
 class BigDecimal
   # BigDecimals are duplicable:
   #
-  #   BigDecimal.new("1.2").duplicable? # => true
-  #   BigDecimal.new("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  #   BigDecimal("1.2").duplicable? # => true
+  #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
   def duplicable?
     true
   end

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -36,7 +36,7 @@ module ActiveSupport
           return 0 if number.zero?
           digits = digit_count(number)
           multiplier = 10**(digits - precision)
-          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+          (number / BigDecimal(multiplier.to_f.to_s)).round * multiplier
         end
 
         def convert_to_decimal(number)

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -90,7 +90,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_hash_elements
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object>', xml.first(30)
@@ -173,7 +173,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_instruct
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: false, indent: 0)
 
     assert_match(/^<\?xml [^>]*/, xml)
@@ -183,7 +183,7 @@ class ToXmlTest < ActiveSupport::TestCase
   def test_to_xml_with_block
     xml = [
       { name: "David", age: 26, age_in_millis: 820497600000 },
-      { name: "Jason", age: 31, age_in_millis: BigDecimal.new("1.0") }
+      { name: "Jason", age: 31, age_in_millis: BigDecimal("1.0") }
     ].to_xml(skip_instruct: true, indent: 0) do |builder|
       builder.count 2
     end

--- a/activesupport/test/core_ext/bigdecimal_test.rb
+++ b/activesupport/test/core_ext/bigdecimal_test.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/big_decimal"
 
 class BigDecimalTest < ActiveSupport::TestCase
   def test_to_s
-    bd = BigDecimal.new "0.01"
+    bd = BigDecimal "0.01"
     assert_equal "0.01", bd.to_s
     assert_equal "+0.01", bd.to_s("+F")
     assert_equal "+0.0 1", bd.to_s("+1F")

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -8,16 +8,16 @@ require "active_support/core_ext/numeric/time"
 class DuplicableTest < ActiveSupport::TestCase
   if RUBY_VERSION >= "2.5.0"
     RAISE_DUP = [method(:puts)]
-    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
+    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
   elsif RUBY_VERSION >= "2.4.1"
     RAISE_DUP = [method(:puts), Complex(1), Rational(1)]
-    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3]
+    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3]
   elsif RUBY_VERSION >= "2.4.0"  # Due to 2.4.0 bug. This elsif cannot be removed unless we drop 2.4.0 support...
     RAISE_DUP = [method(:puts), Complex(1), Rational(1), "symbol_from_string".to_sym]
-    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3]
   else
     RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts), Complex(1), Rational(1)]
-    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56")]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56")]
   end
 
   def test_duplicable

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -114,7 +114,7 @@ module XmlMiniTest
     end
 
     test "#to_tag accepts decimal types" do
-      @xml.to_tag(:b, ::BigDecimal.new("1.2"), @options)
+      @xml.to_tag(:b, BigDecimal("1.2"), @options)
       assert_xml("<b type=\"decimal\">1.2</b>")
     end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1978,19 +1978,19 @@ Extensions to `BigDecimal`
 The method `to_s` provides a default specifier of "F". This means that a simple call to `to_s` will result in floating point representation instead of engineering notation:
 
 ```ruby
-BigDecimal.new(5.00, 6).to_s       # => "5.0"
+BigDecimal(5.00, 6).to_s       # => "5.0"
 ```
 
 and that symbol specifiers are also supported:
 
 ```ruby
-BigDecimal.new(5.00, 6).to_s(:db)  # => "5.0"
+BigDecimal(5.00, 6).to_s(:db)  # => "5.0"
 ```
 
 Engineering notation is still supported:
 
 ```ruby
-BigDecimal.new(5.00, 6).to_s("e")  # => "0.5E1"
+BigDecimal(5.00, 6).to_s("e")  # => "0.5E1"
 ```
 
 Extensions to `Enumerable`


### PR DESCRIPTION
### Summary

Suppress `warning: BigDecimal.new is deprecated` in Action Pack, Active Job, Active Model, Active Support and guides

`BigDecimal.new` has been deprecated in BigDecimal 1.3.3
 which will be a default for Ruby 2.5.

Refer
https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503

* This commit has been made as follows:

```
cd rails
git grep -l BigDecimal.new | grep -v guides/source/5_0_release_notes.md | grep -v activesupport/test/xml_mini_test.rb | xargs sed -i -e "s/BigDecimal.new/BigDecimal/g"
```

Excluded these two files.

- activesupport/test/xml_mini_test.rb

It would cause these errors:
```ruby
$ cd activesupport
$ bin/test test/xml_mini_test.rb
Traceback (most recent call last):
        7: from bin/test:5:in `<main>'
        6: from bin/test:5:in `require_relative'
        5: from /home/yahonda/git/rails/tools/test.rb:26:in `<top (required)>'
        4: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:39:in `run'
        3: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `load_tests'
        2: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `each'
        1: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
/home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:51:in `require': /home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:117: syntax error, unexpected '(', expecting ')' (SyntaxError)
...  @xml.to_tag(:b, ::BigDecimal("1.2"), @options)
...                              ^
/home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:117: syntax error, unexpected ')', expecting keyword_end
....to_tag(:b, ::BigDecimal("1.2"), @options)
...                              ^
/home/yahonda/git/rails/activesupport/test/xml_mini_test.rb:355: syntax error, unexpected keyword_end, expecting end-of-input
$
```

- guides/source/5_0_release_notes.md
This is a Rails 5.0 release notes.
