### PR TITLE
Define `supports_foreign_tables?` in AbstractAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -326,6 +326,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support foreign/external tables?
+      def supports_foreign_tables?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end


### PR DESCRIPTION
### Summary

This pull request addresses "undefined method supports_foreign_tables?" errors
by setting `supports_foreign_tables?` method in AbstractAdapter.

Unlike `bundle exec rake test`, `bin/test` does not skip adapter specific test files.

Related to #31549

```ruby
$ cd activerecord
$ bin/test
Using sqlite3
Traceback (most recent call last):
	11: from bin/test:5:in `<main>'
	10: from bin/test:5:in `require_relative'
	 9: from /home/yahonda/git/rails/tools/test.rb:26:in `<top (required)>'
	 8: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:39:in `run'
	 7: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `load_tests'
	 6: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `each'
	 5: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
	 4: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `require'
	 3: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:249:in `load_dependency'
	 2: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `block in require'
	 1: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `require'
/home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb:6:in `<top (required)>': undefined method `supports_foreign_tables?' for #<ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x000055f3ec3c47c8> (NoMethodError)
Did you mean?  supports_foreign_keys?
```

```ruby
$ cd activerecord
$ ARCONN=mysql2 bin/test
Using mysql2
Traceback (most recent call last):
	11: from bin/test:5:in `<main>'
	10: from bin/test:5:in `require_relative'
	 9: from /home/yahonda/git/rails/tools/test.rb:26:in `<top (required)>'
	 8: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:39:in `run'
	 7: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `load_tests'
	 6: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `each'
	 5: from /home/yahonda/git/rails/railties/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
	 4: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `require'
	 3: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:249:in `load_dependency'
	 2: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `block in require'
	 1: from /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:283:in `require'
/home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb:6:in `<top (required)>': undefined method `supports_foreign_tables?' for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x0000563d22f93160> (NoMethodError)
Did you mean?  supports_foreign_keys?
$
```