### PR TITLE
Add assertion methods for Rails loggers to public API

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -5,6 +5,50 @@ module ActiveSupport
     module Assertions
       UNTRACKED = Object.new # :nodoc:
 
+      # Asserts that a message matching <tt>regex</tt> was logged
+      # within the provided block. Passes if content logged in
+      # the block matches the regex provided.
+      #
+      #   assert_logs /an informational log message/ do
+      #     Rails.logger.info 'an informational log message'
+      #   end
+      def assert_logs(regex)
+        old_logger = Rails.logger
+        log = StringIO.new
+        Rails.logger = Logger.new(log)
+
+        begin
+          yield
+
+          log.rewind
+          assert_match message, log.read, message
+        ensure
+          Rails.logger = old_logger
+        end
+      end
+
+      # Asserts that no messages matching the provided regex
+      # were logged in the provided block. Passes if the content
+      # logged inside the block doesn't match the regex provided.
+      #
+      #   assert_no_logs /an informational log message/ do
+      #     Rails.logger.info 'not very informational'
+      #   end
+      def assert_no_logs(regex)
+        old_logger = Rails.logger
+        log = StringIO.new
+        Rails.logger = Logger.new(log)
+
+        begin
+          yield
+
+          log.rewind
+          assert_no_match message, log.read
+        ensure
+          Rails.logger = old_logger
+        end
+      end
+
       # Asserts that an expression is not truthy. Passes if <tt>object</tt> is
       # +nil+ or +false+. "Truthy" means "considered true in a conditional"
       # like <tt>if foo</tt>.


### PR DESCRIPTION
This adds two assertion methods for asserting logging behaviour.

### Summary

When working on a gem internally, I found that there are no methods in Rails to check if a message has been logged to the Logger, but that one already existed in one of ActionView's test suite helper: https://github.com/rails/rails/blob/309bb6c4d068b0d480681cf4ef1b90158527dfe5/actionview/test/template/digestor_test.rb#L304-L317 This pulls them up into public API.

### Questions

* Are there tests for these methods? I can't find any but am totally willing to write them if they're tested.
