### PR TITLE
Fix custome serializer setting

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -14,8 +14,10 @@ module ActiveJob
     end
 
     initializer "active_job.custom_serializers" do |app|
-      custom_serializers = app.config.active_job.delete(:custom_serializers)
-      ActiveJob::Serializers.add_serializers custom_serializers
+      config.after_initialize do
+        custom_serializers = app.config.active_job.delete(:custom_serializers)
+        ActiveJob::Serializers.add_serializers custom_serializers
+      end
     end
 
     initializer "active_job.set_configs" do |app|
@@ -23,7 +25,10 @@ module ActiveJob
       options.queue_adapter ||= :async
 
       ActiveSupport.on_load(:active_job) do
-        options.each { |k, v| send("#{k}=", v) }
+        options.each do  |k, v|
+          k = "#{k}="
+          send(k, v) if respond_to? k
+        end
       end
     end
 

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -49,7 +49,7 @@ module ActiveJob
 
       # Adds a new serializer to a list of known serializers
       def add_serializers(*new_serializers)
-        self._additional_serializers += new_serializers
+        self._additional_serializers += new_serializers.flatten
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1940,6 +1940,18 @@ module ApplicationTests
       assert_equal Digest::SHA1, ActiveSupport::Digest.hash_digest_class
     end
 
+    test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do
+      class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer; end
+
+      app_file "config/initializers/custom_serializers.rb", <<-RUBY
+      Rails.application.config.active_job.custom_serializers << DummySerializer
+      RUBY
+
+      app "development"
+
+      assert_includes ActiveJob::Serializers.serializers, DummySerializer
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.


### PR DESCRIPTION
The serializer should be set up in `after_initialize` so that it work properly even if the user specifies serializer with initializers.

Also, since `custom_serializers` is `Array`, it needs to be flattened before setting the value.
