### PR TITLE
Pass HTML responses as plain-text in rails-ujs

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -69,7 +69,7 @@ processResponse = (response, type) ->
       script.nonce = cspNonce()
       script.text = response
       document.head.appendChild(script).parentNode.removeChild(script)
-    else if type.match(/\b(xml|html|svg)\b/)
+    else if type.match(/\bxml\b/)
       parser = new DOMParser()
       type = type.replace(/;.+/, '') # remove something like ';charset=utf-8'
       try response = parser.parseFromString(response, type)

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -128,6 +128,17 @@ asyncTest('execution of JS code does not modify current DOM', 1, function() {
   })
 })
 
+asyncTest('HTML content should be plain-text', 1, function() {
+  buildForm({ method: 'post', 'data-type': 'html' })
+
+  $('form').append('<input type="text" name="content_type" value="text/html">')
+  $('form').append('<input type="text" name="content" value="<p>hello</p>">')
+
+  submit(function(e, data, status, xhr) {
+    ok(data === '<p>hello</ps>', 'returned data should be a plain-text string')
+  })
+})
+
 asyncTest('XML document should be parsed', 1, function() {
   buildForm({ method: 'post', 'data-type': 'html' })
 


### PR DESCRIPTION
### Summary

Running HTML responses through `DOMParser#parseFromString` results in
complete `HTMLDocument` instances with unnecessary surrounding tags.

#### For example

```js
new DOMParser().parseFromString('<p>hello</p>', 'text/html')
```

#### Will output

```html
<html>
  <head></head>
  <body>
    <p>hello</p>
  </body>
</html>
```

This is passed to the `ajax:success` handler as `event.detail[0]`
(`data`), but cannot be used directly without first traversing the
document.

To resolve this, only XML content is passed through `parseFromString`,
while HTML content is treated as plain-text.

This matches the behavior of jquery-ujs, which relied on jQuery's
response-type inference.