### PR TITLE
Try to update rubygems 2.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "travis_retry gem update --system 2.6.14"
+  - "travis_retry gem update --system"
   - "travis_retry gem install bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
### Summary

RubyGems 2.7.3 broke Travis environment with Bundler-1.16.1. ref https://travis-ci.org/rails/rails/builds/319911098

I will release RubyGems 2.7.4 after this pull request was a success status. (https://github.com/rails/rails/pull/31558/commits/5938472816740166b8185064dc094a434c8e177e uses pre-release version of RubyGems)

### Other Information

My investigation is here: https://github.com/rubygems/rubygems/issues/2123