### PR TITLE
Handle `FrozenError` explicitly for Ruby 2.5 to 5-1-stable branch

### DIFF
--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -25,7 +25,8 @@ class AggregationsTest < ActiveRecord::TestCase
 
   def test_immutable_value_objects
     customers(:david).balance = Money.new(100)
-    assert_raise(RuntimeError) { customers(:david).balance.instance_eval { @amount = 20 } }
+    expected_exception = Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
+    assert_raise(expected_exception) { customers(:david).balance.instance_eval { @amount = 20 } }
   end
 
   def test_inferred_mapping

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -279,7 +279,8 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    assert_raises RuntimeError do
+    expected_exception = Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
+    assert_raises expected_exception do
       ActiveRecord::Base.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -504,7 +504,8 @@ class TransactionTest < ActiveRecord::TestCase
   def test_rollback_when_saving_a_frozen_record
     topic = Topic.new(title: "test")
     topic.freeze
-    e = assert_raise(RuntimeError) { topic.save }
+    expected_exception = Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
+    e = assert_raise(expected_exception) { topic.save }
     # Not good enough, but we can't do much
     # about it since there is no specific error
     # for frozen objects.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1025,7 +1025,8 @@ class HashExtTest < ActiveSupport::TestCase
     original.freeze
     assert_nothing_raised { original.except(:a) }
 
-    assert_raise(RuntimeError) { original.except!(:a) }
+    expected_exception = Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
+    assert_raise(expected_exception) { original.except!(:a) }
   end
 
   def test_except_does_not_delete_values_in_original

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -246,7 +246,8 @@ module ApplicationTests
 
     test "can't change middleware after it's built" do
       boot!
-      assert_raise RuntimeError do
+      expected_exception = Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
+      assert_raise expected_exception do
         app.config.middleware.use Rack::Config
       end
     end


### PR DESCRIPTION

### Summary

Ruby 2.5 handles `FrozenError` as subclass of `RuntimeError`
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/61131

These tests raise RuntimeError in Ruby 2.4 or lower, FrozenError in Ruby 2.5.

Current Rails master branch uses minitest 5.10.3 which handles
`assert_raise` subclasses of the expected exception since 5.7.0.

However, Rails `5-1-stable` branch uses minitest 5.3.3 because unit tests
do not run in random order.

It supports Ruby versions which do not have FrozenError exception.

Fixes #31508

### Steps to reproduce:

```ruby
rbenv install 2.5.0-rc1 ; rbenv global 2.5.0-rc1 (or install Ruby 2.5.0 rc1 by any other way, I think).
cd rails
git checkout 5-1-stable
bundle install
cd activerecord
bundle exec ruby -Itest test/cases/aggregations_test.rb -n test_immutable_value_objects
cd ../railties
bundle exec ruby -Itest test/application/middleware_test.rb -n "test_can't_change_middleware_after_it's_built"
cd ../activesupport
bundle exec ruby -Itest test/core_ext/hash_ext_test.rb -n test_except_with_original_frozen
cd ..
```

### Actual results without this commit:

```ruby
$ bundle exec ruby -Itest test/cases/aggregations_test.rb -n test_immutable_value_objects
Using sqlite3
Run options: -n test_immutable_value_objects --seed 24350

# Running:

F

Failure:
AggregationsTest#test_immutable_value_objects [test/cases/aggregations_test.rb:28]:
[RuntimeError] exception expected, not
Class: <FrozenError>
Message: <"can't modify frozen #<Class:#<Money:0x000055772e2db7c0>>">
---Backtrace---
test/cases/aggregations_test.rb:28:in `block (2 levels) in test_immutable_value_objects'
test/cases/aggregations_test.rb:28:in `instance_eval'
test/cases/aggregations_test.rb:28:in `block in test_immutable_value_objects'
---------------


bin/rails test test/cases/aggregations_test.rb:26



Finished in 0.020153s, 49.6207 runs/s, 49.6207 assertions/s.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```


```ruby
$ bundle exec ruby -Itest test/application/middleware_test.rb -n "test_can't_change_middleware_after_it's_built"
Run options: -n test_can't_change_middleware_after_it's_built --seed 57704

# Running:

F

Failure:
ApplicationTests::MiddlewareTest#test_can't_change_middleware_after_it's_built [test/application/middleware_test.rb:249]:
[RuntimeError] exception expected, not
Class: <FrozenError>
Message: <"can't modify frozen Array">
---Backtrace---
/home/yahonda/git/rails/actionpack/lib/action_dispatch/middleware/stack.rb:95:in `push'
/home/yahonda/git/rails/actionpack/lib/action_dispatch/middleware/stack.rb:95:in `use'
test/application/middleware_test.rb:250:in `block (2 levels) in <class:MiddlewareTest>'
---------------


bin/rails test test/application/middleware_test.rb:247



Finished in 1.719112s, 0.5817 runs/s, 0.5817 assertions/s.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

```ruby
$ bundle exec ruby -Itest test/core_ext/hash_ext_test.rb -n test_except_with_original_frozen
Run options: -n test_except_with_original_frozen --seed 1508

# Running:

F

Failure:
HashExtTest#test_except_with_original_frozen [test/core_ext/hash_ext_test.rb:1028]:
[RuntimeError] exception expected, not
Class: <FrozenError>
Message: <"can't modify frozen Hash">
---Backtrace---
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/except.rb:19:in `delete'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/except.rb:19:in `block in except!'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/except.rb:19:in `each'
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/hash/except.rb:19:in `except!'
test/core_ext/hash_ext_test.rb:1028:in `block in test_except_with_original_frozen'
---------------


bin/rails test test/core_ext/hash_ext_test.rb:1023



Finished in 0.002550s, 392.1399 runs/s, 392.1399 assertions/s.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

