### PR TITLE
Use dup'ed options hash

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -315,11 +315,13 @@ module Rails
 
       def convert_database_option_for_jruby
         if defined?(JRUBY_VERSION)
-          case options[:database]
-          when "postgresql" then options[:database].replace "jdbcpostgresql"
-          when "mysql"      then options[:database].replace "jdbcmysql"
-          when "sqlite3"    then options[:database].replace "jdbcsqlite3"
+          opt = options.dup
+          case opt[:database]
+          when "postgresql" then opt[:database] = "jdbcpostgresql"
+          when "mysql"      then opt[:database] = "jdbcmysql"
+          when "sqlite3"    then opt[:database] = "jdbcsqlite3"
           end
+          self.options = opt.freeze
         end
       end
 


### PR DESCRIPTION
Otherwise, at least using JRuby, the replacements in `convert_database_option_for_jruby` won't work. Thus a call to

    bundle exec rails app:update

fails. Simply replacing those replace statements doesn't seem to work either, since the options hash seems to be frozen, too.