### PR TITLE
Allow some purge in many.rb

### DIFF
--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -85,17 +85,13 @@ module ActiveStorage
 
       has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record do
         def purge
-          if any?
-            each(&:purge)
-            reset
-          end
+          each(&:purge)
+          reset
         end
 
         def purge_later
-          if any?
-            each(&:purge_later)
-            reset
-          end
+          each(&:purge_later)
+          reset
         end
       end
       has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob

--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -84,8 +84,6 @@ module ActiveStorage
       CODE
 
       has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record do
-        # Directly purges each associated attachment (i.e. destroys the blobs and
-        # attachments and deletes the files on the service).
         def purge
           if any?
             each(&:purge)
@@ -93,7 +91,6 @@ module ActiveStorage
           end
         end
 
-        # Purges each associated attachment through the queuing system unless ID(s) given.
         def purge_later
           if any?
             each(&:purge_later)

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -46,8 +46,14 @@ module ActiveStorage
 
     ##
     # :method purge
+    #
+    # Directly purges each associated attachment (i.e. destroys the blobs and
+    # attachments and deletes the files on the service).
+
 
     ##
     # :method purge_later
+    #
+    # Purges each associated attachment through the queuing system.
   end
 end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -64,6 +64,5 @@ module ActiveStorage
     #
     # Attachments can be selectively purged later using queries
     # e.g. User.highlights.where(id: []).purge_later
-
   end
 end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -46,7 +46,7 @@ module ActiveStorage
 
     # Directly purges each associated attachment (i.e. destroys the blobs and
     # attachments and deletes the files on the service).
-    def purge(args)
+    def purge(*args)
       if attached?
         if args.any?
           attachments.where(id: [args]).each(&:purge)

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -49,7 +49,7 @@ module ActiveStorage
     def purge(*args)
       if attached?
         if args.any?
-          attachments.where(id: [args]).each(&:purge)
+          attachments.where(id: args).each(&:purge)
         else
           attachments.each(&:purge)
           attachments.reload

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -46,10 +46,14 @@ module ActiveStorage
 
     # Directly purges each associated attachment (i.e. destroys the blobs and
     # attachments and deletes the files on the service).
-    def purge
+    def purge(args)
       if attached?
-        attachments.each(&:purge)
-        attachments.reload
+        if args.any?
+          attachments.where(id: [args]).each(&:purge)
+        else
+          attachments.each(&:purge)
+          attachments.reload
+        end
       end
     end
 

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -45,7 +45,7 @@ module ActiveStorage
     end
 
     # Directly purges each associated attachment (i.e. destroys the blobs and
-    # attachments and deletes the files on the service).
+    # attachments and deletes the files on the service) unless ID(s) given.
     def purge(*args)
       if attached?
         if args.any?
@@ -57,10 +57,15 @@ module ActiveStorage
       end
     end
 
-    # Purges each associated attachment through the queuing system.
-    def purge_later
+    # Purges each associated attachment through the queuing system unless ID(s) given.
+    def purge_later(*args)
       if attached?
-        attachments.each(&:purge_later)
+        if args.any?
+          attachments.where(id: args).each(&:purge)
+        else
+          attachments.each(&:purge)
+          attachments.reload
+        end
       end
     end
   end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -46,23 +46,8 @@ module ActiveStorage
 
     ##
     # :method purge
-    #
-    # :call-seq: User.highlights.purge
-    #
-    # Directly purges each associated attachment (i.e. destroys the blobs and
-    # attachments and deletes the files on the service).
-    #
-    # Attachments can be selectively purged using queries
-    # e.g. User.highlights.where(id: []).purge
 
     ##
     # :method purge_later
-    #
-    # :call-seq: User.highlights.purge_later
-    #
-    # Purges each associated attachment through the queing system
-    #
-    # Attachments can be selectively purged later using queries
-    # e.g. User.highlights.where(id: []).purge_later
   end
 end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -43,30 +43,5 @@ module ActiveStorage
     def detach
       attachments.destroy_all if attached?
     end
-
-    # Directly purges each associated attachment (i.e. destroys the blobs and
-    # attachments and deletes the files on the service) unless ID(s) given.
-    def purge(*args)
-      if attached?
-        if args.any?
-          attachments.where(id: args).each(&:purge)
-        else
-          attachments.each(&:purge)
-          attachments.reload
-        end
-      end
-    end
-
-    # Purges each associated attachment through the queuing system unless ID(s) given.
-    def purge_later(*args)
-      if attached?
-        if args.any?
-          attachments.where(id: args).each(&:purge)
-        else
-          attachments.each(&:purge)
-          attachments.reload
-        end
-      end
-    end
   end
 end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -43,5 +43,27 @@ module ActiveStorage
     def detach
       attachments.destroy_all if attached?
     end
+
+    ##
+    # :method purge
+    #
+    # :call-seq: User.highlights.purge
+    #
+    # Directly purges each associated attachment (i.e. destroys the blobs and
+    # attachments and deletes the files on the service).
+    #
+    # Attachments can be selectively purged using queries
+    # e.g. User.highlights.where(id: []).purge
+
+    ##
+    # :method purge_later
+    #
+    # :call-seq: User.highlights.purge_later
+    #
+    # Purges each associated attachment through the queing system
+    #
+    # Attachments can be selectively purged later using queries
+    # e.g. User.highlights.where(id: []).purge_later
+
   end
 end

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -187,12 +187,20 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     end
   end
 
-  test "selectively purge attached blob from has_many association" do
+  test "selectively purge single attached blob" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
 
-    @user.highlights.purge(1)
+    @user.highlights.purge(@user.highlights.first.id)
 
-    assert_nothing_raised
+    assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
+  end
+
+  test "selectively purge multiple attached blobs" do
+    @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg"), create_blob(filename: "still_here.jpg")
+
+    @user.highlights.purge(@user.highlights.first.id, @user.highlights.second.id)
+
+    assert_equal "still_here.jpg", @user.highlights.first.filename.to_s
   end
 
   test "find with attached blob" do

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -190,7 +190,7 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
   test "selectively purge single attached blob" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
 
-    @user.highlights.purge(@user.highlights.first.id)
+    @user.highlights.where(id: @user.highlights.first.id).purge
 
     assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
   end
@@ -198,7 +198,7 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
   test "selectively purge multiple attached blobs" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg"), create_blob(filename: "still_here.jpg")
 
-    @user.highlights.purge(@user.highlights.first.id, @user.highlights.second.id)
+    @user.highlights.where(id: [@user.highlights.first.id, @user.highlights.second.id]).purge
 
     assert_equal "still_here.jpg", @user.highlights.first.filename.to_s
   end
@@ -207,7 +207,7 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
 
     perform_enqueued_jobs do
-      @user.highlights.purge_later(@user.highlights.first.id)
+      @user.highlights.where(id: @user.highlights.first.id).purge
     end
 
     assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
@@ -217,7 +217,7 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg"), create_blob(filename: "still_here.jpg")
 
     perform_enqueued_jobs do
-      @user.highlights.purge_later(@user.highlights.first.id, @user.highlights.second.id)
+      @user.highlights.where(id: [@user.highlights.first.id, @user.highlights.second.id]).purge
     end
     assert_equal "still_here.jpg", @user.highlights.first.filename.to_s
   end

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -187,6 +187,14 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     end
   end
 
+  test "selectively purge attached blob from has_many association" do
+    @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
+
+    @user.highlights.purge(1)
+
+    assert_nothing_raised
+  end
+
   test "find with attached blob" do
     records = %w[alice bob].map do |name|
       User.create!(name: name).tap do |user|

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -203,6 +203,25 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "still_here.jpg", @user.highlights.first.filename.to_s
   end
 
+  test "selectively purge single attached blob later" do
+    @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
+
+    perform_enqueued_jobs do
+      @user.highlights.purge_later(@user.highlights.first.id)
+    end
+
+    assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
+  end
+
+  test "selectively purge multiple attached blobs later" do
+    @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg"), create_blob(filename: "still_here.jpg")
+
+    perform_enqueued_jobs do
+      @user.highlights.purge_later(@user.highlights.first.id, @user.highlights.second.id)
+    end
+    assert_equal "still_here.jpg", @user.highlights.first.filename.to_s
+  end
+
   test "find with attached blob" do
     records = %w[alice bob].map do |name|
       User.create!(name: name).tap do |user|


### PR DESCRIPTION
This changes the purge method in `attachment/many.rb` to
allow it to take an array of IDs so that records can be selectively
deleted.

### Summary

For the has_many relationship of attachments, I expected there to be a way to delete both the attachment and blob for a single record, even if there were multiple attachments. In the source, I see that `purge` and `purge_later` in both `one.rb` and `many.rb` remove all records. I changed the method to perform an additional check if the user passes an array of IDs to then selectively delete only these. If no arguments are passed, purge still works as before.

### Other Information

I made a small test where you can see the changes in action here: https://github.com/nicholasshirley/some-purge-test