### PR TITLE
Delegate child session assertions to parent session

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Include child session assertion count in ActionDispatch::IntegrationTest
+
+    `IntegrationTest#open_session` uses `dup` to create the new session, which
+    meant it had its own copy of `@assertions`. This prevented the assertions
+    from being correctly counted and reported.
+
+    Child sessions now have their `attr_accessor` overriden to delegate to the
+    root session.
+
+    Fixes #32142
+
+    *Sam Bostock*
 
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -310,6 +310,7 @@ module ActionDispatch
       APP_SESSIONS = {}
 
       attr_reader :app
+      attr_accessor :root_session # :nodoc:
 
       def initialize(*args, &blk)
         super(*args, &blk)
@@ -373,8 +374,17 @@ module ActionDispatch
       def open_session
         dup.tap do |session|
           session.reset!
+          session.root_session = self.root_session || self
           yield session if block_given?
         end
+      end
+
+      def assertions # :nodoc:
+        root_session ? root_session.assertions : super
+      end
+
+      def assertions=(assertions) # :nodoc:
+        root_session ? root_session.assertions = assertions : super
       end
 
       # Copy the instance variables from the current session instance into the

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -138,6 +138,14 @@ class IntegrationTestTest < ActiveSupport::TestCase
     assert_not session1.equal?(session2)
   end
 
+  def test_child_session_assertions_bubble_up_to_root
+    assertions_before = @test.assertions
+    @test.open_session.assert(true)
+    assertions_after = @test.assertions
+
+    assert_equal 1, assertions_after - assertions_before
+  end
+
   # RSpec mixes Matchers (which has a #method_missing) into
   # IntegrationTest's superclass.  Make sure IntegrationTest does not
   # try to delegate these methods to the session object.


### PR DESCRIPTION
### Summary

This fixes #32142, in which assertions made in sub-sessions in `ActionDispatch::IntegrationTest` are not counted in the test run report.

By overriding the `assertions` accessor methods on the child session to use the parent's `assertions`, the count is accurately tracked.

### Other Information

- Is this the appropriate fix, or is there a better way to delegate to the parent session?
- Is this the appropriate test? Should test report output be asserted on instead?

----
cc. @aud