### PR TITLE
relation.select.not

### DIFF
--- a/activerecord/test/cases/relation/select_chain_test.rb
+++ b/activerecord/test/cases/relation/select_chain_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+module ActiveRecord
+  class SelectChainTest < ActiveRecord::TestCase
+    fixtures :posts
+
+    def test_not_inverts_select_clause
+      post = Post.select.not(:title).first
+      refute post.has_attribute?(:title)
+    end
+
+    def test_not_works_with_multiple_columns
+      negated = %i[title body]
+      post = Post.select.not(*negated).first
+
+      negated.each do |column|
+        refute post.has_attribute?(column)
+      end
+    end
+
+    def test_not_works_with_arbitrary_columns
+      post = Post.select(:id, 'id + 1 AS arbitrary').select.not(:arbitrary).first
+      refute post.has_attribute?(:arbitrary)
+    end
+
+    def test_plain_selects_all
+      post = Post.select.first
+      assert Post.column_names.all? { |column| post.has_attribute?(column) }
+    end
+
+    def test_chaining_multiple_select_alls
+      post = Post.select.select.select.first
+      assert Post.column_names.all? { |column| post.has_attribute?(column) }
+    end
+
+    def test_chaining_selects_with_select_nots
+      post = Post.select.select.not(:title).first
+      refute post.has_attribute?(:title)
+    end
+  end
+end


### PR DESCRIPTION
Add a method for deselecting a specific column from a relation, for the instance where you don't need a particularly large column but don't want to list each individual column that should be selected besides that one. Additionally provide the ability to select each column name individually through `relation.select`, which grants speed improvements on certain backends.

Noticed that this also gives particularly good memory gains (in addition to speed) when there's a blob column that takes up a lot of space. 