### PR TITLE
Change doc for "polymorphic_path" in polymorphic_routes.rb

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -120,8 +120,7 @@ module ActionDispatch
                                                opts
       end
 
-      # Returns the path component of a URL for the given record. It uses
-      # <tt>polymorphic_url</tt> with <tt>routing_type: :path</tt>.
+      # Returns the path component of a URL for the given record.
       def polymorphic_path(record_or_hash_or_array, options = {})
         if Hash === record_or_hash_or_array
           options = record_or_hash_or_array.merge(options)


### PR DESCRIPTION
### Summary

- Changing docs for the `polymorphic_path` in `polymorphic_routes.rb`
- The method `polymorphic_path` is not using `polymorphic_url` with `routing_type: :path` anymore in polymorphic_routes.rb

