### PR TITLE
Postgresql bulk_change_table should flatten procs array

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -375,7 +375,7 @@ module ActiveRecord
             if respond_to?(method, true)
               sqls, procs = Array(send(method, table, *arguments)).partition { |v| v.is_a?(String) }
               sql_fragments << sqls
-              non_combinable_operations << procs if procs.present?
+              non_combinable_operations.concat(procs)
             else
               execute "ALTER TABLE #{quote_table_name(table_name)} #{sql_fragments.join(", ")}" unless sql_fragments.empty?
               non_combinable_operations.each(&:call)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -866,7 +866,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 3, # one query for columns, one query for primary key, one query to do the bulk change
-        "PostgreSQLAdapter" => 2, # one query for columns, one for bulk change
+        "PostgreSQLAdapter" => 3, # one query for columns, one for bulk change, one for comment
       }.fetch(classname) {
         raise "need an expected query count for #{classname}"
       }
@@ -874,12 +874,13 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_queries(expected_query_count, ignore_none: true) do
         with_bulk_change_table do |t|
           t.change :name, :string, default: "NONAME"
-          t.change :birthdate, :datetime
+          t.change :birthdate, :datetime, comment: "This is a comment"
         end
       end
 
       assert_equal "NONAME", column(:name).default
       assert_equal :datetime, column(:birthdate).type
+      assert_equal "This is a comment", column(:birthdate).comment
     end
 
     private


### PR DESCRIPTION
### Summary
An untested path introduced in https://github.com/rails/rails/pull/31331 led to a crash when a comment was added within an `alter_table` block. The array of processes must be flattened before each can be called.