### PR TITLE
Update active_storage_overview.md

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -35,6 +35,8 @@ files.
 
 ## Setup
 
+If you are upgrading to Rails 5.2, make sure `require "active_storage/engine"` is declared in `config/application.rb`. This should already be set for new Rails 5.2 applications.
+
 Active Storage uses two tables in your application’s database named
 `active_storage_blobs` and `active_storage_attachments`. After upgrading your
 application to Rails 5.2, run `rails active_storage:install` to generate a


### PR DESCRIPTION
### Summary

When I upgraded from Rails 5.1 to 5.2 and tried to install ActiveStorage, the migrations rake task was not found because I had not added the engine.

Adding this reminder in the guides or in the ActiveStorage readme could save time for other developers.

This was the issue I referenced: [https://github.com/rails/rails/issues/31245](https://github.com/rails/rails/issues/31245)
