### PR TITLE
Include source code in published activestorage npm package

### DIFF
--- a/activestorage/.gitignore
+++ b/activestorage/.gitignore
@@ -1,5 +1,6 @@
 .byebug_history
 node_modules
+src
 test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add source code to published npm package
 
+    This allows activestorage users to depend on the javascript source code
+    rather than the compiled code, which can produce smaller javascript bundles.
+
+    *Richard Macklin*
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/package.json
+++ b/activestorage/package.json
@@ -4,7 +4,8 @@
   "description": "Attach cloud and local files in Rails applications",
   "main": "app/assets/javascripts/activestorage.js",
   "files": [
-    "app/assets/javascripts/*.js"
+    "app/assets/javascripts/*.js",
+    "src/*.js"
   ],
   "homepage": "http://rubyonrails.org/",
   "repository": {
@@ -16,18 +17,21 @@
   },
   "author": "Javan Makhmali <javan@javan.us>",
   "license": "MIT",
+  "dependencies": {
+    "spark-md5": "^3.0.0"
+  },
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-preset-env": "^1.6.0",
     "eslint": "^4.3.0",
     "eslint-plugin-import": "^2.7.0",
-    "spark-md5": "^3.0.0",
     "webpack": "^3.4.0"
   },
   "scripts": {
     "prebuild": "yarn lint",
     "build": "webpack -p",
-    "lint": "eslint app/javascript"
+    "lint": "eslint app/javascript",
+    "prepublishOnly": "rm -rf src && cp -R app/javascript/activestorage src"
   }
 }


### PR DESCRIPTION
### Summary

By including the source code in the published npm package, we enable activestorage users to ship smaller javascript bundles to visitors using modern browsers. (And it seems like there is already support from rails core members for doing precisely that: https://github.com/rails/webpacker/issues/887#issuecomment-334276744.)

I've demonstrated this in this sample repository:
https://github.com/rmacklin/activestorage-es2015-build-example

In that example, the bundle shrinks by 5K (24%).

In addition to allowing smaller bundles for those who ship untranspiled code to modern browsers, including the source code in the published package can be useful in other ways:

1. Users can import individual modules rather than the whole library
2. As a result of (1), users can also monkey patch individual parts of activestorage by importing the relevant module, modifying the exported object, and then importing the rest of activestorage (which would then use the patched object).

### Other Information

In order to allow the source code to be depended on rather than the compiled code, we have to declare the external dependency on spark-md5 as a regular dependency, not a development dependency.

This means that even users who depend on the compiled code will have to download this package. However, spark-md5 is a small package (and may already be downloaded as a transitive dependency of another package), so this tradeoff seems worth it.