### PR TITLE
Change Active Storage destroy callbacks

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use `after_destroy_commit` instead of `before_destroy` for purging
+    attachments when a record is destroyed.
+
+    *Hiroki Zenigami*
+
+
 *   Force `:attachment` disposition for specific, configurable content types.
     This mitigates possible security issues such as XSS or phishing when
     serving them inline. A list of such content types is included by default,

--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -44,7 +44,7 @@ module ActiveStorage
       scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
 
       if dependent == :purge_later
-        before_destroy { public_send(name).purge_later }
+        after_destroy_commit { public_send(name).purge_later }
       end
     end
 
@@ -89,7 +89,7 @@ module ActiveStorage
       scope :"with_attached_#{name}", -> { includes("#{name}_attachments": :blob) }
 
       if dependent == :purge_later
-        before_destroy { public_send(name).purge_later }
+        after_destroy_commit { public_send(name).purge_later }
       end
     end
   end


### PR DESCRIPTION
There is concern that only blob are deleted depending on the `before_destroy` definition order which throws abort.

For example following code doesn't destroy an user, and keep a record of `active_storage_attachments`, but a record of `active_storage_blobs` is destroyed.

```ruby
class User < ApplicationRecord
  has_one_attached :avatar
  
  before_destroy { throw(:abort) }

  # Currently it works fine if there is a code on lower line
  # has_one_attached :avatar
end
```

refs:
[carrierwave/activerecord.rb · carrierwaveuploader/carrierwave](https://github.com/carrierwaveuploader/carrierwave/blob/16c0eb5a7869d49930e165bc6a519033f067e9c6/lib/carrierwave/orm/activerecord.rb#L57)
[paperclip/has_attached_file.rb · thoughtbot/paperclip](https://github.com/thoughtbot/paperclip/blob/7edb35a2a9a80c9598dfde235c7e593c023fc914/lib/paperclip/has_attached_file.rb#L95-L97)