### PR TITLE
Fix failing `QuotingTest#test_quoted_time_utc`

### DIFF
--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -71,8 +71,8 @@ module ActiveRecord
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
 
-          expected = t.change(year: 2000, month: 1, day: 1)
-          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
+          expected = t.getutc.change(year: 2000, month: 1, day: 1)
+          expected = expected.to_s(:db).sub("2000-01-01 ", "")
 
           assert_equal expected, @quoter.quoted_time(t)
         end


### PR DESCRIPTION
This test fails in specific time.
Example:

f run this test on the machine with time 01:00 am UTC+2,
this test will fail.
Changing representing of 2000-01-01 01:00 am UTC+2 to UTC+0 change
the day, month and even year in our case,
so substitution `"2000-01-01 "` to `""` isn't possible.

```
Failure:
ActiveRecord::ConnectionAdapters::QuotingTest#test_quoted_time_utc
Expected: "1999-12-31 23:01:27"
  Actual: "23:01:27"
```

Related to 7c479cbf
r? @pixeltrix