### PR TITLE
Fix system tests transactions not closed between examples

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -19,6 +19,7 @@ module ActionDispatch
         def after_teardown
           take_failed_screenshot
           Capybara.reset_sessions!
+        ensure
           super
         end
       end


### PR DESCRIPTION
### Summary

BUG.

In some cases, there is happening `Capybara::CapybaraError` which prevents further execution of `super` inside `after_teardown` and that **brakes transactions between tests**. As well that `CapybaraError` sometimes is not seen directly in stacktrace which makes everything even more complicated.