### PR TITLE
Consistent behavior for session and cookies with to_h and to_hash method

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -338,6 +338,9 @@ module ActionDispatch
       end
       alias :has_key? :key?
 
+      # Returns the cookies as Hash.
+      alias :to_hash :to_h
+
       def update(other_hash)
         @cookies.update other_hash.stringify_keys
         self

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -130,6 +130,7 @@ module ActionDispatch
         load_for_read!
         @delegate.dup.delete_if { |_, v| v.nil? }
       end
+      alias :to_h :to_hash
 
       # Updates the session with given Hash.
       #

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -36,6 +36,12 @@ class CookieJarTest < ActiveSupport::TestCase
     assert_equal "bar", request.cookie_jar.fetch(:foo)
   end
 
+  def test_to_hash
+    request.cookie_jar["foo"] = "bar"
+    assert_equal({ "foo" => "bar" }, request.cookie_jar.to_hash)
+    assert_equal({ "foo" => "bar" }, request.cookie_jar.to_h)
+  end
+
   def test_fetch_type_error
     assert_raises(KeyError) do
       request.cookie_jar.fetch(:omglolwut)

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -22,6 +22,7 @@ module ActionDispatch
         s["foo"] = "bar"
         assert_equal "bar", s["foo"]
         assert_equal({ "foo" => "bar" }, s.to_hash)
+        assert_equal({ "foo" => "bar" }, s.to_h)
       end
 
       def test_create_merges_old


### PR DESCRIPTION
### Summary

When I was debugging one issue I noticed some inconsistency with session and cookies. Session has method `.to_hash`, but no `.to_h`. And Cookies has `.to_h`, but no `.to_hash`. So I've added them as aliases.