### PR TITLE
Introduce `ActiveRecord::Relation#one`

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -371,4 +371,12 @@ module ActiveRecord
   # values, such as request parameters or model attributes to query methods.
   class UnknownAttributeReference < ActiveRecordError
   end
+
+  # Raised when one record is expected but none are found
+  class NoRecordFound < ActiveRecordError
+  end
+
+  # Raised when one record is expected but more than one is found
+  class MultipleRecordsFound < ActiveRecordError
+  end
 end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -516,6 +516,21 @@ module ActiveRecord
       ActiveRecord::Associations::AliasTracker.create(connection, table.name, joins)
     end
 
+    # Asserts that the collection contains exactly one record, and returns it.
+    #
+    # If the collection is empty, it raises <tt>ActiveRecord::NoRecordFound</tt>.
+    # If the collection contains more than one record, it raises
+    # <tt>ActiveRecord::MultipleRecordsFound</tt>.
+    def one
+      if size.zero?
+        raise ActiveRecord::NoRecordFound
+      elsif size == 1
+        first
+      else
+        raise ActiveRecord::MultipleRecordsFound
+      end
+    end
+
     protected
 
       def load_records(records)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -110,6 +110,22 @@ class AssociationsTest < ActiveRecord::TestCase
     firm = companies(:first_firm)
     assert_includes firm.association_with_references.references_values, "foo"
   end
+
+  def test_one_returns_single_result
+    david = authors(:david)
+
+    assert_nothing_raised do
+      assert_equal david, Author.where(name: "David").one
+    end
+  end
+
+  def test_one_raises_exception_when_many_results
+    assert_raises(ActiveRecord::MultipleRecordsFound) { Author.where.not(id: nil).one }
+  end
+
+  def test_one_raises_exception_when_zero_results
+    assert_raises(ActiveRecord::NoRecordFound) { Author.where(name: "Alice").one }
+  end
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase


### PR DESCRIPTION
`#one` asserts that the relation contains exactly one record, and
returns it. If there are no records or more than one, an
`ActiveRecord::NoRecordFound` or `ActiveRecord::MultipleRecordsFound`
exception is raised, respectively.

This is a concept borrowed from other ORM tools. Is useful when a
data schema has a "many" relationship, but only a single record is
expected in some situation.

Due to potential confusion with `ActiveRecord::Relation#one?`, I
also suggest the name `#single`.