### PR TITLE
Enable block in params filter to return a replacement value

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -69,9 +69,10 @@ module ActionDispatch
             elsif value.is_a?(Array)
               value = value.map { |v| v.is_a?(Hash) ? call(v, parents) : v }
             elsif blocks.any?
-              key = key.dup if key.duplicable?
               value = value.dup if value.duplicable?
-              blocks.each { |b| b.call(key, value) }
+              value = blocks.reduce(value) do |current_value, block|
+                block.call(key, current_value) || current_value
+              end
             end
             parents.pop if deep_regexps
 

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -62,18 +62,16 @@ module ActionDispatch
             parents.push(key) if deep_regexps
             if regexps.any? { |r| key =~ r }
               value = FILTERED
-            elsif deep_regexps &&
-               (joined = parents.join(".")) &&
-               deep_regexps.any? { |r| joined =~ r }
+            elsif deep_regexps && (joined = parents.join(".")) && deep_regexps.any? { |r| joined =~ r }
               value = FILTERED
             elsif value.is_a?(Hash)
               value = call(value, parents)
             elsif value.is_a?(Array)
               value = value.map { |v| v.is_a?(Hash) ? call(v, parents) : v }
             elsif blocks.any?
-              value = blocks.reduce(value) do |current_value, block|
-                block.call(key, current_value)
-              end
+              key = key.dup if key.duplicable?
+              value = value.dup if value.duplicable?
+              blocks.each { |b| b.call(key, value) }
             end
             parents.pop if deep_regexps
 

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -62,16 +62,18 @@ module ActionDispatch
             parents.push(key) if deep_regexps
             if regexps.any? { |r| key =~ r }
               value = FILTERED
-            elsif deep_regexps && (joined = parents.join(".")) && deep_regexps.any? { |r| joined =~ r }
+            elsif deep_regexps &&
+               (joined = parents.join(".")) &&
+               deep_regexps.any? { |r| joined =~ r }
               value = FILTERED
             elsif value.is_a?(Hash)
               value = call(value, parents)
             elsif value.is_a?(Array)
               value = value.map { |v| v.is_a?(Hash) ? call(v, parents) : v }
             elsif blocks.any?
-              key = key.dup if key.duplicable?
-              value = value.dup if value.duplicable?
-              blocks.each { |b| b.call(key, value) }
+              value = blocks.reduce(value) do |current_value, block|
+                block.call(key, current_value)
+              end
             end
             parents.pop if deep_regexps
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1076,7 +1076,7 @@ class RequestParameterFilter < BaseRequestTest
 
       filter_words << "blah"
       filter_words << lambda { |key, value|
-        key =~ /bargain/ ? value.reverse : value
+        value.reverse! if key =~ /bargain/
       }
 
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1076,7 +1076,7 @@ class RequestParameterFilter < BaseRequestTest
 
       filter_words << "blah"
       filter_words << lambda { |key, value|
-        value.reverse! if key =~ /bargain/
+        key =~ /bargain/ ? value.reverse : value
       }
 
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)


### PR DESCRIPTION
### Summary

As written, a block in the params filter list can only alter the mutable content of the value. It cannot wholesale replace it.

This enables a block in the params filter to be a pure function, returning the new value.

### Other Information

It *does* change behavior. I had to alter a test.

Before I do any more work on this, I want to know if it is looked upon favorably and would be at all likely to be merged.

The change enables the following strategy to white-list, rather than black-list the params.

`config/initializers/filter_parameter_logging.rb:`
```ruby
Rails.application.config.filter_parameters << lambda { |key, value|
  Logging::WhiteList.filter_param(key, value)
}
```

`app/services/logging/white_list.rb (not a complete implementation):`
```ruby
module Logging
  class WhiteList
    class << self
      def filter_param(key, value)
        puts "FILTER SAYS #{key} #{value}"
        # param_permitted?(key) ? value : '[FILTERED]'
        '[FILTERED]'
      end
    end
  end
end
```