### PR TITLE
Update docs for creating custom types for attributes api.

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -131,8 +131,23 @@ module ActiveRecord
       #       end
       #     end
       #   end
+      # #
+      #   # app/models/store_listing.rb
+      #   class StoreListing < ActiveRecord::Base
+      #     attribute :price_in_cents, MoneyType.new
+      #   end
+      #
+      #   store_listing = StoreListing.new(price_in_cents: '$10.00')
+      #   store_listing.price_in_cents # => 1000
+      #
+      # For more details on creating custom types, see the documentation for
+      # ActiveRecord::Type::Value.
+      #
+      # Note that it is also possible to register a type, so that you can use a symbol instead of passing an
+      # instantiated type directly within attribute, ie.:
       #
       #   # config/initializers/types.rb
+      #   require 'lib/money_type' # NB: don't use an autoloaded location from initializers
       #   ActiveRecord::Type.register(:money, MoneyType)
       #
       #   # app/models/store_listing.rb
@@ -140,13 +155,8 @@ module ActiveRecord
       #     attribute :price_in_cents, :money
       #   end
       #
-      #   store_listing = StoreListing.new(price_in_cents: '$10.00')
-      #   store_listing.price_in_cents # => 1000
-      #
-      # For more details on creating custom types, see the documentation for
-      # ActiveModel::Type::Value. For more details on registering your types
-      # to be referenced by a symbol, see ActiveRecord::Type.register. You can
-      # also pass a type object directly, in place of a symbol.
+      # see ActiveRecord::Type.register for more details
+
       #
       # ==== \Querying
       #

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -143,8 +143,8 @@ module ActiveRecord
       # For more details on creating custom types, see the documentation for
       # ActiveRecord::Type::Value.
       #
-      # Note that it is also possible to register a type, so that you can use a symbol instead of passing an
-      # instantiated type directly within attribute, ie.:
+      # It is also possible to register a type within an initializer. It is then possible to use a symbol to refer to
+      # the type rather than passing an instantiated type directly within attribute:
       #
       #   # config/initializers/types.rb
       #   require 'lib/money_type' # NB: don't use an autoloaded location from initializers

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -131,7 +131,7 @@ module ActiveRecord
       #       end
       #     end
       #   end
-      # #
+      #
       #   # app/models/store_listing.rb
       #   class StoreListing < ActiveRecord::Base
       #     attribute :price_in_cents, MoneyType.new


### PR DESCRIPTION
### Summary

Updates the API docs for creating a custom type. Gives the primary example as instantiation of a custom type (making registration and using a symbol an alternative) 
because this avoids problems with autoloading in development, as
pointed out in #27337 and
https://christoph.luppri.ch/articles/rails/adding-custom-types-to-your-activerecord-models-with-the-attributes-api/

### Other information

As a side note, I wonder if registration should be marked as part of the "low-level api" mentioned under `define_attribute` below, intended more for plugin authors than application code.
