### PR TITLE
Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -63,7 +63,12 @@ module Rails
         numbered_destination = File.join(dir, ["%migration_number%", base].join("_"))
 
         create_migration numbered_destination, nil, config do
-          ERB.new(::File.binread(source), nil, "-", "@output_buffer").result(context)
+          match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
+          if match && match[:version] >= "2.2.0" # Ruby 2.6+
+            ERB.new(::File.binread(source), trim_mode: "-", eoutvar: "@output_buffer").result(context)
+          else
+            ERB.new(::File.binread(source), nil, "-", "@output_buffer").result(context)
+          end
         end
       end
     end

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -247,6 +247,12 @@ task :announce do
 
     require "erb"
     template = File.read("../tasks/release_announcement_draft.erb")
-    puts ERB.new(template, nil, "<>").result(binding)
+
+    match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
+    if match && match[:version] >= "2.2.0" # Ruby 2.6+
+      puts ERB.new(template, trim_mode: "<>").result(binding)
+    else
+      puts ERB.new(template, nil, "<>").result(binding)
+    end
   end
 end


### PR DESCRIPTION
### Summary

In a Rails application using Ruby 2.6.0-dev, when running `bin/rails g migration` with `RUBYOPT=-w`, an ERB deprecation warnings will be displayed.

```console
% ruby -v
ruby 2.6.0dev (2018-03-03 trunk 62644) [x86_64-darwin17]
% bin/rails -v
Rails 6.0.0.alpha
% RUBYOPT=-w bin/rails g migration create_foos

(snip)

/Users/koic/src/github.com/rails/rails/railties/lib/rails/generators/migration.rb:66:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword
arguments.
/Users/koic/src/github.com/rails/rails/railties/lib/rails/generators/migration.rb:66:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
instead.
/Users/koic/src/github.com/rails/rails/railties/lib/rails/generators/migration.rb:66:
warning: Passing eoutvar with the 4th argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, eoutvar: ...)
instead.
      create    db/migrate/20180304002144_create_foos.rb
```

This PR suppresses the above deprecation warnings in Ruby 2.6.0-dev.

This warning is due to the interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

The following addresses are related Ruby's commit.
https://github.com/ruby/ruby/commit/cc777d0

Also this PR will change `ERB.new` used in `tasks/release.rb`.

### Other Information

This PR uses `ERB.version` to switch `ERB.new` interface. Because Rails 6 supports multiple Ruby versions (Ruby 2.4.1 or higher), it need to use the appropriate interface.

Using `ERB.version` instead of `RUBY_VERSON` is based on the following patch.
https://github.com/ruby/ruby/pull/1826

This patch is built into Ruby.
https://github.com/ruby/ruby/commit/40db89c0934c23d7464d47946bb682b9035411f9
