### PR TITLE
Fix `Encoding::CompatibilityError` in `StaticEncodingTest`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -89,7 +89,7 @@ module ActionDispatch
 
       def gzip_file_path(path)
         can_gzip_mime = content_type(path) =~ /\A(?:text\/|application\/javascript)/
-        gzip_path     = "#{path}.gz"
+        gzip_path     = "#{path}.gz".b
         if can_gzip_mime && File.exist?(File.join(@root, ::Rack::Utils.unescape_path(gzip_path)))
           gzip_path
         else


### PR DESCRIPTION
Currently, the test of combination of Ruby 2.2 + `StaticEncodingTest` is broken.
https://travis-ci.org/rails/rails/jobs/357161461#L1451-L1477

This seems to be due to the behavior of String interpolation being different in Ruby 2.2 and later.
In Ruby 2.3 and later, the encoding of String is preserved, but before that, the encoding of the file is used.

```ruby
puts RUBY_DESCRIPTION

path = "abc"
path = path.b
puts path.encoding
gzip_path = "#{path}.gz"
puts gzip_path.encoding
```

```
ruby 2.2.8p477 (2017-09-14 revision 59906) [x86_64-linux]
ASCII-8BIT
UTF-8
```

```
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]
ASCII-8BIT
ASCII-8BIT
```

Therefore, I added `String#b` to forcibly become `ASCII-8BIT`.