### PR TITLE
Define callbacks on descendants.

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -806,28 +806,30 @@ module ActiveSupport
         def define_callbacks(*names)
           options = names.extract_options!
 
-          names.each do |name|
-            name = name.to_sym
+          ([self] + ActiveSupport::DescendantsTracker.descendants(self)).each do |target|
+            names.each do |name|
+              name = name.to_sym
 
-            set_callbacks name, CallbackChain.new(name, options)
+              target.set_callbacks name, CallbackChain.new(name, options)
 
-            module_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def _run_#{name}_callbacks(&block)
-                run_callbacks #{name.inspect}, &block
-              end
+              target.module_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def _run_#{name}_callbacks(&block)
+                  run_callbacks #{name.inspect}, &block
+                end
 
-              def self._#{name}_callbacks
-                get_callbacks(#{name.inspect})
-              end
+                def self._#{name}_callbacks
+                  get_callbacks(#{name.inspect})
+                end
 
-              def self._#{name}_callbacks=(value)
-                set_callbacks(#{name.inspect}, value)
-              end
+                def self._#{name}_callbacks=(value)
+                  set_callbacks(#{name.inspect}, value)
+                end
 
-              def _#{name}_callbacks
-                __callbacks[#{name.inspect}]
-              end
-            RUBY
+                def _#{name}_callbacks
+                  __callbacks[#{name.inspect}]
+                end
+              RUBY
+            end
           end
         end
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -806,30 +806,30 @@ module ActiveSupport
         def define_callbacks(*names)
           options = names.extract_options!
 
-          ([self] + ActiveSupport::DescendantsTracker.descendants(self)).each do |target|
-            names.each do |name|
-              name = name.to_sym
+          names.each do |name|
+            name = name.to_sym
 
+            ([self] + ActiveSupport::DescendantsTracker.descendants(self)).each do |target|
               target.set_callbacks name, CallbackChain.new(name, options)
-
-              target.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def _run_#{name}_callbacks(&block)
-                  run_callbacks #{name.inspect}, &block
-                end
-
-                def self._#{name}_callbacks
-                  get_callbacks(#{name.inspect})
-                end
-
-                def self._#{name}_callbacks=(value)
-                  set_callbacks(#{name.inspect}, value)
-                end
-
-                def _#{name}_callbacks
-                  __callbacks[#{name.inspect}]
-                end
-              RUBY
             end
+
+            module_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def _run_#{name}_callbacks(&block)
+                run_callbacks #{name.inspect}, &block
+              end
+
+              def self._#{name}_callbacks
+                get_callbacks(#{name.inspect})
+              end
+
+              def self._#{name}_callbacks=(value)
+                set_callbacks(#{name.inspect}, value)
+              end
+
+              def _#{name}_callbacks
+                __callbacks[#{name.inspect}]
+              end
+            RUBY
           end
         end
 

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -176,3 +176,13 @@ class DynamicInheritedCallbacks < ActiveSupport::TestCase
     assert_equal 1, child.count
   end
 end
+
+class DynamicDefinedCallbacks < ActiveSupport::TestCase
+  def test_callbacks_should_be_performed_once_in_child_class_after_dynamic_define
+    GrandParent.define_callbacks(:foo)
+    GrandParent.set_callback(:foo, :before, :before1)
+    parent = Parent.new("foo")
+    parent.run_callbacks(:foo)
+    assert_equal %w(before1), parent.log
+  end
+end


### PR DESCRIPTION
### Summary

We call `set_callbacks` on all descendants, so we need to make sure that callbacks are also defined on all descendants. Otherwise, you will get an error when running `set_callback` for a callback that was defined after subclasses were added.

```ruby
class Foo < ActiveRecord::Base
end

ActiveRecord::Base.define_model_callbacks :greet
ActiveRecord::Base.after_greet { puts 'goodbye' }
=> NoMethodError: undefined method `prepend' for nil:NilClass
```