### PR TITLE
Introduced Model.where.any method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Introduced Model.where.any method
+    Designed to pass several conditions to where
+    that should be joined with OR predicate.
+    Only accepts a Hash now.
+
+    ``` ruby
+    User.where.any(name: 'Jon', id: 1)
+    # SELECT * FROM users WHERE name = 'Jon' OR id = 1
+    
+    User.joins(:manager).where.any(name: 'Jon', managers: {name: 'Bob'})
+    # SELECT * FROM users LEFT managers ON managers.id = users.manager_id 
+    #   WHERE name = 'Jon' OR managers.name = 'Bob'
+    ```
+
+    *Bogdan Gusiev*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -53,6 +53,26 @@ module ActiveRecord
         @scope.where_clause += where_clause.invert
         @scope
       end
+
+      # Returns a new relation expressing passed Hash is transformed into
+      # where conditions joined by OR predicate
+      #
+      # #any only accepts conditions as a Hash.
+      #
+      #    User.where.any(name: 'Jon', id: 1)
+      #    # SELECT * FROM users WHERE name = 'Jon' OR id = 1
+      #
+      #    User.joins(:manager).where.any(name: 'Jon', managers: {name: 'Bob'})
+      #    # SELECT * FROM users LEFT managers ON managers.id = users.manager_id WHERE name = 'Jon' OR managers.name = 'Bob'
+      def any(opts)
+        opts = sanitize_forbidden_attributes(opts)
+        raise ArgumentError unless Hash === opts
+
+        where_clause = @scope.send(:where_clause_factory).build(opts, [])
+        @scope.references!(PredicateBuilder.references(opts))
+        @scope.where_clause += where_clause.or_clause
+        @scope
+      end
     end
 
     FROZEN_EMPTY_ARRAY = [].freeze

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -74,6 +74,14 @@ module ActiveRecord
         WhereClause.new(inverted_predicates)
       end
 
+      def or_clause
+        WhereClause.new([
+          predicates.reduce do |left, right|
+            Arel::Nodes::Or.new(left, right)
+          end
+        ])
+      end
+
       def self.empty
         @empty ||= new([])
       end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -103,5 +103,21 @@ module ActiveRecord
 
       assert_equal Post.where(comments_count: 3..5), relation
     end
+
+    def test_where_any
+      relation = Post.where.any(author_id: 2, id: 1)
+      assert_equal Post.where("author_id = 2 OR id = 1").to_a, relation.to_a
+    end
+
+    def test_where_any_reference
+      relation = Post.joins(:author).where.any(id: 1, authors: {name: 'Mary'})
+      assert_equal Post.joins(:author).where("posts.id = 1 OR authors.name = 'Mary'").to_a, relation.to_a
+    end
+
+    def test_where_any_argument_error
+      assert_raise ArgumentError do
+        Post.where.any("created_at > 0")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

ActiveRecord has a pretty weird way to build the OR conditions.
According to Doc of `AR::Relation#or` it should look like this:

``` ruby
Post.where("id = 1").or(Post.where("author_id = 3"))
```

While it could be useful as a powerful tool, in most cases we just need a simple OR statment between two or three conditions that can be done like this:

``` ruby
Post.where.any(id: 1, author_id: 3) # where id = 1 OR author_id = 3
```

It fits well into the multiple `where` calls idea where `AND` is till a basic operation but not `OR`:

``` ruby
Post.where.any(id: 1, author_id: 3).where(created_at: 2.days.ago..Time.now)
  # where (id = 1 OR author_id = 3) AND created_at BETWEEN ? AND ?
```
