### PR TITLE
Avoid method_redefined warnings in  RouteSet::NamedRouteCollection

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -153,13 +153,13 @@ module ActionDispatch
           url_name = :"#{name}_url"
 
           @path_helpers_module.module_eval do
-            define_method(path_name) do |*args|
+            redefine_method(path_name) do |*args|
               helper.call(self, args, true)
             end
           end
 
           @url_helpers_module.module_eval do
-            define_method(url_name) do |*args|
+            redefine_method(url_name) do |*args|
               helper.call(self, args, false)
             end
           end


### PR DESCRIPTION
Before:
```
~/.rbenv/versions/2.5.0/bin/ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/routing_test.rb
Run options: --seed 5851

# Running:

.......~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:156: warning: method redefined; discarding old custom_path
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_path was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:162: warning: method redefined; discarding old custom_url
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_url was here
....~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:156: warning: method redefined; discarding old custom_path
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_path was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:162: warning: method redefined; discarding old custom_url
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_url was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:156: warning: method redefined; discarding old custom_path
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_path was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:162: warning: method redefined; discarding old custom_url
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_url was here
..........~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:156: warning: method redefined; discarding old custom_path
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_path was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:162: warning: method redefined; discarding old custom_url
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_url was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:156: warning: method redefined; discarding old custom_path
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_path was here
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:162: warning: method redefined; discarding old custom_url
~/code/rails/actionpack/lib/action_dispatch/routing/route_set.rb:321: warning: previous definition of custom_url was here
.....

Finished in 13.233638s, 1.9647 runs/s, 5.8185 assertions/s.
26 runs, 77 assertions, 0 failures, 0 errors, 0 skips
```

After:
```
~/.rbenv/versions/2.5.0/bin/ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/routing_test.rb
Run options: --seed 38072

# Running:

..........................

Finished in 12.009632s, 2.1649 runs/s, 6.4115 assertions/s.
26 runs, 77 assertions, 0 failures, 0 errors, 0 skips
```

Ruby 2.5.0