### PR TITLE
Hash.from_xml handle argument errors

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -249,10 +249,16 @@ module ActiveSupport
       def process_content(value)
         content = value["__content__"]
         if parser = ActiveSupport::XmlMini::PARSING[value["type"]]
-          parser.arity == 1 ? parser.call(content) : parser.call(content, value)
+          process_content_with_parser(parser, content, value)
         else
           content
         end
+      end
+
+      def process_content_with_parser(parser, content, value)
+        parser.arity == 1 ? parser.call(content) : parser.call(content, value)
+      rescue ArgumentError
+        content
       end
 
       def process_array(value)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -977,6 +977,20 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal expected_product_hash, Hash.from_xml(product_xml)["product"]
   end
 
+  def test_type_date_with_invalid_value
+    xml = <<-EOT
+    <table>
+      <field type="date">a invalid date</field>
+    </table>
+    EOT
+
+    expected_hash = {
+      field: "a invalid date"
+    }.stringify_keys
+
+    assert_equal expected_hash, Hash.from_xml(xml)["table"]
+  end
+
   def test_from_xml_raises_on_disallowed_type_attributes
     assert_raise ActiveSupport::XMLConverter::DisallowedType do
       Hash.from_xml '<product><name type="foo">value</name></product>', %w(foo)


### PR DESCRIPTION
It is able to handle invalid values for custom types like for example
invalid dates:

    <table>
      <field type="date">a invalid date</field>
    </table>

I understand that this is not a valid XML but it is a real case anyway that
could be parsed with `Hash.from_xml`

