### PR TITLE
 Flip the order of the after_create callbacks

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -14,7 +14,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
 
   delegate_missing_to :blob
 
-  after_create_commit :identify_blob, :analyze_blob_later
+  after_create_commit :analyze_blob_later, :identify_blob
 
   # Synchronously purges the blob (deletes it from the configured service) and destroys the attachment.
   def purge

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -54,6 +54,16 @@ class ActiveSupport::TestCase
       ActiveStorage::Blob.create_before_direct_upload! filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type
     end
 
+    def directly_upload_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+      file = file_fixture(filename)
+      byte_size = file.size
+      checksum = Digest::MD5.file(file).base64digest
+
+      create_blob_before_direct_upload(filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type).tap do |blob|
+        ActiveStorage::Blob.service.upload(blob.key, file.open)
+      end
+    end
+
     def read_image(blob_or_variant)
       MiniMagick::Image.open blob_or_variant.service.send(:path_for, blob_or_variant.key)
     end


### PR DESCRIPTION
### Summary

This is an attempt to fix #32247 by flipping the after_create callbacks to avoid a race condition. Because `after_create_commit` calls it's callbacks in reverse order we should identify the blob before queuing any jobs.
