### PR TITLE
[ci skip]Change requring order of files in doc

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -532,12 +532,12 @@ require "rails"
 
 %w(
   active_record/railtie
+  active_storage/engine
   action_controller/railtie
   action_view/railtie
   action_mailer/railtie
   active_job/railtie
   action_cable/engine
-  active_storage/engine
   rails/test_unit/railtie
   sprockets/railtie
 ).each do |railtie|


### PR DESCRIPTION
This change was made at 4a835aa3236eedb135ccf8b59ed3c03e040b8b01

Current all.rb is [rails/all.rb at f86b221a53e8363b7c8a5688df603fc388b62b7c · rails/rails](https://github.com/rails/rails/blob/f86b221a53e8363b7c8a5688df603fc388b62b7c/railties/lib/rails/all.rb)