### PR TITLE
Skip generating empty CSP header when no policy is configured

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -21,7 +21,10 @@ module ActionDispatch #:nodoc:
         return response if policy_present?(headers)
 
         if policy = request.content_security_policy
-          headers[header_name(request)] = policy.build(request.controller_instance)
+          built_policy = policy.build(request.controller_instance)
+          if built_policy
+            headers[header_name(request)] = built_policy
+          end
         end
 
         response
@@ -172,7 +175,12 @@ module ActionDispatch #:nodoc:
     end
 
     def build(context = nil)
-      build_directives(context).compact.join("; ") + ";"
+      built_directives = build_directives(context).compact
+      if built_directives.empty?
+        nil
+      else
+        built_directives.join("; ") + ";"
+      end
     end
 
     private

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -8,7 +8,7 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
   end
 
   def test_build
-    assert_equal ";", @policy.build
+    assert_nil @policy.build
 
     @policy.script_src :self
     assert_equal "script-src 'self';", @policy.build
@@ -271,6 +271,10 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def empty_policy
+      head :ok
+    end
+
     private
       def condition?
         params[:condition] == "true"
@@ -284,12 +288,14 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       get "/inline", to: "policy#inline"
       get "/conditional", to: "policy#conditional"
       get "/report-only", to: "policy#report_only"
+      get "/empty-policy", to: "policy#empty_policy"
     end
   end
 
   POLICY = ActionDispatch::ContentSecurityPolicy.new do |p|
     p.default_src :self
   end
+  EMPTY_POLICY = ActionDispatch::ContentSecurityPolicy.new
 
   class PolicyConfigMiddleware
     def initialize(app)
@@ -297,7 +303,12 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     def call(env)
-      env["action_dispatch.content_security_policy"] = POLICY
+      env["action_dispatch.content_security_policy"] =
+        if env["PATH_INFO"] == "/empty-policy"
+          EMPTY_POLICY
+        else
+          POLICY
+        end
       env["action_dispatch.content_security_policy_report_only"] = false
       env["action_dispatch.show_exceptions"] = false
 
@@ -335,6 +346,13 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
   def test_generates_report_only_content_security_policy
     get "/report-only"
     assert_policy "default-src 'self'; report-uri /violations;", report_only: true
+  end
+
+  def test_empty_policy
+    get "/empty-policy"
+    assert_response :success
+    assert_not response.headers.key?("Content-Security-Policy")
+    assert_not response.headers.key?("Content-Security-Policy-Report-Only")
   end
 
   private

--- a/railties/test/application/content_security_policy_test.rb
+++ b/railties/test/application/content_security_policy_test.rb
@@ -34,7 +34,7 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_equal ";", last_response.headers["Content-Security-Policy"]
+      assert_not last_response.headers.key?("Content-Security-Policy")
     end
 
     test "global content security policy in an initializer" do


### PR DESCRIPTION
### Summary

`Rails.application.config.content_security_policy` is configured with no
policies by default. In this case, Content-Security-Policy header should
not be generated instead of generating the header with no directives.

### Other Information

Firefox also warns "Content Security Policy: Couldn't process unknown
directive ''".
