### PR TITLE
Prevent to install gems when run test

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -324,7 +324,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     generator.stub :rails_command, command_check do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, nil do
+        quietly { generator.invoke_all }
+      end
     end
   end
 
@@ -762,7 +764,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     generator([destination_root], webpack: "webpack").stub(:rails_command, command_check) do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, nil do
+        quietly { generator.invoke_all }
+      end
     end
 
     assert_gem "webpacker"
@@ -783,7 +787,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     generator([destination_root], webpack: "react").stub(:rails_command, command_check) do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, nil do
+        quietly { generator.invoke_all }
+      end
     end
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -92,7 +92,9 @@ module SharedGeneratorTests
     end
 
     generator([destination_root], template: path).stub(:open, check_open, template) do
-      quietly { assert_match(/It works!/, capture(:stdout) { generator.invoke_all }) }
+      generator.stub :bundle_command, nil do
+        quietly { assert_match(/It works!/, capture(:stdout) { generator.invoke_all }) }
+      end
     end
   end
 


### PR DESCRIPTION
`invoke_all` cause `bundle install`. This will install gems actually defined in `Gemfile`. To avoid this, stubbed `bundle_command`.

Fixes #31557

