### PR TITLE
Do not attempt to find inverse for polymorphic associations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Do not attempt to automatically find the inverse of a polymorphic
+    `belongs_to` association.
 
+    Fixes #31876.
+
+    *Eric K Idema*
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -736,6 +736,10 @@ module ActiveRecord
         def calculate_constructable(macro, options)
           !polymorphic?
         end
+
+        def can_find_inverse_of_automatically?(reflection)
+          !polymorphic? && super
+        end
     end
 
     class HasAndBelongsToManyReflection < AssociationReflection # :nodoc:

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -188,6 +188,9 @@ class InverseAssociationTests < ActiveRecord::TestCase
 
     belongs_to_ref = Sponsor.reflect_on_association(:sponsor_club)
     assert_nil belongs_to_ref.inverse_of
+
+    belongs_to_ref = Sponsor.reflect_on_association(:sponsor)
+    assert_nil belongs_to_ref.inverse_of
   end
 
   def test_this_inverse_stuff

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -3,6 +3,7 @@
 class Sponsor < ActiveRecord::Base
   belongs_to :sponsor_club, class_name: "Club", foreign_key: "club_id"
   belongs_to :sponsorable, polymorphic: true
+  belongs_to :sponsor, polymorphic: true
   belongs_to :thing, polymorphic: true, foreign_type: :sponsorable_type, foreign_key: :sponsorable_id
   belongs_to :sponsorable_with_conditions, -> { where name: "Ernie" }, polymorphic: true,
              foreign_type: "sponsorable_type", foreign_key: "sponsorable_id"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -814,6 +814,7 @@ ActiveRecord::Schema.define do
   create_table :sponsors, force: true do |t|
     t.integer :club_id
     t.references :sponsorable, polymorphic: true, index: false
+    t.references :sponsor, polymorphic: true, index: false
   end
 
   create_table :string_key_objects, id: false, force: true do |t|


### PR DESCRIPTION
### Summary

Do not attempt to find an inverse association for polymorphic associations. This fixes the regression I found in my own rails app when upgrading from Rails 5.1.4 to 5.2.0.rc1.

See #31876.

### Other Information

I'm not familiar enough with automatic inverse associations to know if disabling this for all polymorphic associations is a reasonable thing to do?

This is also my first attempt at contributing to Rails, so apologies in advance if I've done anything wrong here. I'd be happy to make any requested changes.