### PR TITLE
Update `guides/CHANGELOG.md`

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Rails 5.2.0.rc1 (January 30, 2018) ##
 
-*   No changes.
+*   Add "Active Storage Overview" Guide.
+
+    *Jeffrey Guenther*, *George Claghorn*
 
 
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
@@ -10,6 +12,9 @@
 
 ## Rails 5.2.0.beta1 (November 27, 2017) ##
 
-*   No changes.
+*   Add "Threading and Code Execution in Rails" Guide.
+
+    *Matthew Draper*
+
 
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/guides/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
To Rails 5.2.0.beta1 was added "Threading and Code Execution in Rails" Guide
by 8bfa617e9990b05061c2f481afe87e055b6a6106.

To Rails 5.2.0.rc1 was added "Active Storage Overview" Guide
by 48fbc4aec845eeb51708a68806453528fab07d14.

This commit adds changelogs about adding these guides.
I think it deserves to be mentioned in`guides/CHANGELOG.md`