### PR TITLE
add current_scope method for translations

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -22,6 +22,10 @@ module AbstractController
     end
     alias :t :translate
 
+    def current_scope
+      "#{controller_path.tr('/', '.')}.#{action_name}"
+    end
+
     # Delegates to <tt>I18n.localize</tt>. Also aliased as <tt>l</tt>.
     def localize(*args)
       I18n.localize(*args)

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -49,6 +49,12 @@ module AbstractController
         end
       end
 
+      def test_current_scope
+        @controller.stub :action_name, :index do
+          assert_equal "abstract_controller.testing.translation.index", @controller.current_scope
+        end
+      end
+
       def test_lazy_lookup_with_symbol
         @controller.stub :action_name, :index do
           assert_equal "bar", @controller.t(:'.foo')


### PR DESCRIPTION
### Summary

I implemented a `current_scope` method in the `AbstractController::Translation` module in order to have the default scope used by `translate`.

I created a topic on the google group but got no answer since two weeks.
https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/ngz9RW7COC4