### PR TITLE
Attachable from url or URI::HTTP or URI::HTTPS

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Attachable from url or URI::HTTP or URI::HTTPS
+
+    *Yoshiyuki Hirano*
+
 *   Add source code to published npm package
 
     This allows activestorage users to depend on the javascript source code

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -16,8 +16,10 @@ module ActiveStorage
     #
     #   document.images.attach(params[:images]) # Array of ActionDispatch::Http::UploadedFile objects
     #   document.images.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
+    #   document.images.attach(params[:image_urls]) # Array of image url
     #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpg")
     #   document.images.attach([ first_blob, second_blob ])
+    #   document.images.attach(URI.parse("http://rubyonrails.org/images/imagine.png"))
     def attach(*attachables)
       attachables.flatten.collect do |attachable|
         if record.new_record?

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -17,8 +17,10 @@ module ActiveStorage
     #
     #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object
     #   person.avatar.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
+    #   person.avatar.attach(params[:image_url])
     #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
+    #   person.avatar.attach(URI.parse("http://rubyonrails.org/images/imagine.png"))
     def attach(attachable)
       if attached? && dependent == :purge_later
         replace attachable

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -31,6 +31,18 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "racecar.jpg", @user.avatar.filename.to_s
   end
 
+  test "attach new blob from a URI::HTTP" do
+    uri = URI.parse("http://rubyonrails.org/images/imagine.png")
+    @user.avatar.attach(uri)
+    assert_equal "imagine.png", @user.avatar.filename.to_s
+  end
+
+  test "attach new blob from url" do
+    url = "http://rubyonrails.org/images/imagine.png"
+    @user.avatar.attach(url)
+    assert_equal "imagine.png", @user.avatar.filename.to_s
+  end
+
   test "replace attached blob" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
 


### PR DESCRIPTION
### Summary

I thought it's nice for us to be able to attach from url.

```ruby
# attach from url
user.avatar.attach "http://rubyonrails.org/images/imagine.png"

# attach from URI::HTTP or URI::HTTPS
user.avatar.attach URI.parse("http://rubyonrails.org/images/imagine.png")
```