### PR TITLE
`id_in_database` should be respected as primary key value for persisted records

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -94,7 +94,7 @@ module ActiveRecord
             relation = self.class.unscoped
 
             affected_rows = relation.where(
-              self.class.primary_key => id,
+              self.class.primary_key => id_in_database,
               lock_col => previous_lock_value
             ).update_all(
               attributes_for_update(attribute_names).map do |name|

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -691,7 +691,7 @@ module ActiveRecord
     end
 
     def _relation_for_itself
-      self.class.unscoped.where(self.class.primary_key => id)
+      self.class.unscoped.where(self.class.primary_key => id_in_database)
     end
 
     def create_or_update(*args, &block)

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -194,6 +194,45 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_update_with_dirty_primary_key
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      person = Person.find(1)
+      person.id = 2
+      person.save!
+    end
+
+    person = Person.find(1)
+    person.id = 42
+    person.save!
+
+    assert Person.find(42)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Person.find(1)
+    end
+  end
+
+  def test_delete_with_dirty_primary_key
+    person = Person.find(1)
+    person.id = 2
+    person.delete
+
+    assert Person.find(2)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Person.find(1)
+    end
+  end
+
+  def test_destroy_with_dirty_primary_key
+    person = Person.find(1)
+    person.id = 2
+    person.destroy
+
+    assert Person.find(2)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Person.find(1)
+    end
+  end
+
   def test_explicit_update_lock_column_raise_error
     person = Person.find(1)
 


### PR DESCRIPTION
Currently primary key value can not be updated if a record has a locking
column because of `_update_record` in `Locking::Optimistic` doesn't
respect `id_in_database` as primary key value unlike in `Persistence`.

And also, if a record has dirty primary key value, it may destroy any
other record by the lock version of dirty record itself.

When updating/destroying persisted records, it should identify
themselves by `id_in_database`, not by dirty primary key value.