### PR TITLE
Update guide text not to contradict image

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -462,8 +462,7 @@ You're getting this error now because Rails expects plain actions like this one
 to have views associated with them to display their information. With no view
 available, Rails will raise an exception.
 
-In the above image, the bottom line has been truncated. Let's see what the full
-error message looks like:
+Let's look at the full error message looks again:
 
 >ArticlesController#new is missing a template for this request format and variant. request.formats: ["text/html"] request.variant: [] NOTE! For XHR/Ajax or API requests, this action would normally respond with 204 No Content: an empty white screen. Since you're loading it in a web browser, we assume that you expected to actually render a template, not… nothing, so we're showing an error to be extra-clear. If you expect 204 No Content, carry on. That's what you'll get from an XHR or API request. Give it a shot.
 


### PR DESCRIPTION
The bottom line in the image of `ActionController::UnknownFormat`is not
truncated. Now the text does not say it is.

[ci skip]
