### PR TITLE
Use Base.configurations in QueryCache.cache

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -7,7 +7,7 @@ module ActiveRecord
       # Enable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
       def cache(&block)
-        if connected? || !configurations.empty?
+        if connected? || !Base.configurations.empty?
           connection.cache(&block)
         else
           yield
@@ -17,7 +17,7 @@ module ActiveRecord
       # Disable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
       def uncached(&block)
-        if connected? || !configurations.empty?
+        if connected? || !Base.configurations.empty?
           connection.uncached(&block)
         else
           yield

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -302,6 +302,22 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_cache_uses_base_configurations
+    skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
+
+    model = Class.new(Post) do
+      def self.configurations
+        nil
+      end
+    end
+
+    with_temporary_connection_pool do
+      model.cache do
+        assert_queries(1) { Task.find(1); Task.find(1) }
+      end
+    end
+  end
+
   def test_cache_does_not_wrap_results_in_arrays
     Task.cache do
       if current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :PostgreSQLAdapter, :OracleAdapter)


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/29609.

Overriding the `.configurations` method doesn't affect how connections are established; it shouldn't change the query cache behaviour either.

This is going in the opposite direction to https://github.com/rails/rails/pull/32135 - but even if we want to allow models to override the base configuration we shouldn't make that change in a stable branch, and https://github.com/rails/rails/pull/29609 was backported to 5-1-stable and 5-0-stable.