### PR TITLE
CI with `jruby-head` compatible with Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,17 +99,17 @@ matrix:
         - "GEM=ar:postgresql POSTGRES=9.2"
       addons:
         postgresql: "9.2"
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-head
       jdk: oraclejdk8
       env:
         - "GEM=ap"
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-head
       jdk: oraclejdk8
       env:
         - "GEM=am,amo,aj"
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-head
     - env: "GEM=ac:integration"
   fast_finish: true
 


### PR DESCRIPTION
### Summary

Since #32034 Rails 6 requires Ruby 2.4.1 or higher.
Two CI jobs configured with the latest version of`jruby-9.1.15.0`
compatibile with Ruby 2.3.3 are getting errors:

https://travis-ci.org/rails/rails/jobs/343519339

```
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby java
    rails java was resolved to 6.0.0.alpha, which depends on
      ruby (>= 2.4.1) java
Could not find gem 'ruby (>= 2.4.1)', which is required by gem 'rails', in any
of the relevant sources:
```

### Other Information

Instead of running CI with `jruby-head`, there could be other way 
to just dropping CI with JRuby 9.1.x and add CI with JRuby 9.2 once it is generally released.