### PR TITLE
Ruby 2.6 will not require monkey patched `URI#unescape`

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -2,16 +2,8 @@
 
 require "uri"
 str = "\xE6\x97\xA5"
-parser = URI::Parser.new
 
-needs_monkeypatch =
-  begin
-    str + str != parser.unescape(str + parser.escape(str).force_encoding(Encoding::UTF_8))
-  rescue Encoding::CompatibilityError
-    true
-  end
-
-if needs_monkeypatch
+if RUBY_VERSION < "2.6.0"
   require "active_support/core_ext/module/redefine_method"
   URI::Parser.class_eval do
     silence_redefinition_of_method :unescape


### PR DESCRIPTION
### Summary

Ruby 2.6 will not require monkey patched `URI#unescape` since revision 62897 https://github.com/ruby/ruby/commit/234a30459cdae6aa7da6e28a1082d9c11f315696

I think it is better to handle by checking RUBY_VERSION compare with possibly raising `Encoding::CompatibilityError` exception.

Related to #32294