### PR TITLE
Allow ActiveStorage::Blob#service_url to pass addition options to service.url

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -109,8 +109,9 @@ class ActiveStorage::Blob < ActiveRecord::Base
   # with users. Instead, the +service_url+ should only be exposed as a redirect from a stable, possibly authenticated URL.
   # Hiding the +service_url+ behind a redirect also gives you the power to change services without updating all URLs. And
   # it allows permanent URLs that redirect to the +service_url+ to be cached in the view.
-  def service_url(expires_in: service.url_expires_in, disposition: :inline, filename: self.filename)
-    service.url key, expires_in: expires_in, disposition: forcibly_serve_as_binary? ? :attachment : disposition, filename: filename, content_type: content_type
+  def service_url(expires_in: service.url_expires_in, disposition: :inline, filename: self.filename, **options)
+    service.url key, expires_in: expires_in, filename: filename, content_type: content_type,
+      disposition: forcibly_serve_as_binary? ? :attachment : disposition, **options
   end
 
   # Returns a URL that can be used to directly upload a file for this blob on the service. This URL is intended to be

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -2,8 +2,11 @@
 
 require "test_helper"
 require "database/setup"
+require "active_support/testing/method_call_assertions"
 
 class ActiveStorage::BlobTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   test "create after upload sets byte size and checksum" do
     data = "Hello world!"
     blob = create_blob data: data
@@ -79,6 +82,23 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     freeze_time do
       assert_equal expected_url_for(blob), blob.service_url
       assert_equal expected_url_for(blob, filename: new_filename), blob.service_url(filename: new_filename)
+    end
+  end
+
+  test "urls allow for custom options" do
+    blob = create_blob(filename: "original.txt")
+
+    options = [
+      blob.key,
+      expires_in: blob.service.url_expires_in,
+      disposition: :inline,
+      content_type: blob.content_type,
+      filename: blob.filename,
+      thumb_size: "300x300",
+      thumb_mode: "crop"
+    ]
+    assert_called_with(blob.service, :url, options) do
+      blob.service_url(thumb_size: "300x300", thumb_mode: "crop")
     end
   end
 


### PR DESCRIPTION
Allow `ActiveStorage::Blob#service_url` to pass addition options to `service.url`.

Because there have some service needs more parameters for file URL:

https://www.alibabacloud.com/help/doc-detail/44687.htm

```rb
class AlicloudOSSService < Service
  def url(key, options = {})
    image_process = options[:oss_process] || "image/resize,w_800"
    "http://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg?x-oss-process=#{image_process}"
  end
end
```

https://github.com/huacnlee/activestorage-aliyun/blob/master/lib/active_storage/service/aliyun_service.rb#L43

```erb
<%= image_tag @user.avatar.service_url(oss_process: "image/resize,m_fill,h_100,w_100" %>
```