### PR TITLE
Add "rails routes --expanded" mode

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -243,7 +243,8 @@ module ActionDispatch
   #
   #   rails routes
   #
-  # Target specific controllers by prefixing the command with <tt>-c</tt> option.
+  # Target specific controllers by prefixing the command with <tt>-c</tt> option. Use
+  # <tt>--expanded</tt> to turn on the expanded table formatting mode.
   #
   module Routing
     extend ActiveSupport::Autoload

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1183,7 +1183,7 @@ $ bin/rails routes -c Comments
 $ bin/rails routes -c Articles::CommentsController
 ```
 
-TIP: You'll find that the output from `rails routes` is much more readable if you widen your terminal window until the output lines don't wrap.
+TIP: You'll find that the output from `rails routes` is much more readable if you widen your terminal window until the output lines don't wrap. You can also use --expanded option to turn on the expanded table formatting mode.
 
 ### Testing Routes
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Add "rails routes --expanded" option to output routes in expanded mode like
+    "psql --expanded". Result looks like:
+
+    ```
+    $ rails routes --expanded
+    --[ Route 1 ]------------------------------------------------------------
+    Prefix            | high_scores
+    Verb              | GET
+    URI               | /high_scores(.:format)
+    Controller#Action | high_scores#index
+    --[ Route 2 ]------------------------------------------------------------
+    Prefix            | new_high_score
+    Verb              | GET
+    URI               | /high_scores/new(.:format)
+    Controller#Action | high_scores#new
+    ```
+
+    *Benoit Tigeot*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -7,12 +7,14 @@ module Rails
     class RoutesCommand < Base # :nodoc:
       class_option :controller, aliases: "-c", type: :string, desc: "Specifies the controller."
       class_option :grep_pattern, aliases: "-g", type: :string, desc: "Specifies grep pattern."
+      class_option :expanded_format, aliases: "--expanded", type: :string, desc: "Turn on expanded format mode."
 
       no_commands do
         def help
           say "Usage: Print out all defined routes in match order, with names."
           say ""
           say "Target specific controller with -c option, or grep routes using -g option"
+          say "Use expanded format with --expanded option"
           say ""
         end
       end
@@ -24,7 +26,11 @@ module Rails
         all_routes = Rails.application.routes.routes
         inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
 
-        say inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, routes_filter)
+        if options.has_key?("expanded_format")
+          say inspector.format(ActionDispatch::Routing::ConsoleFormatter::Expanded.new, routes_filter)
+        else
+          say inspector.format(ActionDispatch::Routing::ConsoleFormatter::Sheet.new, routes_filter)
+        end
       end
 
       private

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -122,46 +122,6 @@ module ApplicationTests
         rails("stats")
     end
 
-    def test_rails_routes_calls_the_route_inspector
-      app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-          get '/cart', to: 'cart#show'
-        end
-      RUBY
-
-      output = rails("routes")
-      assert_equal <<~MESSAGE, output
-                              Prefix Verb URI Pattern                                                                       Controller#Action
-                                cart GET  /cart(.:format)                                                                   cart#show
-                  rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                        active_storage/blobs#show
-                rails_blob_variation GET  /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format) active_storage/variants#show
-                  rails_blob_preview GET  /rails/active_storage/previews/:signed_blob_id/:variation_key/*filename(.:format) active_storage/previews#show
-                  rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                       active_storage/disk#show
-           update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:format)                               active_storage/disk#update
-                rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                                    active_storage/direct_uploads#create
-      MESSAGE
-    end
-
-    def test_singular_resource_output_in_rake_routes
-      app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-          resource :post
-        end
-      RUBY
-
-      expected_output = ["   Prefix Verb   URI Pattern          Controller#Action",
-                         " new_post GET    /post/new(.:format)  posts#new",
-                         "edit_post GET    /post/edit(.:format) posts#edit",
-                         "     post GET    /post(.:format)      posts#show",
-                         "          PATCH  /post(.:format)      posts#update",
-                         "          PUT    /post(.:format)      posts#update",
-                         "          DELETE /post(.:format)      posts#destroy",
-                         "          POST   /post(.:format)      posts#create\n"].join("\n")
-
-      output = rails("routes", "-c", "PostController")
-      assert_equal expected_output, output
-    end
-
     def test_logger_is_flushed_when_exiting_production_rake_tasks
       add_to_config <<-RUBY
         rake_tasks do

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -119,6 +119,53 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     MESSAGE
   end
 
+  test "test rails routes with expanded option" do
+    app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/cart', to: 'cart#show'
+        end
+    RUBY
+
+    output = rails("routes", "--expanded")
+    assert_equal <<~MESSAGE, output
+    --[ Route 1 ]------------------------------------------------------------
+    Prefix            | cart
+    Verb              | GET
+    URI               | /cart(.:format)
+    Controller#Action | cart#show
+    --[ Route 2 ]------------------------------------------------------------
+    Prefix            | rails_service_blob
+    Verb              | GET
+    URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
+    Controller#Action | active_storage/blobs#show
+    --[ Route 3 ]------------------------------------------------------------
+    Prefix            | rails_blob_variation
+    Verb              | GET
+    URI               | /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format)
+    Controller#Action | active_storage/variants#show
+    --[ Route 4 ]------------------------------------------------------------
+    Prefix            | rails_blob_preview
+    Verb              | GET
+    URI               | /rails/active_storage/previews/:signed_blob_id/:variation_key/*filename(.:format)
+    Controller#Action | active_storage/previews#show
+    --[ Route 5 ]------------------------------------------------------------
+    Prefix            | rails_disk_service
+    Verb              | GET
+    URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
+    Controller#Action | active_storage/disk#show
+    --[ Route 6 ]------------------------------------------------------------
+    Prefix            | update_rails_disk_service
+    Verb              | PUT
+    URI               | /rails/active_storage/disk/:encoded_token(.:format)
+    Controller#Action | active_storage/disk#update
+    --[ Route 7 ]------------------------------------------------------------
+    Prefix            | rails_direct_uploads
+    Verb              | POST
+    URI               | /rails/active_storage/direct_uploads(.:format)
+    Controller#Action | active_storage/direct_uploads#create
+    MESSAGE
+  end
+
   private
 
     def run_routes_command(args = [])


### PR DESCRIPTION
### Summary

When using rails routes with small terminal or complicated routes it can be very difficult to understand where a specific element is, especially when using header. psql had the same issue, that's why they created "expanded mode" [long time ago](https://github.com/postgres/postgres/commit/a45195a191eec367a4f305bb71ab541d17a3b9f9#diff-c8870df945d6a1270e9d5ed30e41d3f4R107) that you can
switch using `\x` or by starting psql with
```
-x
--expanded

    Turn on the expanded table formatting mode. This is equivalent to the \x command.
```
The output is similar to one implemented here for `rails routes`:

```
db_user-# \du
List of roles
-[ RECORD 1 ]----------------------------------------------
Role name  | super
Attributes | Superuser, Create role, Create DB
Member of  | {}
-[ RECORD 2 ]----------------------------------------------
Role name  | role
Attributes | Superuser, Create role, Create DB, Replication
Member of  | {}
```

Here is an output expanded mode (I removed active storage routes):
```
$ rails routes --expanded
--[ Route 1 ]------------------------------------------------------------
Prefix            | high_scores
Verb              | GET
URI               | /high_scores(.:format)
Controller#Action | high_scores#index
--[ Route 2 ]------------------------------------------------------------
Prefix            | new_high_score
Verb              | GET
URI               | /high_scores/new(.:format)
Controller#Action | high_scores#new
--[ Route 3 ]------------------------------------------------------------
Prefix            | blog
Verb              |
URI               | /blog
Controller#Action | Blog::Engine

[ Routes for Blog::Engine ]
--[ Route 1 ]------------------------------------------------------------
Prefix            | cart
Verb              | GET
URI               | /cart(.:format)
Controller#Action | cart#show
````

### Other Information

- I didn't add an entry to changelog because it seems too early for me. Also, I didn't know where you want this to be targeted if it was approved.
- [App used to display routes](https://github.com/benoittgt/rails_app_test_rake_routes)
