### PR TITLE
Add Relation#pick as short-hand for single-value plucks

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -200,8 +200,8 @@ module ActiveRecord
       end
     end
 
-    # Pick the first value from the named column in the current relation.
-    # This is short-hand for `relation.limit(1).pluck(column_name).first`, and is primarily useful
+    # Pick the value(s) from the named column(s) in the current relation.
+    # This is short-hand for `relation.limit(1).pluck(*column_names).first`, and is primarily useful
     # when you have a relation that's already narrowed down to a single row.
     #
     # Just like #pluck, #pick will only load the actual value, not the entire record object, so it's also
@@ -210,8 +210,12 @@ module ActiveRecord
     #   Person.where(id: 1).pick(:name)
     #   # SELECT people.name FROM people WHERE id = 1 LIMIT 1
     #   # => 'David'
-    def pick(column_name)
-      limit(1).pluck(column_name).first
+    #
+    #   Person.where(id: 1).pick(:name, :email_address)
+    #   # SELECT people.name, people.email_address FROM people WHERE id = 1 LIMIT 1
+    #   # => [ 'David', 'david@loudthinking.com' ]
+    def pick(*column_names)
+      limit(1).pluck(*column_names).first
     end
 
     # Pluck all the ID's for the relation using the table's primary key

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -200,6 +200,20 @@ module ActiveRecord
       end
     end
 
+    # Pick the first value from the named column in the current relation.
+    # This is short-hand for `relation.limit(1).pluck(column_name).first`, and is primarily useful
+    # when you have a relation that's already narrowed down to a single row.
+    #
+    # Just like #pluck, #pick will only load the actual value, not the entire record object, so it's also
+    # more efficient. The value is, again like with pluck, typecast by the column type.
+    #
+    #   Person.where(id: 1).pick(:name)
+    #   # SELECT people.name FROM people WHERE id = 1 LIMIT 1
+    #   # => 'David'
+    def pick(column_name)
+      limit(1).pluck(column_name).first
+    end
+
     # Pluck all the ID's for the relation using the table's primary key
     #
     #   Person.ids # SELECT people.id FROM people

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -793,6 +793,11 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_pick
+    assert_equal "The First Topic", Topic.order(:id).pick(:heading)
+    assert_nil Topic.where(id: 9999999999999999999).pick(:heading)
+  end
+
   def test_grouped_calculation_with_polymorphic_relation
     part = ShipPart.create!(name: "has trinket")
     part.trinkets.create!

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -793,9 +793,14 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_pick
+  def test_pick_one
     assert_equal "The First Topic", Topic.order(:id).pick(:heading)
-    assert_nil Topic.where(id: 9999999999999999999).pick(:heading)
+    assert_nil Topic.where("1=0").pick(:heading)
+  end
+
+  def test_pick_two
+    assert_equal ["David", "david@loudthinking.com"], Topic.order(:id).pick(:author_name, :author_email_address)
+    assert_nil Topic.where("1=0").pick(:author_name, :author_email_address)
   end
 
   def test_grouped_calculation_with_polymorphic_relation


### PR DESCRIPTION
Pick the first value from the named column in the current relation. This is short-hand for `relation.limit(1).pluck(column_name).first`, and is primarily useful when you have a relation that's already narrowed down to a single row.

Just like #pluck, #pick will only load the actual value, not the entire record object, so it's also more efficient. The value is, again like with pluck, typecast by the column type.

```ruby
  Person.where(id: 1).pick(:name)
  # SELECT people.name FROM people WHERE id = 1 LIMIT 1
  # => 'David'
```