### PR TITLE
Refactor tests for request parameters to use more realistic setup

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -785,50 +785,44 @@ end
 
 class RequestFormat < BaseRequestTest
   test "xml format" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :xml }) do
-      assert_equal Mime[:xml], request.format
-    end
+    request = stub_request "QUERY_STRING" => "format=xml"
+
+    assert_equal Mime[:xml], request.format
   end
 
   test "xhtml format" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :xhtml }) do
-      assert_equal Mime[:html], request.format
-    end
+    request = stub_request "QUERY_STRING" => "format=xhtml"
+
+    assert_equal Mime[:html], request.format
   end
 
   test "txt format" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :txt }) do
-      assert_equal Mime[:text], request.format
-    end
+    request = stub_request "QUERY_STRING" => "format=txt"
+
+    assert_equal Mime[:text], request.format
   end
 
   test "XMLHttpRequest" do
     request = stub_request(
       "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
-      "HTTP_ACCEPT" => [Mime[:js], Mime[:html], Mime[:xml], "text/xml", "*/*"].join(",")
+      "HTTP_ACCEPT" => [Mime[:js], Mime[:html], Mime[:xml], "text/xml", "*/*"].join(","),
+      "QUERY_STRING" => ""
     )
 
-    assert_called(request, :parameters, times: 1, returns: {}) do
-      assert request.xhr?
-      assert_equal Mime[:js], request.format
-    end
+    assert request.xhr?
+    assert_equal Mime[:js], request.format
   end
 
   test "can override format with parameter negative" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :txt }) do
-      assert !request.format.xml?
-    end
+    request = stub_request("QUERY_STRING" => "format=txt")
+
+    assert !request.format.xml?
   end
 
   test "can override format with parameter positive" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :xml }) do
-      assert request.format.xml?
-    end
+    request = stub_request("QUERY_STRING" => "format=xml")
+
+    assert request.format.xml?
   end
 
   test "formats text/html with accept header" do
@@ -853,27 +847,24 @@ class RequestFormat < BaseRequestTest
   end
 
   test "formats format:text with accept header" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :txt }) do
-      assert_equal [Mime[:text]], request.formats
-    end
+    request = stub_request("QUERY_STRING" => "format=txt")
+
+    assert_equal [Mime[:text]], request.formats
   end
 
   test "formats format:unknown with accept header" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :unknown }) do
-      assert_instance_of Mime::NullType, request.format
-    end
+    request = stub_request("QUERY_STRING" => "format=unknown")
+
+    assert_instance_of Mime::NullType, request.format
   end
 
   test "format is not nil with unknown format" do
-    request = stub_request
-    assert_called(request, :parameters, times: 2, returns: { format: :hello }) do
-      assert request.format.nil?
-      assert_not request.format.html?
-      assert_not request.format.xml?
-      assert_not request.format.json?
-    end
+    request = stub_request("QUERY_STRING" => "format=hello")
+
+    assert_nil request.format
+    assert_not request.format.html?
+    assert_not request.format.xml?
+    assert_not request.format.json?
   end
 
   test "format does not throw exceptions when malformed parameters" do
@@ -883,10 +874,10 @@ class RequestFormat < BaseRequestTest
   end
 
   test "formats with xhr request" do
-    request = stub_request "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"
-    assert_called(request, :parameters, times: 1, returns: {}) do
-      assert_equal [Mime[:js]], request.formats
-    end
+    request = stub_request "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+                           "QUERY_STRING" => ""
+
+    assert_equal [Mime[:js]], request.formats
   end
 
   test "ignore_accept_header" do
@@ -894,62 +885,58 @@ class RequestFormat < BaseRequestTest
     ActionDispatch::Request.ignore_accept_header = true
 
     begin
-      request = stub_request "HTTP_ACCEPT" => "application/xml"
-      assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime[:html] ], request.formats
-      end
+      request = stub_request "HTTP_ACCEPT" => "application/xml",
+                             "QUERY_STRING" => ""
 
-      request = stub_request "HTTP_ACCEPT" => "koz-asked/something-crazy"
-      assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime[:html] ], request.formats
-      end
+      assert_equal [ Mime[:html] ], request.formats
 
-      request = stub_request "HTTP_ACCEPT" => "*/*;q=0.1"
-      assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime[:html] ], request.formats
-      end
+      request = stub_request "HTTP_ACCEPT" => "koz-asked/something-crazy",
+                             "QUERY_STRING" => ""
 
-      request = stub_request "HTTP_ACCEPT" => "application/jxw"
-      assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime[:html] ], request.formats
-      end
+      assert_equal [ Mime[:html] ], request.formats
+
+      request = stub_request "HTTP_ACCEPT" => "*/*;q=0.1",
+                             "QUERY_STRING" => ""
+
+      assert_equal [ Mime[:html] ], request.formats
+
+      request = stub_request "HTTP_ACCEPT" => "application/jxw",
+                             "QUERY_STRING" => ""
+
+      assert_equal [ Mime[:html] ], request.formats
 
       request = stub_request "HTTP_ACCEPT" => "application/xml",
-                             "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"
+                             "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+                             "QUERY_STRING" => ""
 
-      assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime[:js] ], request.formats
-      end
+      assert_equal [ Mime[:js] ], request.formats
 
       request = stub_request "HTTP_ACCEPT" => "application/xml",
-                             "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"
-      assert_called(request, :parameters, times: 2, returns: { format: :json }) do
-        assert_equal [ Mime[:json] ], request.formats
-      end
+                             "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+                             "QUERY_STRING" => "format=json"
+
+      assert_equal [ Mime[:json] ], request.formats
     ensure
       ActionDispatch::Request.ignore_accept_header = old_ignore_accept_header
     end
   end
 
   test "format taken from the path extension" do
-    request = stub_request "PATH_INFO" => "/foo.xml"
-    assert_called(request, :parameters, times: 1, returns: {}) do
-      assert_equal [Mime[:xml]], request.formats
-    end
+    request = stub_request "PATH_INFO" => "/foo.xml", "QUERY_STRING" => ""
 
-    request = stub_request "PATH_INFO" => "/foo.123"
-    assert_called(request, :parameters, times: 1, returns: {}) do
-      assert_equal [Mime[:html]], request.formats
-    end
+    assert_equal [Mime[:xml]], request.formats
+
+    request = stub_request "PATH_INFO" => "/foo.123", "QUERY_STRING" => ""
+
+    assert_equal [Mime[:html]], request.formats
   end
 
   test "formats from accept headers have higher precedence than path extension" do
     request = stub_request "HTTP_ACCEPT" => "application/json",
-                           "PATH_INFO" => "/foo.xml"
+                           "PATH_INFO" => "/foo.xml",
+                           "QUERY_STRING" => ""
 
-    assert_called(request, :parameters, times: 1, returns: {}) do
-      assert_equal [Mime[:json]], request.formats
-    end
+    assert_equal [Mime[:json]], request.formats
   end
 end
 
@@ -997,15 +984,14 @@ end
 
 class RequestParameters < BaseRequestTest
   test "parameters" do
-    request = stub_request
+    request = stub_request "CONTENT_TYPE" => "application/json",
+                           "CONTENT_LENGTH" => 9,
+                           "RAW_POST_DATA" => '{"foo":1}',
+                           "QUERY_STRING" => "bar=2"
 
-    assert_called(request, :request_parameters, times: 2, returns: { "foo" => 1 }) do
-      assert_called(request, :query_parameters, times: 2, returns: { "bar" => 2 }) do
-        assert_equal({ "foo" => 1, "bar" => 2 }, request.parameters)
-        assert_equal({ "foo" => 1 }, request.request_parameters)
-        assert_equal({ "bar" => 2 }, request.query_parameters)
-      end
-    end
+    assert_equal({ "foo" => 1, "bar" => "2" }, request.parameters)
+    assert_equal({ "foo" => 1 }, request.request_parameters)
+    assert_equal({ "bar" => "2" }, request.query_parameters)
   end
 
   test "parameters not accessible after rack parse error" do


### PR DESCRIPTION
While I was looking into https://github.com/rails/rails/issues/29947 I noticed that some tests were out of date, so I thought I should refactor them before actually fixing the bug.

These assertions did matter due to the inconsistent behavior of [the #parameters method][1]. Today it behaves consistently and they could be removed. Also, one of the methods was stubbed somewhat incorrectly, so it is better not to stub, and instead, make them close to more realistic use cases.

[1]: https://github.com/rails/rails/pull/13999#issuecomment-34601746