### PR TITLE
Add `use_year_names` option to date_select tag

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `year_format` option to date_select tag. This option makes it possible to customize year
+    names. Lambda should be passed to use this option. Example:
+
+        date_select('user_birthday', '', start_year: 1998, end_year: 2000, year_format: ->year { "Heisei #{year - 1988}" })
+
+    The HTML produced: 
+
+        <select id="user_birthday__1i" name="user_birthday[(1i)]">
+        <option value="1998">Heisei 10</option>
+        <option value="1999">Heisei 11</option>
+        <option value="2000">Heisei 12</option>
+        </select>
+        /* The rest is omitted */
+
+    *Koki Ryu*
+
 *   Fix JavaScript views rendering does not work with Firefox when using
     Content Security Policy.
 

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -560,6 +560,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_year(Date.current, include_position: true,  start_year: 2003, end_year: 2005)
   end
 
+  def test_select_year_with_custom_names
+    year_format_lambda = ->year { "Heisei #{ year - 1988 }" }
+    expected = %(<select id="date_year" name="date[year]">\n).dup
+    expected << %(<option value="2003">Heisei 15</option>\n<option value="2004">Heisei 16</option>\n<option value="2005">Heisei 17</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_year(nil, start_year: 2003, end_year: 2005, year_format: year_format_lambda)
+  end
+
   def test_select_hour
     expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)


### PR DESCRIPTION
### Summary

Add `use_year_names` option to date_select tag.
This option makes it possible to customize year names. Example:

```ruby
    date_select('user_birthday', '', start_year: 1998, end_year: 2000, use_year_names: ["Heisei 10", "Heisei 11", "Heisei 12"])
```

The HTML produced:

```HTML
    <select id="user_birthday__1i" name="user_birthday[(1i)]">
    <option value="1998">Heisei 10</option>
    <option value="1999">Heisei 11</option>
    <option value="2000">Heisei 12</option>
    </select>
    /* The rest is omitted */
```
P.S.(on March 8)
Changed option name to `labels_for_year_options`. The argument is also changed from Array to Lambda. Example:

```ruby
    date_select('user_birthday', '', start_year: 1998, end_year: 2000, labels_for_year_options: ->year { "Heisei #{ year - 1988 }" })
```
The same HTML as written above is produced.

P.S.(on March 9)
Changed option name again to `label_for_year`. Nothing has changed except it and code style since March 8.

P.S.(on March 15)
Changed option name again to `year_format`. 

### Other Information

In Japan, Wareki, the Japanese calender, is used as often as Western Calender. For example, 2000 A.D. is Heisei 12 in Wareki. It is even used in official documents. Therefore, there is a need for date select box with Wareki years. Some other countries like Israel and Thailand also have their own calenders, so I think the number of people who need this `use_year_names` option is not small.

