### PR TITLE
Hide internal docs from root ActiveSupport module

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -14,6 +14,7 @@ require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/date_time/conversions"
 require "active_support/core_ext/date/conversions"
 
+#--
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
 # their default behavior. That said, we need to define the basic to_json method in all of them,
 # otherwise they will always use to_json gem implementation, which is backwards incompatible in


### PR DESCRIPTION
### Summary

See http://api.rubyonrails.org/classes/ActiveSupport.html (scroll down a bit) — there's a bunch of documentation related to JSON extensions appearing on the top-level ActiveSupport module. It's not clear that this is intended for inclusion in the API docs, so we hide it.