### PR TITLE
Allow ActiveStorage::Variant#service_url to pass addition options to service.url

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -67,8 +67,8 @@ class ActiveStorage::Variant
   # Use <tt>url_for(variant)</tt> (or the implied form, like +link_to variant+ or +redirect_to variant+) to get the stable URL
   # for a variant that points to the ActiveStorage::VariantsController, which in turn will use this +service_call+ method
   # for its redirection.
-  def service_url(expires_in: service.url_expires_in, disposition: :inline)
-    service.url key, expires_in: expires_in, disposition: disposition, filename: filename, content_type: content_type
+  def service_url(expires_in: service.url_expires_in, disposition: :inline, **options)
+    service.url key, expires_in: expires_in, disposition: disposition, filename: filename, content_type: content_type, **options
   end
 
   # Returns the receiving variant. Allows ActiveStorage::Variant and ActiveStorage::Preview instances to be used interchangeably.


### PR DESCRIPTION
### Summary

Same reason to #31854, variants can storage multi format/sized documents, but sometimes we want to add more parameters to URL.

### Usage

Copied and modified the example of #31854.

```ruby
<%= image_tag @user.avatar.variant(resize: "200x200").service_url(oss_process: "image/resize,m_fill,h_100,w_100" %>
```