### PR TITLE
Deprecate "active_support/core_ext/numeric/inquiry"

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric.rb
+++ b/activesupport/lib/active_support/core_ext/numeric.rb
@@ -2,5 +2,4 @@
 
 require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"
-require "active_support/core_ext/numeric/inquiry"
 require "active_support/core_ext/numeric/conversions"

--- a/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
@@ -1,28 +1,5 @@
 # frozen_string_literal: true
 
-unless 1.respond_to?(:positive?) # TODO: Remove this file when we drop support to ruby < 2.3
-  class Numeric
-    # Returns true if the number is positive.
-    #
-    #   1.positive?  # => true
-    #   0.positive?  # => false
-    #   -1.positive? # => false
-    def positive?
-      self > 0
-    end
+require "active_support/deprecation"
 
-    # Returns true if the number is negative.
-    #
-    #   -1.negative? # => true
-    #   0.negative?  # => false
-    #   1.negative?  # => false
-    def negative?
-      self < 0
-    end
-  end
-
-  class Complex
-    undef :positive?
-    undef :negative?
-  end
-end
+ActiveSupport::Deprecation.warn "Ruby 2.4+ (required by Rails 6) provides Numeric#positive? and Numeric#negative? natively, so requiring active_support/core_ext/numeric/inquiry is no longer necessary. Requiring it will raise LoadError in Rails 6.1."

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/numeric/inquiry"
-
 module ActiveSupport
   module NumberHelper
     class NumberToCurrencyConverter < NumberConverter # :nodoc:

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -406,86 +406,9 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal 10_000, 10.seconds.in_milliseconds
   end
 
-  # TODO: Remove positive and negative tests when we drop support to ruby < 2.3
-  b = 2**64
-
-  T_ZERO = b.coerce(0).first
-  T_ONE  = b.coerce(1).first
-  T_MONE = b.coerce(-1).first
-
-  def test_positive
-    assert_predicate(1, :positive?)
-    assert_not_predicate(0, :positive?)
-    assert_not_predicate(-1, :positive?)
-    assert_predicate(+1.0, :positive?)
-    assert_not_predicate(+0.0, :positive?)
-    assert_not_predicate(-0.0, :positive?)
-    assert_not_predicate(-1.0, :positive?)
-    assert_predicate(+(0.0.next_float), :positive?)
-    assert_not_predicate(-(0.0.next_float), :positive?)
-    assert_predicate(Float::INFINITY, :positive?)
-    assert_not_predicate(-Float::INFINITY, :positive?)
-    assert_not_predicate(Float::NAN, :positive?)
-
-    a = Class.new(Numeric) do
-      def >(x); true; end
-    end.new
-    assert_predicate(a, :positive?)
-
-    a = Class.new(Numeric) do
-      def >(x); false; end
-    end.new
-    assert_not_predicate(a, :positive?)
-
-    assert_predicate(1 / 2r, :positive?)
-    assert_not_predicate(-1 / 2r, :positive?)
-
-    assert_predicate(T_ONE, :positive?)
-    assert_not_predicate(T_MONE, :positive?)
-    assert_not_predicate(T_ZERO, :positive?)
-
-    e = assert_raises(NoMethodError) do
-      Complex(1).positive?
+  def test_requiring_inquiry_is_deprecated
+    assert_deprecated do
+      require "active_support/core_ext/numeric/inquiry"
     end
-
-    assert_match(/positive\?/, e.message)
-  end
-
-  def test_negative
-    assert_predicate(-1, :negative?)
-    assert_not_predicate(0, :negative?)
-    assert_not_predicate(1, :negative?)
-    assert_predicate(-1.0, :negative?)
-    assert_not_predicate(-0.0, :negative?)
-    assert_not_predicate(+0.0, :negative?)
-    assert_not_predicate(+1.0, :negative?)
-    assert_predicate(-(0.0.next_float), :negative?)
-    assert_not_predicate(+(0.0.next_float), :negative?)
-    assert_predicate(-Float::INFINITY, :negative?)
-    assert_not_predicate(Float::INFINITY, :negative?)
-    assert_not_predicate(Float::NAN, :negative?)
-
-    a = Class.new(Numeric) do
-      def <(x); true; end
-    end.new
-    assert_predicate(a, :negative?)
-
-    a = Class.new(Numeric) do
-      def <(x); false; end
-    end.new
-    assert_not_predicate(a, :negative?)
-
-    assert_predicate(-1 / 2r, :negative?)
-    assert_not_predicate(1 / 2r, :negative?)
-
-    assert_not_predicate(T_ONE, :negative?)
-    assert_predicate(T_MONE, :negative?)
-    assert_not_predicate(T_ZERO, :negative?)
-
-    e = assert_raises(NoMethodError) do
-      Complex(1).negative?
-    end
-
-    assert_match(/negative\?/, e.message)
   end
 end


### PR DESCRIPTION
Numeric#positive? and Numeric#negative? was added to Ruby since 2.3,
see https://github.com/ruby/ruby/blob/ruby_2_3/NEWS
Rails 6 requires Ruby 2.4.1+ since #32034