### PR TITLE
Update "Layouts and Rendering in Rails" guide [ci skip]

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -97,7 +97,7 @@ If we want to display the properties of all the books in our view, we can do so 
 <%= link_to "New book", new_book_path %>
 ```
 
-NOTE: The actual rendering is done by subclasses of `ActionView::TemplateHandlers`. This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler. Beginning with Rails 2, the standard extensions are `.erb` for ERB (HTML with embedded Ruby), and `.builder` for Builder (XML generator).
+NOTE: The actual rendering is done by nested classes of the module [`ActionView::Template::Handlers`](http://api.rubyonrails.org/classes/ActionView/Template/Handlers.html). This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler.
 
 ### Using `render`
 


### PR DESCRIPTION
  - Remove mention about `ActionView::TemplateHandlers` since this
    module was removed by c1304098cca8a9247a9ad1461a1a343354650843.
    Change word `subclasses` to `nested classes`.
    See c7408a0e40545558872efb4129fe4bf097c9ce2f
  - Remove useless sentence "Beginning with Rails 2, the standard extensions
    are `.erb` for ERB (HTML with embedded Ruby), and `.builder` for Builder (XML generator)."