### PR TITLE
Modify test to correctly pass attributes hash

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -353,12 +353,13 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_create_columns_not_equal_attributes
     topic = Topic.instantiate(
-      "attributes" => {
-        "title"          => "Another New Topic",
-        "does_not_exist" => "test"
-      }
+      "title"          => "Another New Topic",
+      "does_not_exist" => "test"
     )
+    topic = topic.dup # reset @new_record
     assert_nothing_raised { topic.save }
+    assert topic.persisted?
+    assert_equal "Another New Topic", topic.reload.title
   end
 
   def test_create_through_factory_with_block
@@ -405,6 +406,8 @@ class PersistenceTest < ActiveRecord::TestCase
     topic_reloaded = Topic.instantiate(topic.attributes.merge("does_not_exist" => "test"))
     topic_reloaded.title = "A New Topic"
     assert_nothing_raised { topic_reloaded.save }
+    assert topic_reloaded.persisted?
+    assert_equal "A New Topic", topic_reloaded.reload.title
   end
 
   def test_update_for_record_with_only_primary_key


### PR DESCRIPTION
`instantiate` takes as its first argument an attributes hash, but the test is passing the attributes hash nested under a string key named `"attributes"`. As a result, the test is not actually testing what it says it is testing.