### PR TITLE
Update bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -13,7 +13,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "5.1.0"
+  gem "rails", "5.2.0.rc1"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -13,7 +13,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activejob", "5.1.0"
+  gem "activejob", "5.2.0.rc1"
 end
 
 require "minitest/autorun"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -13,7 +13,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.1.0"
+  gem "activerecord", "5.2.0.rc1"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -13,7 +13,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.1.0"
+  gem "activerecord", "5.2.0.rc1"
   gem "sqlite3"
 end
 
@@ -37,7 +37,7 @@ end
 class Payment < ActiveRecord::Base
 end
 
-class ChangeAmountToAddScale < ActiveRecord::Migration[5.1]
+class ChangeAmountToAddScale < ActiveRecord::Migration[5.2]
   def change
     reversible do |dir|
       dir.up do

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -36,7 +36,7 @@ end
 class Payment < ActiveRecord::Base
 end
 
-class ChangeAmountToAddScale < ActiveRecord::Migration[5.2]
+class ChangeAmountToAddScale < ActiveRecord::Migration[6.0]
   def change
     reversible do |dir|
       dir.up do

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -13,9 +13,10 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activesupport", "5.1.0"
+  gem "activesupport", "5.2.0.rc1"
 end
 
+require "active_support"
 require "active_support/core_ext/object/blank"
 require "minitest/autorun"
 


### PR DESCRIPTION
Prepare bug report templates for Rails 6.0 development
Add missing `require "active_support"` in `guides/bug_report_templates/generic_gem.rb`