### PR TITLE
[ci skip] Remove needless  from doc for ActiveStorage::Variant

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -18,7 +18,7 @@ require "active_storage/downloading"
 # To refer to such a delayed on-demand variant, simply link to the variant through the resolved route provided
 # by Active Storage like so:
 #
-#   <%= image_tag url_for(Current.user.avatar.variant(resize: "100x100")) %>
+#   <%= image_tag Current.user.avatar.variant(resize: "100x100") %>
 #
 # This will create a URL for that specific blob with that specific variant, which the ActiveStorage::VariantsController
 # can then produce on-demand.


### PR DESCRIPTION
### Summary

* The url for `ActiveStorage::Variant` is resolved on [routing](https://github.com/rails/rails/blob/master/activestorage/config/routes.rb#L24). So I've removed `url_for` from a document of `ActiveStorage::Variant`.
* On the [example codes](https://github.com/rails/rails/blob/master/activestorage/README.md#examples) in README, `url_for` is not used.