### PR TITLE
Update "Upgrading from Rails 5.1 to Rails 5.2" [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -502,6 +502,10 @@ Defaults to `'signed cookie'`.
 * `config.action_dispatch.cookies_rotations` allows rotating
   secrets, ciphers, and digests for encrypted and signed cookies.
 
+* `config.action_dispatch.use_authenticated_cookie_encryption` controls whether
+  signed and encrypted cookies use the AES-256-GCM cipher or
+  the older AES-256-CBC cipher. It defaults to `true`.
+
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)
   for more information. It defaults to `true`.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -77,6 +77,16 @@ Rails 5.2 adds bootsnap gem in the [newly generated app's Gemfile](https://githu
 The `app:update` task sets it up in `boot.rb`. If you want to use it, then add it in the Gemfile,
 otherwise change the `boot.rb` to not use bootsnap.
 
+### Expiry in signed or encrypted cookie is now embedded in the cookies values
+
+To improve security, Rails now embeds the expiry information also in encrypted or signed cookies value.
+
+This new embed information make those cookies incompatible with versions of Rails older than 5.2.
+
+If you require your cookies to be read by 5.1 and older, or you are still validating your 5.2 deploy and want
+to allow you to rollback set
+`Rails.application.config.action_dispatch.use_authenticated_cookie_encryption` to `false`.
+
 Upgrading from Rails 5.0 to Rails 5.1
 -------------------------------------
 


### PR DESCRIPTION
Add section "Expiry in signed or encrypted cookie is now embedded in the cookies values"
to `master` since it should always be in the guides, not only for version 5.2.

Add info about `config.action_dispatch.use_authenticated_cookie_encryption`
to the "Configuring Rails Applications" guide.

It was committed straight  to `5-2-stable` since we don't need this
functionality in 6.0. Related to b25fcbc074ea688765af62a163698d5449221a8c.
