### PR TITLE
Part 1 Easy Multi db in Rails: Add basic rake tasks for multi db setup

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -40,6 +40,7 @@ module ActiveRecord
   autoload :Core
   autoload :ConnectionHandling
   autoload :CounterCache
+  autoload :DatabaseConfigurations
   autoload :DynamicMatchers
   autoload :Enum
   autoload :InternalMetadata

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -290,6 +290,7 @@ module ActiveRecord #:nodoc:
     extend CollectionCacheKey
 
     include Core
+    include DatabaseConfigurations
     include Persistence
     include ReadonlyAttributes
     include ModelSchema

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -60,45 +60,6 @@ module ActiveRecord
         @@configurations
       end
 
-      DatabaseConfig = Struct.new(:env_name, :spec_name, :config) # :nodoc
-
-      # Given an env, spec and config creates DatabaseConfig structs with
-      # each attribute set.
-      def self.walk_configs(env_name, spec_name, config) # :nodoc:
-        if config["database"] || env_name == "default"
-          DatabaseConfig.new(env_name, spec_name, config)
-        else
-          config.each_pair.map do |spec_name, sub_config|
-            walk_configs(env_name, spec_name, sub_config)
-          end
-        end
-      end
-
-      # Walks all the configs passed in and returns an array
-      # of DatabaseConfig structs for each configuration.
-      def self.db_configs(configs = configurations) # :nodoc:
-        configs.each_pair.flat_map do |env_name, config|
-          walk_configs(env_name, "primary", config)
-        end
-      end
-
-      # Collects the configs for the environment passed in.
-      #
-      # If a block is given returns the specification name and configuration
-      # otherwise returns an array of DatabaseConfig structs for the environment.
-      def self.configs_for(environment, configs = configurations, &blk) # :nodoc:
-        env_with_configs = db_configs(configs).select do |db_config|
-          db_config.env_name == environment
-        end
-
-        if block_given?
-          env_with_configs.each do |env_with_config|
-            yield env_with_config.spec_name, env_with_config.config
-          end
-        else
-          env_with_configs
-        end
-      end
       ##
       # :singleton-method:
       # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -60,6 +60,45 @@ module ActiveRecord
         @@configurations
       end
 
+      DatabaseConfig = Struct.new(:env_name, :spec_name, :config) # :nodoc
+
+      # Given an env, spec and config creates DatabaseConfig structs with
+      # each attribute set.
+      def self.walk_configs(env_name, spec_name, config) # :nodoc:
+        if config["database"] || env_name == "default"
+          DatabaseConfig.new(env_name, spec_name, config)
+        else
+          config.each_pair.map do |spec_name, sub_config|
+            walk_configs(env_name, spec_name, sub_config)
+          end
+        end
+      end
+
+      # Walks all the configs passed in and returns an array
+      # of DatabaseConfig structs for each configuration.
+      def self.db_configs(configs = configurations) # :nodoc:
+        configs.each_pair.flat_map do |env_name, config|
+          walk_configs(env_name, "primary", config)
+        end
+      end
+
+      # Collects the configs for the environment passed in.
+      #
+      # If a block is given returns the specification name and configuration
+      # otherwise returns an array of DatabaseConfig structs for the environment.
+      def self.configs_for(environment, configs = configurations, &blk) # :nodoc:
+        env_with_configs = db_configs(configs).select do |db_config|
+          db_config.env_name == environment
+        end
+
+        if block_given?
+          env_with_configs.each do |env_with_config|
+            yield env_with_config.spec_name, env_with_config.config
+          end
+        else
+          env_with_configs
+        end
+      end
       ##
       # :singleton-method:
       # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module DatabaseConfigurations # :nodoc:
+    class DatabaseConfig
+      attr_reader :env_name, :spec_name, :config
+
+      def initialize(env_name, spec_name, config)
+        @env_name = env_name
+        @spec_name = spec_name
+        @config = config
+      end
+    end
+
+    # Selects the config for the specified environment and specification name
+    #
+    # For example if passed :development, and :animals it will select the database
+    # under the :development and :animals configuration level
+    def self.config_for_env_and_spec(environment, specification_name, configs = ActiveRecord::Base.configurations) # :nodoc:
+      configs_for(environment, configs).find do |db_config|
+        db_config.spec_name == specification_name
+      end
+    end
+
+    # Collects the configs for the environment passed in.
+    #
+    # If a block is given returns the specification name and configuration
+    # otherwise returns an array of DatabaseConfig structs for the environment.
+    def self.configs_for(env, configs = ActiveRecord::Base.configurations, &blk) # :nodoc:
+      env_with_configs = db_configs(configs).select do |db_config|
+        db_config.env_name == env
+      end
+
+      if block_given?
+        env_with_configs.each do |env_with_config|
+          yield env_with_config.spec_name, env_with_config.config
+        end
+      else
+        env_with_configs
+      end
+    end
+
+    # Given an env, spec and config creates DatabaseConfig structs with
+    # each attribute set.
+    def self.walk_configs(env_name, spec_name, config) # :nodoc:
+      if config["database"] || env_name == "default"
+        DatabaseConfig.new(env_name, spec_name, config)
+      else
+        config.each_pair.map do |spec_name, sub_config|
+          walk_configs(env_name, spec_name, sub_config)
+        end
+      end
+    end
+
+    # Walks all the configs passed in and returns an array
+    # of DatabaseConfig structs for each configuration.
+    def self.db_configs(configs = ActiveRecord::Base.configurations) # :nodoc:
+      configs.each_pair.flat_map do |env_name, config|
+        walk_configs(env_name, "primary", config)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -73,8 +73,11 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
-    ActiveRecord::Tasks::DatabaseTasks.migrate
-    db_namespace["_dump"].invoke
+    ActiveRecord::Base.configs_for(Rails.env) do |spec_name, config|
+      ActiveRecord::Base.establish_connection(config)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
+      db_namespace["_dump"].invoke
+    end
   end
 
   # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -252,12 +252,26 @@ module ActiveRecord
       end
 
       def schema_file(format = ActiveRecord::Base.schema_format)
+        File.join(db_dir, schema_file_type(format))
+      end
+
+      def schema_file_type(format = ActiveRecord::Base.schema_format)
         case format
         when :ruby
-          File.join(db_dir, "schema.rb")
+          "schema.rb"
         when :sql
-          File.join(db_dir, "structure.sql")
+          "structure.sql"
         end
+      end
+
+      def dump_filename(namespace, format = ActiveRecord::Base.schema_format)
+        filename = if namespace == "primary"
+          schema_file_type(format)
+        else
+          "#{namespace}_#{schema_file_type(format)}"
+        end
+
+        ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
       end
 
       def load_schema_current(format = ActiveRecord::Base.schema_format, file = nil, environment = env)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -134,6 +134,13 @@ module ActiveRecord
         end
       end
 
+      def for_each
+        databases = Rails.application.config.load_database_yaml
+        ActiveRecord::DatabaseConfigurations.configs_for(Rails.env, databases) do |spec_name, _|
+          yield spec_name
+        end
+      end
+
       def create_current(environment = env)
         each_current_configuration(environment) { |configuration|
           create configuration
@@ -327,7 +334,7 @@ module ActiveRecord
           environments << "test" if environment == "development"
 
           environments.each do |env|
-            ActiveRecord::Base.configs_for(env) do |spec_name, configuration|
+            ActiveRecord::DatabaseConfigurations.configs_for(env) do |spec_name, configuration|
               yield configuration, spec_name, env
             end
           end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -261,8 +261,8 @@ module ActiveRecord
       end
 
       def load_schema_current(format = ActiveRecord::Base.schema_format, file = nil, environment = env)
-        each_current_configuration(environment) { |configuration, configuration_environment|
-          load_schema configuration, format, file, configuration_environment
+        each_current_configuration(environment) { |configuration, spec_name, env|
+          load_schema configuration, format, file, env
         }
         ActiveRecord::Base.establish_connection(environment.to_sym)
       end
@@ -312,10 +312,10 @@ module ActiveRecord
           environments = [environment]
           environments << "test" if environment == "development"
 
-          ActiveRecord::Base.configurations.slice(*environments).each do |configuration_environment, configuration|
-            next unless configuration["database"]
-
-            yield configuration, configuration_environment
+          environments.each do |env|
+            ActiveRecord::Base.configs_for(env) do |spec_name, configuration|
+              yield configuration, spec_name, env
+            end
           end
         end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -221,7 +221,76 @@ module ActiveRecord
       ENV["RAILS_ENV"] = old_env
     end
 
-    def test_establishes_connection_for_the_given_environment
+    def test_establishes_connection_for_the_given_environments
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+
+      ActiveRecord::Base.expects(:establish_connection).with(:development)
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new("development")
+      )
+    end
+  end
+
+  class DatabaseTasksCreateCurrentThreeTierTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
+        "test" => { "primary" => { "database" => "test-db" }, "secondary" => { "database" => "secondary-test-db" } },
+        "production" => { "primary" => { "database" => "prod-db" }, "secondary" => { "database" => "secondary-prod-db" } }
+      }
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+    end
+
+    def test_creates_current_environment_database
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "prod-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "secondary-prod-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new("production")
+      )
+    end
+
+    def test_creates_test_and_development_databases_when_env_was_not_specified
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "secondary-dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "test-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "secondary-test-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new("development")
+      )
+    end
+
+    def test_creates_test_and_development_databases_when_rails_env_is_development
+      old_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "development"
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "secondary-dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "test-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with("database" => "secondary-test-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.create_current(
+        ActiveSupport::StringInquirer.new("development")
+      )
+    ensure
+      ENV["RAILS_ENV"] = old_env
+    end
+
+    def test_establishes_connection_for_the_given_environments_config
       ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
 
       ActiveRecord::Base.expects(:establish_connection).with(:development)
@@ -338,6 +407,64 @@ module ActiveRecord
         with("database" => "dev-db")
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with("database" => "test-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new("development")
+      )
+    ensure
+      ENV["RAILS_ENV"] = old_env
+    end
+  end
+
+  class DatabaseTasksDropCurrentThreeTierTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
+        "test" => { "primary" => { "database" => "test-db" }, "secondary" => { "database" => "secondary-test-db" } },
+        "production" => { "primary" => { "database" => "prod-db" }, "secondary" => { "database" => "secondary-prod-db" } }
+      }
+
+      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
+    end
+
+    def test_drops_current_environment_database
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "prod-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "secondary-prod-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new("production")
+      )
+    end
+
+    def test_drops_test_and_development_databases_when_env_was_not_specified
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "secondary-dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "test-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "secondary-test-db")
+
+      ActiveRecord::Tasks::DatabaseTasks.drop_current(
+        ActiveSupport::StringInquirer.new("development")
+      )
+    end
+
+    def test_drops_testand_development_databases_when_rails_env_is_development
+      old_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "development"
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "secondary-dev-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "test-db")
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with("database" => "secondary-test-db")
 
       ActiveRecord::Tasks::DatabaseTasks.drop_current(
         ActiveSupport::StringInquirer.new("development")

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -166,6 +166,18 @@ module Rails
         end
       end
 
+      # Loads the database YAML without evaluating ERB.  People seem to
+      # write ERB that makes the database configuration depend on
+      # Rails configuration.  But we want Rails configuration (specifically
+      # `rake` and `rails` tasks) to be generated based on information in
+      # the database yaml, so we need a method that loads the database
+      # yaml *without* the context of the Rails application.
+      def load_database_yaml # :nodoc:
+        path = paths["config/database"].existent.first
+        return {} unless path
+        YAML.load_file(path.to_s)
+      end
+
       # Loads and returns the entire raw configuration of database from
       # values stored in <tt>config/database.yml</tt>.
       def database_configuration


### PR DESCRIPTION
For multi db applications you always had to create your own rake tasks which made setting up multi db a major PITA. This PR is Part 1 of a many that adds the initial underpinning for supporting multiple databases through the rake db commands. I'm doing this in small PR's so that reviewing is easier.

This app can be used to test out the features here. Just clone and use the commands below to play with testing re rake tasks for create, migrate, drop, and dump. https://github.com/eileencodes/multiple_databases_demo

Examples below are assuming a three-tier database.yml like this:

```yaml
development:
  primary:
    <<: *default
    database: multiple_databases_development
  animals:
    <<: *default
    database: multiple_databases_development_animals
    migrations_paths: "db/animals_migrate"

test:
  primary:
    <<: *default
    database: multiple_databases_test
  animals:
    <<: *default
    database: multiple_databases_test_animals
    migrations_paths: "db/animals_migrate"
```

* Creates internal DatabaseConfig objects so it's easier to pass around the configs. We can then ask a DatabaseConfig for it's env or spec or config directly. This will come in handy for a larger refactoring I'm working on.
* Ensures when running `bin/rails db:create`, `bin/rails db:migrate`, `bin/rails db:drop`, and `bin/rails db:schema|structure:dump` that tasks are run for all relevant envs and all databases in that env so given the above config `bin/rails db:create` will create the dev and test dbs for both primary and animals configs.
* Adds new Rails db tasks that can perform create/migrate/drop on a specific database in an environment
  * `bin/rails db:create:primary` or `bin/rails db:create:animals`
  * `bin/rails db:drop:primary` or `bin/rails db:drop:animals`
  * `bin/rails db:migrate:primary` or `bin/rails db:migrate:animals`

Future parts of this work will:
* Add more rake task support for multi db as this only does the first 4 major ones
* Add documentation for multi-db three-tier database.yml applications
* Add documentation for the rake tasks
* Refactoring of the connection management to fix the assumption that the config lives directly under development (see https://github.com/rails/rails/pull/32271 for more info there on what I'm talking about).
* Eventually porting these to Rails commands
* Dealing with rw/ro connection setups

cc/ @matthewd @tenderlove @dhh 