### PR TITLE
Instrument model schema load

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Instrument model's schema load
+
+    This allows to configure models from application or gems based on available
+    columns and without connecting to database on startup:
+
+        module HasSomething
+          extend ActiveSupport::Concern
+          class_methods do
+            def has_something(*columns, except: nil, only: list)
+              event = "#{self}.load_schema.active_record"
+              ActiveSupport::Notifications.subscribe(event) do |*, payload|
+                # do some stuff
+                if self.column_names.include?("extra_something")
+                  # do more stuff
+                end
+              end
+            end
+          end
+        end
+
+    *Andrey Novikov*
+
 *   Take into account association conditions when deleting through records.
 
     Fixes #18424.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -454,7 +454,10 @@ module ActiveRecord
           @load_schema_monitor.synchronize do
             return if defined?(@columns_hash) && @columns_hash
 
-            load_schema!
+            instrumenter = ActiveSupport::Notifications.instrumenter
+            instrumenter.instrument("#{self}.load_schema.active_record", model: self) do
+              load_schema!
+            end
 
             @schema_loaded = true
           end

--- a/activerecord/test/models/unused_model.rb
+++ b/activerecord/test/models/unused_model.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UnusedModel < ActiveRecord::Base
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1050,6 +1050,8 @@ ActiveRecord::Schema.define do
     t.string :string_with_default, default: "the original default"
   end
 
+  create_table :unused_models, comment: "Unused table for single test", force: true
+
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -288,6 +288,25 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
+### MODEL.schema_load.active_record
+
+This hook will be called once for every model class when database connection will be established and columns information is retrieved.
+
+Gems can use this hook to configure models behavior depending on available columns.
+
+`Model` in the key will be replaced by model class name (e.g. `User`).
+
+| Key              | Value                                    |
+| ---------------- | ---------------------------------------- |
+| `:model`         | Model class                              |
+
+
+```ruby
+{
+  model: User,
+}
+```
+
 Action Mailer
 -------------
 


### PR DESCRIPTION
It looks like there is no hook that will allow configuring ActiveRecord models based on what columns they have but only when information about columns will be loaded from DB.

The problem is that if I ask in the model about available columns, then ActiveRecord will try to connect to DB and load this information. But at that time DB may not be available (or even may not exist!)

See https://github.com/ClosureTree/closure_tree/issues/264 for example.

We have such internal model extensions in our app too. After upgrade to current 5.2 beta one of them started to ruin even `rake db:create` command, trying to connect to not yet created database:

```ruby
class Product < ActiveRecord::Base
  include AttrTainted

  attr_tainted :name, :address
end

# This is how most gems works, you know
module AttrTainted
  extend ActiveSupport::Concern

  class_methods do
    def attr_tainted(*list, except: nil, only: list)
      unless column_names.include?("attr_tainted")
        Rails.logger.warn "You must add jsonb column attr_tainted to #{table_name}"
        return
      end
      # Do some setup, callbacks, validations, whatever
    end
  end
end
```

The target of this PR is to create some hook that may be useful for gems and internal concern modules in applications to configure models at the right time.

For now, it looks like this:

```ruby
    def attr_tainted(*list, except: nil, only: list)
      cattr_reader :attr_tainted_columns, instance_reader: false
      event = "#{self}.load_schema.active_record"
      ActiveSupport::Notifications.subscribe(event) do |*, payload|
        unless payload[:model].column_names.include?("attr_tainted")
          Rails.logger.warn "You must add jsonb column attr_tainted to #{payload[:model].table_name}"
          next
        end
        # more setup
      end
    end
```

Maybe it worth to write helper method like `on_configure` which will do all that stuff in it (where it is better to define it?). What do you think?

## Implementation notes

I've chosen ActiveSupport Instrumentation as it allows to have multiple hooks for every model and have them called in turn without writing much code.

ActiveSupport Callbacks are designed for defining callbacks at the class level and using at the instance level. I need to define _and_ use callbacks at the class level.

I'm waiting for your suggestions, advice and corrections! Thanks in advance.