### PR TITLE
Fix Illegal parameter data type bigint for operation 'get_lock' error

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -117,11 +117,11 @@ module ActiveRecord
       end
 
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
-        query_value("SELECT GET_LOCK(#{quote(lock_name)}, #{timeout})") == 1
+        query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end
 
       def release_advisory_lock(lock_name) # :nodoc:
-        query_value("SELECT RELEASE_LOCK(#{quote(lock_name)})") == 1
+        query_value("SELECT RELEASE_LOCK(#{quote(lock_name.to_s)})") == 1
       end
 
       def native_database_types


### PR DESCRIPTION
### Summary

Got this error when running the `db:migrate` command:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Illegal parameter data type bigint for operation 'get_lock': SELECT GET_LOCK(3176440259963731740, 0)
```

The MySQL `GET_LOCK` function is awaiting for  a string as a lock name (https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock) but an integer is generated by `ActiveRecord::Migration#generate_migrator_advisory_lock_id()` method.