### PR TITLE
Clarify docs for delegate :allow_nil option

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -115,11 +115,8 @@ class Module
   #   invoice.customer_address # => 'Vimmersvej 13'
   #
   # If the target is +nil+ and does not respond to the delegated method a
-  # +Module::DelegationError+ is raised, as with any other value. Sometimes,
-  # however, it makes sense to be robust to that situation and that is the
-  # purpose of the <tt>:allow_nil</tt> option: If the target is not +nil+, or it
-  # is and responds to the method, everything works as usual. But if it is +nil+
-  # and does not respond to the delegated method, +nil+ is returned.
+  # +Module::DelegationError+ is raised. If you wish to instead return +nil+,
+  # use the <tt>:allow_nil</tt> option.
   #
   #   class User < ActiveRecord::Base
   #     has_one :profile


### PR DESCRIPTION
### Summary

Small documentation update with the expressed goal of making it easier to grok the purpose of the `:allow_nil` option of the `delegate` method.

I hope this helps! Happy to iterate on wording if there are further improvements to make ❤️ 
