### PR TITLE
Fix casing in documentation, task descriptions and error messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :ujs do
   gem "chromedriver-helper"
 end
 
-# Add your own local bundler stuff.
+# Add your own local Bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -450,7 +450,7 @@ class ResponseHeadersTest < ActiveSupport::TestCase
 end
 
 class ResponseIntegrationTest < ActionDispatch::IntegrationTest
-  test "response cache control from railsish app" do
+  test "response cache control from Railsish app" do
     @app = lambda { |env|
       ActionDispatch::Response.new.tap { |resp|
         resp.cache_control[:public] = true
@@ -487,7 +487,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal({ public: true }, @response.cache_control)
   end
 
-  test "response charset and content type from railsish app" do
+  test "response charset and content type from Railsish app" do
     @app = lambda { |env|
       ActionDispatch::Response.new.tap { |resp|
         resp.charset = "utf-16"

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -309,7 +309,7 @@ module ActionView
   #
   # ==== Examples
   #
-  # Default pattern, loads views the same way as previous versions of rails, eg. when you're
+  # Default pattern, loads views the same way as previous versions of Rails, eg. when you're
   # looking for <tt>users/new</tt> it will produce query glob: <tt>users/new{.{en},}{.{html,js},}{.{erb,haml},}</tt>
   #
   #   FileSystemResolver.new("/path/to/views", ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:handlers,}")

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -338,7 +338,7 @@ module ActiveModel
         end
 
         # The methods +method_missing+ and +respond_to?+ of this module are
-        # invoked often in a typical rails, both of which invoke the method
+        # invoked often in a typical Rails, both of which invoke the method
         # +matched_attribute_method+. The latter method iterates through an
         # array doing regular expression matches, which results in a lot of
         # object creations. Most of the time it returns a +nil+ match. As the

--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -164,7 +164,7 @@ Railties
 
 #### Deprecations
 
-* `Rails::Plugin` is deprecated and will be removed in Rails 4.0. Instead of adding plugins to `vendor/plugins` use gems or bundler with path or git dependencies.
+* `Rails::Plugin` is deprecated and will be removed in Rails 4.0. Instead of adding plugins to `vendor/plugins` use gems or Bundler with path or git dependencies.
 
 Action Mailer
 -------------

--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -142,7 +142,7 @@ Please refer to the [Changelog](https://github.com/rails/rails/blob/4-0-stable/r
 
 * `config.threadsafe!` is deprecated in favor of `config.eager_load` which provides a more fine grained control on what is eager loaded.
 
-* `Rails::Plugin` has gone. Instead of adding plugins to `vendor/plugins` use gems or bundler with path or git dependencies.
+* `Rails::Plugin` has gone. Instead of adding plugins to `vendor/plugins` use gems or Bundler with path or git dependencies.
 
 Action Mailer
 -------------

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -17,7 +17,7 @@ RDoc
 
 The [Rails API documentation](http://api.rubyonrails.org) is generated with
 [RDoc](https://ruby.github.io/rdoc/). To generate it, make sure you are
-in the rails root directory, run `bundle install` and execute:
+in the Rails root directory, run `bundle install` and execute:
 
 ```bash
   bundle exec rake rdoc

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -235,7 +235,7 @@ end
 
 If we generate another resource with the scaffold generator, we can see that stylesheet, JavaScript and fixture files are not created anymore. If you want to customize it further, for example to use DataMapper and RSpec instead of Active Record and TestUnit, it's just a matter of adding their gems to your application and configuring your generators.
 
-To demonstrate this, we are going to create a new helper generator that simply adds some instance variable readers. First, we create a generator within the rails namespace, as this is where rails searches for generators used as hooks:
+To demonstrate this, we are going to create a new helper generator that simply adds some instance variable readers. First, we create a generator within the Rails namespace, as this is where Rails searches for generators used as hooks:
 
 ```bash
 $ bin/rails generate generator rails/my_helper

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -826,7 +826,7 @@ as follows:
 article GET    /articles/:id(.:format)      articles#show
 ```
 
-The special syntax `:id` tells rails that this route expects an `:id`
+The special syntax `:id` tells Rails that this route expects an `:id`
 parameter, which in our case will be the id of the article.
 
 As we did before, we need to add the `show` action in
@@ -1114,7 +1114,7 @@ A few things are going on. We check if there are any errors with
 `@article.errors.any?`, and in that case we show a list of all
 errors with `@article.errors.full_messages`.
 
-`pluralize` is a rails helper that takes a number and a string as its
+`pluralize` is a Rails helper that takes a number and a string as its
 arguments. If the number is greater than one, the string will be automatically
 pluralized.
 
@@ -2043,7 +2043,7 @@ Authentication challenge:
 
 Other authentication methods are available for Rails applications. Two popular
 authentication add-ons for Rails are the
-[Devise](https://github.com/plataformatec/devise) rails engine and
+[Devise](https://github.com/plataformatec/devise) Rails engine and
 the [Authlogic](https://github.com/binarylogic/authlogic) gem,
 along with a number of others.
 

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -161,7 +161,7 @@ The above creates `lib/tasks/bootstrap.rake` with a `boot:strap` rake task.
 
 ### generate(what, *args)
 
-Runs the supplied rails generator with given arguments.
+Runs the supplied Rails generator with given arguments.
 
 ```ruby
 generate(:scaffold, "person", "name:string", "address:text", "age:number")
@@ -205,7 +205,7 @@ route "root to: 'person#index'"
 
 ### inside(dir)
 
-Enables you to run a command from the given directory. For example, if you have a copy of edge rails that you wish to symlink from your new apps, you can do this:
+Enables you to run a command from the given directory. For example, if you have a copy of edge Rails that you wish to symlink from your new apps, you can do this:
 
 ```ruby
 inside('vendor') do
@@ -232,7 +232,7 @@ CODE
 These methods let you ask questions from templates and decide the flow based on the user's answer. Let's say you want to Freeze Rails only if the user wants to:
 
 ```ruby
-rails_command("rails:freeze:gems") if yes?("Freeze rails gems?")
+rails_command("rails:freeze:gems") if yes?("Freeze Rails gems?")
 # no?(question) acts just the opposite.
 ```
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -402,11 +402,11 @@ module Rails
         say_status :run, "bundle #{command}"
 
         # We are going to shell out rather than invoking Bundler::CLI.new(command)
-        # because `rails new` loads the Thor gem and on the other hand bundler uses
+        # because `rails new` loads the Thor gem and on the other hand Bundler uses
         # its own vendored Thor, which could be a different version. Running both
         # things in the same process is a recipe for a night with paracetamol.
         #
-        # We unset temporary bundler variables to load proper bundler and Gemfile.
+        # We unset temporary Bundler variables to load proper Bundler and Gemfile.
         #
         # Thanks to James Tucker for the Gem tricks involved in this call.
         _bundle_command = Gem.bin_path("bundler", "bundle")

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -38,7 +38,7 @@ module Rails
         @desc ||= if usage_path
           ERB.new(File.read(usage_path)).result(binding)
         else
-          "Description:\n    Create #{base_name.humanize.downcase} files for #{generator_name} generator."
+          "Description:\n    Create #{base_name.humanize} files for #{generator_name} generator."
         end
       end
 
@@ -112,7 +112,7 @@ module Rails
       #
       #   "test_unit:controller", "test_unit"
       #
-      # Similarly, if you want it to also look up in the rails namespace, you
+      # Similarly, if you want it to also look up in the Rails namespace, you
       # just need to provide the :in value:
       #
       #   class AwesomeGenerator < Rails::Generators::Base
@@ -208,7 +208,7 @@ module Rails
       end
 
       # Returns the default source root for a given generator. This is used internally
-      # by rails to set its generators source root. If you want to customize your source
+      # by Rails to set its generators source root. If you want to customize your source
       # root, you should use source_root.
       def self.default_source_root
         return unless base_name && generator_name

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -4,7 +4,7 @@ begin
   require "thor/group"
 rescue LoadError
   puts "Thor is not available.\nIf you ran this command from a git checkout " \
-       "of Rails, please make sure thor is installed,\nand run this command " \
+       "of Rails, please make sure Thor is installed,\nand run this command " \
        "as `ruby #{$0} #{(ARGV | ['--dev']).join(" ")}`"
   exit
 end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -38,7 +38,7 @@ module Rails
 
       private
 
-        # FIXME: We are avoiding to use alias because a bug on thor that make
+        # FIXME: We are avoiding to use alias because a bug on Thor that make
         # this method public and add it to the task list.
         def singular_name # :doc:
           file_name

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -183,7 +183,7 @@ task default: :test
                                   desc: "Create dummy application at given path"
 
       class_option :full,         type: :boolean, default: false,
-                                  desc: "Generate a rails engine with bundled Rails application for testing"
+                                  desc: "Generate a Rails engine with bundled Rails application for testing"
 
       class_option :mountable,    type: :boolean, default: false,
                                   desc: "Generate mountable isolated application"

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -40,7 +40,7 @@ namespace :app do
   namespace :update do
     require "rails/app_updater"
 
-    # desc "Update config/boot.rb from your current rails install"
+    # desc "Update config/boot.rb from your current Rails install"
     task :configs do
       Rails::AppUpdater.invoke_from_app_generator :create_boot_file
       Rails::AppUpdater.invoke_from_app_generator :update_config_files

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -22,7 +22,7 @@ module ApplicationTests
       ActiveSupport::Notifications.notifier.wait
     end
 
-    test "rails log_subscribers are added" do
+    test "Rails log_subscribers are added" do
       add_to_config <<-RUBY
         config.colorize_logging = false
       RUBY
@@ -42,7 +42,7 @@ module ApplicationTests
       assert_match(/SHOW tables/, logger.logged(:debug).last)
     end
 
-    test "rails load_config_initializer event is instrumented" do
+    test "Rails load_config_initializer event is instrumented" do
       app_file "config/initializers/foo.rb", ""
 
       events = []

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -32,7 +32,7 @@ module ApplicationTests
       assert_match(/DEPRECATION WARNING: Use `Rails::Application` subclass to start the server is deprecated/, log)
     end
 
-    test "restart rails server with custom pid file path" do
+    test "restart Rails server with custom pid file path" do
       skip "PTY unavailable" unless available_pty?
 
       File.open("#{app_path}/config/boot.rb", "w") do |f|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -631,7 +631,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_default_usage
     assert_called(Rails::Generators::AppGenerator, :usage_path, returns: nil) do
-      assert_match(/Create rails files for app generator/, Rails::Generators::AppGenerator.desc)
+      assert_match(/Create Rails files for app generator/, Rails::Generators::AppGenerator.desc)
     end
   end
 

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -11,7 +11,7 @@ module Rails
         Class.new(AppBase) do
           add_shared_options_for "application"
 
-          # include a module to get around thor's method_added hook
+          # include a module to get around Thor's method_added hook
           include(Module.new {
             def gemfile_entries; super; end
             def invoke_all; super; self; end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -396,11 +396,11 @@ class ActiveSupport::TestCase
   end
 end
 
-# Create a scope and build a fixture rails app
+# Create a scope and build a fixture Rails app
 Module.new do
   extend TestHelpers::Paths
 
-  # Build a rails app
+  # Build a Rails app
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir(app_template_path)
 


### PR DESCRIPTION
I've fixed casing for Rails, Bundler and Thor in documentation.

This is my reasoning:
* Rails as in *the framework* should be capitalized
* rails as in the *CLI tool* should be uncapitalized
* Bundler should be capitalized since it's a gem name
* Thor should be capitalized since it's a gem name

Let me know what you think!