### PR TITLE
Fix `new_framework_defaults_6_0.rb`

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -610,8 +610,8 @@ module ActionView
       #   unnecessary unless you support browsers without JavaScript.
       # * <tt>:local</tt> - By default form submits are remote and unobtrusive XHRs.
       #   Disable remote submits with <tt>local: true</tt>.
-      # * <tt>:skip_enforcing_utf8</tt> - By default a hidden field named +utf8+
-      #   is output to enforce UTF-8 submits. Set to true to skip the field.
+      # * <tt>:skip_enforcing_utf8</tt> - If set to true, a hidden input with name
+      #   utf8 is not output.
       # * <tt>:builder</tt> - Override the object used to build the form.
       # * <tt>:id</tt> - Optional HTML id attribute.
       # * <tt>:class</tt> - Optional HTML class attribute.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -7,4 +7,4 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Don't force requests from old versions of IE to be UTF-8 encoded
-# Rails.application.config.action_controller.default_enforce_utf8 = false
+# Rails.application.config.action_view.default_enforce_utf8 = false


### PR DESCRIPTION
`default_enforce_utf8` belongs to `config.action_view`

Update info about `:skip_enforcing_utf8` since we can change default
behavior via `config.action_controller.default_enforce_utf8`

Related to #32125
