### PR TITLE
Undefine attribute methods of descendants when resetting column information

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Undefine attribute methods on descendants when resetting column
+    information.
+
+    *Chris Salzberg*
+
 *   Log database query callers
 
     Add `verbose_query_logs` configuration option to display the caller

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -425,7 +425,7 @@ module ActiveRecord
       #  end
       def reset_column_information
         connection.clear_cache!
-        undefine_attribute_methods
+        ([self] + descendants).each(&:undefine_attribute_methods)
         connection.schema_cache.clear_data_source_cache!(table_name)
 
         reload_schema_from_cache

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1106,13 +1106,18 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_reset_column_information_resets_children
-    child = Class.new(Topic)
-    child.new # force schema to load
+    child_class = Class.new(Topic)
+    child_class.new # force schema to load
 
     ActiveRecord::Base.connection.add_column(:topics, :foo, :string)
     Topic.reset_column_information
 
-    assert_equal "bar", child.new(foo: :bar).foo
+    # this should redefine attribute methods
+    child_class.new
+
+    assert child_class.instance_methods.include?(:foo)
+    assert child_class.instance_methods.include?(:foo_changed?)
+    assert_equal "bar", child_class.new(foo: :bar).foo
   ensure
     ActiveRecord::Base.connection.remove_column(:topics, :foo)
     Topic.reset_column_information


### PR DESCRIPTION
I'm not quite sure if this is the right solution, but while looking through these tests I notice that the test checking that "reset column information resets children" is not really correct. I've modified the test to show that it fails in the sense that when column information is changed on the parent, the child does not reset its attribute methods, and thus although the (current) test passes, the method is actually falling through to `method_missing`, which I don't believe it should do.

My fix is to undefine attribute methods on all descendants when they are undefined on the parent, which passes this and other tests. But mostly I'd just like to clarify the expected behaviour.