### PR TITLE
Use map instead of each for ActiveRecord::Relation#destroy_all

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a bug when `destroy_all` and `Klass.destroy([id_1, id_2])` will return
+    all records instead of only affected ones
+
+    *Philip Kurlovich*
+
 *   Take into account association conditions when deleting through records.
 
     Fixes #18424.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -123,6 +123,11 @@ module ActiveRecord
       # This essentially finds the object (or multiple objects) with the given id, creates a new object
       # from the attributes, and then calls destroy on it.
       #
+      # For single id argument: Returns frozen destroyed object. If destroy callback chain halted
+      # returns +false+
+      # For array of ids argument: Returns the collection of objects that were destroyed; each will
+      # be frozen, to reflect that no changes should be made (since they can't be persisted).
+      #
       # ==== Parameters
       #
       # * +id+ - This should be the id or an array of ids to be destroyed.
@@ -137,7 +142,7 @@ module ActiveRecord
       #   Todo.destroy(todos)
       def destroy(id)
         if id.is_a?(Array)
-          find(id).each(&:destroy)
+          find(id).select(&:destroy)
         else
           find(id).destroy
         end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -346,7 +346,7 @@ module ActiveRecord
     #
     #   Person.where(age: 0..18).destroy_all
     def destroy_all
-      records.map(&:destroy).select{ |record| record.present? }.tap { reset }
+      records.select(&:destroy).tap { reset }
     end
 
     # Deletes the records without instantiating the records

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -346,7 +346,7 @@ module ActiveRecord
     #
     #   Person.where(age: 0..18).destroy_all
     def destroy_all
-      records.each(&:destroy).tap { reset }
+      records.map(&:destroy).select{ |record| record.present? }.tap { reset }
     end
 
     # Deletes the records without instantiating the records


### PR DESCRIPTION
### Summary
As per documentation `destroy_all` should return a collection of destroyed records, but since it uses `each(&:destroy)` it instead returns a collection it attempted to destroy. Made it to match the current documentation but maybe it should have more informative response ( somehow notify about records that failed to be destroyed )
