### PR TITLE
Fix actionview tests execution

### DIFF
--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -4,10 +4,6 @@ require "abstract_unit"
 require "active_model"
 require "controller/fake_models"
 
-class ApplicationController < ActionController::Base
-  self.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
-end
-
 module Quiz
   # Models
   Question = Struct.new(:name, :id) do
@@ -20,7 +16,7 @@ module Quiz
   end
 
   # Controller
-  class QuestionsController < ApplicationController
+  class QuestionsController < ActionController::Base
     def new
       render partial: Quiz::Question.new("Namespaced Partial")
     end
@@ -28,7 +24,7 @@ module Quiz
 end
 
 module Fun
-  class GamesController < ApplicationController
+  class GamesController < ActionController::Base
     def hello_world; end
 
     def nested_partial_with_form_builder
@@ -37,7 +33,7 @@ module Fun
   end
 end
 
-class TestController < ApplicationController
+class TestController < ActionController::Base
   protect_from_forgery
 
   before_action :set_variable_for_layout
@@ -640,10 +636,15 @@ class RenderTest < ActionController::TestCase
     ActionView::Base.logger = ActiveSupport::Logger.new(nil)
 
     @request.host = "www.nextangle.com"
+
+    @old_view_paths = ActionController::Base.view_paths
+    ActionController::Base.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
   end
 
   def teardown
     ActionView::Base.logger = nil
+
+    ActionController::Base.view_paths = @old_view_paths
   end
 
   # :ported:


### PR DESCRIPTION
On my local environment execution of `cd actionview/ && bin/test` raises error:

```
(snip)
rails/actionview/test/template/render_test.rb:6:in `<top (required)>': superclass mismatch for class TestController (TypeError)
```

In some test files `TestController` inherited from `ActionController::Base`,
but in `test/actionpack/controller/render_test.rb` file `TestController`
inherited from `ApplicationController`.
This produces error `superclass mismatch for class TestController (TypeError)`

Step to reproduce this on any environment:
```
cd actionview/ && bin/test test/template/streaming_render_test.rb test/actionpack/controller/render_test.rb
```