### PR TITLE
Remove extra conditions in HWIDA since Rails 6 does not support Ruby 2.2

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -279,8 +279,11 @@ module Mime
 
     def all?; false; end
 
-    private
+    protected
+
       attr_reader :string, :synonyms
+
+    private
 
       def to_ary; end
       def to_a; end

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -53,6 +53,9 @@ module ActiveRecord
       end
 
       protected
+
+        attr_reader :name, :block, :adapter, :override
+
         def priority
           result = 0
           if adapter
@@ -69,7 +72,6 @@ module ActiveRecord
         end
 
       private
-        attr_reader :name, :block, :adapter, :override
 
         def matches_adapter?(adapter: nil, **)
           (self.adapter.nil? || adapter == self.adapter)

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -177,20 +177,18 @@ module ActiveSupport
       super(convert_key(key), *extras)
     end
 
-    if Hash.new.respond_to?(:dig)
-      # Same as <tt>Hash#dig</tt> where the key passed as argument can be
-      # either a string or a symbol:
-      #
-      #   counters = ActiveSupport::HashWithIndifferentAccess.new
-      #   counters[:foo] = { bar: 1 }
-      #
-      #   counters.dig('foo', 'bar')     # => 1
-      #   counters.dig(:foo, :bar)       # => 1
-      #   counters.dig(:zoo)             # => nil
-      def dig(*args)
-        args[0] = convert_key(args[0]) if args.size > 0
-        super(*args)
-      end
+    # Same as <tt>Hash#dig</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = { bar: 1 }
+    #
+    #   counters.dig('foo', 'bar')     # => 1
+    #   counters.dig(:foo, :bar)       # => 1
+    #   counters.dig(:zoo)             # => nil
+    def dig(*args)
+      args[0] = convert_key(args[0]) if args.size > 0
+      super(*args)
     end
 
     # Same as <tt>Hash#default</tt> where the key passed as argument can be
@@ -228,7 +226,7 @@ module ActiveSupport
     #   hash.fetch_values('a', 'c') # => KeyError: key not found: "c"
     def fetch_values(*indices, &block)
       indices.collect { |key| fetch(key, &block) }
-    end if Hash.method_defined?(:fetch_values)
+    end
 
     # Returns a shallow copy of the hash.
     #

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -169,8 +169,6 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
   end
 
   def test_indifferent_fetch_values
-    skip unless Hash.method_defined?(:fetch_values)
-
     @mixed = @mixed.with_indifferent_access
 
     assert_equal [1, 2], @mixed.fetch_values("a", "b")


### PR DESCRIPTION
See https://github.com/ruby/ruby/blob/ruby_2_3/NEWS

Originally I sent patch to https://github.com/jeremy/rails/pull/1 in order to merge this with https://github.com/rails/rails/pull/32028, but https://github.com/jeremy/rails/pull/1 was unnoticed.

@jeremy Could you please review?