### PR TITLE
Update rails-ujs readme

### DIFF
--- a/actionview/app/assets/javascripts/README.md
+++ b/actionview/app/assets/javascripts/README.md
@@ -23,6 +23,8 @@ Note that the `data` attributes this library adds are a feature of HTML5. If you
     
     yarn add rails-ujs
 
+Ensure that `.yarnclean` does not include `assets` if you use [yarn autoclean](https://yarnpkg.com/lang/en/docs/cli/autoclean/).
+
 ## Usage
 
 ### Asset pipeline


### PR DESCRIPTION
### Summary

Add a note on using `yarn autoclean`.

### Other Information

`yarn autoclean --init` creates `.yarnclean` including `assets` as for  [current stable version](https://github.com/yarnpkg/yarn/blob/v1.3.2/src/cli/commands/autoclean.js#L27).