### PR TITLE
Allow Capybara 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "rake", ">= 11.1"
 # be loaded after loading the test library.
 gem "mocha", require: false
 
-gem "capybara", "~> 2.15"
+gem "capybara", ">= 2.15", "< 4.0"
 
 gem "rack-cache", "~> 1.2"
 gem "coffee-rails"

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "capybara", "~> 2.15"
+gem "capybara", ">= 2.15", "< 4.0"
 
 require "capybara/dsl"
 require "capybara/minitest"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -69,7 +69,7 @@ end
 <%- if depends_on_system_test? -%>
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.15'
+  gem 'capybara', '>= 2.15', '< 4.0'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'


### PR DESCRIPTION
### Summary

Capybara 3.0.0.rc1 has been released, and contains no changes that affect how Rails system tests integrate with it. 

This PR allows Rails users to use Capybara 3.x.  Would be great to have it backported to Rails 5.1 and 5.2 too

