### PR TITLE
Fix `transaction` reverting for migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `transaction` reverting for migrations.
+
+    Before: Commands inside a `transaction` in a reverted migration ran uninverted.
+    Now: This change fixes that by reverting commands inside `transaction` block.
+
+    *fatkodima*, *David Verhasselt*
+
 *   Raise an error instead of scanning the filesystem root when `fixture_path` is blank.
 
     *Gannon McGibbon*, *Max Albrecht*

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -16,6 +16,21 @@ module ActiveRecord
       V6_0 = Current
 
       class V5_2 < V6_0
+        module CommandRecorder
+          def invert_transaction(args, &block)
+            [:transaction, args, block]
+          end
+        end
+
+        private
+
+          def command_recorder
+            recorder = super
+            class << recorder
+              prepend CommandRecorder
+            end
+            recorder
+          end
       end
 
       class V5_1 < V5_2

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -22,6 +22,14 @@ module ActiveRecord
       end
     end
 
+    class InvertibleTransactionMigration < InvertibleMigration
+      def change
+        transaction do
+          super
+        end
+      end
+    end
+
     class InvertibleRevertMigration < SilentMigration
       def change
         revert do
@@ -269,6 +277,14 @@ module ActiveRecord
       assert revert.connection.table_exists?("horses")
       revert.migrate :up
       assert_not revert.connection.table_exists?("horses")
+    end
+
+    def test_migrate_revert_transaction
+      migration = InvertibleTransactionMigration.new
+      migration.migrate :up
+      assert migration.connection.table_exists?("horses")
+      migration.migrate :down
+      assert_not migration.connection.table_exists?("horses")
     end
 
     def test_migrate_revert_change_column_default

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -360,6 +360,16 @@ module ActiveRecord
           @recorder.inverse_of :remove_foreign_key, [:dogs]
         end
       end
+
+      def test_invert_transaction_with_irreversible_inside_is_irreversible
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert do
+            @recorder.transaction do
+              @recorder.execute "some sql"
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -127,6 +127,20 @@ module ActiveRecord
         assert_match(/LegacyMigration < ActiveRecord::Migration\[4\.2\]/, e.message)
       end
 
+      def test_legacy_migrations_not_raise_exception_on_reverting_transaction
+        migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def change
+            transaction do
+              execute "select 1"
+            end
+          end
+        }.new
+
+        assert_nothing_raised do
+          migration.migrate(:down)
+        end
+      end
+
       if current_adapter?(:PostgreSQLAdapter)
         class Testing < ActiveRecord::Base
         end


### PR DESCRIPTION
Commands than run inside a `transaction` block in a reverted migration ran uninverted, as is. 
So, e.g. reverting this a bit contrived migration will fail:
```
class CreateComments < ActiveRecord::Migration[5.2]
  def change
    transaction do
      create_table :posts do |t|
        t.string :title
        t.text :body

        t.timestamps
      end
    end
  end
end
```
But, intuitively, it should be reverted and table should be removed.

This change fixes that problems with uninverted `transaction` blocks.

Originates from outdated https://github.com/rails/rails/pull/22141 and addresses only new migrations.