### PR TITLE
Move up activestorage' changelog added by 5292cdf59a2052c453d6016c69b90b790cbf2547

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,11 +1,12 @@
-## Rails 5.2.0.rc1 (January 30, 2018) ##
-
 *   Add source code to published npm package
 
     This allows activestorage users to depend on the javascript source code
     rather than the compiled code, which can produce smaller javascript bundles.
 
     *Richard Macklin*
+
+
+## Rails 5.2.0.rc1 (January 30, 2018) ##
 
 *   Preserve display aspect ratio when extracting width and height from videos
     with rectangular samples in `ActiveStorage::Analyzer::VideoAnalyzer`.


### PR DESCRIPTION
It wasn't fixed in Rails 5.2.0.rc1 since it was backported after this release.