### PR TITLE
Add queue name support to ActiveJob::QueueAdapters::QueAdapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Add queue name support to `ActiveJob::QueueAdapters::QueAdapter`.
+
+    *Brad Nauta*
+
 *   Add support for timezones to Active Job
 
     Record what was the current timezone in effect when the job was
@@ -15,6 +19,5 @@
 *   Add support to define custom argument serializers.
 
     *Evgenii Pecherkin*, *Rafael Mendonça França*
-
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -18,13 +18,13 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :que
     class QueAdapter
       def enqueue(job) #:nodoc:
-        que_job = JobWrapper.enqueue job.serialize, priority: job.priority
+        que_job = JobWrapper.enqueue job.serialize, priority: job.priority, queue: job.queue_name
         job.provider_job_id = que_job.attrs["job_id"]
         que_job
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        que_job = JobWrapper.enqueue job.serialize, priority: job.priority, run_at: Time.at(timestamp)
+        que_job = JobWrapper.enqueue job.serialize, priority: job.priority, queue: job.queue_name, run_at: Time.at(timestamp)
         job.provider_job_id = que_job.attrs["job_id"]
         que_job
       end

--- a/activejob/test/adapters/que.rb
+++ b/activejob/test/adapters/que.rb
@@ -4,3 +4,4 @@ require "support/que/inline"
 
 ActiveJob::Base.queue_adapter = :que
 Que.mode = :sync
+Que.queue_name = :integration_tests

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -14,7 +14,7 @@ class QueuingTest < ActiveSupport::TestCase
   end
 
   test "should not run jobs queued on a non-listening queue" do
-    skip if adapter_is?(:inline, :async, :sucker_punch, :que)
+    skip if adapter_is?(:inline, :async, :sucker_punch)
     old_queue = TestJob.queue_name
 
     begin

--- a/activejob/test/support/que/inline.rb
+++ b/activejob/test/support/que/inline.rb
@@ -9,6 +9,7 @@ Que::Job.class_eval do
       options = args.pop
       options.delete(:run_at)
       options.delete(:priority)
+      options.delete(:queue)
       args << options unless options.empty?
     end
     run(*args)


### PR DESCRIPTION
### Summary

`ActiveJob::QueueAdapters::QueAdapter` is documented as [supporting queues](https://github.com/rails/rails/blob/master/activejob/lib/active_job/queue_adapters.rb#L27), however the adapter doesn't actually set [Que](https://github.com/chanks/que) queue names when creating jobs. Rather, all jobs are lumped into a `''`/blank queue for workers to pick up.

This commit simply passes the queue_name as set by ActiveJob to Que's own queue handler. Trivial patch that's long overdue for Que users 😃 