### PR TITLE
Fix guide generation error [ci skip]

### DIFF
--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -151,15 +151,6 @@ ToDo
 
 ToDo
 
-Active Storage
---------------
-
-Please refer to the [Changelog][active-support] for detailed changes.
-
-### Notable changes
-
-ToDo
-
 Active Support
 --------------
 
@@ -205,6 +196,5 @@ framework it is. Kudos to all of them.
 [action-cable]:   https://github.com/rails/rails/blob/5-2-stable/actioncable/CHANGELOG.md
 [active-record]:  https://github.com/rails/rails/blob/5-2-stable/activerecord/CHANGELOG.md
 [active-model]:   https://github.com/rails/rails/blob/5-2-stable/activemodel/CHANGELOG.md
-[active-storage]: https://github.com/rails/rails/blob/5-2-stable/activestorage/CHANGELOG.md
 [active-support]: https://github.com/rails/rails/blob/5-2-stable/activesupport/CHANGELOG.md
 [active-job]:     https://github.com/rails/rails/blob/5-2-stable/activejob/CHANGELOG.md


### PR DESCRIPTION
Currently, generation of guide is an error in `5_2_release_notes.html`.

```
$ bunele exec rake guides:generate:html
Generating 5_2_release_notes.md as 5_2_release_notes.html
rails/guides/rails_guides/markdown.rb:44:in `dom_id': undefined method `[]' for nil:NilClass (NoMethodError)
	from rails/guides/rails_guides/markdown.rb:106:in `block (2 levels) in generate_structure'
```

It seems that it is an error because there are multiple `active-storage` anchors.

Since Active Storage is a Major feature, it is unnecessary to show CHANGELOGs, so remove from `Incompatibilities` section.

