### PR TITLE
Fix PostgreSQL index parsing with multiline expression

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -107,7 +107,7 @@ module ActiveRecord
             oid = row[4]
             comment = row[5]
 
-            using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/).flatten
+            using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
 
             orders = {}
             opclasses = {}


### PR DESCRIPTION
Hi folks,

This looks like a small bug in PostgreSQL connection adapter. Here's how it goes.

Given the following index definition, which is valid in PostgreSQL:

```ruby
# (byebug) inddef
"CREATE INDEX organizations_on_normalized_name ON organizations USING btree (translate(lower((name)::text), '（）／＋－；“”‘’ \t\n\r'::text, '()/+-;\"\"'''''::text))"
```

The original code used to parse it is `inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/).flatten`.

There's a `\n` in the index expression so the index definition is treated as a two line string. Therefore the original regexp failed to parse it as a whole.

The solution is to simply indicate this regexp is ready to parse multiline text by adding the `/m` suffix flag to the regexp.

```
inddef = "CREATE INDEX organizations_on_normalized_name ON organizations USING btree (translate(lower((name)::text), '（）／＋－；“”‘’ \t\n\r'::text, '()/+-;\"\"'''''::text))"

## Original code

inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/).flatten
# => []

## Fixed code
inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
# => ["btree", "translate(lower((name)::text), '（）／＋－；“”‘’ \t\n\r'::text, '()/+-;\"\"'''''::text)", nil]
```

Thanks!