### PR TITLE
delegate to, with private: true option

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,42 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Add `private: true` option to ActiveSupport's `delegate`.
+
+    In order to delegate methods as private methods:
+
+        class User < ActiveRecord::Base
+          has_one :profile
+          delegate :date_of_birth, to: :profile, private: true
+
+          def age
+            Date.today.year - date_of_birth.year
+          end
+        end
+
+        # User.new.age  # => 29
+        # User.new.date_of_birth
+        # => NoMethodError: private method `date_of_birth' called for #<User:0x00000008221340>
+
+    More information in #31944.
+
+    *Tomas Valent*
+
+*   Return all mappings for a timezone identifier in `country_zones`
+
+    Some timezones like `Europe/London` have multiple mappings in
+    `ActiveSupport::TimeZone::MAPPING` so return all of them instead
+    of the first one found by using `Hash#value`. e.g:
+
+        # Before
+        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh"]
+
+        # After
+        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh", "London"]
+
+    Fixes #31668.
+
+    *Andrew White*
+
 *   `String#truncate_bytes` to truncate a string to a maximum bytesize without
     breaking multibyte characters or grapheme clusters like 👩‍👩‍👦‍👦.
 

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -114,6 +114,24 @@ class Module
   #   invoice.customer_name    # => 'John Doe'
   #   invoice.customer_address # => 'Vimmersvej 13'
   #
+  # If you want the delegated method to be a private method,
+  # use the <tt>:private</tt> option.
+  #
+  #   class User < ActiveRecord::Base
+  #     has_one :profile
+  #     delegate :first_name, to: :profile
+  #     delegate :date_of_birth, :religion, to: :profile, private: true
+  #
+  #     def age
+  #       Date.today.year - date_of_birth.year
+  #     end
+  #   end
+  #
+  #   User.new.age # 2
+  #   User.new.first_name # Tomas
+  #   User.new.date_of_birth # NoMethodError: private method `date_of_birth' called for #<User:0x00000008221340>
+  #   User.new.religion # NoMethodError: private method `religion' called for #<User:0x00000008221340>
+  #
   # If the target is +nil+ and does not respond to the delegated method a
   # +Module::DelegationError+ is raised. If you wish to instead return +nil+,
   # use the <tt>:allow_nil</tt> option.
@@ -151,7 +169,7 @@ class Module
   #   Foo.new("Bar").name # raises NoMethodError: undefined method `name'
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
-  def delegate(*methods, to: nil, prefix: nil, allow_nil: nil)
+  def delegate(*methods, to: nil, prefix: nil, allow_nil: nil, private: nil)
     unless to
       raise ArgumentError, "Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter)."
     end
@@ -173,7 +191,7 @@ class Module
     to = to.to_s
     to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
 
-    methods.map do |method|
+    method_names = methods.map do |method|
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.
       definition = /[^\]]=$/.match?(method) ? "arg" : "*args, &block"
@@ -213,6 +231,9 @@ class Module
 
       module_eval(method_def, file, line)
     end
+
+    private(*method_names) if private
+    method_names
   end
 
   # When building decorators, a common pattern may emerge:

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -440,4 +440,61 @@ class ModuleTest < ActiveSupport::TestCase
     assert_not_respond_to place, :the_city
     assert place.respond_to?(:the_city, true)
   end
+
+  def test_private_delegate_with_private_option
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      delegate(:street, :city, to: :@place, private: true)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not_respond_to place, :street
+    assert_not_respond_to place, :city
+
+    assert place.respond_to?(:street, true) # Asking for private method
+    assert place.respond_to?(:city, true)
+  end
+
+  def test_some_public_some_private_delegate_with_private_option
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      delegate(:street, to: :@place)
+      delegate(:city, to: :@place, private: true)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_respond_to place, :street
+    assert_not_respond_to place, :city
+
+    assert place.respond_to?(:city, true) # Asking for private method
+  end
+
+  def test_private_delegate_prefixed_with_private_option
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+    end
+
+    assert_equal %i(the_street the_city),
+      location.delegate(:street, :city, to: :@place, prefix: :the, private: true)
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not_respond_to place, :street
+    assert_not_respond_to place, :city
+
+    assert_not_respond_to place, :the_street
+    assert place.respond_to?(:the_street, true)
+    assert_not_respond_to place, :the_city
+    assert place.respond_to?(:the_city, true)
+  end
 end


### PR DESCRIPTION

### Summary

alternative version for PR https://github.com/rails/rails/pull/31933   (pls read description there) with `private: true` option

```ruby
class Foo
   # ...
   delegate :foo, :bar, to: :baz
   delegate :car, :dar, to: :daz, private: true
   # ...
end

foo = Foo.new
foo.foo
foo.bar
foo.car # => NoMethodError: private method `car' called for #<Foo:0x000000015e8b10>
foo.dar # => NoMethodError: private method `dar' called for #<Foo:0x000000015e8b10>
```

https://github.com/rails/rails/pull/31933#issuecomment-364108705


