### PR TITLE
Reduce log noise handling ActionController::RoutingErrors

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Reduced log noise handling ActionController::RoutingErrors.
+
+    *Alberto Fernández-Capel*
+
 *   Keep part when scope option has value
 
     When a route was defined within an optional scope, if that route didn't

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -138,9 +138,7 @@ module ActionDispatch
         return unless logger
 
         exception = wrapper.exception
-
-        trace = wrapper.application_trace
-        trace = wrapper.framework_trace if trace.empty?
+        trace = wrapper.exception_trace
 
         ActiveSupport::Deprecation.silence do
           message = []

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -62,6 +62,12 @@ module ActionDispatch
       self.class.status_code_for_exception(unwrapped_exception.class.name)
     end
 
+    def exception_trace
+      trace = application_trace
+      trace = framework_trace if trace.empty? && !exception.is_a?(ActionController::RoutingError)
+      trace
+    end
+
     def application_trace
       clean_backtrace(:silent)
     end


### PR DESCRIPTION
### Summary

Each time a missing route is hit a trace with 32 lines of rails internals are written to the log. This is overly verbose and doesn't offer any actionable information to the user.

With this change we'll still write an error message showing the route error but the trace will be omitted.

### Other Information

Example trace in a new rails app:

```
Started GET "/asjdhaskda" for 127.0.0.1 at 2018-01-04 11:00:07 +0000
  
ActionController::RoutingError (No route matches [GET] "/asjdhaskda"):
  
actionpack (5.0.6) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
web-console (3.5.1) lib/web_console/middleware.rb:135:in `call_app'
web-console (3.5.1) lib/web_console/middleware.rb:28:in `block in call'
web-console (3.5.1) lib/web_console/middleware.rb:18:in `catch'
web-console (3.5.1) lib/web_console/middleware.rb:18:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
railties (5.0.6) lib/rails/rack/logger.rb:36:in `call_app'
railties (5.0.6) lib/rails/rack/logger.rb:24:in `block in call'
activesupport (5.0.6) lib/active_support/tagged_logging.rb:69:in `block in tagged'
activesupport (5.0.6) lib/active_support/tagged_logging.rb:26:in `tagged'
activesupport (5.0.6) lib/active_support/tagged_logging.rb:69:in `tagged'
railties (5.0.6) lib/rails/rack/logger.rb:24:in `call'
sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/request_id.rb:24:in `call'
rack (2.0.3) lib/rack/method_override.rb:22:in `call'
rack (2.0.3) lib/rack/runtime.rb:22:in `call'
activesupport (5.0.6) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.0.6) lib/action_dispatch/middleware/static.rb:136:in `call'
rack (2.0.3) lib/rack/sendfile.rb:111:in `call'
railties (5.0.6) lib/rails/engine.rb:522:in `call'
puma (3.11.0) lib/puma/configuration.rb:225:in `call'
puma (3.11.0) lib/puma/server.rb:624:in `handle_request'
puma (3.11.0) lib/puma/server.rb:438:in `process_client'
puma (3.11.0) lib/puma/server.rb:302:in `block in run'
puma (3.11.0) lib/puma/thread_pool.rb:120:in `block in spawn_thread'
  Rendering /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout
  Rendering /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
  Rendered /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.3ms)
  Rendered /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/routes/_table.html.erb (7.8ms)
  Rendering /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
  Rendered /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (7.8ms)
  Rendered /Users/afcapel/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (118.8ms)
```

With the change:

```
Started GET "/asjdhaskda" for 127.0.0.1 at 2018-01-04 10:47:23 +0000
  
ActionController::RoutingError (No route matches [GET] "/asjdhaskda"):
```
