### PR TITLE
Model error as object

### DIFF
--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -20,11 +20,11 @@ class ActiveModelHelperTest < ActionView::TestCase
     super
 
     @post = Post.new
-    @post.errors[:author_name] << "can't be empty"
-    @post.errors[:body] << "foo"
-    @post.errors[:category] << "must exist"
-    @post.errors[:published] << "must be accepted"
-    @post.errors[:updated_at] << "bar"
+    assert_deprecated { @post.errors[:author_name] << "can't be empty" }
+    assert_deprecated { @post.errors[:body] << "foo" }
+    assert_deprecated { @post.errors[:category] << "must exist" }
+    assert_deprecated { @post.errors[:published] << "must be accepted" }
+    assert_deprecated { @post.errors[:updated_at] << "bar" }
 
     @post.author_name = ""
     @post.body        = "Back to the hill and over it again!"

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -29,8 +29,18 @@ class FormOptionsHelperTest < ActionView::TestCase
                   end
     Continent   = Struct.new("Continent", :continent_name, :countries)
     Country     = Struct.new("Country", :country_id, :country_name)
-    Firm        = Struct.new("Firm", :time_zone)
     Album       = Struct.new("Album", :id, :title, :genre)
+  end
+
+  class Firm
+    include ActiveModel::Validations
+    extend ActiveModel::Naming
+
+    attr_accessor :time_zone
+
+    def initialize(time_zone = nil)
+      @time_zone = time_zone
+    end
   end
 
   module FakeZones
@@ -1294,7 +1304,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_priority_zones_and_errors
     @firm = Firm.new("D")
     @firm.extend ActiveModel::Validations
-    @firm.errors[:time_zone] << "invalid"
+    assert_deprecated { @firm.errors[:time_zone] << "invalid" }
     zones = [ ActiveSupport::TimeZone.new("A"), ActiveSupport::TimeZone.new("D") ]
     html = time_zone_select("firm", "time_zone", zones)
     assert_dom_equal "<div class=\"field_with_errors\">" \

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -8,7 +8,7 @@ module ActiveModel
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
     MESSAGE_OPTIONS = [:message]
 
-    def initialize(base, attribute, type, **options)
+    def initialize(base, attribute, type = :invalid, **options)
       @base = base
       @attribute = attribute
       @raw_type = type
@@ -55,6 +55,12 @@ module ActiveModel
       end
 
       true
+    end
+
+    def strict_match?(attribute, type, **options)
+      return false unless match?(attribute, type, **options)
+
+      full_message == Error.new(@base, attribute, type, **options).full_message
     end
   end
 end

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  # == Active \Model \Error
+  #
+  # Represents one single error
+  class Error
+    CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
+    MESSAGE_OPTIONS = [:message]
+
+    def initialize(base, attribute, type, **options)
+      @base = base
+      @attribute = attribute
+      @raw_type = type
+      @type = type || :invalid
+      @options = options
+    end
+
+    def initialize_dup(other)
+      @attribute = @attribute.dup
+      @raw_type = @raw_type.dup
+      @type = @type.dup
+      @options = @options.deep_dup
+    end
+
+    attr_reader :base, :attribute, :type, :raw_type, :options
+
+    def message
+      case raw_type
+      when Symbol
+        base.errors.generate_message(attribute, raw_type, options.except(*CALLBACKS_OPTIONS))
+      else
+        raw_type
+      end
+    end
+
+    def detail
+      { error: raw_type }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
+    end
+
+    def full_message
+      base.errors.full_message(attribute, message)
+    end
+
+    # See if error matches provided +attribute+, +type+ and +options+.
+    def match?(attribute, type = nil, **options)
+      if @attribute != attribute || (type && @type != type)
+        return false
+      end
+
+      options.each do |key, value|
+        if @options[key] != value
+          return false
+        end
+      end
+
+      true
+    end
+  end
+end

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -64,7 +64,7 @@ module ActiveModel
     end
 
     def ==(other)
-      attributes_for_hash == other.attributes_for_hash
+      other.is_a?(self.class) && attributes_for_hash == other.attributes_for_hash
     end
     alias eql? ==
 

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -62,5 +62,20 @@ module ActiveModel
 
       full_message == Error.new(@base, attribute, type, **options).full_message
     end
+
+    def ==(other)
+      attributes_for_hash == other.attributes_for_hash
+    end
+    alias eql? ==
+
+    def hash
+      attributes_for_hash.hash
+    end
+
+    protected
+
+      def attributes_for_hash
+        [@base, @attribute, @raw_type, @options]
+      end
   end
 end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -119,6 +119,11 @@ module ActiveModel
     # @option override_options [Symbol] :attribute Override the attribute the error belongs to
     # @option override_options [Symbol] :type Override type of the error.
     def import(error, override_options = {})
+      [:attribute, :type].each do |key|
+        if override_options.key?(key)
+          override_options[key] = override_options[key].to_sym
+        end
+      end
       @errors.append(NestedError.new(@base, error, override_options))
     end
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -292,18 +292,9 @@ module ActiveModel
     #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
     def to_hash(full_messages = false)
       hash = {}
-      @errors.each do |error|
-        if full_messages
-          message = error.full_message
-        else
-          message = error.message
-        end
-
-        if hash.has_key?(error.attribute)
-          hash[error.attribute] << message
-        else
-          hash[error.attribute] = [message]
-        end
+      message_method = full_messages ? :full_message : :message
+      group_by_attribute.each do |attribute, errors|
+        hash[attribute] = errors.map(&message_method)
       end
       hash
     end
@@ -311,16 +302,14 @@ module ActiveModel
 
     def details
       hash = {}
-      @errors.each do |error|
-        detail = error.detail
-
-        if hash.has_key?(error.attribute)
-          hash[error.attribute] << detail
-        else
-          hash[error.attribute] = [detail]
-        end
+      group_by_attribute.each do |attribute, errors|
+        hash[attribute] = errors.map(&:detail)
       end
       hash
+    end
+
+    def group_by_attribute
+      group_by(&:attribute)
     end
 
     # Adds +message+ to the error messages and used validator type to +details+ on +attribute+.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -65,6 +65,8 @@ module ActiveModel
 
     extend Forwardable
     def_delegators :@errors, :size, :clear, :blank?, :empty?
+    # TODO: forward all enumerable methods after `each` deprecation is removed.
+    def_delegators :@errors, :count
 
     LEGACY_ATTRIBUTES = [:messages, :details].freeze
 
@@ -199,7 +201,7 @@ module ActiveModel
     #   person.errors[:name]  # => ["cannot be nil"]
     #   person.errors['name'] # => ["cannot be nil"]
     def [](attribute)
-      where(attribute.to_sym).map { |error| error.message }
+      messages_for(attribute)
     end
 
     # Iterates through each error key, value pair in the error messages hash.
@@ -603,6 +605,10 @@ module ActiveModel
 
       def deprecation_removal_warning(method_name)
         ActiveSupport::Deprecation.warn("ActiveModel::Errors##{method_name} is deprecated and will be removed in Rails 6.1")
+      end
+
+      def deprecation_rename_warning(old_method_name, new_method_name)
+        ActiveSupport::Deprecation.warn("ActiveModel::Errors##{old_method_name} is deprecated. Please call ##{new_method_name} instead.")
       end
   end
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -74,6 +74,7 @@ module ActiveModel
     self.i18n_customize_full_message = false
 
     attr_reader :errors
+    alias :objects :errors
 
     # Pass in the instance of the object that is using the errors object.
     #

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -151,7 +151,7 @@ module ActiveModel
 
       keys = keys.map(&:to_sym)
 
-      results = messages.slice!(*keys)
+      results = messages.dup.slice!(*keys)
 
       @errors.keep_if do |error|
         keys.include?(error.attribute)
@@ -625,16 +625,7 @@ module ActiveModel
   class DeprecationHandlingMessageHash < SimpleDelegator
     def initialize(errors)
       @errors = errors
-
-      content = @errors.to_hash
-      content.each do |attribute, value|
-        content[attribute] = DeprecationHandlingMessageArray.new(value, @errors, attribute)
-      end
-      content.default_proc = proc do |hash, attribute|
-        hash[attribute] = DeprecationHandlingMessageArray.new([], @errors, attribute)
-      end
-
-      super(content)
+      super(prepare_content)
     end
 
     def []=(attribute, value)
@@ -644,15 +635,31 @@ module ActiveModel
         @errors.add(attribute, message)
       end
 
-      super(attribute, DeprecationHandlingMessageArray.new(@errors.messages_for(attribute), @errors, attribute))
+      __setobj__ prepare_content
     end
+
+    private
+
+      def prepare_content
+        content = @errors.to_hash
+        content.each do |attribute, value|
+          content[attribute] = DeprecationHandlingMessageArray.new(value, @errors, attribute)
+        end
+        content.default_proc = proc do |hash, attribute|
+          hash = hash.dup
+          hash[attribute] = DeprecationHandlingMessageArray.new([], @errors, attribute)
+          __setobj__ hash.freeze
+          hash[attribute]
+        end
+        content.freeze
+      end
   end
 
   class DeprecationHandlingMessageArray < SimpleDelegator
     def initialize(content, errors, attribute)
       @errors = errors
       @attribute = attribute
-      super(content)
+      super(content.freeze)
     end
 
     def <<(message)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -64,7 +64,7 @@ module ActiveModel
     include Enumerable
 
     extend Forwardable
-    def_delegators :@errors, :size, :clear, :blank?, :empty?, *(Enumerable.instance_methods(false) - [:to_a, :include?])
+    def_delegators :@errors, :size, :clear, :blank?, :empty?
 
     LEGACY_ATTRIBUTES = [:messages, :details].freeze
 
@@ -309,7 +309,7 @@ module ActiveModel
     end
 
     def group_by_attribute
-      group_by(&:attribute)
+      @errors.group_by(&:attribute)
     end
 
     # Adds +message+ to the error messages and used validator type to +details+ on +attribute+.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -318,7 +318,7 @@ module ActiveModel
       group_by_attribute.each do |attribute, errors|
         hash[attribute] = errors.map(&:detail)
       end
-      hash
+      DeprecationHandlingDetailsHash.new(hash)
     end
 
     def group_by_attribute
@@ -669,6 +669,14 @@ module ActiveModel
       @errors.add(@attribute, message)
       __setobj__ @errors.messages_for(@attribute)
       self
+    end
+  end
+
+  class DeprecationHandlingDetailsHash < SimpleDelegator
+    def initialize(details)
+      details.default = []
+      details.freeze
+      super(details)
     end
   end
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -147,6 +147,8 @@ module ActiveModel
     #   person.errors.slice!(:age, :gender) # => { :name=>["cannot be nil"], :city=>["cannot be nil"] }
     #   person.errors.keys                  # => [:age, :gender]
     def slice!(*keys)
+      deprecation_removal_warning(:slice!)
+
       keys = keys.map(&:to_sym)
 
       results = messages.slice!(*keys)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -631,6 +631,7 @@ module ActiveModel
     def []=(attribute, value)
       ActiveSupport::Deprecation.warn("Calling `[]=` to an ActiveModel::Errors is deprecated. Please call `ActiveModel::Errors#add` instead.")
 
+      @errors.delete(attribute)
       Array(value).each do |message|
         @errors.add(attribute, message)
       end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -64,7 +64,7 @@ module ActiveModel
     include Enumerable
 
     extend Forwardable
-    def_delegators :@errors, :size, :clear, :blank?, :empty?
+    def_delegators :@errors, :size, :clear, :blank?, :empty?, :uniq!
     # TODO: forward all enumerable methods after `each` deprecation is removed.
     def_delegators :@errors, :count
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -59,9 +59,6 @@ module ActiveModel
   class Errors
     include Enumerable
 
-    CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
-    MESSAGE_OPTIONS = [:message]
-
     class << self
       attr_accessor :i18n_customize_full_message # :nodoc:
     end
@@ -532,19 +529,6 @@ module ActiveModel
     end
 
   private
-    def normalize_message(attribute, message, options)
-      case message
-      when Symbol
-        generate_message(attribute, message, options.except(*CALLBACKS_OPTIONS))
-      else
-        message
-      end
-    end
-
-    def normalize_detail(message, options)
-      { error: message }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
-    end
-
     def without_default_proc(hash)
       hash.dup.tap do |new_h|
         new_h.default_proc = nil

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -101,7 +101,7 @@ module ActiveModel
       # locale. If no error is present, the method should return an empty array.
       def test_errors_aref
         assert_respond_to model, :errors
-        assert model.errors[:hello].is_a?(Array), "errors#[] should return an Array"
+        assert_equal [], model.errors[:hello], "errors#[] should return an empty Array"
       end
 
       private

--- a/activemodel/lib/active_model/nested_error.rb
+++ b/activemodel/lib/active_model/nested_error.rb
@@ -28,6 +28,6 @@ module ActiveModel
     attr_reader :inner_error
 
     extend Forwardable
-    def_delegators :@inner_error, :full_message, :message
+    def_delegators :@inner_error, :message
   end
 end

--- a/activemodel/lib/active_model/nested_error.rb
+++ b/activemodel/lib/active_model/nested_error.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "active_model/error"
+require "forwardable"
+
+module ActiveModel
+  # Represents one single error
+  # @!attribute [r] base
+  #   @return [ActiveModel::Base] the object which the error belongs to
+  # @!attribute [r] attribute
+  #   @return [Symbol] attribute of the object which the error belongs to
+  # @!attribute [r] type
+  #   @return [Symbol] error's type
+  # @!attribute [r] options
+  #   @return [Hash] additional options
+  # @!attribute [r] inner_error
+  #   @return [Error] inner error
+  class NestedError < Error
+    def initialize(base, inner_error, override_options = {})
+      @base = base
+      @inner_error = inner_error
+      @attribute = override_options.fetch(:attribute) { inner_error.attribute }
+      @type = override_options.fetch(:type) { inner_error.type }
+      @raw_type = inner_error.raw_type
+      @options = inner_error.options
+    end
+
+    attr_reader :inner_error
+
+    extend Forwardable
+    def_delegators :@inner_error, :full_message, :message
+  end
+end

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_model/error"
+
+class ErrorTest < ActiveModel::TestCase
+  class Person
+    extend ActiveModel::Naming
+    def initialize
+      @errors = ActiveModel::Errors.new(self)
+    end
+
+    attr_accessor :name, :age
+    attr_reader   :errors
+
+    def read_attribute_for_validation(attr)
+      send(attr)
+    end
+
+    def self.human_attribute_name(attr, options = {})
+      attr
+    end
+
+    def self.lookup_ancestors
+      [self]
+    end
+  end
+
+  def test_initialize
+    base = Person.new
+    error = ActiveModel::Error.new(base, :name, :too_long, foo: :bar)
+    assert_equal base, error.base
+    assert_equal :name, error.attribute
+    assert_equal :too_long, error.type
+    assert_equal({ foo: :bar }, error.options)
+  end
+
+  test "initialize without type" do
+    error = ActiveModel::Error.new(Person.new, :name)
+    assert_equal :invalid, error.type
+    assert_equal({}, error.options)
+  end
+
+  test "initialize without type but with options" do
+    options = { message: "bar" }
+    error = ActiveModel::Error.new(Person.new, :name, options)
+    assert_equal :invalid, error.type
+    assert_equal(options, error.options)
+  end
+
+  # match?
+
+  test "match? handles mixed condition" do
+    subject = ActiveModel::Error.new(Person.new, :mineral, :not_enough, count: 2)
+    assert_not subject.match?(:mineral, :too_coarse)
+    assert subject.match?(:mineral, :not_enough)
+    assert subject.match?(:mineral, :not_enough, count: 2)
+    assert_not subject.match?(:mineral, :not_enough, count: 1)
+  end
+
+  test "match? handles attribute match" do
+    subject = ActiveModel::Error.new(Person.new, :mineral, :not_enough, count: 2)
+    assert_not subject.match?(:foo)
+    assert subject.match?(:mineral)
+  end
+
+  test "match? handles error type match" do
+    subject = ActiveModel::Error.new(Person.new, :mineral, :not_enough, count: 2)
+    assert_not subject.match?(:mineral, :too_coarse)
+    assert subject.match?(:mineral, :not_enough)
+  end
+
+  test "match? handles extra options match" do
+    subject = ActiveModel::Error.new(Person.new, :mineral, :not_enough, count: 2)
+    assert_not subject.match?(:mineral, :not_enough, count: 1)
+    assert subject.match?(:mineral, :not_enough, count: 2)
+  end
+
+  # message
+
+  test "message with type as a symbol" do
+    error = ActiveModel::Error.new(Person.new, :name, :blank)
+    assert_equal "can't be blank", error.message
+  end
+
+  test "message with custom interpolation" do
+    subject = ActiveModel::Error.new(Person.new, :name, :inclusion, message: "custom message %{value}", value: "name")
+    assert_equal "custom message name", subject.message
+  end
+
+  test "message returns plural interpolation" do
+    subject = ActiveModel::Error.new(Person.new, :name, :too_long, count: 10)
+    assert_equal "is too long (maximum is 10 characters)", subject.message
+  end
+
+  test "message returns singular interpolation" do
+    subject = ActiveModel::Error.new(Person.new, :name, :too_long, count: 1)
+    assert_equal "is too long (maximum is 1 character)", subject.message
+  end
+
+  test "message returns count interpolation" do
+    subject = ActiveModel::Error.new(Person.new, :name, :too_long, message: "custom message %{count}", count: 10)
+    assert_equal "custom message 10", subject.message
+  end
+
+  test "message handles lambda in messages and option values, and i18n interpolation" do
+    subject = ActiveModel::Error.new(Person.new, :name, :invalid,
+      foo: "foo",
+      bar: "bar",
+      baz: Proc.new { "baz" },
+      message: Proc.new { |model, options|
+        "%{attribute} %{foo} #{options[:bar]} %{baz}"
+      }
+    )
+    assert_equal "name foo bar baz", subject.message
+  end
+
+  test "generate_message works without i18n_scope" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, :blank)
+    assert_not_respond_to Person, :i18n_scope
+    assert_nothing_raised {
+      error.message
+    }
+  end
+
+  test "message with type as custom message" do
+    error = ActiveModel::Error.new(Person.new, :name, message: "cannot be blank")
+    assert_equal "cannot be blank", error.message
+  end
+
+  test "message with options[:message] as custom message" do
+    error = ActiveModel::Error.new(Person.new, :name, :blank, message: "cannot be blank")
+    assert_equal "cannot be blank", error.message
+  end
+
+  test "message renders lazily using current locale" do
+    error = nil
+
+    I18n.backend.store_translations(:pl, errors: { messages: { invalid: "jest nieprawidłowe" } })
+
+    I18n.with_locale(:en) { error = ActiveModel::Error.new(Person.new, :name, :invalid) }
+    I18n.with_locale(:pl) {
+      assert_equal "jest nieprawidłowe", error.message
+    }
+  end
+
+  test "message uses current locale" do
+    I18n.backend.store_translations(:en, errors: { messages: { inadequate: "Inadequate %{attribute} found!" } })
+    error = ActiveModel::Error.new(Person.new, :name, :inadequate)
+    assert_equal "Inadequate name found!", error.message
+  end
+
+  # full_message
+
+  test "full_message returns the given message when attribute is :base" do
+    error = ActiveModel::Error.new(Person.new, :base, message: "press the button")
+    assert_equal "press the button", error.full_message
+  end
+
+  test "full_message returns the given message with the attribute name included" do
+    error = ActiveModel::Error.new(Person.new, :name, :blank)
+    assert_equal "name can't be blank", error.full_message
+  end
+
+  test "full_message uses default format" do
+    error = ActiveModel::Error.new(Person.new, :name, message: "can't be blank")
+
+    # Use a locale without errors.format
+    I18n.with_locale(:unknown) {
+      assert_equal "name can't be blank", error.full_message
+    }
+  end
+end

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -170,4 +170,24 @@ class ErrorTest < ActiveModel::TestCase
       assert_equal "name can't be blank", error.full_message
     }
   end
+
+  test "equality by base attribute, type and options" do
+    person = Person.new
+
+    e1 = ActiveModel::Error.new(person, :name, foo: :bar)
+    e2 = ActiveModel::Error.new(person, :name, foo: :bar)
+    e2.instance_variable_set(:@_humanized_attribute, "Name")
+
+    assert_equal(e1, e2)
+  end
+
+  test "inequality" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, foo: :bar)
+
+    assert error != ActiveModel::Error.new(person, :name, foo: :baz)
+    assert error != ActiveModel::Error.new(person, :name)
+    assert error != ActiveModel::Error.new(person, :title, foo: :bar)
+    assert error != ActiveModel::Error.new(Person.new, :name, foo: :bar)
+  end
 end

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -44,7 +44,6 @@ class ErrorTest < ActiveModel::TestCase
   test "initialize without type but with options" do
     options = { message: "bar" }
     error = ActiveModel::Error.new(Person.new, :name, options)
-    assert_equal :invalid, error.type
     assert_equal(options, error.options)
   end
 

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -190,4 +190,11 @@ class ErrorTest < ActiveModel::TestCase
     assert error != ActiveModel::Error.new(person, :title, foo: :bar)
     assert error != ActiveModel::Error.new(Person.new, :name, foo: :bar)
   end
+
+  test "comparing against different class would not raise error" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, foo: :bar)
+
+    assert error != person
+  end
 end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -494,6 +494,14 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
   end
 
+  test "group_by_attribute" do
+    person = Person.new
+    error = person.errors.add(:name, :invalid, message: "is bad")
+    hash = person.errors.group_by_attribute
+
+    assert_equal({ name: [error] }, hash)
+  end
+
   test "dup duplicates details" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -576,6 +576,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal [:name], person.errors.details.keys
   end
 
+  test "details returns empty array when accessed with non-existent attribute" do
+    errors = ActiveModel::Errors.new(Person.new)
+
+    assert_equal [], errors.details[:foo]
+  end
+
   test "copy errors" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -101,6 +101,14 @@ class ErrorsTest < ActiveModel::TestCase
     end
   end
 
+  test "[]= overrides values" do
+    errors = ActiveModel::Errors.new(self)
+    assert_deprecated { errors.messages[:foo] = "omg" }
+    assert_deprecated { errors.messages[:foo] = "zomg" }
+
+    assert_equal ["zomg"], errors[:foo]
+  end
+
   test "values returns an empty array after try to get a message only" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.messages[:foo]

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -159,14 +159,14 @@ class ErrorsTest < ActiveModel::TestCase
 
     assert_equal :name, error.attribute
     assert_equal :blank, error.type
-    assert_equal error, person.errors.first
+    assert_equal error, person.errors.objects.first
   end
 
   test "add, with type as symbol" do
     person = Person.new
     person.errors.add(:name, :blank)
 
-    assert_equal :blank, person.errors.first.type
+    assert_equal :blank, person.errors.objects.first.type
     assert_equal ["can't be blank"], person.errors[:name]
   end
 
@@ -183,7 +183,7 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name)
 
-    assert_equal :invalid, person.errors.first.type
+    assert_equal :invalid, person.errors.objects.first.type
     assert_equal ["is invalid"], person.errors[:name]
   end
 
@@ -203,7 +203,7 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name, type)
 
-    assert_equal :blank, person.errors.first.type
+    assert_equal :blank, person.errors.objects.first.type
     assert_equal ["can't be blank"], person.errors[:name]
   end
 
@@ -214,7 +214,7 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name, :blank, message: type)
 
-    assert_equal :blank, person.errors.first.type
+    assert_equal :blank, person.errors.objects.first.type
     assert_equal [msg], person.errors[:name]
   end
 
@@ -225,7 +225,7 @@ class ErrorsTest < ActiveModel::TestCase
     person = Person.new
     person.errors.add(:name, message: type)
 
-    assert_equal :invalid, person.errors.first.type
+    assert_equal :invalid, person.errors.objects.first.type
     assert_equal [msg], person.errors[:name]
   end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -528,6 +528,24 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({ name: [{ error: :invalid }] }, person.errors.details)
   end
 
+  test "details retains original type as error" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, "cannot be nil")
+    errors.add("foo", "bar")
+    errors.add(:baz, nil)
+    errors.add(:age, :invalid, count: 3, message: "%{count} is too low")
+
+    assert_equal(
+      {
+        name: [{ error: "cannot be nil" }],
+        foo: [{ error: "bar" }],
+        baz: [{ error: nil }],
+        age: [{ error: :invalid, count: 3 }]
+      },
+      errors.details
+    )
+  end
+
   test "group_by_attribute" do
     person = Person.new
     error = person.errors.add(:name, :invalid, message: "is bad")

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -39,7 +39,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   def test_include?
     errors = ActiveModel::Errors.new(Person.new)
-    errors[:foo] << "omg"
+    assert_deprecated { errors[:foo] << "omg" }
     assert_includes errors, :foo, "errors should include :foo"
     assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end
@@ -93,8 +93,8 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "values returns an array of messages" do
     errors = ActiveModel::Errors.new(Person.new)
-    errors.messages[:foo] = "omg"
-    errors.messages[:baz] = "zomg"
+    assert_deprecated { errors.messages[:foo] = "omg" }
+    assert_deprecated { errors.messages[:baz] = "zomg" }
 
     assert_deprecated do
       assert_equal ["omg", "zomg"], errors.values
@@ -113,11 +113,11 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "keys returns the error keys" do
     errors = ActiveModel::Errors.new(Person.new)
-    errors.add(:name)
-    errors.add(:age)
+    assert_deprecated { errors.messages[:foo] << "omg" }
+    assert_deprecated { errors.messages[:baz] << "zomg" }
 
     assert_deprecated do
-      assert_equal [:name, :age], errors.keys
+      assert_equal [:foo, :baz], errors.keys
     end
   end
 
@@ -151,6 +151,32 @@ class ErrorsTest < ActiveModel::TestCase
     person.validate!
     assert_equal ["name cannot be nil"], person.errors.full_messages
     assert_equal ["cannot be nil"], person.errors[:name]
+  end
+
+  test "add an error message on a specific attribute (deprecated)" do
+    person = Person.new
+    person.errors.add(:name, "cannot be blank")
+    assert_equal ["cannot be blank"], person.errors[:name]
+  end
+
+  test "add an error message on a specific attribute with a defined type (deprecated)" do
+    person = Person.new
+    person.errors.add(:name, :blank, message: "cannot be blank")
+    assert_equal ["cannot be blank"], person.errors[:name]
+  end
+
+  test "add an error with a symbol (deprecated)" do
+    person = Person.new
+    person.errors.add(:name, :blank)
+    message = person.errors.generate_message(:name, :blank)
+    assert_equal [message], person.errors[:name]
+  end
+
+  test "add an error with a proc (deprecated)" do
+    person = Person.new
+    message = Proc.new { "cannot be blank" }
+    person.errors.add(:name, message)
+    assert_equal ["cannot be blank"], person.errors[:name]
   end
 
   test "add creates an error object and returns it" do
@@ -532,6 +558,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_empty person.errors.details
   end
 
+  test "copy errors (deprecated)" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    person = Person.new
+    person.errors.copy!(errors)
+
+    assert_equal [:name], person.errors.messages.keys
+    assert_equal [:name], person.errors.details.keys
+  end
+
   test "copy errors" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)
@@ -542,6 +578,18 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.each do |error|
       assert_same person, error.base
     end
+  end
+
+  test "merge errors (deprecated)" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+
+    person = Person.new
+    person.errors.add(:name, :blank)
+    person.errors.merge!(errors)
+
+    assert_equal({ name: ["can't be blank", "is invalid"] }, person.errors.messages)
+    assert_equal({ name: [{ error: :blank }, { error: :invalid }] }, person.errors.details)
   end
 
   test "merge errors" do

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -563,11 +563,9 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:gender, "cannot be nil")
     person.errors.add(:city, "cannot be nil")
 
-    person.errors.slice!(:age, "gender")
+    assert_deprecated { person.errors.slice!(:age, "gender") }
 
-    assert_deprecated do
-      assert_equal [:age, :gender], person.errors.keys
-    end
+    assert_equal [:age, :gender], assert_deprecated { person.errors.keys }
   end
 
   test "slice! returns the deleted errors" do
@@ -577,7 +575,7 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:gender, "cannot be nil")
     person.errors.add(:city, "cannot be nil")
 
-    removed_errors = person.errors.slice!(:age, "gender")
+    removed_errors = assert_deprecated { person.errors.slice!(:age, "gender") }
 
     assert_equal({ name: ["cannot be nil"], city: ["cannot be nil"] }, removed_errors)
   end

--- a/activemodel/test/cases/nested_error_test.rb
+++ b/activemodel/test/cases/nested_error_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_model/nested_error"
+require "models/topic"
+require "models/reply"
+
+class ErrorTest < ActiveModel::TestCase
+  def test_initialize
+    topic = Topic.new
+    inner_error = ActiveModel::Error.new(topic, :title, :not_enough, count: 2)
+    reply = Reply.new
+    error = ActiveModel::NestedError.new(reply, inner_error)
+
+    assert_equal reply, error.base
+    assert_equal inner_error.attribute, error.attribute
+    assert_equal inner_error.type, error.type
+    assert_equal(inner_error.options, error.options)
+  end
+
+  test "initialize with overriding attribute and type" do
+    topic = Topic.new
+    inner_error = ActiveModel::Error.new(topic, :title, :not_enough, count: 2)
+    reply = Reply.new
+    error = ActiveModel::NestedError.new(reply, inner_error, attribute: :parent, type: :foo)
+
+    assert_equal reply, error.base
+    assert_equal :parent, error.attribute
+    assert_equal :foo, error.type
+    assert_equal(inner_error.options, error.options)
+  end
+
+  def test_message
+    topic = Topic.new(author_name: "Bruce")
+    inner_error = ActiveModel::Error.new(topic, :title, :not_enough, message: Proc.new { |model, options|
+      "not good enough for #{model.author_name}"
+    })
+    reply = Reply.new(author_name: "Mark")
+    error = ActiveModel::NestedError.new(reply, inner_error)
+
+    assert_equal "not good enough for Bruce", error.message
+  end
+
+  def test_full_message
+    topic = Topic.new(author_name: "Bruce")
+    inner_error = ActiveModel::Error.new(topic, :title, :not_enough, message: Proc.new { |model, options|
+      "not good enough for #{model.author_name}"
+    })
+    reply = Reply.new(author_name: "Mark")
+    error = ActiveModel::NestedError.new(reply, inner_error)
+
+    assert_equal "Title not good enough for Bruce", error.full_message
+  end
+end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -179,6 +179,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title_confirmation, :confirmation, generate_message_options.merge(attribute: "Title")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -189,6 +190,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :accepted, generate_message_options]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -199,6 +201,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :blank, generate_message_options]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -209,6 +212,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :too_short, generate_message_options.merge(count: 3)]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -220,6 +224,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :too_long, generate_message_options.merge(count: 5)]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -230,6 +235,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :wrong_length, generate_message_options.merge(count: 5)]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -241,6 +247,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :invalid, generate_message_options.merge(value: "72x")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -252,6 +259,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :inclusion, generate_message_options.merge(value: "z")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -263,6 +271,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :inclusion, generate_message_options.merge(value: "z")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -274,6 +283,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :exclusion, generate_message_options.merge(value: "a")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -285,6 +295,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :exclusion, generate_message_options.merge(value: "a")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -296,6 +307,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :not_a_number, generate_message_options.merge(value: "a")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -307,6 +319,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :not_an_integer, generate_message_options.merge(value: "0.0")]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -318,6 +331,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :odd, generate_message_options.merge(value: 0)]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end
@@ -329,6 +343,7 @@ class I18nValidationTest < ActiveModel::TestCase
       call = [:title, :less_than, generate_message_options.merge(value: 1, count: 0)]
       assert_called_with(@person.errors, :generate_message, call) do
         @person.valid?
+        @person.errors.messages
       end
     end
   end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -167,8 +167,8 @@ class I18nValidationTest < ActiveModel::TestCase
     # [ case,                              validation_options,            generate_message_options]
     [ "given no options",                  {},                            {}],
     [ "given custom message",              { message: "custom" },         { message: "custom" }],
-    [ "given if condition",                { if:                          lambda { true } },  {}],
-    [ "given unless condition",            { unless:                      lambda { false } }, {}],
+    [ "given if condition",                { if: lambda { true } },       {}],
+    [ "given unless condition",            { unless: lambda { false } },  {}],
     [ "given option that is not reserved", { format: "jpg" },             { format: "jpg" }]
   ]
 

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -14,13 +14,13 @@ class ValidationsContextTest < ActiveModel::TestCase
 
   class ValidatorThatAddsErrors < ActiveModel::Validator
     def validate(record)
-      record.errors[:base] << ERROR_MESSAGE
+      record.errors.add(:base, ERROR_MESSAGE)
     end
   end
 
   class AnotherValidatorThatAddsErrors < ActiveModel::Validator
     def validate(record)
-      record.errors[:base] << ANOTHER_ERROR_MESSAGE
+      record.errors.add(:base, ANOTHER_ERROR_MESSAGE)
     end
   end
 

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -14,13 +14,13 @@ class ValidatesWithTest < ActiveModel::TestCase
 
   class ValidatorThatAddsErrors < ActiveModel::Validator
     def validate(record)
-      record.errors[:base] << ERROR_MESSAGE
+      record.errors.add(:base, message: ERROR_MESSAGE)
     end
   end
 
   class OtherValidatorThatAddsErrors < ActiveModel::Validator
     def validate(record)
-      record.errors[:base] << OTHER_ERROR_MESSAGE
+      record.errors.add(:base, message: OTHER_ERROR_MESSAGE)
     end
   end
 
@@ -32,14 +32,14 @@ class ValidatesWithTest < ActiveModel::TestCase
   class ValidatorThatValidatesOptions < ActiveModel::Validator
     def validate(record)
       if options[:field] == :first_name
-        record.errors[:base] << ERROR_MESSAGE
+        record.errors.add(:base, message: ERROR_MESSAGE)
       end
     end
   end
 
   class ValidatorPerEachAttribute < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
-      record.errors[attribute] << "Value is #{value}"
+      record.errors.add(attribute, message: "Value is #{value}")
     end
   end
 

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -53,7 +53,7 @@ class ValidationsTest < ActiveModel::TestCase
     r = Reply.new
     r.valid?
 
-    errors = r.errors.collect { |attr, messages| [attr.to_s, messages] }
+    errors = assert_deprecated { r.errors.collect { |attr, messages| [attr.to_s, messages] } }
 
     assert_includes errors, ["title", "is Empty"]
     assert_includes errors, ["content", "is Empty"]
@@ -216,7 +216,7 @@ class ValidationsTest < ActiveModel::TestCase
     t = Topic.new
     assert_predicate t, :invalid?
 
-    xml = t.errors.to_xml
+    xml = assert_deprecated { t.errors.to_xml }
     assert_match %r{<errors>}, xml
     assert_match %r{<error>Title can't be blank</error>}, xml
     assert_match %r{<error>Content can't be blank</error>}, xml
@@ -241,14 +241,14 @@ class ValidationsTest < ActiveModel::TestCase
     t = Topic.new title: ""
     assert_predicate t, :invalid?
 
-    assert_equal :title, key = t.errors.keys[0]
+    assert_equal :title, key = assert_deprecated { t.errors.keys[0] }
     assert_equal "can't be blank", t.errors[key][0]
     assert_equal "is too short (minimum is 2 characters)", t.errors[key][1]
-    assert_equal :author_name, key = t.errors.keys[1]
+    assert_equal :author_name, key = assert_deprecated { t.errors.keys[1] }
     assert_equal "can't be blank", t.errors[key][0]
-    assert_equal :author_email_address, key = t.errors.keys[2]
+    assert_equal :author_email_address, key = assert_deprecated { t.errors.keys[2] }
     assert_equal "will never be valid", t.errors[key][0]
-    assert_equal :content, key = t.errors.keys[3]
+    assert_equal :content, key = assert_deprecated { t.errors.keys[3] }
     assert_equal "is too short (minimum is 2 characters)", t.errors[key][0]
   end
 

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -74,7 +74,7 @@ class ValidationsTest < ActiveModel::TestCase
 
   def test_errors_on_nested_attributes_expands_name
     t = Topic.new
-    t.errors["replies.name"] << "can't be blank"
+    assert_deprecated { t.errors["replies.name"] << "can't be blank" }
     assert_equal ["Replies name can't be blank"], t.errors.full_messages
   end
 

--- a/activemodel/test/models/person_with_validator.rb
+++ b/activemodel/test/models/person_with_validator.rb
@@ -5,7 +5,7 @@ class PersonWithValidator
 
   class PresenceValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
-      record.errors[attribute] << "Local validator#{options[:custom]}" if value.blank?
+      record.errors.add(attribute, message: "Local validator#{options[:custom]}") if value.blank?
     end
   end
 

--- a/activemodel/test/models/reply.rb
+++ b/activemodel/test/models/reply.rb
@@ -11,24 +11,24 @@ class Reply < Topic
   validate :check_wrong_update,     on: :update
 
   def check_empty_title
-    errors[:title] << "is Empty" unless title && title.size > 0
+    errors.add(:title, "is Empty") unless title && title.size > 0
   end
 
   def errors_on_empty_content
-    errors[:content] << "is Empty" unless content && content.size > 0
+    errors.add(:content, "is Empty") unless content && content.size > 0
   end
 
   def check_content_mismatch
     if title && content && content == "Mismatch"
-      errors[:title] << "is Content Mismatch"
+      errors.add(:title, "is Content Mismatch")
     end
   end
 
   def title_is_wrong_create
-    errors[:title] << "is Wrong Create" if title && title == "Wrong Create"
+    errors.add(:title, "is Wrong Create") if title && title == "Wrong Create"
   end
 
   def check_wrong_update
-    errors[:title] << "is Wrong Update" if title && title == "Wrong Update"
+    errors.add(:title, "is Wrong Update") if title && title == "Wrong Update"
   end
 end

--- a/activemodel/test/validators/email_validator.rb
+++ b/activemodel/test/validators/email_validator.rb
@@ -2,7 +2,8 @@
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors[attribute] << (options[:message] || "is not an email") unless
-      /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
+    unless /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
+      record.errors.add(attribute, message: options[:message] || "is not an email")
+    end
   end
 end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -491,9 +491,7 @@ module ActiveRecord
       end
 
       def _ensure_no_duplicate_errors
-        errors.messages.each_key do |attribute|
-          errors[attribute].uniq!
-        end
+        errors.uniq!
       end
   end
 end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -330,21 +330,16 @@ module ActiveRecord
           if reflection.options[:autosave]
             indexed_attribute = !index.nil? && (reflection.options[:index_errors] || ActiveRecord::Base.index_nested_attribute_errors)
 
-            record.errors.each do |attribute, message|
+            record.errors.group_by_attribute.each { |attribute, errors|
               attribute = normalize_reflection_attribute(indexed_attribute, reflection, index, attribute)
-              errors[attribute] << message
-              errors[attribute].uniq!
-            end
 
-            record.errors.details.each_key do |attribute|
-              reflection_attribute =
-                normalize_reflection_attribute(indexed_attribute, reflection, index, attribute).to_sym
-
-              record.errors.details[attribute].each do |error|
-                errors.details[reflection_attribute] << error
-                errors.details[reflection_attribute].uniq!
-              end
-            end
+              errors.each { |error|
+                self.errors.import(
+                  error,
+                  attribute: attribute
+                )
+              }
+            }
           else
             errors.add(reflection.name)
           end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -746,10 +746,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
       firm = companies(:first_firm)
       lifo = Developer.new(name: "lifo")
-      assert_raises(ActiveRecord::RecordInvalid) { firm.developers << lifo }
+      assert_raises(ActiveRecord::RecordInvalid) do
+        assert_deprecated { firm.developers << lifo }
+      end
 
       lifo = Developer.create!(name: "lifo")
-      assert_raises(ActiveRecord::RecordInvalid) { firm.developers << lifo }
+      assert_raises(ActiveRecord::RecordInvalid) do
+        assert_deprecated { firm.developers << lifo }
+      end
     end
   end
 
@@ -1160,7 +1164,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_create_should_not_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
-      Category.create(name: "Fishing", authors: [Author.first])
+      assert_deprecated { Category.create(name: "Fishing", authors: [Author.first]) }
     end
   end
 
@@ -1173,7 +1177,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
       assert_raises(ActiveRecord::RecordInvalid) do
-        Category.create!(name: "Fishing", authors: [Author.first])
+        assert_deprecated { Category.create!(name: "Fishing", authors: [Author.first]) }
       end
     end
   end
@@ -1183,7 +1187,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
       c = Category.new(name: "Fishing", authors: [Author.first])
       assert_raises(ActiveRecord::RecordInvalid) do
-        c.save!
+        assert_deprecated { c.save! }
       end
     end
   end
@@ -1192,7 +1196,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
       c = Category.new(name: "Fishing", authors: [Author.first])
-      assert_not c.save
+      assert_deprecated { assert_not c.save }
     end
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -183,7 +183,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_predicate company, :valid?
     original_errors = company.errors
     client = company.becomes(Client)
-    assert_equal original_errors.keys, client.errors.keys
+    assert_equal assert_deprecated { original_errors.keys }, assert_deprecated { client.errors.keys }
   end
 
   def test_becomes_errors_base
@@ -197,7 +197,7 @@ class PersistenceTest < ActiveRecord::TestCase
     admin.errors.add :token, :invalid
     child = admin.becomes(child_class)
 
-    assert_equal [:token], child.errors.keys
+    assert_equal [:token], assert_deprecated { child.errors.keys }
     assert_nothing_raised do
       child.errors.add :foo, :invalid
     end

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -40,11 +40,11 @@ class I18nValidationTest < ActiveRecord::TestCase
   COMMON_CASES = [
     # [ case,                              validation_options,            generate_message_options]
     [ "given no options",                  {},                            {}],
-    [ "given custom message",              { message: "custom" },        { message: "custom" }],
-    [ "given if condition",                { if: lambda { true } },  {}],
-    [ "given unless condition",            { unless: lambda { false } }, {}],
-    [ "given option that is not reserved", { format: "jpg" },            { format: "jpg" }],
-    [ "given on condition",                { on: [:create, :update] },     {}]
+    [ "given custom message",              { message: "custom" },         { message: "custom" }],
+    [ "given if condition",                { if: lambda { true } },       {}],
+    [ "given unless condition",            { unless: lambda { false } },  {}],
+    [ "given option that is not reserved", { format: "jpg" },             { format: "jpg" }],
+    [ "given on condition",                { on: [:create, :update] },    {}]
   ]
 
   COMMON_CASES.each do |name, validation_options, generate_message_options|

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -53,6 +53,7 @@ class I18nValidationTest < ActiveRecord::TestCase
       @topic.title = unique_topic.title
       assert_called_with(@topic.errors, :generate_message, [:title, :taken, generate_message_options.merge(value: "unique!")]) do
         @topic.valid?
+        @topic.errors.messages
       end
     end
   end
@@ -62,6 +63,7 @@ class I18nValidationTest < ActiveRecord::TestCase
       Topic.validates_associated :replies, validation_options
       assert_called_with(replied_topic.errors, :generate_message, [:replies, :invalid, generate_message_options.merge(value: replied_topic.replies)]) do
         replied_topic.save
+        replied_topic.errors.messages
       end
     end
   end

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -34,29 +34,29 @@ class WrongReply < Reply
   validate :check_author_name_is_secret, on: :special_case
 
   def check_empty_title
-    errors[:title] << "Empty" unless attribute_present?("title")
+    errors.add(:title, "Empty") unless attribute_present?("title")
   end
 
   def errors_on_empty_content
-    errors[:content] << "Empty" unless attribute_present?("content")
+    errors.add(:content, "Empty") unless attribute_present?("content")
   end
 
   def check_content_mismatch
     if attribute_present?("title") && attribute_present?("content") && content == "Mismatch"
-      errors[:title] << "is Content Mismatch"
+      errors.add(:title, "is Content Mismatch")
     end
   end
 
   def title_is_wrong_create
-    errors[:title] << "is Wrong Create" if attribute_present?("title") && title == "Wrong Create"
+    errors.add(:title, "is Wrong Create") if attribute_present?("title") && title == "Wrong Create"
   end
 
   def check_wrong_update
-    errors[:title] << "is Wrong Update" if attribute_present?("title") && title == "Wrong Update"
+    errors.add(:title, "is Wrong Update") if attribute_present?("title") && title == "Wrong Update"
   end
 
   def check_author_name_is_secret
-    errors[:author_name] << "Invalid" unless author_name == "secret"
+    errors.add(:author_name, "Invalid") unless author_name == "secret"
   end
 end
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -664,7 +664,7 @@ This helper passes the record to a separate class for validation.
 class GoodnessValidator < ActiveModel::Validator
   def validate(record)
     if record.first_name == "Evil"
-      record.errors[:base] << "This person is evil"
+      record.errors.add :base, "This person is evil"
     end
   end
 end
@@ -692,7 +692,7 @@ validator class as `options`:
 class GoodnessValidator < ActiveModel::Validator
   def validate(record)
     if options[:fields].any?{|field| record.send(field) == "Evil" }
-      record.errors[:base] << "This person is evil"
+      record.errors.add :base, "This person is evil"
     end
   end
 end
@@ -723,7 +723,7 @@ class GoodnessValidator
 
   def validate
     if some_complex_condition_involving_ivars_and_private_methods?
-      @person.errors[:base] << "This person is evil"
+      @person.errors.add :base, "This person is evil"
     end
   end
 
@@ -1004,7 +1004,7 @@ and performs the validation on it. The custom validator is called using the
 class MyValidator < ActiveModel::Validator
   def validate(record)
     unless record.name.starts_with? 'X'
-      record.errors[:name] << 'Need a name starting with X please!'
+      record.errors.add :name, "Need a name starting with X please!"
     end
   end
 end
@@ -1026,7 +1026,7 @@ instance.
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-      record.errors[attribute] << (options[:message] || "is not an email")
+      record.errors.add attribute, (options[:message] || "is not an email")
     end
   end
 end
@@ -1203,7 +1203,7 @@ You can add error messages that are related to the object's state as a whole, in
 ```ruby
 class Person < ApplicationRecord
   def a_method_used_for_validation_purposes
-    errors[:base] << "This person is invalid because ..."
+    errors.add :base, "This person is invalid because ..."
   end
 end
 ```


### PR DESCRIPTION
### Summary

Add `ActiveModel::Error` class for encapsulating a single error. It handles message generation and details access. 
Utilize this in `Errors` class, changing it from a hash based interface, to an array of `Error` objects. Add more flexible query methods like `where`.

### Introduction

ActiveModel#errors interface is currently not very object oriented. For some complex use cases, this design made it a bit tedious to use. I feel these issues can be remedied by encapsulating each individual error as an object.

Last year I implemented AdequateErrors gem to do this, and it solved many of my problems. I later found out that back in 2016, @eprothro suggested the [same idea too](https://groups.google.com/forum/#!topic/rubyonrails-core/dRxdSeV4JQE) on the core mailinglist, and Rafael was positive about this. So I made this PR.

I've made it to respect Rails’ deprecation policy. As this contains breaking changes, can this go straight into Rails 6.0?

I will fix other specs/add doc/performance tuning once interface is finalized.

### Benefits

#### More flexible query interface such as `where`

It’s easy to query one particular object using the `where` clause.

```ruby
model.errors.where(:name, :foo, bar: 3).first
```

`delete`, `add`, `added?`, `where` all share the same method signature (attribute, type, options). So we are able to delete specific errors now:

```ruby
model.errors.delete(:name, :too_powerful, level: 9000)
```

#### Testing is more precise and flexible

We can now test if “foo” error exists, regardless of its options hash.

```ruby
model.errors.add(:name, :too_powerful, level: 9000)

model.errors.added?(:name, :too_powerful, level: 9000) # returns true
model.errors.added?(:name, :too_powerful) # will be false in the past, but be true now.
```

In the past, added? works by re-render the message and compare it against current message. Therefore if level is not provided, it will return false. In the PR, `added?` only compare Error's attributes against what's provided, so it can be more general or more specific depending on the needs.

#### Get message of corresponding details of one particular error

If you saw that name attribute has two `foo_error` and one `bar_error`, e.g.:

```ruby
# model.errors.details
{:name=>[{error: :foo_error, count: 1}, {error: :bar_error}, {error: :foo_error, count: 3}]}
```

How do you back track the message on the third particular error? With the current implementation, we have to resort to using array indexes:

```ruby
model.errors.messages[:name][2]
```

Or we can call `generate_message` to recreate a message from the details, but that's also tedious.

With OO, we won't have this problem. Error is represented as an object, message and details are its attributes, so accessing those are straightforward:

```ruby
e = model.errors.where(:name, :foo_error).last
e.full_message
e.options # similar to details, where meta informations such as `:count` is stored.
```

#### Lazily evaluating message for internationalization

[@morgoth](https://github.com/morgoth) mentioned this issue that when you're adding error, it's translated right away.

```ruby
# actual:
I18n.with_locale(:pl) { user.error.full_messages } # => outputs EN errors always

# expecting:
I18n.with_locale(:pl) { user.error.full_messages } # => outputs PL errors
I18n.with_locale(:pt) { user.error.full_messages } # => outputs PT errors
```

This PR addresses this by lazily evaluating messages only when `message` is called.

#### Opens possibility to advanced modding

Once errors are objects, it’s easy to add functionality on top of them. We can have custom methods to disable global attribute prefix on error’s full messages.

### List of API changes

`[]`
unchanged, deprecated (use `messages_for` instead)

`as_json`, `blank?`, `clear`, `count`, `empty?`
unchanged

`add`
unchanged

`added?`
mostly unchanged, for the one change see "Testing is more precise and flexible"

`delete`
extended, so we can give more specific condition such as error type or options.

`each`
If we use `each{|attr,msgs|}` then it behaves the same as before. Deprecated
If we use `each{|error|}` then it loops through Error array.

`full_message`
deprecated as it is no longer needed.
unchanged ~~message is generated in Error.~~

`full_messages`, `full_messages_for`
unchanged

`messages_for`
new, to replace deprecated `[]`

`where`
new, query for error objects
`generate_message`
deprecated ~~Part of Error as message is generated there.~~

`has_key?` `key?`, `keys`
deprecated

`include?`, `size`, `to_hash`, `to_xml`, `to_a`
unchanged

`values` 
deprecated

`import`
new, imports one error as a nested error. Useful in Form Object and nested attribute error importing.

`messages`, `details`
unchanged 

### Some questions I have

~~I am not sure what's the policy for marshal across versions. `marshal_dump` and `marshal_load` are implemented, but do they have to support marshaling across Rails versions?~~

This has been done.

Can we deprecate `to_xml`? I bet is rarely used, and can exists as a gem.