### PR TITLE
Fix Cache `read_multi` with local_cache bug, should returns raw value, not `ActiveSupport::Cache::Entry` instance.

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -55,7 +55,14 @@ module ActiveSupport
           end
 
           def read_multi_entries(keys, options)
-            Hash[keys.map { |name| [name, read_entry(name, options)] }.keep_if { |_name, value| value }]
+            values = {}
+
+            keys.each do |name|
+              entry = read_entry(name, options)
+              values[name] = entry.value if entry
+            end
+
+            values
           end
 
           def write_entry(key, value, options)

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -129,6 +129,18 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_read_multi
+    @cache.with_local_cache do
+      @cache.write("foo", "foo", raw: true)
+      @cache.write("bar", "bar", raw: true)
+      values = @cache.read_multi("foo", "bar")
+      assert_equal "foo", @cache.read("foo")
+      assert_equal "bar", @cache.read("bar")
+      assert_equal "foo", values["foo"]
+      assert_equal "bar", values["bar"]
+    end
+  end
+
   def test_middleware
     app = lambda { |env|
       result = @cache.write("foo", "bar")


### PR DESCRIPTION
ref issue: https://github.com/hooopo/second_level_cache/issues/74

```rb
@cache.with_local_cache do
  @cache.write("foo", "foo", raw: true)
  @cache.write("bar", "bar", raw: true)
  # Before:
  @cache.read_multi("foo", "bar")
  # => { "foo" => <ActiveSupport::Cache::Entry>, "bar" => <ActiveSupport::Cache::Entry> }
  # After:
  @cache.read_multi("foo", "bar")
  # => { "foo" => "foo", "bar" => "bar" }
end
```

<img width="1062" alt="2018-03-21 13 34 03" src="https://user-images.githubusercontent.com/5518/37695845-42fe42b2-2d0d-11e8-8118-4b24bf54c6af.png">

