### PR TITLE
Do not update `load_defaults` version when running `app:update`

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -19,7 +19,7 @@ module Rails
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :require_master_key
 
-      attr_reader :encoding, :api_only
+      attr_reader :encoding, :api_only, :loaded_config_version
 
       def initialize(*)
         super
@@ -58,6 +58,7 @@ module Rails
         @content_security_policy             = nil
         @content_security_policy_report_only = false
         @require_master_key                  = false
+        @loaded_config_version               = nil
       end
 
       def load_defaults(target_version)
@@ -118,6 +119,8 @@ module Rails
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end
+
+        @loaded_config_version = target_version
       end
 
       def encoding=(value)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -130,6 +130,8 @@ module Rails
       assets_config_exist            = File.exist?("config/initializers/assets.rb")
       csp_config_exist               = File.exist?("config/initializers/content_security_policy.rb")
 
+      @config_target_version = Rails.application.config.loaded_config_version || "5.0"
+
       config
 
       unless cookie_serializer_config_exist
@@ -232,6 +234,10 @@ module Rails
 
     def vendor
       empty_directory_with_keep_file "vendor"
+    end
+
+    def config_target_version
+      defined?(@config_target_version) ? @config_target_version : Rails::VERSION::STRING.to_f
     end
   end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -24,7 +24,7 @@ Bundler.require(*Rails.groups)
 module <%= app_const_base %>
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults <%= Rails::VERSION::STRING.to_f %>
+    config.load_defaults <%= build(:config_target_version) %>
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -219,6 +219,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root]
     output = nil
 
+    assert_file "#{app_root}/config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/
+
     Dir.chdir(app_root) do
       output = `./bin/rails r "puts Rails.application.config.assets.unknown_asset_fallback"`
     end
@@ -365,6 +367,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "#{app_root}/Gemfile" do |content|
       assert_no_match(/gem 'mini_magick'/, content)
     end
+  end
+
+  def test_app_update_does_not_change_config_target_version
+    run_generator
+
+    FileUtils.cd(destination_root) do
+      config = "config/application.rb"
+      content = File.read(config)
+      File.write(config, content.gsub(/config\.load_defaults #{Rails::VERSION::STRING.to_f}/, "config.load_defaults 5.1"))
+      quietly { system("bin/rails app:update") }
+    end
+
+    assert_file "config/application.rb", /\s+config\.load_defaults 5\.1/
   end
 
   def test_application_names_are_not_singularized


### PR DESCRIPTION
Incompatible settings are included in the settings set by `load_defaults`.
So, I think that target version should be updated by a user when becomes available, and should not be updated with `app:update`.
