### PR TITLE
Remove label 'work in progress' for AM and AV guides

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -36,7 +36,6 @@
       name: Active Model Basics
       url: active_model_basics.html
       description: This guide covers the use of model classes without Active Record.
-      work_in_progress: true
 -
   name: Views
   documents:
@@ -44,7 +43,6 @@
       name: Action View Overview
       url: action_view_overview.html
       description: This guide provides an introduction to Action View and introduces a few of the more common view helpers.
-      work_in_progress: true
     -
       name: Layouts and Rendering in Rails
       url: layouts_and_rendering.html


### PR DESCRIPTION
I've reviewed "Active Model Basics" and "Action View Overview" guides
and looks like they have good enough information and don't have errors.
This PR removes label 'work in progress' for these guides.

[History for rails/guides/source/active_model_basics.md](https://github.com/rails/rails/commits/master/guides/source/active_model_basics.md)

[History for rails/guides/source/action_view_overview.md](https://github.com/rails/rails/commits/master/guides/source/action_view_overview.md)