### PR TITLE
[ci skip] Update guide index for active storage

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -84,6 +84,10 @@
       url: active_job_basics.html
       description: This guide provides you with all you need to get started creating, enqueuing, and executing background jobs.
     -
+      name: Active Storage
+      url: active_storage_overview.html
+      description: This guide covers how to attach files to your Active Record models.
+    -
       name: Testing Rails Applications
       url: testing.html
       description: This is a rather comprehensive guide to the various testing facilities in Rails. It covers everything from 'What is a test?' to Integration Testing. Enjoy.


### PR DESCRIPTION
### Summary

* Add `active_storage_overview.html` link to an index page of guide.

### Screenshot

I've confirmed after `rake guides:generate:html`

![image](https://user-images.githubusercontent.com/15371677/34026651-d562afee-e19a-11e7-85bf-774cf5f5fc02.png)