### PR TITLE
URI.unescape "extension" fails with Unicode input

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Fix bug where `URI.unscape` would fail with mixed Unicode/escaped character input:
+
+        URI.unescape("\xe3\x83\x90")  # => "バ"
+        URI.unescape("%E3%83%90")  # => "バ"
+        URI.unescape("\xe3\x83\x90%E3%83%90")  # => Encoding::CompatibilityError
+
+    GH#32183
+
+    *Ashe Connor*, *Aaron Patterson*
+
 *   Add `:private` option to ActiveSupport's `Module#delegate`
     in order to delegate methods as private:
 

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -13,7 +13,7 @@ unless str == parser.unescape(parser.escape(str))
       # YK: My initial experiments say yes, but let's be sure please
       enc = str.encoding
       enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
-      str.gsub(escaped) { |match| [match[1, 2].hex].pack("C") }.force_encoding(enc)
+      str.dup.force_encoding(Encoding::ASCII_8BIT).gsub(escaped) { |match| [match[1, 2].hex].pack("C") }.force_encoding(enc)
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -9,6 +9,6 @@ class URIExtTest < ActiveSupport::TestCase
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 
     parser = URI.parser
-    assert_equal str, parser.unescape(parser.escape(str))
+    assert_equal str + str, parser.unescape(str + parser.escape(str).encode(Encoding::UTF_8))
   end
 end


### PR DESCRIPTION
### Summary

This is a fix for a bug @tenderlove and I have been stepping through together.

`URI.unescape` in Rails 4.2 throws an `Encoding::CompatibilityError` if the (UTF-8 tagged) argument contains actual Unicode characters. ~This doesn't happen on 3.x; compare the monkey-patches:~ Turns out this was a patch made in our own application. Looks like we should be able to just pull this across.

#### ~3.x~ patched

```ruby
      def unescape(str, escaped = /%[a-fA-F\d]{2}/)
        # TODO: Are we actually sure that ASCII == UTF-8?
        # YK: My initial experiments say yes, but let’s be sure please
        enc = str.encoding
        enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
        str.dup.force_encoding(Encoding::ASCII_8BIT).gsub(escaped) { [$&[1, 2].hex].pack(‘C’) }.force_encoding(enc)
      end
```

#### 4.2

```ruby
    def unescape(str, escaped = /%[a-fA-F\d]{2}/)
      # TODO: Are we actually sure that ASCII == UTF-8?
      # YK: My initial experiments say yes, but let’s be sure please
      enc = str.encoding
      enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
      str.gsub(escaped) { [$&[1, 2].hex].pack(‘C’) }.force_encoding(enc)
    end
```

The issue is that `[$&[1, 2].hex].pack('C')` returns an ASCII-8BIT tagged string, which we then fail to gsub into `str`. This wasn't a problem in the ~3.x~ patched variant where the string was tagged as ASCII-8BIT anyway.

This PR opens by correcting the test; `parser.escape(str)` returns an US-ASCII (!) tagged string, so `parser.unescape` succeeds for similar reasons as why the ~3.x~ patched variant succeeded. This corrects the test to resemble the actual use-case: passing UTF-8 tagged strings into `URI.unescape`.