### PR TITLE
Use bind params for basic where strings

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -48,19 +48,20 @@ module ActiveRecord
       Arel::Nodes::BindParam.new(attr)
     end
 
+    def build_comparison(column_name, value, comparison_method)
+      bind = build_bind_attribute(column_name, value)
+      table.arel_attribute(column_name).send(comparison_method, bind)
+    end
+
+    def associated_predicate_builder(association_name)
+      self.class.new(table.associated_table(association_name))
+    end
+
     protected
 
       attr_reader :table
 
     private
-
-      def associated_predicate_builder(association_name)
-        self.class.new(table.associated_table(association_name))
-      end
-
-      def handler_for(object)
-        @handlers.detect { |klass, _| klass === object }.last
-      end
 
       def build_from_key_value(key, value)
         if value.is_a?(Hash) && !table.has_column?(key)
@@ -92,6 +93,10 @@ module ActiveRecord
         else
           build(table.arel_attribute(key), value)
         end
+      end
+
+      def handler_for(object)
+        @handlers.detect { |klass, _| klass === object }.last
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -17,19 +17,11 @@ module ActiveRecord
     end
 
     def build_from_hash(attributes)
-      attributes = convert_dot_notation_to_hash(attributes)
-      expand_from_hash(attributes)
-    end
+      return ["1=0"] if attributes.empty?
 
-    def self.references(attributes)
-      attributes.map do |key, value|
-        if value.is_a?(Hash)
-          key
-        else
-          key = key.to_s
-          key.split(".".freeze).first if key.include?(".".freeze)
-        end
-      end.compact
+      attributes.flat_map do |key, value|
+        build_from_key_value(key, value)
+      end
     end
 
     # Define how a class is converted to Arel nodes when passed to +where+.
@@ -60,66 +52,46 @@ module ActiveRecord
 
       attr_reader :table
 
-      def expand_from_hash(attributes)
-        return ["1=0"] if attributes.empty?
-
-        attributes.flat_map do |key, value|
-          if value.is_a?(Hash) && !table.has_column?(key)
-            associated_predicate_builder(key).expand_from_hash(value)
-          elsif table.associated_with?(key)
-            # Find the foreign key when using queries such as:
-            # Post.where(author: author)
-            #
-            # For polymorphic relationships, find the foreign key and type:
-            # PriceEstimate.where(estimate_of: treasure)
-            associated_table = table.associated_table(key)
-            if associated_table.polymorphic_association?
-              case value.is_a?(Array) ? value.first : value
-              when Base, Relation
-                value = [value] unless value.is_a?(Array)
-                klass = PolymorphicArrayValue
-              end
-            end
-
-            klass ||= AssociationQueryValue
-            queries = klass.new(associated_table, value).queries.map do |query|
-              expand_from_hash(query).reduce(&:and)
-            end
-            queries.reduce(&:or)
-          # FIXME: Deprecate this and provide a public API to force equality
-          elsif (value.is_a?(Range) || value.is_a?(Array)) &&
-            table.type(key.to_s).respond_to?(:subtype)
-            BasicObjectHandler.new(self).call(table.arel_attribute(key), value)
-          else
-            build(table.arel_attribute(key), value)
-          end
-        end
-      end
-
     private
 
       def associated_predicate_builder(association_name)
         self.class.new(table.associated_table(association_name))
       end
 
-      def convert_dot_notation_to_hash(attributes)
-        dot_notation = attributes.select do |k, v|
-          k.include?(".".freeze) && !v.is_a?(Hash)
-        end
-
-        dot_notation.each_key do |key|
-          table_name, column_name = key.split(".".freeze)
-          value = attributes.delete(key)
-          attributes[table_name] ||= {}
-
-          attributes[table_name] = attributes[table_name].merge(column_name => value)
-        end
-
-        attributes
-      end
-
       def handler_for(object)
         @handlers.detect { |klass, _| klass === object }.last
+      end
+
+      def build_from_key_value(key, value)
+        if value.is_a?(Hash) && !table.has_column?(key)
+          associated_predicate_builder(key).build_from_hash(value)
+        elsif table.associated_with?(key)
+          # Find the foreign key when using queries such as:
+          # Post.where(author: author)
+          #
+          # For polymorphic relationships, find the foreign key and type:
+          # PriceEstimate.where(estimate_of: treasure)
+          associated_table = table.associated_table(key)
+          if associated_table.polymorphic_association?
+            case value.is_a?(Array) ? value.first : value
+            when Base, Relation
+              value = [value] unless value.is_a?(Array)
+              klass = PolymorphicArrayValue
+            end
+          end
+
+          klass ||= AssociationQueryValue
+          queries = klass.new(associated_table, value).queries.map do |query|
+            build_from_hash(query).reduce(&:and)
+          end
+          queries.reduce(&:or)
+        # FIXME: Deprecate this and provide a public API to force equality
+        elsif (value.is_a?(Range) || value.is_a?(Array)) &&
+          table.type(key.to_s).respond_to?(:subtype)
+          BasicObjectHandler.new(self).call(table.arel_attribute(key), value)
+        else
+          build(table.arel_attribute(key), value)
+        end
       end
   end
 end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -47,10 +47,10 @@ module ActiveRecord
       def not(opts, *rest)
         opts = sanitize_forbidden_attributes(opts)
 
-        clause, table_names = @scope.send(:where_clause_factory).build(opts, rest)
+        where_clause, table_names = @scope.send(:where_clause_factory).build(opts, rest)
 
         @scope.references!(table_names)
-        @scope.where_clause += clause.invert
+        @scope.where_clause += where_clause.invert
         @scope
       end
     end
@@ -587,9 +587,9 @@ module ActiveRecord
 
     def where!(opts, *rest) # :nodoc:
       opts = sanitize_forbidden_attributes(opts)
-      clause, table_names = where_clause_factory.build(opts, rest)
+      where_clause, table_names = where_clause_factory.build(opts, rest)
       references!(table_names)
-      self.where_clause += clause
+      self.where_clause += where_clause
       self
     end
 
@@ -652,9 +652,9 @@ module ActiveRecord
 
     def having!(opts, *rest) # :nodoc:
       opts = sanitize_forbidden_attributes(opts)
-      clause, table_names = having_clause_factory.build(opts, rest)
+      having_clause, table_names = having_clause_factory.build(opts, rest)
       references!(table_names)
-      self.having_clause += clause
+      self.having_clause += having_clause
       self
     end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -47,10 +47,10 @@ module ActiveRecord
       def not(opts, *rest)
         opts = sanitize_forbidden_attributes(opts)
 
-        where_clause = @scope.send(:where_clause_factory).build(opts, rest)
+        clause, table_names = @scope.send(:where_clause_factory).build(opts, rest)
 
-        @scope.references!(PredicateBuilder.references(opts)) if Hash === opts
-        @scope.where_clause += where_clause.invert
+        @scope.references!(table_names)
+        @scope.where_clause += clause.invert
         @scope
       end
     end
@@ -587,8 +587,9 @@ module ActiveRecord
 
     def where!(opts, *rest) # :nodoc:
       opts = sanitize_forbidden_attributes(opts)
-      references!(PredicateBuilder.references(opts)) if Hash === opts
-      self.where_clause += where_clause_factory.build(opts, rest)
+      clause, table_names = where_clause_factory.build(opts, rest)
+      references!(table_names)
+      self.where_clause += clause
       self
     end
 
@@ -651,9 +652,9 @@ module ActiveRecord
 
     def having!(opts, *rest) # :nodoc:
       opts = sanitize_forbidden_attributes(opts)
-      references!(PredicateBuilder.references(opts)) if Hash === opts
-
-      self.having_clause += having_clause_factory.build(opts, rest)
+      clause, table_names = having_clause_factory.build(opts, rest)
+      references!(table_names)
+      self.having_clause += clause
       self
     end
 

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -3,33 +3,104 @@
 module ActiveRecord
   class Relation
     class WhereClauseFactory # :nodoc:
+      DOT = ".".freeze
+
+      class ArelClause
+        def initialize(arel_node)
+          @arel_node = arel_node
+        end
+
+        def references
+          []
+        end
+
+        def predicates
+          [@arel_node]
+        end
+      end
+
+      class ArrayClause
+        def initialize(where_array, klass)
+          @where_array = where_array
+          @klass = klass
+        end
+
+        def references
+          []
+        end
+
+        def predicates
+          [@klass.sanitize_sql(@where_array)]
+        end
+      end
+
+      class HashClause
+        def initialize(where_hash, klass, predicate_builder)
+          @where_hash = where_hash
+          @klass = klass
+          @predicate_builder = predicate_builder
+        end
+
+        def references
+          attributes.select { |_, v| Hash === v }.keys
+        end
+
+        def predicates
+          @predicate_builder.build_from_hash(attributes)
+        end
+
+        private
+
+          def attributes
+            @attributes ||= build_attributes_from_where_hash
+          end
+
+          def build_attributes_from_where_hash
+            attributes = @predicate_builder.resolve_column_aliases(@where_hash)
+            attributes = @klass.send(:expand_hash_conditions_for_aggregates, attributes)
+            attributes.stringify_keys!
+
+            convert_dot_notation_to_hash!(attributes)
+          end
+
+          def convert_dot_notation_to_hash!(attributes)
+            dot_notation = attributes.select do |k, v|
+              k.include?(DOT) && !v.is_a?(Hash)
+            end
+
+            dot_notation.each_key do |key|
+              table_name, column_name = key.split(DOT)
+              value = attributes.delete(key)
+              attributes[table_name] ||= {}
+
+              attributes[table_name] = attributes[table_name].merge(column_name => value)
+            end
+
+            attributes
+          end
+      end
+
       def initialize(klass, predicate_builder)
         @klass = klass
         @predicate_builder = predicate_builder
       end
 
       def build(opts, other)
-        case opts
-        when String, Array
-          parts = [klass.sanitize_sql(other.empty? ? opts : ([opts] + other))]
-        when Hash
-          attributes = predicate_builder.resolve_column_aliases(opts)
-          attributes = klass.send(:expand_hash_conditions_for_aggregates, attributes)
-          attributes.stringify_keys!
+        clause =
+          case opts
+          when String, Array
+            all_opts = other.empty? ? opts : ([opts] + other)
+            ArrayClause.new(all_opts, @klass)
+          when Hash
+            HashClause.new(opts, @klass, @predicate_builder)
+          when Arel::Nodes::Node
+            ArelClause.new(opts)
+          else
+            raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
+          end
 
-          parts = predicate_builder.build_from_hash(attributes)
-        when Arel::Nodes::Node
-          parts = [opts]
-        else
-          raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
-        end
-
-        WhereClause.new(parts)
+        [WhereClause.new(clause.predicates), clause.references]
       end
-
-      protected
-
-        attr_reader :klass, :predicate_builder
     end
   end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -395,7 +395,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_unquoted_table_name
     assert_nothing_raised do
-      Comment.includes(:post).references(:posts).where("posts.id = ?", 4)
+      Comment.includes(:post).where("posts.id = ?", 4)
     end
   end
 
@@ -591,10 +591,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_has_many_and_limit_and_conditions_array_on_the_eagers
-    posts = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", "David")
+    posts = Post.includes(:author, :comments).limit(2).where("authors.name = ?", "David")
     assert_equal 2, posts.size
 
-    count = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", "David").count
+    count = Post.includes(:author, :comments).limit(2).where("authors.name = ?", "David").count
     assert_equal posts.size, count
   end
 
@@ -1492,7 +1492,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preloading a polymorphic association with references to the associated table" do
-    post = Post.includes(:tags).references(:tags).where("tags.name = ?", "General").first
+    post = Post.includes(:tags).where("tags.name = ?", "General").first
     assert_equal posts(:welcome), post
   end
 

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -20,6 +20,13 @@ module ActiveRecord
       assert_equal expected_where_clause, relation.where_clause
     end
 
+    def test_not_inverts_where_clause_with_string
+      relation = Post.where.not("title = ?", "hello")
+      expected_where_clause = Post.where(title: "hello").where_clause.invert
+
+      assert_equal expected_where_clause, relation.where_clause
+    end
+
     def test_not_with_nil
       assert_raise ArgumentError do
         Post.where.not(nil)
@@ -29,6 +36,12 @@ module ActiveRecord
     def test_association_not_eq
       expected = Comment.arel_table[@name].not_eq(Arel::Nodes::BindParam.new(1))
       relation = Post.joins(:comments).where.not(comments: { title: "hello" })
+      assert_equal(expected.to_sql, relation.where_clause.ast.to_sql)
+    end
+
+    def test_assocation_not_eq_with_string
+      expected = Comment.arel_table[@name].not_eq(Arel::Nodes::BindParam.new(1))
+      relation = Post.joins(:comments).where.not("comments.title = ?", "hello")
       assert_equal(expected.to_sql, relation.where_clause.ast.to_sql)
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -180,14 +180,14 @@ module ActiveRecord
     test "merging a hash interpolates conditions" do
       klass = Class.new(FakeKlass) do
         def self.sanitize_sql(args)
-          raise unless args == ["foo = ?", "bar"]
-          "foo = bar"
+          raise unless args == ["foo = ? AND 1 = 1", "bar"]
+          "foo = bar AND 1 = 1"
         end
       end
 
       relation = Relation.new(klass)
-      relation.merge!(where: ["foo = ?", "bar"])
-      assert_equal Relation::WhereClause.new(["foo = bar"]), relation.where_clause
+      relation.merge!(where: ["foo = ? AND 1 = 1", "bar"])
+      assert_equal Relation::WhereClause.new(["foo = bar AND 1 = 1"]), relation.where_clause
     end
 
     def test_merging_readonly_false


### PR DESCRIPTION
This is something of a work in progress that starts to address #31219.

`Post.where('id = ?', 1)` used to generate this query:

```sql
 SELECT  "posts".* FROM "posts" WHERE ("id" = 1) LIMIT ?  [["LIMIT", 11]]
```

now it will generate this query with a bind parameter:

```sql
SELECT  "posts".* FROM "posts" WHERE "posts"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 11]]
```

I did the same thing for some other simple cases:

```ruby
Post.where('id != ?', 1)
Post.where('id <> ?', 1)
Post.where('id <= ?', 1)
Post.where('id >= ?', 1)
Post.where('id < ?', 1)
Post.where('id > ?', 1)
```

It also works with associations:

```ruby
Post.joins(:comments).where('comments.id = ?', 1)
Comment.joins(:post).where('comments.id = ?', 1)
```

And we can use `includes` without explicitly calling `references`:

```ruby
Post.includes(:comments).where('comments.id = ?', 1)
```

There are cases that this does NOT cover, and I am unsure how many of them we should try to cover:
- Keyword binds: `where('id = :id', id: 1) - this one seems doable,
- Quoted table and column names: `where('"posts"."id" = ?', 1)- not sure if it makes sense to deal with this
- Multiple conditions with `AND` or `OR` - Maybe not? This might get out of hand
- Expressions with "LIKE", "IN", "SIMILAR TO"

I'm guessing ideal solution is somewhere between what I have now and a library that parses SQL where clauses into ASTs 😄 .