### PR TITLE
Fix typos and improve text_helper documentation regarding sanitization

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1573,7 +1573,7 @@ module ActionDispatch
         # Matches a URL pattern to one or more routes.
         # For more information, see match[rdoc-ref:Base#match].
         #
-        #   match 'path' => 'controller#action', via: patch
+        #   match 'path' => 'controller#action', via: :patch
         #   match 'path', to: 'controller#action', via: :post
         #   match 'path', 'otherpath', on: :member, via: :get
         def match(path, *rest, &block)
@@ -2082,9 +2082,9 @@ module ActionDispatch
         #     [ :products, options.merge(params.permit(:page, :size).to_h.symbolize_keys) ]
         #   end
         #
-        # In this instance the +params+ object comes from the context in which the the
+        # In this instance the +params+ object comes from the context in which the
         # block is executed, e.g. generating a URL inside a controller action or a view.
-        # If the block is executed where there isn't a params object such as this:
+        # If the block is executed where there isn't a +params+ object such as this:
         #
         #   Rails.application.routes.url_helpers.browse_path
         #

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -13,9 +13,9 @@ module ActionView
     #
     # ==== Sanitization
     #
-    # Most text helpers by default sanitize the given content, but do not escape it.
-    # This means HTML tags will appear in the page but all malicious code will be removed.
-    # Let's look at some examples using the +simple_format+ method:
+    # Most text helpers that generate HTML output sanitize the given input by default,
+    # but do not escape it. This means HTML tags will appear in the page but all malicious
+    # code will be removed. Let's look at some examples using the +simple_format+ method:
     #
     #   simple_format('<a href="http://example.com/">Example</a>')
     #   # => "<p><a href=\"http://example.com/\">Example</a></p>"
@@ -128,7 +128,7 @@ module ActionView
       #   # => You searched for: <a href="search?q=rails">rails</a>
       #
       #   highlight('<a href="javascript:alert(\'no!\')">ruby</a> on rails', 'rails', sanitize: false)
-      #   # => "<a>ruby</a> on <mark>rails</mark>"
+      #   # => <a href="javascript:alert('no!')">ruby</a> on <mark>rails</mark>
       def highlight(text, phrases, options = {})
         text = sanitize(text) if options.fetch(:sanitize, true)
 


### PR DESCRIPTION
### Summary

* Fixes doc typos in `actionpack/lib/action_dispatch/routing/mapper.rb`
* Fixes an example given for the `highlight` helper with `sanitize: false`
* Improves the introductory paragraph about sanitization in `text_helper.rb`

### Other Information

With `sanitize: false`, the helper leaves the input HTML alone, but the documentation was incorrectly showing it as sanitized for the `highlight` helper.

The introductory sentence about sanitization said "Most text helpers by default sanitize the given content..."  However, only 2 of the 11 helpers actually sanitize their given inputs, so I clarified it by adding "that generate HTML output" since that was the original reasoning when sanitization was added in 84d387bc0f3f3f6641b08d0ce40e924f09105c19.

I'm open to any suggestions for clarifying the sanitization description further.