### PR TITLE
Add cloud service's links to README of Active Storage [ci skip]

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -1,6 +1,6 @@
 # Active Storage
 
-Active Storage makes it simple to upload and reference files in cloud services like Amazon S3, Google Cloud Storage, or Microsoft Azure Storage, and attach those files to Active Records. Supports having one main service and mirrors in other services for redundancy. It also provides a disk service for testing or local deployments, but the focus is on cloud storage.
+Active Storage makes it simple to upload and reference files in cloud services like [Amazon S3](https://aws.amazon.com/s3/), [Google Cloud Storage](https://cloud.google.com/storage/docs/), or [Microsoft Azure Storage](https://azure.microsoft.com/en-us/services/storage/), and attach those files to Active Records. Supports having one main service and mirrors in other services for redundancy. It also provides a disk service for testing or local deployments, but the focus is on cloud storage.
 
 Files can be uploaded from the server to the cloud or directly from the client to the cloud.
 
@@ -144,7 +144,7 @@ Active Storage, with its included JavaScript library, supports uploading directl
 
 Active Storage is released under the [MIT License](https://opensource.org/licenses/MIT).
 
- ## Support
+## Support
 
 API documentation is at:
 


### PR DESCRIPTION
### Summary

* I've added cloud service's links to README of Active Storage (For people who don't have enough knowledge about each cloud service.)
* If you feel commercial, please reject this request.