### PR TITLE
[ci skip] Use :amazon, not :s3, so that guides reflect the current code

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -46,7 +46,7 @@ the migration is generated automatically.
 
 Declare Active Storage services in `config/storage.yml`. For each service your
 application uses, provide a name and the requisite configuration. The example
-below declares three services named `local`, `test`, and `s3`:
+below declares three services named `local`, `test`, and `amazon`:
 
 ```yaml
 local:
@@ -57,7 +57,7 @@ test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
 
-s3:
+amazon:
   service: S3
   access_key_id: ""
   secret_access_key: ""
@@ -75,12 +75,12 @@ development environment, you would add the following to
 config.active_storage.service = :local
 ```
 
-To use the s3 service in production, you add the following to
+To use the Amazon S3 service in production, you add the following to
 `config/environments/production.rb`:
 
 ```ruby
-# Store files in S3.
-config.active_storage.service = :s3
+# Store files on Amazon S3.
+config.active_storage.service = :amazon
 ```
 
 Continue reading for more information on the built-in service adapters (e.g.
@@ -101,7 +101,7 @@ local:
 Declare an S3 service in `config/storage.yml`:
 
 ``` yaml
-s3:
+amazon:
   service: S3
   access_key_id: ""
   secret_access_key: ""


### PR DESCRIPTION
The [template](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt#L10) that generates the `config/storage.yml` file has the Amazon S3 key specified as `:amazon`, not `:s3`.

The guides should reflect the nomenclature, given that every other service also has the name of the company as the key (:google, :microsoft).
