### PR TITLE
Adding irregular plural of hero

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -66,6 +66,7 @@ module ActiveSupport
     inflect.irregular("sex", "sexes")
     inflect.irregular("move", "moves")
     inflect.irregular("zombie", "zombies")
+    inflect.irregular("hero", "heroes")
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -76,6 +76,7 @@ module InflectorTestCases
     "tomato"      => "tomatoes",
     "dwarf"       => "dwarves",
     "elf"         => "elves",
+    "hero"        => "heroes",
     "information" => "information",
     "equipment"   => "equipment",
     "bus"         => "buses",


### PR DESCRIPTION
### Summary

I was creating a project in rails and I used a scaffold with the name hero. Rails made the plural of this heros and I wanted that to be correct.
