### PR TITLE
Active Record distinct & order #count regression

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -132,7 +132,7 @@ module ActiveRecord
       if has_include?(column_name)
         relation = apply_join_dependency
 
-        if operation.to_s.downcase == "count" && !distinct_value
+        if operation.to_s.downcase == "count"
           relation.distinct!
           # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
           if (column_name == :all || column_name.nil?) && select_values.empty?

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -242,6 +242,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_queries(1) { assert_equal 11, posts.count(:all) }
   end
 
+  def test_count_with_eager_loading_and_custom_order_and_distinct
+    posts = Post.includes(:comments).order("comments.id").distinct
+    assert_queries(1) { assert_equal 11, posts.count }
+    assert_queries(1) { assert_equal 11, posts.count(:all) }
+    assert_queries(1) { assert_equal 11, posts.size }
+    assert_queries(1) { assert_equal 11, posts.load.size }
+  end
+
   def test_distinct_count_all_with_custom_select_and_order
     accounts = Account.distinct.select("credit_limit % 10").order(Arel.sql("credit_limit % 10"))
     assert_queries(1) { assert_equal 3, accounts.count(:all) }


### PR DESCRIPTION
### Summary

ebc09ed9ad9a04338138739226a1a92c7a2707ee Broke `#count` for ordered queries with eager loaded tables. 4ada273 shows the break; 6fa0d79 shows the fix. I'm unsure what the clause `&& !distinct_value` was supposed to guard against @kamipo ? 