### PR TITLE
Make Active Storage work with API-only apps

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveStorage::BaseController` now inherits from `ActionController::API`
+
+    This allows Active Storage to be used from within API-only applications.
+    
+    *Andrew White*
+
 *   Files can now be served by proxying them from the underlying storage service
     instead of redirecting to a signed service URL. Use the
     `rails_storage_proxy_path` and `_url` helpers to proxy an attached file:

--- a/activestorage/app/controllers/active_storage/base_controller.rb
+++ b/activestorage/app/controllers/active_storage/base_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 # The base class for all Active Storage controllers.
-class ActiveStorage::BaseController < ActionController::Base
+class ActiveStorage::BaseController < ActionController::API
+  include ActionController::RequestForgeryProtection
   include ActiveStorage::SetCurrent
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, if: :protect_against_forgery?
 
   private
     def stream(blob)
@@ -14,4 +15,8 @@ class ActiveStorage::BaseController < ActionController::Base
     ensure
       response.stream.close
     end
+
+  public
+
+  ActiveSupport.run_load_hooks :active_storage_base_controller, self
 end

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -7,7 +7,7 @@
 class ActiveStorage::DiskController < ActiveStorage::BaseController
   include ActiveStorage::FileServer
 
-  skip_forgery_protection
+  skip_forgery_protection if: :protect_against_forgery?
 
   def show
     if key = decode_verified_key

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -150,5 +150,11 @@ module ActiveStorage
         ActiveRecord::Reflection.singleton_class.prepend(Reflection::ReflectionExtension)
       end
     end
+
+    initializer "active_storage.request_forgery_protection" do |app|
+      ActiveSupport.on_load(:active_storage_base_controller) do
+        self.allow_forgery_protection = app.config.action_controller.allow_forgery_protection
+      end
+    end
   end
 end


### PR DESCRIPTION
Inherit from ActionController::API and include only the required features.

Fixes #32208.