### PR TITLE
Remove warning from 4 years ago [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -34,8 +34,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
   <%- end -%>
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
`config/initializers/assets.rb` has been a part of Rails apps since Rails 4.2 (https://github.com/rails/rails/commit/f612c2b0526e326eb6c25a7bbf375ac3ac793a3c#diff-d8d3aae5c0da726d02fd2978256ff6a9R36). This comment is probably unnecessary by now.