### PR TITLE
remove utf8 enforce

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -187,8 +187,6 @@ module ActionView
       # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive
       #   JavaScript drivers to control the submit behavior. By default this
       #   behavior is an ajax submit.
-      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name
-      #   utf8 is not output.
       # * <tt>:html</tt> - Optional HTML attributes for the form tag.
       #
       # Also note that +form_for+ doesn't create an exclusive scope. It's still
@@ -445,7 +443,6 @@ module ActionView
         html_options[:data]   = options.delete(:data)   if options.has_key?(:data)
         html_options[:remote] = options.delete(:remote) if options.has_key?(:remote)
         html_options[:method] = options.delete(:method) if options.has_key?(:method)
-        html_options[:enforce_utf8] = options.delete(:enforce_utf8) if options.has_key?(:enforce_utf8)
         html_options[:authenticity_token] = options.delete(:authenticity_token)
 
         builder = instantiate_builder(object_name, object, options)
@@ -610,8 +607,6 @@ module ActionView
       #   unnecessary unless you support browsers without JavaScript.
       # * <tt>:local</tt> - By default form submits are remote and unobtrusive XHRs.
       #   Disable remote submits with <tt>local: true</tt>.
-      # * <tt>:skip_enforcing_utf8</tt> - By default a hidden field named +utf8+
-      #   is output to enforce UTF-8 submits. Set to true to skip the field.
       # * <tt>:builder</tt> - Override the object used to build the form.
       # * <tt>:id</tt> - Optional HTML id attribute.
       # * <tt>:class</tt> - Optional HTML class attribute.
@@ -1519,10 +1514,9 @@ module ActionView
 
       private
         def html_options_for_form_with(url_for_options = nil, model = nil, html: {}, local: !form_with_generates_remote_forms,
-          skip_enforcing_utf8: false, **options)
+          **options)
           html_options = options.slice(:id, :class, :multipart, :method, :data).merge(html)
           html_options[:method] ||= :patch if model.respond_to?(:persisted?) && model.persisted?
-          html_options[:enforce_utf8] = !skip_enforcing_utf8
 
           html_options[:enctype] = "multipart/form-data" if html_options.delete(:multipart)
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -39,7 +39,6 @@ module ActionView
       #   support browsers without JavaScript.
       # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive JavaScript drivers to control the
       #   submit behavior. By default this behavior is an ajax submit.
-      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name utf8 is not output.
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples
@@ -810,15 +809,6 @@ module ActionView
         number_field_tag(name, value, options.merge(type: :range))
       end
 
-      # Creates the hidden UTF8 enforcer tag. Override this method in a helper
-      # to customize the tag.
-      def utf8_enforcer_tag
-        # Use raw HTML to ensure the value is written as an HTML entity; it
-        # needs to be the right character regardless of which encoding the
-        # browser infers.
-        '<input name="utf8" type="hidden" value="&#x2713;" />'.html_safe
-      end
-
       private
         def html_options_for_form(url_for_options, options)
           options.stringify_keys.tap do |html_options|
@@ -866,11 +856,7 @@ module ActionView
               })
             end
 
-          if html_options.delete("enforce_utf8") { true }
-            utf8_enforcer_tag + method_tag
-          else
-            method_tag
-          end
+          method_tag
         end
 
         def form_tag_html(html_options)

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -57,7 +57,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   private
 
     def hidden_fields(method = nil)
-      txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
+      txt = "".dup
 
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -25,13 +25,8 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
   def hidden_fields(options = {})
     method = options[:method]
-    skip_enforcing_utf8 = options.fetch(:skip_enforcing_utf8, false)
 
     "".dup.tap do |txt|
-      unless skip_enforcing_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
-      end
-
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}
       end
@@ -102,13 +97,6 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     expected = whole_form("http://www.example.com", local: true)
     assert_dom_equal expected, actual
-  end
-
-  def test_form_with_skip_enforcing_utf8_true
-    actual = form_with(skip_enforcing_utf8: true)
-    expected = whole_form("http://www.example.com", skip_enforcing_utf8: true)
-    assert_dom_equal expected, actual
-    assert_predicate actual, :html_safe?
   end
 
   def test_form_with_with_block_in_erb
@@ -790,30 +778,6 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, output_buffer
   ensure
     ActionView::Helpers::FormHelper.form_with_generates_remote_forms = old_value
-  end
-
-  def test_form_with_skip_enforcing_utf8_true
-    form_with(scope: :post, skip_enforcing_utf8: true) do |f|
-      concat f.text_field(:title)
-    end
-
-    expected = whole_form("/", skip_enforcing_utf8: true) do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
-  def test_form_with_skip_enforcing_utf8_false
-    form_with(scope: :post, skip_enforcing_utf8: false) do |f|
-      concat f.text_field(:title)
-    end
-
-    expected = whole_form("/", skip_enforcing_utf8: false) do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
-    end
-
-    assert_dom_equal expected, output_buffer
   end
 
   def test_form_with_without_object
@@ -2232,11 +2196,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     def hidden_fields(options = {})
       method = options[:method]
 
-      if options.fetch(:skip_enforcing_utf8, false)
-        txt = "".dup
-      else
-        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
-      end
+      txt = "".dup
 
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}
@@ -2260,7 +2220,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
       method, multipart = options.values_at(:method, :multipart)
 
-      form_text(action, id, html_class, local, multipart, method) + hidden_fields(options.slice :method, :skip_enforcing_utf8) + contents + "</form>"
+      form_text(action, id, html_class, local, multipart, method) + hidden_fields(options.slice :method) + contents + "</form>"
     end
 
     def protect_against_forgery?

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1968,30 +1968,6 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def test_form_for_enforce_utf8_true
-    form_for(:post, enforce_utf8: true) do |f|
-      concat f.text_field(:title)
-    end
-
-    expected = whole_form("/", nil, nil, enforce_utf8: true) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
-  def test_form_for_enforce_utf8_false
-    form_for(:post, enforce_utf8: false) do |f|
-      concat f.text_field(:title)
-    end
-
-    expected = whole_form("/", nil, nil, enforce_utf8: false) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
   def test_form_for_with_remote_in_html
     form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
@@ -3510,11 +3486,7 @@ class FormHelperTest < ActionView::TestCase
     def hidden_fields(options = {})
       method = options[:method]
 
-      if options.fetch(:enforce_utf8, true)
-        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
-      else
-        txt = "".dup
-      end
+      txt = "".dup
 
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}
@@ -3538,7 +3510,7 @@ class FormHelperTest < ActionView::TestCase
 
       method, remote, multipart = options.values_at(:method, :remote, :multipart)
 
-      form_text(action, id, html_class, remote, multipart, method) + hidden_fields(options.slice :method, :enforce_utf8) + contents + "</form>"
+      form_text(action, id, html_class, remote, multipart, method) + hidden_fields(options.slice :method) + contents + "</form>"
     end
 
     def protect_against_forgery?

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -24,13 +24,8 @@ class FormTagHelperTest < ActionView::TestCase
 
   def hidden_fields(options = {})
     method = options[:method]
-    enforce_utf8 = options.fetch(:enforce_utf8, true)
 
     "".dup.tap do |txt|
-      if enforce_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
-      end
-
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}
       end
@@ -136,20 +131,6 @@ class FormTagHelperTest < ActionView::TestCase
 
     expected = whole_form
     assert_dom_equal expected, actual
-  end
-
-  def test_form_tag_enforce_utf8_true
-    actual = form_tag({}, { enforce_utf8: true })
-    expected = whole_form("http://www.example.com", enforce_utf8: true)
-    assert_dom_equal expected, actual
-    assert_predicate actual, :html_safe?
-  end
-
-  def test_form_tag_enforce_utf8_false
-    actual = form_tag({}, { enforce_utf8: false })
-    expected = whole_form("http://www.example.com", enforce_utf8: false)
-    assert_dom_equal expected, actual
-    assert_predicate actual, :html_safe?
   end
 
   def test_form_tag_with_block_in_erb

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -808,7 +808,6 @@ The HTML generated for this would be:
 
 ```html
 <form class="new_person" id="new_person" action="/people" accept-charset="UTF-8" method="post">
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <input type="hidden" name="authenticity_token" value="lTuvBzs7ANygT0NFinXj98tfw3Emfm65wwYLbUvoWsK2pngccIQSUorM2C035M9dZswXgWTvKwFS8W5TVblpYw==" />
   <input type="text" name="person[first_name]" id="person_first_name" />
   <input type="text" name="person[last_name]" id="person_last_name" />
@@ -819,7 +818,7 @@ The HTML generated for this would be:
 The params object created when this form is submitted would look like:
 
 ```ruby
-{"utf8" => "✓", "authenticity_token" => "lTuvBzs7ANygT0NFinXj98tfw3Emfm65wwYLbUvoWsK2pngccIQSUorM2C035M9dZswXgWTvKwFS8W5TVblpYw==", "person" => {"first_name" => "William", "last_name" => "Smith"}, "commit" => "Create", "controller" => "people", "action" => "create"}
+{"authenticity_token" => "lTuvBzs7ANygT0NFinXj98tfw3Emfm65wwYLbUvoWsK2pngccIQSUorM2C035M9dZswXgWTvKwFS8W5TVblpYw==", "person" => {"first_name" => "William", "last_name" => "Smith"}, "commit" => "Create", "controller" => "people", "action" => "create"}
 ```
 
 The params hash has a nested person value, which can therefore be accessed with `params[:person]` in the controller.

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -34,15 +34,14 @@ When called without arguments like this, it creates a `<form>` tag which, when s
 
 ```html
 <form accept-charset="UTF-8" action="/" method="post">
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <input name="authenticity_token" type="hidden" value="J7CBxfHalt49OSHp27hblqK20c9PgwJ108nDHX/8Cts=" />
   Form contents
 </form>
 ```
 
-You'll notice that the HTML contains an `input` element with type `hidden`. This `input` is important, because the form cannot be successfully submitted without it. The hidden input element with the name `utf8` enforces browsers to properly respect your form's character encoding and is generated for all forms whether their action is "GET" or "POST".
+You'll notice that the HTML contains an `input` element with type `hidden`. This `input` is important, because the form cannot be successfully submitted without it.
 
-The second input element with the name `authenticity_token` is a security feature of Rails called **cross-site request forgery protection**, and form helpers generate it for every non-GET form (provided that this security feature is enabled). You can read more about this in the [Security Guide](security.html#cross-site-request-forgery-csrf).
+The input element with the name `authenticity_token` is a security feature of Rails called **cross-site request forgery protection**, and form helpers generate it for every non-GET form (provided that this security feature is enabled). You can read more about this in the [Security Guide](security.html#cross-site-request-forgery-csrf).
 
 ### A Generic Search Form
 
@@ -67,7 +66,6 @@ This will generate the following HTML:
 
 ```html
 <form accept-charset="UTF-8" action="/search" method="get">
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <label for="q">Search for:</label>
   <input id="q" name="q" type="text" />
   <input name="commit" type="submit" value="Search" />
@@ -275,7 +273,6 @@ The resulting HTML is:
 
 ```html
 <form class="nifty_form" id="new_article" action="/articles" accept-charset="UTF-8" method="post">
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <input type="hidden" name="authenticity_token" value="NRkFyRWxdYNfUg7vYxLOp2SLf93lvnl+QwDWorR42Dp6yZXPhHEb6arhDOIWcqGit8jfnrPwL781/xlrzj63TA==" />
   <input type="text" name="article[title]" id="article_title" />
   <textarea name="article[body]" id="article_body" cols="60" rows="12"></textarea>
@@ -302,7 +299,6 @@ which produces the following output:
 
 ```html
 <form class="new_person" id="new_person" action="/people" accept-charset="UTF-8" method="post">
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <input type="hidden" name="authenticity_token" value="bL13x72pldyDD8bgtkjKQakJCpd4A8JdXGbfksxBDHdf1uC0kCMqe2tvVdUYfidJt0fj3ihC4NxiVHv8GVYxJA==" />
   <input type="text" name="person[name]" id="person_name" />
   <input type="text" name="contact_detail[phone_number]" id="contact_detail_phone_number" />
@@ -374,7 +370,6 @@ output:
 ```html
 <form accept-charset="UTF-8" action="/search" method="post">
   <input name="_method" type="hidden" value="patch" />
-  <input name="utf8" type="hidden" value="&#x2713;" />
   <input name="authenticity_token" type="hidden" value="f755bb0ed134b76c432144748a6d4b7a7ddf2b71" />
   ...
 </form>


### PR DESCRIPTION
`<input name="utf8" type="hidden" value="✓" />` is obsolete. It was required for IE5-8, which are not supported by **rails-ujs** and **Turbolinks** anyway. https://github.com/rails/rails/issues/30852