### PR TITLE
Use stopgap_13632 on Ruby 2.2 again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "rubocop", ">= 0.47", require: false
 gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", require: false
 
 # https://github.com/puma/puma/pull/1345
-gem "stopgap_13632", platforms: :mri if RUBY_VERSION == "2.2.8"
+gem "stopgap_13632", platforms: :mri if RUBY_VERSION == "2.2.9"
 
 group :doc do
   gem "sdoc", "~> 1.0"


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/31853.

This conditional wasn't updated when we moved to Ruby 2.2.9 on Travis, which meant that the workaround was no longer active and we started to see spurious `IOError`s again:

https://travis-ci.org/rails/rails/jobs/339518009