### PR TITLE
[ci skip]  Updated the links to images in association_basics.md

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -94,7 +94,7 @@ class Book < ApplicationRecord
 end
 ```
 
-![belongs_to Association Diagram](images/belongs_to.png)
+![belongs_to Association Diagram](../assets/images/belongs_to.png)
 
 NOTE: `belongs_to` associations _must_ use the singular term. If you used the pluralized form in the above example for the `author` association in the `Book` model, you would be told that there was an "uninitialized constant Book::Authors". This is because Rails automatically infers the class name from the association name. If the association name is wrongly pluralized, then the inferred class will be wrongly pluralized too.
 
@@ -127,7 +127,7 @@ class Supplier < ApplicationRecord
 end
 ```
 
-![has_one Association Diagram](images/has_one.png)
+![has_one Association Diagram](../assets/images/has_one.png)
 
 The corresponding migration might look like this:
 
@@ -171,7 +171,7 @@ end
 
 NOTE: The name of the other model is pluralized when declaring a `has_many` association.
 
-![has_many Association Diagram](images/has_many.png)
+![has_many Association Diagram](../assets/images/has_many.png)
 
 The corresponding migration might look like this:
 
@@ -213,7 +213,7 @@ class Patient < ApplicationRecord
 end
 ```
 
-![has_many :through Association Diagram](images/has_many_through.png)
+![has_many :through Association Diagram](../assets/images/has_many_through.png)
 
 The corresponding migration might look like this:
 
@@ -299,7 +299,7 @@ class AccountHistory < ApplicationRecord
 end
 ```
 
-![has_one :through Association Diagram](images/has_one_through.png)
+![has_one :through Association Diagram](../assets/images/has_one_through.png)
 
 The corresponding migration might look like this:
 
@@ -340,7 +340,7 @@ class Part < ApplicationRecord
 end
 ```
 
-![has_and_belongs_to_many Association Diagram](images/habtm.png)
+![has_and_belongs_to_many Association Diagram](../assets/images/habtm.png)
 
 The corresponding migration might look like this:
 
@@ -494,7 +494,7 @@ class CreatePictures < ActiveRecord::Migration[5.0]
 end
 ```
 
-![Polymorphic Association Diagram](images/polymorphic.png)
+![Polymorphic Association Diagram](../assets/images/polymorphic.png)
 
 ### Self Joins
 


### PR DESCRIPTION
### Summary
Some links to images has expired in [association_basics.md](https://github.com/rails/rails/blob/master/guides/source/association_basics.md), so I updated them so that the page shows the images correctly.
