### PR TITLE
Remove the cache_key_with_version method

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -101,15 +101,6 @@ module ActiveRecord
       end
     end
 
-    # Returns a cache key along with the version.
-    def cache_key_with_version
-      if version = cache_version
-        "#{cache_key}-#{version}"
-      else
-        cache_key
-      end
-    end
-
     module ClassMethods
       # Defines your model's +to_param+ method to generate "pretty" URLs
       # using +method_name+, which can be any attribute or method that

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -41,13 +41,5 @@ module ActiveRecord
       assert CacheMeWithVersion.create.cache_version.present?
       assert_not CacheMe.create.cache_version.present?
     end
-
-    test "cache_key_with_version always has both key and version" do
-      r1 = CacheMeWithVersion.create
-      assert_equal "active_record/cache_key_test/cache_me_with_versions/#{r1.id}-#{r1.updated_at.to_s(:usec)}", r1.cache_key_with_version
-
-      r2 = CacheMe.create
-      assert_equal "active_record/cache_key_test/cache_mes/#{r2.id}-#{r2.updated_at.to_s(:usec)}", r2.cache_key_with_version
-    end
   end
 end

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -214,21 +214,4 @@ class IntegrationTest < ActiveRecord::TestCase
   ensure
     Developer.cache_versioning = false
   end
-
-  def test_cache_key_retains_version_when_custom_timestamp_is_used
-    Developer.cache_versioning = true
-
-    developer = Developer.first
-    first_key = developer.cache_key_with_version
-
-    travel 10.seconds do
-      developer.touch
-    end
-
-    second_key = developer.cache_key_with_version
-
-    assert_not_equal first_key, second_key
-  ensure
-    Developer.cache_versioning = false
-  end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Remove the `cache_key_with_version` method
+
+    ActiveSupport::Cache now use 2 conventional methods:
+    `cache_key` and `cache_version` (instead of 3)
+
+    The concatenation of key with version is now performed inside
+    `AS::Cache.expand_cache_key` instead of `cache_key_with_version`
+
+    *Bogdan Gusiev*
+
 *   Allow the hash function used to generate non-sensitive digests, such as the
     ETag header, to be specified with `config.active_support.hash_digest_class`.
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -179,8 +179,8 @@ module CacheStoreBehavior
     def obj.cache_key
       "foo"
     end
-    def obj.cache_key_with_version
-      "foo-v1"
+    def obj.cache_version
+      "v1"
     end
     @cache.write(obj, "bar")
     assert_equal "bar", @cache.read("foo")

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -78,6 +78,20 @@ class CacheKeyTest < ActiveSupport::TestCase
     assert_equal "foo/bar/baz", ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
   end
 
+  def test_expand_cache_key_object_with_version
+    object = Object.new
+    def object.cache_key
+      "foo"
+    end
+    def object.cache_version
+      "v1"
+    end
+    assert_equal "foo-v1", ActiveSupport::Cache.expand_cache_key(object)
+    assert_equal "foo", ActiveSupport::Cache.expand_cache_key(object, version: false)
+    assert_equal "foo-v1/foo-v1", ActiveSupport::Cache.expand_cache_key([object, object])
+    assert_equal "foo/foo", ActiveSupport::Cache.expand_cache_key([object, object], version: false)
+  end
+
   private
 
     def with_env(kv)


### PR DESCRIPTION
### Summary

Remove the `cache_key_with_version` method

ActiveSupport::Cache now use 2 conventional methods:
`cache_key` and `cache_version` (instead of 3)

The concatenation of key with version is now performed inside
`AS::Cache.expand_cache_key` instead of `cache_key_with_version`

r? @georgeclaghorn

  
  