### PR TITLE
Add missing require for `strip_heredoc`

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -3,6 +3,7 @@
 require "rack/session/abstract/id"
 require "action_controller/metal/exceptions"
 require "active_support/security_utils"
+require "active_support/core_ext/string/strip"
 
 module ActionController #:nodoc:
   class InvalidAuthenticityToken < ActionControllerError #:nodoc:


### PR DESCRIPTION
In some cases, it was possible to load request_forgery_protection without
the `strip_heredoc` helper being loaded, which caused an exception.
Explicitly require the helper as done in other file.
