### PR TITLE
Use `delayed_job` master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :job do
   gem "resque-scheduler", require: false
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
-  gem "delayed_job", require: false
+  gem "delayed_job", require: false, github: "collectiveidea/delayed_job"
   gem "queue_classic", github: "QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby
   gem "sneakers", require: false
   gem "que", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,13 @@ GIT
       pg (>= 0.17, < 0.20)
 
 GIT
+  remote: https://github.com/collectiveidea/delayed_job.git
+  revision: 6cf9b0b2c256d20148172d074ca60e13d6439903
+  specs:
+    delayed_job (4.1.3)
+      activesupport (>= 3.0, < 5.2)
+
+GIT
   remote: https://github.com/matthewd/rb-inotify.git
   revision: 856730aad4b285969e8dd621e44808a7c5af4242
   branch: close-handling
@@ -201,8 +208,6 @@ GEM
     dante (0.2.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    delayed_job (4.1.3)
-      activesupport (>= 3.0, < 5.2)
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
@@ -513,7 +518,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails
   dalli (>= 2.2.1)
-  delayed_job
+  delayed_job!
   delayed_job_active_record
   google-cloud-storage (~> 1.8)
   hiredis


### PR DESCRIPTION
For pass Active Job integration tests with Ruby 2.5.
Ref: https://github.com/collectiveidea/delayed_job/pull/996