### PR TITLE
Fix `as` attribute value for preload link

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -133,7 +133,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          early_hints_links << "<#{href}>; rel=preload; as=stylesheet"
+          early_hints_links << "<#{href}>; rel=preload; as=style"
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",


### PR DESCRIPTION
`as` attribute value should be `style` for stylesheet preload link

See https://w3c.github.io/preload/#as-attribute

https://github.com/rails/rails/pull/30744#discussion_r164954159 thanks for the report @mengqing

shall I backport it to `5-2-stable`?

r? @eileencodes 