### PR TITLE
Fix comment about initializers to adapt to the fact

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -27,8 +27,9 @@ module <%= app_const_base %>
     config.load_defaults <%= Rails::VERSION::STRING.to_f %>
 
     # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    # Application configuration can go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded after loading
+    # the framework and any gems in your application.
 <%- if options.api? -%>
 
     # Only loads a smaller set of middleware suitable for API only apps.


### PR DESCRIPTION
refs #27920, closes #27920

Currently the comment says application configuration should go into files in `config/initializers`.
However some configuration couldn't initialize correctly because of the initializing process(e.g. `config.time_zone`).

It should be changed by framework but this is large change and it may occur malfunction to some applications which depends on current initializing process.

So I think this comment should be changed to adapt to the fact.

cc @matthewd 