### PR TITLE
Fix save inside after_create_commit looping indefinitely

### DIFF
--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -576,6 +576,37 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
   end
 end
 
+class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  class TopicWithSaveInCallback < ActiveRecord::Base
+    self.table_name = :topics
+    after_commit :cache_topic, on: :create
+    after_commit :call_update, on: :update
+    attr_accessor :cached, :record_updated
+
+    def call_update
+      self.record_updated = true
+    end
+
+    def cache_topic
+      unless cached
+        self.cached = true
+        self.save
+      else
+        self.cached = false
+      end
+    end
+  end
+
+  def test_after_commit_in_save
+    topic = TopicWithSaveInCallback.new
+    topic.save
+    assert_equal true, topic.cached
+    assert_equal true, topic.record_updated
+  end
+end
+
 class CallbacksOnActionAndConditionTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -143,6 +143,8 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     r = ReplyWithCallbacks.new(content: "foo")
     r.save_on_after_create = true
     r.save!
+    assert_equal [:commit_on_create], r.history
+
     r.content = "bar"
     r.save!
     r.save!
@@ -582,12 +584,7 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
   class TopicWithSaveInCallback < ActiveRecord::Base
     self.table_name = :topics
     after_commit :cache_topic, on: :create
-    after_commit :call_update, on: :update
-    attr_accessor :cached, :record_updated
-
-    def call_update
-      self.record_updated = true
-    end
+    attr_accessor :cached
 
     def cache_topic
       unless cached
@@ -603,7 +600,6 @@ class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
     topic = TopicWithSaveInCallback.new
     topic.save
     assert_equal true, topic.cached
-    assert_equal true, topic.record_updated
   end
 end
 


### PR DESCRIPTION
### Summary

Following along #31106, this PR fixes `after_create_commit` being called recursively when the underlying record was saved inside it.

Before these changes when the added test was executed, the callback would loop indefinitely, overflowing the stack and erroring it.

The fix is done by storing state for whether the current transaction was committed for creation or not, and avoiding further callbacks in subsequent calls.

### Other Information

Feedback is very appreciated as I'd like to find a better way to perform this without having to store an instance variable.

Fixes #31104