### PR TITLE
Fix default connection handling with three-tier config

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -156,7 +156,6 @@ module ActiveRecord
             env_config = config[env] if config[env].is_a?(Hash) && !(config[env].key?("adapter") || config[env].key?("url"))
           end
 
-          config.reject! { |k, v| v.is_a?(Hash) && !(v.key?("adapter") || v.key?("url")) }
           config.merge! env_config if env_config
 
           config.each do |key, value|

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -57,6 +57,10 @@ module ActiveRecord
       spec = resolver.resolve(config).symbolize_keys
       spec[:name] = spec_name
 
+      # use the primary config if a config is not passed in and
+      # it's a three tier config
+      spec = spec[spec_name.to_sym] if spec[spec_name.to_sym]
+
       connection_handler.establish_connection(spec)
     end
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -97,7 +97,7 @@ module Rails
         elsif configurations[environment].blank? && configurations[connection].blank?
           raise ActiveRecord::AdapterNotSpecified, "'#{environment}' database is not configured. Available configuration: #{configurations.inspect}"
         else
-          configurations[environment].presence || configurations[connection]
+          configurations[connection] || configurations[environment].presence
         end
       end
     end


### PR DESCRIPTION
If you had a three-tier config, the `establish_connection` that's called
in the Railtie on load can't figure out how to access the default
configuration.

This is because Rails assumes that the config is the first value in the
hash and always associated with the key from the environment. With a
three tier config however we need to go one level deeper.

This commit includes 2 changes. 1) removes a line from `resolve_all`
which was parsing out the the environment from the config so instead of
getting

```
{
  :development => {
    :primary => {
      :database => "whatever"
    }
  },
    :animals => {
      :database => "whatever-animals"
    }
  },
  etc with test / prod
}
```

We'd instead end up with a config that had no attachment to it's
envioronment.

```
{
  :primary => {
    :database => "whatever"
  }
  :animals => {
    :database => "whatever-animals"
  }
  etc - without test and prod
}
```

Not only did this mean that Active Record didn't know how to establish a
connection, it didn't have the other necessary configs along with it in
the configs list.

So fix this I removed the line that deletes these configs.

The second thing this commit changes is adding this line to
`establish_connection`

```
spec = spec[spec_name.to_sym] if spec[spec_name.to_sym]
```

When you have a three-tier config and don't pass any hash/symbol/env etc
to `establish_connection` the resolver will automatically return both
the primary and secondary (in this case animals db) configurations.
We'll get an `database configuration does not specify adapter` error
because AR will try to establish a connection on the `primary` key
rather than the `primary` key's config. It assumes that the
`development` or default env automatically will return a config hash,
but with a three-tier config we actually get a key and config `primary
=> config`.

This fix is a bit of a bandaid because it's not the "correct" way to
handle this situation, but it does solve our immediate problem. The new
code here is saying "if the config returned from the resolver (I know
it's called spec in here but we interchange our meanings a LOT and what
is returned is a three-tier config) has a key matching the "primary"
spec name, grab the config from the spec and pass that to the
estalbish_connection method".

This works because if we pass `:animals` or a hash, or `:primary` we'll
already have the correct configuration to connect with.

This fixes the case where we want Rail to connect with the default
connection.

Coming soon is a refactoring that should eliminate the need to do this
but I need this fix in order to write the multi-db rake tasks that I
promised in my RailsConf submission. `@tenderlove` and I are working on
the refactoring of the internals for connection management but it won't
be ready for a few weeks and this issue has been blocking progress.

cc/ @tenderlove 