### PR TITLE
Fix "NameError: uninitialized constant Categorization::Category"

### DIFF
--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -5,6 +5,7 @@ require "models/post"
 require "models/comment"
 require "models/author"
 require "models/essay"
+require "models/category"
 require "models/categorization"
 require "models/person"
 


### PR DESCRIPTION
Since #31895, build of 2.5 and AR combination failed.
https://travis-ci.org/rails/rails/jobs/346064349#L1638

It seems to be the reason that model is not loading properly, so I added require. But I'm not sure if this is correct
