### PR TITLE
Allow the use of callable objects as group methods for grouped selects.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow the use of callable objects as group methods for grouped selects.
+
+    Until now, the `option_groups_from_collection_for_select` method was only able to
+    handle method names as `group_method` and `group_label_method` parameters,
+    it is now able to receive procs and other callable objects too.
+
+    *Jérémie Bonal*
+
 *   Add `preload_link_tag` helper
 
     This helper that allows to the browser to initiate early fetch of resources

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -214,9 +214,15 @@ module ActionView
       # * +method+ - The attribute of +object+ corresponding to the select tag
       # * +collection+ - An array of objects representing the <tt><optgroup></tt> tags.
       # * +group_method+ - The name of a method which, when called on a member of +collection+, returns an
-      #   array of child objects representing the <tt><option></tt> tags.
+      #   array of child objects representing the <tt><option></tt> tags. It can also be any object that responds
+      #   to +call+, such as a +proc+, that will be called for each member of the +collection+ to retrieve the
+      #   value.
+
       # * +group_label_method+ - The name of a method which, when called on a member of +collection+, returns a
-      #   string to be used as the +label+ attribute for its <tt><optgroup></tt> tag.
+      #   string to be used as the +label+ attribute for its <tt><optgroup></tt> tag. It can also be any object
+      #   that responds to +call+, such as a +proc+, that will be called for each member of the +collection+ to
+      #   retrieve the label.
+
       # * +option_key_method+ - The name of a method which, when called on a child object of a member of
       #   +collection+, returns a value to be used as the +value+ attribute for its <tt><option></tt> tag.
       # * +option_value_method+ - The name of a method which, when called on a child object of a member of
@@ -457,9 +463,9 @@ module ActionView
       def option_groups_from_collection_for_select(collection, group_method, group_label_method, option_key_method, option_value_method, selected_key = nil)
         collection.map do |group|
           option_tags = options_from_collection_for_select(
-            group.send(group_method), option_key_method, option_value_method, selected_key)
+            value_for_collection(group, group_method), option_key_method, option_value_method, selected_key)
 
-          content_tag("optgroup".freeze, option_tags, label: group.send(group_label_method))
+          content_tag("optgroup".freeze, option_tags, label: value_for_collection(group, group_label_method))
         end.join.html_safe
       end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -337,6 +337,22 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_option_groups_from_collection_for_select_with_callable_group_method
+    group_proc = Proc.new { |c| c.countries }
+    assert_dom_equal(
+      "<optgroup label=\"&lt;Africa&gt;\"><option value=\"&lt;sa&gt;\">&lt;South Africa&gt;</option>\n<option value=\"so\">Somalia</option></optgroup><optgroup label=\"Europe\"><option value=\"dk\" selected=\"selected\">Denmark</option>\n<option value=\"ie\">Ireland</option></optgroup>",
+      option_groups_from_collection_for_select(dummy_continents, group_proc, "continent_name", "country_id", "country_name", "dk")
+    )
+  end
+
+  def test_option_groups_from_collection_for_select_with_callable_group_label_method
+    label_proc = Proc.new { |c| c.continent_name }
+    assert_dom_equal(
+      "<optgroup label=\"&lt;Africa&gt;\"><option value=\"&lt;sa&gt;\">&lt;South Africa&gt;</option>\n<option value=\"so\">Somalia</option></optgroup><optgroup label=\"Europe\"><option value=\"dk\" selected=\"selected\">Denmark</option>\n<option value=\"ie\">Ireland</option></optgroup>",
+      option_groups_from_collection_for_select(dummy_continents, "countries", label_proc, "country_id", "country_name", "dk")
+    )
+  end
+
   def test_option_groups_from_collection_for_select_returns_html_safe_string
     assert option_groups_from_collection_for_select(dummy_continents, "countries", "continent_name", "country_id", "country_name", "dk").html_safe?
   end


### PR DESCRIPTION
The `option_groups_from_collection_for_select` helper could only take method names as `group_method` and `group_label_method` parameters. This wasn't consistent with `option_from_collection_for_select` which could take either method names or callable objects.

This PR replaces the uses of `group.send(...)` in the helper by calls to `value_for_collection(group, ...)`, allowing the use of procs, lambdas and other callable objects as parameters.