### PR TITLE
Add :render_discarded option to date_helper

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1056,7 +1056,7 @@ module ActionView
         #  build_hidden(:year, 2008)
         #  => "<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="2008" />"
         def build_hidden(type, value)
-          return ''.html_safe unless @options.fetch(:render_discarded, true)
+          return "".html_safe unless @options.fetch(:render_discarded, true)
 
           select_options = {
             type: "hidden",

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -212,6 +212,8 @@ module ActionView
       #   as a hidden field instead of showing a select field. Also note that this implicitly sets :discard_day to true.
       # * <tt>:discard_year</tt>      - Set to true if you don't want to show a year select. This includes the year
       #   as a hidden field instead of showing a select field.
+      # * <tt>:render_discarded</tt>  - Set to false to avoid rendering discarded fields altogether. In other words,
+      #   discarded fields will not be rendered as input fields or as hidden fields - they will not be rendered at all.
       # * <tt>:order</tt>             - Set to an array containing <tt>:day</tt>, <tt>:month</tt> and <tt>:year</tt> to
       #   customize the order in which the select fields are shown. If you leave out any of the symbols, the respective
       #   select will not be shown (like when you set <tt>discard_xxx: true</tt>. Defaults to the order defined in
@@ -1054,6 +1056,8 @@ module ActionView
         #  build_hidden(:year, 2008)
         #  => "<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="2008" />"
         def build_hidden(type, value)
+          return ''.html_safe unless @options.fetch(:render_discarded, true)
+
           select_options = {
             type: "hidden",
             id: input_id_from_type(type),

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -1914,6 +1914,31 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, date_select("post", "written_on", order: [ :year ])
   end
 
+  def test_date_select_with_no_rendering_of_discarded_fields
+    @post = Post.new
+    @post.written_on = Date.new(2004, 2, 29)
+
+    expected =  %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
+    expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
+    expected << "</select>\n"
+
+    assert_dom_equal expected, date_select("post", "written_on", order: [ :year ], render_discarded: false)
+  end
+
+  def test_date_select_with_explicit_rendering_of_discarded_fields
+    @post = Post.new
+    @post.written_on = Date.new(2004, 2, 29)
+
+    expected = "<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" />\n".dup
+    expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+
+    expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
+    expected << "</select>\n"
+
+    assert_dom_equal expected, date_select("post", "written_on", order: [ :year ], render_discarded: true)
+  end
+
   def test_date_select_without_day_with_separator
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -1116,6 +1116,25 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_month: true, discard_day: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
   end
 
+  def test_select_date_with_no_rendering_of_discarded_fields
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
+    expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_month: true, discard_day: true, render_discarded: false, start_year: 2003, end_year: 2005, prefix: "date[first]")
+  end
+
+  def test_select_date_with_explicit_rendering_of_discarded_fields
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
+    expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
+    expected << "</select>\n"
+
+    expected << %(<input type="hidden" id="date_first_month" name="date[first][month]" value="8" />\n)
+    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" />\n)
+
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_month: true, discard_day: true, render_discarded: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
+  end
+
   def test_select_date_with_hidden
     expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003"/>\n).dup
     expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)


### PR DESCRIPTION
### Summary

In the Lumosity.com codebase, our sign up form renders a birthdate field using the `date_select` helper. We purposely exclude the year field because we prefer a free-form text field instead of a dropdown list. Our code looks something like this:

```ruby
date_select @user, :date_of_birth, { order: [:month, :day] }
```

We then render the year field by hand and give it the expected ID, i.e. `user_date_of_birth_1i`. This has worked as intended for quite some time even though two input elements with the same ID are getting rendered to the page. This happens because `date_select` will render "discarded" elements as hidden input tags instead of omitting them (the year is marked as discarded because it does not appear in the `:order` array).

It came as a surprise to all of us when we saw this error message in Chrome yesterday:

![34233468-75b01a38-e59a-11e7-944c-9ecdf30b73f2](https://user-images.githubusercontent.com/575280/34271184-11f3aa86-e640-11e7-909f-2bbf2bd0d9e9.png)

### The Fix

This PR adds the `render_discarded` option to `date_select`. You can set it to false to skip rendering discarded fields altogether. This seemed easier to support than an option to render the year field as a text input type. The default behavior is also maintained - omitting the `render_discarded` option will cause discarded fields to be rendered as hidden inputs as they are now.

### Other Information

We're using Rails 4.2 and Ruby 2.4.3 (currently working on the upgrade to Rails 5.0). We have monkeypatched in the `render_discarded` option for now with the following code:

```ruby
module ActionView
  # ActionView's date_select helper provides the option to "discard" certain fields. Discarded
  # fields are (confusingly) still rendered to the page using hidden inputs, i.e.
  # <input type="hidden" />. This patch adds an additional option to the date_select helper
  # that allows the caller to skip rendering the chosen fields altogether. For example, to
  # render all but the year field, you might have this in one of your views:
  #
  # date_select(:date_of_birth, order: [:month, :day])
  #
  # or, equivalently:
  #
  # date_select(:date_of_birth, discard_year: true)
  #
  # To avoid rendering the year field altogether, set :render_discarded to false:
  #
  # date_select(:date_of_birth, discard_year: true, render_discarded: false)
  #
  # Since this is a monkeypatch messing around inside Rails' internals, there's a chance it
  # could fail to work in future versions of the framework. Measures have been taken to bail
  # out if the right conditions aren't met.
  #
  module RenderDiscarded
    def self.apply_patch
      # make sure the class we want to patch exists
      const = begin
        Kernel.const_get('ActionView::Helpers::DateTimeSelector')
      rescue NameError
      end

      # make sure the method we want to overwrite actually exists
      mtd = if const
        begin
          const.instance_method(:build_hidden)
        rescue NameError
        end
      end

      # method should have an arity of 2 (i.e. accept 2 arguments)
      # avoid patching more than once by checking the ancestor chain
      if const && mtd && mtd.arity == 2 && !const.ancestors.include?(RenderDiscarded)
        # actually patch the helper class
        const.prepend(RenderDiscarded)
      else
        puts "WARNING: Something went wrong patching actionview's date_select helper. "\
          "Please investigate #{__FILE__}:#{__LINE__}. Falling back to original behavior."
      end
    end

    private

    def build_hidden(type, value)
      # :render_discarded is an additional option you can pass to the date_select helper in
      # your views. Use it to avoid rendering "discarded" fields, i.e. fields marked as discarded
      # or simply not included in date_select's :order array. For example, specifying
      # order: [:day, :month] will cause the helper to "discard" the :year field. Discarding a
      # field renders it as a hidden input. Set :render_discarded to false to avoid rendering
      # it altogether.
      if @options.fetch(:render_discarded, true)
        super
      else
        ''
      end
    end
  end

  RenderDiscarded.apply_patch
end
```