### PR TITLE
Remove needless requiring 'active_support/core_ext/string/strip'

### DIFF
--- a/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails/generators/base"
-require "active_support/core_ext/string/strip"
 require "active_support/encrypted_file"
 
 module Rails


### PR DESCRIPTION
### Summary

- `active_support/core_ext/string/strip` was added on #31942.
- `strip_heredoc` was removed on https://github.com/rails/rails/commit/89bcca59e91fa9da941de890012872e8288e77b0
- But it still remains `require "active_support/core_ext/string/strip"` statement.