### PR TITLE
Temporary disabled using rubygems 2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "travis_retry gem update --system"
+  - "travis_retry gem update --system 2.6.14"
   - "travis_retry gem install bundler -v 1.15.4"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
### Summary

RubyGems 2.7 promote bundler-1.16 to default gems. It conflicts Travis environment and user installed bundler.

I'm investigating RubyGems updater and bundler both. (I also maintain them.)

### Other Information

This pr fixes https://travis-ci.org/rails/rails/builds/319911098

/cc @rafaelfranca 