### PR TITLE
Let select render default selected option for required field

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Enable select tag helper to mark `prompt` option as `selected` and/or `disabled` for `required`
+    field. Example:
+    
+        select :post, 
+               :category, 
+               ["lifestyle", "programming", "spiritual"], 
+               { selected: "", disabled: "", prompt: "Choose one" }, 
+               { required: true }
+    
+    Placeholder option would be selected and disabled. The HTML produced:
+    
+        <select required="required" name="post[category]" id="post_category">
+        <option disabled="disabled" selected="selected" value="">Choose one</option>
+        <option value="lifestyle">lifestyle</option>
+        <option value="programming">programming</option>
+        <option value="spiritual">spiritual</option></select>
+
+    For details see GH#32080
+ 
+    *Sergey Prikhodko*
+
 *   Don't enforce UTF-8 by default
 
     With the disabling of TLS 1.0 by most major websites, continuing to run

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -170,7 +170,11 @@ module ActionView
               option_tags = tag_builder.content_tag_string("option", options[:include_blank].kind_of?(String) ? options[:include_blank] : nil, value: "") + "\n" + option_tags
             end
             if value.blank? && options[:prompt]
-              option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), value: "") + "\n" + option_tags
+              tag_options = { value: "" }.tap do |prompt_opts|
+                prompt_opts[:disabled] = true if options[:disabled] == ""
+                prompt_opts[:selected] = true if options[:selected] == ""
+              end
+              option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), tag_options) + "\n" + option_tags
             end
             option_tags
           end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -511,6 +511,16 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_required_select_with_default_and_selected_placeholder
+    assert_dom_equal(
+      ['<select required="required" name="post[category]" id="post_category"><option disabled="disabled" selected="selected" value="">Choose one</option>',
+      '<option value="lifestyle">lifestyle</option>',
+      '<option value="programming">programming</option>',
+      '<option value="spiritual">spiritual</option></select>'].join("\n"),
+      select(:post, :category, ["lifestyle", "programming", "spiritual"], { selected: "", disabled: "", prompt: "Choose one" }, { required: true })
+    )
+  end
+
   def test_select_with_grouped_collection_as_nested_array
     @post = Post.new
 


### PR DESCRIPTION
### Summary

Let select tag be required and have a selected disabled placeholder option.

Closes related issue https://github.com/rails/rails/issues/32080