### PR TITLE
Do not check `ActiveStorage::Engine` when updating to 5.2

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -22,7 +22,7 @@ module Rails
         def generator_options
           options = { api: !!Rails.application.config.api_only, update: true }
           options[:skip_active_record]  = !defined?(ActiveRecord::Railtie)
-          options[:skip_active_storage] = !defined?(ActiveStorage::Engine) || !defined?(ActiveRecord::Railtie)
+          options[:skip_active_storage] = !defined?(ActiveRecord::Railtie)
           options[:skip_action_mailer]  = !defined?(ActionMailer::Railtie)
           options[:skip_action_cable]   = !defined?(ActionCable::Engine)
           options[:skip_sprockets]      = !defined?(Sprockets::Railtie)


### PR DESCRIPTION
When upgrading from 5.1 to 5.2, if the application did not require `rails/all`, `ActiveStorage` not be defined.
In that case, Active Storage content is not generated regardless of whether the user wants to use or not.

As for the new component, I think it is preferable to check whether to use it for the user, but since it is not yet able to deal with it, I think that it is good to forcibly generate the content.
