### PR TITLE
Allow @ in X-Request-Id header

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -30,7 +30,7 @@ module ActionDispatch
     private
       def make_request_id(request_id)
         if request_id.presence
-          request_id.gsub(/[^\w\-]/, "".freeze).first(255)
+          request_id.gsub(/[^\w\-@]/, "".freeze).first(255)
         else
           internal_request_id
         end

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -11,6 +11,11 @@ class RequestIdTest < ActiveSupport::TestCase
     assert_equal "X-Hacked-HeaderStuff", stub_request("HTTP_X_REQUEST_ID" => "; X-Hacked-Header: Stuff").request_id
   end
 
+  test "accept Apache mod_unique_id format" do
+    mod_unique_id = "abcxyz@ABCXYZ-0123456789"
+    assert_equal mod_unique_id, stub_request("HTTP_X_REQUEST_ID" => mod_unique_id).request_id
+  end
+
   test "ensure that 255 char limit on the request id is being enforced" do
     assert_equal "X" * 255, stub_request("HTTP_X_REQUEST_ID" => "X" * 500).request_id
   end


### PR DESCRIPTION
It makes sense to be as strict as possible
with headers from the outside world, but I
believe the primary concern is CRLF injection.
Allowing @ to support Apache's mod_unique_id
(see #31644) seems OK to me, but I definitely
want to get confirmation from an expert.