### PR TITLE
Don't update counter cache when through record was not destroyed

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -145,7 +145,7 @@ module ActiveRecord
           case method
           when :destroy
             if scope.klass.primary_key
-              count = scope.destroy_all.length
+              count = scope.destroy_all.count(&:destroyed?)
             else
               scope.each(&:_run_destroy_callbacks)
               count = scope.delete_all

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -538,6 +538,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_update_counter_caches_on_destroy_with_indestructible_through_record
+    post = posts(:welcome)
+    tag  = post.indestructible_tags.create!(name: "doomed")
+    post.update_columns(indestructible_tags_count: post.indestructible_tags.count)
+
+    assert_no_difference "post.reload.indestructible_tags_count" do
+      posts(:welcome).indestructible_tags.destroy(tag)
+    end
+  end
+
   def test_replace_association
     assert_queries(4) { posts(:welcome);people(:david);people(:michael); posts(:welcome).people.reload }
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -22,8 +22,8 @@ module ActiveRecord
 
         new_cache = YAML.load(YAML.dump(@cache))
         assert_no_queries do
-          assert_equal 11, new_cache.columns("posts").size
-          assert_equal 11, new_cache.columns_hash("posts").size
+          assert_equal 12, new_cache.columns("posts").size
+          assert_equal 12, new_cache.columns_hash("posts").size
           assert new_cache.data_sources("posts")
           assert_equal "id", new_cache.primary_keys("posts")
         end
@@ -75,8 +75,8 @@ module ActiveRecord
         @cache = Marshal.load(Marshal.dump(@cache))
 
         assert_no_queries do
-          assert_equal 11, @cache.columns("posts").size
-          assert_equal 11, @cache.columns_hash("posts").size
+          assert_equal 12, @cache.columns("posts").size
+          assert_equal 12, @cache.columns_hash("posts").size
           assert @cache.data_sources("posts")
           assert_equal "id", @cache.primary_keys("posts")
         end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -106,6 +106,9 @@ class Post < ActiveRecord::Base
     end
   end
 
+  has_many :indestructible_taggings, as: :taggable, counter_cache: :indestructible_tags_count
+  has_many :indestructible_tags, through: :indestructible_taggings, source: :tag
+
   has_many :taggings_with_delete_all, class_name: "Tagging", as: :taggable, dependent: :delete_all, counter_cache: :taggings_with_delete_all_count
   has_many :taggings_with_destroy, class_name: "Tagging", as: :taggable, dependent: :destroy, counter_cache: :taggings_with_destroy_count
 

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -14,3 +14,7 @@ class Tagging < ActiveRecord::Base
   belongs_to :taggable, polymorphic: true, counter_cache: :tags_count
   has_many :things, through: :taggable
 end
+
+class IndestructibleTagging < Tagging
+  before_destroy { throw :abort }
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -690,6 +690,7 @@ ActiveRecord::Schema.define do
     t.integer :taggings_with_delete_all_count, default: 0
     t.integer :taggings_with_destroy_count, default: 0
     t.integer :tags_count, default: 0
+    t.integer :indestructible_tags_count, default: 0
     t.integer :tags_with_destroy_count, default: 0
     t.integer :tags_with_nullify_count, default: 0
   end
@@ -847,6 +848,7 @@ ActiveRecord::Schema.define do
     t.column :taggable_type, :string
     t.column :taggable_id, :integer
     t.string :comment
+    t.string :type
   end
 
   create_table :tasks, force: true do |t|


### PR DESCRIPTION
When removing a record from a has many through association, the counter cache was being updated even if the through record halted the callback chain and prevented itself from being destroyed.

https://github.com/rails/rails/pull/31687 would also fix this problem, but in a different way: records which were not destroyed would no longer be returned from `destroy_all`. This approach is more appropriate to backport however, as it doesn't change any public APIs, and I think having test coverage for this case is useful.