### PR TITLE
Fix AM::Serializers::JSON#as_json method for timestamps

### DIFF
--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -26,13 +26,13 @@ module ActiveModel
       #   user = User.find(1)
       #   user.as_json
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #     "created_at" => "2006/08/01", "awesome" => true}
+      #   #     "created_at" => "2006-08-01T17:27:133.000Z", "awesome" => true}
       #
       #   ActiveRecord::Base.include_root_in_json = true
       #
       #   user.as_json
       #   # => { "user" => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #                  "created_at" => "2006/08/01", "awesome" => true } }
+      #   #                  "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true } }
       #
       # This behavior can also be achieved by setting the <tt>:root</tt> option
       # to +true+ as in:
@@ -40,7 +40,7 @@ module ActiveModel
       #   user = User.find(1)
       #   user.as_json(root: true)
       #   # => { "user" => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #                  "created_at" => "2006/08/01", "awesome" => true } }
+      #   #                  "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true } }
       #
       # Without any +options+, the returned Hash will include all the model's
       # attributes.
@@ -48,7 +48,7 @@ module ActiveModel
       #   user = User.find(1)
       #   user.as_json
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #      "created_at" => "2006/08/01", "awesome" => true}
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true}
       #
       # The <tt>:only</tt> and <tt>:except</tt> options can be used to limit
       # the attributes included, and work similar to the +attributes+ method.
@@ -63,14 +63,14 @@ module ActiveModel
       #
       #   user.as_json(methods: :permalink)
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #      "created_at" => "2006/08/01", "awesome" => true,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
       #   #      "permalink" => "1-konata-izumi" }
       #
       # To include associations use <tt>:include</tt>:
       #
       #   user.as_json(include: :posts)
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #      "created_at" => "2006/08/01", "awesome" => true,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
       #   #      "posts" => [ { "id" => 1, "author_id" => 1, "title" => "Welcome to the weblog" },
       #   #                   { "id" => 2, "author_id" => 1, "title" => "So I was thinking" } ] }
       #
@@ -81,7 +81,7 @@ module ActiveModel
       #                                             only: :body } },
       #                              only: :title } })
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #      "created_at" => "2006/08/01", "awesome" => true,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
       #   #      "posts" => [ { "comments" => [ { "body" => "1st post!" }, { "body" => "Second!" } ],
       #   #                     "title" => "Welcome to the weblog" },
       #   #                   { "comments" => [ { "body" => "Don't think too hard" } ],
@@ -93,11 +93,12 @@ module ActiveModel
           include_root_in_json
         end
 
+        hash = serializable_hash(options).as_json
         if root
           root = model_name.element if root == true
-          { root => serializable_hash(options) }
+          { root => hash }
         else
-          serializable_hash(options)
+          hash
         end
       end
 

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -129,6 +129,10 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_equal :name, options[:except]
   end
 
+  test "as_json should serialize timestamps" do
+    assert_equal "2006-08-01T00:00:00.000Z", @contact.as_json["created_at"]
+  end
+
   test "as_json should return a hash if include_root_in_json is true" do
     begin
       original_include_root_in_json = Contact.include_root_in_json


### PR DESCRIPTION
According to doc the method should return
non-json compatible types as strings.

The original idea behind `as_json` is that:

``` ruby
object.as_json == JSON.parse(object.to_json)
```

This patch fixes the compatibility for types that are not supported by JSON.
Also this patch makes `Hash#as_json` compatible `AR::Base#as_json`:

``` ruby
{created_at: Time.now}.as_json # => {"created_at": "2010-10-13T22:05:30.000-07:00"}
```