### PR TITLE
Fix typos [ci skip]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -805,7 +805,7 @@ config.action_mailer.smtp_settings = {
   user_name:            '<username>',
   password:             '<password>',
   authentication:       'plain',
-  enable_starttls_auto: true  }
+  enable_starttls_auto: true }
 ```
 Note: As of July 15, 2014, Google increased [its security measures](https://support.google.com/accounts/answer/6010255) and now blocks attempts from apps it deems less secure.
 You can change your Gmail settings [here](https://www.google.com/settings/security/lesssecureapps) to allow the attempts. If your Gmail account has 2-factor authentication enabled,

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -953,7 +953,7 @@ should happen, an `Array` can be used. Moreover, you can apply both `:if` and
 ```ruby
 class Computer < ApplicationRecord
   validates :mouse, presence: true,
-                    if: [Proc.new  { |c| c.market.retail? }, :desktop?],
+                    if: [Proc.new { |c| c.market.retail? }, :desktop?],
                     unless: Proc.new { |c| c.trackpad.present? }
 end
 ```

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -474,7 +474,7 @@ The common admin interface works like this: it's located at www.example.com/admi
 
 * Does the admin really have to access the interface from everywhere in the world? Think about _limiting the login to a bunch of source IP addresses_. Examine request.remote_ip to find out about the user's IP address. This is not bullet-proof, but a great barrier. Remember that there might be a proxy in use, though.
 
-* _Put the admin interface to a special sub-domain_ such as admin.application.com and make it a separate application with its own user management. This makes stealing an admin cookie from the usual domain, www.application.com, impossible. This is because of the same origin policy in your browser: An injected (XSS) script on www.application.com may not read the cookie for admin.application.com and vice-versa.
+* _Put the admin interface to a special subdomain_ such as admin.application.com and make it a separate application with its own user management. This makes stealing an admin cookie from the usual domain, www.application.com, impossible. This is because of the same origin policy in your browser: An injected (XSS) script on www.application.com may not read the cookie for admin.application.com and vice-versa.
 
 User Management
 ---------------

--- a/guides/source/threading_and_code_execution.md
+++ b/guides/source/threading_and_code_execution.md
@@ -272,7 +272,7 @@ that promise is to put it as close as possible to the blocking call:
 Rails.application.executor.wrap do
   th = Thread.new do
     Rails.application.executor.wrap do
-      User # inner thread can acquire the load lock,
+      User # inner thread can acquire the 'load' lock,
            # load User, and continue
     end
   end

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -373,7 +373,7 @@ Example usage:
 ```html
 document.body.addEventListener('ajax:success', function(event) {
   var detail = event.detail;
-  var data = detail[0], status = detail[1],  xhr = detail[2];
+  var data = detail[0], status = detail[1], xhr = detail[2];
 })
 ```
 


### PR DESCRIPTION
1) https://en.wikipedia.org/wiki/Subdomain
2) Line 262 of the same guide
3) extra spaces