### PR TITLE
WIP - Add comparison methods for where [ci skip]

### DIFF
--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -59,6 +59,38 @@ module ActiveRecord
       assert_equal expected_where_clause, relation.where_clause
     end
 
+    def test_greater_than
+      relation = Post.where.greater_than(:id, 1)
+      expected = Post.arel_table[:id].gt(Arel::Nodes::BindParam.new(1))
+
+      assert_equal expected.to_sql, relation.where_clause.ast.to_sql
+    end
+
+    def test_greater_than_with_string
+      relation = Post.where.greater_than("id", 1)
+      expected = Post.arel_table[:id].gt(Arel::Nodes::BindParam.new(1))
+
+      assert_equal expected.to_sql, relation.where_clause.ast.to_sql
+    end
+
+    def test_greater_than_with_dot
+      relation = Post.where.greater_than("posts.id", 1)
+      expected = Post.arel_table[:id].gt(Arel::Nodes::BindParam.new(1))
+
+      assert_equal expected.to_sql, relation.where_clause.ast.to_sql
+    end
+
+    def test_greater_than_with_joins
+      # Would need to uses joins(:comments) or includes(:comments) for
+      # this query to actually work
+      relation = Post.where.greater_than("comments.id", 1)
+      expected = Comment.arel_table[:id].gt(Arel::Nodes::BindParam.new(1))
+
+      assert_equal expected.to_sql, relation.where_clause.ast.to_sql
+    end
+
+    # TODO test the other methods
+
     def test_rewhere_with_one_condition
       relation = Post.where(title: "hello").where(title: "world").rewhere(title: "alone")
       expected = Post.where(title: "alone")


### PR DESCRIPTION
I wanted to check if this is something we want to do before getting too far into it, but this would add 4 methods to chain onto `where`:

```rb
Post.where.greater_than(:id, 42)
Post.joins(:comments).where.greater_than('comments.id', 42)

Post.where.less_than(:id, 42)

Post.where.greater_than_or_equal(:id, 42)

Post.where.less_than_or_equal(:id, 42)
```

This is another possibility, but I think it would be difficult to handle strings, since string arguments
to where are treated as SQL strings:

```rb
Post.where(:id).greater_than(42)

Post.where("id").greater_than(42) # <- This would be difficult to deal with
```

Thoughts?

