### PR TITLE
Convert keys to binary in the Redis cache store

### DIFF
--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -14,10 +14,30 @@ Rake::TestTask.new do |t|
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
+Rake::Task[:test].enhance do
+  Rake::Task["test:cache_stores:redis:ruby"].invoke
+end
+
 namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
     end || raise("Failures")
+  end
+
+  namespace :cache_stores do
+    namespace :redis do
+      %w[ ruby hiredis ].each do |driver|
+        task("env:#{driver}") { ENV["REDIS_DRIVER"] = driver }
+
+        Rake::TestTask.new(driver => "env:#{driver}") do |t|
+          t.libs << "test"
+          t.test_files = ["test/cache/stores/redis_cache_store_test.rb"]
+          t.warning = true
+          t.verbose = true
+          t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
+        end
+      end
+    end
   end
 end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -363,7 +363,7 @@ module ActiveSupport
 
         # Truncate keys that exceed 1kB.
         def normalize_key(key, options)
-          truncate_key super
+          truncate_key super.b
         end
 
         def truncate_key(key)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -5,6 +5,12 @@ require "active_support/cache"
 require "active_support/cache/redis_cache_store"
 require_relative "../behaviors"
 
+driver_name = %w[ ruby hiredis ].include?(ENV["REDIS_DRIVER"]) ? ENV["REDIS_DRIVER"] : "hiredis"
+driver = Object.const_get("Redis::Connection::#{driver_name.camelize}")
+
+Redis::Connection.drivers.clear
+Redis::Connection.drivers.append(driver)
+
 module ActiveSupport::Cache::RedisCacheStoreTests
   class LookupTest < ActiveSupport::TestCase
     test "may be looked up as :redis_cache_store" do


### PR DESCRIPTION
Fix encoding errors when using the pure-Ruby Redis driver instead of Hiredis. Dodge incompatibilities between UTF-8 and arbitrary value encodings, which rear their heads when the Redis driver tries to build a single command string from incompatibly-encoded keys and values.

/cc @jeremy