### PR TITLE
Express `ActionDispatch::Routing::UrlFor#route_for` as public api

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -191,7 +191,19 @@ module ActionDispatch
         end
       end
 
-      def route_for(name, *args) # :nodoc:
+      # Allows calling direct or regular named route.
+      #
+      #   resources :buckets
+      #
+      #   direct :recordable do |recording|
+      #     route_for(:bucket, recording.bucket)
+      #   end
+      #
+      #   direct :threadable do |threadable|
+      #     route_for(:recordable, threadable.parent)
+      #   end
+      #
+      def route_for(name, *args)
         public_send(:"#{name}_url", *args)
       end
 


### PR DESCRIPTION
This method was added by #28462 but marked as private api.
Since `route_for` looks good in pair with `ActionDispatch::Routing::Mapper::CustomUrls#direct`
let's make it as public api.
We use it in https://github.com/rails/rails/blob/e83575ff533690db86c92447a539d76b648e9fed/activestorage/config/routes.rb

Closes #31417

r? @pixeltrix