### PR TITLE
add a generator for concerns

### DIFF
--- a/railties/lib/rails/generators/rails/concern/USAGE
+++ b/railties/lib/rails/generators/rails/concern/USAGE
@@ -1,0 +1,12 @@
+Description:
+    Stubs out a new concern. Pass the concern name, either CamelCased
+    or under_scored.
+
+    To create a concern within a module, specify the concern name
+    as a path like 'parent_module/concern_name'.
+
+Example:
+    `rails generate concern Taggable`
+
+    Taggable concern.
+        Concern:     app/models/concerns/taggable.rb

--- a/railties/lib/rails/generators/rails/concern/concern_generator.rb
+++ b/railties/lib/rails/generators/rails/concern/concern_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    class ConcernGenerator < NamedBase # :nodoc:
+      check_class_collision suffix: "Concern"
+
+      def create_concern_files
+        template "concern.rb", File.join("app/models/concerns", class_path, "#{file_name}.rb")
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/concern/templates/concern.rb
+++ b/railties/lib/rails/generators/rails/concern/templates/concern.rb
@@ -1,0 +1,11 @@
+<% module_namespacing do -%>
+module <%= class_name %>
+  extend ActiveSupport::Concern
+
+  included do
+  end
+
+  class_methods do
+  end
+end
+<% end -%>

--- a/railties/test/generators/concern_generator_test.rb
+++ b/railties/test/generators/concern_generator_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/concern/concern_generator"
+
+class ConcernGeneratorTest < Rails::Generator::TestCase
+  include GeneratorsTestHelper
+
+  def test_concern_skeleton_is_created
+    run_generator ["taggable"]
+    assert_file "app/models/concerns/taggable.rb" do |concern|
+      assert_match(/module Taggable/, concern)
+    end
+  end
+
+  def test_concern_namespace
+    run_generator ["admin/taggable"]
+    assert_file "app/models/concerns/admin/taggable.rb" do |concern|
+      assert_match(/module Admin::Taggable < ApplicationJob/)
+    end
+  end
+
+  def test_check_class_collision
+    content = capture(:stderr) { run_generator ["concern"] }
+    assert_match(/The name 'Concern' is either already used in your application or reserved/, content)
+  end
+end


### PR DESCRIPTION
### Summary

Bonjour 👋

This adds a new generator for concerns.

i.e.: The command `rails generate concern taggable` will create the Taggable
module in `app/models/concerns`, with the basic concern template.
