### PR TITLE
Fix yaml deserialization of ActiveSupport::Duration

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -334,6 +334,14 @@ module ActiveSupport
       to_i
     end
 
+    def init_with(coder) #:nodoc:
+      initialize(coder["value"], coder["parts"])
+    end
+
+    def encode_with(coder) #:nodoc:
+      coder.map = { "value" => @value, "parts" => @parts }
+    end
+
     # Build ISO 8601 Duration string for this duration.
     # The +precision+ parameter can be used to limit seconds' precision of duration.
     def iso8601(precision: nil)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -585,6 +585,12 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal time + d1, time + d2
   end
 
+  def test_durations_survive_yaml_serialization
+    d1 = YAML.load(YAML.dump(10.minutes))
+    assert_equal 600, d1.to_i
+    assert_equal 660, (d1 + 60).to_i
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
This ensures the duration's `@parts` hash has a default value, to avoid this regression introduced in 5.1:

```ruby
YAML.load(YAML.dump(10.minutes)) + 1  # => NoMethodError: undefined method `+' for nil:NilClass
```