### PR TITLE
[ci skip] Inherit ActiveRecord::Base in example codes

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -232,7 +232,7 @@ module ActiveRecord
   #
   # For example:
   #
-  #   class Topic
+  #   class Topic < ActiveRecord::Base
   #     has_many :children
   #
   #     after_save :log_children
@@ -257,7 +257,7 @@ module ActiveRecord
   #
   # For example:
   #
-  #   class Topic
+  #   class Topic < ActiveRecord::Base
   #     has_many :children
   #
   #     after_commit :log_children


### PR DESCRIPTION
### Summary

* It seems AR models, but there are not inheriting AR::Base. So I've fixed them.