### PR TITLE
Change Scoping Behavior of ActiveRecord::Relation#new

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -53,7 +53,12 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new(attributes = nil, &block)
-      klass.new(scope_for_create(attributes), &block)
+      begin
+        klass.scope_attributes_populated = true
+        klass.new(scope_for_create(attributes), &block)
+      ensure
+        klass.scope_attributes_populated = false
+      end
     end
 
     alias build new
@@ -81,7 +86,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create(attr, &block) }
       else
-        klass.create(scope_for_create(attributes), &block)
+        new(attributes, &block).tap(&:save)
       end
     end
 
@@ -95,7 +100,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create!(attr, &block) }
       else
-        klass.create!(scope_for_create(attributes), &block)
+        new(attributes, &block).tap(&:save!)
       end
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -40,8 +40,8 @@ module ActiveRecord
       klass.arel_attribute(name, table)
     end
 
-    # Initializes new record from relation while maintaining the current
-    # scope.
+    # Initializes new record with the same scoped attributes
+    # defined in the relation.
     #
     # Expects arguments in the same format as {ActiveRecord::Base.new}[rdoc-ref:Core.new].
     #
@@ -53,7 +53,7 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new(attributes = nil, &block)
-      scoping { klass.new(scope_for_create(attributes), &block) }
+      klass.new(scope_for_create(attributes), &block)
     end
 
     alias build new
@@ -81,7 +81,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create(attr, &block) }
       else
-        scoping { klass.create(scope_for_create(attributes), &block) }
+        klass.create(scope_for_create(attributes), &block)
       end
     end
 
@@ -95,7 +95,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create!(attr, &block) }
       else
-        scoping { klass.create!(scope_for_create(attributes), &block) }
+        klass.create!(scope_for_create(attributes), &block)
       end
     end
 


### PR DESCRIPTION
related issues: #9894 #12015 #12305 #17577 #18952 #24853

These two code behaves different, and I think it should be fixed.
```ruby
user.comments.create(args) # validations, assigns, and other callbacks are executed within scoping
user.comments.new.update(args) # validations are executed normaly, not within scoping
```

```ruby
class User < ApplicationRecord
  before_validation { puts "before_validation: #{User.count}" }
  def name=(name); puts "name=: #{User.count}"; end
end
User.count #=> 15
User.where(name: 'a').create
#=> name=: 1
#=> before_validation: 1
```

One way to avoid this is to use `unscoped do end` but it will clear all necessary scopes.

```ruby
User.banned.where(country: country).scoping do
  User.where(name: 'jack').where(other_condition).create do |user|
    # want to clear `name: 'jack'`, but unscoped will clear `.banned` and `country: country`
    User.unscoped.banned.where(country: country).scoping do # unscope and restore necessary scopings
      user.name ||= "banned_#{User.count}"
    end
  end
end
```

So I think this problem should be solved by changing the behavour of `relation.new`.
If someone wants scoping to be applied to callbacks, (I think it's a very rare case)
in my opinion it should be explicitly written like:
```ruby
where(cond).scoping { Klass.create(params) } # when you want scoping to be applied to callbacks
where(cond).create(params) # when you don't want scoping to be applied to callbacks
```


I removed `scoping{ }` from `relation.new` `relation.create` `relation.create!`.
then the test for `DefaultScopedClass.unscoped.create()`, so I add a way to skip `populate_with_current_scope_attributes` (scope attributes are already populated, and unscoped default_scope attributes must not be populated)