### PR TITLE
Add `skip_bootsnap` option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -84,6 +84,9 @@ module Rails
         class_option :skip_system_test,    type: :boolean, default: false,
                                            desc: "Skip system test files"
 
+        class_option :skip_bootsnap,       type: :boolean, default: false,
+                                           desc: "Skip bootsnap gem"
+
         class_option :dev,                 type: :boolean, default: false,
                                            desc: "Setup the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -433,6 +436,10 @@ module Rails
 
       def depend_on_listen?
         !options[:skip_listen] && os_supports_listen_out_of_the_box?
+      end
+
+      def depend_on_bootsnap?
+        !options[:skip_bootsnap]
       end
 
       def os_supports_listen_out_of_the_box?

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -29,9 +29,11 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+<% if depend_on_bootsnap? -%>
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+<%- end -%>
 <%- if options.api? -%>
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,7 +1,9 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+<% if depend_on_bootsnap? -%>
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+<%- end -%>
 
 if %w[s server c console].any? { |a| ARGV.include?(a) }
   puts "=> Booting Rails"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -792,6 +792,26 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_bootsnap
+    run_generator
+
+    assert_gem "bootsnap"
+    assert_file "config/boot.rb" do |content|
+      assert_match(/require 'bootsnap\/setup'/, content)
+    end
+  end
+
+  def test_skip_bootsnap
+    run_generator [destination_root, "--skip-bootsnap"]
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/bootsnap/, content)
+    end
+    assert_file "config/boot.rb" do |content|
+      assert_no_match(/require 'bootsnap\/setup'/, content)
+    end
+  end
+
   def test_inclusion_of_ruby_version
     run_generator
 


### PR DESCRIPTION
`bootsnap` is a useful gem normally. However, `bootsnap` is unnecessary when generating a Rails application to be used only for testing. 
So I want to control whether use this or not by option.

