### PR TITLE
Add custom prefix to ActiveRecord::Store accessors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add custom prefix option to ActiveRecord::Store.store_accessor.
+
+    *Tan Huynh*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -8,7 +8,12 @@ class StoreTest < ActiveRecord::TestCase
   fixtures :'admin/users'
 
   setup do
-    @john = Admin::User.create!(name: "John Doe", color: "black", remember_login: true, height: "tall", is_a_good_guy: true)
+    @john = Admin::User.create!(
+      name: "John Doe", color: "black", remember_login: true,
+      height: "tall", is_a_good_guy: true,
+      parent_name: "Quinn", partner_name: "Dallas",
+      partner_birthday: "1997-11-1"
+    )
   end
 
   test "reading store attributes through accessors" do
@@ -22,6 +27,21 @@ class StoreTest < ActiveRecord::TestCase
 
     assert_equal "red", @john.color
     assert_equal "37signals.com", @john.homepage
+  end
+
+  test "reading store attributes through accessors with prefix" do
+    assert_equal "Quinn", @john.parent_name
+    assert_nil @john.parent_birthday
+    assert_equal "Dallas", @john.partner_name
+    assert_equal "1997-11-1", @john.partner_birthday
+  end
+
+  test "writing store attributes through accessors with prefix" do
+    @john.partner_name = "River"
+    @john.partner_birthday = "1999-2-11"
+
+    assert_equal "River", @john.partner_name
+    assert_equal "1999-2-11", @john.partner_birthday
   end
 
   test "accessing attributes not exposed by accessors" do

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -19,6 +19,9 @@ class Admin::User < ActiveRecord::Base
   store :params, accessors: [ :token ], coder: YAML
   store :settings, accessors: [ :color, :homepage ]
   store_accessor :settings, :favorite_food
+  store :parent, accessors: [:birthday, :name], prefix: true
+  store :spouse, accessors: [:birthday], prefix: :partner
+  store_accessor :spouse, :name, prefix: :partner
   store :preferences, accessors: [ :remember_login ]
   store :json_data, accessors: [ :height, :weight ], coder: Coder.new
   store :json_data_empty, accessors: [ :is_a_good_guy ], coder: Coder.new

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define do
   create_table :admin_users, force: true do |t|
     t.string :name
     t.string :settings, null: true, limit: 1024
+    t.string :parent, null: true, limit: 1024
+    t.string :spouse, null: true, limit: 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
     t.string :preferences, null: true, default: "", limit: 1024


### PR DESCRIPTION
Add a prefix option to ActiveRecord::Store.store_accessor and
ActiveRecord::Store.store. This option allows stores to have identical keys
with different accessors.

### Summary

I often bump into problems at work when using ActiveRecord::Store because of name collision of 
accessors in a store. Consider this snippet of code:
```ruby
class RequestOff < ApplicationRecord
  store :from, accessors: [:date, :period], coder: JSON
  store :to, accessors: [:date, :period], coder: JSON
end
```
The accessors above will not work because there are two accessors with the same name. To solve the 
problems I either have to change the keys in the store or write my own accessors. The new prefix option
will fix the problem above by adding a unique prefix to the accessor without changing the underlying key.
Example:

```ruby
class RequestOff < ApplicationRecord
  store :from, accessors: [:date, :period], coder: JSON, prefix: true
  store :to, accessors: [:date, :period], coder: JSON, prefix: :to
end

ro = RequestOff.new
ro.from_date = "2018-11-1"
```
