### PR TITLE
Support local cache on memcache store read multi

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -54,6 +54,10 @@ module ActiveSupport
             @data[key]
           end
 
+          def read_multi_entries(keys, options)
+            Hash[keys.map { |name| [name, read_entry(name, options)] }.keep_if { |_name, value| value }]
+          end
+
           def write_entry(key, value, options)
             @data[key] = value
             true
@@ -116,13 +120,13 @@ module ActiveSupport
             end
           end
 
-          def read_multi_entries(names, options)
+          def read_multi_entries(keys, options)
             return super unless local_cache
 
-            local_entries = Hash[names.map { |name| [name, local_cache.read_entry(name, options)] }.keep_if { |_name, value| value }]
-            missed_keys = names - local_entries.keys
+            local_entries = local_cache.read_multi_entries(keys, options)
+            missed_keys = keys - local_entries.keys
 
-            if missed_keys.present?
+            if missed_keys.any?
               local_entries.merge!(super(missed_keys, options))
             else
               local_entries

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -116,6 +116,19 @@ module ActiveSupport
             end
           end
 
+          def read_multi_entries(names, options)
+            return super unless local_cache
+
+            local_entries = Hash[names.map { |name| [name, local_cache.read_entry(name, options)] }.keep_if { |_name, value| value }]
+            missed_keys = names - local_entries.keys
+
+            if missed_keys.present?
+              local_entries.merge!(super(missed_keys, options))
+            else
+              local_entries
+            end
+          end
+
           def write_entry(key, entry, options)
             if options[:unless_exist]
               local_cache.delete_entry(key, options) if local_cache

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -119,6 +119,16 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_fetch_multi
+    @cache.with_local_cache do
+      @cache.fetch_multi("foo", "bar") { |_key| true }
+      @peek.delete("foo")
+      @peek.delete("bar")
+      assert_equal true, @cache.read("foo")
+      assert_equal true, @cache.read("bar")
+    end
+  end
+
   def test_middleware
     app = lambda { |env|
       result = @cache.write("foo", "bar")


### PR DESCRIPTION
### Summary

Cache stores have a local cache strategy that is not used on fetch multi because read multi entries is not aware of it.

Closes #31909.

### Other Information

Using bug report template won't detect the issue for some reason.

You have to create a real application, add dalli to Gemfile, configure the environment to use mem cache as cache store and create a controller with that:

```ruby
class MoviesController < ApplicationController
  def index
    if params[:dalli]
      d = Dalli::Client.new('127.0.0.1:11211')
      k = "x" * 1024

      if params[:clear]
        d.flush
      else
        d.set("#{k}1", true)
        d.set("#{k}2", true)
        d.set("#{k}3", true)
      end

      fetch_multi_time = Benchmark.measure do
        1_000.times do
          d.get_multi("#{k}1", "#{k}2", "#{k}3") { |_key| true }
        end
      end

      if params[:clear]
        d.flush
      else
        d.set("#{k}1", true)
        d.set("#{k}2", true)
        d.set("#{k}3", true)
      end

      read_write_time = Benchmark.measure do
        1_000.times do
          d.get("#{k}1") || d.set("#{k}1", true)
          d.get("#{k}2") || d.set("#{k}2", true)
          d.get("#{k}3") || d.set("#{k}3", true)
        end
      end

      render json: {
        fetch_multi_time: fetch_multi_time.real,
        read_write_time: read_write_time.real,
      }
    else
      driver = Rails.cache

      if params[:clear]
        driver.clear
      else
        driver.write("#{k}1", true)
        driver.write("#{k}2", true)
        driver.write("#{k}3", true)
      end

      fetch_multi_time = Benchmark.measure do
        1_000.times do
          driver.read_multi("#{k}1", "#{k}2", "#{k}3") { |_key| true }
        end
      end

      if params[:clear]
        driver.clear
      else
        driver.write("#{k}1", true)
        driver.write("#{k}2", true)
        driver.write("#{k}3", true)
      end

      read_write_time = Benchmark.measure do
        1_000.times do
          driver.read("#{k}1") || driver.write("#{k}1", true)
          driver.read("#{k}2") || driver.write("#{k}2", true)
          driver.read("#{k}3") || driver.write("#{k}3", true)
        end
      end

      render json: {
        fetch_multi_time: fetch_multi_time.real,
        read_write_time: read_write_time.real
      }
    end
  end
end
```

This benchmark is rudimentary but it shows the problem in the most simple way.

Before:

```js
{
  "fetch_multi_time": 1.5901559998746961,
  "read_write_time": 0.020418000174686313
}
```

After (the difference falls in no statistic difference):

```js
{
  "fetch_multi_time": 0.014100000029429793,
  "read_write_time": 0.023772000102326274
}
```

This was detected while writing some benchmarks for [abstract builder](https://github.com/sobrinho/abstract_builder).