### PR TITLE
Change AR::Migration version from 5.2 to 6.0 in activestorage

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,4 +1,4 @@
-class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+class CreateActiveStorageTables < ActiveRecord::Migration[6.0]
   def change
     create_table :active_storage_blobs do |t|
       t.string   :key,        null: false


### PR DESCRIPTION
I have some doubt about this change, just want to know your thoughts about this.
Should we update AS migration every major/minor release?

r? @georgeclaghorn