### PR TITLE
Inflector.constantize should not remove intermediate modules if constants aren't loaded yet

### DIFF
--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -194,6 +194,15 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
+  def test_half_way_constantize
+    with_autoloading_fixtures do
+      assert_raise(NameError, "A::B should not be returned.") { "A::C::B".constantize }
+    end
+    with_autoloading_fixtures do
+      assert_no_changes(-> { "A::C::B".safe_constantize }, "Result should not depend on constant being loaded.") {}
+    end
+  end
+
   def test_non_existing_const_raises_name_error
     with_autoloading_fixtures do
       assert_raise(NameError) { DoesNotExist }


### PR DESCRIPTION
### Summary
`'::A::B::C'.constantize` used to return `::A::C` if it was not yet loaded and there is no matching constant, though `'::A::D'.constantize` would not return `::D` in the same conditions, but would fail. Should this be fixed?
