### PR TITLE
Update to fix the same error as issue #26132

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -127,7 +127,7 @@ end
 
 module Enumerable
   def as_json(options = nil) #:nodoc:
-    to_a.as_json(options)
+    to_s.as_json(options)
   end
 end
 


### PR DESCRIPTION
There is some incompatibility generating the following error when you use the gems JSON and ActiveSupport:
IOError (not opened for reading).
This change fixes it.

### Summary

This fix was implemented for master branch (commit 813f8e333d) and I'm adding it to the 5-0 stable.