### PR TITLE
Allow camelize to take a string or an old school boolean

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -89,13 +89,15 @@ class String
   #   'active_record/errors'.camelize         # => "ActiveRecord::Errors"
   #   'active_record/errors'.camelize(:lower) # => "activeRecord::Errors"
   def camelize(first_letter = :upper)
-    case first_letter
+    case first_letter.to_sym
     when :upper
       ActiveSupport::Inflector.camelize(self, true)
     when :lower
       ActiveSupport::Inflector.camelize(self, false)
+    when true, false
+      ActiveSupport::Inflector.camelize(self, first_letter)
     else
-      raise ArgumentError, "Invalid option, use either :upper or :lower."
+      raise ArgumentError, "Invalid option, use either :upper or :lower, true or false, was provided #{first_letter.inspect}"
     end
   end
   alias_method :camelcase, :camelize


### PR DESCRIPTION
### Summary

I was annoyed to find out this interface weirdly changed in a breaking way (twice) on minor version, but also seemingly avoided allowing the user to follow the lower interface *for seemingly no reason* and forced the user to use symbols.


I know this will need changes, but I wanted to get the ball roling before spending more energy.