### PR TITLE
Remove extra arg passed to `Rails::Command::RoutesTest#run_routes_command`

### DIFF
--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -69,7 +69,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     output = run_routes_command(["-c", "cart"])
     assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
 
-    output = run_routes_command(["routes", "-c", "Cart"])
+    output = run_routes_command(["-c", "Cart"])
     assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
 
     output = run_routes_command(["-c", "CartController"])


### PR DESCRIPTION
Related to 6bd33d66dde015a55912af20b469788ba20ddb4e
