### PR TITLE
Provide access to MemCacheStore's internal client

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Provide access to MemCacheStore's internal client. Now additional directly
+    unsupported methods can be accessed through it.
+
+    ```
+    Rails.cache.mem_cache.reset_stats
+    ```
+
+    *fatkodima*
+
 *   Support hash as first argument in `assert_difference`. This allows to specify multiple
     numeric differences in the same assertion.
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -33,7 +33,6 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
     @cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, expires_in: 60)
     @peek = ActiveSupport::Cache.lookup_store(:mem_cache_store)
-    @data = @cache.instance_variable_get(:@data)
     @cache.clear
     @cache.silence!
     @cache.logger = ActiveSupport::Logger.new(File::NULL)
@@ -122,7 +121,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   def test_increment_expires_in
     cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, raw: true)
     cache.clear
-    assert_called_with cache.instance_variable_get(:@data), :incr, [ "foo", 1, 60 ] do
+    assert_called_with cache.mem_cache, :incr, [ "foo", 1, 60 ] do
       cache.increment("foo", 1, expires_in: 60)
     end
   end
@@ -130,7 +129,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   def test_decrement_expires_in
     cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, raw: true)
     cache.clear
-    assert_called_with cache.instance_variable_get(:@data), :decr, [ "foo", 1, 60 ] do
+    assert_called_with cache.mem_cache, :decr, [ "foo", 1, 60 ] do
       cache.decrement("foo", 1, expires_in: 60)
     end
   end


### PR DESCRIPTION
Now additional features can be used without directly implementing it in store's class itself.
For example, to reset memcache's statistics, get versions, etc.
Btw, `RedisCacheStore` already [does it](http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html#method-i-redis). 