### PR TITLE
Uses the absolute path for system test screenshots

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -43,7 +43,7 @@ module ActionDispatch
           end
 
           def image_path
-            @image_path ||= absolute_image_path.relative_path_from(Pathname.pwd).to_s
+            @image_path ||= absolute_image_path.to_s
           end
 
           def absolute_image_path

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -9,7 +9,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     new_test = DrivenBySeleniumWithChrome.new("x")
 
     Rails.stub :root, Pathname.getwd do
-      assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+      assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
     end
   end
 
@@ -18,7 +18,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
 
     Rails.stub :root, Pathname.getwd do
       new_test.stub :passed?, false do
-        assert_equal "tmp/screenshots/failures_x.png", new_test.send(:image_path)
+        assert_equal Rails.root.join("tmp/screenshots/failures_x.png").to_s, new_test.send(:image_path)
       end
     end
   end
@@ -29,7 +29,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     Rails.stub :root, Pathname.getwd do
       new_test.stub :passed?, false do
         new_test.stub :skipped?, true do
-          assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+          assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
         end
       end
     end
@@ -59,11 +59,11 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     end
   end
 
-  test "image path returns the relative path from current directory" do
+  test "image path returns the absolute path from root" do
     new_test = DrivenBySeleniumWithChrome.new("x")
 
     Rails.stub :root, Pathname.getwd.join("..") do
-      assert_equal "../tmp/screenshots/x.png", new_test.send(:image_path)
+      assert_equal Rails.root.join("tmp/screenshots/x.png").to_s, new_test.send(:image_path)
     end
   end
 end


### PR DESCRIPTION
### Summary

* When getting an error that generates a screenshot it would be helpful
  to be able to ctrl+click it to quickly open it in the browser, which
  does not work with relative paths.
* This changes `image_path` to disregard the relative path and use the
  absolute one instead
