### PR TITLE
Use singular define_attribute_method

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -23,7 +23,7 @@ module ActiveModel
         end
         self.attribute_types = attribute_types.merge(name => type)
         define_default_attribute(name, options.fetch(:default, NO_DEFAULT_PROVIDED), type)
-        define_attribute_methods(name)
+        define_attribute_method(name)
       end
 
       private


### PR DESCRIPTION
`define_attribute_methods` splats the arguments,
then calls out to `define_attribute_method` for
each. When defining a singule attribute, using
the singular version of the method saves us an
array and an extra method call.


