### PR TITLE
Lock Minitest 5.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
+  gem "minitest", "= 5.11.1"
   gem "minitest-bisect"
 
   platforms :mri do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,6 +533,7 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   mini_magick
+  minitest (= 5.11.1)
   minitest-bisect
   mocha
   mysql2 (>= 0.4.4)


### PR DESCRIPTION
### Summary
To workaround `undefined method `error?' for` reported at https://travis-ci.org/rails/rails/jobs/333456146

By taking a look at CI history and compare Minitest version. The last successful one uses  `5.11.1` and the first failed one uses `5.11.2`, which has been released on 1/25 https://rubygems.org/gems/minitest/versions/5.11.2

[Last successful one](https://travis-ci.org/rails/rails/jobs/333180697)
[First failed one](https://travis-ci.org/rails/rails/jobs/333456162)

This pull request locks Minitest version to make CI green in the meantime. We will need to investigate and address later.

