### PR TITLE
`nil` test parameters should be `nil` in the controller

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -90,6 +90,7 @@ module ActionController
 
       if get?
         if query_string.blank?
+          non_path_parameters.delete_if { |_,v| v.nil? }
           self.query_string = non_path_parameters.to_query
         end
       else

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -90,7 +90,7 @@ module ActionController
 
       if get?
         if query_string.blank?
-          non_path_parameters.delete_if { |_,v| v.nil? }
+          non_path_parameters.delete_if { |_, v| v.nil? }
           self.query_string = non_path_parameters.to_query
         end
       else

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -81,7 +81,7 @@ class TestCaseTest < ActionController::TestCase
     end
 
     def test_empty_param
-      render plain: ::JSON.dump({ foo: params[:foo] })
+      render plain: ::JSON.dump(foo: params[:foo])
     end
 
     def test_html_output

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -80,6 +80,10 @@ class TestCaseTest < ActionController::TestCase
       render plain: ::JSON.dump(request.headers.env)
     end
 
+    def test_empty_param
+      render plain: ::JSON.dump({ foo: params[:foo] })
+    end
+
     def test_html_output
       render plain: <<HTML
 <html>
@@ -178,6 +182,13 @@ XML
         end
       end
     end
+  end
+
+  def test_nil_param
+    response = get :test_empty_param, params: { foo: nil }
+    payload = JSON.parse(response.body)
+    assert payload.key?("foo"), "payload should have foo key"
+    assert_nil payload["foo"]
   end
 
   class DefaultUrlOptionsCachingController < ActionController::Base


### PR DESCRIPTION
This commit fixes a regression where `nil` parameters in the test would
get converted to empty strings in the controller. I added a test to
`4-2-stable` to demonstrate the existing behavior in 3acf0de35533a4d26a1299f63deb2be9875d06c0

This commit will fix the regression, but raises a broader issue about
the behavior of `to_query`.  It seems that our `to_query` implementation
doesn't generate query strings that round trip via Rack's query parser:

```
irb(main):011:0> { :foo => nil }.to_query
=> "foo="
irb(main):012:0> Rack::Utils.default_query_parser.parse_nested_query({ :foo => nil }.to_query)
=> {"foo"=>""}
```

I'm not sure if we *should* fix this, but I guess it's something we need
to know about.

/cc @mistydemeo 