### PR TITLE
Use `rubocop-0-52` channel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-51
+    channel: rubocop-0-52
 
 ratings:
   paths:


### PR DESCRIPTION
### Summary

This pull request updates the RuboCop version used at codeclimate.
Since https://github.com/rails/rails/pull/32091 expects RuboCop 0.52.1
