### PR TITLE
Fix the example of 'finding records by a value object'

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -177,9 +177,9 @@ module ActiveRecord
       #
       # Once a #composed_of relationship is specified for a model, records can be loaded from the database
       # by specifying an instance of the value object in the conditions hash. The following example
-      # finds all customers with +balance_amount+ equal to 20 and +balance_currency+ equal to "USD":
+      # finds all customers with +address_street+ equal to "May Street" and +address_city+ equal to "Chicago":
       #
-      #   Customer.where(balance: Money.new(20, "USD"))
+      #   Customer.where(address: Address.new("May Street", "Chicago"))
       #
       module ClassMethods
         # Adds reader and writer methods for manipulating a value object:


### PR DESCRIPTION
This example was added in abdf546ad6d02ecb95766e73cd3c645a48c954de
but was inconsistent with `composed_of :balance` definition in the
'Customer'.

Related to #31346, https://github.com/rails/rails/pull/31346#issuecomment-361169424

r? @kamipo 