### PR TITLE
Don't overwrite config/master.key even on --force

### DIFF
--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -27,7 +27,9 @@ module Rails
       end
 
       def add_master_key_file_silently(key = nil)
-        key_file_generator.add_key_file_silently(MASTER_KEY_PATH, key)
+        unless MASTER_KEY_PATH.exist?
+          key_file_generator.add_key_file_silently(MASTER_KEY_PATH, key)
+        end
       end
 
       def ignore_master_key_file

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -653,10 +653,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_empty output
   end
 
-  def test_force_option
+  def test_force_option_overwrites_every_file_except_master_key
     run_generator [File.join(destination_root, "myapp")]
     output = run_generator [File.join(destination_root, "myapp"), "--force"]
     assert_match(/force/, output)
+    assert_no_match("force  config/master.key", output)
   end
 
   def test_application_name_with_spaces


### PR DESCRIPTION
See https://github.com/rails/rails/pull/31957#issuecomment-364817423

The purpose of `--force` is not to have any prompt whether a file should
be kept or overwritten. In general, all existing files should be overwritten.
However, `config/master.key` is special because it is git-ignored, and
overwriting it will cause the app not to run (since there won't be a way
to decrypt the credentials).

As a result, it's probably better to keep the existing config/master.key.

@y-yagi Is this what you had in mind?