### PR TITLE
Default action_on_unpermitted_parameters to :raise in development

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -20,7 +20,7 @@ module Rails
 
     private
       def new_mail
-        Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
+        Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body, attachments: []).to_h).tap do |mail|
           params[:mail][:attachments].to_a.each do |attachment|
             mail.add_file(filename: attachment.path, content: attachment.read)
           end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -86,7 +86,7 @@ module ActionController
   # * +action_on_unpermitted_parameters+ - Allow to control the behavior when parameters
   #   that are not explicitly permitted are found. The values can be +false+ to just filter them
   #   out, <tt>:log</tt> to additionally write a message on the logger, or <tt>:raise</tt> to raise
-  #   ActionController::UnpermittedParameters exception. The default value is <tt>:log</tt>
+  #   ActionController::UnpermittedParameters exception. The default value is <tt>:raise</tt>
   #   in test and development environments, +false+ otherwise.
   #
   # Examples:

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -431,7 +431,7 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.
 
-* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
+* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:raise` in development and test environments, and `false` in all other environments.
 
 * `config.action_controller.always_permitted_parameters` sets a list of permitted parameters that are permitted by default. The default values are `['controller', 'action']`.
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -142,6 +142,10 @@ module Rails
             active_storage.queues.analysis = :active_storage_analysis
             active_storage.queues.purge    = :active_storage_purge
           end
+
+          if respond_to?(:action_controller) && %w(development test).include?(Rails.env)
+            action_controller.action_on_unpermitted_parameters = :raise
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -31,3 +31,6 @@
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
 # Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+
+# Raise exception when unpermitted params are submitted in development and test
+# Rails.application.config.action_controller.action_on_unpermitted_parameters = :raise if %w(development test).include?(Rails.env)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1421,22 +1421,22 @@ module ApplicationTests
       assert_equal 200, last_response.status
     end
 
-    test "config.action_controller.action_on_unpermitted_parameters is :log by default in development" do
+    test "config.action_controller.action_on_unpermitted_parameters is :raise by default in development" do
       app "development"
 
       force_lazy_load_hooks { ActionController::Base }
       force_lazy_load_hooks { ActionController::API }
 
-      assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
-    test "config.action_controller.action_on_unpermitted_parameters is :log by default in test" do
+    test "config.action_controller.action_on_unpermitted_parameters is :raise by default in test" do
       app "test"
 
       force_lazy_load_hooks { ActionController::Base }
       force_lazy_load_hooks { ActionController::API }
 
-      assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
     test "config.action_controller.action_on_unpermitted_parameters is false by default in production" do


### PR DESCRIPTION
Our team, 4 rails developers with 7-10 years experience each just started a fresh rails app for some rapid prototyping. One of the most surprising issues for us was the default behavior of `config.action_controller.action_on_unpermitted_parameters` to only log. Our long-lived app has had`:raise` set as a development default since `strong_parameters` was merged into rails.

Scenario: 
* create a scaffold, migrate, click thru, realize you forgot a field. 
* Create a new migration to add a field..... scratch head for a few minutes why it's not working, to realize you haven't added it to `params.permit`.

This must cause undue confusion for new developers. I'm sure we're missing a valid use case for only logging these, but we couldn't come up with one, especially in development. If this just raised an exception it would have been totally obvious.