### PR TITLE
Fix marshaling of models with `has_many :through` associations

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -156,9 +156,9 @@ module ActiveRecord
         reset
       end
 
-      # We can't dump @reflection since it contains the scope proc
+      # We can't dump @reflection and @through_reflection since it contains the scope proc
       def marshal_dump
-        ivars = (instance_variables - [:@reflection]).map { |name| [name, instance_variable_get(name)] }
+        ivars = (instance_variables - [:@reflection, :@through_reflection]).map { |name| [name, instance_variable_get(name)] }
         [@reflection.name, ivars]
       end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -46,6 +46,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
+  def test_marshal_dump
+    post = posts :welcome
+    preloaded = Post.includes(:first_blue_tags).find(post.id)
+    assert_equal preloaded, Marshal.load(Marshal.dump(preloaded))
+  end
+
   def test_preload_sti_rhs_class
     developers = Developer.includes(:firms).all.to_a
     assert_no_queries do


### PR DESCRIPTION
This is a missing backport of https://github.com/rails/rails/pull/31934 into `5-2-stable`. 