### PR TITLE
Add locale selector to email preview

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -6,9 +6,9 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
   prepend_view_path ActionDispatch::DebugExceptions::RESCUES_TEMPLATE_PATH
 
   before_action :require_local!, unless: :show_previews?
-  before_action :find_preview, only: :preview
+  before_action :find_preview, :set_locale, only: :preview
 
-  helper_method :part_query
+  helper_method :part_query, :locale_query
 
   def index
     @previews = ActionMailer::Preview.all
@@ -83,5 +83,13 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
     def part_query(mime_type)
       request.query_parameters.merge(part: mime_type).to_query
+    end
+
+    def locale_query(locale)
+      request.query_parameters.merge(locale: locale).to_query
+    end
+
+    def set_locale
+      I18n.locale = params[:locale] || I18n.default_locale
     end
 end

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -96,10 +96,22 @@
     <% end %>
 
     <% if @email.multipart? %>
+      <dt>Format:</dt>
       <dd>
-        <select onchange="formatChanged(this);">
-          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="?<%= part_query('text/html') %>">View as HTML email</option>
-          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="?<%= part_query('text/plain') %>">View as plain-text email</option>
+        <select id="part" onchange="refreshBody();">
+          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="<%= part_query('text/html') %>">View as HTML email</option>
+          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
+        </select>
+      </dd>
+    <% end %>
+
+    <% if I18n.available_locales.count > 1 %>
+      <dt>Locale:</dt>
+      <dd>
+        <select id="locale" onchange="refreshBody();">
+          <% I18n.available_locales.each do |locale| %>
+            <option <%= I18n.locale == locale ? 'selected' : '' %> value="<%= locale_query(locale) %>"><%= locale %></option>
+          <% end %>
         </select>
       </dd>
     <% end %>
@@ -116,15 +128,18 @@
 <% end %>
 
 <script>
-  function formatChanged(form) {
-    var part_name = form.options[form.selectedIndex].value
-    var iframe =document.getElementsByName('messageBody')[0];
-    iframe.contentWindow.location.replace(part_name);
+  function refreshBody() {
+    var part_select = document.querySelector('select#part');
+    var locale_select = document.querySelector('select#locale');
+    var part_param = part_select.options[part_select.selectedIndex].value;
+    var locale_param = locale_select.options[locale_select.selectedIndex].value;
+    var iframe = document.getElementsByName('messageBody')[0];
+    iframe.contentWindow.location = '?' + part_param + '&' + locale_param;
 
     if (history.replaceState) {
-      var url    = location.pathname.replace(/\.(txt|html)$/, '');
-      var format = /html/.test(part_name) ? '.html' : '.txt';
-      window.history.replaceState({}, '', url + format);
+      var url = location.pathname.replace(/\.(txt|html)$/, '');
+      var format = /html/.test(part_param) ? '.html' : '.txt';
+      window.history.replaceState({}, '', url + format + '?' + locale_param);
     }
   }
 </script>


### PR DESCRIPTION
### Summary

This Pull Request make it possible to select location on ActionMailer Preview. Just like below.

![actionmailer-preview-locale-selection](https://user-images.githubusercontent.com/106567/34454066-f8bf06ec-eda5-11e7-82ba-1c2a0961b6b8.gif)

This is a rework of https://github.com/rails/rails/pull/19923. #19923 was almost done, but had not been merged and now it gets conflict against master.

What I did:

- Add set_locale to detect suitable locale ( #19923's author @plus3x's work)
- Fix conflicts.
- Append query parameter `?locale=<locale_name>` if locale were changed.
- Update JavaScript function to refresh format and locale of mail preview.
- Add test case for the feature.