### PR TITLE
Clarify that config.eager_load controls eager loading [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1516,12 +1516,12 @@ To hook into the initialization process of one of the following classes use the 
 
 These are the available configuration hooks. They do not hook into any particular framework, but instead they run in context of the entire application.
 
-| Hook                   | Use Case                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| `before_configuration` | First configurable block to run. Called before any initializers are run.              |
-| `before_initialize`    | Second configurable block to run. Called before frameworks initialize.                |
-| `before_eager_load`    | Third configurable block to run. Does not run if `config.cache_classes` set to false. |
-| `after_initialize`     | Last configurable block to run. Called after frameworks initialize.                   |
+| Hook                   | Use Case                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `before_configuration` | First configurable block to run. Called before any initializers are run.           |
+| `before_initialize`    | Second configurable block to run. Called before frameworks initialize.             |
+| `before_eager_load`    | Third configurable block to run. Does not run if `config.eager_load` set to false. |
+| `after_initialize`     | Last configurable block to run. Called after frameworks initialize.                |
 
 ### Example
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -58,7 +58,7 @@ module Rails
       end
 
       # This needs to happen before eager load so it happens
-      # in exactly the same point regardless of config.cache_classes
+      # in exactly the same point regardless of config.eager_load
       initializer :run_prepare_callbacks do |app|
         app.reloader.prepare!
       end

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -55,7 +55,7 @@ module Rails
         ActiveSupport.on_load(:before_configuration, yield: true, &block)
       end
 
-      # Third configurable block to run. Does not run if +config.cache_classes+
+      # Third configurable block to run. Does not run if +config.eager_load+
       # set to false.
       def before_eager_load(&block)
         ActiveSupport.on_load(:before_eager_load, yield: true, &block)


### PR DESCRIPTION
Before Rails 4.0, `config.cache_classes` determined whether application code was eager loaded. The `config.eager_load` option was introduced in https://github.com/rails/rails/pull/7225 to allow the two behaviours to be configured independently, but this documentation was never updated to reflect that change.