### PR TITLE
5-1-stable: Fix that after commit callbacks on update does not triggered when optimistic locking is enabled

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix that after commit callbacks on update does not triggered when optimistic locking is enabled.
+
+    *Ryuta Kamizono*
+
 *   `ActiveRecord::Persistence#touch` does not work well when optimistic locking enabled and
     `locking_column`, without default value, is null in the database.
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -60,13 +60,6 @@ module ActiveRecord
       end
 
       private
-
-        def increment_lock
-          lock_col = self.class.locking_column
-          previous_lock_value = send(lock_col).to_i
-          send(lock_col + "=", previous_lock_value + 1)
-        end
-
         def _create_record(attribute_names = self.attribute_names, *)
           if locking_enabled?
             # We always want to persist the locking version, even if we don't detect
@@ -76,45 +69,13 @@ module ActiveRecord
           super
         end
 
-        def _update_record(attribute_names = self.attribute_names)
-          attribute_names &= self.class.column_names
-          return super unless locking_enabled?
-          return 0 if attribute_names.empty?
-
-          begin
-            lock_col = self.class.locking_column
-
-            previous_lock_value = read_attribute_before_type_cast(lock_col)
-
-            increment_lock
-
-            attribute_names.push(lock_col)
-
-            relation = self.class.unscoped
-
-            affected_rows = relation.where(
-              self.class.primary_key => id,
-              lock_col => previous_lock_value
-            ).update_all(
-              attributes_for_update(attribute_names).map do |name|
-                [name, _read_attribute(name)]
-              end.to_h
-            )
-
-            unless affected_rows == 1
-              raise ActiveRecord::StaleObjectError.new(self, "update")
-            end
-
-            affected_rows
-
-          # If something went wrong, revert the locking_column value.
-          rescue Exception
-            send(lock_col + "=", previous_lock_value.to_i)
-            raise
-          end
+        def _touch_row(attribute_names, time)
+          super
+        ensure
+          clear_attribute_change(self.class.locking_column) if locking_enabled?
         end
 
-        def _update_row(attribute_names, attempted_action)
+        def _update_row(attribute_names, attempted_action = "update")
           return super unless locking_enabled?
 
           begin
@@ -138,10 +99,8 @@ module ActiveRecord
 
           # If something went wrong, revert the locking_column value.
           rescue Exception
-            self[locking_column] = previous_lock_value
+            self[locking_column] = previous_lock_value.to_i
             raise
-          ensure
-            clear_attribute_change(locking_column)
           end
         end
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -114,6 +114,37 @@ module ActiveRecord
           end
         end
 
+        def _update_row(attribute_names, attempted_action)
+          return super unless locking_enabled?
+
+          begin
+            locking_column = self.class.locking_column
+            previous_lock_value = read_attribute_before_type_cast(locking_column)
+            attribute_names << locking_column
+
+            self[locking_column] += 1
+
+            affected_rows = self.class.unscoped._update_record(
+              arel_attributes_with_values(attribute_names),
+              self.class.primary_key => id_in_database,
+              locking_column => previous_lock_value
+            )
+
+            if affected_rows != 1
+              raise ActiveRecord::StaleObjectError.new(self, attempted_action)
+            end
+
+            affected_rows
+
+          # If something went wrong, revert the locking_column value.
+          rescue Exception
+            self[locking_column] = previous_lock_value
+            raise
+          ensure
+            clear_attribute_change(locking_column)
+          end
+        end
+
         def destroy_row
           affected_rows = super
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -569,7 +569,7 @@ module ActiveRecord
         rows_affected = 0
         @_trigger_update_callback = true
       else
-        rows_affected = self.class.unscoped._update_record attributes_values, id, id_in_database
+        rows_affected = self.class.unscoped._update_record(attributes_values, id_in_database)
         @_trigger_update_callback = rows_affected > 0
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -67,7 +67,7 @@ module ActiveRecord
         binds)
     end
 
-    def _update_record(values, id) # :nodoc:
+    def _update_record(values, constraints) # :nodoc:
       substitutes, binds = substitute_values values
 
       scope = @klass.unscoped
@@ -76,7 +76,7 @@ module ActiveRecord
         scope.unscope!(where: @klass.inheritance_column)
       end
 
-      relation = scope.where(@klass.primary_key => id)
+      relation = scope.where(constraints)
       bvs = binds + relation.bound_attributes
       um = relation
         .arel

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -67,7 +67,7 @@ module ActiveRecord
         binds)
     end
 
-    def _update_record(values, id, id_was) # :nodoc:
+    def _update_record(values, id) # :nodoc:
       substitutes, binds = substitute_values values
 
       scope = @klass.unscoped
@@ -76,7 +76,7 @@ module ActiveRecord
         scope.unscope!(where: @klass.inheritance_column)
       end
 
-      relation = scope.where(@klass.primary_key => (id_was || id))
+      relation = scope.where(@klass.primary_key => id)
       bvs = binds + relation.bound_attributes
       um = relation
         .arel

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id_in_database || record.id)
+            relation = relation.where.not(finder_class.primary_key => record.id_in_database)
           else
             raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
           end


### PR DESCRIPTION
Backport of #32167.