### PR TITLE
Fix changelog entries of `5-1-stable` [ci skip]

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Rails 5.1.5 (February 14, 2018) ##
 
-*   No changes.
+*   Support redis-rb 4.0.
+
+    *Jeremy Daer*
 
 
 ## Rails 5.1.4 (September 07, 2017) ##

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Rails 5.1.5 (February 14, 2018) ##
 
-*   Gemfile for new apps: upgrade redis-rb from ~> 3.0 to 4.0.
+*   Support redis-rb 4.0.
 
     *Jeremy Daer*
+
 
 ## Rails 5.1.4 (September 07, 2017) ##
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -13,6 +13,7 @@
 
     *Jeremy Daer*
 
+
 ## Rails 5.1.4 (September 07, 2017) ##
 
 *   No changes.


### PR DESCRIPTION
https://github.com/rails/rails/pull/30748 was backported to `5-1-stable`
by 37895311514a35333e5597018852eb0fe2c9eb28.
This commit adds missing changelog entry and fixes others.