### PR TITLE
Fix a bug where DebugExceptions errors out when malformed query parameters are provided

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Fix a bug where DebugExceptions errors out when malformed query parameters are provided
+
+    *Yuki Nishijima*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -141,6 +141,12 @@ module ActionDispatch
           source_to_show_id = source_to_show[:id]
         end
 
+        params_readable = begin
+                            request.parameters
+                          rescue ActionController::BadRequest
+                            false
+                          end
+
         DebugView.new([RESCUES_TEMPLATE_PATH],
           request: request,
           exception: wrapper.exception,
@@ -150,7 +156,8 @@ module ActionDispatch
           routes_inspector: routes_inspector(wrapper.exception),
           source_extracts: wrapper.source_extracts,
           line_number: wrapper.line_number,
-          file: wrapper.file
+          file: wrapper.file,
+          params_readable: params_readable
         )
       end
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
@@ -6,7 +6,9 @@
 <% end %>
 
 <h2 style="margin-top: 30px">Request</h2>
-<p><b>Parameters</b>:</p> <pre><%= debug_params(@request.filtered_parameters) %></pre>
+<% if @params_readable %>
+  <p><b>Parameters</b>:</p> <pre><%= debug_params(@request.filtered_parameters) %></pre>
+<% end %>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="return toggleSessionDump()">Toggle session dump</a></div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.text.erb
@@ -1,5 +1,5 @@
 <%
-  clean_params = @request.filtered_parameters.clone
+  clean_params = @params_readable ? @request.filtered_parameters.clone : {}
   clean_params.delete("action")
   clean_params.delete("controller")
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -1,7 +1,7 @@
 <header>
   <h1>
     <%= @exception.class.to_s %>
-    <% if @request.parameters['controller'] %>
+    <% if @params_readable && @request.parameters['controller'] %>
       in <%= @request.parameters['controller'].camelize %>Controller<% if @request.parameters['action'] %>#<%= @request.parameters['action'] %><% end %>
     <% end %>
   </h1>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.text.erb
@@ -1,5 +1,5 @@
 <%= @exception.class.to_s %><%
-  if @request.parameters['controller']
+  if @params_readable && @request.parameters['controller']
 %> in <%= @request.parameters['controller'].camelize %>Controller<% if @request.parameters['action'] %>#<%= @request.parameters['action'] %><% end %>
 <% end %>
 

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -499,4 +499,23 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test "debug exceptions app shows diagnostics when malformed query parameters are provided" do
+    @app = DevelopmentApp
+
+    get "/bad_request?x[y]=1&x[y][][w]=2"
+
+    assert_response 400
+    assert_match "ActionController::BadRequest", body
+  end
+
+  test "debug exceptions app shows diagnostics when malformed query parameters are provided by xhr" do
+    @app = DevelopmentApp
+    xhr_request_env = { "action_dispatch.show_exceptions" => true, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest" }
+
+    get "/bad_request?x[y]=1&x[y][][w]=2", headers: xhr_request_env
+
+    assert_response 400
+    assert_match "ActionController::BadRequest", body
+  end
 end


### PR DESCRIPTION
This PR fixes #29947. Please see the issue for more details about the bug.

This PR adds a check to see if the `request.parameters` is safe to call, and skips showing `params` when it's malformed. There's another PR https://github.com/rails/rails/pull/29948 that allows for refactoring the code added by this PR, but I think it's out of this PR and we can take care of it later.

cc @xtina-starr 