### PR TITLE
Fixes #32198 wrong Session name for Capybara

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -134,8 +134,11 @@ module ActionDispatch
     #   driven_by :selenium, using: :firefox
     #
     #   driven_by :selenium, using: :headless_firefox
-    def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {})
-      self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
+    def self.driven_by(driver, using: nil, screen_size: [1400, 1400], options: {})
+      Capybara.session_name = options.fetch(:session_name) do 
+        [driver, using].compact.join('_').to_sym
+      end
+      self.driver = SystemTesting::Driver.new(driver, using: using || :chrome, screen_size: screen_size, options: options)
     end
 
     driven_by :selenium

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -138,7 +138,7 @@ module ActionDispatch
       Capybara.session_name = options.fetch(:session_name) do 
         [driver, using].compact.join('_').to_sym
       end
-      self.driver = SystemTesting::Driver.new(driver, using: using || :chrome, screen_size: screen_size, options: options)
+      self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end
 
     driven_by :selenium

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -135,8 +135,8 @@ module ActionDispatch
     #
     #   driven_by :selenium, using: :headless_firefox
     def self.driven_by(driver, using: nil, screen_size: [1400, 1400], options: {})
-      Capybara.session_name = options.fetch(:session_name) do 
-        [driver, using].compact.join('_').to_sym
+      Capybara.session_name = options.fetch(:session_name) do
+        [driver, using].compact.join("_").to_sym
       end
       self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -135,9 +135,6 @@ module ActionDispatch
     #
     #   driven_by :selenium, using: :headless_firefox
     def self.driven_by(driver, using: nil, screen_size: [1400, 1400], options: {})
-      Capybara.session_name = options.fetch(:session_name) do
-        [driver, using].compact.join("_").to_sym
-      end
       self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end
 

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -35,6 +35,10 @@ module ActionDispatch
           @options.merge(options: @browser.options).compact
         end
 
+        def default_session_name
+          [@name, @browser.name].compact.join("_").to_sym
+        end
+
         def register_selenium(app)
           Capybara::Selenium::Driver.new(app, { browser: @browser.type }.merge(browser_options)).tap do |driver|
             driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
@@ -52,7 +56,12 @@ module ActionDispatch
         end
 
         def setup
+          Capybara.session_name = session_name
           Capybara.current_driver = @name
+        end
+
+        def session_name
+          @options.respond_to?(:[]) ? @options[:session_name] || default_session_name : default_session_name
         end
     end
   end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -9,6 +9,21 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal :selenium, driver.instance_variable_get(:@name)
   end
 
+  test "using driver provide proper session name with override session name" do
+    ActionDispatch::SystemTesting::Driver.new(:poltergeist, options: { session_name: :selenium_chrome_windows_10 }).use
+    assert_equal :selenium_chrome_windows_10, Capybara.session_name
+  end
+
+  test "using driver provide proper session name with driver and browser name" do
+    ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_chrome).use
+    assert_equal :selenium_headless_chrome, Capybara.session_name
+  end
+
+  test "using driver provide proper session name with driver name" do
+    ActionDispatch::SystemTesting::Driver.new(:poltergeist).use
+    assert_equal :poltergeist, Capybara.session_name
+  end
+
   test "initializing the driver with a browser" do
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :chrome, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
     assert_equal :selenium, driver.instance_variable_get(:@name)

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -22,6 +22,23 @@ class SetDriverToSeleniumTest < DrivenBySeleniumWithChrome
   end
 end
 
+class ActiveSupport::TestCase
+  test "uses provided session name for Capybara session name" do
+    ActionDispatch::SystemTestCase.driven_by :poltergeist, options: { session_name: :selenium_chrome_windows_10 }
+    assert_equal :selenium_chrome_windows_10, Capybara.session_name
+  end
+
+  test "uses using and driver name" do
+    ActionDispatch::SystemTestCase.driven_by :selenium, using: :headless_chrome
+    assert_equal :selenium_headless_chrome, Capybara.session_name
+  end
+
+  test "uses only driver name if using is ommited" do
+    ActionDispatch::SystemTestCase.driven_by :poltergeist
+    assert_equal :poltergeist, Capybara.session_name
+  end
+end
+
 class SetDriverToSeleniumHeadlessChromeTest < DrivenBySeleniumWithHeadlessChrome
   test "uses selenium headless chrome" do
     assert_equal :selenium, Capybara.current_driver

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -22,23 +22,6 @@ class SetDriverToSeleniumTest < DrivenBySeleniumWithChrome
   end
 end
 
-class ActiveSupport::TestCase
-  test "uses provided session name for Capybara session name" do
-    ActionDispatch::SystemTestCase.driven_by :poltergeist, options: { session_name: :selenium_chrome_windows_10 }
-    assert_equal :selenium_chrome_windows_10, Capybara.session_name
-  end
-
-  test "uses using and driver name" do
-    ActionDispatch::SystemTestCase.driven_by :selenium, using: :headless_chrome
-    assert_equal :selenium_headless_chrome, Capybara.session_name
-  end
-
-  test "uses only driver name if using is ommited" do
-    ActionDispatch::SystemTestCase.driven_by :poltergeist
-    assert_equal :poltergeist, Capybara.session_name
-  end
-end
-
 class SetDriverToSeleniumHeadlessChromeTest < DrivenBySeleniumWithHeadlessChrome
   test "uses selenium headless chrome" do
     assert_equal :selenium, Capybara.current_driver


### PR DESCRIPTION
### Summary

This PR fixes: 
https://github.com/rails/rails/issues/32198
