### PR TITLE
Add support for root-relative path URLs to the disk service

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Add support for root-relative path URLs to the disk service.
+
+    Fixes #32129.
+
+    *Andrew White*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activestorage/test/service/configurator_test.rb
+++ b/activestorage/test/service/configurator_test.rb
@@ -4,11 +4,18 @@ require "service/shared_service_tests"
 
 class ActiveStorage::Service::ConfiguratorTest < ActiveSupport::TestCase
   test "builds correct service instance based on service name" do
-    service = ActiveStorage::Service::Configurator.build(:foo, foo: { service: "Disk", root: "path" })
+    configs = <<-YAML.strip_heredoc
+      foo:
+        service: Disk
+        root: path
+        host: https://example.com
+    YAML
+
+    service = ActiveStorage::Service::Configurator.build(:foo, YAML.load(configs))
 
     assert_instance_of ActiveStorage::Service::DiskService, service
     assert_equal "path", service.root
-    assert_equal "http://localhost:3000", service.host
+    assert_equal "https://example.com", service.host
   end
 
   test "raises error when passing non-existent service name" do

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -34,7 +34,7 @@ rescue Errno::ENOENT
 end
 
 require "tmpdir"
-ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"))
+ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"), host: "http://localhost:3000")
 
 ActiveStorage.logger = ActiveSupport::Logger.new(nil)
 ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
@@ -59,6 +59,10 @@ class ActiveSupport::TestCase
 
     def read_image(blob_or_variant)
       MiniMagick::Image.open blob_or_variant.service.send(:path_for, blob_or_variant.key)
+    end
+
+    def build_disk_service(host:)
+      ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"), host: host)
     end
 end
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -93,7 +93,7 @@ local:
   root: <%= Rails.root.join("storage") %>
 ```
 
-Optionally specify a host for generating URLs (the default is `http://localhost:3000`):
+Optionally specify a host for generating URLs (the default is to use root-relative path URLs):
 
 ```yaml
 local:


### PR DESCRIPTION
Also caches the url helpers module since that was being created every time an Active Storage url was generated.