### PR TITLE
Change the system test default driver to Headless Chrome

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -49,11 +49,11 @@ module ActionDispatch
   #   require "test_helper"
   #
   #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  #     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  #     driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   #   end
   #
   # By default, <tt>ActionDispatch::SystemTestCase</tt> is driven by the
-  # Selenium driver, with the Chrome browser, and a browser size of 1400x1400.
+  # Selenium driver, with the Headless Chrome browser, and a browser size of 1400x1400.
   #
   # Changing the driver configuration options is easy. Let's say you want to use
   # the Firefox browser instead of Chrome. In your +application_system_test_case.rb+
@@ -118,7 +118,7 @@ module ActionDispatch
 
     # System Test configuration options
     #
-    # The default settings are Selenium, using Chrome, with a screen size
+    # The default settings are Selenium, using Headless Chrome, with a screen size
     # of 1400x1400.
     #
     # Examples:

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -632,8 +632,8 @@ class UsersTest < ApplicationSystemTestCase
 end
 ```
 
-By default, system tests are run with the Selenium driver, using the Chrome
-browser, and a screen size of 1400x1400. The next section explains how to
+By default, system tests are run with the Selenium driver, using the Headless
+Chrome browser, and a screen size of 1400x1400. The next section explains how to
 change the default settings.
 
 ### Changing the default settings

--- a/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb.tt
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb.tt
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
Due to the ease of environmental setup at CI and the short execution time of tests, I think that headless driver is appropriate as default.

