### PR TITLE
Disable content security policy in the internal controllers

### DIFF
--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -4,6 +4,15 @@ class Rails::ApplicationController < ActionController::Base # :nodoc:
   self.view_paths = File.expand_path("templates", __dir__)
   layout "application"
 
+  before_action :disable_content_security_policy_nonce!
+
+  content_security_policy do |policy|
+    if policy
+      policy.script_src :unsafe_inline
+      policy.style_src :unsafe_inline
+    end
+  end
+
   private
 
     def require_local!
@@ -14,5 +23,9 @@ class Rails::ApplicationController < ActionController::Base # :nodoc:
 
     def local_request?
       Rails.application.config.consider_all_requests_local || request.local?
+    end
+
+    def disable_content_security_policy_nonce!
+      request.content_security_policy_nonce_generator = nil
     end
 end


### PR DESCRIPTION
We use inline style and script for the view held inside rails like welcome page and mailer preview.
Therefore, if inline is prohibited by CSP, they will not work properly. I think that this is not as expected. 
These are views that users can not change, so I think that CSP should be disabled regardless of the setting.

