### PR TITLE
Add support for PostgreSQL nulls order to add_index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add support for PostgreSQL nulls order to add_index.
+
+    Example:
+
+        add_index(:accounts, [:branch_id, :party_id], order: { party_id: :desc }, nulls: { party_id: :last })
+
+    *fatkodima*
+
 *   Fix `count(:all)` with eager loading and having an order other than the driving table.
 
     Fixes #31783.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :nulls, :opclasses, :where, :type, :using, :comment
 
       def initialize(
         table, name,
@@ -14,6 +14,7 @@ module ActiveRecord
         columns = [],
         lengths: {},
         orders: {},
+        nulls: {},
         opclasses: {},
         where: nil,
         type: nil,
@@ -26,6 +27,7 @@ module ActiveRecord
         @columns = columns
         @lengths = concise_options(lengths)
         @orders = concise_options(orders)
+        @nulls = concise_options(nulls)
         @opclasses = concise_options(opclasses)
         @where = where
         @type = type

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -186,6 +186,7 @@ HEADER
         index_parts << "unique: true" if index.unique
         index_parts << "length: #{format_index_parts(index.lengths)}" if index.lengths.present?
         index_parts << "order: #{format_index_parts(index.orders)}" if index.orders.present?
+        index_parts << "nulls: #{format_index_parts(index.nulls)}" if index.nulls.present?
         index_parts << "opclass: #{format_index_parts(index.opclasses)}" if index.opclasses.present?
         index_parts << "where: #{index.where.inspect}" if index.where
         index_parts << "using: #{index.using.inspect}" if !@connection.default_index_type?(index)

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -62,6 +62,12 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING gist ("last_name" bpchar_pattern_ops))
     assert_equal expected, add_index(:people, :last_name, using: :gist, opclass: { last_name: :bpchar_pattern_ops })
 
+    expected = %(CREATE  INDEX  "index_people_on_last_name_and_first_name" ON "people"  ("last_name" DESC NULLS LAST, "first_name" ASC NULLS FIRST))
+    assert_equal expected, add_index(:people, [:last_name, :first_name], order: { last_name: :desc, first_name: :asc }, nulls: { last_name: :last, first_name: :first })
+
+    expected = %(CREATE  INDEX  "index_people_on_last_name_and_first_name" ON "people"  ("last_name" NULLS FIRST, "first_name" NULLS FIRST))
+    assert_equal expected, add_index(:people, [:last_name, :first_name], nulls: :first)
+
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :copy)
     end


### PR DESCRIPTION
## Use case

When using `ORDER BY "column"` in PostgreSQL, `NULL` values will come last.
When using `ORDER BY "column" DESC`, `NULL`s will come first. But this is often not useful (e.g. I want to show all products sorted by price in descending order, but those without price to show last). 

I can tell where I want my NULLs, by saying
```sql
... ORDER BY price DESC NULLS LAST
```

But indexes should specify this as well. Without this PR, this can be done by
```ruby
add_index :products, :price, order: "DESC NULLS LAST"
```
While this correctly creates index on postgresql, it is not correctly dumped into `schema.rb` and requires to have postgresql for all other environments for `DESC NULLS LAST` to work.

## Solution 

Nulls order can be explicitly specified in `add_index` as:
```ruby
  add_index :products, :price, order: :desc, nulls: :last
```
