### PR TITLE
delegate_privately - ability to delegate methods while keeping them private

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -215,6 +215,32 @@ class Module
     end
   end
 
+
+  # Provides a +delegate_privately+ class method to easily expose contained objects'
+  # public methods as your own private methods.
+  #
+  #   class Greeter < ActiveRecord::Base
+  #     def hello
+  #       'hello'
+  #     end
+  #   end
+  #
+  #   class Foo < ActiveRecord::Base
+  #     belongs_to :greeter
+  #     delegate_privately :hello, to: :greeter
+  #
+  #     def public_hello
+  #       "#{hello} world"
+  #     end
+  #   end
+  #
+  #   Foo.new.hello # => NoMethodError: private method `goodbye' called for for #<Foo:0x1af30c>
+  #   Foo.new.public_hello   # => "hello world"
+  #
+  def delegate_privately(*methods, **options)
+    private *delegate(*methods, **options)
+  end
+
   # When building decorators, a common pattern may emerge:
   #
   #   class Partition

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -440,4 +440,42 @@ class ModuleTest < ActiveSupport::TestCase
     assert_not_respond_to place, :the_city
     assert place.respond_to?(:the_city, true)
   end
+
+  def test_private_delegate_with_delegate_privately
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      delegate_privately(:street, :city, to: :@place)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not_respond_to place, :street
+    assert_not_respond_to place, :city
+
+    assert place.respond_to?(:street, true) # Asking for private method
+    assert place.respond_to?(:city, true)
+  end
+
+  def test_private_delegate_prefixed_with_delegate_privately
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      delegate_privately(:street, :city, to: :@place, prefix: :the)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not_respond_to place, :street
+    assert_not_respond_to place, :city
+
+    assert_not_respond_to place, :the_street
+    assert place.respond_to?(:the_street, true)
+    assert_not_respond_to place, :the_city
+    assert place.respond_to?(:the_city, true)
+  end
 end


### PR DESCRIPTION
### Summary

for delegation as  public methods there is existing `#delegate` method :

```ruby
class Foo
   # ...
   delegate :foo, :bar, to: :baz
   # ...
end

foo = Foo.new
foo.foo
foo.bar
```

https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/delegation.rb#L154

And this PR provides method `#delegate_privately` 

```ruby
class Foo
   # ...
   delegate_privately :car, :dar, to: :daz
   # ...
end

foo = Foo.new
foo.car  # => NoMethodError: private method `car' called for #<Foo:0x000000015e8b10>
foo.dar # => NoMethodError: private method `car' called for #<Foo:0x000000015e8b10>
```

**Reason**

from my understanding,  currently the only way how to delegate as private method is by doing:

```ruby
class Foo
   # ...
   private *delegate( :car, :dar, to: :daz)
   # ...
end

foo = Foo.new
foo.car  # => NoMethodError: private method `car' called for #<Foo:0x000000015e8b10>
foo.dar # => NoMethodError: private method `dar' called for #<Foo:0x000000015e8b10>
```

* https://blog.eq8.eu/til/how-to-delegate-methods-in-rails-as-private.html
* https://stackoverflow.com/questions/15643172/make-delegated-methods-private

and there are some cases when I want to delegate methods to other object and not expose those methods as part of  primary object  interface methods

**Why is `private *delegate(...)` not enough:**

Seems to me like developers might feels discouraged to use the `private *delegate(...)` as it's 4 responsibility in one line: 

*  private
*  splat operator
* the actual delegation 
* knowledge of what delegate returns 

...this way all these 4 responsibilities are hidden in one method `#delegate_privately` and tested outside of the application => Rails framework

Also there is misconception amongs developers that this works (which does not)

```ruby
class Bar
   def car
      12
   end
end

class Foo
   private  
   delegate :car, to: :bar  
   def bar
     Bar.new
   end  
end  

Foo.new.car
#=> 12

Foo.new.public_methods - Object.new.public_methods 
#=> [:car]
```

> Actually that is my case,  I was (at least) 4 years in understanding that this works, and never bothered to check it :disappointed:

 

Related discussion:

* https://github.com/rails/rails/issues/31932


