### PR TITLE
Add priority options for form.select, options_for_select and options_from_collection_for_select

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   `form.select`, `options_for_select` and `options_from_collection_for_select`
+    now accept `priority`, `priority_separator` and `priority_unique` options.
+    When specified the given `priority` values will be placed at the top of the
+    select options, followed by all the options separated by the
+    `priority_separator` (which defaults to "-------------"). If `priority_unique`
+    is set to +true+ the values from the priority list will not be shown below
+    the separator.
+
+    Examples:
+
+        f.select :country, COUNTRIES, :priority => ["United States", "Canada"]
+
+        options_for_select({"English" => "en", "German" => "de", "Dutch" => "nl", "Japanese" => "jp"},
+                           priority: ["en", "jp"],
+                           priority_separator: "-----",
+                           priority_unique: true)
+        # => <option value="en">English</option>
+        #    <option value="jp">Japanese</option>
+        #    <option value="" disabled="disabled">-----</option>
+        #    <option value="de">German</option>
+        #    <option value="nl">Dutch</option>
+
+        options_for_select(["Denmark", "Japan", "Sweden", "United States"],
+                           priority: "Japan",
+                           priority_separator: lambda { |options| "-" * options.max_by(&:length).length })
+
+    *fatkodima*, *Lawrence Pit*
+
 *   Allow the use of callable objects as group methods for grouped selects.
 
     Until now, the `option_groups_from_collection_for_select` method was only able to

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -353,24 +353,56 @@ module ActionView
       #   # => <option value="Advanced">Advanced</option>
       #   # => <option value="Super Platinum" disabled="disabled">Super Platinum</option>
       #
+      # If you wish to specify priority option tags, so that they will
+      # be listed above the rest of the (long) list set +selected+ to be a hash, with <tt>:priority</tt> being
+      # either a value or array of values to be placed at the top of the options. You can then also specify
+      # how the separator should look like using the <tt>:priority_separator</tt> option, which can be a String
+      # or a Proc receiving the container. Set the <tt>:priority_unique</tt> option to +true+ if the values
+      # in the priority list should be unique, i.e. they will not be shown below the separator.
+      #
+      #   options_for_select(["Afghanistan", "Bahrain", "Cook Islands", "USA"], priority: ["USA"])
+      #   # => <option value="USA">USA</option>
+      #   # => <option value="" disabled="disabled">-------------</option>
+      #   # => <option value="Afghanistan">Afghanistan</option>
+      #   # => <option value="Bahrain">Bahrain</option>
+      #   # => <option value="Cook Islands">Cook Islands</option>
+      #   # => <option value="USA">USA</option>
+      #
       # NOTE: Only the option tags are returned, you have to wrap this call in a regular HTML select tag.
       def options_for_select(container, selected = nil)
         return container if String === container
 
-        selected, disabled = extract_selected_and_disabled(selected).map do |r|
-          Array(r).map(&:to_s)
-        end
+        selected, disabled, priority, priority_separator, priority_unique = extract_select_options(selected)
+        disabled = Array(disabled).map(&:to_s)
+        priority_options, options = [], []
 
-        container.map do |element|
+        container.each do |element|
           html_attributes = option_html_attributes(element)
           text, value = option_text_and_value(element).map(&:to_s)
 
-          html_attributes[:selected] ||= option_value_selected?(value, selected)
-          html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
+          html_attributes[:selected] ||= selected.include?(value)
+          html_attributes[:disabled] ||= disabled && disabled.include?(value)
           html_attributes[:value] = value
 
-          tag_builder.content_tag_string(:option, text, html_attributes)
-        end.join("\n").html_safe
+          option = tag_builder.content_tag_string(:option, text, html_attributes)
+
+          if priority.include?(value)
+            priority_options << option
+
+            unless priority_unique
+              option = tag_builder.content_tag_string(:option, text, html_attributes.except!(:selected))
+              options << option
+            end
+          else
+            options << option
+          end
+        end
+
+        return options.join("\n").html_safe if priority_options.empty?
+
+        priority_separator = priority_separator.is_a?(Proc) ? priority_separator.call(container) : priority_separator
+        priority_separator_option = tag_builder.content_tag_string(:option, priority_separator, value: "", disabled: true)
+        (priority_options + [priority_separator_option] + options).join("\n").html_safe
       end
 
       # Returns a string of option tags that have been compiled by iterating over the +collection+ and assigning
@@ -389,9 +421,10 @@ module ActionView
       # If +selected+ is specified as a Proc, those members of the collection that return true for the anonymous
       # function are the selected values.
       #
-      # +selected+ can also be a hash, specifying both <tt>:selected</tt> and/or <tt>:disabled</tt> values as required.
+      # +selected+ can also be a hash, specifying <tt>:selected</tt>, <tt>:disabled</tt>, <tt>:priority</tt>,
+      # <tt>:priority_separator</tt> and/or <tt>:priority_unique</tt> values as required.
       #
-      # Be sure to specify the same class as the +value_method+ when specifying selected or disabled options.
+      # Be sure to specify the same class as the +value_method+ when specifying selected, disabled or priority options.
       # Failure to do this will produce undesired results. Example:
       #   options_from_collection_for_select(@people, 'id', 'name', '1')
       # Will not select a person with the id of 1 because 1 (an Integer) is not the same as '1' (a string)
@@ -401,10 +434,14 @@ module ActionView
         options = collection.map do |element|
           [value_for_collection(element, text_method), value_for_collection(element, value_method), option_html_attributes(element)]
         end
-        selected, disabled = extract_selected_and_disabled(selected)
+        selected, disabled, priority, priority_separator, priority_unique = extract_select_options(selected)
+
         select_deselect = {
           selected: extract_values_from_collection(collection, value_method, selected),
-          disabled: extract_values_from_collection(collection, value_method, disabled)
+          disabled: extract_values_from_collection(collection, value_method, disabled),
+          priority: priority,
+          priority_separator: priority_separator,
+          priority_unique: priority_unique
         }
 
         options_for_select(options, select_deselect)
@@ -573,24 +610,16 @@ module ActionView
       # NOTE: Only the option tags are returned, you have to wrap this call in
       # a regular HTML select tag.
       def time_zone_options_for_select(selected = nil, priority_zones = nil, model = ::ActiveSupport::TimeZone)
-        zone_options = "".html_safe
-
         zones = model.all
-        convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
 
         if priority_zones
           if priority_zones.is_a?(Regexp)
             priority_zones = zones.select { |z| z =~ priority_zones }
           end
-
-          zone_options.safe_concat options_for_select(convert_zones[priority_zones], selected)
-          zone_options.safe_concat content_tag("option".freeze, "-------------", value: "", disabled: true)
-          zone_options.safe_concat "\n"
-
-          zones = zones - priority_zones
+          priority_zones = priority_zones.map(&:name)
         end
 
-        zone_options.safe_concat options_for_select(convert_zones[zones], selected)
+        options_from_collection_for_select(zones, :name, :to_s, selected: selected, priority: priority_zones, priority_unique: true)
       end
 
       # Returns radio button tags for the collection of existing return values
@@ -776,18 +805,20 @@ module ActionView
           end
         end
 
-        def option_value_selected?(value, selected)
-          Array(selected).include? value
-        end
-
-        def extract_selected_and_disabled(selected)
+        def extract_select_options(selected)
           if selected.is_a?(Proc)
-            [selected, nil]
+            [selected, nil, nil, nil, nil]
           else
             selected = Array.wrap(selected)
             options = selected.extract_options!.symbolize_keys
             selected_items = options.fetch(:selected, selected)
-            [selected_items, options[:disabled]]
+            [
+              Array(selected_items).map(&:to_s),
+              options[:disabled],
+              Array(options[:priority]).map(&:to_s),
+              options.fetch(:priority_separator) { "-------------" },
+              options.fetch(:priority_unique, false)
+            ]
           end
         end
 

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -14,10 +14,8 @@ module ActionView
         end
 
         def render
-          option_tags_options = {
-            selected: @options.fetch(:selected) { value },
-            disabled: @options[:disabled]
-          }
+          option_tags_options = @options.dup
+          option_tags_options[:selected] = @options.fetch(:selected) { value }
 
           option_tags = if grouped_choices?
             grouped_options_for_select(@choices, option_tags_options)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -110,6 +110,27 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_options_with_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", priority: ["Cabe", "Babe"])
+    )
+  end
+
+  def test_collection_options_with_preselected_and_disabled_and_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", selected: "Cabe", disabled: "Babe", priority: ["Cabe", "Babe"])
+    )
+  end
+
+  def test_collection_options_with_preselected_value_array_and_priority_values
+    assert_dom_equal(
+      "<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\" selected=\"selected\">Cabe went home</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"&lt;Abe&gt;\" selected=\"selected\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option>",
+      options_from_collection_for_select(dummy_posts, "author_name", "title", selected: ["Cabe", "<Abe>"], priority: ["Cabe", "Babe"])
+    )
+  end
+
   def test_collection_options_with_proc_for_disabled
     assert_dom_equal(
       "<option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\" disabled=\"disabled\">Babe went home</option>\n<option value=\"Cabe\" disabled=\"disabled\">Cabe went home</option>",
@@ -212,6 +233,62 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<option value=\"true\">true</option>\n<option value=\"false\" selected=\"selected\">false</option>",
       options_for_select([ true, false ], selected: false, disabled: nil)
+    )
+  end
+
+  def test_array_options_for_select_with_selection_and_disabled_and_priority_value
+    assert_dom_equal(
+      "<option disabled=\"disabled\" value=\"&lt;USA&gt;\">&lt;USA&gt;</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"&lt;USA&gt;\" disabled=\"disabled\">&lt;USA&gt;</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "<USA>", "Sweden", "Japan" ], selected: "Denmark", disabled: "<USA>", priority: ["<USA>", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_selected_priority_value
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\" selected=\"selected\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Japan", priority: ["Sweden", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_unselected_priority_value
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"])
+    )
+  end
+
+  def test_array_options_for_select_with_non_existing_priority_value
+    assert_dom_equal(
+      "<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Zweden"])
+    )
+  end
+
+  def test_array_options_for_select_with_string_for_priority_separator
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">_____</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"], priority_separator: "_____")
+    )
+  end
+
+  def test_array_options_for_select_with_proc_for_priority_separator
+    assert_dom_equal(
+      "<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>\n<option value=\"\" disabled=\"disabled\">-------</option>\n<option value=\"Denmark\" selected=\"selected\">Denmark</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Japan\">Japan</option>",
+      options_for_select([ "Denmark", "Sweden", "Japan" ], selected: "Denmark", priority: ["Sweden", "Japan"], priority_separator: lambda { |options| "-" * options.max_by(&:length).length })
+    )
+  end
+
+  def test_array_options_for_select_with_priority_unique
+    assert_dom_equal(
+      "<option value=\"en\" class=\"bold\">English</option>\n<option value=\"jp\">Japanese</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"de\">German</option>\n<option value=\"nl\">Dutch</option>",
+      options_for_select([["English", "en", { class: "bold" }], ["German", "de"], ["Dutch", "nl"], ["Japanese", "jp"]], priority: ["en", "jp"], priority_unique: true)
+    )
+  end
+
+  def test_hash_options_for_select_with_priority_unique
+    assert_dom_equal(
+      "<option value=\"en\">English</option>\n<option value=\"jp\">Japanese</option>\n<option value=\"\" disabled=\"disabled\">-----</option>\n<option value=\"de\">German</option>\n<option value=\"nl\">Dutch</option>",
+      options_for_select({ "English" => "en", "German" => "de", "Dutch" => "nl", "Japanese" => "jp" }, { priority: ["en", "jp"], priority_separator: "-----", priority_unique: true })
     )
   end
 
@@ -452,7 +529,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new("B"), ActiveSupport::TimeZone.new("E") ]
     opts = time_zone_options_for_select(nil, zones)
     assert_dom_equal "<option value=\"B\">B</option>\n" \
-                 "<option value=\"E\">E</option>" \
+                 "<option value=\"E\">E</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"A\">A</option>\n" \
                  "<option value=\"C\">C</option>\n" \
@@ -464,7 +541,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new("B"), ActiveSupport::TimeZone.new("E") ]
     opts = time_zone_options_for_select("E", zones)
     assert_dom_equal "<option value=\"B\">B</option>\n" \
-                 "<option value=\"E\" selected=\"selected\">E</option>" \
+                 "<option value=\"E\" selected=\"selected\">E</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"A\">A</option>\n" \
                  "<option value=\"C\">C</option>\n" \
@@ -476,7 +553,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     zones = [ ActiveSupport::TimeZone.new("B"), ActiveSupport::TimeZone.new("E") ]
     opts = time_zone_options_for_select("C", zones)
     assert_dom_equal "<option value=\"B\">B</option>\n" \
-                 "<option value=\"E\">E</option>" \
+                 "<option value=\"E\">E</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"A\">A</option>\n" \
                  "<option value=\"C\" selected=\"selected\">C</option>\n" \
@@ -897,6 +974,33 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_priority_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest ), priority: "hest")
+    )
+  end
+
+  def test_select_with_priority_separator_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">--</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest ), priority: "hest", priority_separator: "--")
+    )
+  end
+
+  def test_select_with_priority_unique_value
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"hest\">hest</option>\n<option value=\"\" disabled=\"disabled\">-------------</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option></select>",
+      select("post", "category", %w( abe <mus> hest ), priority: "hest", priority_unique: true)
+    )
+  end
+
   def test_select_not_existing_method_with_selected_value
     @post = Post.new
     assert_dom_equal(
@@ -1218,7 +1322,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     html = time_zone_select("firm", "time_zone", zones)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" \
                  "<option value=\"A\">A</option>\n" \
-                 "<option value=\"D\" selected=\"selected\">D</option>" \
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"B\">B</option>\n" \
                  "<option value=\"C\">C</option>\n" \
@@ -1237,7 +1341,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     html = time_zone_select("firm", "time_zone", /A|D/)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" \
                  "<option value=\"A\">A</option>\n" \
-                 "<option value=\"D\" selected=\"selected\">D</option>" \
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"B\">B</option>\n" \
                  "<option value=\"C\">C</option>\n" \
@@ -1257,7 +1361,6 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     html = time_zone_select("firm", "time_zone", /A|D/)
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" \
-                 "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"A\">A</option>\n" \
                  "<option value=\"B\">B</option>\n" \
                  "<option value=\"C\">C</option>\n" \
@@ -1276,7 +1379,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal "<div class=\"field_with_errors\">" \
                  "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" \
                  "<option value=\"A\">A</option>\n" \
-                 "<option value=\"D\" selected=\"selected\">D</option>" \
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" \
                  "<option value=\"\" disabled=\"disabled\">-------------</option>\n" \
                  "<option value=\"B\">B</option>\n" \
                  "<option value=\"C\">C</option>\n" \


### PR DESCRIPTION
This is an updated and combined version of https://github.com/rails/rails/pull/9620 and https://github.com/rails/rails/pull/9640.

For details and reasoning of this useful feature, please read [first PR's description](https://github.com/rails/rails/pull/9620) and for why `priority_unique` option is should be useful please read [discussion](https://github.com/rails/rails/pull/9620#discussion-diff-3307962).