### PR TITLE
Remove extra changelog added by #31944

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -21,22 +21,6 @@
 
     *Tomas Valent*
 
-*   Return all mappings for a timezone identifier in `country_zones`
-
-    Some timezones like `Europe/London` have multiple mappings in
-    `ActiveSupport::TimeZone::MAPPING` so return all of them instead
-    of the first one found by using `Hash#value`. e.g:
-
-        # Before
-        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh"]
-
-        # After
-        ActiveSupport::TimeZone.country_zones("GB") # => ["Edinburgh", "London"]
-
-    Fixes #31668.
-
-    *Andrew White*
-
 *   `String#truncate_bytes` to truncate a string to a maximum bytesize without
     breaking multibyte characters or grapheme clusters like 👩‍👩‍👦‍👦.
 


### PR DESCRIPTION
Previously it was removed by #32106 since it was backported to `5-2-stable`.

[ci skip]