### PR TITLE
Draw line of a route name to the end of row console on `rails routes --expanded`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "delegate"
+require "io/console/size"
 
 module ActionDispatch
   module Routing
@@ -225,13 +226,21 @@ module ActionDispatch
           def draw_expanded_section(routes)
             routes.map.each_with_index do |r, i|
               <<~MESSAGE
-              --[ Route #{i + 1} ]#{'-' * 60}
+              #{route_header(index: i + 1)}
               Prefix            | #{r[:name]}
               Verb              | #{r[:verb]}
               URI               | #{r[:path]}
               Controller#Action | #{r[:reqs]}
               MESSAGE
             end
+          end
+
+          def route_header(index:)
+            console_width = IO.console_size.second
+            header_prefix = "--[ Route #{index} ]"
+            dash_remainder = [console_width - header_prefix.size, 0].max
+
+            "#{header_prefix}#{'-' * dash_remainder}"
           end
       end
     end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 require "rails/engine"
 require "action_dispatch/routing/inspector"
+require "io/console/size"
 
 class MountedRackApp
   def self.call(env)
@@ -322,6 +323,9 @@ module ActionDispatch
       end
 
       def test_routes_when_expanded
+        previous_console_winsize = IO.console.winsize
+        IO.console.winsize = [0, 23]
+
         engine = Class.new(Rails::Engine) do
           def self.inspect
             "Blog::Engine"
@@ -337,30 +341,31 @@ module ActionDispatch
           mount engine => "/blog", :as => "blog"
         end
 
-        assert_equal ["--[ Route 1 ]------------------------------------------------------------",
+        assert_equal ["--[ Route 1 ]----------",
                       "Prefix            | custom_assets",
                       "Verb              | GET",
                       "URI               | /custom/assets(.:format)",
                       "Controller#Action | custom_assets#show",
-                      "--[ Route 2 ]------------------------------------------------------------",
+                      "--[ Route 2 ]----------",
                       "Prefix            | custom_furnitures",
                       "Verb              | GET",
                       "URI               | /custom/furnitures(.:format)",
                       "Controller#Action | custom_furnitures#show",
-                      "--[ Route 3 ]------------------------------------------------------------",
+                      "--[ Route 3 ]----------",
                       "Prefix            | blog",
                       "Verb              | ",
                       "URI               | /blog",
                       "Controller#Action | Blog::Engine",
                       "",
                       "[ Routes for Blog::Engine ]",
-                      "--[ Route 1 ]------------------------------------------------------------",
+                      "--[ Route 1 ]----------",
                       "Prefix            | cart",
                       "Verb              | GET",
                       "URI               | /cart(.:format)",
                       "Controller#Action | cart#show"], output
+      ensure
+        IO.console.winsize = previous_console_winsize
       end
-
 
       def test_no_routes_matched_filter_when_expanded
         output = draw("rails/dummy", ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -3,6 +3,7 @@
 require "isolation/abstract_unit"
 require "rails/command"
 require "rails/commands/routes/routes_command"
+require "io/console/size"
 
 class Rails::Command::RoutesTest < ActiveSupport::TestCase
   setup :build_app
@@ -117,45 +118,53 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
   end
 
   test "rails routes with expanded option" do
-    app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-          get '/cart', to: 'cart#show'
-        end
-    RUBY
+    begin
+      previous_console_winsize = IO.console.winsize
+      IO.console.winsize = [0, 27]
 
-    output = rails("routes", "--expanded")
-    assert_equal <<~MESSAGE, output
-    --[ Route 1 ]------------------------------------------------------------
-    Prefix            | cart
-    Verb              | GET
-    URI               | /cart(.:format)
-    Controller#Action | cart#show
-    --[ Route 2 ]------------------------------------------------------------
-    Prefix            | rails_service_blob
-    Verb              | GET
-    URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
-    Controller#Action | active_storage/blobs#show
-    --[ Route 3 ]------------------------------------------------------------
-    Prefix            | rails_blob_representation
-    Verb              | GET
-    URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
-    Controller#Action | active_storage/representations#show
-    --[ Route 4 ]------------------------------------------------------------
-    Prefix            | rails_disk_service
-    Verb              | GET
-    URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
-    Controller#Action | active_storage/disk#show
-    --[ Route 5 ]------------------------------------------------------------
-    Prefix            | update_rails_disk_service
-    Verb              | PUT
-    URI               | /rails/active_storage/disk/:encoded_token(.:format)
-    Controller#Action | active_storage/disk#update
-    --[ Route 6 ]------------------------------------------------------------
-    Prefix            | rails_direct_uploads
-    Verb              | POST
-    URI               | /rails/active_storage/direct_uploads(.:format)
-    Controller#Action | active_storage/direct_uploads#create
-    MESSAGE
+      app_file "config/routes.rb", <<-RUBY
+          Rails.application.routes.draw do
+            get '/cart', to: 'cart#show'
+          end
+      RUBY
+
+      output = run_routes_command(["--expanded"])
+
+      assert_equal <<~MESSAGE, output
+      --[ Route 1 ]--------------
+      Prefix            | cart
+      Verb              | GET
+      URI               | /cart(.:format)
+      Controller#Action | cart#show
+      --[ Route 2 ]--------------
+      Prefix            | rails_service_blob
+      Verb              | GET
+      URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
+      Controller#Action | active_storage/blobs#show
+      --[ Route 3 ]--------------
+      Prefix            | rails_blob_representation
+      Verb              | GET
+      URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
+      Controller#Action | active_storage/representations#show
+      --[ Route 4 ]--------------
+      Prefix            | rails_disk_service
+      Verb              | GET
+      URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
+      Controller#Action | active_storage/disk#show
+      --[ Route 5 ]--------------
+      Prefix            | update_rails_disk_service
+      Verb              | PUT
+      URI               | /rails/active_storage/disk/:encoded_token(.:format)
+      Controller#Action | active_storage/disk#update
+      --[ Route 6 ]--------------
+      Prefix            | rails_direct_uploads
+      Verb              | POST
+      URI               | /rails/active_storage/direct_uploads(.:format)
+      Controller#Action | active_storage/direct_uploads#create
+      MESSAGE
+    ensure
+      IO.console.winsize = previous_console_winsize
+    end
   end
 
   private


### PR DESCRIPTION
In order to get width of console use `IO::console_size`,
See https://ruby-doc.org/stdlib-2.4.1/libdoc/io/console/rdoc/IO.html#method-c-console_size

Related to #32130
