### PR TITLE
Use Redis#mget for RedisCacheStore#fetch_multi

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -303,6 +303,14 @@ module ActiveSupport
           end
         end
 
+        def read_multi_entries(names, _options)
+          if mget_capable?
+            read_multi_mget(*names)
+          else
+            super
+          end
+        end
+
         def read_multi_mget(*names)
           options = names.extract_options!
           options = merged_options(options)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -108,6 +108,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include LocalCacheBehavior
     include CacheIncrementDecrementBehavior
     include AutoloadingCacheBehavior
+
+    def test_fetch_multi_uses_redis_mget
+      assert_called(@cache.redis, :mget, returns: []) do
+        @cache.fetch_multi("a", "b", "c") do |key|
+          key * 2
+        end
+      end
+    end
   end
 
   # Separate test class so we can omit the namespace which causes expected,


### PR DESCRIPTION
```ruby
# config/development.rb
...
config.cache_store = :redis_cache_store
...
```

```ruby
Rails.cache.fetch_multi(:a, :b, :c) { "value" }
```

```
▶ redis-cli monitor
OK
1517844254.700679 [0 127.0.0.1:58616] "get" "a"
1517844254.700936 [0 127.0.0.1:58616] "get" "b"
1517844254.701301 [0 127.0.0.1:58616] "get" "c"
1517844254.701731 [0 127.0.0.1:58616] "mset" "a" "\x04\bo: ActiveSupport::Cache::Entry\t:\x0b@valueI\"\nvalue\x06:\x06ET:\r@version0:\x10@created_atf\x151517844254.70148:\x10@expires_in0" "b" "\x04\bo: ActiveSupport::Cache::Entry\t:\x0b@valueI\"\nvalue\x06:\x06ET:\r@version0:\x10@created_atf\x161517844254.701498:\x10@expires_in0" "c" "\x04\bo: ActiveSupport::Cache::Entry\t:\x0b@valueI\"\nvalue\x06:\x06ET:\r@version0:\x10@created_atf\x171517844254.7015092:\x10@expires_in0"
```

`RedisCacheStore` is not using `Redis#mget`.