### PR TITLE
Change the condition for monkey patching `unescape` method

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -6,7 +6,7 @@ parser = URI::Parser.new
 
 needs_monkeypatch =
   begin
-    str + str != parser.unescape(str + parser.escape(str).force_encoding(Encoding::UTF_8))
+    RUBY_VERSION >= "2.6.0" || str + str != parser.unescape(str + parser.escape(str).force_encoding(Encoding::UTF_8))
   rescue Encoding::CompatibilityError
     true
   end


### PR DESCRIPTION
### Summary

Change the condition for monkey patching `unescape` method since Ruby 2.6.0  will not raise `Encoding::CompatibilityError` for the mixed unicode and percent escaped strings. 

Addresses #32294 and related to #32210
Refer https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=62695&view=revision
