### PR TITLE
Avoid extra calls to to_s

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
       def ids_writer(ids)
         primary_key = reflection.association_primary_key
-        pk_type = klass.type_for_attribute(primary_key.to_s)
+        pk_type = klass.type_for_attribute(primary_key)
         ids = Array(ids).reject(&:blank?)
         ids.map! { |i| pk_type.cast(i) }
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -82,11 +82,11 @@ module ActiveRecord
           end
 
           def association_key_type
-            @klass.type_for_attribute(association_key_name.to_s).type
+            @klass.type_for_attribute(association_key_name).type
           end
 
           def owner_key_type
-            @model.type_for_attribute(owner_key_name.to_s).type
+            @model.type_for_attribute(owner_key_name).type
           end
 
           def load_records(&block)

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         if collection.eager_loading?
           collection = collection.send(:apply_join_dependency)
         end
-        column_type = type_for_attribute(timestamp_column.to_s)
+        column_type = type_for_attribute(timestamp_column)
         column = connection.column_name_from_arel_node(collection.arel_attribute(timestamp_column))
         select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -242,7 +242,7 @@ module ActiveRecord
       def aggregate_column(column_name)
         return column_name if Arel::Expressions === column_name
 
-        if @klass.has_attribute?(column_name.to_s) || @klass.attribute_alias?(column_name.to_s)
+        if @klass.has_attribute?(column_name) || @klass.attribute_alias?(column_name)
           @klass.arel_attribute(column_name)
         else
           Arel.sql(column_name == :all ? "*" : column_name.to_s)

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       def sanitize_sql_hash_for_assignment(attrs, table)
         c = connection
         attrs.map do |attr, value|
-          type = type_for_attribute(attr.to_s)
+          type = type_for_attribute(attr)
           value = type.serialize(type.cast(value))
           "#{c.quote_table_name_for_assignment(table, attr)} = #{c.quote(value)}"
         end.join(", ")

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -135,7 +135,7 @@ module ActiveRecord
       end
 
       def store_accessor_for(store_attribute)
-        type_for_attribute(store_attribute.to_s).accessor
+        type_for_attribute(store_attribute).accessor
       end
 
       class HashAccessor # :nodoc:

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -30,7 +30,7 @@ module ActiveRecord
 
     def type(column_name)
       if klass
-        klass.type_for_attribute(column_name.to_s)
+        klass.type_for_attribute(column_name)
       else
         Type.default_value
       end

--- a/activerecord/lib/active_record/type_caster/map.rb
+++ b/activerecord/lib/active_record/type_caster/map.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def type_cast_for_database(attr_name, value)
         return value if value.is_a?(Arel::Nodes::BindParam)
-        type = types.type_for_attribute(attr_name.to_s)
+        type = types.type_for_attribute(attr_name)
         type.serialize(value)
       end
 


### PR DESCRIPTION
With #31615 `type_for_attribute` accepts
a symbol as well as a string. `has_attribute?` and `attribute_alias`
also accept either. Since these methods already call `to_s` on the argument,
we no longer need to do that at the call site.
