### PR TITLE
More natural reading aliases for Object#presence and Object#presence_in

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -42,10 +42,13 @@ class Object
   #
   #   region = params[:state].presence || params[:country].presence || 'US'
   #
+  # Aliased to if_present
+  #
   # @return [Object]
   def presence
     self if present?
   end
+  alias_method :if_present, :presence
 end
 
 class NilClass

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -16,14 +16,19 @@ class Object
   end
 
   # Returns the receiver if it's included in the argument otherwise returns +nil+.
-  # Argument must be any object which responds to +#include?+. Usage:
+  # The first argument must be any object which responds to +#include?+. The second
+  # optional argument is the default to return if it's not present (defaults to nil).
+  # Usage:
   #
   #   params[:bucket_type].presence_in %w( project calendar )
   #
   # This will throw an +ArgumentError+ if the argument doesn't respond to +#include?+.
   #
+  # Aliased to if_present_in
+  #
   # @return [Object]
-  def presence_in(another_object)
-    in?(another_object) ? self : nil
+  def presence_in(another_object, default = nil)
+    in?(another_object) ? self : default
   end
+  alias_method :if_present_in, :presence_in
 end

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -33,4 +33,9 @@ class BlankTest < ActiveSupport::TestCase
     BLANK.each { |v| assert_nil v.presence, "#{v.inspect}.presence should return nil" }
     NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
   end
+
+  def test_if_present
+    BLANK.each { |v| assert_nil v.if_present, "#{v.inspect}.if_present should return nil" }
+    NOT.each   { |v| assert_equal v, v.if_present, "#{v.inspect}.if_present should return self" }
+  end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -56,6 +56,14 @@ class InTest < ActiveSupport::TestCase
   def test_presence_in
     assert_equal "stuff", "stuff".presence_in(%w( lots of stuff ))
     assert_nil "stuff".presence_in(%w( lots of crap ))
+    assert_equal "stuff", "else".presence_in(%w( lots of stuff ), "stuff")
     assert_raise(ArgumentError) { 1.presence_in(1) }
+  end
+
+  def test_if_present_in
+    assert_equal "stuff", "stuff".if_present_in(%w( lots of stuff ))
+    assert_nil "stuff".if_present_in(%w( lots of crap ))
+    assert_equal "stuff", "else".if_present_in(%w( lots of stuff ), "stuff")
+    assert_raise(ArgumentError) { 1.if_present_in(1) }
   end
 end


### PR DESCRIPTION
### Summary

After having recently read about `Object#presence` and `Object#presence_in` I thought they didn't seem as readable as they could. So I've added aliased methods for them.

### Other Information

In my opinion:

`region = params[:state].if_present || params[:country].if_present || 'US'`

is more readable than:

`region = params[:state].presence || params[:country].presence || 'US'`

Also, from watching @dhh's Writing Software Well videos today, I noticed he uses `Object#presence_in` like this:

`redis_set granulary_key, option.presence_in(OPTIONS) || DEFAULT`

I think it's more readable with a method name tweak and if you can just add the default to the method:

`redis_set granulary_key, option.if_present_in(OPTIONS, DEFAULT)`

I'd welcome any thoughts...