### PR TITLE
Use separate folders in Rails.root call

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store


### PR DESCRIPTION
### Summary

Since we're using `Rails.root` here, we should take full advantage of it and use separate folders.  This issue is flagged as a rubocop issue, so it'll save people from having to deal with 1 rubocop issue.

### Other Information

None
