### PR TITLE
Fix activestorage direct upload on ie11

### DIFF
--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -28,8 +28,11 @@ export class BlobRecord {
   }
 
   requestDidLoad(event) {
-    const { status, response } = this.xhr
+    let { status, response } = this.xhr
     if (status >= 200 && status < 300) {
+      if (typeof response === "string" || response instanceof String) {
+        response = JSON.parse(response)
+      }
       const { direct_upload } = response
       delete response.direct_upload
       this.attributes = response


### PR DESCRIPTION
Direct upload on ie11 is not working because the response of the XMLHttpRequest is a string when `xhr.responseType` is set to `"json"` (see https://connect.microsoft.com/IE/feedback/details/794808).
Parsing the response using `JSON.parse` when the response is a string solves the issue.

My javascript skills are a bit "rusty", let me know if you see a better way to implement this fix. 

Closes #31531 


