### PR TITLE
Add `touch_all` method to `ActiveRecord::Relation`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `touch_all` method to `ActiveRecord::Relation`.
+
+    Example:
+
+        Person.where(name: "David").touch_all(time: Time.new(2020, 5, 16, 0, 0, 0))
+
+    *fatkodima*, *duggiefresh*
+
 *   Add `ActiveRecord::Base.base_class?` predicate.
 
     *Bogdan Gusiev*

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -53,13 +53,17 @@ module ActiveRecord
     end
 
     module ClassMethods # :nodoc:
+      def timestamp_attributes_for_update_in_model
+        timestamp_attributes_for_update.select { |c| column_names.include?(c) }
+      end
+
+      def current_time_from_proper_timezone
+        default_timezone == :utc ? Time.now.utc : Time.now
+      end
+
       private
         def timestamp_attributes_for_create_in_model
           timestamp_attributes_for_create.select { |c| column_names.include?(c) }
-        end
-
-        def timestamp_attributes_for_update_in_model
-          timestamp_attributes_for_update.select { |c| column_names.include?(c) }
         end
 
         def all_timestamp_attributes_in_model
@@ -72,10 +76,6 @@ module ActiveRecord
 
         def timestamp_attributes_for_update
           ["updated_at", "updated_on"]
-        end
-
-        def current_time_from_proper_timezone
-          default_timezone == :utc ? Time.now.utc : Time.now
         end
     end
 
@@ -116,7 +116,7 @@ module ActiveRecord
     end
 
     def timestamp_attributes_for_update_in_model
-      self.class.send(:timestamp_attributes_for_update_in_model)
+      self.class.timestamp_attributes_for_update_in_model
     end
 
     def all_timestamp_attributes_in_model
@@ -124,7 +124,7 @@ module ActiveRecord
     end
 
     def current_time_from_proper_timezone
-      self.class.send(:current_time_from_proper_timezone)
+      self.class.current_time_from_proper_timezone
     end
 
     def max_updated_column_timestamp(timestamp_names = timestamp_attributes_for_update_in_model)


### PR DESCRIPTION
This PR is an update for https://github.com/rails/rails/pull/8343.

Differences/changes:
- accepts multiple column names
- accepts optional `time` argument
- addresses optimistic locking
- not hardcoding `:updated_at/on` as an always updated column 