### PR TITLE
Implicitly skip bootsnap for `rails new --dev`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -439,7 +439,7 @@ module Rails
       end
 
       def depend_on_bootsnap?
-        !options[:skip_bootsnap]
+        !options[:skip_bootsnap] && !options[:dev]
       end
 
       def os_supports_listen_out_of_the_box?

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -812,6 +812,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_bootsnap_with_dev_option
+    run_generator [destination_root, "--dev"]
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/bootsnap/, content)
+    end
+    assert_file "config/boot.rb" do |content|
+      assert_no_match(/require 'bootsnap\/setup'/, content)
+    end
+  end
+
   def test_inclusion_of_ruby_version
     run_generator
 


### PR DESCRIPTION
Specifying the `--dev` option is when want to change the codebase, as it is not necessary to cache it.

Context: https://github.com/rails/rails/pull/31485#issuecomment-352452653
