### PR TITLE
Enable autocorrect for `Lint/EndAlignment` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Layout/CaseIndentation:
 Layout/CommentIndentation:
   Enabled: true
 
+Layout/ElseAlignment:
+  Enabled: true
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
@@ -140,6 +143,7 @@ Style/UnneededPercentQ:
 Lint/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
+  AutoCorrect: true
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -83,7 +83,7 @@ module ActionCable
         when Numeric then @driver.text(message.to_s)
         when String  then @driver.text(message)
         when Array   then @driver.binary(message)
-          else false
+        else false
         end
       end
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -274,7 +274,7 @@ module ActionDispatch
       def standard_port
         case protocol
         when "https://" then 443
-          else 80
+        else 80
         end
       end
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -116,7 +116,7 @@ module ActionView
             when 10..19 then locale.t :less_than_x_seconds, count: 20
             when 20..39 then locale.t :half_a_minute
             when 40..59 then locale.t :less_than_x_minutes, count: 1
-              else             locale.t :x_minutes,           count: 1
+            else             locale.t :x_minutes,           count: 1
             end
 
           when 2...45           then locale.t :x_minutes,      count: distance_in_minutes
@@ -131,7 +131,7 @@ module ActionView
           when 43200...86400    then locale.t :about_x_months, count: (distance_in_minutes.to_f / 43200.0).round
             # 60 days up to 365 days
           when 86400...525600   then locale.t :x_months,       count: (distance_in_minutes.to_f / 43200.0).round
-            else
+          else
             from_year = from_time.year
             from_year += 1 if from_time.month >= 3
             to_year = to_time.year

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -38,7 +38,7 @@ module ActiveRecord
                       " TABLESPACE = \"#{value}\""
                     when :connection_limit
                       " CONNECTION LIMIT = #{value}"
-            else
+                    else
                       ""
             end
           end

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -165,7 +165,7 @@ module ActiveSupport
           Hash[params.map { |k, v| [k.to_s.tr("-", "_"), normalize_keys(v)] } ]
         when Array
           params.map { |v| normalize_keys(v) }
-          else
+        else
           params
         end
       end
@@ -178,7 +178,7 @@ module ActiveSupport
           process_array(value)
         when String
           value
-          else
+        else
           raise "can't typecast #{value.class.name} - #{value.inspect}"
         end
       end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -670,7 +670,7 @@ module ActiveSupport #:nodoc:
       when Module
         desc.name ||
           raise(ArgumentError, "Anonymous modules have no name to be referenced by")
-        else raise TypeError, "Not a valid constant descriptor: #{desc.inspect}"
+      else raise TypeError, "Not a valid constant descriptor: #{desc.inspect}"
       end
     end
 

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -61,7 +61,7 @@ module ActiveSupport
           case message
           when Symbol then "#{warning} (use #{message} instead)"
           when String then "#{warning} (#{message})"
-            else warning
+          else warning
           end
         end
 

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -227,7 +227,7 @@ module ActiveSupport
         case scope
         when :all
           @plurals, @singulars, @uncountables, @humans = [], [], Uncountables.new, []
-          else
+        else
           instance_variable_set "@#{scope}", []
         end
       end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -350,7 +350,7 @@ module ActiveSupport
         when 1; "st"
         when 2; "nd"
         when 3; "rd"
-          else    "th"
+        else    "th"
         end
       end
     end

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -276,7 +276,7 @@ module ActiveSupport
           reorder_characters(decompose(:compatibility, codepoints))
         when :kc
           compose(reorder_characters(decompose(:compatibility, codepoints)))
-          else
+        else
           raise ArgumentError, "#{form} is not a valid normalization variant", caller
         end.pack("U*".freeze)
       end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -238,7 +238,7 @@ module ActiveSupport
         when Numeric, ActiveSupport::Duration
           arg *= 3600 if arg.abs <= 13
           all.find { |z| z.utc_offset == arg.to_i }
-          else
+        else
           raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}"
         end
       end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -75,7 +75,7 @@ module Rails
                         when :date                 then :date_select
                         when :text                 then :text_area
                         when :boolean              then :check_box
-          else
+                        else
                           :text_field
         end
       end
@@ -91,7 +91,7 @@ module Rails
                      when :text                        then "MyText"
                      when :boolean                     then false
                      when :references, :belongs_to     then nil
-          else
+                     else
                        ""
         end
       end


### PR DESCRIPTION
### Summary

This PR changes .rubocop.yml.

Regarding the code using `if ... else ... end`, I think the coding style that Rails expects is as follows.

```ruby
var = if cond
  a
else
  b
end
```

However, the current .rubocop.yml setting does not offense for the following code.

```ruby
var = if cond
        a
      else
        b
      end
```

I think that the above code expects offense to be warned.

Moreover, the layout by autocorrect is unnatural.

```ruby
var = if cond
  a
      else
        b
      end
```

This PR adds a setting to .rubocop.yml to make an offense warning and autocorrect as expected by the coding style.
And this change also fixes `case ... when ... end` together.

Also this PR itself is an example that arranges the layout using `rubocop -a`.

### Other Information

Autocorrect of `Lint/EndAlignment` cop is `false` by default.
https://github.com/bbatsov/rubocop/blob/v0.51.0/config/default.yml#L1443

This PR changes this value to `true`.

Also this PR has changed it together as it is necessary to enable `Layout/ElseAlignment` cop to make this behavior.
