### PR TITLE
Permit using the AWS Credentials Provider chain for S3 storage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,8 +1,8 @@
-*   Allow the use of the AWS Credentials Provider chain for S3 storage. If
-    an explicit AWS access key id and secret access key are not provided in
-    `storage.yml`, attempt to use environment variables, shared credentials,
-    or IAM (instance or task) role credentials. Order of precedence is
-    determined by the [AWS SDK].(https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)
+*   Allow full use of the AWS S3 SDK options for authentication. If an
+    explicit AWS key pair and/or region is not provided in  `storage.yml`, 
+    attempt to use environment variables, shared credentials, or IAM 
+    (instance or task) role credentials. Order of precedence is determined 
+    by the [AWS SDK](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html).
 
     *Brian Knight*
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow the use of the AWS Credentials Provider chain for S3 storage. If
+    an explicit AWS access key id and secret access key are not provided in
+    `storage.yml`, attempt to use environment variables, shared credentials,
+    or IAM (instance or task) role credentials. Order of precedence is
+    determined by the [AWS SDK].(https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html)
+
+    *Brian Knight*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -103,7 +103,7 @@ module ActiveStorage
       end
 
       def region(region)
-        region || ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+        region || ENV["AWS_REGION"] || ENV["AWS_DEFAULT_REGION"] || "us-east-1"
       end
 
       def object_for(key)

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -93,7 +93,6 @@ module ActiveStorage
     end
 
     private
-
       def credentials(access_key_id, secret_access_key)
         if access_key_id && secret_access_key
           Aws::Credentials.new(access_key_id, secret_access_key)

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::S3Service < Service
     attr_reader :client, :bucket, :upload_options
 
-    def initialize(access_key_id: nil, secret_access_key: nil, region:, bucket:, upload: {}, **options)
-      @client = Aws::S3::Resource.new(credentials: credentials(access_key_id, secret_access_key), region: region, **options)
+    def initialize(access_key_id: nil, secret_access_key: nil, region: nil, bucket:, upload: {}, **options)
+      @client = Aws::S3::Resource.new(credentials: credentials(access_key_id, secret_access_key), region: region(region), **options)
       @bucket = @client.bucket(bucket)
 
       @upload_options = upload
@@ -100,6 +100,10 @@ module ActiveStorage
         else
           Aws::CredentialProviderChain.new.resolve
         end
+      end
+
+      def region(region)
+        region || ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
       end
 
       def object_for(key)

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::S3Service < Service
     attr_reader :client, :bucket, :upload_options
 
-    def initialize(access_key_id: nil, secret_access_key: nil, region: nil, bucket:, upload: {}, **options)
-      @client = Aws::S3::Resource.new(credentials: credentials(access_key_id, secret_access_key), region: region(region), **options)
+    def initialize(bucket:, upload: {}, **options)
+      @client = Aws::S3::Resource.new(**options)
       @bucket = @client.bucket(bucket)
 
       @upload_options = upload
@@ -93,18 +93,6 @@ module ActiveStorage
     end
 
     private
-      def credentials(access_key_id, secret_access_key)
-        if access_key_id && secret_access_key
-          Aws::Credentials.new(access_key_id, secret_access_key)
-        else
-          Aws::CredentialProviderChain.new.resolve
-        end
-      end
-
-      def region(region)
-        region || ENV["AWS_REGION"] || ENV["AWS_DEFAULT_REGION"] || "us-east-1"
-      end
-
       def object_for(key)
         bucket.object(key)
       end

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "aws-sdk-core"
 require "aws-sdk-s3"
 require "active_support/core_ext/numeric/bytes"
 

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -3,7 +3,7 @@
 require "service/shared_service_tests"
 require "net/http"
 
-if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].present?
+if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:service].present?
   class ActiveStorage::Service::S3ServiceTest < ActiveSupport::TestCase
     SERVICE = ActiveStorage::Service.configure(:s3, SERVICE_CONFIGURATIONS)
 

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -3,7 +3,7 @@
 require "service/shared_service_tests"
 require "net/http"
 
-if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:service].present?
+if SERVICE_CONFIGURATIONS[:s3]
   class ActiveStorage::Service::S3ServiceTest < ActiveSupport::TestCase
     SERVICE = ActiveStorage::Service.configure(:s3, SERVICE_CONFIGURATIONS)
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -114,6 +114,13 @@ gem "aws-sdk-s3", require: false
 
 NOTE: The core features of Active Storage require the following permissions: `s3:ListBucket`, `s3:PutObject`, `s3:GetObject`, and `s3:DeleteObject`. If you have additional upload options configured such as setting ACLs then additional permissions may be required.
 
+NOTE: If you want to use environment variables, standard SDK configuration files, profiles,
+IAM instance profiles or task roles, you can omit the `access_key_id`, `secret_access_key`,
+and `region` keys in the example above. The Amazon S3 Service supports all of the
+authentication options described in the [AWS SDK documentation]
+(https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html).
+
+
 ### Microsoft Azure Storage Service
 
 Declare an Azure Storage service in `config/storage.yml`:


### PR DESCRIPTION
### Summary

Allow the use of the AWS Credentials Provider chain for S3 storage. If an explicit AWS `access_key_id` and `secret_access_key` are not provided in `storage.yml`, attempt to use environment variables, shared credentials, or IAM (instance or task) role credentials. Order of precedence is determined by the AWS SDK.

Access key ids and secret keys provided in `storage.yml` take precedence over any other credentials. Therefore, this change will not have any upgrade impact.

**Thank you for the consideration**