### PR TITLE
Add cancellation info to before filter docs

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -103,6 +103,10 @@ module AbstractController
       # :call-seq: before_action(names, block)
       #
       # Append a callback before actions. See _insert_callbacks for parameter details.
+      #
+      # If the callback renders or redirects, the action will not run. If there
+      # are additional callbacks scheduled to run after that callback, they are
+      # also cancelled.
 
       ##
       # :method: prepend_before_action
@@ -110,6 +114,10 @@ module AbstractController
       # :call-seq: prepend_before_action(names, block)
       #
       # Prepend a callback before actions. See _insert_callbacks for parameter details.
+      #
+      # If the callback renders or redirects, the action will not run. If there
+      # are additional callbacks scheduled to run after that callback, they are
+      # also cancelled.
 
       ##
       # :method: skip_before_action
@@ -124,6 +132,10 @@ module AbstractController
       # :call-seq: append_before_action(names, block)
       #
       # Append a callback before actions. See _insert_callbacks for parameter details.
+      #
+      # If the callback renders or redirects, the action will not run. If there
+      # are additional callbacks scheduled to run after that callback, they are
+      # also cancelled.
 
       ##
       # :method: after_action


### PR DESCRIPTION
### Summary
It is important for users to know that a render or redirect in a "before"
filter causes the action to be cancelled. This was addressed in [the guide](http://guides.rubyonrails.org/action_controller_overview.html#filters),
but not the API docs.

[ci skip]