### PR TITLE
Update new_framework_defaults_5_2.rb.tt

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -10,7 +10,7 @@
 # This is needed for recyclable cache keys.
 # Rails.application.config.active_record.cache_versioning = true
 
-# Use AES 256 GCM authenticated encryption for encrypted cookies.
+# Use AES-256-GCM authenticated encryption for encrypted cookies.
 # Existing cookies will be converted on read then written with the new scheme.
 # Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
 


### PR DESCRIPTION
Be consistent in comments when mentioning AES. Expand the PR to see lines 17 and 18 where it's used with a hyphen.