### PR TITLE
[WIP] Add a integration test for Digital Ocean spaces

### DIFF
--- a/activestorage/test/service/configurations.example.yml
+++ b/activestorage/test/service/configurations.example.yml
@@ -5,6 +5,14 @@
 #   region: ""
 #   bucket: ""
 #
+# spaces:
+#   service: S3
+#   access_key_id: ""
+#   secret_access_key: ""
+#   region: "nyc3"
+#   bucket: ""
+#   endpoint: "https://nyc3.digitaloceanspaces.com"
+#
 # gcs:
 #   service: GCS
 #   credentials: {

--- a/activestorage/test/service/spaces_service_test.rb
+++ b/activestorage/test/service/spaces_service_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "service/shared_service_tests"
+require "net/http"
+
+if SERVICE_CONFIGURATIONS[:spaces] && SERVICE_CONFIGURATIONS[:spaces][:access_key_id].present?
+  class ActiveStorage::Service::SpacesServiceTest < ActiveSupport::TestCase
+    SERVICE = ActiveStorage::Service.configure(:spaces, SERVICE_CONFIGURATIONS)
+
+    include ActiveStorage::Service::SharedServiceTests
+
+    test "direct upload" do
+      begin
+        key      = SecureRandom.base58(24)
+        data     = "Something else entirely!"
+        checksum = Digest::MD5.base64digest(data)
+        url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+        uri = URI.parse url
+        request = Net::HTTP::Put.new uri.request_uri
+        request.body = data
+        request.add_field "Content-Type", "text/plain"
+        request.add_field "Content-MD5", checksum
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.request request
+        end
+
+        assert_equal data, @service.download(key)
+      ensure
+        @service.delete key
+      end
+    end
+
+    test "signed URL generation" do
+      url = @service.url(FIXTURE_KEY, expires_in: 5.minutes,
+        disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+
+      assert_match(/digitaloceanspaces\.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url)
+      assert_match SERVICE_CONFIGURATIONS[:spaces][:bucket], url
+    end
+
+    test "uploading with server-side encryption" do
+      skip "Spaces currently doesn't support server side encryption"
+
+      config  = SERVICE_CONFIGURATIONS.deep_merge(spaces: { upload: { server_side_encryption: "AES256" } })
+      service = ActiveStorage::Service.configure(:spaces, config)
+
+      begin
+        key  = SecureRandom.base58(24)
+        data = "Something else entirely!"
+        service.upload key, StringIO.new(data), checksum: Digest::MD5.base64digest(data)
+
+        assert_equal "AES256", service.bucket.object(key).server_side_encryption
+      ensure
+        service.delete key
+      end
+    end
+  end
+else
+  puts "Skipping Spaces Service tests because no Spaces configuration was supplied"
+end


### PR DESCRIPTION
Digital Ocean's Spaces service is API-compatible with AWS S3 so add an integration test to ensure that it works with the Active Storage S3 service class.

Not everything is supported, for example server side encryption doesn't work.
