### PR TITLE
Allow env-specific credentials by config

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -11,9 +11,11 @@ module ActiveSupport
     delegate :[], :fetch, to: :config
     delegate_missing_to :options
 
-    def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
+    def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:, section: nil)
       super content_path: config_path, key_path: key_path,
         env_key: env_key, raise_if_missing_key: raise_if_missing_key
+
+      @section = section
     end
 
     # Allow a config to be started without a file present
@@ -30,7 +32,10 @@ module ActiveSupport
     end
 
     def config
-      @config ||= deserialize(read).deep_symbolize_keys
+      @config ||= begin
+        config = deserialize(read).deep_symbolize_keys
+        @section ? config[@section.to_sym] : config
+      end
     end
 
     private

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -42,6 +42,16 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert @credentials.something[:good]
   end
 
+  test "reading configuration with specifying section" do
+    credentials = ActiveSupport::EncryptedConfiguration.new(
+      config_path: @credentials_config_path, key_path: @credentials_key_path,
+      env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true, section: :development
+    )
+    credentials.write({ development: { something: { good: true } } }.to_yaml)
+
+    assert credentials.something[:good]
+  end
+
   test "change configuration by key file" do
     @credentials.write({ something: { good: true } }.to_yaml)
     @credentials.change do |config_file|

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -439,7 +439,8 @@ module Rails
     # the Rails master key, which is either taken from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading
     # +config/master.key+.
     def credentials
-      @credentials ||= encrypted("config/credentials.yml.enc")
+      section = config.read_credentials_per_env ? Rails.env : nil
+      @credentials ||= encrypted("config/credentials.yml.enc", section: section)
     end
 
     # Shorthand to decrypt any encrypted configurations or files.
@@ -469,12 +470,13 @@ module Rails
     # Or to decrypt with a file, that should be version control ignored, relative to +Rails.root+:
     #
     #   Rails.application.encrypted("config/special_tokens.yml.enc", key_path: "config/special_tokens.key")
-    def encrypted(path, key_path: "config/master.key", env_key: "RAILS_MASTER_KEY")
+    def encrypted(path, key_path: "config/master.key", env_key: "RAILS_MASTER_KEY", section: nil)
       ActiveSupport::EncryptedConfiguration.new(
         config_path: Rails.root.join(path),
         key_path: Rails.root.join(key_path),
         env_key: env_key,
-        raise_if_missing_key: config.require_master_key
+        raise_if_missing_key: config.require_master_key,
+        section: section
       )
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -17,7 +17,8 @@ module Rails
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
-                    :content_security_policy_nonce_generator, :require_master_key
+                    :content_security_policy_nonce_generator, :require_master_key,
+                    :read_credentials_per_env
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -60,6 +61,7 @@ module Rails
         @content_security_policy_nonce_generator = nil
         @require_master_key                      = false
         @loaded_config_version                   = nil
+        @read_credentials_per_env                = false
       end
 
       def load_defaults(target_version)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1952,6 +1952,17 @@ module ApplicationTests
       assert_includes ActiveJob::Serializers.serializers, DummySerializer
     end
 
+    test "credentials return only current env values when specified read_credentials_per_env" do
+      add_to_config <<-RUBY
+        config.read_credentials_per_env = true
+      RUBY
+
+      app "development"
+      app.credentials.write({ development: { api_key: 123 } }.to_yaml)
+
+      assert_equal 123, app.credentials.api_key
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -73,6 +73,14 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/Missing master key to decrypt credentials/, run_show_command)
   end
 
+  test "show all values when read_credential_per_env is specified" do
+    add_to_config <<-RUBY
+      config.read_credentials_per_env = true
+    RUBY
+
+    assert_match(/access_key_id: 123/, run_show_command)
+  end
+
   private
     def run_edit_command(editor: "cat")
       switch_env("EDITOR", editor) do


### PR DESCRIPTION
In many cases, credentials is only necessary for production.
However, if use a service like payment, want to change the api key in staging and production.
By changing the behavior by config, I think that credentials can be used smoothly even in such a case.

Also, if an application using the secret encrypted with 5.1, this will make it possible to upgrade smoothly.
