### PR TITLE
Fix RedisCacheStore #write_multi to correctly store entries

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -113,6 +113,16 @@ module CacheStoreBehavior
     assert_equal("fufu", @cache.read("fu"))
   end
 
+  def test_fetch_multi_without_expires_in
+    @cache.write("foo", "bar")
+    @cache.write("fud", "biz")
+
+    values = @cache.fetch_multi("foo", "fu", "fud", expires_in: nil) { |value| value * 2 }
+
+    assert_equal({ "foo" => "bar", "fu" => "fufu", "fud" => "biz" }, values)
+    assert_equal("fufu", @cache.read("fu"))
+  end
+
   def test_multi_with_objects
     cache_struct = Struct.new(:cache_key, :title)
     foo = cache_struct.new("foo", "FOO!")


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/31884.

Before, values were incorrectly stored as strings like
`"#<ActiveSupport::Cache::Entry:0x007fd63671af48>"`. So now they are stored correctly.

I created a test with explicit `expires_in` as `nil` to test this code path https://github.com/rails/rails/blob/5d1999547d81edb07c0ce9149023b1bcd5de8a57/activesupport/lib/active_support/cache/redis_cache_store.rb#L361-L364 which was always avoided before by tests, because of `expires_in` here https://github.com/rails/rails/blob/5d1999547d81edb07c0ce9149023b1bcd5de8a57/activesupport/test/cache/stores/redis_cache_store_test.rb#L92