### PR TITLE
Allow use_authenticated_message_encryption to be set in new_framework_defaults_5_2.rb

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -81,9 +81,9 @@ module ActiveSupport
   class MessageEncryptor
     prepend Messages::Rotator::Encryptor
 
-    class << self
-      attr_accessor :use_authenticated_message_encryption #:nodoc:
+    cattr_accessor :use_authenticated_message_encryption, instance_accessor: false, default: false
 
+    class << self
       def default_cipher #:nodoc:
         if use_authenticated_message_encryption
           "aes-256-gcm"

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -10,9 +10,11 @@ module ActiveSupport
     config.eager_load_namespaces << ActiveSupport
 
     initializer "active_support.set_authenticated_message_encryption" do |app|
-      if app.config.active_support.respond_to?(:use_authenticated_message_encryption)
-        ActiveSupport::MessageEncryptor.use_authenticated_message_encryption =
-          app.config.active_support.use_authenticated_message_encryption
+      config.after_initialize do
+        unless app.config.active_support.use_authenticated_message_encryption.nil?
+          ActiveSupport::MessageEncryptor.use_authenticated_message_encryption =
+            app.config.active_support.use_authenticated_message_encryption
+        end
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1739,9 +1739,7 @@ module ApplicationTests
 
     test "default SQLite3Adapter.represent_boolean_as_integer for 5.1 is false" do
       remove_from_config '.*config\.load_defaults.*\n'
-      add_to_top_of_config <<-RUBY
-        config.load_defaults 5.1
-      RUBY
+
       app_file "app/models/post.rb", <<-RUBY
         class Post < ActiveRecord::Base
         end
@@ -1888,6 +1886,32 @@ module ApplicationTests
 
       assert_equal 301, last_response.status
       assert_equal "https://example.org/", last_response.location
+    end
+
+    test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption is true by default for new apps" do
+      app "development"
+
+      assert_equal true, ActiveSupport::MessageEncryptor.use_authenticated_message_encryption
+    end
+
+    test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal false, ActiveSupport::MessageEncryptor.use_authenticated_message_encryption
+    end
+
+    test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption can be configured via config.active_support.use_authenticated_message_encryption" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_5_2.rb", <<-RUBY
+      Rails.application.config.active_support.use_authenticated_message_encryption = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveSupport::MessageEncryptor.use_authenticated_message_encryption
     end
 
     test "config.active_support.hash_digest_class is Digest::MD5 by default" do


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/29263.

Enabling this option in `new_framework_defaults_5_2.rb` didn't work before, as railtie initializers run before application initializers.

Using `respond_to?` to decide whether to set the option wasn't working either, as `ActiveSupport::OrderedOptions` responds to any message.

r? @kaspth 