### PR TITLE
Add missing instrumentation to RedisCacheStore#read_multi

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -187,7 +187,11 @@ module ActiveSupport
       # fetched values.
       def read_multi(*names)
         if mget_capable?
-          read_multi_mget(*names)
+          instrument(:read_multi, names, options) do |payload|
+            read_multi_mget(*names).tap do |results|
+              payload[:hits] = results.keys
+            end
+          end
         else
           super
         end

--- a/activesupport/test/cache/behaviors.rb
+++ b/activesupport/test/cache/behaviors.rb
@@ -3,6 +3,7 @@
 require_relative "behaviors/autoloading_cache_behavior"
 require_relative "behaviors/cache_delete_matched_behavior"
 require_relative "behaviors/cache_increment_decrement_behavior"
+require_relative "behaviors/cache_instrumentation_behavior"
 require_relative "behaviors/cache_store_behavior"
 require_relative "behaviors/cache_store_version_behavior"
 require_relative "behaviors/connection_pool_behavior"

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -30,6 +30,7 @@ class FileStoreTest < ActiveSupport::TestCase
   include LocalCacheBehavior
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
+  include CacheInstrumentationBehavior
   include AutoloadingCacheBehavior
 
   def test_clear

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -49,6 +49,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   include CacheStoreVersionBehavior
   include LocalCacheBehavior
   include CacheIncrementDecrementBehavior
+  include CacheInstrumentationBehavior
   include EncodedKeyCacheBehavior
   include AutoloadingCacheBehavior
   include ConnectionPoolBehavior

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -14,6 +14,7 @@ class MemoryStoreTest < ActiveSupport::TestCase
   include CacheStoreVersionBehavior
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
+  include CacheInstrumentationBehavior
 
   def test_prune_size
     @cache.write(1, "aaaaaaaaaa") && sleep(0.001)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -107,6 +107,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include CacheStoreVersionBehavior
     include LocalCacheBehavior
     include CacheIncrementDecrementBehavior
+    include CacheInstrumentationBehavior
     include AutoloadingCacheBehavior
   end
 


### PR DESCRIPTION
I have basically extracted instrumentation tests into a separate module to test against **all** (not just `null_store` or `memory_store`) cache stores and added missing `RedisCacheStore#read_multi` instrumentation.