### PR TITLE
[Webpack] Raise an error when lockfile diff is generated

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -3,7 +3,7 @@
 namespace :yarn do
   desc "Install all JavaScript dependencies as specified via Yarn"
   task :install do
-    system("./bin/yarn install --no-progress --production")
+    system("./bin/yarn install --no-progress --freeze-lockfile --production")
   end
 end
 


### PR DESCRIPTION
https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile

### Summary

I can't imagine a situation in which you'd want to allow a production yarn install to generate a diff in the lockfile. Inevitably _someone_ will have a problem with this, so I imagine it would go behind a flag, but for everyone else, I think this should be the default