### PR TITLE
Fix not expanded problem when passing an Array object as argument to the where method using composed_of column.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix not expanded problem when passing an Array object as argument to the where method using composed_of column.
+
+    Fixes #31723
+
+    ```
+    david_balance = customers(:david).balance
+    Customer.where(balance: [david_balance]).to_sql
+
+    # Before: WHERE `customers`.`balance` = NULL
+    # After : WHERE `customers`.`balance` = 50
+    ```
+    
+    *Yutaro Kanagawa*
+
 *   Fix `count(:all)` with eager loading and having an order other than the driving table.
 
     Fixes #31783.

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -155,10 +155,14 @@ module ActiveRecord
             if aggregation = reflect_on_aggregation(attr.to_sym)
               mapping = aggregation.mapping
               mapping.each do |field_attr, aggregate_attr|
-                if mapping.size == 1 && !value.respond_to?(aggregate_attr)
-                  expanded_attrs[field_attr] = value
+                expanded_attrs[field_attr] = if mapping.size == 1 && !value.respond_to?(aggregate_attr)
+                  if value.is_a?(Array)
+                    value.map { |it| it.respond_to?(aggregate_attr) ? it.send(aggregate_attr) : it }
+                  else
+                    value
+                  end
                 else
-                  expanded_attrs[field_attr] = value.send(aggregate_attr)
+                  value.send(aggregate_attr)
                 end
               end
             else

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -155,12 +155,10 @@ module ActiveRecord
             if aggregation = reflect_on_aggregation(attr.to_sym)
               mapping = aggregation.mapping
               mapping.each do |field_attr, aggregate_attr|
-                expanded_attrs[field_attr] = if mapping.size == 1 && !value.respond_to?(aggregate_attr)
-                  if value.is_a?(Array)
-                    value.map { |it| it.respond_to?(aggregate_attr) ? it.send(aggregate_attr) : it }
-                  else
-                    value
-                  end
+                expanded_attrs[field_attr] = if value.is_a?(Array)
+                  value.map { |it| it.send(aggregate_attr) }
+                elsif mapping.size == 1 && !value.respond_to?(aggregate_attr)
+                  value
                 else
                   value.send(aggregate_attr)
                 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -868,6 +868,25 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal customers(:david), found_customer
   end
 
+  def test_hash_condition_find_with_aggregate_having_three_mapping_array
+    david_address = customers(:david).address
+    zaphod_address = customers(:zaphod).address
+    assert_kind_of Address, david_address
+    assert_kind_of Address, zaphod_address
+    assert_raise(NoMethodError) do
+      Customer.where(address: [david_address, zaphod_address])
+    end
+  end
+
+  def test_hash_condition_find_with_aggregate_having_one_mapping_array
+    david_balance = customers(:david).balance
+    zaphod_balance = customers(:zaphod).balance
+    assert_kind_of Money, david_balance
+    assert_kind_of Money, zaphod_balance
+    found_customers = Customer.where(balance: [david_balance, zaphod_balance])
+    assert_equal [customers(:david), customers(:zaphod)], found_customers
+  end
+
   def test_hash_condition_find_with_aggregate_attribute_having_same_name_as_field_and_key_value_being_aggregate
     gps_location = customers(:david).gps_location
     assert_kind_of GpsLocation, gps_location

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -873,9 +873,8 @@ class FinderTest < ActiveRecord::TestCase
     zaphod_address = customers(:zaphod).address
     assert_kind_of Address, david_address
     assert_kind_of Address, zaphod_address
-    assert_raise(NoMethodError) do
-      Customer.where(address: [david_address, zaphod_address])
-    end
+    found_customers = Customer.where(address: [david_address, zaphod_address])
+    assert_equal [customers(:david), customers(:zaphod)], found_customers
   end
 
   def test_hash_condition_find_with_aggregate_having_one_mapping_array


### PR DESCRIPTION
Fixes #31723

```
david_balance = customers(:david).balance
Customer.where(balance: [david_balance]).to_sql

# Before: WHERE `customers`.`balance` = NULL
# After : WHERE `customers`.`balance` = 50
```

