### PR TITLE
PERF: symbolize ivar, to reduce dupes

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -98,7 +98,7 @@ class Class
       singleton_class.silence_redefinition_of_method("#{name}?")
       define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
 
-      ivar = "@#{name}"
+      ivar = "@#{name}".to_sym
 
       singleton_class.silence_redefinition_of_method("#{name}=")
       define_singleton_method("#{name}=") do |val|


### PR DESCRIPTION
I noticed this in my memory profiler report.

```
 153  "@default_url_options"
       152  /home/sam/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/core_ext/class/attribute.rb:84
```

152 copies of the string `@default_url_options` are retained on the heap in Discourse post boot. 

Since this is just used for ivar lookups there is no need to use a string.
