### PR TITLE
Fix: `Testing an ActionController::Live controller leads to a deadlock `

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -141,20 +141,6 @@ module ActionController
         @cv = new_cond
         @aborted = false
         @ignore_disconnect = false
-
-        # https://github.com/rails/rails/issues/31813:
-        #
-        # In a browser context, the browser consumes data as soon as it's
-        # generated, freeing up space in the SizedQueue. However, in a rack
-        # test context, this is not the case, as data is never consumed. This
-        # leads to a deadlock upon trying to insert the 11th element in the
-        # queue, since the queue is waiting for space to become available
-        # before inserting the element:
-        #
-        #   http://ruby-doc.org/stdlib-2.0.0/libdoc/thread/rdoc/SizedQueue.html#method-i-push
-        #
-        # Thus, use an infinite sized Queue in rack test contexts to work around
-        # the issue where data is never consumed from the queue.
         super(response, Rails.env.test? ? Queue.new : SizedQueue.new(10))
       end
 


### PR DESCRIPTION
Use an infinite sized queue in rack test context to avoid deadlock situation on insertion into a full queue when data is never consumed from the `Action::Dispatch::Response::Buffer`.

### Summary

Hi rails team!

This is my first time contributing to rails. I saw issue https://github.com/rails/rails/issues/31200, and the subsequent follow-up issue https://github.com/rails/rails/issues/31813, and thought it would be a good first problem to tackle.

I implemented the second tentative solution listed in #31813, where an infinite queue is used for streaming in a rack test context.

If the team believes it's better to proceed with the third solution (consuming the response in async) over the second one, I'd be happy to try and tackle it and would appreciate any guidance or advice from the team.

### Other Information

Just for my understanding _(and this may be a silly question, so I apologize in advance if it is)_. Why was a `SizedQueue` used over a regular `Queue`? Was the limit of `10` chosen arbitrarily, or was it chosen for a specific reason?

Thank you! 🙂 