### PR TITLE
`#ordinal` and `#ordinalize` now support I18n

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   `ActiveSupport::Inflector#ordinal` and `ActiveSupport::Inflector#ordinalize` now support
+    translations through I18n.
+
+        # locale/fr.rb
+
+        {
+          fr: {
+            number: {
+              nth: {
+                ordinals: lambda do |_key, number:, **_options|
+                  if number.to_i.abs == 1
+                    'er'
+                  else
+                    'e'
+                  end
+                end,
+
+                ordinalized: lambda do |_key, number:, **_options|
+                  "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+                end
+              }
+            }
+          }
+        }
+
+
+    *Christian Blais*
+
 *   Add `:private` option to ActiveSupport's `Module#delegate`
     in order to delegate methods as private:
 

--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -13,3 +13,4 @@ require "active_support/lazy_load_hooks"
 
 ActiveSupport.run_load_hooks(:i18n)
 I18n.load_path << File.expand_path("locale/en.yml", __dir__)
+I18n.load_path << File.expand_path("locale/en.rb", __dir__)

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -341,18 +341,7 @@ module ActiveSupport
     #   ordinal(-11)   # => "th"
     #   ordinal(-1021) # => "st"
     def ordinal(number)
-      abs_number = number.to_i.abs
-
-      if (11..13).include?(abs_number % 100)
-        "th"
-      else
-        case abs_number % 10
-        when 1; "st"
-        when 2; "nd"
-        when 3; "rd"
-        else    "th"
-        end
-      end
+      I18n.translate("number.nth.ordinals", number: number)
     end
 
     # Turns a number into an ordinal string used to denote the position in an
@@ -365,7 +354,7 @@ module ActiveSupport
     #   ordinalize(-11)   # => "-11th"
     #   ordinalize(-1021) # => "-1021st"
     def ordinalize(number)
-      "#{number}#{ordinal(number)}"
+      I18n.translate("number.nth.ordinalized", number: number)
     end
 
     private

--- a/activesupport/lib/active_support/locale/en.rb
+++ b/activesupport/lib/active_support/locale/en.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+{
+  en: {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+
+          if (11..13).cover?(abs_number % 100)
+            "th"
+          else
+            case abs_number % 10
+            when 1 then "st"
+            when 2 then "nd"
+            when 3 then "rd"
+            else "th"
+            end
+          end
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}


### PR DESCRIPTION
`ActiveSupport::Inflector#ordinal` and `ActiveSupport::Inflector#ordinalize` now support translations through I18n.

```ruby
        {
          fr: {
            number: {
              nth: {
                ordinals: lambda do |_key, number:, **_options|
                  if number.to_i.abs == 1
                    'er'
                  else
                    'e'
                  end
                end,

                ordinalized: lambda do |_key, number:, **_options|
                  "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
                end
              }
            }
          }
        }
```

### Summary

The current implementation of `ActiveSupport::Inflector#ordinal` and `ActiveSupport::Inflector#ordinalize` only work in English. The `st`, `nd`, and `th` logic is all hardcoded, and obviously doesn't work in other languages. This patch moves that logic to I18n so it can be defined on a per-language basis.

This is technically a noop; English should still work as usual, and no other language was added.

### Other Information

I found one previous attempt [here](https://github.com/rails/rails/pull/17180), dating back to 2014. Unfortunately, the approach wasn't flexible enough to support most languages.