### PR TITLE
Check value of result.source_location in test_unit/reporter.rb#format_rerun_snippet

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -69,7 +69,7 @@ module Rails
       end
 
       def format_rerun_snippet(result)
-        location, line = if result.respond_to?(:source_location)
+        location, line = if result.respond_to?(:source_location) && result.source_location
           result.source_location
         else
           result.method(result.name).source_location


### PR DESCRIPTION
With Ruby 2.5 format_rerun_snippet can return nil, which crashes the test
suite, F.e.:

```
  TestUnitReporterTest#test_outputs_failures_inline:
  NoMethodError: undefined method `sub' for nil:NilClass
      test/test_unit/reporter_test.rb:62:in `block in <class:TestUnitReporterTest>'
  bin/rails test test/test_unit/reporter_test.rb:61
```