### PR TITLE
PERF: reduce retained objects in Journey

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -32,7 +32,7 @@ module ActionDispatch
         end
 
         def name
-          left.tr "*:".freeze, "".freeze
+          -(left.tr "*:", "")
         end
 
         def type
@@ -82,7 +82,7 @@ module ActionDispatch
         def initialize(left)
           super
           @regexp = DEFAULT_EXP
-          @name = left.tr "*:".freeze, "".freeze
+          @name = -(left.tr "*:", "")
         end
 
         def default_regexp?


### PR DESCRIPTION
Before:

Total allocated: 209050523 bytes (2219202 objects)
Total retained:  36580305 bytes (323462 objects)

After:

Total allocated: 209180253 bytes (2222455 objects)
Total retained:  36515599 bytes (321850 objects)

---

Modest saving of 1612 RVALUEs in the heap on Discourse boot
