### PR TITLE
Fix .ruby-version doesn't match ruby version other than stable version

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= RUBY_VERSION -%>
+<%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || RUBY_VERSION -%>


### PR DESCRIPTION
If you use ruby 2.5.0-rc1 with rbenv and do `rails new`, .ruby-version becomes "2.5.0". But it should be "2.5.0-rc1" so any `bundle exec` command fails like following.

```
rbenv: version `2.5.0' is not installed (set by /Your/rails/project/.ruby-version)
```

It also fails when using rvm for the same reason.

ENV["RBENV_VERSION"] and ENV["rvm_ruby_string"] have their respective correct version information.

