### PR TITLE
Fixes a typo and updates active_job_basics.md

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -290,7 +290,7 @@ For example, you could send metrics for every job enqueued:
 
 ```ruby
 class ApplicationJob
-  before_enqueue { |job| $statsd.increment "#{job.name.underscore}.enqueue" }
+  before_enqueue { |job| $statsd.increment "#{job.class.name.underscore}.enqueue" }
 end
 ```
 


### PR DESCRIPTION
Fixes a typo. `job` is an instance which does not have access to `name` method.