### PR TITLE
Ruby 2.4: take advantage of String#unpack1

### DIFF
--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -23,7 +23,7 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
     end
 
     safe, unsafe = %w(: @ & = + $ , ;), %w(^ ? # [ ])
-    hex = unsafe.map { |char| "%" + char.unpack("H2").first.upcase }
+    hex = unsafe.map { |char| "%" + char.unpack1("H2").upcase }
 
     @segment = "#{safe.join}#{unsafe.join}".freeze
     @escaped = "#{safe.join}#{hex.join}".freeze

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -29,7 +29,7 @@ module ActiveModel
       private
 
         def define_method_attribute=(name)
-          safe_name = name.unpack("h*".freeze).first
+          safe_name = name.unpack1("h*".freeze)
           ActiveModel::AttributeMethods::AttrNames.set_name_cache safe_name, name
 
           generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1

--- a/activemodel/lib/active_model/type/binary.rb
+++ b/activemodel/lib/active_model/type/binary.rb
@@ -40,7 +40,7 @@ module ActiveModel
         alias_method :to_str, :to_s
 
         def hex
-          @value.unpack("H*")[0]
+          @value.unpack1("H*")
         end
 
         def ==(other)

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -27,7 +27,7 @@ module ActiveRecord
           # Making it frozen means that it doesn't get duped when used to
           # key the @attributes in read_attribute.
           def define_method_attribute(name)
-            safe_name = name.unpack("h*".freeze).first
+            safe_name = name.unpack1("h*".freeze)
             temp_method = "__temp__#{safe_name}"
 
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         private
 
           def define_method_attribute=(name)
-            safe_name = name.unpack("h*".freeze).first
+            safe_name = name.unpack1("h*".freeze)
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
             sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
 

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -56,7 +56,7 @@ module ActiveSupport
           write.close
           result = read.read
           Process.wait2(pid)
-          result.unpack("m")[0]
+          result.unpack1("m")
         end
       end
 
@@ -98,7 +98,7 @@ module ActiveSupport
                 nil
               end
 
-              return tmpfile.read.unpack("m")[0]
+              return tmpfile.read.unpack1("m")
             end
           end
         end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -36,13 +36,13 @@ else
       # key would break.
 
       expected = "b129376f68f1ecae788d7433310249d65ceec090ecacd4c872a3a9e9ec78e055739be5cc6956345d5ae38e7e1daa66f1de587dc8da2bf9e8b965af4b3918a122"
-      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64).generate_key("some_salt").unpack("H*").first
+      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64).generate_key("some_salt").unpack1("H*")
 
       expected = "b129376f68f1ecae788d7433310249d65ceec090ecacd4c872a3a9e9ec78e055"
-      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64).generate_key("some_salt", 32).unpack("H*").first
+      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64).generate_key("some_salt", 32).unpack1("H*")
 
       expected = "cbea7f7f47df705967dc508f4e446fd99e7797b1d70011c6899cd39bbe62907b8508337d678505a7dc8184e037f1003ba3d19fc5d829454668e91d2518692eae"
-      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64, iterations: 2).generate_key("some_salt").unpack("H*").first
+      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64, iterations: 2).generate_key("some_salt").unpack1("H*")
     end
   end
 


### PR DESCRIPTION
Now that we require Ruby 2.4, we can use `String#unpack1` instead of `str.unpack(…).first`.

https://bugs.ruby-lang.org/issues/12752
https://ruby-doc.org/core-2.4.0/String.html#method-i-unpack1