### PR TITLE
Change temporary file name extension while editing encrypted file.

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -57,7 +57,7 @@ module ActiveSupport
 
     private
       def writing(contents)
-        tmp_file = "#{content_path.basename}.#{Process.pid}"
+        tmp_file = "#{Process.pid}.#{content_path.basename.to_s.chomp('.enc')}"
         tmp_path = Pathname.new File.join(Dir.tmpdir, tmp_file)
         tmp_path.binwrite contents
 


### PR DESCRIPTION
To have syntax higlihting in an editor try to preserve original extension of edited file
