### PR TITLE
Fix ActiveModel::MissingAttributeError: can't write unknown attribute `type`

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -54,6 +54,8 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     t.save!
     t = Reply.last
     assert_equal({ foo: :bar }, t.content)
+  ensure
+    Topic.reset_column_information
   end
 
   def test_serialized_attribute_calling_dup_method


### PR DESCRIPTION
### Summary

This pull request addreses ActiveModel::MissingAttributeError: can't write unknown attribute `type`
Reported at https://travis-ci.org/rails/rails/jobs/337434035

### Steps to reproduce

```ruby
$ cd activerecord
$ bin/test test/cases/serialized_attribute_test.rb test/cases/persistence_test.rb --seed 19139 -n "/^(?:SerializedAttributeTest#(?:test_serialized_attributes_from_database_on_subclass)|PersistenceTest#(?:test_becomes))$/"
Using sqlite3
Run options: --seed 19139 -n "/^(?:SerializedAttributeTest#(?:test_serialized_attributes_from_database_on_subclass)|PersistenceTest#(?:test_becomes))$/"

# Running:

.E

Error:
PersistenceTest#test_becomes:
ActiveModel::MissingAttributeError: can't write unknown attribute `type`
    /home/yahonda/git/rails/activemodel/lib/active_model/attribute.rb:207:in `with_value_from_database'
    /home/yahonda/git/rails/activemodel/lib/active_model/attribute_set.rb:57:in `write_from_user'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/write.rb:51:in `_write_attribute'
    /home/yahonda/git/rails/activerecord/lib/active_record/inheritance.rb:249:in `ensure_proper_type'
    /home/yahonda/git/rails/activerecord/lib/active_record/inheritance.rb:238:in `initialize_internals_callback'
    /home/yahonda/git/rails/activerecord/lib/active_record/scoping.rb:43:in `initialize_internals_callback'
    /home/yahonda/git/rails/activerecord/lib/active_record/core.rb:312:in `initialize'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:363:in `becomes'
    /home/yahonda/git/rails/activerecord/test/cases/persistence_test.rb:250:in `test_becomes'


bin/test test/cases/persistence_test.rb:249



Finished in 0.131432s, 15.2169 runs/s, 15.2169 assertions/s.
2 runs, 2 assertions, 0 failures, 1 errors, 0 skips
$
```

### Actual result
```ruby
$ bin/test test/cases/serialized_attribute_test.rb test/cases/persistence_test.rb --seed 19139 -n "/^(?:SerializedAttributeTest#(?:test_serialized_attributes_from_database_on_subclass)|PersistenceTest#(?:test_becomes))$/"
Using sqlite3
Run options: --seed 19139 -n "/^(?:SerializedAttributeTest#(?:test_serialized_attributes_from_database_on_subclass)|PersistenceTest#(?:test_becomes))$/"

# Running:

.E

Error:
PersistenceTest#test_becomes:
ActiveModel::MissingAttributeError: can't write unknown attribute `type`
    /home/yahonda/git/rails/activemodel/lib/active_model/attribute.rb:207:in `with_value_from_database'
    /home/yahonda/git/rails/activemodel/lib/active_model/attribute_set.rb:57:in `write_from_user'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/write.rb:51:in `_write_attribute'
    /home/yahonda/git/rails/activerecord/lib/active_record/inheritance.rb:249:in `ensure_proper_type'
    /home/yahonda/git/rails/activerecord/lib/active_record/inheritance.rb:238:in `initialize_internals_callback'
    /home/yahonda/git/rails/activerecord/lib/active_record/scoping.rb:43:in `initialize_internals_callback'
    /home/yahonda/git/rails/activerecord/lib/active_record/core.rb:312:in `initialize'
    /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:363:in `becomes'
    /home/yahonda/git/rails/activerecord/test/cases/persistence_test.rb:250:in `test_becomes'


bin/test test/cases/persistence_test.rb:249



Finished in 0.131432s, 15.2169 runs/s, 15.2169 assertions/s.
2 runs, 2 assertions, 0 failures, 1 errors, 0 skips
$
```

 Thanks @y-yagi for helping about minitest_bisect at #31893