### PR TITLE
Disable CSP by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -4,17 +4,17 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data
-  policy.object_src  :none
-  policy.script_src  :self, :https, :unsafe_inline
-  policy.style_src   :self, :https, :unsafe_inline
+# Rails.application.config.content_security_policy do |policy|
+#   policy.default_src :self, :https
+#   policy.font_src    :self, :https, :data
+#   policy.img_src     :self, :https, :data
+#   policy.object_src  :none
+#   policy.script_src  :self, :https
+#   policy.style_src   :self, :https, :unsafe_inline
 
-  # Specify URI for violation reports
-  # policy.report_uri "/csp-violation-report-endpoint"
-end
+#   # Specify URI for violation reports
+#   # policy.report_uri "/csp-violation-report-endpoint"
+# end
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
Before this patch, to be able to use webpacker and webconsole we were
defining an used default in the script-src policy. White we don't
implement the automatic nonce approach defined in
https://github.com/rails/rails/issues/31689 it is better to not have any
default configuration in Rails 5.2.