### PR TITLE
Make ActiveStorage::Variant#processed? public

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -76,11 +76,12 @@ class ActiveStorage::Variant
     self
   end
 
-  private
-    def processed?
-      service.exist?(key)
-    end
+  # Returns true if the existing processing has been found on the service
+  def processed?
+    service.exist?(key)
+  end
 
+  private
     def process
       open_image do |image|
         transform image
@@ -88,7 +89,6 @@ class ActiveStorage::Variant
         upload image
       end
     end
-
 
     def filename
       if WEB_IMAGE_CONTENT_TYPES.include?(blob.content_type)


### PR DESCRIPTION
### Summary

This small change makes `ActiveStorage::Variant#processed?` public.
What's the reasoning behind it?

Suppose that you want to execute the processing in the background (e.g. thru ActiveJob); then in your views you want to decide on whether to show the variant (if it's ready) or the original image as a fallback:

```ruby
<% if image.variant(resize: "500x500").processed? %>
  <%= image_tag image.variant(resize: "500x500") %>
<% else %>
  <%= image_tag image %>
<% end %>
```

That is, maybe, a very simple example.

Nevertheless, I think it could be useful to have this method as a part of public API.