### PR TITLE
bin/yarn: Pass through arguments with spaces

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,7 +1,7 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   begin
-    exec "yarnpkg #{ARGV.join(' ')}"
+    exec %w(yarnpkg) + ARGV
   rescue Errno::ENOENT
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
### Summary

Previously, the `bin/yarn` wrapper would "unquote" arguments to yarn like this:
`yarn run add-copyright "(c) 2017, 2018 MyCompany"`
That results in an ARGV of ['run', 'add-copyright', '(c) 2017, 2018 MyCompany'] in the yarn wrapper,
but a ARGV in the yarn executable of ['run', 'add-copyright', '(c)',  '2017,', '2018', MyCompany']

### Other Information

N/A