### PR TITLE
Don't include ellipsis in truncated digest output

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,7 @@
-*   Introduced `ActiveSupport::Digest` that allows to specify hash function implementation
-    and defaults to `Digest::MD5`.
+*   Allow the hash function used to generate non-sensitive digests, such as the
+    ETag header, to be specified with `config.active_support.hash_digest_class`.
 
-    Replaced calls to `::Digest::MD5.hexdigest` with calls to `ActiveSupport::Digest.hexdigest`.
+    The object provided must respond to `#hexdigest`, e.g. `Digest::SHA1`.
 
     *Dmitri Dolguikh*
  

--- a/activesupport/lib/active_support/digest.rb
+++ b/activesupport/lib/active_support/digest.rb
@@ -13,16 +13,8 @@ module ActiveSupport
       end
 
       def hexdigest(arg)
-        new.hexdigest(arg)
+        hash_digest_class.hexdigest(arg)[0...32]
       end
-    end
-
-    def initialize(digest_class: nil)
-      @digest_class = digest_class || self.class.hash_digest_class
-    end
-
-    def hexdigest(arg)
-      @digest_class.hexdigest(arg).truncate(32)
     end
   end
 end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -68,9 +68,9 @@ module ActiveSupport
     end
 
     initializer "active_support.set_hash_digest_class" do |app|
-      if app.config.active_support.respond_to?(:use_hash_digest_class) && app.config.active_support.use_hash_digest_class
+      if app.config.active_support.respond_to?(:hash_digest_class) && app.config.active_support.hash_digest_class
         ActiveSupport::Digest.hash_digest_class =
-          app.config.active_support.use_hash_digest_class
+          app.config.active_support.hash_digest_class
       end
     end
   end

--- a/activesupport/test/digest_test.rb
+++ b/activesupport/test/digest_test.rb
@@ -16,7 +16,7 @@ class DigestTest < ActiveSupport::TestCase
     digest = ActiveSupport::Digest.hexdigest("hello friend")
 
     assert_equal 32, digest.length
-    assert_equal ::Digest::SHA1.hexdigest("hello friend").truncate(32), digest
+    assert_equal ::Digest::SHA1.hexdigest("hello friend")[0...32], digest
   ensure
     ActiveSupport::Digest.hash_digest_class = original_hash_digest_class
   end


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/31289.

Using `truncate` to limit the length of the digest has the unwanted side effect of adding an ellipsis when the input is longer than the limit.

Also:
 - Don't instantiate a new object for every digest
 - Rename the configuration option to `hash_digest_class`
 - Update the CHANGELOG entry to describe how to use the feature