### PR TITLE
Ensure that autoloaded constants is unique

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -73,7 +73,7 @@ module ActiveSupport #:nodoc:
     # An array of qualified constant names that have been loaded. Adding a name
     # to this array will cause it to be unloaded the next time Dependencies are
     # cleared.
-    mattr_accessor :autoloaded_constants, default: []
+    mattr_accessor :autoloaded_constants, default: Set.new
 
     # An array of constant names that need to be unloaded on every request. Used
     # to allow arbitrary constants to be marked for unloading.
@@ -467,8 +467,7 @@ module ActiveSupport #:nodoc:
         result = Kernel.load path
       end
 
-      autoloaded_constants.concat newly_defined_paths unless load_once_path?(path)
-      autoloaded_constants.uniq!
+      autoloaded_constants.merge(newly_defined_paths) unless load_once_path?(path)
       result
     end
 

--- a/activesupport/test/autoloading_fixtures/another_constant/reload_error.rb
+++ b/activesupport/test/autoloading_fixtures/another_constant/reload_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AnotherConstant::ReloadError
+  # no_such_method_as_this
+end

--- a/activesupport/test/autoloading_fixtures/constant_reload_error.rb
+++ b/activesupport/test/autoloading_fixtures/constant_reload_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ConstantReloadError
+  # Nothing to see here, except another constant load:
+  AnotherConstant::ReloadError
+end


### PR DESCRIPTION
Motivation:
- It has been shown that autoloaded constants are not ensuring that
constants are only loaded once in the situation where a valid constant
is then edited to be exceptional, then said exception is corrected. In
this scenario we are seeing the constant being added in an infinite
loop. I tested switching the array to a set and this resoloved the
issue.

Relate Issue:
- #31694

Changes:
- Change autoloaded constant from array to set.
- Change methods called against this set from array methods to
equivalent array methods.

