### PR TITLE
Randomize order of projects testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,8 @@ task default: %w(test test:isolated)
   desc "Run #{task_name} task for all projects"
   task task_name do
     errors = []
-    FRAMEWORKS.each do |project|
+    FRAMEWORKS.shuffle.each do |project|
+      puts "Running #{project} tests"
       system(%(cd #{project} && #{$0} #{task_name} --trace)) || errors << project
     end
     fail("Errors in #{errors.join(', ')}") unless errors.empty?


### PR DESCRIPTION
### Summary

> Randomization helps detect order-dependent tests (aka. crappy tests). Test
methods have been randomized for a long time; this commit randomizes the
order test suites are run in as well.

seattlerb/minitest#426 (2014)

This commit randomizes the order that Rails components are are run in.

