### PR TITLE
Fix build failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 sudo: false
 
 cache:
-  bundler: true
   directories:
+    - vendor/bundle
     - /tmp/cache/unicode_conformance
     - /tmp/beanstalkd-1.10
     - node_modules


### PR DESCRIPTION
I'm not sure cause, but due to the influence of `gem clean`, the expected　gem seems not to be installed correctly.
In order to avoid a test failure due to this, I fixed that `gem clean` not be executed.
Ref: travis-ci/travis-ci#2518
