### PR TITLE
Allow to reset cache counters for multiple records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow to reset cache counters for multiple records.
+
+    ```
+    Aircraft.reset_counters([1, 2, 3], :wheels_count) # generates one query per counter
+    ```
+
+    *fatkodima*
+
 *   Support default expression for MySQL.
 
     MySQL 8.0.13 and higher supports default value to be a function or expression.

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -65,6 +65,15 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "reset counters for multiple records" do
+    t1, t2 = topics(:first, :second)
+    Topic.increment_counter(:replies_count, [t1.id, t2.id])
+
+    assert_difference ["t1.reload.replies_count", "t2.reload.replies_count"], -1 do
+      Topic.reset_counters([t1.id, t2.id], :replies_count)
+    end
+  end
+
   test "reset multiple counters" do
     Topic.update_counters @topic.id, replies_count: 1, unique_replies_count: 1
     assert_difference ["@topic.reload.replies_count", "@topic.reload.unique_replies_count"], -1 do
@@ -165,6 +174,16 @@ class CounterCacheTest < ActiveRecord::TestCase
 
     assert_difference "subscriber.reload.books_count", -1 do
       Subscriber.reset_counters(subscriber.id, "books")
+    end
+  end
+
+  test "reset counter of polymorphic association" do
+    aircraft = Aircraft.create!
+    aircraft.wheels << Wheel.create!
+    Aircraft.increment_counter(:wheels_count, aircraft.id)
+
+    assert_difference "aircraft.reload.wheels_count", -1 do
+      Aircraft.reset_counters(aircraft.id, :wheels_count)
     end
   end
 


### PR DESCRIPTION
This allows to efficiently reset counters in batch for any amount of records (generating one query per counter).

```ruby
Aircraft.reset_counters([1, 2, 3], :wheels_count)
```

Generated sql (formatted):
```sql
UPDATE "aircraft"
SET wheels_count = (
	SELECT COUNT(*)
	FROM (
		SELECT aircraft.id FROM "aircraft" INNER JOIN "wheels" ON "wheels"."wheelable_id" = "aircraft"."id" AND "wheels"."wheelable_type" = 'Aircraft'
	) subquery_for_counter_cache
	WHERE (subquery_for_counter_cache.id = aircraft.id)
) WHERE "aircraft"."id" IN ($1, $2, $3)
``` 

Subquery for count may seem a little more complicated than it should be (maybe there is a better solution, though), but it allows to calculate counts for polymorphic and sti relations.


Currently, [all](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-decrement_counter), [other](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-increment_counter), [methods](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters) from `CounterCache` module support batching.
