### PR TITLE
fix casting zero-float numbers to boolean

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -14,7 +14,7 @@ module ActiveModel
     # - Empty strings are coerced to +nil+
     # - All other values will be coerced to +true+
     class Boolean < Value
-      FALSE_VALUES = [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"].to_set
+      FALSE_VALUES = [false, 0, 0.0, "0", "f", "F", "false", "FALSE", "off", "OFF"].to_set
 
       def type # :nodoc:
         :boolean

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -5,35 +5,26 @@ require "cases/helper"
 module ActiveModel
   module Type
     class BooleanTest < ActiveModel::TestCase
+      VALUES_FOR_CAST = [1, "1",
+                         true, "t", "true", "TRUE",
+                         "on", "ON",
+                         " ",
+                         "\u3000\r\n", "\u0000",
+                         "random string"]
+
       def test_type_cast_boolean
         type = Type::Boolean.new
         assert_predicate type.cast(""), :nil?
         assert_predicate type.cast(nil), :nil?
 
-        assert type.cast(true)
-        assert type.cast(1)
-        assert type.cast("1")
-        assert type.cast("t")
-        assert type.cast("T")
-        assert type.cast("true")
-        assert type.cast("TRUE")
-        assert type.cast("on")
-        assert type.cast("ON")
-        assert type.cast(" ")
-        assert type.cast("\u3000\r\n")
-        assert type.cast("\u0000")
-        assert type.cast("SOMETHING RANDOM")
+        VALUES_FOR_CAST.each do |value|
+          assert type.cast(value)
+        end
 
         # explicitly check for false vs nil
-        assert_equal false, type.cast(false)
-        assert_equal false, type.cast(0)
-        assert_equal false, type.cast("0")
-        assert_equal false, type.cast("f")
-        assert_equal false, type.cast("F")
-        assert_equal false, type.cast("false")
-        assert_equal false, type.cast("FALSE")
-        assert_equal false, type.cast("off")
-        assert_equal false, type.cast("OFF")
+        ::ActiveModel::Type::Boolean::FALSE_VALUES.each do |value|
+          assert_equal false, type.cast(value)
+        end
       end
     end
   end


### PR DESCRIPTION
I was a little bit wondering... why?

```ruby
> Boolean(0.0)
true
```

but if we compare, it will be okay because of type casting, its ok 

```ruby
0.0 == 0
true
```

but what is 0.0 ? is that zero ? 

```ruby
0.0.zero?
true
```
lets see a C code

```C
    if (RFLOAT_VALUE(num) == 0.0) {
        return Qtrue;
    }
```

so 0.0 is zero, but 

```ruby
> Boolean(0)
false
```

so if 0.0 is zero it should be casted as 0 and has to be false, right ?

now 0.0, 0.0000000, etc will be false
