### PR TITLE
`String#strip_heredoc` preserves frozenness

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   `String#strip_heredoc` preserves frozenness.
+
+        "foo".freeze.strip_heredoc.frozen?  # => true
+
+    Fixes that frozen string literals would inadvertently become unfrozen:
+
+        # frozen_string_literal: true
+
+        foo = <<-MSG.strip_heredoc
+          la la la
+        MSG
+
+        foo.frozen?  # => false !??
+
+    *Jeremy Daer*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -20,6 +20,8 @@ class String
   # Technically, it looks for the least indented non-empty line
   # in the whole string, and removes that amount of leading whitespace.
   def strip_heredoc
-    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
+    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "".freeze).tap do |stripped|
+      stripped.freeze if frozen?
+    end
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -24,6 +24,10 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "", "".strip_heredoc
   end
 
+  def test_strip_heredoc_on_a_frozen_string
+    assert "".freeze.strip_heredoc.frozen?
+  end
+
   def test_strip_heredoc_on_a_string_with_no_lines
     assert_equal "x", "x".strip_heredoc
     assert_equal "x", "    x".strip_heredoc


### PR DESCRIPTION
```ruby
"foo".freeze.strip_heredoc.frozen?  # => true
```

Fixes the case where frozen string literals would inadvertently become unfrozen:
```ruby
# frozen_string_literal: true
foo = <<-MSG.strip_heredoc
  la la la
MSG

foo.frozen?  # => false !??
```