### PR TITLE
Improve system test screenshots

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -23,7 +23,7 @@ module ActionDispatch
         #                           artifact format (https://buildkite.github.io/terminal/inline-images/).
         def take_screenshot
           save_image
-          save_html
+          save_page
           puts display_screenshot
         end
 
@@ -47,15 +47,15 @@ module ActionDispatch
             @image_path ||= absolute_image_path.to_s
           end
 
-          def html_path
-            @html_path ||= absolute_html_path.to_s
+          def page_path
+            @page_path ||= absolute_page_path.to_s
           end
 
           def absolute_image_path
             Rails.root.join("tmp/screenshots/#{screenshot_name}.png")
           end
 
-          def absolute_html_path
+          def absolute_page_path
             Rails.root.join("tmp/screenshots/#{screenshot_name}.html")
           end
 
@@ -63,8 +63,8 @@ module ActionDispatch
             page.save_screenshot(absolute_image_path)
           end
 
-          def save_html
-            page.save_page(absolute_html_path)
+          def save_page
+            page.save_page(absolute_page_path)
           end
 
           def output_type
@@ -79,7 +79,7 @@ module ActionDispatch
 
           def display_screenshot
             message = "[Image screenshot]: file://#{image_path}\n".dup
-            message << "     [HTML screenshot]: file://#{html_path}\n"
+            message << "     [Page HTML]: file://#{page_path}\n"
 
             case output_type
             when "artifact"

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -23,7 +23,8 @@ module ActionDispatch
         #                           artifact format (https://buildkite.github.io/terminal/inline-images/).
         def take_screenshot
           save_image
-          puts display_image
+          save_html
+          puts display_screenshot
         end
 
         # Takes a screenshot of the current page in the browser if the test
@@ -38,7 +39,7 @@ module ActionDispatch
         end
 
         private
-          def image_name
+          def screenshot_name
             failed? ? "failures_#{method_name}" : method_name
           end
 
@@ -46,12 +47,24 @@ module ActionDispatch
             @image_path ||= absolute_image_path.to_s
           end
 
+          def html_path
+            @html_path ||= absolute_html_path.to_s
+          end
+
           def absolute_image_path
-            Rails.root.join("tmp/screenshots/#{image_name}.png")
+            Rails.root.join("tmp/screenshots/#{screenshot_name}.png")
+          end
+
+          def absolute_html_path
+            Rails.root.join("tmp/screenshots/#{screenshot_name}.html")
           end
 
           def save_image
             page.save_screenshot(absolute_image_path)
+          end
+
+          def save_html
+            page.save_page(absolute_html_path)
           end
 
           def output_type
@@ -64,8 +77,9 @@ module ActionDispatch
             output_type
           end
 
-          def display_image
-            message = "[Screenshot]: #{image_path}\n".dup
+          def display_screenshot
+            message = "[Image screenshot]: #{image_path}\n".dup
+            message << "     [HTML screenshot]: #{html_path}\n"
 
             case output_type
             when "artifact"

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -78,8 +78,8 @@ module ActionDispatch
           end
 
           def display_screenshot
-            message = "[Image screenshot]: #{image_path}\n".dup
-            message << "     [HTML screenshot]: #{html_path}\n"
+            message = "[Image screenshot]: file://#{image_path}\n".dup
+            message << "     [HTML screenshot]: file://#{html_path}\n"
 
             case output_type
             when "artifact"

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -5,32 +5,44 @@ require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "capybara/dsl"
 
 class ScreenshotHelperTest < ActiveSupport::TestCase
-  test "image path is saved in tmp directory" do
-    new_test = DrivenBySeleniumWithChrome.new("x")
+  %w(image html).each do |format|
+    ext = format == "image" ? "png" : "html"
 
-    Rails.stub :root, Pathname.getwd do
-      assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
-    end
-  end
+    test "#{format} path is saved in tmp directory" do
+      new_test = DrivenBySeleniumWithChrome.new("x")
 
-  test "image path includes failures text if test did not pass" do
-    new_test = DrivenBySeleniumWithChrome.new("x")
-
-    Rails.stub :root, Pathname.getwd do
-      new_test.stub :passed?, false do
-        assert_equal Rails.root.join("tmp/screenshots/failures_x.png").to_s, new_test.send(:image_path)
+      Rails.stub :root, Pathname.getwd do
+        assert_equal Rails.root.join("tmp/screenshots/x.#{ext}").to_s, new_test.send(:"#{format}_path")
       end
     end
-  end
 
-  test "image path does not include failures text if test skipped" do
-    new_test = DrivenBySeleniumWithChrome.new("x")
+    test "#{format} path includes failures text if test did not pass" do
+      new_test = DrivenBySeleniumWithChrome.new("x")
 
-    Rails.stub :root, Pathname.getwd do
-      new_test.stub :passed?, false do
-        new_test.stub :skipped?, true do
-          assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
+      Rails.stub :root, Pathname.getwd do
+        new_test.stub :passed?, false do
+          assert_equal Rails.root.join("tmp/screenshots/failures_x.#{ext}").to_s, new_test.send(:"#{format}_path")
         end
+      end
+    end
+
+    test "#{format} path does not include failures text if test skipped" do
+      new_test = DrivenBySeleniumWithChrome.new("x")
+
+      Rails.stub :root, Pathname.getwd do
+        new_test.stub :passed?, false do
+          new_test.stub :skipped?, true do
+            assert_equal Rails.root.join("tmp/screenshots/x.#{ext}").to_s, new_test.send(:"#{format}_path")
+          end
+        end
+      end
+    end
+
+    test "#{format} path returns the absolute path from root" do
+      new_test = DrivenBySeleniumWithChrome.new("x")
+
+      Rails.stub :root, Pathname.getwd.join("..") do
+        assert_equal Rails.root.join("tmp/screenshots/x.#{ext}").to_s, new_test.send(:"#{format}_path")
       end
     end
   end
@@ -40,7 +52,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     assert_equal "simple", new_test.send(:output_type)
   end
 
-  test "display_image includes artifact protocol when RAILS_SYSTEM_TESTING_SCREENSHOT environment specified" do
+  test "display_screenshot includes artifact protocol when RAILS_SYSTEM_TESTING_SCREENSHOT environment specified" do
     begin
       original_output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "artifact"
@@ -50,18 +62,10 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       assert_equal "artifact", new_test.send(:output_type)
 
       Rails.stub :root, Pathname.getwd do
-        assert_match %r|url=artifact://.+?tmp/screenshots/x\.png|, new_test.send(:display_image)
+        assert_match %r|url=artifact://.+?tmp/screenshots/x\.png|, new_test.send(:display_screenshot)
       end
     ensure
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
-    end
-  end
-
-  test "image path returns the absolute path from root" do
-    new_test = DrivenBySeleniumWithChrome.new("x")
-
-    Rails.stub :root, Pathname.getwd.join("..") do
-      assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
     end
   end
 end

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -5,7 +5,7 @@ require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "capybara/dsl"
 
 class ScreenshotHelperTest < ActiveSupport::TestCase
-  %w(image html).each do |format|
+  %w(image page).each do |format|
     ext = format == "image" ? "png" : "html"
 
     test "#{format} path is saved in tmp directory" do

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -40,7 +40,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     assert_equal "simple", new_test.send(:output_type)
   end
 
-  test "display_image return artifact format when specify RAILS_SYSTEM_TESTING_SCREENSHOT environment" do
+  test "display_image includes artifact protocol when RAILS_SYSTEM_TESTING_SCREENSHOT environment specified" do
     begin
       original_output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "artifact"
@@ -50,9 +50,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       assert_equal "artifact", new_test.send(:output_type)
 
       Rails.stub :root, Pathname.getwd do
-        new_test.stub :passed?, false do
-          assert_match %r|url=artifact://.+?tmp/screenshots/failures_x\.png|, new_test.send(:display_image)
-        end
+        assert_match %r|url=artifact://.+?tmp/screenshots/x\.png|, new_test.send(:display_image)
       end
     ensure
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -68,6 +68,15 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
     end
   end
+
+  test "display_screenshot includes file protocol easily opening links" do
+    new_test = DrivenBySeleniumWithChrome.new("x")
+
+    Rails.stub :root, Pathname.getwd do
+      assert_match %r|file://.+?tmp/screenshots/x\.png|, new_test.send(:display_screenshot)
+      assert_match %r|file://.+?tmp/screenshots/x\.html|, new_test.send(:display_screenshot)
+    end
+  end
 end
 
 class RackTestScreenshotsTest < DrivenByRackTest


### PR DESCRIPTION
### Summary

This PR improves system test screenshots in ~two ways~ one way:

* ~It prints the absolute path to the screenshots preceded by "file://". That way, we can directly click on it and open the image.~ Included in #32127, without the `file://` protocol.

* It adds HTML captures of the page as well. Sometimes a capture of the HTML is more useful than an image screenshot.

### Other Information

This is a sample output of the information printed before and after these changes. The "after" is much more useful because I can click on the HTML link and more easily see why the test failed.

#### Before

```console
$ bundle exec rspec ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb

Randomized with seed 29751
F.

Failures:

  1) Admin manages gravity forms behaves like manage gravity forms creating a gravity form shows a success message and displays the new form on the index page
     Failure/Error:
       fill_in_i18n(
         :gravity_form_title,
         "#gravity-form-title-tabs",
         en: "My gravity form",
         es: "Mi gravity form",
         ca: "Meu gravity form"
       )
     
     Capybara::ElementNotFound:
       Unable to find visible css "#gravity-form-title-tabs" within #<Capybara::Node::Element tag="form" path="/html/body/main/div/div[2]/div[2]/form">
     
     [Screenshot]: spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_gravity_forms_behaves_like_manage_gravity_forms_creating_a_gravity_form_shows_a_success_message_and_displays_the_new_form_on_the_index_page_957.png

     
     Shared Example Group: "manage gravity forms" called from ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb:12
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:86:in `block in fill_in_i18n_fields'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:85:in `each'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:85:in `fill_in_i18n_fields'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:49:in `fill_in_i18n'
     # ./spec/shared/manage_gravity_forms_examples.rb:15:in `block (4 levels) in <top (required)>'
     # ./spec/shared/manage_gravity_forms_examples.rb:14:in `block (3 levels) in <top (required)>'

Finished in 12.98 seconds (files took 4.66 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb[1:1:1:1] # Admin manages gravity forms behaves like manage gravity forms creating a gravity form shows a success message and displays the new form on the index page

Randomized with seed 29751
```

#### After

```console
$ bundle exec rspec ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb

Randomized with seed 47932
F.

Failures:

  1) Admin manages gravity forms behaves like manage gravity forms creating a gravity form shows a success message and displays the new form on the index page
     Failure/Error:
       fill_in_i18n(
         :gravity_form_title,
         "#gravity-form-title-tabs",
         en: "My gravity form",
         es: "Mi gravity form",
         ca: "Meu gravity form"
       )
     
     Capybara::ElementNotFound:
       Unable to find visible css "#gravity-form-title-tabs" within #<Capybara::Node::Element tag="form" path="/html/body/main/div/div[2]/div[2]/form">
     
     [Image screenshot]: file:///home/deivid/Code/decidim-module-gravity_forms/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_gravity_forms_behaves_like_manage_gravity_forms_creating_a_gravity_form_shows_a_success_message_and_displays_the_new_form_on_the_index_page_564.png
     [HTML screenshot]: file:///home/deivid/Code/decidim-module-gravity_forms/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_gravity_forms_behaves_like_manage_gravity_forms_creating_a_gravity_form_shows_a_success_message_and_displays_the_new_form_on_the_index_page_564.html

     
     Shared Example Group: "manage gravity forms" called from ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb:12
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:86:in `block in fill_in_i18n_fields'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:85:in `each'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:85:in `fill_in_i18n_fields'
     # /home/deivid/Code/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:49:in `fill_in_i18n'
     # ./spec/shared/manage_gravity_forms_examples.rb:15:in `block (4 levels) in <top (required)>'
     # ./spec/shared/manage_gravity_forms_examples.rb:14:in `block (3 levels) in <top (required)>'

Finished in 13.35 seconds (files took 4.62 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/system/decidim/gravity_forms/admin/admin_manages_gravity_forms_spec.rb[1:1:1:1] # Admin manages gravity forms behaves like manage gravity forms creating a gravity form shows a success message and displays the new form on the index page

Randomized with seed 47932
```