### PR TITLE
Fix typo in API document FormHelper#fields

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1014,14 +1014,13 @@ module ActionView
       #   <%= fields :comment do |fields| %>
       #     <%= fields.text_field :body %>
       #   <% end %>
-      #   # => <input type="text" name="comment[body]>
+      #   # => <input type="text" name="comment[body]">
       #
       #   # Using a model infers the scope and assigns field values:
-      #   <%= fields model: Comment.new(body: "full bodied") do |fields| %<
+      #   <%= fields model: Comment.new(body: "full bodied") do |fields| %>
       #     <%= fields.text_field :body %>
       #   <% end %>
-      #   # =>
-      #   <input type="text" name="comment[body] value="full bodied">
+      #   # => <input type="text" name="comment[body]" value="full bodied">
       #
       #   # Using +fields+ with +form_with+:
       #   <%= form_with model: @post do |form| %>


### PR DESCRIPTION
The syntax highlight of FormHelper#fields was broken as the following URL so I fixed it.
This commit fixes typo and adjusts output example to other example's format.
http://api.rubyonrails.org/v5.1/classes/ActionView/Helpers/FormHelper.html#method-i-fields