### PR TITLE
Improve ActiveJob custom argument serializers #30941

### DIFF
--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -38,7 +38,7 @@ module ActiveJob
         raise ArgumentError, "Serializer name is not present in the argument: #{argument.inspect}" unless serializer_name
 
         serializer = serializer_name.safe_constantize
-        raise ArgumentError, "Serializer #{serializer_name} is not know" unless serializer
+        raise ArgumentError, "Serializer #{serializer_name} is not known" unless serializer
 
         serializer.deserialize(argument)
       end

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -4,8 +4,8 @@ require "set"
 
 module ActiveJob
   # The <tt>ActiveJob::Serializers</tt> module is used to store a list of known serializers
-  # and to add new ones. It also has helpers to serialize/deserialize objects
-  module Serializers
+  # and to add new ones. It also has helpers to serialize/deserialize objects.
+  module Serializers # :nodoc:
     extend ActiveSupport::Autoload
     extend ActiveSupport::Concern
 
@@ -23,7 +23,7 @@ module ActiveJob
     class << self
       # Returns serialized representative of the passed object.
       # Will look up through all known serializers.
-      # Raises `ActiveJob::SerializationError` if it can't find a proper serializer.
+      # Raises <tt>ActiveJob::SerializationError</tt> if it can't find a proper serializer.
       def serialize(argument)
         serializer = serializers.detect { |s| s.serialize?(argument) }
         raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
@@ -32,7 +32,7 @@ module ActiveJob
 
       # Returns deserialized object.
       # Will look up through all known serializers.
-      # If no serializers found will raise `ArgumentError`
+      # If no serializer found will raise <tt>ArgumentError</tt>.
       def deserialize(argument)
         serializer_name = argument[Arguments::OBJECT_SERIALIZER_KEY]
         raise ArgumentError, "Serializer name is not present in the argument: #{argument.inspect}" unless serializer_name
@@ -43,12 +43,12 @@ module ActiveJob
         serializer.deserialize(argument)
       end
 
-      # Returns list of known serializers
+      # Returns list of known serializers.
       def serializers
         self._additional_serializers
       end
 
-      # Adds a new serializer to a list of known serializers
+      # Adds new serializers to a list of known serializers.
       def add_serializers(*new_serializers)
         self._additional_serializers += new_serializers.flatten
       end

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -12,9 +12,10 @@ module ActiveJob
     autoload :ObjectSerializer
     autoload :SymbolSerializer
     autoload :DurationSerializer
-    autoload :DateSerializer
-    autoload :TimeSerializer
     autoload :DateTimeSerializer
+    autoload :DateSerializer
+    autoload :TimeWithZoneSerializer
+    autoload :TimeSerializer
 
     mattr_accessor :_additional_serializers
     self._additional_serializers = Set.new
@@ -57,6 +58,7 @@ module ActiveJob
       DurationSerializer,
       DateTimeSerializer,
       DateSerializer,
+      TimeWithZoneSerializer,
       TimeSerializer
   end
 end

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -2,25 +2,25 @@
 
 module ActiveJob
   module Serializers
-    # Base class for serializing and deserializing custom times.
+    # Base class for serializing and deserializing custom objects.
     #
-    # Example
+    # Example:
     #
-    #     class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
-    #       def serialize(money)
-    #         super("cents" => money.cents, "currency" => money.currency)
-    #       end
-    #
-    #       def deserialize(hash)
-    #         Money.new(hash["cents"], hash["currency"])
-    #       end
-    #
-    #       private
-    #
-    #         def klass
-    #           Money
-    #         end
+    #   class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+    #     def serialize(money)
+    #       super("amount" => money.amount, "currency" => money.currency)
     #     end
+    #
+    #     def deserialize(hash)
+    #       Money.new(hash["amount"], hash["currency"])
+    #     end
+    #
+    #     private
+    #
+    #       def klass
+    #         Money
+    #       end
+    #   end
     class ObjectSerializer
       include Singleton
 
@@ -43,10 +43,10 @@ module ActiveJob
         raise NotImplementedError
       end
 
-      protected
+      private
 
         # The class of the object that will be serialized.
-        def klass
+        def klass # :doc:
           raise NotImplementedError
         end
     end

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class TimeWithZoneSerializer < ObjectSerializer # :nodoc:
+      def serialize(time)
+        super("value" => time.iso8601)
+      end
+
+      def deserialize(hash)
+        Time.iso8601(hash["value"]).in_time_zone
+      end
+
+      private
+
+        def klass
+          ActiveSupport::TimeWithZone
+        end
+    end
+  end
+end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -102,6 +102,14 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, perform_round_trip([indifferent_access]).first
   end
 
+  test "should maintain time with zone" do
+    Time.use_zone "Alaska" do
+      time_with_zone = Time.new(2002, 10, 31, 2, 2, 2).in_time_zone
+      assert_instance_of ActiveSupport::TimeWithZone, perform_round_trip([time_with_zone]).first
+      assert_arguments_unchanged time_with_zone
+    end
+  end
+
   test "should disallow non-string/symbol hash keys" do
     assert_raises ActiveJob::SerializationError do
       ActiveJob::Arguments.serialize [ { 1 => 2 } ]

--- a/activejob/test/cases/serializers_test.rb
+++ b/activejob/test/cases/serializers_test.rb
@@ -73,7 +73,7 @@ class SerializersTest < ActiveSupport::TestCase
       ActiveJob::Serializers.deserialize(hash)
     end
     assert_equal(
-      "Serializer DoNotExist is not know",
+      "Serializer DoNotExist is not known",
       error.message
     )
   end

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -346,12 +346,12 @@ ActiveJob supports the following types of arguments by default:
 
   - Basic types (`NilClass`, `String`, `Integer`, `Fixnum`, `Bignum`, `Float`, `BigDecimal`, `TrueClass`, `FalseClass`)
   - `Symbol`
-  - `ActiveSupport::Duration`
   - `Date`
   - `Time`
   - `DateTime`
   - `ActiveSupport::TimeWithZone`
-  - `Hash`. Keys should be of `String` or `Symbol` type
+  - `ActiveSupport::Duration`
+  - `Hash` (Keys should be of `String` or `Symbol` type)
   - `ActiveSupport::HashWithIndifferentAccess`
   - `Array`
 
@@ -385,38 +385,37 @@ by default has been mixed into Active Record classes.
 
 ### Serializers
 
-You can extend list of supported types for arguments. You just need to define your own serializer.
+You can extend the list of supported argument types. You just need to define your own serializer:
 
 ```ruby
 class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
-  # Check if this object should be serialized using this serializer.
+  # Checks if an argument should be serialized by this serializer.
   def serialize?(argument)
     argument.is_a? Money
   end
 
-  # Convert an object to a simpler representative using supported object types.
+  # Converts an object to a simpler representative using supported object types.
   # The recommended representative is a Hash with a specific key. Keys can be of basic types only.
-  # You should call `super` to add the custom serializer type to the hash
-  def serialize(object)
+  # You should call `super` to add the custom serializer type to the hash.
+  def serialize(money)
     super(
-      "cents" => object.cents,
-      "currency" => object.currency
+      "amount" => money.amount,
+      "currency" => money.currency
     )
   end
 
-  # Convert serialized value into a proper object
+  # Converts serialized value into a proper object.
   def deserialize(hash)
-    Money.new hash["cents"], hash["currency"]
+    Money.new(hash["amount"], hash["currency"])
   end
 end
 ```
 
-And now you just need to add this serializer to a list:
+and add this serializer to the list:
 
 ```ruby
-Rails.application.config.active_job.custom_serializers << MySpecialSerializer
+Rails.application.config.active_job.custom_serializers << MoneySerializer
 ```
-
 
 Exceptions
 ----------


### PR DESCRIPTION
- Add argument serializer `TimeWithZoneSerializer`
  - The serializer serializes an instance of `ActiveSupport::TimeWithZone`.
  - The serializer deserializes value to `ActiveSupport::TimeWithZone` if possible.
-  Fix docs of ActiveJob custom argument serializers
   - Add `:nodoc:` to `ActiveJob::Serializers`
   - Add `:doc:` to `ActiveJob::Serializers::ObjectSerializer#klass`
   - Express `ActiveJob::Serializers::ObjectSerializer#klass` as private method
- Fix error message about unknown `ActiveJob` argument serializer
- <s>Express `ActiveJob::Serializers::ObjectSerializer#klass` as private method</s>
  - <s>We don't use any benefits of `protected` in this case.</s>
- <s>Make more strict condition of choosing of `ActiveJob` argument serializer</s>
  - <s>Use `#instance_of?` instead of `#is_a?` to remove
    dependance on order of argument serializers in `_additional_serializers`.
    I changed order of adding custom argument serializers in order to
    express the issue and ensure that it is solved

    Example of the issue:
    ```
     ActiveJob::Serializers.add_serializers DateSerializer, DateTimeSerializer
    ActiveJob::Serializers.deserialize(
      ActiveJob::Serializers.serialize(
        DateTime.new(2001, 2, 3, 4, 5, 6, "+03:00")
      )
    ).class # returns `Date` instead of `DateTime`
    ```
</s>
  - <s>Use `serialize?` instead of `klass` in `SerializersTest::DummyValueObject`
    since `klass` is more look like private API.</s>

Related to #30941, fa9e791

r? @rafaelfranca 