### PR TITLE
Use require_dependency inside Active Storage

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -14,9 +14,13 @@
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
-  include ActiveStorage::Blob::Analyzable
-  include ActiveStorage::Blob::Identifiable
-  include ActiveStorage::Blob::Representable
+  require_dependency "active_storage/blob/analyzable"
+  require_dependency "active_storage/blob/identifiable"
+  require_dependency "active_storage/blob/representable"
+
+  include Analyzable
+  include Identifiable
+  include Representable
 
   self.table_name = "active_storage_blobs"
 

--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -3,6 +3,8 @@
 # Encapsulates a string representing a filename to provide convenient access to parts of it and sanitization.
 # A Filename instance is returned by ActiveStorage::Blob#filename, and is comparable so it can be used for sorting.
 class ActiveStorage::Filename
+  require_dependency "active_storage/filename/parameters"
+
   include Comparable
 
   class << self


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/31968; see https://github.com/rails/rails/pull/31968#issuecomment-365618034.

Active Storage is an engine which means its models, jobs and controllers are autoloaded by Rails rather than Ruby. Unfortunately this means it's subject to the same gotchas as applications, including this one:

http://guides.rubyonrails.org/v5.1.4/autoloading_and_reloading_constants.html#when-constants-aren-t-missed-qualified-references

On Ruby < 2.5, constants nested under classes can't be autoloaded by Rails if a top level constant already exists with the same name.

To avoid clashing with constants defined in users' applications or gems, we can use `require_dependency` to ensure that the nested constants are loaded before they're used.

r? @rafaelfranca 