### PR TITLE
Fix array routing constraints

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -90,7 +90,7 @@ module ActionDispatch
             return @separator_re unless @matchers.key?(node)
 
             re = @matchers[node]
-            "(#{re})"
+            "(#{Regexp.union(re)})"
           end
 
           def visit_GROUP(node)
@@ -183,7 +183,7 @@ module ActionDispatch
               node = node.to_sym
 
               if @requirements.key?(node)
-                re = /#{@requirements[node]}|/
+                re = /#{Regexp.union(@requirements[node])}|/
                 @offsets.push((re.match("").length - 1) + @offsets.last)
               else
                 @offsets << @offsets.last

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4500,7 +4500,7 @@ class TestPortConstraints < ActionDispatch::IntegrationTest
 
       get "/integer", to: ok, constraints: { port: 8080  }
       get "/string",  to: ok, constraints: { port: "8080" }
-      get "/array",   to: ok, constraints: { port: [8080] }
+      get "/array/:idx",   to: ok, constraints: { port: [8080], idx: %w[first last] }
       get "/regexp",  to: ok, constraints: { port: /8080/ }
     end
   end
@@ -4529,7 +4529,10 @@ class TestPortConstraints < ActionDispatch::IntegrationTest
     get "http://www.example.com/array"
     assert_response :not_found
 
-    get "http://www.example.com:8080/array"
+    get "http://www.example.com:8080/array/middle"
+    assert_response :not_found
+
+    get "http://www.example.com:8080/array/first"
     assert_response :success
   end
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/32013.

```ruby
Rails.application.routes.draw do
  scope '/(:locale)', constraints: { locale: %w[en de es fr dk] } do
    root to: 'home#index'
  end
end
```

Path constraints generated incorrect regexp:
```diff
- /\A\/(?:(["en", "de", "es", "fr", "dk"]))?(?:\.([^\/.?]+))?\Z/
+ /\A\/(?:((?-mix:en|de|es|fr|dk)))?(?:\.([^\/.?]+))?\Z/
```