### PR TITLE
Fix bug with ActiveModel::Errors#added?

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -327,7 +327,7 @@ module ActiveModel
       else
         message = message.call if message.respond_to?(:call)
         message = normalize_message(attribute, message, options)
-        self[attribute].include? message
+        self.has_key?(attribute) && self[attribute].include?(message)
       end
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -229,9 +229,14 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not person.errors.added?(:name, :used)
   end
 
-  test "added? does not modify messages" do
+  test "added? does not modify messages when checking for a String message" do
     person = Person.new
     person.errors.added?(:name, "cannot be blank")
+    assert person.errors.messages.empty?
+  end
+
+  test "added? does not modify messages when checking for a Symbol message" do
+    person = Person.new
     person.errors.added?(:name, :blank)
     assert person.errors.messages.empty?
   end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -229,6 +229,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not person.errors.added?(:name, :used)
   end
 
+  test "added? does not modify messages" do
+    person = Person.new
+    person.errors.added?(:name, "cannot be blank")
+    person.errors.added?(:name, :blank)
+    assert person.errors.messages.empty?
+  end
+
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
This fixes a bug with `ActiveModel::Errors#added?`.  Calling `added?` with an attribute name that was not already a key in the `messages` Hash would unexpectedly add it as a key, with an empty Array as its value.  Now calling `#added?` will not modify `messages`.  

Replication instructions:
```
class FakeModel; include ActiveModel::Validations; end
fake_model = FakeModel.new
fake_model.errors.messages.has_key?(:some_attribute) # false
fake_model.errors.added?(:some_attribute, 'some message')
fake_model.errors.messages.has_key?(:some_attribute) # true
```