### PR TITLE
Refactored safe assignment in condition

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -33,7 +33,7 @@ module ActiveSupport
   #
   #     private
   #       def authenticate
-  #         if authenticated_user = User.find_by(id: cookies.encrypted[:user_id])
+  #         if (authenticated_user = User.find_by(id: cookies.encrypted[:user_id]))
   #           Current.user = authenticated_user
   #         else
   #           redirect_to new_session_url


### PR DESCRIPTION
It seems in this example we are not using safe assignment inside a condition.
I propose to change it, even if it's just a comment. 

Here the references regarding why is a good idea to wrap it inside parenthesis:
[Ruby style guide](https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition)
[Explanation](https://github.com/bbatsov/ruby-style-guide/issues/53)