### PR TITLE
Move SourceAnnotationExtractor under Rails module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,9 +156,7 @@ GEM
       childprocess
       faraday
       selenium-webdriver
-    bootsnap (1.1.2)
-      msgpack (~> 1.0)
-    bootsnap (1.1.2-java)
+    bootsnap (1.2.1)
       msgpack (~> 1.0)
     builder (3.2.3)
     bunny (2.6.6)
@@ -311,10 +309,10 @@ GEM
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
-    msgpack (1.1.0)
-    msgpack (1.1.0-java)
-    msgpack (1.1.0-x64-mingw32)
-    msgpack (1.1.0-x86-mingw32)
+    msgpack (1.2.4)
+    msgpack (1.2.4-java)
+    msgpack (1.2.4-x64-mingw32)
+    msgpack (1.2.4-x86-mingw32)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     mustache (1.0.5)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -241,7 +241,7 @@ module Rails
       end
 
       def annotations
-        SourceAnnotationExtractor::Annotation
+        Rails::SourceAnnotationExtractor::Annotation
       end
 
       def content_security_policy(&block)

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -16,7 +16,7 @@ module Rails
   # start with the tag optionally followed by a colon. Everything up to the end
   # of the line (or closing ERB comment tag) is considered to be their text.
   class SourceAnnotationExtractor
-    Annotation = Struct.new(:line, :tag, :text) do
+    class Annotation < Struct.new(:line, :tag, :text)
       def self.directories
         @@directories ||= %w(app config db lib test) + (ENV["SOURCE_ANNOTATION_DIRECTORIES"] || "").split(",")
       end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -1,141 +1,143 @@
 # frozen_string_literal: true
 
-# Implements the logic behind the rake tasks for annotations like
-#
-#   rails notes
-#   rails notes:optimize
-#
-# and friends. See <tt>rails -T notes</tt> and <tt>railties/lib/rails/tasks/annotations.rake</tt>.
-#
-# Annotation objects are triplets <tt>:line</tt>, <tt>:tag</tt>, <tt>:text</tt> that
-# represent the line where the annotation lives, its tag, and its text. Note
-# the filename is not stored.
-#
-# Annotations are looked for in comments and modulus whitespace they have to
-# start with the tag optionally followed by a colon. Everything up to the end
-# of the line (or closing ERB comment tag) is considered to be their text.
-class SourceAnnotationExtractor
-  Annotation = Struct.new(:line, :tag, :text) do
-    def self.directories
-      @@directories ||= %w(app config db lib test) + (ENV["SOURCE_ANNOTATION_DIRECTORIES"] || "").split(",")
-    end
-
-    # Registers additional directories to be included
-    #   SourceAnnotationExtractor::Annotation.register_directories("spec", "another")
-    def self.register_directories(*dirs)
-      directories.push(*dirs)
-    end
-
-    def self.extensions
-      @@extensions ||= {}
-    end
-
-    # Registers new Annotations File Extensions
-    #   SourceAnnotationExtractor::Annotation.register_extensions("css", "scss", "sass", "less", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
-    def self.register_extensions(*exts, &block)
-      extensions[/\.(#{exts.join("|")})$/] = block
-    end
-
-    register_extensions("builder", "rb", "rake", "yml", "yaml", "ruby") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
-    register_extensions("css", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
-    register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/ }
-
-    # Returns a representation of the annotation that looks like this:
-    #
-    #   [126] [TODO] This algorithm is simple and clearly correct, make it faster.
-    #
-    # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
-    # Otherwise the string contains just line and text.
-    def to_s(options = {})
-      s = "[#{line.to_s.rjust(options[:indent])}] ".dup
-      s << "[#{tag}] " if options[:tag]
-      s << text
-    end
-  end
-
-  # Prints all annotations with tag +tag+ under the root directories +app+,
-  # +config+, +db+, +lib+, and +test+ (recursively).
+module Rails
+  # Implements the logic behind the rake tasks for annotations like
   #
-  # Additional directories may be added using a comma-delimited list set using
-  # <tt>ENV['SOURCE_ANNOTATION_DIRECTORIES']</tt>.
+  #   rails notes
+  #   rails notes:optimize
   #
-  # Directories may also be explicitly set using the <tt>:dirs</tt> key in +options+.
+  # and friends. See <tt>rails -T notes</tt> and <tt>railties/lib/rails/tasks/annotations.rake</tt>.
   #
-  #   SourceAnnotationExtractor.enumerate 'TODO|FIXME', dirs: %w(app lib), tag: true
+  # Annotation objects are triplets <tt>:line</tt>, <tt>:tag</tt>, <tt>:text</tt> that
+  # represent the line where the annotation lives, its tag, and its text. Note
+  # the filename is not stored.
   #
-  # If +options+ has a <tt>:tag</tt> flag, it will be passed to each annotation's +to_s+.
-  #
-  # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
-  #
-  # This class method is the single entry point for the rake tasks.
-  def self.enumerate(tag, options = {})
-    extractor = new(tag)
-    dirs = options.delete(:dirs) || Annotation.directories
-    extractor.display(extractor.find(dirs), options)
-  end
+  # Annotations are looked for in comments and modulus whitespace they have to
+  # start with the tag optionally followed by a colon. Everything up to the end
+  # of the line (or closing ERB comment tag) is considered to be their text.
+  class SourceAnnotationExtractor
+    Annotation = Struct.new(:line, :tag, :text) do
+      def self.directories
+        @@directories ||= %w(app config db lib test) + (ENV["SOURCE_ANNOTATION_DIRECTORIES"] || "").split(",")
+      end
 
-  attr_reader :tag
+      # Registers additional directories to be included
+      #   SourceAnnotationExtractor::Annotation.register_directories("spec", "another")
+      def self.register_directories(*dirs)
+        directories.push(*dirs)
+      end
 
-  def initialize(tag)
-    @tag = tag
-  end
+      def self.extensions
+        @@extensions ||= {}
+      end
 
-  # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
-  # with their annotations.
-  def find(dirs)
-    dirs.inject({}) { |h, dir| h.update(find_in(dir)) }
-  end
+      # Registers new Annotations File Extensions
+      #   SourceAnnotationExtractor::Annotation.register_extensions("css", "scss", "sass", "less", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
+      def self.register_extensions(*exts, &block)
+        extensions[/\.(#{exts.join("|")})$/] = block
+      end
 
-  # Returns a hash that maps filenames under +dir+ (recursively) to arrays
-  # with their annotations. Only files with annotations are included. Files
-  # with extension +.builder+, +.rb+, +.rake+, +.yml+, +.yaml+, +.ruby+,
-  # +.css+, +.js+ and +.erb+ are taken into account.
-  def find_in(dir)
-    results = {}
+      register_extensions("builder", "rb", "rake", "yml", "yaml", "ruby") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+      register_extensions("css", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
+      register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/ }
 
-    Dir.glob("#{dir}/*") do |item|
-      next if File.basename(item)[0] == ?.
-
-      if File.directory?(item)
-        results.update(find_in(item))
-      else
-        extension = Annotation.extensions.detect do |regexp, _block|
-          regexp.match(item)
-        end
-
-        if extension
-          pattern = extension.last.call(tag)
-          results.update(extract_annotations_from(item, pattern)) if pattern
-        end
+      # Returns a representation of the annotation that looks like this:
+      #
+      #   [126] [TODO] This algorithm is simple and clearly correct, make it faster.
+      #
+      # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
+      # Otherwise the string contains just line and text.
+      def to_s(options = {})
+        s = "[#{line.to_s.rjust(options[:indent])}] ".dup
+        s << "[#{tag}] " if options[:tag]
+        s << text
       end
     end
 
-    results
-  end
-
-  # If +file+ is the filename of a file that contains annotations this method returns
-  # a hash with a single entry that maps +file+ to an array of its annotations.
-  # Otherwise it returns an empty hash.
-  def extract_annotations_from(file, pattern)
-    lineno = 0
-    result = File.readlines(file, encoding: Encoding::BINARY).inject([]) do |list, line|
-      lineno += 1
-      next list unless line =~ pattern
-      list << Annotation.new(lineno, $1, $2)
+    # Prints all annotations with tag +tag+ under the root directories +app+,
+    # +config+, +db+, +lib+, and +test+ (recursively).
+    #
+    # Additional directories may be added using a comma-delimited list set using
+    # <tt>ENV['SOURCE_ANNOTATION_DIRECTORIES']</tt>.
+    #
+    # Directories may also be explicitly set using the <tt>:dirs</tt> key in +options+.
+    #
+    #   SourceAnnotationExtractor.enumerate 'TODO|FIXME', dirs: %w(app lib), tag: true
+    #
+    # If +options+ has a <tt>:tag</tt> flag, it will be passed to each annotation's +to_s+.
+    #
+    # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
+    #
+    # This class method is the single entry point for the rake tasks.
+    def self.enumerate(tag, options = {})
+      extractor = new(tag)
+      dirs = options.delete(:dirs) || Annotation.directories
+      extractor.display(extractor.find(dirs), options)
     end
-    result.empty? ? {} : { file => result }
-  end
 
-  # Prints the mapping from filenames to annotations in +results+ ordered by filename.
-  # The +options+ hash is passed to each annotation's +to_s+.
-  def display(results, options = {})
-    options[:indent] = results.flat_map { |f, a| a.map(&:line) }.max.to_s.size
-    results.keys.sort.each do |file|
-      puts "#{file}:"
-      results[file].each do |note|
-        puts "  * #{note.to_s(options)}"
+    attr_reader :tag
+
+    def initialize(tag)
+      @tag = tag
+    end
+
+    # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
+    # with their annotations.
+    def find(dirs)
+      dirs.inject({}) { |h, dir| h.update(find_in(dir)) }
+    end
+
+    # Returns a hash that maps filenames under +dir+ (recursively) to arrays
+    # with their annotations. Only files with annotations are included. Files
+    # with extension +.builder+, +.rb+, +.rake+, +.yml+, +.yaml+, +.ruby+,
+    # +.css+, +.js+ and +.erb+ are taken into account.
+    def find_in(dir)
+      results = {}
+
+      Dir.glob("#{dir}/*") do |item|
+        next if File.basename(item)[0] == ?.
+
+        if File.directory?(item)
+          results.update(find_in(item))
+        else
+          extension = Annotation.extensions.detect do |regexp, _block|
+            regexp.match(item)
+          end
+
+          if extension
+            pattern = extension.last.call(tag)
+            results.update(extract_annotations_from(item, pattern)) if pattern
+          end
+        end
       end
-      puts
+
+      results
+    end
+
+    # If +file+ is the filename of a file that contains annotations this method returns
+    # a hash with a single entry that maps +file+ to an array of its annotations.
+    # Otherwise it returns an empty hash.
+    def extract_annotations_from(file, pattern)
+      lineno = 0
+      result = File.readlines(file, encoding: Encoding::BINARY).inject([]) do |list, line|
+        lineno += 1
+        next list unless line =~ pattern
+        list << Annotation.new(lineno, $1, $2)
+      end
+      result.empty? ? {} : { file => result }
+    end
+
+    # Prints the mapping from filenames to annotations in +results+ ordered by filename.
+    # The +options+ hash is passed to each annotation's +to_s+.
+    def display(results, options = {})
+      options[:indent] = results.flat_map { |f, a| a.map(&:line) }.max.to_s.size
+      results.keys.sort.each do |file|
+        puts "#{file}:"
+        results[file].each do |note|
+          puts "  * #{note.to_s(options)}"
+        end
+        puts
+      end
     end
   end
 end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
+# Remove this deprecated class in the next minor version
+#:nodoc:
+SourceAnnotationExtractor = ActiveSupport::Deprecation::DeprecatedConstantProxy.
+  new("SourceAnnotationExtractor", "Rails::SourceAnnotationExtractor")
+
 module Rails
   # Implements the logic behind the rake tasks for annotations like
   #

--- a/railties/lib/rails/tasks/annotations.rake
+++ b/railties/lib/rails/tasks/annotations.rake
@@ -4,19 +4,19 @@ require "rails/source_annotation_extractor"
 
 desc "Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)"
 task :notes do
-  SourceAnnotationExtractor.enumerate "OPTIMIZE|FIXME|TODO", tag: true
+  Rails::SourceAnnotationExtractor.enumerate "OPTIMIZE|FIXME|TODO", tag: true
 end
 
 namespace :notes do
   ["OPTIMIZE", "FIXME", "TODO"].each do |annotation|
     # desc "Enumerate all #{annotation} annotations"
     task annotation.downcase.intern do
-      SourceAnnotationExtractor.enumerate annotation
+      Rails::SourceAnnotationExtractor.enumerate annotation
     end
   end
 
   desc "Enumerate a custom annotation, specify with ANNOTATION=CUSTOM"
   task :custom do
-    SourceAnnotationExtractor.enumerate ENV["ANNOTATION"]
+    Rails::SourceAnnotationExtractor.enumerate ENV["ANNOTATION"]
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1509,7 +1509,7 @@ module ApplicationTests
         end
       end
 
-      assert_not_nil SourceAnnotationExtractor::Annotation.extensions[/\.(coffee)$/]
+      assert_not_nil Rails::SourceAnnotationExtractor::Annotation.extensions[/\.(coffee)$/]
     end
 
     test "rake_tasks block works at instance level" do

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -101,7 +101,7 @@ module ApplicationTests
           task :notes_custom do
             tags = 'TODO|FIXME'
             opts = { dirs: %w(lib test), tag: true }
-            SourceAnnotationExtractor.enumerate(tags, opts)
+            Rails::SourceAnnotationExtractor.enumerate(tags, opts)
           end
         EOS
 


### PR DESCRIPTION
This is pretty much just a housekeeping PR.

I was browsing http://edgeapi.rubyonrails.org/ and notices that this class is listed on the left size with no namespace prefix. Given that this class belongs to Rails framework, and that it's already in `railties/lib/rails` hierarchy, I believe it's best to move this class down into `Rails` module.

In some sense, I believe that this could be considered a breaking change. However, given that user will access this class through rake task, I think this is fine to change.

Please let me know what you think.