### PR TITLE
Change message on the empty result of searching routes by `rails routes` with `-c` or `-g` 

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -243,9 +243,9 @@ module ActionDispatch
   #
   #   rails routes
   #
-  # Target specific controllers by prefixing the command with <tt>-c</tt> option. Use
-  # <tt>--expanded</tt> to turn on the expanded table formatting mode.
-  #
+  # Target a specific controller with <tt>-c</tt>, or grep routes
+  # using <tt>-g</tt>. Useful in conjunction with <tt>--expanded</tt>
+  # which displays routes vertically.
   module Routing
     extend ActiveSupport::Autoload
 

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         @set = ActionDispatch::Routing::RouteSet.new
       end
 
-      def draw(options = nil, formater = ActionDispatch::Routing::ConsoleFormatter::Sheet.new, &block)
+      def draw(options = {}, formater = ActionDispatch::Routing::ConsoleFormatter::Sheet.new, &block)
         @set.draw(&block)
         inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)
         inspector.format(formater, options).split("\n")
@@ -306,7 +306,7 @@ module ActionDispatch
       end
 
       def test_routes_can_be_filtered
-        output = draw("posts") do
+        output = draw(grep_pattern: "posts") do
           resources :articles
           resources :posts
         end
@@ -335,7 +335,7 @@ module ActionDispatch
           get "/cart", to: "cart#show"
         end
 
-        output = draw(nil, ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
+        output = draw({}, ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
           get "/custom/assets", to: "custom_assets#show"
           get "/custom/furnitures", to: "custom_furnitures#show"
           mount engine => "/blog", :as => "blog"
@@ -368,18 +368,18 @@ module ActionDispatch
       end
 
       def test_no_routes_matched_filter_when_expanded
-        output = draw("rails/dummy", ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
+        output = draw({ grep_pattern: "rails/dummy" }, ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
           get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
         end
 
         assert_equal [
-          "No routes were found for this controller",
+          "No routes were found for this grep pattern.",
           "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
         ], output
       end
 
       def test_not_routes_when_expanded
-        output = draw("rails/dummy", ActionDispatch::Routing::ConsoleFormatter::Expanded.new) {}
+        output = draw({ grep_pattern: "rails/dummy" }, ActionDispatch::Routing::ConsoleFormatter::Expanded.new) {}
 
         assert_equal [
           "You don't have any routes defined!",
@@ -391,7 +391,7 @@ module ActionDispatch
       end
 
       def test_routes_can_be_filtered_with_namespaced_controllers
-        output = draw("admin/posts") do
+        output = draw(grep_pattern: "admin/posts") do
           resources :articles
           namespace :admin do
             resources :posts
@@ -439,24 +439,24 @@ module ActionDispatch
         end
 
         assert_equal [
-          "No routes were found for this controller",
+          "No routes were found for this controller.",
           "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
         ], output
       end
 
       def test_no_routes_matched_filter
-        output = draw("rails/dummy") do
+        output = draw(grep_pattern: "rails/dummy") do
           get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
         end
 
         assert_equal [
-          "No routes were found for this controller",
+          "No routes were found for this grep pattern.",
           "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
         ], output
       end
 
       def test_no_routes_were_defined
-        output = draw("Rails::DummyController") {}
+        output = draw(grep_pattern: "Rails::DummyController") {}
 
         assert_equal [
           "You don't have any routes defined!",

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -36,13 +36,7 @@ module Rails
       private
 
         def routes_filter
-          if options.has_key?("controller")
-            { controller: options["controller"] }
-          elsif options.has_key?("grep_pattern")
-            options["grep_pattern"]
-          else
-            nil
-          end
+          options.symbolize_keys.slice(:controller, :grep_pattern)
         end
     end
   end


### PR DESCRIPTION
- Improve docs of `ActionDispatch::Routing`
  - Add a mention about `-g`.
  - Improve info about `--expanded` option of `rails routes`.

- Introduce `ActionDispatch::Routing::ConsoleFormatter::Base`
  - Create `Base` and inherit `Sheet` and `Expanded` in order to
    prevent code duplication.
    - Remove trailing "\n" for components of `Expanded`.
    - There is no need for `Expanded#header` to return `@buffer` so return `nil` instead.
  - Change `no_routes` message "No routes were found for this controller"
    since if use `-g`, it sounds incorrect.
    - Display `No routes were found for this controller.` if apply `-c`.
    - Display `No routes were found for this grep pattern.` if apply `-g`.

Related to #32130