### PR TITLE
yarnpkg: correct exec syntax

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,7 +1,8 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   begin
-    exec %w(yarnpkg) + ARGV
+    command = %w(yarnpkg) + ARGV
+    exec(*command)
   rescue Errno::ENOENT
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
Previous change didn’t expand this array of arguments. 

Sorry for the mistake!
