### PR TITLE
Use Oracle enhanced adapter `release52` to support Rails `5-2-stable`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ if ENV["ORACLE_ENHANCED"]
   platforms :ruby do
     gem "ruby-oci8", "~> 2.2"
   end
-  gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "release52"
 end
 
 # A gem necessary for Active Record tests with IBM DB.


### PR DESCRIPTION
### Summary

This pull request changes Gemfile at `5-2-stable` so that Oracle enhanced adapter `release52` branch will be used.

There was a same kind of pull request for `5-1-stable` #28578