### PR TITLE
Use lazy load hook to configure ActiveStorage::Blob

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -202,4 +202,6 @@ class ActiveStorage::Blob < ActiveRecord::Base
     def forcibly_serve_as_binary?
       ActiveStorage.content_types_to_serve_as_binary.include?(content_type)
     end
+
+    ActiveSupport.run_load_hooks(:active_storage_blob, self)
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -68,7 +68,7 @@ module ActiveStorage
     end
 
     initializer "active_storage.services" do
-      config.to_prepare do
+      ActiveSupport.on_load(:active_storage_blob) do
         if config_choice = Rails.configuration.active_storage.service
           configs = Rails.configuration.active_storage.service_configurations ||= begin
             config_file = Pathname.new(Rails.root.join("config/storage.yml"))

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -359,6 +359,18 @@ class LoadingTest < ActiveSupport::TestCase
     assert_predicate Rails.application, :initialized?
   end
 
+  test "frameworks aren't loaded during initialization" do
+    app_file "config/initializers/raise_when_frameworks_load.rb", <<-RUBY
+      %i(action_controller action_mailer active_job active_record).each do |framework|
+        ActiveSupport.on_load(framework) { raise "\#{framework} loaded!" }
+      end
+    RUBY
+
+    assert_nothing_raised do
+      require "#{app_path}/config/environment"
+    end
+  end
+
   private
 
     def setup_ar!


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/30118.

`to_prepare` callbacks are run during initialization; using one here meant that `ActiveStorage::Blob` would be loaded when the app boots, which would in turn load `ActiveRecord::Base`.

By using a lazy load hook to configure `ActiveStorage::Blob` instead, we can avoid loading `ActiveRecord::Base` unnecessarily.

r? @georgeclaghorn