### PR TITLE
 ActiveSupport::Cache::RedisCacheStore should support Redis instances for `redis` kwarg

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -118,9 +118,7 @@ module ActiveSupport
         def build_redis(redis: nil, url: nil, **redis_options) #:nodoc:
           urls = Array(url)
 
-          if redis.is_a?(Redis)
-            redis
-          elsif redis.respond_to?(:call)
+          if redis.is_a?(Proc)
             redis.call
           elsif redis
             redis

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -118,7 +118,9 @@ module ActiveSupport
         def build_redis(redis: nil, url: nil, **redis_options) #:nodoc:
           urls = Array(url)
 
-          if redis.respond_to?(:call)
+          if redis.is_a?(Redis)
+            redis
+          elsif redis.respond_to?(:call)
             redis.call
           elsif redis
             redis

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -97,7 +97,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     test "instance of Redis uses given instance" do
       redis_instance = Redis.new
-      @cache = build(redis: redis_instance).redis
+      @cache = build(redis: redis_instance)
       assert_same @cache.redis, redis_instance
     end
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -95,6 +95,12 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    test "instance of Redis uses given instance" do
+      redis_instance = Redis.new
+      @cache = build(redis: redis_instance).redis
+      assert_same @cache.redis, redis_instance
+    end
+
     private
       def build(**kwargs)
         ActiveSupport::Cache::RedisCacheStore.new(driver: DRIVER, **kwargs).tap do |cache|


### PR DESCRIPTION
### Summary

Fixes a bug in https://github.com/rails/rails/pull/31134

ActiveSupport::Cache::RedisCacheStore should support operating upon a Redis instance given in its initializer (via the `redis` keyword argument). Ref: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/redis_cache_store.rb#L109-L116

In actual fact, because `Redis.new.respond_to?(:call)`, `RedisCacheStore` will instead treat a Redis instance like a proc, `call`ing it to populate its `@redis`: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/redis_cache_store.rb#L121-L122

Obviously this doesn't have the correct semantics. The test case added in my first commit fails with a `Redis::TimeoutError` (if indeed a Redis instance is running on `127.0.0.1:6379`).

With the fix given in my second commit, `RedisCacheStore#redis` is precisely equal to the Redis instance given to the initializer, if indeed one was given.

### Other Information

I'm a first-time contributor 😁 please let me know if I need to update any changelog or open this PR against a branch other than master.