### PR TITLE
BigDecimal#duplicable? returns false if Ruby is 2.5.0 or higher

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -110,8 +110,12 @@ class BigDecimal
   #
   #   BigDecimal("1.2").duplicable? # => true
   #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  #
+  # Ruby 2.5 deprecates BigDecimal#dup
+  # https://github.com/ruby/bigdecimal/commit/bd12a259aa5583b873a640edd337cbb906c6add5
+  #
   def duplicable?
-    true
+    RUBY_VERSION >= "2.5.0" ? false : true
   end
 end
 

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -8,7 +8,7 @@ require "active_support/core_ext/numeric/time"
 class DuplicableTest < ActiveSupport::TestCase
   if RUBY_VERSION >= "2.5.0"
     RAISE_DUP = [method(:puts)]
-    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
+    ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, nil, false, true, 1, 2.3, Complex(1), Rational(1)]
   elsif RUBY_VERSION >= "2.4.1"
     RAISE_DUP = [method(:puts), Complex(1), Rational(1)]
     ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3]


### PR DESCRIPTION
### Summary

This pull request addresses #31465 

* BigDecimal#dup is deprecated in BigDecimal 1.3.3 which is bundled
with Ruby 2.5.0 rc1

https://github.com/ruby/bigdecimal/commit/bd12a259aa5583b873a640edd337cbb906c6add5

It may not be the best idea to return `false` based on `RUBY_VESION` constant but at least it addresses #31465

I'd like to get feedback like It would be better to show warnings in Ruby 2.5 or something like that.

