### PR TITLE
Removes OS specific directory separator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store


### PR DESCRIPTION
### Summary

Removes the hardcoded OS specific directory separator.

### Other Information

Although most OS use `/` as a directory separator, this is not something 100% universal. For that reason, it may be appropriate to delegate the task of building the route to the class `Pathname`.