### PR TITLE
Show host in default storage.yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
@@ -1,10 +1,12 @@
 test:
   service: Disk
   root: <%%= Rails.root.join("tmp/storage") %>
+  host: http://localhost:3000
 
 local:
   service: Disk
   root: <%%= Rails.root.join("storage") %>
+  host: http://localhost:3000
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
Right now in `/active_storage/service/disk_service.rb` we put `http://localhost:3000` by default and from documentation people have no idea if they can change the port. Only one way to understand it - open rails source code.

In my case, Puma started on port 5000 and ActiveStorage returns an error. This edit in default `storage.yml` at least will show that you can easily change the port from config.

Also I thought about approuch with `fetch`:

```ruby
# /active_storage/service/disk_service.rb
class Service::DiskService < Service
  attr_reader :root, :host
  DEFAULT_HOST = "http://localhost:#{ENV.fetch('PORT')}"

  def initialize(root:, host: DEFAULT_HOST)
    @root, @host = root, host
  end
end
```

But this still don't make port option in `storage.yml` more obvious.

Thank you!