### PR TITLE
Make bin/yarn use warn

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -3,8 +3,8 @@ Dir.chdir(VENDOR_PATH) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn "Yarn executable was not detected in the system."
+    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1
   end
 end


### PR DESCRIPTION
### Summary

Using [warn](https://ruby-doc.org/core-2.5.0/Kernel.html#method-i-warn) will allow people to disable the error output if desired.
