### PR TITLE
Eager loading with polymorphic associations should behave consistently

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -67,9 +67,8 @@ module ActiveRecord
         end
       end
 
-      def initialize(base, table, associations, alias_tracker, eager_loading: true)
+      def initialize(base, table, associations, alias_tracker)
         @alias_tracker = alias_tracker
-        @eager_loading = eager_loading
         tree = self.class.make_tree associations
         @join_root = JoinBase.new(base, table, build(tree, base))
         @join_root.children.each { |child| construct_tables! @join_root, child }
@@ -200,12 +199,11 @@ module ActiveRecord
             reflection.check_eager_loadable!
 
             if reflection.polymorphic?
-              next unless @eager_loading
               raise EagerLoadPolymorphicError.new(reflection)
             end
 
             JoinAssociation.new(reflection, build(right, reflection.klass), alias_tracker)
-          end.compact
+          end
         end
 
         def construct(ar_parent, parent, row, rs, seen, model_cache, aliases)

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -371,16 +371,16 @@ module ActiveRecord
         relation
       end
 
-      def construct_join_dependency(eager_loading: true)
+      def construct_join_dependency
         including = eager_load_values + includes_values
         joins = joins_values.select { |join| join.is_a?(Arel::Nodes::Join) }
         ActiveRecord::Associations::JoinDependency.new(
-          klass, table, including, alias_tracker(joins), eager_loading: eager_loading
+          klass, table, including, alias_tracker(joins)
         )
       end
 
       def apply_join_dependency(eager_loading: true)
-        join_dependency = construct_join_dependency(eager_loading: eager_loading)
+        join_dependency = construct_join_dependency
         relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
 
         if eager_loading && !using_limitable_reflections?(join_dependency.reflections)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1501,8 +1501,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal posts(:welcome), post
   end
 
-  test "eager-loading with a polymorphic association and using the existential predicate" do
-    assert_equal true, authors(:david).essays.eager_load(:writer).exists?
+  test "eager-loading with a polymorphic association won't work consistently" do
+    assert_raise(ActiveRecord::EagerLoadPolymorphicError) { authors(:david).essays.eager_load(:writer).to_a }
+    assert_raise(ActiveRecord::EagerLoadPolymorphicError) { authors(:david).essays.eager_load(:writer).count }
+    assert_raise(ActiveRecord::EagerLoadPolymorphicError) { authors(:david).essays.eager_load(:writer).exists? }
   end
 
   # CollectionProxy#reader is expensive, so the preloader avoids calling it.


### PR DESCRIPTION
This reverts ignoring polymorphic error introduced at 02da8ae.

What the ignoring want to solve was caused by force eager loading
regardless of whether it is necessary, but it has been fixed by #29043.

The ignoring is now only causing a mismatch of `exists?` behavior with
`to_a`, `count`, etc. It should behave consistently.