### PR TITLE
Typo in new RedisCacheStore docs

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -150,7 +150,7 @@ module ActiveSupport
       #
       # Compression is enabled by default with a 1kB threshold, so cached
       # values larger than 1kB are automatically compressed. Disable by
-      # passing <tt>cache: false</tt> or change the threshold by passing
+      # passing <tt>compress: false</tt> or change the threshold by passing
       # <tt>compress_threshold: 4.kilobytes</tt>.
       #
       # No expiry is set on cache entries by default. Redis is expected to


### PR DESCRIPTION
In the edge documentation I found that the wrong keyword is used for this parameter.
Instead of `cache: false`, it should be `compress: false`

Thanks !