### PR TITLE
Make test queue adapter the default for testing

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -28,6 +28,8 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  config.active_job.queue_adapter = :test
+
   <%- unless skip_active_storage? -%>
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test


### PR DESCRIPTION
### Summary

This updates the template for `config/environments/test.rb` so that the default ActiveJob adapter in the test environment is the test driver.

I noticed that [Rails 5.2.0 now sets the `async` adapter as the default adapter in development](https://github.com/rails/rails/commit/625baa69d14881ac49ba2e5c7d9cac4b222d7022) but am curious as to why this would apply in the test environment.

If the test adapter exists, I imagine that it should be the default adapter for when tests are running.