### PR TITLE
Do not add master key when `RAILS_MASTER_KEY` env specified

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -20,7 +20,7 @@ module Rails
         require_application_and_environment!
 
         ensure_editor_available(command: "bin/rails credentials:edit") || (return)
-        ensure_master_key_has_been_added
+        ensure_master_key_has_been_added if Rails.application.credentials.key.nil?
         ensure_credentials_have_been_added
 
         catch_editing_exceptions do

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -21,9 +21,10 @@ module Rails
 
       def edit(file_path)
         require_application_and_environment!
+        encrypted = Rails.application.encrypted(file_path, key_path: options[:key])
 
         ensure_editor_available(command: "bin/rails encrypted:edit") || (return)
-        ensure_encryption_key_has_been_added(options[:key])
+        ensure_encryption_key_has_been_added(options[:key]) if encrypted.key.nil?
         ensure_encrypted_file_has_been_added(file_path, options[:key])
 
         catch_editing_exceptions do

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -43,6 +43,18 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/api_key: abc/, run_show_command)
   end
 
+  test "edit command does not add master key when `RAILS_MASTER_KEY` env specified" do
+    Dir.chdir(app_path) do
+      key = IO.binread("config/master.key").strip
+      FileUtils.rm("config/master.key")
+
+      switch_env("RAILS_MASTER_KEY", key) do
+        run_edit_command
+        assert_not File.exist?("config/master.key")
+      end
+    end
+  end
+
   test "show credentials" do
     assert_match(/access_key_id: 123/, run_show_command)
   end

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -33,6 +33,18 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "edit command does not add master key when `RAILS_MASTER_KEY` env specified" do
+    Dir.chdir(app_path) do
+      key = IO.binread("config/master.key").strip
+      FileUtils.rm("config/master.key")
+
+      switch_env("RAILS_MASTER_KEY", key) do
+        run_edit_command("config/tokens.yml.enc")
+        assert_not File.exist?("config/master.key")
+      end
+    end
+  end
+
   test "edit encrypts file with custom key" do
     run_edit_command("config/tokens.yml.enc", key: "config/tokens.key")
 


### PR DESCRIPTION
Fixes #31917