### PR TITLE
Bugfix activejob improper serialization and deserialization of scheduled_at

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -80,14 +80,15 @@ module ActiveJob
     # queueing adapter.
     def serialize
       {
-        "job_class"  => self.class.name,
-        "job_id"     => job_id,
+        "job_class"       => self.class.name,
+        "job_id"          => job_id,
         "provider_job_id" => provider_job_id,
-        "queue_name" => queue_name,
-        "priority"   => priority,
-        "arguments"  => serialize_arguments(arguments),
-        "executions" => executions,
-        "locale"     => I18n.locale.to_s
+        "queue_name"      => queue_name,
+        "priority"        => priority,
+        "arguments"       => serialize_arguments(arguments),
+        "executions"      => executions,
+        "locale"          => I18n.locale.to_s,
+        "scheduled_at"    => scheduled_at
       }
     end
 
@@ -125,6 +126,7 @@ module ActiveJob
       self.serialized_arguments = job_data["arguments"]
       self.executions           = job_data["executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
+      self.scheduled_at         = job_data["scheduled_at"]
     end
 
     private

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -47,6 +47,20 @@ class JobSerializationTest < ActiveSupport::TestCase
     assert_equal "en", job.locale
   end
 
+  test "serialize and deserialize job with scheduled_at" do
+    current_time = Time.now.to_f
+
+    job = HelloJob.new
+    job.scheduled_at = current_time
+    serialized_job = job.serialize
+    assert_equal current_time, serialized_job["scheduled_at"]
+
+    deserialized_job = HelloJob.new
+    deserialized_job.deserialize(serialized_job)
+    assert_equal current_time, deserialized_job.serialize["scheduled_at"]
+    assert_equal job.serialize, deserialized_job.serialize
+  end
+
   test "serialize stores provider_job_id" do
     job = HelloJob.new
     assert_nil job.serialize["provider_job_id"]


### PR DESCRIPTION
### Summary

ActiveJob was not serializing and deserializing `scheduled_at` properly

### Other Information

We use ActiveJob with DelayedJob as adapter. And we are scheduling job in advance for monitoring purpose. However, `scheduled_at` value is always missing once because it's not even serialized, and also not deserialized as well if given. To achieve that, currently we are monkey patching the `ActiveJob::Core`.

This PR fix the issue.