### PR TITLE
Update em-socksify to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
       em-socksify (>= 0.3)
       eventmachine (>= 1.0.3)
       http_parser.rb (>= 0.6.0)
-    em-socksify (0.3.1)
+    em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
     erubi (1.7.0)
     et-orbi (1.0.8)


### PR DESCRIPTION
Avoid `warning: parentheses after method name is interpreted as an argument list, not a decomposed argument`.
This has been fixed in 0.3.2.