### PR TITLE
Relax minitest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,6 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
-  gem "minitest", "= 5.11.1"
   gem "minitest-bisect"
 
   platforms :mri do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,6 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   mini_magick
-  minitest (= 5.11.1)
   minitest-bisect
   mocha
   mysql2 (>= 0.4.4)


### PR DESCRIPTION
We locked Minitest to 5.11.1 in #31799
because 5.11.2 included a breaking change.
The change was fixed in 5.11.3, so we no
longer need to lock in the version.