### PR TITLE
Relax bundler version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system 2.6.14"
-  - "travis_retry gem install bundler -v 1.15.4"
+  - "travis_retry gem install bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
   - "[[ -z $encrypted_8a915ebdd931_key && -z $encrypted_8a915ebdd931_iv ]] || openssl aes-256-cbc -K $encrypted_8a915ebdd931_key -iv $encrypted_8a915ebdd931_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_job_master.rb
+++ b/guides/bug_report_templates/active_job_master.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "bundler", "< 1.16"
-
 begin
   require "bundler/inline"
 rescue LoadError => e


### PR DESCRIPTION
Bundler 1.16.1 fixed https://github.com/bundler/bundler/issues/6072.

I believe RubyGems 2.6 and Bundler 1.16.1 works fine with Rails master.