### PR TITLE
Clear the transaction state when AR object is duped

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Clear the transaction state when AR object is duped.
+
+    Fixes #31670.
+
+    *Yuriy Ustushenko*
+
 *   Support for PostgreSQL foreign tables.
 
     *fatkodima*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -382,8 +382,10 @@ module ActiveRecord
 
       _run_initialize_callbacks
 
-      @new_record  = true
-      @destroyed   = false
+      @new_record               = true
+      @destroyed                = false
+      @_start_transaction_state = {}
+      @transaction_state        = nil
 
       super
     end

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/reply"
 require "models/topic"
+require "models/movie"
 
 module ActiveRecord
   class DupTest < ActiveRecord::TestCase
@@ -156,6 +157,21 @@ module ActiveRecord
       assert_nothing_raised do
         record.dup
       end
+    end
+
+    def test_dup_record_not_persisted_after_rollback_transaction
+      movie = Movie.new(name: "test")
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        Movie.transaction do
+          movie.save!
+          duped = movie.dup
+          duped.name = nil
+          duped.save!
+        end
+      end
+
+      assert !movie.persisted?
     end
   end
 end


### PR DESCRIPTION
Fixes #31670 
