### PR TITLE
Fix that after commit callbacks on update does not triggered when optimistic locking is enabled

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -656,18 +656,11 @@ module ActiveRecord
         MSG
       end
 
-      time ||= current_time_from_proper_timezone
       attribute_names = timestamp_attributes_for_update_in_model
       attribute_names.concat(names)
 
       unless attribute_names.empty?
-        attribute_names.each do |attr_name|
-          write_attribute(attr_name, time)
-          clear_attribute_change(attr_name)
-        end
-
-        affected_rows = _update_row(attribute_names, "touch")
-
+        affected_rows = _touch_row(attribute_names, time)
         @_trigger_update_callback = affected_rows == 1
       else
         true
@@ -688,7 +681,18 @@ module ActiveRecord
       self.class._delete_record(self.class.primary_key => id_in_database)
     end
 
-    def _update_row(attribute_names, attempted_action)
+    def _touch_row(attribute_names, time)
+      time ||= current_time_from_proper_timezone
+
+      attribute_names.each do |attr_name|
+        write_attribute(attr_name, time)
+        clear_attribute_change(attr_name)
+      end
+
+      _update_row(attribute_names, "touch")
+    end
+
+    def _update_row(attribute_names, attempted_action = "update")
       self.class._update_record(
         attributes_with_values(attribute_names),
         self.class.primary_key => id_in_database
@@ -712,7 +716,7 @@ module ActiveRecord
         affected_rows = 0
         @_trigger_update_callback = true
       else
-        affected_rows = _update_row(attribute_names, "update")
+        affected_rows = _update_row(attribute_names)
         @_trigger_update_callback = affected_rows == 1
       end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -394,6 +394,28 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
 end
 
+class TransactionAfterCommitCallbacksWithOptimisticLockingTest < ActiveRecord::TestCase
+  class PersonWithCallbacks < ActiveRecord::Base
+    self.table_name = :people
+
+    after_create_commit { |record| record.history << :commit_on_create }
+    after_update_commit { |record| record.history << :commit_on_update }
+    after_destroy_commit { |record| record.history << :commit_on_destroy }
+
+    def history
+      @history ||= []
+    end
+  end
+
+  def test_after_commit_callbacks_with_optimistic_locking
+    person = PersonWithCallbacks.create!(first_name: "first name")
+    person.update!(first_name: "another name")
+    person.destroy
+
+    assert_equal [:commit_on_create, :commit_on_update, :commit_on_destroy], person.history
+  end
+end
+
 class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 


### PR DESCRIPTION
This issue is caused by `@_trigger_update_callback` won't be updated due
to `_update_record` in `Locking::Optimistic` doesn't call `super` when
optimistic locking is enabled.

Now optimistic locking concern when updating is supported by
`_update_row` low level API, therefore overriding `_update_record` is no
longer necessary.

Removing the method just fix the issue.

Closes #29096.
Closes #29321.
Closes #30823.