### PR TITLE
Fix invalid byte sequence error without `en_US.UTF-8` environment while rake guides:generate:html

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -4,28 +4,15 @@ namespace :guides do
   desc 'Generate guides (for authors), use ONLY=foo to process just "foo.md"'
   task generate: "generate:html"
 
-  # Guides are written in UTF-8, but the environment may be configured for some
-  # other locale, these tasks are responsible for ensuring the default external
-  # encoding is UTF-8.
-  #
-  # Real use cases: Generation was reported to fail on a machine configured with
-  # GBK (Chinese). The docs server once got misconfigured somehow and had "C",
-  # which broke generation too.
-  task :encoding do
-    %w(LANG LANGUAGE LC_ALL).each do |env_var|
-      ENV[env_var] = "en_US.UTF-8"
-    end
-  end
-
   namespace :generate do
     desc "Generate HTML guides"
-    task html: :encoding do
+    task :html do
       ENV["WARNINGS"] = "1" # authors can't disable this
       ruby "-Eutf-8:utf-8", "rails_guides.rb"
     end
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"
-    task kindle: :encoding do
+    task :kindle do
       require "kindlerb"
       unless Kindlerb.kindlegen_available?
         abort "Please run `setupkindlerb` to install kindlegen"

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -21,7 +21,7 @@ namespace :guides do
     desc "Generate HTML guides"
     task html: :encoding do
       ENV["WARNINGS"] = "1" # authors can't disable this
-      ruby "rails_guides.rb"
+      ruby "-Eutf-8:utf-8", "rails_guides.rb"
     end
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"


### PR DESCRIPTION
### Environment

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux unstable (sid)
Release:        unstable
Codename:       sid
$ uname -a
Linux genbu 4.14.0-3-amd64 #1 SMP Debian 4.14.13-1 (2018-01-14) x86_64 GNU/Linux
$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
```
### Actual reault

Following error occured while running `rake guides:generate:html`.

```
$ bundle exec rake guides:generate:html
/home/kenji/.rbenv/versions/2.5.0/bin/ruby rails_guides.rb
Generating 5_2_release_notes.md as 5_2_release_notes.html
Generating contributing_to_ruby_on_rails.md as contributing_to_ruby_on_rails.html
Generating form_helpers.md as form_helpers.html
Generating working_with_javascript_in_rails.md as working_with_javascript_in_rails.html
Generating debugging_rails_applications.md as debugging_rails_applications.html
Traceback (most recent call last):
        9: from rails_guides.rb:29:in `<main>'
        8: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:39:in `generate'
        7: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:91:in `generate_guides'
        6: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:91:in `each'
        5: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:93:in `block in generate_guides'
        4: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:144:in `generate_guide'
        3: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:144:in `open'
        2: from /home/kenji/ruby/rails/guides/rails_guides/generator.rb:165:in `block in generate_guide'
        1: from /home/kenji/ruby/rails/guides/rails_guides/markdown.rb:21:in `render'
/home/kenji/ruby/rails/guides/rails_guides/markdown.rb:72:in `extract_raw_header_and_body': invalid byte sequence in US-ASCII (ArgumentError)
rake aborted!
Command failed with status (1): [/home/kenji/.rbenv/versions/2.5.0/bin/ruby...]
/home/kenji/ruby/rails/guides/Rakefile:24:in `block (3 levels) in <top (required)>'
/home/kenji/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
/home/kenji/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
Tasks: TOP => guides:generate:html
(See full trace by running task with --trace)
```
### My investigation

Ruby does not set `Encoding.default_external` with non-existent locale such as `en_US.UTF-8` as original code expected.
For example,

```
$ LANG=ja_JP.UTF-8 ruby -e "p Encoding.default_external"
#<Encoding:UTF-8>
$ LANG=C ruby -e "p Encoding.default_external"
#<Encoding:US-ASCII>
$ LANG=C.UTF-8 ruby -e "p Encoding.default_external"
#<Encoding:UTF-8>
$ LANG=GB2312 ruby -e "p Encoding.default_external"
#<Encoding:US-ASCII
$ LANG=en_US.UTF-8 ruby -e "p Encoding.default_external"
#<Encoding:US-ASCII>
```

Available locales on my PC are following:

```
$ locale -a
C
C.UTF-8
POSIX
ja_JP.utf8
```

`en_US.UTF-8` does not exist.

We can specify external encoding and internal encoding via command line option as following:

```
$ LANG=en_US.UTF-8 ruby -Eutf-8:utf-8 -e "p Encoding.default_external"
#<Encoding:UTF-8>
```

### Expected result

We can run `rake guide:generate:html` successfully with any locale.