### PR TITLE
ActiveStorage: use the full class name for the JSON coder

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -19,7 +19,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   self.table_name = "active_storage_blobs"
 
   has_secure_token :key
-  store :metadata, accessors: [ :analyzed, :identified ], coder: JSON
+  store :metadata, accessors: [ :analyzed, :identified ], coder: ActiveRecord::Coders::JSON
 
   class_attribute :service
 


### PR DESCRIPTION
The `JSON` constant can refer to another object than the AR Coder, so the full name should be used.

For example, this is causing issues when using the `representable` gem (https://github.com/trailblazer/representable/issues/224):

```
/Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/coders/yaml_column.rb:24:in `load': undefined method `new' for Representable::JSON:Module (NoMethodError)
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/coders/yaml_column.rb:44:in `check_arity_of_constructor'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/coders/yaml_column.rb:13:in `initialize'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/store.rb:187:in `new'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/store.rb:187:in `initialize'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/store.rb:83:in `new'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activerecord-5.2.0.rc1/lib/active_record/store.rb:83:in `store'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activestorage-5.2.0.rc1/app/models/active_storage/blob.rb:22:in `<class:Blob>'
	from /Users/renchap/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activestorage-5.2.0.rc1/app/models/active_storage/blob.rb:16:in `<main>'
```

I checked the change with my application and it fixed the issue.