### PR TITLE
Enum behaviour improvement for strings

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -508,4 +508,28 @@ class EnumTest < ActiveRecord::TestCase
   test "data type of Enum type" do
     assert_equal :integer, Book.type_for_attribute("status").type
   end
+
+  test "enum with string attribute defined as hash" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum cover: { hardcover: :hardcover, paperback: :paperback }
+    end
+
+    book = klass.hardcover.create!
+    assert_equal "hardcover", klass.last.cover
+  end
+
+  test "enum with string attribute defined as array of symbols" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum cover: %i[hardcover paperback]
+    end
+
+    book = klass.paperback.create!
+    assert_equal "paperback", klass.last.cover
+
+    assert_raise(ArgumentError, "'softcover' is not a valid cover") do
+      klass.create!(cover: :softcover)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

If `enum` is defined as an array of symbols and the type of underlying field is `string`, allow the user to store the value as a plain string.

So you can write:

```ruby

# If the type of field difficulty is string
# t.column :difficulty, :string, default: "easy"
enum difficulty: %i[easy medium hard]

```
Instead of:

```ruby

# If the type of field difficulty is string
# t.column :difficulty, :string, default: "easy"
DIFFICULTIES = %i[easy medium hard]
enum difficulty: DIFFICULTIES.zip(DIFFICULTIES.map(&:to_s)).to_h

```

OR instead of:

```ruby

enum difficulty: { easy: "easy", medium: "medium", hard: "hard" }

```


When selecting the difficulty by calling the `#easy!` method, it will be stored as a string "easy" if the type of the column is a string. 