### PR TITLE
Fix: reloading code won't work when eager loading is enabled

### DIFF
--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -57,7 +57,7 @@ module ActionDispatch
 
       def simulator
         @simulator ||= begin
-          gtg = GTG::Builder.new(ast).transition_table
+          gtg = GTG::Builder.new(ast).transition_table unless ast.blank?
           GTG::Simulator.new(gtg)
         end
       end

--- a/actionpack/test/journey/routes_test.rb
+++ b/actionpack/test/journey/routes_test.rb
@@ -39,6 +39,11 @@ module ActionDispatch
         assert_not_equal sim, routes.simulator
       end
 
+      def test_simulator_works_with_empty_routes
+        routes.clear
+        assert_nothing_raised { routes.simulator }
+      end
+
       def test_partition_route
         mapper.get "/foo(/:id)", to: "foo#bar", as: "aaron"
 


### PR DESCRIPTION
### Summary

The patch prevents `Routes#simulator` from failing when the routes are empty (no `anchored_routes`).

Fixes #30578 

## Other information

The error is reproducible with `5.2.0.rc1`. I am creating the PR against `master`. Please let me know if I should do it against `5-2-stable` instead.

The culprit seems to be the `RouteSet` inserted automatically by `ActiveStorage`. The code was failing for not having any `anchored_routes`.

