### PR TITLE
Fix root engine URL helpers not generating with a subdirectory

### DIFF
--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -58,6 +58,8 @@ module ActionDispatch
       def merge_script_names(previous_script_name, new_script_name)
         return new_script_name unless previous_script_name
 
+        return previous_script_name if routes.relative_url_root == previous_script_name && new_script_name == "/"
+
         resolved_parts = new_script_name.count("/")
         previous_parts = previous_script_name.count("/")
         context_parts = previous_parts - resolved_parts + 1


### PR DESCRIPTION
This references the following RAILS issue that has a sample application and
further expands upon the content of this pull request:
https://github.com/rails/rails/issues/31476

This fix is a bit hacky as the way subdirectories are handled needs to be
cleaned up. Essentially the issue boils down to the following:

* In order to support multiple engine mount points, a function is run to strip
away the last "/" of an engine's path. Without a subdirectory, this would be
the engine name (ie. "/myengine") if a value existed there.

* However, with a subdirectory configured there, that last value isn't always
the engine name. Rather, it can be the subdirectory itself if the engine is
mounted to the root path. An example of this would be something like
"/subdirectory" that then causes that method to incorrectly remove
the "subdirectory" value. (NOTE: This did not effect non-root engines as the
logic would still work for them, ie: "/subdirectory/myengine" would correctly
remove the "myengine" mount point).

* This fix checks the setting "relative_url_root" and prevents that value from
being stripped out if the engine reports itself to be mounted at "/". This could
potentially break an engine mounted at "/" and "/myengine" but I don't believe
it would.

* I added a Unit Test based on one that already existed for this use case. I
further added a note about what they are testing as they only return the paths
correctly rather than resolve them correctly. I'm unsure how to correct that
existing limitation of the test as I'm not familiar with Rails routing logic
beyond this debugging.

Thanks!

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
