### PR TITLE
Use quotes to express a returned value of a route helper as a string [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -206,8 +206,8 @@ module ActionDispatch
       # This maintains the context of the original caller on
       # whether to return a path or full url, e.g:
       #
-      #   threadable_path(threadable)  # => /buckets/1
-      #   threadable_url(threadable)   # => http://example.com/buckets/1
+      #   threadable_path(threadable) # => '/buckets/1'
+      #   threadable_url(threadable)  # => 'http://example.com/buckets/1'
       #
       def route_for(name, *args)
         public_send(:"#{name}_url", *args)


### PR DESCRIPTION
r? @pixeltrix
Related to 22777c80b4c6716c120c6c7f4f9221d58a679fad
