### PR TITLE
Allow `false` for `config.generators.system_tests=`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -200,6 +200,7 @@ The full set of methods that can be used in this block are as follows:
 * `force_plural` allows pluralized model names. Defaults to `false`.
 * `helper` defines whether or not to generate helpers. Defaults to `true`.
 * `integration_tool` defines which integration tool to use to generate integration tests. Defaults to `:test_unit`.
+* `system_tests` defines which integration tool to use to generate system tests. Defaults to `:test_unit`.
 * `javascripts` turns on the hook for JavaScript files in generators. Used in Rails for when the `scaffold` generator is run. Defaults to `true`.
 * `javascript_engine` configures the engine to be used (for eg. coffee) when generating assets. Defaults to `:js`.
 * `orm` defines which orm to use. Defaults to `false` and will use Active Record by default.

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -23,7 +23,7 @@ module TestUnit # :nodoc:
         template template_file,
                  File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
 
-        unless options.api? || options[:system_tests].nil?
+        if !options.api? && options[:system_tests]
           template "system_test.rb", File.join("test/system", class_path, "#{file_name.pluralize}_test.rb")
         end
       end


### PR DESCRIPTION
- Allow `false` for `config.generators.system_tests=`
  I think using `config.generators.system_tests=` with `false` should guarantee the same behavior as with `nil`.
- Mention `config.generators.system_tests` in the "Configuring Rails Applications" guide.