### PR TITLE
Add support for combined MiniMagick transformations

### DIFF
--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -46,13 +46,15 @@ class ActiveStorage::Variation
   # Accepts an open MiniMagick image instance, like what's returned by <tt>MiniMagick::Image.read(io)</tt>,
   # and performs the +transformations+ against it. The transformed image instance is then returned.
   def transform(image)
-    transformations.each do |method, argument|
-      image.mogrify do |command|
-        if eligible_argument?(argument)
-          command.public_send(method, argument)
-        else
-          command.public_send(method)
+    transformations.each do |(method, argument)|
+      if method.to_s == "combine_options"
+        image.combine_options do |combination|
+          argument.each do |(method, argument)|
+            pass_transform_argument(combination, method, argument)
+          end
         end
+      else
+        pass_transform_argument(image, method, argument)
       end
     end
   end
@@ -65,5 +67,13 @@ class ActiveStorage::Variation
   private
     def eligible_argument?(argument)
       argument.present? && argument != true
+    end
+
+    def pass_transform_argument(instance, method, argument)
+      if eligible_argument?(argument)
+        instance.public_send(method, argument)
+      else
+        instance.public_send(method)
+      end
     end
 end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -25,6 +25,20 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_match(/Gray/, image.colorspace)
   end
 
+  test "center-weighted crop of JPEG blob" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(combine_options: {
+      gravity: "center",
+      resize: "100x100^",
+      crop: "100x100+0+0",
+    }).processed
+    assert_match(/racecar\.jpg/, variant.service_url)
+
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 100, image.height
+  end
+
   test "resized variation of PSD blob" do
     blob = create_file_blob(filename: "icon.psd", content_type: "image/vnd.adobe.photoshop")
     variant = blob.variant(resize: "20x20").processed


### PR DESCRIPTION
### Summary

This adds support for MiniMagick's `combine_options`. It's needed when transformations
can't be applied sequentially, but need to be applied in the same step, e.g. center-weighted
cropping.

Belongs to #31518.