### PR TITLE
Remove key from session by using session.delete

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -458,6 +458,8 @@ class LoginsController < ApplicationController
   def destroy
     # Remove the user id from the session
     session.delete(:current_user_id)
+    # Clear the memoized current user
+    @_current_user = nil
     redirect_to root_url
   end
 end

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -457,7 +457,7 @@ class LoginsController < ApplicationController
   # "Delete" a login, aka "log the user out"
   def destroy
     # Remove the user id from the session
-    @_current_user = session[:current_user_id] = nil
+    session.delete(:current_user_id)
     redirect_to root_url
   end
 end


### PR DESCRIPTION
This PR only changes the guides.

Since you are not deleting a key from session when you assign nil to that key (`session[key] = nil`), the correct way of deleting a key from session should be `session.delete(key)`.