### PR TITLE
Use frozen string literal in activestorage migration schema.

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -125,7 +125,7 @@ module ActionCable
         end
 
         private
-          # action_methods are cached and there is sometimes need to refresh
+          # action_methods are cached and sometimes there is need to refresh
           # them. ::clear_action_methods! allows you to do that, so next time
           # you run action_methods, they will be recalculated.
           def clear_action_methods! # :doc:

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
     create_table :active_storage_blobs do |t|


### PR DESCRIPTION
- Use frozen string literal in activestorage migration schema.
- Updated the sentence in base.rb from actioncable.