### PR TITLE
Fix typos, update documentation

### DIFF
--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -4,7 +4,7 @@ require "base64"
 
 module ActionMailer
   # Implements a mailer preview interceptor that converts image tag src attributes
-  # that use inline cid: style urls to data: style urls so that they are visible
+  # that use inline cid: style URLs to data: style URLs so that they are visible
   # when previewing an HTML email in a web browser.
   #
   # This interceptor is enabled by default. To disable it, delete it from the

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -39,7 +39,7 @@ module ActionController
       #     end
       #
       # ==== URL Options
-      # You can pass any of the following options to affect the redirect url
+      # You can pass any of the following options to affect the redirect URL
       # * <tt>host</tt>       - Redirect to a different host name
       # * <tt>subdomain</tt>  - Redirect to a different subdomain
       # * <tt>domain</tt>     - Redirect to a different domain
@@ -73,7 +73,7 @@ module ActionController
     # Redirect the existing request to use the HTTPS protocol.
     #
     # ==== Parameters
-    # * <tt>host_or_options</tt> - Either a host name or any of the url and
+    # * <tt>host_or_options</tt> - Either a host name or any of the URL and
     #   redirect options available to the <tt>force_ssl</tt> method.
     def force_ssl_redirect(host_or_options = nil)
       unless request.ssl?

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -47,11 +47,11 @@ module ActionView
       # When the last parameter is a hash you can add HTML attributes using that
       # parameter. The following options are supported:
       #
-      # * <tt>:extname</tt>  - Append an extension to the generated url unless the extension
-      #   already exists. This only applies for relative urls.
-      # * <tt>:protocol</tt>  - Sets the protocol of the generated url, this option only
-      #   applies when a relative url and +host+ options are provided.
-      # * <tt>:host</tt>  - When a relative url is provided the host is added to the
+      # * <tt>:extname</tt>  - Append an extension to the generated URL unless the extension
+      #   already exists. This only applies for relative URLs.
+      # * <tt>:protocol</tt>  - Sets the protocol of the generated URL. This option only
+      #   applies when a relative URL and +host+ options are provided.
+      # * <tt>:host</tt>  - When a relative URL is provided the host is added to the
       #   that path.
       # * <tt>:skip_pipeline</tt>  - This option is used to bypass the asset pipeline
       #   when it is set to true.
@@ -224,8 +224,8 @@ module ActionView
       end
 
       # Returns a link tag that browsers can use to preload the +source+.
-      # The +source+ can be the path of an resource managed by asset pipeline,
-      # a full path or an URI.
+      # The +source+ can be the path of a resource managed by asset pipeline,
+      # a full path, or an URI.
       #
       # ==== Options
       #
@@ -285,7 +285,7 @@ module ActionView
       end
 
       # Returns an HTML image tag for the +source+. The +source+ can be a full
-      # path, a file or an Active Storage attachment.
+      # path, a file, or an Active Storage attachment.
       #
       # ==== Options
       #
@@ -373,12 +373,13 @@ module ActionView
       # Returns an HTML video tag for the +sources+. If +sources+ is a string,
       # a single video tag will be returned. If +sources+ is an array, a video
       # tag with nested source tags for each source will be returned. The
-      # +sources+ can be full paths or files that exists in your public videos
+      # +sources+ can be full paths or files that exist in your public videos
       # directory.
       #
       # ==== Options
-      # You can add HTML attributes using the +options+. The +options+ supports
-      # two additional keys for convenience and conformance:
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter. The following options are supported:
       #
       # * <tt>:poster</tt> - Set an image (like a screenshot) to be shown
       #   before the video loads. The path is calculated like the +src+ of +image_tag+.
@@ -395,7 +396,7 @@ module ActionView
       #   video_tag("trailer.ogg")
       #   # => <video src="/videos/trailer.ogg"></video>
       #   video_tag("trailer.ogg", controls: true, preload: 'none')
-      #   # => <video preload="none" controls="controls" src="/videos/trailer.ogg" ></video>
+      #   # => <video preload="none" controls="controls" src="/videos/trailer.ogg"></video>
       #   video_tag("trailer.m4v", size: "16x10", poster: "screenshot.png")
       #   # => <video src="/videos/trailer.m4v" width="16" height="10" poster="/assets/screenshot.png"></video>
       #   video_tag("trailer.m4v", size: "16x10", poster: "screenshot.png", poster_skip_pipeline: true)
@@ -422,9 +423,14 @@ module ActionView
         end
       end
 
-      # Returns an HTML audio tag for the +source+.
-      # The +source+ can be full path or file that exists in
-      # your public audios directory.
+      # Returns an HTML audio tag for the +sources+. If +sources+ is a string,
+      # a single audio tag will be returned. If +sources+ is an array, an audio
+      # tag with nested source tags for each source will be returned. The
+      # +sources+ can be full paths or files that exist in your public audios
+      # directory.
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter.
       #
       #   audio_tag("sound")
       #   # => <audio src="/audios/sound"></audio>

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -6,7 +6,7 @@ module ActionView
   # = Action View Asset URL Helpers
   module Helpers #:nodoc:
     # This module provides methods for generating asset paths and
-    # urls.
+    # URLs.
     #
     #   image_path("rails.png")
     #   # => "/assets/rails.png"
@@ -57,8 +57,8 @@ module ActionView
     # You can read more about setting up your DNS CNAME records from your ISP.
     #
     # Note: This is purely a browser performance optimization and is not meant
-    # for server load balancing. See http://www.die.net/musings/page_load_time/
-    # for background and http://www.browserscope.org/?category=network for
+    # for server load balancing. See https://www.die.net/musings/page_load_time/
+    # for background and https://www.browserscope.org/?category=network for
     # connection limit data.
     #
     # Alternatively, you can exert more control over the asset host by setting
@@ -97,7 +97,7 @@ module ActionView
     # still sending assets for plain HTTP requests from asset hosts. If you don't
     # have SSL certificates for each of the asset hosts this technique allows you
     # to avoid warnings in the client about mixed media.
-    # Note that the request parameter might not be supplied, e.g. when the assets
+    # Note that the +request+ parameter might not be supplied, e.g. when the assets
     # are precompiled via a Rake task. Make sure to use a +Proc+ instead of a lambda,
     # since a +Proc+ allows missing parameters and sets them to +nil+.
     #
@@ -149,13 +149,13 @@ module ActionView
       # Below lists scenarios that apply to +asset_path+ whether or not you're
       # using the asset pipeline.
       #
-      # - All fully qualified urls are returned immediately. This bypasses the
+      # - All fully qualified URLs are returned immediately. This bypasses the
       #   asset pipeline and all other behavior described.
       #
       #     asset_path("http://www.example.com/js/xmlhr.js") # => "http://www.example.com/js/xmlhr.js"
       #
       # - All assets that begin with a forward slash are assumed to be full
-      #   urls and will not be expanded. This will bypass the asset pipeline.
+      #   URLs and will not be expanded. This will bypass the asset pipeline.
       #
       #     asset_path("/foo.png") # => "/foo.png"
       #

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -19,7 +19,7 @@ module ActionView
     # compared to using vanilla HTML.
     #
     # Typically, a form designed to create or update a resource reflects the
-    # identity of the resource in several ways: (i) the url that the form is
+    # identity of the resource in several ways: (i) the URL that the form is
     # sent to (the form element's +action+ attribute) should result in a request
     # being routed to the appropriate controller action (with the appropriate <tt>:id</tt>
     # parameter in the case of an existing resource), (ii) input fields should
@@ -166,7 +166,7 @@ module ActionView
       #   So for example you may use a named route directly. When the model is
       #   represented by a string or symbol, as in the example above, if the
       #   <tt>:url</tt> option is not specified, by default the form will be
-      #   sent back to the current url (We will describe below an alternative
+      #   sent back to the current URL (We will describe below an alternative
       #   resource-oriented usage of +form_for+ in which the URL does not need
       #   to be specified explicitly).
       # * <tt>:namespace</tt> - A namespace for your form to ensure uniqueness of
@@ -608,7 +608,7 @@ module ActionView
       #   This is helpful when fragment-caching the form. Remote forms
       #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
       #   unnecessary unless you support browsers without JavaScript.
-      # * <tt>:local</tt> - By default form submits are remote and unobstrusive XHRs.
+      # * <tt>:local</tt> - By default form submits are remote and unobtrusive XHRs.
       #   Disable remote submits with <tt>local: true</tt>.
       # * <tt>:skip_enforcing_utf8</tt> - By default a hidden field named +utf8+
       #   is output to enforce UTF-8 submits. Set to true to skip the field.


### PR DESCRIPTION
This fixes several issues in the documentation that I noticed:

### Corrections
* In asset_tag_helper.rb, the documentation for `audio_tag` and `video_tag` doesn't match the methods' current parameter inputs.  I've updated them, using wording similar to that of other methods in the file.

### Cleanup
* Throughout the Rails documentation, "URL" is written in all-caps, since it's an acronym.  I found a few instances where it was lowercase and capitalized them for consistency.
* Updated two external links in asset_url_helper.rb to use HTTPS
* Fixed one instance where a literal was missing its code markup (`+request+`)
* Added two missing Oxford commas
* Typo fixes:
  * `an resource` → `a resource`
  * `files that exists` → `files that exist`
  * `unobstrusive` → `unobtrusive`
