### PR TITLE
Update "Action View Form Helpers" guide

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -30,7 +30,7 @@ The main form helper is `form_with`.
 <% end %>
 ```
 
-When called without arguments like this, it creates a `<form>` tag which, when submitted, will POST to the current page. For instance, assuming the current page is `/home/index`, the generated HTML will look like this (some line breaks added for readability):
+When called without arguments like this, it creates a form tag which, when submitted, will POST to the current page. For instance, assuming the current page is a home page, the generated HTML will look like this:
 
 ```html
 <form accept-charset="UTF-8" action="/" data-remote="true" method="post">
@@ -39,8 +39,8 @@ When called without arguments like this, it creates a `<form>` tag which, when s
 </form>
 ```
 
-You'll notice that the HTML contains an `input` element with type `hidden`. This `input` is important, because the form cannot be successfully submitted without it.
-The hidden input element with the name `authenticity_token` is a security feature of Rails called **cross-site request forgery protection**, and form helpers generate it for every non-GET form (provided that this security feature is enabled). You can read more about this in the [Security Guide](security.html#cross-site-request-forgery-csrf).
+You'll notice that the HTML contains an `input` element with type `hidden`. This `input` is important, because non-GET form cannot be successfully submitted without it.
+The hidden input element with the name `authenticity_token` is a security feature of Rails called **cross-site request forgery protection**, and form helpers generate it for every non-GET form (provided that this security feature is enabled). You can read more about this in the [Security Guide](security.html#cross-site-request-forgery-csrf) guide.
 
 ### A Generic Search Form
 
@@ -75,9 +75,7 @@ TIP: Passing `url: my_specified_path` to `form_with` tells the form where to mak
 
 TIP: For every form input, an ID attribute is generated from its name (`"q"` in above example). These IDs can be very useful for CSS styling or manipulation of form controls with JavaScript.
 
-Besides `text_field_tag` and `submit_tag`, there is a similar helper for _every_ form control in HTML.
-
-IMPORTANT: Always use "GET" as the method for search forms. This allows users to bookmark a specific search and get back to it. More generally Rails encourages you to use the right HTTP verb for an action.
+IMPORTANT: Use "GET" as the method for search forms. This allows users to bookmark a specific search and get back to it. More generally Rails encourages you to use the right HTTP verb for an action.
 
 ### Helpers for Generating Form Elements
 
@@ -91,7 +89,7 @@ value entered by the user for that field. For example, if the form contains
 `<%= text_field_tag(:query) %>`, then you would be able to get the value of this
 field in the controller with `params[:query]`.
 
-When naming inputs, Rails uses certain conventions that make it possible to submit parameters with non-scalar values such as arrays or hashes, which will also be accessible in `params`. You can read more about them in [chapter 7 of this guide](#understanding-parameter-naming-conventions). For details on the precise usage of these helpers, please refer to the [API documentation](http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html).
+When naming inputs, Rails uses certain conventions that make it possible to submit parameters with non-scalar values such as arrays or hashes, which will also be accessible in `params`. You can read more about them in chapter [Understanding Parameter Naming Conventions](#understanding-parameter-naming-conventions) of this guide. For details on the precise usage of these helpers, please refer to the [API documentation](http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html).
 
 #### Checkboxes
 
@@ -123,7 +121,7 @@ Radio buttons, while similar to checkboxes, are controls that specify a set of o
 <%= radio_button_tag(:age, "child") %>
 <%= label_tag(:age_child, "I am younger than 21") %>
 <%= radio_button_tag(:age, "adult") %>
-<%= label_tag(:age_adult, "I'm over 21") %>
+<%= label_tag(:age_adult, "I am over 21") %>
 ```
 
 Output:
@@ -132,7 +130,7 @@ Output:
 <input id="age_child" name="age" type="radio" value="child" />
 <label for="age_child">I am younger than 21</label>
 <input id="age_adult" name="age" type="radio" value="adult" />
-<label for="age_adult">I'm over 21</label>
+<label for="age_adult">I am over 21</label>
 ```
 
 As with `check_box_tag`, the second parameter to `radio_button_tag` is the value of the input. Because these two radio buttons share the same name (`age`), the user will only be able to select one of them, and `params[:age]` will contain either `"child"` or `"adult"`.
@@ -196,7 +194,7 @@ There is definitely [no shortage of solutions for this](https://github.com/Moder
 [Modernizr](https://modernizr.com/), which provides a simple way to add functionality based on the presence of
 detected HTML5 features.
 
-TIP: If you're using password input fields (for any purpose), you might want to configure your application to prevent those parameters from being logged. You can learn about this in the [Security Guide](security.html#logging).
+TIP: If you're using password input fields (for any purpose), you might want to configure your application to prevent those parameters from being logged. You can learn about this in the [Securing Rails Applications](security.html#logging) guide.
 
 Dealing with Model Objects
 --------------------------
@@ -214,10 +212,10 @@ For these helpers the first argument is the name of an instance variable and the
 will produce output similar to
 
 ```erb
-<input id="person_name" name="person[name]" type="text" value="Henry"/>
+<input id="person_name" name="person[name]" type="text" value="Henry" />
 ```
 
-Upon form submission the value entered by the user will be stored in `params[:person][:name]`. The `params[:person]` hash is suitable for passing to `Person.new` or, if `@person` is an instance of Person, `@person.update`. While the name of an attribute is the most common second parameter to these helpers this is not compulsory. In the example above, as long as person objects have a `name` and a `name=` method Rails will be happy.
+Upon form submission the value entered by the user will be stored in `params[:person][:name]`.
 
 WARNING: You must pass the name of an instance variable, i.e. `:person` or `"person"`, not an actual instance of your model object.
 
@@ -250,7 +248,7 @@ There are a few things to note here:
 * `@article` is the actual object being edited.
 * There is a single hash of options. HTML options (except `id` and `class`) are passed in the `:html` hash. Also you can provide a `:namespace` option for your form to ensure uniqueness of id attributes on form elements. The scope attribute will be prefixed with underscore on the generated HTML id.
 * The `form_with` method yields a **form builder** object (the `f` variable).
-* If you wish to direct your form request to a particular url, you would use `form_with url: my_nifty_url_path` instead. To see more in depth options on what `form_with` accepts be sure to [check out the API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with)
+* If you wish to direct your form request to a particular url, you would use `form_with url: my_nifty_url_path` instead. To see more in depth options on what `form_with` accepts be sure to [check out the API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with).
 * Methods to create form controls are called **on** the form builder object `f`.
 
 The resulting HTML is:
@@ -264,7 +262,7 @@ The resulting HTML is:
 </form>
 ```
 
-The name passed to `:model` in `form_with` controls the key used in `params` to access the form's values. Here the name is `article` and so all the inputs have names of the form `article[attribute_name]`. Accordingly, in the `create` action `params[:article]` will be a hash with keys `:title` and `:body`. You can read more about the significance of input names in the [parameter_names section](#understanding-parameter-naming-conventions).
+The object passed as `:model` in `form_with` controls the key used in `params` to access the form's values. Here the name is `article` and so all the inputs have names of the form `article[attribute_name]`. Accordingly, in the `create` action `params[:article]` will be a hash with keys `:title` and `:body`. You can read more about the significance of input names in chapter [Understanding Parameter Naming Conventions](#understanding-parameter-naming-conventions) of this guide.
 
 TIP: Conventionally your inputs will mirror model attributes. However, they don't have to! If there is other information you need you can include it in your form just as with attributes and access it via `params[:article][:my_nifty_non_attribute_input]`.
 
@@ -275,7 +273,7 @@ You can create a similar binding without actually creating `<form>` tags with th
 ```erb
 <%= form_with model: @person do |person_form| %>
   <%= person_form.text_field :name %>
-  <%= fields_for @person.contact_detail do |contact_detail_form| %>
+  <%= fields_for :contact_detail, @person.contact_detail do |contact_detail_form| %>
     <%= contact_detail_form.text_field :phone_number %>
   <% end %>
 <% end %>
@@ -301,7 +299,7 @@ The Article model is directly available to users of the application, so - follow
 resources :articles
 ```
 
-TIP: Declaring a resource has a number of side effects. See [Rails Routing From the Outside In](routing.html#resource-routing-the-rails-default) for more information on setting up and using resources.
+TIP: Declaring a resource has a number of side effects. See [Rails Routing from the Outside In](routing.html#resource-routing-the-rails-default) guide for more information on setting up and using resources.
 
 When dealing with RESTful resources, calls to `form_with` can get significantly easier if you rely on **record identification**. In short, you can just pass the model instance and have Rails figure out model name and the rest:
 
@@ -309,21 +307,19 @@ When dealing with RESTful resources, calls to `form_with` can get significantly 
 ## Creating a new article
 # long-style:
 form_with(model: @article, url: articles_path)
-# same thing, short-style (record identification gets used):
+short-style:
 form_with(model: @article)
 
 ## Editing an existing article
 # long-style:
-form_with(model: @article, url: article_path(@article), html: {method: "patch"})
+form_with(model: @article, url: article_path(@article), method: "patch")
 # short-style:
 form_with(model: @article)
 ```
 
-Notice how the short-style `form_with` invocation is conveniently the same, regardless of the record being new or existing. Record identification is smart enough to figure out if the record is new by asking `record.new_record?`. It also selects the correct path to submit to and the name based on the class of the object.
+Notice how the short-style `form_with` invocation is conveniently the same, regardless of the record being new or existing. Record identification is smart enough to figure out if the record is new by asking `record.new_record?`. It also selects the correct path to submit to, and the name based on the class of the object.
 
-Rails will also automatically set the `class` and `id` of the form appropriately: a form creating an article would have `id` and `class` `new_article`. If you were editing the article with id 23, the `class` would be set to `edit_article` and the id to `edit_article_23`. These attributes will be omitted for brevity in the rest of this guide.
-
-WARNING: When you're using STI (single-table inheritance) with your models, you can't rely on record identification on a subclass if only their parent class is declared a resource. You will have to specify the model name, `:url`, and `:method` explicitly.
+WARNING: When you're using STI (single-table inheritance) with your models, you can't rely on record identification on a subclass if only their parent class is declared a resource. You will have to specify `:url`, and `:scope` (the model name) explicitly.
 
 #### Dealing with Namespaces
 
@@ -339,11 +335,11 @@ will create a form that submits to the `ArticlesController` inside the admin nam
 form_with model: [:admin, :management, @article]
 ```
 
-For more information on Rails' routing system and the associated conventions, please see the [routing guide](routing.html).
+For more information on Rails' routing system and the associated conventions, please see [Rails Routing from the Outside In](routing.html) guide.
 
 ### How do forms with PATCH, PUT, or DELETE methods work?
 
-The Rails framework encourages RESTful design of your applications, which means you'll be making a lot of "PATCH" and "DELETE" requests (besides "GET" and "POST"). However, most browsers _don't support_ methods other than "GET" and "POST" when it comes to submitting forms.
+The Rails framework encourages RESTful design of your applications, which means you'll be making a lot of "PATCH", "PUT", and "DELETE" requests (besides "GET" and "POST"). However, most browsers _don't support_ methods other than "GET" and "POST" when it comes to submitting forms.
 
 Rails works around this issue by emulating other methods over POST with a hidden input named `"_method"`, which is set to reflect the desired method:
 
@@ -351,10 +347,10 @@ Rails works around this issue by emulating other methods over POST with a hidden
 form_with(url: search_path, method: "patch")
 ```
 
-output:
+Output:
 
 ```html
-<form accept-charset="UTF-8" action="/search"  data-remote="true" method="post">
+<form accept-charset="UTF-8" action="/search" data-remote="true" method="post">
   <input name="_method" type="hidden" value="patch" />
   <input name="authenticity_token" type="hidden" value="f755bb0ed134b76c432144748a6d4b7a7ddf2b71" />
   ...
@@ -363,7 +359,7 @@ output:
 
 When parsing POSTed data, Rails will take into account the special `_method` parameter and act as if the HTTP method was the one specified inside it ("PATCH" in this example).
 
-IMPORTANT: All forms using `form_with` implement `remote: true` by default. These forms will submit data using an XHR (Ajax) request. To disable this include `local: true`. To dive deeper see [working with Javascript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html#remote-elements).
+IMPORTANT: All forms using `form_with` implement `remote: true` by default. These forms will submit data using an XHR (Ajax) request. To disable this include `local: true`. To dive deeper see [Working with JavaScript in Rails](working_with_javascript_in_rails.html#remote-elements) guide.
 
 Making Select Boxes with Ease
 -----------------------------
@@ -376,8 +372,7 @@ Here is what the markup might look like:
 <select name="city_id" id="city_id">
   <option value="1">Lisbon</option>
   <option value="2">Madrid</option>
-  ...
-  <option value="12">Berlin</option>
+  <option value="3">Berlin</option>
 </select>
 ```
 
@@ -388,19 +383,21 @@ Here you have a list of cities whose names are presented to the user. Internally
 The most generic helper is `select_tag`, which - as the name implies - simply generates the `SELECT` tag that encapsulates an options string:
 
 ```erb
-<%= select_tag(:city_id, '<option value="1">Lisbon</option>...') %>
+<%= select_tag(:city_id, raw('<option value="1">Lisbon</option><option value="2">Madrid</option><option value="3">Berlin</option>')) %>
 ```
 
 This is a start, but it doesn't dynamically create the option tags. You can generate option tags with the `options_for_select` helper:
 
 ```html+erb
-<%= options_for_select([['Lisbon', 1], ['Madrid', 2], ...]) %>
+<%= options_for_select([['Lisbon', 1], ['Madrid', 2], ['Berlin', 3]]) %>
+```
 
-output:
+Output:
 
+```html
 <option value="1">Lisbon</option>
 <option value="2">Madrid</option>
-...
+<option value="3">Berlin</option>
 ```
 
 The first argument to `options_for_select` is a nested array where each element has two elements: option text (city name) and option value (city id). The option value is what will be submitted to your controller. Often this will be the id of a corresponding database object but this does not have to be the case.
@@ -414,18 +411,18 @@ Knowing this, you can combine `select_tag` and `options_for_select` to achieve t
 `options_for_select` allows you to pre-select an option by passing its value.
 
 ```html+erb
-<%= options_for_select([['Lisbon', 1], ['Madrid', 2], ...], 2) %>
+<%= options_for_select([['Lisbon', 1], ['Madrid', 2], ['Berlin', 3]], 2) %>
+```
 
-output:
+Output:
 
+```html
 <option value="1">Lisbon</option>
 <option value="2" selected="selected">Madrid</option>
-...
+<option value="3">Berlin</option>
 ```
 
 Whenever Rails sees that the internal value of an option being generated matches this value, it will add the `selected` attribute to that option.
-
-WARNING: When `:include_blank` or `:prompt` are not present, `:include_blank` is forced true if the select attribute `required` is true, display `size` is one, and `multiple` is not true.
 
 You can add arbitrary attributes to the options using hashes:
 
@@ -433,29 +430,42 @@ You can add arbitrary attributes to the options using hashes:
 <%= options_for_select(
   [
     ['Lisbon', 1, { 'data-size' => '2.8 million' }],
-    ['Madrid', 2, { 'data-size' => '3.2 million' }]
+    ['Madrid', 2, { 'data-size' => '3.2 million' }],
+    ['Berlin', 3, { 'data-size' => '3.4 million' }]
   ], 2
 ) %>
-
-output:
-
-<option value="1" data-size="2.8 million">Lisbon</option>
-<option value="2" selected="selected" data-size="3.2 million">Madrid</option>
-...
 ```
 
-### Select Boxes for Dealing with Models
+Output:
 
-In most cases form controls will be tied to a specific database model and as you might expect Rails provides helpers tailored for that purpose. Consistent with other form helpers, when dealing with models you drop the `_tag` suffix from `select_tag`:
+```html
+<option value="1" data-size="2.8 million">Lisbon</option>
+<option value="2" selected="selected" data-size="3.2 million">Madrid</option>
+<option value="3" data-size="3.4 million">Berlin</option>
+```
+
+### Select Boxes for Dealing with Model Objects
+
+In most cases form controls will be tied to a specific model and as you might expect Rails provides helpers tailored for that purpose. Consistent with other form helpers, when dealing with a model object drop the `_tag` suffix from `select_tag`:
+
+If your controller has defined `@person` and that person's city_id is 2:
 
 ```ruby
-# controller:
 @person = Person.new(city_id: 2)
 ```
 
 ```erb
-# view:
-<%= select(:person, :city_id, [['Lisbon', 1], ['Madrid', 2], ...]) %>
+<%= select(:person, :city_id, [['Lisbon', 1], ['Madrid', 2], ['Berlin', 3]]) %>
+```
+
+will produce output similar to
+
+```html
+<select name="person[city_id]" id="person_city_id">
+  <option value="1">Lisbon</option>
+  <option value="2" selected="selected">Madrid</option>
+  <option value="3">Berlin</option>
+</select>
 ```
 
 Notice that the third parameter, the options array, is the same kind of argument you pass to `options_for_select`. One advantage here is that you don't have to worry about pre-selecting the correct city if the user already has one - Rails will do this for you by reading from the `@person.city_id` attribute.
@@ -463,21 +473,26 @@ Notice that the third parameter, the options array, is the same kind of argument
 As with other helpers, if you were to use the `select` helper on a form builder scoped to the `@person` object, the syntax would be:
 
 ```erb
-# select on a form builder
-<%= f.select(:city_id, ...) %>
+<%= form_with model: @person do |person_form| %>
+  <%= person_form.select(:city_id, [['Lisbon', 1], ['Madrid', 2], ['Berlin', 3]]) %>
+<% end %>
 ```
 
 You can also pass a block to `select` helper:
 
 ```erb
-<%= f.select(:city_id) do %>
-  <% [['Lisbon', 1], ['Madrid', 2]].each do |c| -%>
-    <%= content_tag(:option, c.first, value: c.last) %>
+<%= form_with model: @person do |person_form| %>
+  <%= person_form.select(:city_id) do %>
+    <% [['Lisbon', 1], ['Madrid', 2], ['Berlin', 3]].each do |c| %>
+      <%= content_tag(:option, c.first, value: c.last) %>
+    <% end %>
   <% end %>
 <% end %>
 ```
 
-WARNING: If you are using `select` (or similar helpers such as `collection_select`, `select_tag`) to set a `belongs_to` association you must pass the name of the foreign key (in the example above `city_id`), not the name of association itself. If you specify `city` instead of `city_id` Active Record will raise an error along the lines of `ActiveRecord::AssociationTypeMismatch: City(#17815740) expected, got String(#1138750)` when you pass the `params` hash to `Person.new` or `update`. Another way of looking at this is that form helpers only edit attributes. You should also be aware of the potential security ramifications of allowing users to edit foreign keys directly.
+WARNING: If you are using `select` or similar helpers to set a `belongs_to` association you must pass the name of the foreign key (in the example above `city_id`), not the name of association itself.
+
+WARNING: When `:include_blank` or `:prompt` are not present, `:include_blank` is forced true if the select attribute `required` is true, display `size` is one, and `multiple` is not true.
 
 ### Option Tags from a Collection of Arbitrary Objects
 
@@ -494,7 +509,7 @@ This is a perfectly valid solution, but Rails provides a less verbose alternativ
 <%= options_from_collection_for_select(City.all, :id, :name) %>
 ```
 
-As the name implies, this only generates option tags. To generate a working select box you would need to use it in conjunction with `select_tag`, just as you would with `options_for_select`. When working with model objects, just as `select` combines `select_tag` and `options_for_select`, `collection_select` combines `select_tag` with `options_from_collection_for_select`.
+As the name implies, this only generates option tags. To generate a working select box you would need to use `collection_select`:
 
 ```erb
 <%= collection_select(:person, :city_id, City.all, :id, :name) %>
@@ -503,16 +518,16 @@ As the name implies, this only generates option tags. To generate a working sele
 As with other helpers, if you were to use the `collection_select` helper on a form builder scoped to the `@person` object, the syntax would be:
 
 ```erb
-<%= f.collection_select(:city_id, City.all, :id, :name) %>
+<%= form_with model: @person do |person_form| %>
+  <%= person_form.collection_select(:city_id, City.all, :id, :name) %>
+<% end %>
 ```
 
-To recap, `options_from_collection_for_select` is to `collection_select` what `options_for_select` is to `select`.
-
-NOTE: Pairs passed to `options_for_select` should have the name first and the id second, however with `options_from_collection_for_select` the first argument is the value method and the second the text method.
+NOTE: Pairs passed to `options_for_select` should have the text first and the value second, however with `options_from_collection_for_select` should have the value method first and the text method second.
 
 ### Time Zone and Country Select
 
-To leverage time zone support in Rails, you have to ask your users what time zone they are in. Doing so would require generating select options from a list of pre-defined TimeZone objects using `collection_select`, but you can simply use the `time_zone_select` helper that already wraps this:
+To leverage time zone support in Rails, you have to ask your users what time zone they are in. Doing so would require generating select options from a list of pre-defined [`ActiveSupport::TimeZone`](http://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html) objects using `collection_select`, but you can simply use the `time_zone_select` helper that already wraps this:
 
 ```erb
 <%= time_zone_select(:person, :time_zone) %>
@@ -520,21 +535,21 @@ To leverage time zone support in Rails, you have to ask your users what time zon
 
 There is also `time_zone_options_for_select` helper for a more manual (therefore more customizable) way of doing this. Read the [API documentation](http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-time_zone_options_for_select) to learn about the possible arguments for these two methods.
 
-Rails _used_ to have a `country_select` helper for choosing countries, but this has been extracted to the [country_select plugin](https://github.com/stefanpenner/country_select). When using this, be aware that the exclusion or inclusion of certain names from the list can be somewhat controversial (and was the reason this functionality was extracted from Rails).
+Rails _used_ to have a `country_select` helper for choosing countries, but this has been extracted to the [country_select plugin](https://github.com/stefanpenner/country_select).
 
 Using Date and Time Form Helpers
 --------------------------------
 
 You can choose not to use the form helpers generating HTML5 date and time input fields and use the alternative date and time helpers. These date and time helpers differ from all the other form helpers in two important respects:
 
-* Dates and times are not representable by a single input element. Instead you have several, one for each component (year, month, day etc.) and so there is no single value in your `params` hash with your date or time.
+* Dates and times are not representable by a single input element. Instead, you have several, one for each component (year, month, day etc.) and so there is no single value in your `params` hash with your date or time.
 * Other helpers use the `_tag` suffix to indicate whether a helper is a barebones helper or one that operates on model objects. With dates and times, `select_date`, `select_time` and `select_datetime` are the barebones helpers, `date_select`, `time_select` and `datetime_select` are the equivalent model object helpers.
 
 Both of these families of helpers will create a series of select boxes for the different components (year, month, day etc.).
 
 ### Barebones Helpers
 
-The `select_*` family of helpers take as their first argument an instance of `Date`, `Time` or `DateTime` that is used as the currently selected value. You may omit this parameter, in which case the current date is used. For example:
+The `select_*` family of helpers take as their first argument an instance of `Date`, `Time`, or `DateTime` that is used as the currently selected value. You may omit this parameter, in which case the current date is used. For example:
 
 ```erb
 <%= select_date Date.today, prefix: :start_date %>
@@ -543,12 +558,15 @@ The `select_*` family of helpers take as their first argument an instance of `Da
 outputs (with actual option values omitted for brevity)
 
 ```html
-<select id="start_date_year" name="start_date[year]"> ... </select>
-<select id="start_date_month" name="start_date[month]"> ... </select>
-<select id="start_date_day" name="start_date[day]"> ... </select>
+<select id="start_date_year" name="start_date[year]">
+</select>
+<select id="start_date_month" name="start_date[month]">
+</select>
+<select id="start_date_day" name="start_date[day]">
+</select>
 ```
 
-The above inputs would result in `params[:start_date]` being a hash with keys `:year`, `:month`, `:day`. To get an actual `Date`, `Time` or `DateTime` object you would have to extract these values and pass them to the appropriate constructor, for example:
+The above inputs would result in `params[:start_date]` being a hash with keys `:year`, `:month`, `:day`. To get an actual `Date`, `Time`, or `DateTime` object you would have to extract these values and pass them to the appropriate constructor, for example:
 
 ```ruby
 Date.civil(params[:start_date][:year].to_i, params[:start_date][:month].to_i, params[:start_date][:day].to_i)
@@ -568,9 +586,12 @@ The model object helpers for dates and times submit parameters with special name
 outputs (with actual option values omitted for brevity)
 
 ```html
-<select id="person_birth_date_1i" name="person[birth_date(1i)]"> ... </select>
-<select id="person_birth_date_2i" name="person[birth_date(2i)]"> ... </select>
-<select id="person_birth_date_3i" name="person[birth_date(3i)]"> ... </select>
+<select id="person_birth_date_1i" name="person[birth_date(1i)]">
+</select>
+<select id="person_birth_date_2i" name="person[birth_date(2i)]">
+</select>
+<select id="person_birth_date_3i" name="person[birth_date(3i)]">
+</select>
 ```
 
 which results in a `params` hash like
@@ -587,20 +608,18 @@ Both families of helpers use the same core set of functions to generate the indi
 
 As a rule of thumb you should be using `date_select` when working with model objects and `select_date` in other cases, such as a search form which filters results by date.
 
-NOTE: In many cases the built-in date pickers are clumsy as they do not aid the user in working out the relationship between the date and the day of the week.
-
 ### Individual Components
 
 Occasionally you need to display just a single date component such as a year or a month. Rails provides a series of helpers for this, one for each component `select_year`, `select_month`, `select_day`, `select_hour`, `select_minute`, `select_second`. These helpers are fairly straightforward. By default they will generate an input field named after the time component (for example, "year" for `select_year`, "month" for `select_month` etc.) although this can be overridden with the `:field_name` option. The `:prefix` option works in the same way that it does for `select_date` and `select_time` and has the same default value.
 
-The first parameter specifies which value should be selected and can either be an instance of a `Date`, `Time` or `DateTime`, in which case the relevant component will be extracted, or a numerical value. For example:
+The first parameter specifies which value should be selected and can either be an instance of a `Date`, `Time`, or `DateTime`, in which case the relevant component will be extracted, or a numerical value. For example:
 
 ```erb
 <%= select_year(2009) %>
-<%= select_year(Time.now) %>
+<%= select_year(Time.new(2009)) %>
 ```
 
-will produce the same output if the current year is 2009 and the value chosen by the user can be retrieved by `params[:date][:year]`.
+will produce the same output and the value chosen by the user can be retrieved by `params[:date][:year]`.
 
 Uploading Files
 ---------------
@@ -619,27 +638,27 @@ The following two forms both upload a file.
 <% end %>
 ```
 
-Rails provides the usual pair of helpers: the barebones `file_field_tag` and the model oriented `file_field`. The only difference with other helpers is that you cannot set a default value for file inputs as this would have no meaning. As you would expect in the first case the uploaded file is in `params[:picture]` and in the second case in `params[:person][:picture]`.
+Rails provides the usual pair of helpers: the barebones `file_field_tag` and the model oriented `file_field`. As you would expect in the first case the uploaded file is in `params[:picture]` and in the second case in `params[:person][:picture]`.
 
 ### What Gets Uploaded
 
-The object in the `params` hash is an instance of a subclass of `IO`. Depending on the size of the uploaded file it may in fact be a `StringIO` or an instance of `File` backed by a temporary file. In both cases the object will have an `original_filename` attribute containing the name the file had on the user's computer and a `content_type` attribute containing the MIME type of the uploaded file. The following snippet saves the uploaded content in `#{Rails.root}/public/uploads` under the same name as the original file (assuming the form was the one in the previous example).
+The object in the `params` hash is an instance of [`ActionDispatch::Http::UploadedFile`](http://api.rubyonrails.org/classes/ActionDispatch/Http/UploadedFile.html). The following snippet saves the uploaded file in `#{Rails.root}/public/uploads` under the same name as the original file.
 
 ```ruby
 def upload
-  uploaded_io = params[:person][:picture]
-  File.open(Rails.root.join('public', 'uploads', uploaded_io.original_filename), 'wb') do |file|
-    file.write(uploaded_io.read)
+  uploaded_file = params[:picture]
+  File.open(Rails.root.join('public', 'uploads', uploaded_file.original_filename), 'wb') do |file|
+    file.write(uploaded_file.read)
   end
 end
 ```
 
-Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on Disk, Amazon S3, etc), associating them with models, resizing image files, and generating thumbnails, etc. [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) is designed to assist with these tasks.
+Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on Disk, Amazon S3, etc), associating them with models, resizing image files, and generating thumbnails, etc. [Active Storage](active_storage_overview.html) is designed to assist with these tasks.
 
 Customizing Form Builders
 -------------------------
 
-As mentioned previously the object yielded by `form_with` and `fields_for` is an instance of `FormBuilder` (or a subclass thereof). Form builders encapsulate the notion of displaying form elements for a single object. While you can of course write helpers for your forms in the usual way, you can also subclass `FormBuilder` and add the helpers there. For example:
+The object yielded by `form_with` and `fields_for` is an instance of [`ActionView::Helpers::FormBuilder`](http://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html). Form builders encapsulate the notion of displaying form elements for a single object. While you can write helpers for your forms in the usual way, you can also create subclass `ActionView::Helpers::FormBuilder` and add the helpers there. For example:
 
 ```erb
 <%= form_with model: @person do |f| %>
@@ -680,13 +699,12 @@ The form builder used also determines what happens when you do
 <%= render partial: f %>
 ```
 
-If `f` is an instance of `FormBuilder` then this will render the `form` partial, setting the partial's object to the form builder. If the form builder is of class `LabellingFormBuilder` then the `labelling_form` partial would be rendered instead.
+If `f` is an instance of `ActionView::Helpers::FormBuilder` then this will render the `form` partial, setting the partial's object to the form builder. If the form builder is of class `LabellingFormBuilder` then the `labelling_form` partial would be rendered instead.
 
 Understanding Parameter Naming Conventions
 ------------------------------------------
 
-As you've seen in the previous sections, values from forms can be at the top level of the `params` hash or nested in another hash. For example, in a standard `create`
-action for a Person model, `params[:person]` would usually be a hash of all the attributes for the person to create. The `params` hash can also contain arrays, arrays of hashes, and so on.
+Values from forms can be at the top level of the `params` hash or nested in another hash. For example, in a standard `create` action for a Person model, `params[:person]` would usually be a hash of all the attributes for the person to create. The `params` hash can also contain arrays, arrays of hashes, and so on.
 
 Fundamentally HTML forms don't know about any sort of structured data, all they generate is name-value pairs, where pairs are just plain strings. The arrays and hashes you see in your application are the result of some parameter naming conventions that Rails uses.
 
@@ -733,16 +751,19 @@ This would result in `params[:person][:phone_number]` being an array containing 
 We can mix and match these two concepts. One element of a hash might be an array as in the previous example, or you can have an array of hashes. For example, a form might let you create any number of addresses by repeating the following form fragment
 
 ```html
-<input name="addresses[][line1]" type="text"/>
-<input name="addresses[][line2]" type="text"/>
-<input name="addresses[][city]" type="text"/>
+<input name="person[addresses][][line1]" type="text"/>
+<input name="person[addresses][][line2]" type="text"/>
+<input name="person[addresses][][city]" type="text"/>
+<input name="person[addresses][][line1]" type="text"/>
+<input name="person[addresses][][line2]" type="text"/>
+<input name="person[addresses][][city]" type="text"/>
 ```
 
-This would result in `params[:addresses]` being an array of hashes with keys `line1`, `line2` and `city`. Rails decides to start accumulating values in a new hash whenever it encounters an input name that already exists in the current hash.
+This would result in `params[:person][:addresses]` being an array of hashes with keys `line1`, `line2`, and `city`.
 
 There's a restriction, however, while hashes can be nested arbitrarily, only one level of "arrayness" is allowed. Arrays can usually be replaced by hashes; for example, instead of having an array of model objects, one can have a hash of model objects keyed by their id, an array index, or some other parameter.
 
-WARNING: Array parameters do not play well with the `check_box` helper. According to the HTML specification unchecked checkboxes submit no value. However it is often convenient for a checkbox to always submit a value. The `check_box` helper fakes this by creating an auxiliary hidden input with the same name. If the checkbox is unchecked only the hidden input is submitted and if it is checked then both are submitted but the value submitted by the checkbox takes precedence. When working with array parameters this duplicate submission will confuse Rails since duplicate input names are how it decides when to start a new array element. It is preferable to either use `check_box_tag` or to use hashes instead of arrays.
+WARNING: Array parameters do not play well with the `check_box` helper. According to the HTML specification unchecked checkboxes submit no value. However it is often convenient for a checkbox to always submit a value. The `check_box` helper fakes this by creating an auxiliary hidden input with the same name. If the checkbox is unchecked only the hidden input is submitted and if it is checked then both are submitted but the value submitted by the checkbox takes precedence.
 
 ### Using Form Helpers
 
@@ -765,6 +786,7 @@ Assuming the person had two addresses, with ids 23 and 45 this would create outp
 
 ```html
 <form accept-charset="UTF-8" action="/people/1" data-remote="true" method="post">
+  <input name="_method" type="hidden" value="patch" />
   <input id="person_name" name="person[name]" type="text" />
   <input id="person_address_23_city" name="person[address][23][city]" type="text" />
   <input id="person_address_45_city" name="person[address][45][city]" type="text" />
@@ -789,7 +811,7 @@ To create more intricate nestings, you can specify the first part of the input
 name (`person[address]` in the previous example) explicitly:
 
 ```erb
-<%= fields_for 'person[address][primary]', address, index: address do |address_form| %>
+<%= fields_for 'person[address][primary]', address, index: address.id do |address_form| %>
   <%= address_form.text_field :city %>
 <% end %>
 ```
@@ -797,12 +819,12 @@ name (`person[address]` in the previous example) explicitly:
 will create inputs like
 
 ```html
-<input id="person_address_primary_1_city" name="person[address][primary][1][city]" type="text" value="bologna" />
+<input id="person_address_primary_1_city" name="person[address][primary][1][city]" type="text" value="Bologna" />
 ```
 
 As a general rule the final input name is the concatenation of the name given to `fields_for`/`form_with`, the index value, and the name of the attribute. You can also pass an `:index` option directly to helpers such as `text_field`, but it is usually less repetitive to specify this at the form builder level rather than on individual input controls.
 
-As a shortcut you can append [] to the name and omit the `:index` option. This is the same as specifying `index: address` so
+As a shortcut you can append [] to the name and omit the `:index` option. This is the same as specifying `index: address.id` so
 
 ```erb
 <%= fields_for 'person[address][primary][]', address do |address_form| %>
@@ -909,7 +931,7 @@ The `fields_for` yields a form builder. The parameters' name will be what
 
 The keys of the `:addresses_attributes` hash are unimportant, they need merely be different for each address.
 
-If the associated object is already saved, `fields_for` autogenerates a hidden input with the `id` of the saved record. You can disable this by passing `include_id: false` to `fields_for`. You may wish to do this if the autogenerated input is placed in a location where an input tag is not valid HTML or when using an ORM where children do not have an `id`.
+If the associated object is already saved, `fields_for` autogenerates a hidden input with the `id` of the saved record. You can disable this by passing `include_id: false` to `fields_for`.
 
 ### The Controller
 
@@ -940,9 +962,9 @@ class Person < ApplicationRecord
 end
 ```
 
-If the hash of attributes for an object contains the key `_destroy` with a value
-of `1` or `true` then the object will be destroyed. This form allows users to
-remove addresses:
+If the hash of attributes for an object contains the key `_destroy` with a value that
+evaluates to `true` (eg. 1, '1', true, or 'true') then the object will be destroyed.
+This form allows users to remove addresses:
 
 ```erb
 <%= form_with model: @person do |f| %>
@@ -985,7 +1007,7 @@ As a convenience you can instead pass the symbol `:all_blank` which will create 
 
 ### Adding Fields on the Fly
 
-Rather than rendering multiple sets of fields ahead of time you may wish to add them only when a user clicks on an 'Add new address' button. Rails does not provide any built-in support for this. When generating new sets of fields you must ensure the key of the associated array is unique - the current JavaScript date (milliseconds after the epoch) is a common choice.
+Rather than rendering multiple sets of fields ahead of time you may wish to add them only when a user clicks on an 'Add new address' button. Rails does not provide any built-in support for this. When generating new sets of fields you must ensure the key of the associated array is unique - the current JavaScript date (milliseconds since the [epoch](https://en.wikipedia.org/wiki/Unix_time)) is a common choice.
 
 Using form_for and form_tag
 ---------------------------


### PR DESCRIPTION
<details><summary>Details</summary>
@@ -30,7 +30,7 @@
  - Change "`<form>` tag" to "form tag"
  - Change "`/home/index`" to "a home page"
  - Remove "(some line breaks added for readability)" since
    there aren't broken lines below.

@@ -40,9 +40,11 @@
  - Change "an `input` element" to "input elements" since there are
    two hidden elements.
  - Put the sentence "This `input` is important, because non-GET
    form cannot be successfully submitted without it." to paragraph
    about `authenticity_token`.
  - Change title of the link to `security.html#cross-site-request-forgery-csrf`
    from "Security Guide" to "Securing Rails Application"(full name of the guide)
    and append the word "guide".

@@ -76,10 +78,6 @@
  - Remove useless sentence "Besides `text_field_tag` and `submit_tag`,
    there is a similar helper for _every_ form control in HTML." since
    user is able to get this info from the guide below.
  - Remove useless suggestion "IMPORTANT: Always use "GET" as the method
    for search forms. This allows users to bookmark a specific search
    and get back to it. More generally Rails encourages you to use
    the right HTTP verb for an action".

@@ -110,7 +108,7 @@
  - Change "in chapter 7 of this guide" to "in chapter
    Understanding Parameter Naming Conventions of this guide".

@@ -142,7 +140,7 @@
@@ -151,7 +149,7 @@
  - `<%= label_tag(:age_adult, "I'm over 21") %>` outputs
    `<label for="age_adult">I&#39;m over 21</label>`
    I changed "I'm" to "I am" in input/output for consistency with example
    in order to correct output.

@@ -215,7 +213,7 @@
  - Change title of the link to `security.html#logging`
    from "Security Guide" to "Securing Rails Application"(full name of the guide)
    and append the word "guide".

@@ -233,10 +231,10 @@
  - Change `"<input/>"` to `"<input />"` for consistency with other examples
    in the guide and readability.
  - Remove useless sentence "The `params[:person]` hash is suitable for
    passing to `Person.new` or, if `@person` is an instance of Person,
    `@person.update`. While the name of an attribute is the most common
    second parameter to these helpers this is not compulsory.
    In the example above, as long as person objects have a
    `name` and a `name=` method Rails will be happy."

@@ -283,7 +281,7 @@
  - Change "in the parameter_names section" to "in chapter Understanding
    Parameter Naming Conventions of this guide".

@@ -292,7 +290,7 @@
  - Fix the example of using `fields_for` with `:contact_detail`
    argument to ensure that this will work if `@person.contact_detail`
    is  `nil`.

@@ -309,7 +307,9 @@
  - Remove useless and probably incorrect sentence
    "(in fact `form_for` calls `fields_for` internally)"
    We shouldn't express internals same as private API.
  - Add note about (and link to) existing method `form_with`.

@@ -319,7 +319,7 @@
  - Downcase the word "Form" in "Rails Routing From the Outside In"
    (in order to consistency with the name of the guide) and
    append the word "guide".

@@ -327,21 +327,21 @@
  - Change "same thing, short-style (record identification gets used):" to
    "short-style:" for consistency and removing useless info.
  - Change passing of `method:` argument in the example of using `form_for`
    from `html: { method: "patch"}` to `method: "patch"` since it is
    more correct and preferable.
  - Remove useless and incorrect sentence "Record identification is smart
    enough to figure out if the record is new by asking `record.new_record?`"
    We shouldn't express internals same as private API.
  - Add missing comma.
  - Remove incorrect sentence "These attributes will be omitted for brevity in
    the rest of this guide." since our examples show all attributes.
  - Fix warning about using `form_for` with STI:
    Change the sentence "You will have to specify the model name, `:url`,
    and `:method` explicitly." to "You will have to specify `:url`,
    and `:as` (the model name) explicitly." since you'll have to specify
    only `:url` and `:as` when use STI and `form_for`.

@@ -357,11 +357,11 @@
  - Change "the routing guide" to "Rails Routing From the Outside In guide"

@@ -369,7 +369,7 @@
  - Change "output:" to "Output:"
  - Fix example by removing "..." in order for it works.

@@ -405,74 +404,84 @@
  - Fix example by removing "..." in order for it works.
  - Change "output:" to "Output:"
  - Express output as HTML and remove `redundant` dots.
  - Remove useless sentence "Often this will be the id of a corresponding
    database object but this does not have to be the case." and
    useless example of "`select_tag` and `options_for_select`"
  - Remove complicated and incorrect sentence "When `:include_blank` or `:prompt`
    are not present, `:include_blank` is forced true if the select attribute
    `required` is true, display `size` is one and `multiple` is not true."
  - Change "Models" to "Model Objects" for consistency.
  - Change "database model" to "model" since form_for can work with model
    that doesn't related to database.
  - Improve the example by adding output.

@@ -480,21 +489,24 @@
  - Fix example by removing "..." in order for it works.
  - Clarify example
  - Make warning about using `select` with an association more clear to express
    what is important to remember. Remove useless and complicated explanation
    what would happen if you do wrong in this case.

@@ -511,7 +523,7 @@
  - Make the sentence more clear.

@@ -520,16 +532,16 @@
  - Improve the example
  - Make the sentence more clear.
  - Change "TimeZone" to "`ActiveSupport::TimeZone`" and express it as a link

@@ -537,21 +549,21 @@
  - Make the sentence more clear.
  - Add missing comma after "Instead"
  - Add Oxford comma
  - Clear the example by removing "..."

@@ -585,9 +600,12 @@
  - Clear the example by removing "..."

@@ -604,30 +622,28 @@
  - Remove useless note "In many cases the built-in date pickers are clumsy as
    they do not aid the user in working out the relationship between
    the date and the day of the week."
  - Add Oxford comma
  - Change "Time.now" to "Time.new(2009)" in the example to make
    the explanation more clear by removing "if the current year is 2009"
  - Change "encoding **MUST**" to "enctype **must**" since it is more
    clear.

@@ -631,38 +647,32 @@
  - Pass `url: {action: :upload}` to clarify the example since
    below we use `upload` action
  - Remove useless sentence "The only difference with other helpers is that you
    cannot set a default value for file inputs as this would have no meaning."
    in order to pay attention of a reader to main info in this paragraph.
  - Fix and to simpify complicated sentence about instance that
    represent uploaded file by refer to `ActionDispatch::Http::UploadedFile`.
  - Remove useless " (assuming the form was the one in the previous example)".
  - Change the name of the variable in the example from `uploaded_io` to `uploaded_file`.
  - Add mention about and reference to  Active Storage.
    Remove useless section "Dealing with Ajax" since we can rely on
    "Active Storage Overview" guide.
  - Remove beginning of the sentence "As mentioned previously".
    Change `FormBuilder` to `ActionView::Helpers::FormBuilder` and
    express it as a link.

@@ -703,12 +713,12 @@
  - Remove beginning of the sentence "As you've seen in the previous sections".
  - Change `FormBuilder` to `ActionView::Helpers::FormBuilder`.

@@ -756,16 +766,19 @@
  - Change name of the input from "addresses[][line1]" to "person[addresses][][line1]"
    for consistency.
  - Remove useless sentences "Rails decides to start accumulating values in a
    new hash whenever it encounters an input name that
    already exists in the current hash" and "When working with array
    parameters this duplicate submission will confuse Rails since duplicate input
    names are how it decides when to start a new array element.
    It is preferable to either use `check_box_tag` or to use hashes instead of arrays.".

@@ -788,6 +801,7 @@
  - Clarify the example by adding `"<input name="_method" type="hidden" value="patch" />"`
    since this example of edit form.

@@ -812,7 +826,7 @@
  - Fix the value of `:index` option, change `address` to `address.id`.

@@ -820,12 +834,12 @@
  - Capitalize the name of the city Bologna in the example.
  - Fix the value of `:index` option, change `address` to `address.id`.

@@ -862,7 +876,7 @@
  - Downcase "Or" since this isn't beginning of a new sentence.

@@ -948,7 +962,7 @@
  - Remove useless sentence "You may wish to do this if the autogenerated
    input is placed in a location where an input tag is not valid HTML or when
    using an ORM where children do not have an `id`".

@@ -979,9 +993,9 @@
  - Explain more correctly the value of `_destroy`.

@@ -1024,4 +1038,4 @@
  - Change "milliseconds after the epoch" to "milliseconds since the epoch" and
    express as link the word "epoch" that can help to get to know about the "epoch".
</details>
[ci skip]