### PR TITLE
Time column improvements

### DIFF
--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -31,11 +31,7 @@ module ActiveModel
           return apply_seconds_precision(value) unless value.is_a?(::String)
           return if value.empty?
 
-          if value.start_with?("2000-01-01")
-            dummy_time_value = value
-          else
-            dummy_time_value = "2000-01-01 #{value}"
-          end
+          dummy_time_value = value.sub(/\A(\d\d\d\d-\d\d-\d\d |)/, "2000-01-01 ")
 
           fast_string_to_time(dummy_time_value) || begin
             time_hash = ::Date._parse(dummy_time_value)

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -28,7 +28,7 @@ module ActiveModel
       private
 
         def cast_value(value)
-          return value unless value.is_a?(::String)
+          return apply_seconds_precision(value) unless value.is_a?(::String)
           return if value.empty?
 
           if value.start_with?("2000-01-01")

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -130,7 +130,7 @@ module ActiveRecord
       end
 
       def quoted_time(value) # :nodoc:
-        quoted_date(value).sub(/\A2000-01-01 /, "")
+        quoted_date(value).sub(/\A\d\d\d\d-\d\d-\d\d /, "")
       end
 
       def quoted_binary(value) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         end
 
         def quoted_time(value)
-          quoted_date(value)
+          quoted_date(value).sub(/\A\d\d\d\d-\d\d-\d\d /, "2000-01-01 ")
         end
 
         def quoted_binary(value)

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -55,4 +55,11 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
 
     assert_equal "'2000-01-01 12:30:00.999999'", @conn.quote(type.serialize(value))
   end
+
+  def test_quoted_time_normalizes_date_qualified_time
+    value = ::Time.utc(2018, 3, 11, 12, 30, 0, 999999)
+    type = ActiveRecord::Type::Time.new
+
+    assert_equal "'2000-01-01 12:30:00.999999'", @conn.quote(type.serialize(value))
+  end
 end

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -27,6 +27,24 @@ if subsecond_precision_supported?
       assert_equal 5, Foo.columns_hash["updated_at"].precision
     end
 
+    def test_datetime_precision_is_truncated_on_assignment
+      @connection.create_table(:foos, force: true)
+      @connection.add_column :foos, :created_at,  :datetime, precision: 0
+      @connection.add_column :foos, :updated_at, :datetime, precision: 6
+
+      time = ::Time.now.change(nsec: 123456789)
+      foo = Foo.new(created_at: time, updated_at: time)
+
+      assert_equal 0, foo.created_at.nsec
+      assert_equal 123456000, foo.updated_at.nsec
+
+      foo.save!
+      foo.reload
+
+      assert_equal 0, foo.created_at.nsec
+      assert_equal 123456000, foo.updated_at.nsec
+    end
+
     def test_timestamps_helper_with_custom_precision
       @connection.create_table(:foos, force: true) do |t|
         t.timestamps precision: 4

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -46,24 +46,57 @@ module ActiveRecord
         assert_equal t.to_s(:db), @quoter.quoted_date(t)
       end
 
-      def test_quoted_time_utc
+      def test_quoted_timestamp_utc
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
           assert_equal t.getutc.to_s(:db), @quoter.quoted_date(t)
         end
       end
 
-      def test_quoted_time_local
+      def test_quoted_timestamp_local
         with_timezone_config default: :local do
           t = Time.now.change(usec: 0)
           assert_equal t.getlocal.to_s(:db), @quoter.quoted_date(t)
         end
       end
 
-      def test_quoted_time_crazy
+      def test_quoted_timestamp_crazy
         with_timezone_config default: :asdfasdf do
           t = Time.now.change(usec: 0)
           assert_equal t.getlocal.to_s(:db), @quoter.quoted_date(t)
+        end
+      end
+
+      def test_quoted_time_utc
+        with_timezone_config default: :utc do
+          t = Time.now.change(usec: 0)
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
+
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_local
+        with_timezone_config default: :local do
+          t = Time.now.change(usec: 0)
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getlocal.to_s(:db).sub("2000-01-01 ", "")
+
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_crazy
+        with_timezone_config default: :asdfasdf do
+          t = Time.now.change(usec: 0)
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getlocal.to_s(:db).sub("2000-01-01 ", "")
+
+          assert_equal expected, @quoter.quoted_time(t)
         end
       end
 

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -27,6 +27,24 @@ if subsecond_precision_supported?
       assert_equal 6, Foo.columns_hash["finish"].precision
     end
 
+    def test_time_precision_is_truncated_on_assignment
+      @connection.create_table(:foos, force: true)
+      @connection.add_column :foos, :start,  :time, precision: 0
+      @connection.add_column :foos, :finish, :time, precision: 6
+
+      time = ::Time.now.change(nsec: 123456789)
+      foo = Foo.new(start: time, finish: time)
+
+      assert_equal 0, foo.start.nsec
+      assert_equal 123456000, foo.finish.nsec
+
+      foo.save!
+      foo.reload
+
+      assert_equal 0, foo.start.nsec
+      assert_equal 123456000, foo.finish.nsec
+    end
+
     def test_passing_precision_to_time_does_not_set_limit
       @connection.create_table(:foos, force: true) do |t|
         t.time :start,  precision: 3


### PR DESCRIPTION
* Apply precision when assigning values to time columns (Fixes #30301)
* Fixes issues with time columns not being normalised on sqlite
* Ensures that times with a date component other than 2000-01-01 get stripped when quoting for databases like MySQL and PostgreSQL

Probably for Rails 6.0 we might want to introduce storing times without the date component via a config option that defaults to true for new apps.

cc @matthewd @kamipo 