### PR TITLE
Bump i18n to 1.0

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
   }
 
-  s.add_dependency "i18n",       "~> 0.7"
+  s.add_dependency "i18n",       "~> 1.0"
   s.add_dependency "tzinfo",     "~> 1.1"
   s.add_dependency "minitest",   "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"


### PR DESCRIPTION
### Summary

Hi Rails maintainers :wave:

I've released i18n 1.0 today. There's been a number of bugs fixed since the 0.7.x branches, as well as some performance improvements. The changelogs can give you more info.

1.0 tagging is due to i18n now having a minimum Ruby version requirement of 2.0. I bumped the major (finally) because I didn't want to break backwards compatibility with those on earlier Rails versions which still had this `i18n ~> 0.7` dependency, but were on a version of Rails that _did not_ have the Ruby 2.0 minimum requirement.

This should probably be included in a future 5.x release of Rails. It's intended to be backwards compatible with any Rails version. We're testing on all Rails versions since 3.0.x, and our tests pass... so I believe that means it will continue to work for those versions too.

:heart:

