### PR TITLE
ActionController::TestCase: fix #post documentation

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -256,7 +256,7 @@ module ActionController
   #
   #   def test_create
   #     json = {book: { title: "Love Hina" }}.to_json
-  #     post :create, json
+  #     post :create, body: json
   #   end
   #
   # == Special instance variables


### PR DESCRIPTION
Fixes #31823.

### Summary

As I mentioned in #31823, it looks like the documentation for the `ActionController::TestCase#post` documentation did not get updated when the syntax it was using was deleted in https://github.com/rails/rails/commit/98b8309569a326910a723f521911e54994b112fb.