### PR TITLE
Add config.active_storage.mount_path option

### DIFF
--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "/rails/active_storage/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+  scope ActiveStorage.mount_path do
+    get "/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+
+    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
+
+    get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
+    put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
+    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+  end
 
   direct :rails_blob do |blob, options|
     route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
@@ -9,9 +17,6 @@ Rails.application.routes.draw do
 
   resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
   resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
-
-
-  get "/rails/active_storage/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
 
   direct :rails_representation do |representation, options|
     signed_blob_id = representation.blob.signed_id
@@ -23,9 +28,4 @@ Rails.application.routes.draw do
 
   resolve("ActiveStorage::Variant") { |variant, options| route_for(:rails_representation, variant, options) }
   resolve("ActiveStorage::Preview") { |preview, options| route_for(:rails_representation, preview, options) }
-
-
-  get  "/rails/active_storage/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-  put  "/rails/active_storage/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-  post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -35,10 +35,6 @@ require "marcel"
 module ActiveStorage
   extend ActiveSupport::Autoload
 
-  INTERNAL = {
-    default_mount_path: "/rails/active_storage",
-  }
-
   autoload :Attached
   autoload :Service
   autoload :Previewer
@@ -50,7 +46,7 @@ module ActiveStorage
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers, default: []
   mattr_accessor :paths, default: {}
-  mattr_accessor :mount_path
+  mattr_accessor :mount_path, default: "/rails/active_storage"
   mattr_accessor :variable_content_types, default: []
   mattr_accessor :content_types_to_serve_as_binary, default: []
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -35,6 +35,10 @@ require "marcel"
 module ActiveStorage
   extend ActiveSupport::Autoload
 
+  INTERNAL = {
+    default_mount_path: "/rails/active_storage",
+  }
+
   autoload :Attached
   autoload :Service
   autoload :Previewer
@@ -46,6 +50,7 @@ module ActiveStorage
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers, default: []
   mattr_accessor :paths, default: {}
+  mattr_accessor :mount_path
   mattr_accessor :variable_content_types, default: []
   mattr_accessor :content_types_to_serve_as_binary, default: []
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -48,6 +48,7 @@ module ActiveStorage
         ActiveStorage.previewers = app.config.active_storage.previewers || []
         ActiveStorage.analyzers  = app.config.active_storage.analyzers || []
         ActiveStorage.paths      = app.config.active_storage.paths || {}
+        ActiveStorage.mount_path = app.config.active_storage.mount_path || ActiveStorage::INTERNAL[:default_mount_path]
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -48,7 +48,10 @@ module ActiveStorage
         ActiveStorage.previewers = app.config.active_storage.previewers || []
         ActiveStorage.analyzers  = app.config.active_storage.analyzers || []
         ActiveStorage.paths      = app.config.active_storage.paths || {}
-        ActiveStorage.mount_path = app.config.active_storage.mount_path || ActiveStorage::INTERNAL[:default_mount_path]
+
+        unless app.config.active_storage.mount_path.nil?
+          ActiveStorage.mount_path = app.config.active_storage.mount_path
+        end
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -117,7 +117,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       assert_equal 6, details["byte_size"]
       assert_equal checksum, details["checksum"]
       assert_equal "text/plain", details["content_type"]
-      assert_match(/rails\/active_storage\/disk/, details["direct_upload"]["url"])
+      assert_match(Regexp.new("#{Regexp.escape(ActiveStorage.mount_path)}/disk/"), details["direct_upload"]["url"])
       assert_equal({ "Content-Type" => "text/plain" }, details["direct_upload"]["headers"])
     end
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -140,6 +140,6 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     def expected_url_for(blob, disposition: :inline, filename: nil)
       filename ||= blob.filename
       query_string = { content_type: blob.content_type, disposition: "#{disposition}; #{filename.parameters}" }.to_param
-      "/rails/active_storage/disk/#{ActiveStorage.verifier.generate(blob.key, expires_in: 5.minutes, purpose: :blob_key)}/#{filename}?#{query_string}"
+      "#{ActiveStorage.mount_path}/disk/#{ActiveStorage.verifier.generate(blob.key, expires_in: 5.minutes, purpose: :blob_key)}/#{filename}?#{query_string}"
     end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -8,7 +8,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "url generation" do
-    assert_match(/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
+    assert_match(Regexp.new("#{Regexp.escape(ActiveStorage.mount_path)}/disk/.*/avatar\\.png\\?content_type=image%2Fpng&disposition=inline"),
       @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 end


### PR DESCRIPTION
### Summary

In the spirit of "convention over configuration", I think we should allow custom `activestorage` route scope. In order to support this, a new config option `config.active_storage.mount_path` may be introduced. This option currently defaults to `/rails/active_storage` 

### Other Information

In order to keep consistency with other rails's parts, I think we should change `/rails/active_storage` scope to just `/storage` like it is `/cable` for `actioncable`.

### Example

```ruby
config.active_storage.mount_path = "/storage123"
```

```
       rails_service_blob GET    /storage123/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
rails_blob_representation GET    /storage123/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
       rails_disk_service GET    /storage123/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
update_rails_disk_service PUT    /storage123/disk/:encoded_token(.:format)                                      active_storage/disk#update
     rails_direct_uploads POST   /storage123/direct_uploads(.:format)                                           active_storage/direct_uploads#create
```


Thanks!
