### PR TITLE
Namespacing prefix for ActiveStorage S3 Service

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Namespacing for S3 objects by specifying `prefix:` for
+    `ActiveStorage::Service::S3Service`. This is useful when there is only one
+    bucket available and the root namespace should not be cluttered.
+
+    *Halo*
+
 ## Rails 5.2.0.rc1 (January 30, 2018) ##
 
 *   Preserve display aspect ratio when extracting width and height from videos


### PR DESCRIPTION
### Summary

Currently all ActiveStorage blobs are located in the "root directory" of the S3 bucket. This makes manual inspection of the S3 bucket very hard when there already are existing objects not belonging to ActiveStorage.

### Other Information

Maybe this cluttering is not a problem for everyone, but most setups I came across have only one S3 bucket per environment (production, staging) and not an entire bucket dedicated to ActiveStorage.

I [sought feedback](https://groups.google.com/forum/#!topic/rubyonrails-core/t3FPqfc2AB8) on the Rails Core group, but received no response (at least the post had most "views" of the past half year 🙃) Since no one was willing to jump in, I thought I'd show some code to receive feedback. I'd be happy for a "no" as well, as long as I learn why :)

PS: I was not sure whether the variable should be called `prefix` or `namespace` but that's up to code review. The ActiveStorage tests pass locally. I have not run the entire suite yet, I'll let Travis do that for me.

Thank you Rails Team, you're my heroes.