### PR TITLE
Return all mappings for a timezone id in country_zones

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Return all mappings for a timezone identifier in `country_zones`
+
+    Some timezones like `Europe/London` have multiple mappings in
+    `ActiveSupport::TimeZone::MAPPING` so return all of them instead
+    of the first one found by using `Hash#value`. e.g:
+
+        # Before
+        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh"]
+
+        # After
+        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh", "London"]
+
+    Fixes #31668.
+
+    *Andrew White*
+
 *   `String#truncate_bytes` to truncate a string to a maximum bytesize without
     breaking multibyte characters or grapheme clusters like 👩‍👩‍👦‍👦.
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -267,11 +267,14 @@ module ActiveSupport
           country = TZInfo::Country.get(code)
           country.zone_identifiers.map do |tz_id|
             if MAPPING.value?(tz_id)
-              self[MAPPING.key(tz_id)]
+              MAPPING.inject([]) do |memo, (key, value)|
+                memo << self[key] if value == tz_id
+                memo
+              end
             else
               create(tz_id, nil, TZInfo::Timezone.new(tz_id))
             end
-          end.sort!
+          end.flatten(1).sort!
         end
 
         def zones_map

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -756,6 +756,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_not_includes ActiveSupport::TimeZone.country_zones(:ru), ActiveSupport::TimeZone["Kuala Lumpur"]
   end
 
+  def test_country_zones_with_and_without_mappings
+    assert_includes ActiveSupport::TimeZone.country_zones("au"), ActiveSupport::TimeZone["Adelaide"]
+    assert_includes ActiveSupport::TimeZone.country_zones("au"), ActiveSupport::TimeZone["Australia/Lord_Howe"]
+  end
+
+  def test_country_zones_with_multiple_mappings
+    assert_includes ActiveSupport::TimeZone.country_zones("gb"), ActiveSupport::TimeZone["Edinburgh"]
+    assert_includes ActiveSupport::TimeZone.country_zones("gb"), ActiveSupport::TimeZone["London"]
+  end
+
   def test_country_zones_without_mappings
     assert_includes ActiveSupport::TimeZone.country_zones(:sv), ActiveSupport::TimeZone["America/El_Salvador"]
   end


### PR DESCRIPTION
Some timezones like `Europe/London` have multiple mappings in `ActiveSupport::TimeZone::MAPPING` so return all of them instead of the first one found by using `Hash#value`. e.g:

``` ruby
# Before
ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh"]

# After
ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh", "London"]
```

Fixes #31668.
