### PR TITLE
Deprecate `active_support/core_ext/hash/compact`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/compact"
-
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     class SchemaDumper < SchemaDumper # :nodoc:

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/compact"
-
 module ActiveStorage
   # Extracts the following from a video blob:
   #

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/compact"
 require "active_support/core_ext/hash/conversions"
 require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/hash/except"

--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -1,29 +1,5 @@
 # frozen_string_literal: true
 
-class Hash
-  unless Hash.instance_methods(false).include?(:compact)
-    # Returns a hash with non +nil+ values.
-    #
-    #   hash = { a: true, b: false, c: nil }
-    #   hash.compact        # => { a: true, b: false }
-    #   hash                # => { a: true, b: false, c: nil }
-    #   { c: nil }.compact  # => {}
-    #   { c: true }.compact # => { c: true }
-    def compact
-      select { |_, value| !value.nil? }
-    end
-  end
+require "active_support/deprecation"
 
-  unless Hash.instance_methods(false).include?(:compact!)
-    # Replaces current hash with non +nil+ values.
-    # Returns +nil+ if no changes were made, otherwise returns the hash.
-    #
-    #   hash = { a: true, b: false, c: nil }
-    #   hash.compact!        # => { a: true, b: false }
-    #   hash                 # => { a: true, b: false }
-    #   { c: true }.compact! # => nil
-    def compact!
-      reject! { |_, value| value.nil? }
-    end
-  end
-end
+ActiveSupport::Deprecation.warn "Ruby 2.4+ (required by Rails 6) provides Hash#compact and Hash#compact! natively, so requiring active_support/core_ext/hash/compact is no longer necessary. Requiring it will raise LoadError in Rails 6.1."

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -45,8 +45,6 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
-    assert_respond_to h, :compact
-    assert_respond_to h, :compact!
     assert_respond_to h, :except
     assert_respond_to h, :except!
   end
@@ -456,38 +454,10 @@ class HashExtTest < ActiveSupport::TestCase
     end
   end
 
-  def test_compact
-    hash_contain_nil_value = @symbols.merge(z: nil)
-    hash_with_only_nil_values = { a: nil, b: nil }
-
-    h = hash_contain_nil_value.dup
-    assert_equal(@symbols, h.compact)
-    assert_equal(hash_contain_nil_value, h)
-
-    h = hash_with_only_nil_values.dup
-    assert_equal({}, h.compact)
-    assert_equal(hash_with_only_nil_values, h)
-
-    h = @symbols.dup
-    assert_equal(@symbols, h.compact)
-    assert_equal(@symbols, h)
-  end
-
-  def test_compact!
-    hash_contain_nil_value = @symbols.merge(z: nil)
-    hash_with_only_nil_values = { a: nil, b: nil }
-
-    h = hash_contain_nil_value.dup
-    assert_equal(@symbols, h.compact!)
-    assert_equal(@symbols, h)
-
-    h = hash_with_only_nil_values.dup
-    assert_equal({}, h.compact!)
-    assert_equal({}, h)
-
-    h = @symbols.dup
-    assert_nil(h.compact!)
-    assert_equal(@symbols, h)
+  def test_requiring_compact_is_deprecated
+    assert_deprecated do
+      require "active_support/core_ext/hash/compact"
+    end
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2818,16 +2818,6 @@ The method `with_indifferent_access` returns an `ActiveSupport::HashWithIndiffer
 
 NOTE: Defined in `active_support/core_ext/hash/indifferent_access.rb`.
 
-### Compacting
-
-The methods `compact` and `compact!` return a Hash without items with `nil` value.
-
-```ruby
-{a: 1, b: 2, c: nil}.compact # => {a: 1, b: 2}
-```
-
-NOTE: Defined in `active_support/core_ext/hash/compact.rb`.
-
 Extensions to `Regexp`
 ----------------------
 


### PR DESCRIPTION
Ruby 2.4+ provides `Hash#compact` and `Hash#compact!` natively, so `active_support/core_ext/hash/compact` is no longer necessary.

