### PR TITLE
Gracefully handle extra "controller" when generating controller

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -20,9 +20,19 @@ module Rails
         route generate_routing_code
       end
 
-      hook_for :template_engine, :test_framework, :helper, :assets
+      hook_for :template_engine, :test_framework, :helper, :assets do |generator|
+        invoke generator, [ remove_possible_suffix(name), actions ]
+      end
 
       private
+
+        def file_name
+          @_file_name ||= remove_possible_suffix(super)
+        end
+
+        def remove_possible_suffix(name)
+          name.sub(/_?controller$/i, "")
+        end
 
         # This method creates nested route entry for namespaced resources.
         # For eg. rails g controller foo/bar/baz index show

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -116,4 +116,26 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/namespace :admin/, routes)
     end
   end
+
+  def test_controller_suffix_is_not_duplicated
+    run_generator ["account_controller"]
+
+    assert_no_file "app/controllers/account_controller_controller.rb"
+    assert_file "app/controllers/account_controller.rb"
+
+    assert_no_file "app/views/account_controller/"
+    assert_file "app/views/account/"
+
+    assert_no_file "test/controllers/account_controller_controller_test.rb"
+    assert_file "test/controllers/account_controller_test.rb"
+
+    assert_no_file "app/helpers/account_controller_helper.rb"
+    assert_file "app/helpers/account_helper.rb"
+
+    assert_no_file "app/assets/javascripts/account_controller.js"
+    assert_file "app/assets/javascripts/account.js"
+
+    assert_no_file "app/assets/stylesheets/account_controller.css"
+    assert_file "app/assets/stylesheets/account.css"
+  end
 end


### PR DESCRIPTION
No more `users_controller_controller.rb` in rails projects! 😄 
There are already such graceful handlers at least for mailers 
https://github.com/rails/rails/blob/6aa5cf03ea8232180ffbbae4c130b051f813c670/railties/lib/rails/generators/erb/mailer/mailer_generator.rb#L38 and channels https://github.com/rails/rails/blob/6aa5cf03ea8232180ffbbae4c130b051f813c670/actioncable/lib/rails/generators/channel/channel_generator.rb#L30

**Before**
```
$ rails g controller users_controller index create
Running via Spring preloader in process 63441
      create  app/controllers/users_controller_controller.rb
       route  get 'users_controller/index'
get 'users_controller/create'
      invoke  erb
      create    app/views/users_controller
      create    app/views/users_controller/index.html.erb
      create    app/views/users_controller/create.html.erb
      invoke  test_unit
      create    test/controllers/users_controller_controller_test.rb
      invoke  helper
      create    app/helpers/users_controller_helper.rb
      invoke    test_unit
      invoke  assets
      invoke    coffee
      create      app/assets/javascripts/users_controller.coffee
      invoke    scss
      create      app/assets/stylesheets/users_controller.scss
```

**After**

```
$ rails g controller users_controller index create
Running via Spring preloader in process 63932
      create  app/controllers/users_controller.rb
       route  get 'users/index'
get 'users/create'
      invoke  erb
      create    app/views/users
      create    app/views/users/index.html.erb
      create    app/views/users/create.html.erb
      invoke  test_unit
      create    test/controllers/users_controller_test.rb
      invoke  helper
      create    app/helpers/users_helper.rb
      invoke    test_unit
      invoke  assets
      invoke    coffee
      create      app/assets/javascripts/users.coffee
      invoke    scss
      create      app/assets/stylesheets/users.scss
```

Fixes https://github.com/rails/rails/issues/10699.