### PR TITLE
Respect --force option for config/master.key

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -167,7 +167,7 @@ module Rails
       return if options[:pretend] || options[:dummy_app]
 
       require "rails/generators/rails/master_key/master_key_generator"
-      master_key_generator = Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet])
+      master_key_generator = Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet], force: options[:force])
       master_key_generator.add_master_key_file_silently
       master_key_generator.ignore_master_key_file_silently
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -638,6 +638,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_empty output
   end
 
+  def test_force_option
+    run_generator [File.join(destination_root, "myapp")]
+    output = run_generator [File.join(destination_root, "myapp"), "--force"]
+    assert_match(/force/, output)
+  end
+
   def test_application_name_with_spaces
     path = File.join(destination_root, "foo bar")
 


### PR DESCRIPTION
This is similar to #30700 which ensures the `--quiet` option of `rails new` is respected by the `MasterKeyGenerator` (missing from #30067).

Before this commit, running `rails new app --force` would still prompt the user what to do with the conflict in `config/master.key`:

```
              …
   identical  config/locales/en.yml
    conflict  config/master.key
Overwrite /Users/claudiob/Desktop/pizza/config/master.key? (enter "h" for help) [Ynaqdh]
```

After this commit, `config/master.key` is overwritten:

```
           …
identical  config/locales/en.yml
    force  config/master.key
   append  .gitignore
```

The newly added test generates an app and then generates it again with `--force`. Without this commit, the test would just wait forever for user input.