### PR TITLE
Remove verbose_query_logs from new_framework_defaults_5_2.rb

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -15,11 +15,11 @@
 
     Add `verbose_query_logs` configuration option to display the caller
     of database queries in the log to facilitate N+1 query resolution
-    and other debugging. Excludes Ruby and Rails callers but not gems.
+    and other debugging.
 
     Enabled in development only for new and upgraded applications. Not
     recommended for use in the production environment since it relies
-    on Ruby's `Kernel#caller` which is fairly slow.
+    on Ruby's `Kernel#caller_locations` which is fairly slow.
 
     *Olivier Lacan*
 

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -121,8 +121,7 @@ module ActiveRecord
 
         [
           offending_line.path,
-          offending_line.lineno,
-          offending_line.label
+          offending_line.lineno
         ]
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -25,6 +25,3 @@
 # Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
 # 'f' after migrating old data.
 # Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
-
-# Highlight code that triggered database queries in logs.
-Rails.application.config.active_record.verbose_query_logs = Rails.env.development?


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/26815; see https://github.com/rails/rails/pull/26815#discussion_r156957789.

The `app:update` rake task will regenerate `development.rb` so that it contains this option; that means we're currently adding it to existing apps in two places, which is unnecessary and confusing.

Also:
 - Remove inaccurate comment about which stack frames are ignored (see https://github.com/rails/rails/pull/26815#issuecomment-351557607)
 - Clarify that the feature uses `caller_locations`, not `caller`
 - Remove unused return value in `extract_callstack`