### PR TITLE
Support workhorse job backend

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
-*   No changes.
+*   Support workhorse.
+
+    *Remo Fritzsche*
 
 
 ## Rails 5.2.0.beta1 (November 27, 2017) ##

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -14,6 +14,7 @@ module ActiveJob
   # * {Sidekiq}[http://sidekiq.org]
   # * {Sneakers}[https://github.com/jondot/sneakers]
   # * {Sucker Punch}[https://github.com/brandonhilkert/sucker_punch]
+  # * {Workhorse}[https://github.com/sitrox/workhorse]
   # * {Active Job Async Job}[http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html]
   # * {Active Job Inline}[http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html]
   #
@@ -30,6 +31,7 @@ module ActiveJob
   #   | Sidekiq           | Yes   | Yes    | Yes        | Queue      | No      | Job     |
   #   | Sneakers          | Yes   | Yes    | No         | Queue      | Queue   | No      |
   #   | Sucker Punch      | Yes   | Yes    | Yes        | No         | No      | No      |
+  #   | Workhorse         | Yes   | Yes    | No         | No         | No      | No      |
   #   | Active Job Async  | Yes   | Yes    | Yes        | No         | No      | No      |
   #   | Active Job Inline | No    | Yes    | N/A        | N/A        | N/A     | N/A     |
   #
@@ -121,6 +123,7 @@ module ActiveJob
     autoload :SidekiqAdapter
     autoload :SneakersAdapter
     autoload :SuckerPunchAdapter
+    autoload :WorkhorseAdapter
     autoload :TestAdapter
 
     ADAPTER = "Adapter".freeze

--- a/activejob/lib/active_job/queue_adapters/workhorse_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/workhorse_adapter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "workhorse"
+
+module ActiveJob
+  module QueueAdapters
+    # == Workhorse adapter for Active Job
+    #
+    # Workhorse is a multi-threaded job backend with database queuing for ruby.
+    # Jobs are persisted in the database using ActiveRecird.
+    # Read more about Workhorse {here}[https://github.com/sitrox/activejob].
+    #
+    # To use Workhorse, set the queue_adapter config to +:workhorse+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :workhorse
+    class WorkhorseAdapter
+      def enqueue(job) #:nodoc:
+        Workhorse.enqueue_active_job(job)
+      end
+
+      def enqueue_at(job, timestamp) #:nodoc:
+        raise NotImplementedError, "This queueing backend does not support scheduling jobs out-of-the-box. Please consult the Workhorse FAQ for more information on how to schedule jobs."
+      end
+    end
+  end
+end

--- a/activejob/test/adapters/workhorse.rb
+++ b/activejob/test/adapters/workhorse.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActiveJob::Base.queue_adapter = :workhorse


### PR DESCRIPTION
Workhorse is a multi-threaded job backend that persists jobs in the
database using ActiveRecord. This commit adds a new queue backend that
allows ActiveJob to enqueue jobs using the workhorse Gem.

### Summary

We've created a new job backend that is specifically designed for multi-threaded execution within a single or multiple processes and would like to add a queue adapter so our Gem can be used with ActiveJob.

Thanks a lot for having a look at our PR.