### PR TITLE
Properly escape column name embedded into regexp

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1501,7 +1501,7 @@ class BasicsTest < ActiveRecord::TestCase
     query = Developer.from("developers").to_sql
     quoted_id = "#{Developer.quoted_table_name}.#{Developer.quoted_primary_key}"
 
-    assert_match(/SELECT #{quoted_id}.* FROM developers/, query)
+    assert_match(/SELECT #{Regexp.escape(quoted_id)}.* FROM developers/, query)
   end
 
   test "using table name qualified column names unless having SELECT list explicitly" do


### PR DESCRIPTION
SQLServerAdapter (gem `activerecord-sqlserver-adapter`) uses square
brackets for quoting column names (e.g. `[id]`). Those brackets must not
be misinterpreted in regular expressions.

Failure observed when running the AR test suite against that adapter:
```
Expected /SELECT [developers].[id].* FROM developers/ to match "SELECT [developers].[id], [developers].[name], [developers].[salary], [developers].[firm_id], [developers].[mentor_id], [developers].[created_at], [developers].[updated_at], [developers].[created_on], [developers].[updated_on] FROM developers".
```