### PR TITLE
Remove changelogs for Rails 6.0 since they were backported to `5-2-stable`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -4,12 +4,5 @@
 
     *Jeremy Daer*
 
-*   Add source code to published npm package
-
-    This allows activestorage users to depend on the javascript source code
-    rather than the compiled code, which can produce smaller javascript bundles.
-
-    *Richard Macklin*
-
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,26 +1,5 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
-*   Caching: MemCache and Redis `read_multi` and `fetch_multi` speedup.
-    Read from the local in-memory cache before consulting the backend.
-
-    *Gabriel Sobrinho*
-
-*   Return all mappings for a timezone identifier in `country_zones`
-
-    Some timezones like `Europe/London` have multiple mappings in
-    `ActiveSupport::TimeZone::MAPPING` so return all of them instead
-    of the first one found by using `Hash#value`. e.g:
-
-        # Before
-        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh"]
-
-        # After
-        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh", "London"]
-
-    Fixes #31668.
-
-    *Andrew White*
-
 *   `String#truncate_bytes` to truncate a string to a maximum bytesize without
     breaking multibyte characters or grapheme clusters like 👩‍👩‍👦‍👦.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -4,13 +4,5 @@
 
     *Jeremy Daer*
 
-*   Fix minitest rails plugin.
-
-    The custom reporters are added only if needed.
-
-    This will fix conflicts with others plugins.
-
-    *Kevin Robatel*
-
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/railties/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Remove railties' changelog added by 7340596de45dc4c0f62a287b6acc4e71d8ee6c60
since it was backported to `5-2-stable` via ac99916fcf7bf27bb1519d4f7387c6b4c5f0463d

Remove activesupport's changelog added by 1077ae96b34b5a1dfbf10ee0c40b1ceb1eb6b30b
since it was backported to `5-2-stable` via a2b97e4ffef971607a1be8fc7909f099b6840f36

Remove activesupport's changelog added by 0d41a76d0c693000005d79456dee7f9299f5e8d4
since it was backported to `5-2-stable` via cdce6a709e1cbc98fff009effc3b1b3ce4c7e8db

Remove activestorage's changelog added by d57c52a385eb57c6ce8c6d124ab5e186f931d142
since it was backported to `5-2-stable` via 5292cdf59a2052c453d6016c69b90b790cbf2547

Follow up c113bdc9d0c2cffd535ca97aff85c4bdc46b11f6
/cc @guilleiguaran