### PR TITLE
Add `FrozenError` explicitly to 5-1-stable

### DIFF
--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -25,7 +25,7 @@ class AggregationsTest < ActiveRecord::TestCase
 
   def test_immutable_value_objects
     customers(:david).balance = Money.new(100)
-    assert_raise(RuntimeError) { customers(:david).balance.instance_eval { @amount = 20 } }
+    assert_raise(RuntimeError, FrozenError) { customers(:david).balance.instance_eval { @amount = 20 } }
   end
 
   def test_inferred_mapping


### PR DESCRIPTION
### Summary

Ruby 2.5 handles `FrozenError` as subclass of `RuntimeError`
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/61131

`AggregationsTest#test_immutable_value_objects` used to raise RuntimeError in Ruby 2.4 or lower
and raises FrozenError in Ruby 2.5. Current Rails master branch using minitest
5.10.3 whose `assert_raise` handles subclasses of the expected exception.

However, Rails `5-1-stable` branch uses minitest 5.3.3 because unit tests
do not run in random order.

Fixes #31508



