### PR TITLE
Allow unique name for schema_cache.yml file.

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -82,7 +82,11 @@ module ActiveRecord
       if config.active_record.delete(:use_schema_cache_dump)
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
-            filename = File.join(app.config.paths["db"].first, "schema_cache.yml")
+            filename = if app.config.schema_cache_file
+              app.config.schema_cache_file
+            else
+              File.join(app.config.paths["db"].first, "schema_cache.yml")
+            end
 
             if File.file?(filename)
               cache = YAML.load(File.read(filename))

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -253,16 +253,18 @@ db_namespace = namespace :db do
     end
 
     namespace :cache do
-      desc "Creates a db/schema_cache.yml file."
+      desc "Creates a db/schema_cache.yml file. Specify another file with SCHEMA_CACHE=db/my_schema_cache.yml"
       task dump: [:environment, :load_config] do
         conn = ActiveRecord::Base.connection
-        filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
+        filename = ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
+
         ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(conn, filename)
       end
 
-      desc "Clears a db/schema_cache.yml file."
+      desc "Clears a db/schema_cache.yml file. Specify another file with SCHEMA_CACHE=db/my_schema_cache.yml"
       task clear: [:environment, :load_config] do
-        filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
+        filename = ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
+
         rm_f filename, verbose: false
       end
     end


### PR DESCRIPTION
### Summary

In order to help get around https://github.com/rails/rails/issues/31928, we've written code to allow custom naming of schema_cache.yml files. This allows each process that we have running on a shared box to write a file only it reads.

### Other Information

This bug and approach has been explained in the issue listed above.