### PR TITLE
Check exclude before flagging cookies as secure in ActionDispatch::SSL

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Check exclude before flagging cookies as secure.
+ 
+    *Catherine Khuu*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -15,6 +15,8 @@ module ActionDispatch
   #
   #      config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
   #
+  #    Cookies will not be flagged as secure for excluded requests.
+  #
   # 2. <b>Secure cookies</b>: Sets the +secure+ flag on cookies to tell browsers they
   #    must not be sent along with +http://+ requests. Enabled by default. Set
   #    +config.ssl_options+ with <tt>secure_cookies: false</tt> to disable this feature.

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -71,7 +71,7 @@ module ActionDispatch
       if request.ssl?
         @app.call(env).tap do |status, headers, body|
           set_hsts_header! headers
-          flag_cookies_as_secure! headers if @secure_cookies
+          flag_cookies_as_secure! headers if @secure_cookies && !@exclude.call(request)
         end
       else
         return redirect_to_https request unless @exclude.call(request)

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -208,6 +208,14 @@ class SecureCookiesTest < SSLTest
     assert_cookies(*DEFAULT.split("\n"))
   end
 
+  def test_cookies_as_not_secure_with_exclude
+    excluding = { exclude: -> request { request.domain =~ /example/ } }
+    get headers: { "Set-Cookie" => DEFAULT }, ssl_options: { redirect: excluding }
+
+    assert_cookies(*DEFAULT.split("\n"))
+    assert_response :ok
+  end
+
   def test_no_cookies
     get
     assert_nil response.headers["Set-Cookie"]


### PR DESCRIPTION
### Summary
Check exclude before flagging cookies as secure in ActionDispatch::SSL

When `config.force_ssl = true`, it does three things: 

1. Permanently redirects `http://` requests to `https://`
2. Flags cookies as secure and tells the browser to not send cookies along with `http://` requests 
3. Tells the browser to remember the site as TLS-only and automatically redirect non-TLS requests

We would typically want all three of these defaults when we enable `config.force_ssl = true`. However, that might not be the case when we want to exclude a request from redirection to an `https://` enabled host.

```
config.force_ssl = true
config.ssl_options = {
  redirect: {
    host: ENV["APP_HOST"], 
    exclude: -> request { 
      request.domain == "herokuapp.com" 
    }
  }
}
```

I ran into this issue when trying to migrate Review Apps from Heroku's Public Space to Private Space, where all of Heroku's Review Apps have a default domain `http://<my-pr-app>.herokuapp.com`, and the only way to enable `https` on an app in the Private Space is to give it a custom domain and an SSL cert. Since Review Apps are meant to be spun up temporarily, and torn down, I think adding a custom domain and SSL cert to an app that is meant to be destroyed 24 hours later is a hassle. Heroku recommends in their documentation to exclude redirection to an `https://` enabled site for their default domain `herokuapp.com` in order to access an app without a custom domain in the Private Space.

With this setup, I want all requests that don't match the domain `herokuapp.com` to be redirected to an `https://` enabled host, and for all requests that match my example to be excluded from redirection (i.e. `http://<my-pr-app.herokuapp.com`).The problem is, even though I am excluding `herokuapp.com` from redirection, I never get a session cookie because that is automatically set to secure. This means I can never verify the CSRF/authenticity token on any forms I submit. The error I receive when making any `POST`, `PUT`, or `PATCH` request is a status `422 unprocessable entity` and `ActionController::InvalidAuthenticityToken`.
