### PR TITLE
Prevent serializing an active record constant from causing a stack overflow

### DIFF
--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -10,6 +10,12 @@ module ActiveRecord #:nodoc:
       self.include_root_in_json = false
     end
 
+    module ClassMethods
+      def as_json(*)
+        name
+      end
+    end
+
     def serializable_hash(options = nil)
       options = options.try(:dup) || {}
 

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -103,4 +103,8 @@ class SerializationTest < ActiveRecord::TestCase
 
     assert_equal 1, Author.joins(:serialized_posts).where(name: "David", serialized_posts: { title: "Hello" }).length
   end
+
+  def test_serializes_active_record_constant
+    assert_equal Author.name, Author.as_json
+  end
 end


### PR DESCRIPTION
### Summary

This fixes #31915, where serialization of an ActiveRecord constant causes a stack overflow