### PR TITLE
has_(one/many)_attached presence validation

### DIFF
--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -13,6 +13,10 @@ module ActiveStorage
       record.public_send("#{name}_attachment")
     end
 
+    def blank?
+      attachment.blank?
+    end
+
     # Associates a given attachment with the current record, saving it to the database.
     #
     #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object

--- a/activestorage/test/models/presence_validation_test.rb
+++ b/activestorage/test/models/presence_validation_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::PresenceValidationTest < ActiveSupport::TestCase
+  class Admin < User; end
+
+  teardown do
+    Admin.clear_validators!
+  end
+
+  test "validates_presence_of has_one_attached" do
+    Admin.validates_presence_of :avatar
+    a = Admin.new
+    assert_predicate a, :invalid?
+
+    a.avatar.attach create_blob(filename: "funky.jpg")
+    assert_predicate a, :valid?
+  end
+
+  test "validates_presence_of has_many_attached" do
+    Admin.validates_presence_of :highlights
+    a = Admin.new
+    assert_predicate a, :invalid?
+
+    a.highlights.attach create_blob(filename: "funky.jpg")
+    assert_predicate a, :valid?
+  end
+end


### PR DESCRIPTION
Convenient way to check attachments presence.
```ruby
class User < ActiveRecord::Base
  has_one_attached :avatar
  has_many_attached :highlights

  validates :avatar, presence: true
  validates :highlights, presence: true 
end
```

r? @georgeclaghorn @matthewd 