### PR TITLE
Use SuppressedSummaryReporter and Rails::TestUnitReporter only if needed

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,3 @@
-
+*   Fix minitest rails plugin. The custom reporters are added only if needed. This will fix conflicts with others plugins. *Kevin Robatel*
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -43,10 +43,19 @@ module Minitest
       Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)
     end
 
+    self.plugin_rails_replace_reporters(reporter, options)
+  end
+
+  def self.plugin_rails_replace_reporters(minitest_reporter, options)
+    return unless minitest_reporter.kind_of?(Minitest::CompositeReporter)
+
     # Replace progress reporter for colors.
-    reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }
-    reporter << SuppressedSummaryReporter.new(options[:io], options)
-    reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+    if minitest_reporter.reporters.reject! { |reporter| reporter.kind_of?(SummaryReporter) } != nil
+      minitest_reporter << SuppressedSummaryReporter.new(options[:io], options)
+    end
+    if minitest_reporter.reporters.reject! { |reporter| reporter.kind_of?(ProgressReporter) } != nil
+      minitest_reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+    end
   end
 
   # Backwardscompatibility with Rails 5.0 generated plugin test scripts

--- a/railties/test/minitest/rails_plugin_test.rb
+++ b/railties/test/minitest/rails_plugin_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class Minitest::RailsPluginTest < ActiveSupport::TestCase
+  setup do
+    @options = Minitest.process_args []
+    @output = StringIO.new("".encode("UTF-8"))
+  end
+
+  test "default reporters are replaced" do
+    reporter = Minitest::CompositeReporter.new
+    reporter << Minitest::SummaryReporter.new(@output, @options)
+    reporter << Minitest::ProgressReporter.new(@output, @options)
+    reporter << Minitest::Reporter.new(@output, @options)
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+
+    assert_equal 3, reporter.reporters.count
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(Minitest::SuppressedSummaryReporter) }
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(::Rails::TestUnitReporter) }
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(Minitest::Reporter) }
+  end
+
+  test "no custom reporters are added if nothing to replace" do
+    reporter = Minitest::CompositeReporter.new
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+
+    assert_equal 0, reporter.reporters.count
+  end
+
+  test "handle the case when reporter is not CompositeReporter" do
+    reporter = Minitest::Reporter.new
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+  end
+end


### PR DESCRIPTION
### Summary

Rails Minitest plugin should add `SuppressedSummaryReporter` only for replacing `SummaryReporter` and `Rails::TestUnitReporter` for `ProgressReporter`.
Currently, the plugin always add these two reporters without checking if it's necessary.

For example, [kern/minitest-reporters](https://github.com/kern/minitest-reporters) can remove all reporters and set custom ones defined by the configuration.
Currently, `rails` will re-add reporters without checks.
