### PR TITLE
Correct `to` option's value of the route in the Bound Parameters sect…

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -549,7 +549,7 @@ In particular, simple routing makes it very easy to map legacy URLs to new Rails
 When you set up a regular route, you supply a series of symbols that Rails maps to parts of an incoming HTTP request. For example, consider this route:
 
 ```ruby
-get 'photos(/:id)', to: :display
+get 'photos(/:id)', to: 'photos#display'
 ```
 
 If an incoming request of `/photos/1` is processed by this route (because it hasn't matched any previous route in the file), then the result will be to invoke the `display` action of the `PhotosController`, and to make the final parameter `"1"` available as `params[:id]`. This route will also route the incoming request of `/photos` to `PhotosController#display`, since `:id` is an optional parameter, denoted by parentheses.


### PR DESCRIPTION
…ion in routing guide. [ci skip]

### Summary

On defining route `get 'photos(/:id)', to: :display` an exception is raised - `ArgumentError: Missing :controller key on routes definition, please check your routes.`.

So changing`get 'photos(/:id)', to: :display` to `get 'photos(/:id)', to: 'photos#display'`.
