### PR TITLE
Fix 5-2-stable's changelogs [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -23,7 +23,7 @@
 
     *Grant Bourque*
 
-*   Add support for automatic nonce generation for Rails UJS
+*   Add support for automatic nonce generation for Rails UJS.
 
     Because the UJS library creates a script tag to process responses it
     normally requires the script-src attribute of the content security
@@ -92,7 +92,7 @@
 
     *Guillermo Iguaran*
 
-*   Fix optimized url helpers when using relative url root
+*   Fix optimized url helpers when using relative url root.
 
     Fixes #31220.
 
@@ -106,7 +106,7 @@
 
 ## Rails 5.2.0.beta1 (November 27, 2017) ##
 
-*   Add DSL for configuring Content-Security-Policy header
+*   Add DSL for configuring Content-Security-Policy header.
 
     The DSL allows you to configure a global Content-Security-Policy
     header and then override within a controller. For more information
@@ -158,7 +158,7 @@
 
         # controller override
         class PostsController < ApplicationController
-          self.content_security_policy_report_only = true
+          content_security_policy_report_only only: :index
         end
 
     Note that this feature does not validate the header for performance
@@ -166,7 +166,7 @@
 
     *Andrew White*
 
-*   Make `assert_recognizes` to traverse mounted engines
+*   Make `assert_recognizes` to traverse mounted engines.
 
     *Yuichiro Kaneko*
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -8,7 +8,7 @@
 
     *Jérémie Bonal*
 
-*   Add `preload_link_tag` helper
+*   Add `preload_link_tag` helper.
 
     This helper that allows to the browser to initiate early fetch of resources
     (different to the specified in `javascript_include_tag` and `stylesheet_link_tag`).
@@ -68,7 +68,7 @@
 
     *Yuji Yaginuma*
 
-*   Add `:json` type to `auto_discovery_link_tag` to support [JSON Feeds](https://jsonfeed.org/version/1)
+*   Add `:json` type to `auto_discovery_link_tag` to support [JSON Feeds](https://jsonfeed.org/version/1).
 
     *Mike Gunderloy*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -151,7 +151,7 @@
 
     *Chris Salzberg*
 
-*   Log database query callers
+*   Log database query callers.
 
     Add `verbose_query_logs` configuration option to display the caller
     of database queries in the log to facilitate N+1 query resolution
@@ -386,7 +386,7 @@
 
     *Rafael Mendonça França*
 
-*   Fix `bin/rails db:setup` and `bin/rails db:test:prepare` create  wrong
+*   Fix `bin/rails db:setup` and `bin/rails db:test:prepare` create wrong
     ar_internal_metadata's data for a test database.
 
     Before:
@@ -478,7 +478,7 @@
 
     *Yuichiro Kaneko*
 
-*   Ensure `sum` honors `distinct` on `has_many :through` associations
+*   Ensure `sum` honors `distinct` on `has_many :through` associations.
 
     Fixes #16791.
 
@@ -514,7 +514,7 @@
 
     *Lisa Ugray*
 
-*   Fix `unscoped(where: [columns])` removing the wrong bind values
+*   Fix `unscoped(where: [columns])` removing the wrong bind values.
 
     When the `where` is called on a relation after a `or`, unscoping the column of that later `where` removed
     bind values used by the `or` instead. (possibly other cases too)
@@ -541,7 +541,7 @@
 
     *Sean Griffin*
 
-*   Change sqlite3 boolean serialization to use 1 and 0
+*   Change sqlite3 boolean serialization to use 1 and 0.
 
     SQLite natively recognizes 1 and 0 as true and false, but does not natively
     recognize 't' and 'f' as was previously serialized.
@@ -571,7 +571,7 @@
 
     *Ryuta Kamizono*
 
-*   Fix transactions to apply state to child transactions
+*   Fix transactions to apply state to child transactions.
 
     Previously, if you had a nested transaction and the outer transaction was rolledback, the record from the
     inner transaction would still be marked as persisted.
@@ -581,7 +581,7 @@
 
     *Eileen M. Uchitelle*, *Aaron Patterson*
 
-*   Deprecate `set_state` method in `TransactionState`
+*   Deprecate `set_state` method in `TransactionState`.
 
     Deprecated the `set_state` method in favor of setting the state via specific methods. If you need to mark the
     state of the transaction you can now use `rollback!`, `commit!` or `nullify!` instead of
@@ -606,7 +606,9 @@
     *Tobias Kraze*
 
 *   Merging two relations representing nested joins no longer transforms the joins of
-    the merged relation into LEFT OUTER JOIN. Example to clarify:
+    the merged relation into LEFT OUTER JOIN.
+
+    Example:
 
     ```
     Author.joins(:posts).merge(Post.joins(:comments))
@@ -616,8 +618,6 @@
     # After the change:
     #=> SELECT ... FROM authors INNER JOIN posts ON ... INNER JOIN comments ON...
     ```
-
-    TODO: Add to the Rails 5.2 upgrade guide
 
     *Maxime Handfield Lapointe*
 
@@ -658,11 +658,11 @@
 
     *DHH*
 
-*   Respect `SchemaDumper.ignore_tables` in rake tasks for databases structure dump
+*   Respect `SchemaDumper.ignore_tables` in rake tasks for databases structure dump.
 
     *Rusty Geldmacher*, *Guillermo Iguaran*
 
-*   Add type caster to `RuntimeReflection#alias_name`
+*   Add type caster to `RuntimeReflection#alias_name`.
 
     Fixes #28959.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -3,7 +3,7 @@
 
     *Gabriel Sobrinho*
 
-*   Return all mappings for a timezone identifier in `country_zones`
+*   Return all mappings for a timezone identifier in `country_zones`.
 
     Some timezones like `Europe/London` have multiple mappings in
     `ActiveSupport::TimeZone::MAPPING` so return all of them instead
@@ -85,7 +85,7 @@
 
     *Takumasa Ochi*
 
-*   Handle `TZInfo::AmbiguousTime` errors
+*   Handle `TZInfo::AmbiguousTime` errors.
 
     Make `ActiveSupport::TimeWithZone` match Ruby's handling of ambiguous
     times by choosing the later period, e.g.
@@ -164,7 +164,7 @@
 
     *Jeremy Daer*
 
-*   Allow `Range#include?` on TWZ ranges
+*   Allow `Range#include?` on TWZ ranges.
 
     In #11474 we prevented TWZ ranges being iterated over which matched
     Ruby's handling of Time ranges and as a consequence `include?`
@@ -177,7 +177,7 @@
 
     *Andrew White*
 
-*   Fix acronym support in `humanize`
+*   Fix acronym support in `humanize`.
 
     Acronym inflections are stored with lowercase keys in the hash but
     the match wasn't being lowercased before being looked up in the hash.
@@ -305,7 +305,7 @@
 
     *Yuji Yaginuma*
 
-*   Add key rotation support to `MessageEncryptor` and `MessageVerifier`
+*   Add key rotation support to `MessageEncryptor` and `MessageVerifier`.
 
     This change introduces a `rotate` method to both the `MessageEncryptor` and
     `MessageVerifier` classes. This method accepts the same arguments and
@@ -344,7 +344,7 @@
 
     *Anton Khamets*
 
-*   Update `String#camelize` to provide feedback when wrong option is passed
+*   Update `String#camelize` to provide feedback when wrong option is passed.
 
     `String#camelize` was returning nil without any feedback when an
     invalid option was passed as a parameter.
@@ -361,7 +361,7 @@
 
     *Ricardo Díaz*
 
-*   Fix modulo operations involving durations
+*   Fix modulo operations involving durations.
 
     Rails 5.1 introduced `ActiveSupport::Duration::Scalar` as a wrapper
     around numeric values as a way of ensuring a duration was the outcome of
@@ -383,7 +383,7 @@
 
     *Sayan Chakraborty*, *Andrew White*
 
-*   Fix division where a duration is the denominator
+*   Fix division where a duration is the denominator.
 
     PR #29163 introduced a change in behavior when a duration was the denominator
     in a calculation - this was incorrect as dividing by a duration should always
@@ -393,7 +393,7 @@
 
     *Andrew White*
 
-*   Add purpose and expiry support to `ActiveSupport::MessageVerifier` &
+*   Add purpose and expiry support to `ActiveSupport::MessageVerifier` and
    `ActiveSupport::MessageEncryptor`.
 
     For instance, to ensure a message is only usable for one intended purpose:
@@ -430,7 +430,7 @@
 
     *Assain Jaleel*
 
-*   Cache: `write_multi`
+*   Cache: `write_multi`.
 
         Rails.cache.write_multi foo: 'bar', baz: 'qux'
 
@@ -479,7 +479,7 @@
 
     *DHH*
 
-*   Fix implicit coercion calculations with scalars and durations
+*   Fix implicit coercion calculations with scalars and durations.
 
     Previously, calculations where the scalar is first would be converted to a duration
     of seconds, but this causes issues with dates being converted to times, e.g:
@@ -511,17 +511,17 @@
 
     *Willem van Bergen*
 
-*   Add support for `:offset` and `:zone` to `ActiveSupport::TimeWithZone#change`
+*   Add support for `:offset` and `:zone` to `ActiveSupport::TimeWithZone#change`.
 
     *Andrew White*
 
-*   Add support for `:offset` to `Time#change`
+*   Add support for `:offset` to `Time#change`.
 
     Fixes #28723.
 
     *Andrew White*
 
-*   Add `fetch_values` for `HashWithIndifferentAccess`
+*   Add `fetch_values` for `HashWithIndifferentAccess`.
 
     The method was originally added to `Hash` in Ruby 2.3.0.
 


### PR DESCRIPTION
- Add missing dots.
- Change example of using `content_security_policy_report_only`
  in controller.
- Remove TODO.

Related to #32222