### PR TITLE
Optimize `where` when range's begin/end are equal

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
@@ -28,6 +28,8 @@ module ActiveRecord
           attribute.gteq(begin_bind)
         elsif value.exclude_end?
           attribute.gteq(begin_bind).and(attribute.lt(end_bind))
+        elsif value.begin == value.end
+          attribute.eq(begin_bind)
         else
           attribute.between(RangeWithBinds.new(begin_bind, end_bind))
         end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -14,5 +14,10 @@ module ActiveRecord
     ensure
       Topic.reset_column_information
     end
+
+    def test_range_collapsing_with_begin_and_end_equality
+      date = Date.new(2004, 04, 15)
+      assert_no_match(/BETWEEN/i, Topic.where(last_read: date..date).to_sql)
+    end
   end
 end


### PR DESCRIPTION
For PostgreSQL:
```
create table users(
	id serial primary key,
	position  integer not null
);

insert into users (position) values (generate_series(1, 1000000));
analyze;
```

**Without BETWEEN**
```
explain analyze SELECT * FROM users WHERE position = 100000

Seq Scan on users  (cost=0.00..16925.00 rows=1 width=8) (actual time=8.640..86.703 rows=1 loops=1)
  Filter: ("position" = 100000)
  Rows Removed by Filter: 999999
Planning time: 0.040 ms
Execution time: 86.718 ms
```

**With BETWEEN**
```
explain analyze SELECT * FROM users WHERE position between 100000 and 100000;

Seq Scan on users  (cost=0.00..19425.00 rows=1 width=8) (actual time=8.511..105.254 rows=1 loops=1)
  Filter: (("position" >= 100000) AND ("position" <= 100000))
  Rows Removed by Filter: 999999
Planning time: 0.051 ms
Execution time: 105.268 ms
```

Approximately the same time differences are present for other values too.