### PR TITLE
If association is a hash-like object preloading fails

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -98,12 +98,11 @@ module ActiveRecord
 
         # Loads all the given data into +records+ for the +association+.
         def preloaders_on(association, records, scope, polymorphic_parent = false)
-          case association
-          when Hash
+          if association.respond_to?(:to_hash)
             preloaders_for_hash(association, records, scope, polymorphic_parent)
-          when Symbol
+          elsif association.is_a?(Symbol)
             preloaders_for_one(association, records, scope, polymorphic_parent)
-          when String
+          elsif association.respond_to?(:to_str)
             preloaders_for_one(association.to_sym, records, scope, polymorphic_parent)
           else
             raise ArgumentError, "#{association.inspect} was not recognized for preload"

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1618,6 +1618,32 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  # Associations::Preloader#preloaders_on works with hash-like objects
+  test "preloading works with an object that responds to :to_hash" do
+    CustomHash = Class.new(Hash)
+
+    assert_nothing_raised do
+      Post.preload(CustomHash.new(comments: [{ author: :essays }])).first
+    end
+  end
+
+  # Associations::Preloader#preloaders_on works with string-like objects
+  test "preloading works with an object that responds to :to_str" do
+    CustomString = Class.new(String)
+
+    assert_nothing_raised do
+      Post.preload(CustomString.new("comments")).first
+    end
+  end
+
+  # Associations::Preloader#preloaders_on does not work with ranges
+  test "preloading fails when Range is passed" do
+    exception = assert_raises(ArgumentError) do
+      Post.preload(1..10).first
+    end
+    assert_equal("1..10 was not recognized for preload", exception.message)
+  end
+
   private
     def find_all_ordered(klass, include = nil)
       klass.order("#{klass.table_name}.#{klass.primary_key}").includes(include).to_a


### PR DESCRIPTION
### If association is a hash-like object preloading fails

If you pass a hash-like object to preload associations (for example ActionController::Parameters)
preloader will fail with the ArgumentError.
This change allows passing objects that may be converted to a Hash or String into a preloader

### Other Information

` bundle exec ruby -Itest test/cases/associations/eager_test.rb` passes
