### PR TITLE
Only apply URI.unescape monkey-patch if detected to be required

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
 require "uri"
-str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
+str = "\xE6\x97\xA5"
 parser = URI::Parser.new
 
-unless str == parser.unescape(parser.escape(str))
+needs_monkeypatch =
+  begin
+    str + str != parser.unescape(str + parser.escape(str).force_encoding(Encoding::UTF_8))
+  rescue Encoding::CompatibilityError
+    true
+  end
+
+if needs_monkeypatch
   require "active_support/core_ext/module/redefine_method"
   URI::Parser.class_eval do
     silence_redefinition_of_method :unescape


### PR DESCRIPTION
See https://github.com/rails/rails/pull/32183. Commit message included here:

> We test the failing case we're trying to patch; only if it throws an Exception do we patch.
>
> Currently this will *always* throw, but upstream Ruby has patched this bug: https://git.io/vAxKB

Tested against current Ruby 2.5 (monkey-patch applied, tests pass) and nightly (monkey-patch not applied, tests pass).