### PR TITLE
Unify raise_on_missing_translations for views and controllers

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add raise_on_missing_translations support for controllers.
+
+    This configuration determines whether an error should be raised for missing translations.
+    It can be enabled through `config.i18n.raise_on_missing_translations`. Note that described
+    configuration also affects raising error for missing translations in views.
+
+    *fatkodima*
+
 *   Added `compact` and `compact!` to `ActionController::Parameters`.
 
     *Eugene Kenny*

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -4,6 +4,8 @@ require "active_support/core_ext/symbol/starts_ends_with"
 
 module AbstractController
   module Translation
+    mattr_accessor :raise_on_missing_translations, default: false
+
     # Delegates to <tt>I18n.translate</tt>. Also aliased as <tt>t</tt>.
     #
     # When the given key starts with a period, it will be scoped by the current
@@ -20,7 +22,9 @@ module AbstractController
         options[:default] = defaults.flatten
         key = "#{path}.#{action_name}#{key}"
       end
-      I18n.translate(key, **options)
+
+      i18n_raise = options.fetch(:raise, self.raise_on_missing_translations)
+      I18n.translate(key, **options, raise: i18n_raise)
     end
     alias :t :translate
 

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -43,6 +43,22 @@ module AbstractController
         assert_respond_to @controller, :l
       end
 
+      def test_raises_missing_translation_message_with_raise_config_option
+        AbstractController::Translation.raise_on_missing_translations = true
+
+        assert_raise(I18n::MissingTranslationData) do
+          @controller.t("translations.missing")
+        end
+      ensure
+        AbstractController::Translation.raise_on_missing_translations = false
+      end
+
+      def test_raises_missing_translation_message_with_raise_option
+        assert_raise(I18n::MissingTranslationData) do
+          @controller.t(:"translations.missing", raise: true)
+        end
+      end
+
       def test_lazy_lookup
         @controller.stub :action_name, :index do
           assert_equal "bar", @controller.t(".foo")

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `config.action_view.raise_on_missing_translations` in favor of
+    `config.i18n.raise_on_missing_translations`.
+
+    New generalized configuration option now determines whether an error should be raised
+    for missing translations in controllers and views.
+
+    *fatkodima*
+
 *   Instrument layout rendering in `TemplateRenderer#render_with_layout` as `render_layout.action_view`, and include (when necessary) the layout's virtual path in notification payloads for collection and partial renders.
 
     *Zach Kemp*

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -43,6 +43,12 @@ module ActionView
     config.after_initialize do |app|
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
+          if k == :raise_on_missing_translations
+            ActiveSupport::Deprecation.warn \
+              "action_view.raise_on_missing_translations is deprecated and will be removed in Rails 6.2. " \
+              "Set i18n.raise_on_missing_translations instead. " \
+              "Note that this new setting also affects how missing translations are handled in controllers."
+          end
           send "#{k}=", v
         end
       end

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -48,6 +48,8 @@ module I18n
           app.config.i18n.load_path.unshift(*value.flat_map(&:existent))
         when :load_path
           I18n.load_path += value
+        when :raise_on_missing_translations
+          forward_raise_on_missing_translations_config(app)
         else
           I18n.send("#{setting}=", value)
         end
@@ -71,6 +73,16 @@ module I18n
       reloader.execute
 
       @i18n_inited = true
+    end
+
+    def self.forward_raise_on_missing_translations_config(app)
+      ActiveSupport.on_load(:action_view) do
+        self.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
+      end
+
+      ActiveSupport.on_load(:action_controller) do
+        AbstractController::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
+      end
     end
 
     def self.include_fallbacks_module

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -348,6 +348,9 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.i18n.load_path` sets the path Rails uses to look for locale files. Defaults to `config/locales/*.{yml,rb}`.
 
+* `config.i18n.raise_on_missing_translations` determines whether an error should be raised for missing translations
+in controllers and views. This defaults to `false`.
+
 * `config.i18n.fallbacks` sets fallback behavior for missing translations. Here are 3 usage examples for this option:
 
   * You can set the option to `true` for using default locale as fallback, like so:
@@ -653,9 +656,6 @@ Defaults to `'signed cookie'`.
     ```
 
     The default setting is `true`, which uses the partial at `/admin/articles/_article.erb`. Setting the value to `false` would render `/articles/_article.erb`, which is the same behavior as rendering from a non-namespaced controller such as `ArticlesController`.
-
-* `config.action_view.raise_on_missing_translations` determines whether an
-  error should be raised for missing translations. This defaults to `false`.
 
 * `config.action_view.automatically_disable_submit_tag` determines whether
   `submit_tag` should automatically disable on click, this defaults to `true`.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -72,7 +72,7 @@ Rails.application.configure do
   <%- end -%>
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -62,7 +62,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true


### PR DESCRIPTION
This PR generalizes `raise_on_missing_translations` config option from `action_view` scope into `i18n` so it can be used for controllers too.

Existing applications should receive deprecation warnings and continue to use old `config.action_view. raise_on_missing_translations` to affect only view's `#translate` method until they decide to switch to new option. And then it should affect both controllers and views.

Fixes https://github.com/rails/rails/issues/24138.
Fixes https://github.com/rails/rails/issues/25116.
Brief discussion [here](https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/nNrgPhWUl-c).