### PR TITLE
Allow type_for_attribute(:symbol)

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -361,8 +361,9 @@ module ActiveRecord
       # it).
       #
       # +attr_name+ The name of the attribute to retrieve the type for. Must be
-      # a string
+      # a string or a symbol.
       def type_for_attribute(attr_name, &block)
+        attr_name = attr_name.to_s
         if block
           attribute_types.fetch(attr_name, &block)
         else

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -66,6 +66,9 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_column_string_type_and_limit
     assert_equal :string, @first.column_for_attribute("title").type
+    assert_equal :string, @first.column_for_attribute(:title).type
+    assert_equal :string, @first.type_for_attribute("title").type
+    assert_equal :string, @first.type_for_attribute(:title).type
     assert_equal 250, @first.column_for_attribute("title").limit
   end
 
@@ -81,6 +84,9 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_integer_columns
     assert_equal :integer, @first.column_for_attribute("id").type
+    assert_equal :integer, @first.column_for_attribute(:id).type
+    assert_equal :integer, @first.type_for_attribute("id").type
+    assert_equal :integer, @first.type_for_attribute(:id).type
   end
 
   def test_non_existent_columns_return_null_object
@@ -89,12 +95,20 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "attribute_that_doesnt_exist", column.name
     assert_nil column.sql_type
     assert_nil column.type
+
+    column = @first.column_for_attribute(:attribute_that_doesnt_exist)
+    assert_instance_of ActiveRecord::ConnectionAdapters::NullColumn, column
   end
 
   def test_non_existent_types_are_identity_types
     type = @first.type_for_attribute("attribute_that_doesnt_exist")
     object = Object.new
 
+    assert_equal object, type.deserialize(object)
+    assert_equal object, type.cast(object)
+    assert_equal object, type.serialize(object)
+
+    type = @first.type_for_attribute(:attribute_that_doesnt_exist)
     assert_equal object, type.deserialize(object)
     assert_equal object, type.cast(object)
     assert_equal object, type.serialize(object)


### PR DESCRIPTION
Allow `type_for_attribute(:column_name)` to work same as `type_for_attribute("column_name")`.
Closes #31611 — previously for symbols it behaved same as for non-existent column name, returned an identity type that did no casting, which was easy to miss when calling as it doesn't fail loudly.
Similar to `column_for_attribute` that already accepts both string and symbol.

[first-time I'm touching Rails code, please review carefully :-)]
