### PR TITLE
Provide an unescaped version of the body for tests

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -19,6 +19,10 @@ module ActionDispatch
       @response_parser = RequestEncoder.parser(content_type)
     end
 
+    def unescaped_body
+      CGI.unescapeHTML(body)
+    end
+
     # Was the response successful?
     def success?
       ActiveSupport::Deprecation.warn(<<-MSG.squish)

--- a/actionpack/test/dispatch/test_response_test.rb
+++ b/actionpack/test/dispatch/test_response_test.rb
@@ -26,6 +26,10 @@ class TestResponseTest < ActiveSupport::TestCase
 
     response = ActionDispatch::TestResponse.create(200, { "Content-Type" => "application/json" }, '{ "foo": "fighters" }')
     assert_equal({ "foo" => "fighters" }, response.parsed_body)
+
+    response_body = "<script>Hello</script> World &"
+    response = ActionDispatch::TestResponse.create(200, {}, CGI.escapeHTML(response_body))
+    assert_equal response.unescaped_body, response_body
   end
 
   test "response status aliases deprecated" do


### PR DESCRIPTION
### Summary

The issue I am facing is during my request tests when I am writing an assertion like:
`expect(response.body).to include "O' Reilly"`

the body of the response is, of course, escaped.
This brings to the issue that, following testing guides, I have to escape my expected text or unescape the body:

`expect(CGI.unescapeHTML(response.body)).to include "O' Reilly"`

or

`expect(response.body).to include CGI.escapeHTML("O' Reilly")`

This means including un-necessary code to my tests and polluting them with non necessary calls to escape or unescape functions which generate noise.

The situation gets even worse when using FactoryBot, which generates, from time to time, names with characters which get escaped, bringing us to the situation of having tests that randomly fail.

My Pull Request is a proposal to have an additional field that we can use, so that we can always call `expect(response.body_html).to include "O' Reilly"` and not care anymore about escaping/unescaping.

This solution I propose here is a backward compatible solution, with the addition of a new method, but I'd rather prefer to override the `body` method and add an `escaped_body` method which returns the body of the request:

```
def body
  CGI.unescapeHTML(super)
end

def unescaped_body
  CGI.escapeHTML(body)
end
```

this solution would have the advantage of being able to use a much more clear `expect(response.body).to include "O' Reilly"` and only use the `unescaped_body` method in particular cases; however this has the disadvantage of introducing a breaking change.

I'd like a feedback if you think this change would be useful and in which direction I should proceed, in that case I'll proceed by completing my Pull Request with all the necessary tests and stuff 😃 

Thanks for your time!