### PR TITLE
Fix CHANGELOGs [ci skip]

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -3,10 +3,10 @@
 *   Enable select tag helper to mark `prompt` option as `selected` and/or `disabled` for `required`
     field. Example:
 
-        select :post, 
-               :category, 
-               ["lifestyle", "programming", "spiritual"], 
-               { selected: "", disabled: "", prompt: "Choose one" }, 
+        select :post,
+               :category,
+               ["lifestyle", "programming", "spiritual"],
+               { selected: "", disabled: "", prompt: "Choose one" },
                { required: true }
 
     Placeholder option would be selected and disabled. The HTML produced:
@@ -19,7 +19,7 @@
 
     *Sergey Prikhodko*
 
-*   Don't enforce UTF-8 by default
+*   Don't enforce UTF-8 by default.
 
     With the disabling of TLS 1.0 by most major websites, continuing to run
     IE8 or lower becomes increasingly difficult so default to not enforcing

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
-*   Add support for timezones to Active Job
+*   Add support for timezones to Active Job.
 
     Record what was the current timezone in effect when the job was
     enqueued and then restore when the job is executed in same way

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -6,8 +6,6 @@
         URI.unescape("%E3%83%90")  # => "バ"
         URI.unescape("\xe3\x83\x90%E3%83%90")  # => Encoding::CompatibilityError
 
-    GH#32183
-
     *Ashe Connor*, *Aaron Patterson*
 
 *   Add `:private` option to ActiveSupport's `Module#delegate`
@@ -53,7 +51,7 @@
 
     *Jeremy Daer*
 
-*   Adds parallel testing to Rails
+*   Adds parallel testing to Rails.
 
     Parallelize your test suite with forked processes or threads.
 


### PR DESCRIPTION
- Add missing dots.
- Remove reference to itself on GitHub.
  Usually, we add references to fixed issues only in a changelog.

Follow up #32223
