### PR TITLE
PostgreSQL: Allow pg-1.0 gem to be used with ActiveRecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :job do
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
-  gem "queue_classic", github: "QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby
+  gem "queue_classic", github: "Kjarrigan/queue_classic", branch: "update-pg", require: false, platforms: :ruby
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
-  remote: https://github.com/QueueClassic/queue_classic.git
-  revision: cde82d17ded2799ed726dd7b0df6ce1fd4c1b7da
-  branch: master
+  remote: https://github.com/Kjarrigan/queue_classic.git
+  revision: dee64b361355d56700ad7aa3b151bf653a617526
+  branch: update-pg
   specs:
     queue_classic (3.2.0.RC1)
-      pg (>= 0.17, < 0.20)
+      pg (>= 0.17, < 2.0)
 
 GIT
   remote: https://github.com/matthewd/rb-inotify.git
@@ -340,9 +340,9 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     path_expander (1.0.2)
-    pg (0.19.0)
-    pg (0.19.0-x64-mingw32)
-    pg (0.19.0-x86-mingw32)
+    pg (1.0.0)
+    pg (1.0.0-x64-mingw32)
+    pg (1.0.0-x86-mingw32)
     powerpack (0.1.1)
     psych (2.2.4)
     public_suffix (3.0.1)

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "pg", "~> 0.18"
+gem "pg", ">= 0.18", "< 2.0"
 require "pg"
 require "thread"
 require "digest/sha1"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Make sure we're using pg high enough for type casts and Ruby 2.2+ compatibility
-gem "pg", "~> 0.18"
+gem "pg", ">= 0.18", "< 2.0"
 require "pg"
 
 require "active_record/connection_adapters/abstract_adapter"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -301,7 +301,7 @@ module Rails
         # %w( mysql postgresql sqlite3 oracle frontbase ibm_db sqlserver jdbcmysql jdbcsqlite3 jdbcpostgresql )
         case options[:database]
         when "mysql"          then ["mysql2", ["~> 0.4.4"]]
-        when "postgresql"     then ["pg", ["~> 0.18"]]
+        when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -413,7 +413,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcpostgresql-adapter"
     else
-      assert_gem "pg", "'~> 0.18'"
+      assert_gem "pg", "'>= 0.18', '< 2.0'"
     end
   end
 


### PR DESCRIPTION
### Summary

pg-1.0.0 is just released and most Gemfiles don't restrict it's version. But the version is checked when connecting to the database, which leads to the following error, when after `bundle update`:
```
Gem::LoadError: can't activate pg (~> 0.18), already activated pg-1.0.0
```
See also this pg issue: https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start

Preparation for pg-1.0 was done in commit f28a331, but the pg version constraint was not yet relaxed.

The second commit switches the queue_classic repository to an open pull request, in order to enable testing on pg-1.0.0. I'm not sure if this is desired, so take it a proposal only!

### Rails Version Information

The patch is now backported to rails-5.0 and rails-5.1, so that pg-1.0.0 will work together with rails-5.0.7+ and 5.1.5+. Until these versions are released please add a gem version constraint to the Gemfile like:
```
gem "pg", "~> 0.18"
```

__Edit:__ Update information about rails-5.0 and 5.1.