### PR TITLE
Fix `includes` unable to handle joins on case insensitive columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `includes` unable to handle joins on case insensitive columns.
+
+    Fixes #31445.
+
+    *Hendy Tanata*
+
 *   Migrations raise when duplicate column definition.
 
     Fixes #33024.

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -73,11 +73,29 @@ module ActiveRecord
           end
 
           def convert_key(key)
-            if key_conversion_required?
-              key.to_s
-            else
-              key
+            converted_key = key_conversion_required? ? key.to_s : key
+
+            if converted_key.respond_to?(:downcase) && !case_sensitive_comparison?
+              converted_key = converted_key.downcase
             end
+
+            converted_key
+          end
+
+          def case_sensitive_comparison?
+            association_key_case_sensitive? || owner_key_case_sensitive?
+          end
+
+          def association_key_case_sensitive?
+            case_sensitive_column?(klass.columns_hash[association_key_name.to_s])
+          end
+
+          def owner_key_case_sensitive?
+            case_sensitive_column?(model.columns_hash[owner_key_name.to_s])
+          end
+
+          def case_sensitive_column?(column)
+            column.respond_to?(:case_sensitive?) ? column.case_sensitive? : true
           end
 
           def association_key_type


### PR DESCRIPTION
Fixes #31445.