### PR TITLE
Clean up railties tests

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -313,23 +313,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^# gem 'mini_magick'/
   end
 
-  def test_active_storage_install
-    command_check = -> command, _ do
-      @binstub_called ||= 0
-      case command
-      when "active_storage:install"
-        @binstub_called += 1
-        assert_equal 1, @binstub_called, "active_storage:install expected to be called once, but was called #{@binstub_called} times"
-      end
-    end
-
-    generator.stub :rails_command, command_check do
-      generator.stub :bundle_command, nil do
-        quietly { generator.invoke_all }
-      end
-    end
-  end
-
   def test_app_update_does_not_generate_active_storage_contents_when_skip_active_storage_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-active-storage"]

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -245,7 +245,6 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-    assert_no_directory "#{application_path}/db/migrate"
     assert_no_directory "#{application_path}/storage"
     assert_no_directory "#{application_path}/tmp/storage"
 
@@ -276,7 +275,6 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-    assert_no_directory "#{application_path}/db/migrate"
     assert_no_directory "#{application_path}/storage"
     assert_no_directory "#{application_path}/tmp/storage"
 


### PR DESCRIPTION
- Remove AppGeneratorTest#test_active_storage_install
The test is added by 67db41aa7f17c2d34eb5a914ac7a6b2574930ff4,
 since #31534 this test doesn't test anything


- Remove redundant assertions in SharedGeneratorTests
These assertions is added by 4a835aa3236eedb135ccf8b59ed3c03e040b8b01.
Follows 67db41aa7f17c2d34eb5a914ac7a6b2574930ff4, #31534

r? @y-yagi 