### PR TITLE
Delete default configuration

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -315,16 +315,12 @@ module ActiveRecord
           environments << "test" if environment == "development"
 
           ActiveRecord::Base.configurations.slice(*environments).each do |configuration_environment, configuration|
-            next unless configuration["database"]
-
             yield configuration, configuration_environment
           end
         end
 
         def each_local_configuration
           ActiveRecord::Base.configurations.each_value do |configuration|
-            next unless configuration["database"]
-
             if local_database?(configuration)
               yield configuration
             else

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -124,14 +124,6 @@ module ActiveRecord
       ActiveRecord::Base.connection_handler.stubs(:establish_connection)
     end
 
-    def test_ignores_configurations_without_databases
-      @configurations["development"].merge!("database" => nil)
-
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).never
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
-    end
-
     def test_ignores_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
       $stderr.stubs(:puts).returns(nil)
@@ -248,14 +240,6 @@ module ActiveRecord
       @configurations = { development: { "database" => "my-db" } }
 
       ActiveRecord::Base.stubs(:configurations).returns(@configurations)
-    end
-
-    def test_ignores_configurations_without_databases
-      @configurations[:development].merge!("database" => nil)
-
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).never
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
     end
 
     def test_ignores_remote_databases

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -178,6 +178,7 @@ module Rails
               values.reverse_merge!(shared)
             end
           end
+          loaded_yaml.delete("default")
           Hash.new(shared).merge(loaded_yaml)
         elsif ENV["DATABASE_URL"]
           # Value from ENV['DATABASE_URL'] is set to default database connection


### PR DESCRIPTION
Because of this default configuration we're constantly checking if the
database exists when looping through configurations. This is unnecessary
and we should just delete it before we need to loop through
configurations.
