### PR TITLE
Make `Session::MemCacheStore` work with Dalli 2.7.7 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :doc do
 end
 
 # Active Support.
-gem "dalli", "2.7.6"
+gem "dalli", ">= 2.2.1"
 gem "listen", ">= 3.0.5", "< 3.2", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     crass (1.0.3)
     curses (1.0.2)
     daemons (1.2.4)
-    dalli (2.7.6)
+    dalli (2.7.7)
     dante (0.2.0)
     declarative (0.0.10)
     declarative-option (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails
   connection_pool
-  dalli (= 2.7.6)
+  dalli (>= 2.2.1)
   delayed_job
   delayed_job_active_record
   google-cloud-storage (~> 1.8)

--- a/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb
@@ -19,6 +19,8 @@ module ActionDispatch
       include StaleSessionCheck
       include SessionObject
 
+      alias_method :generate_sid_super, :generate_sid
+
       def initialize(app, options = {})
         options[:expire_after] ||= options[:expires]
         super


### PR DESCRIPTION
`Session::MemCacheStore` uses its own method to generate the sid so that it does not use the method provided by rack. 
However, by https://github.com/petergoldstein/dalli/commit/9f9c508afab263a2451f2209c4396daf98d33a1b, an alias is defined for `generate_sid`, and by calling that alias, the method provided by rack is called to generate sid.  
However, `generate_sid` was called while initialization was not done correctly, resulting in an error.
https://travis-ci.org/rails/rails/jobs/353788947#L1429-L1490 

In order to avoid this, `Session::MemCacheStore` also defines the same alias so that `generate_sid` held by `Session::MemCacheStore` is called.
