### PR TITLE
WIP - failing test for dependent: false

### DIFF
--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -43,6 +43,20 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.avatar.filename.to_s
   end
 
+  test "replace attached with dependent: false" do
+    @user.other_avatar.attach create_blob(filename: "funky.jpg")
+
+    perform_enqueued_jobs do
+      assert_difference -> { ActiveStorage::Blob.count }, 1 do
+        assert_no_difference -> { ActiveStorage::Attachment.count } do
+          @user.other_avatar.attach create_blob(filename: "town.jpg")
+        end
+      end
+    end
+
+    assert_equal "town.jpg", @user.other_avatar.filename.to_s
+  end
+
   test "replace attached blob unsuccessfully" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
 

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -68,5 +68,6 @@ ActiveRecord::Base.send :include, GlobalID::Identification
 
 class User < ActiveRecord::Base
   has_one_attached :avatar
+  has_one_attached :other_avatar, dependent: false
   has_many_attached :highlights
 end


### PR DESCRIPTION
This is a failing test for `has_one_attached` with `dependent: false`. When executed, it fails with:

```
ActiveRecord::RecordNotSaved: Failed to remove the existing associated 
other_avatar_attachment. The record failed to save after its foreign key was
set to nil.
```

This error occurs because the generated `has_one :other_avatar_attachment` association does not specify a value for `dependent`, causing the code [here](https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/attached/one.rb#L26) to set the association which attempts to nullify `record_id` on the old `Attachment`.

Adding `dependent: :destroy` to the definition of the association seems to solve the problem, but I'm not confident it doesn't have other unexpected consequences - will investigate further.

This test fails on 5-2-stable as well as master.