### PR TITLE
Bring back ability to insert zero value on primary key for fixtures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -414,6 +414,9 @@ module ActiveRecord
       alias join_to_delete join_to_update
 
       private
+        def default_insert_value(column)
+          Arel.sql("DEFAULT")
+        end
 
         def build_fixture_sql(fixtures, table_name)
           columns = schema_cache.columns_hash(table_name)
@@ -432,7 +435,7 @@ module ActiveRecord
                 bind = Relation::QueryAttribute.new(name, fixture[name], type)
                 with_yaml_fallback(bind.value_for_database)
               else
-                Arel.sql("DEFAULT")
+                default_insert_value(column)
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -526,22 +526,15 @@ module ActiveRecord
         index.using == :btree || super
       end
 
-      def insert_fixtures(*)
-        without_sql_mode("NO_AUTO_VALUE_ON_ZERO") { super }
-      end
-
       def insert_fixtures_set(fixture_set, tables_to_delete = [])
         iterate_over_results = -> { while raw_connection.next_result; end; }
 
         with_multi_statements do
-          without_sql_mode("NO_AUTO_VALUE_ON_ZERO") do
-            super(fixture_set, tables_to_delete, &iterate_over_results)
-          end
+          super(fixture_set, tables_to_delete, &iterate_over_results)
         end
       end
 
       private
-
         def combine_multi_statements(total_sql)
           total_sql.each_with_object([]) do |sql, total_sql_chunks|
             previous_packet = total_sql_chunks.last
@@ -578,19 +571,6 @@ module ActiveRecord
         ensure
           @config[:flags] = previous_flags
           reconnect!
-        end
-
-        def without_sql_mode(mode)
-          result = execute("SELECT @@SESSION.sql_mode")
-          current_mode = result.first[0]
-          return yield unless current_mode.include?(mode)
-
-          sql_mode = "REPLACE(@@sql_mode, '#{mode}', '')"
-          execute("SET @@SESSION.sql_mode = #{sql_mode}")
-          yield
-        ensure
-          sql_mode = "CONCAT(@@sql_mode, ',#{mode}')"
-          execute("SET @@SESSION.sql_mode = #{sql_mode}")
         end
 
         def initialize_type_map(m = type_map)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -50,6 +50,9 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         private
+          def default_insert_value(column)
+            Arel.sql("DEFAULT") unless column.auto_increment?
+          end
 
           def last_inserted_id(result)
             @connection.last_id

--- a/activerecord/test/fixtures/minimalistics.yml
+++ b/activerecord/test/fixtures/minimalistics.yml
@@ -1,2 +1,5 @@
+zero:
+  id: 0
+
 first:
   id: 1


### PR DESCRIPTION
Since #29504, mysql2 adapter lost ability to insert zero value on
primary key due to enforce `NO_AUTO_VALUE_ON_ZERO` disabled.
That is for using `DEFAULT` on auto increment column, but we can use
`NULL` instead in that case.