### PR TITLE
ActiveStorage: use full class names when including concerns to avoid collisions

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -14,7 +14,9 @@
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
-  include Analyzable, Identifiable, Representable
+  include ActiveStorage::Blob::Analyzable
+  include ActiveStorage::Blob::Identifiable
+  include ActiveStorage::Blob::Representable
 
   self.table_name = "active_storage_blobs"
 


### PR DESCRIPTION
`Analyzable, Identifiable, Representable` constants can refer to other classes in the application, and thus the full name should be used.

As an example, when using the [representable gem](https://github.com/trailblazer/representable), the wrong module gets included and it's making some important ActiveStorage features not available:
```ruby
NoMethodError: undefined method `variant' for #<ActiveStorage::Attached::One:0x00007f86c578e508>
```
