### PR TITLE
Fix typo in active_job_basics.md

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -147,7 +147,7 @@ class GuestsCleanupJob < ApplicationJob
   #....
 end
 
-# Now your job will use `resque` as it's backend queue adapter overriding what
+# Now your job will use `resque` as its backend queue adapter overriding what
 # was configured in `config.active_job.queue_adapter`.
 ```
 


### PR DESCRIPTION
`it's` -> `its`
