### PR TITLE
Add ActiveStorage::Blob.unattached scope

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -27,6 +27,8 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   has_many :attachments
 
+  scope :unattached, -> { left_joins(:attachments).where(ActiveStorage::Attachment.table_name => { blob_id: nil }) }
+
   class << self
     # You can used the signed ID of a blob to refer to it on the client side without fear of tampering.
     # This is particularly helpful for direct uploads where the client-side needs to refer to the blob


### PR DESCRIPTION
One blob can be attached to multiple records
(with `has_(one/many)_attached :thingy, dependent: false`) so it is needed to manually do garbage collecting of orphaned blobs when
all related records are destroyed. Also there is a possibility of orphaned records, when for example, user
abandones to submit a form with attachments.

So it seems useful and convenient for me to have `unattached` scope on
`Blob` to simplify said manual garbage collecting. So, GC of orphaned records within some rake task can be done:

```ruby
ActiveStorage::Blob.unattached.find_each(&:purge_later)
```

r? @georgeclaghorn @dhh 