### PR TITLE
Generate tmpname on its own

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -380,7 +380,7 @@ class ForkingExecutor
   def initialize(size)
     @size  = size
     @queue = Server.new
-    file   = File.join Dir.tmpdir, Dir::Tmpname.make_tmpname("rails-tests", "fd")
+    file   = File.join Dir.tmpdir, tmpname
     @url   = "drbunix://#{file}"
     @pool  = nil
     DRb.start_service @url, @queue
@@ -421,6 +421,11 @@ class ForkingExecutor
           Minitest::UnexpectedError.new ex
         end
       }
+    end
+
+    def tmpname
+      t = Time.now.strftime("%Y%m%d")
+      "rails-tests-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}-fd"
     end
 end
 


### PR DESCRIPTION
`make_tmpname` was removed by https://github.com/ruby/ruby/commit/25d56ea7b7b52dc81af30c92a9a0e2d2dab6ff27.
In this case, we want a file name, not a `File`. So cannot use `Tempfile`.

Fixes #31458
