### PR TITLE
let drb make temprary server

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -380,10 +380,8 @@ class ForkingExecutor
   def initialize(size)
     @size  = size
     @queue = Server.new
-    file   = File.join Dir.tmpdir, tmpname
-    @url   = "drbunix://#{file}"
     @pool  = nil
-    DRb.start_service @url, @queue
+    @url = DRb.start_service("drbunix:", @queue).uri
   end
 
   def <<(work); @queue << work; end
@@ -421,11 +419,6 @@ class ForkingExecutor
           Minitest::UnexpectedError.new ex
         end
       }
-    end
-
-    def tmpname
-      t = Time.now.strftime("%Y%m%d")
-      "rails-tests-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}-fd"
     end
 end
 


### PR DESCRIPTION
### Summary

 cc0d272 does not guarantee uniqueness.
It's the wrong usage that is the reason `make_tmpname` has been removed.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
