### PR TITLE
Restrict selenium-webdriver to 3.6

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+* Restrict selenium-webdriver to 3.6 version
+
+  Any version greater than 3.6 currently doesn't work with chrome latest.
+
+  *Dino Maric*
+
+
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
 *   No changes.

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -70,7 +70,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.15'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '3.6'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
 end


### PR DESCRIPTION
We scoped capybara to `~> 2.15`, but we don't have any scope on the `selenium-webdriver`.

I've spend few hours trying to figure out why system tests are not working on the chrome, but they are working the FF. At the end, I found out that any version of selenium-webdriver larger then `3.6` raises this error with chrome(chrome version is 63.0.3239.132 )

<img width="790" alt="screen shot 2018-01-23 at 09 16 35" src="https://user-images.githubusercontent.com/7427365/35266193-c6a84724-0022-11e8-9668-dae71d06aec4.png">


Here is dummy repo that causes this problem on my machine https://github.com/dixpac/capybara_ghostery

Also, maybe we could upgrade `capybara` dependency to the latest `~> 2.17`...but I suppose there is a reason why capybara is scoped to `2.15`...so didn't want to touch it :)
