### PR TITLE
Create TimeZone with consistent utc_offset for Numeric and ActiveSupport::Duration

### DIFF
--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -38,12 +38,19 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal period, zone.period_for_local(Time.utc(2014, 10, 26, 1, 0, 0))
   end
 
-  def test_from_integer_to_map
-    assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone[-28800] # PST
+  (-14..12).each do |offset|
+    define_method("test_from_integer_#{offset}_to_map") do
+      assert_equal ActiveSupport::TimeZone[offset], ActiveSupport::TimeZone.new("Etc/GMT%+d" % offset)
+    end
+
+    offset_seconds = offset * 3600
+    define_method("test_from_integer_#{offset_seconds}_to_map") do
+      assert_equal ActiveSupport::TimeZone[offset_seconds], ActiveSupport::TimeZone.new("Etc/GMT%+d" % offset)
+    end
   end
 
   def test_from_duration_to_map
-    assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone[-480.minutes] # PST
+    assert_equal ActiveSupport::TimeZone["Etc/GMT-8"], ActiveSupport::TimeZone[-480.minutes]
   end
 
   ActiveSupport::TimeZone.all.each do |zone|


### PR DESCRIPTION
### Summary

This fixes #32333 and improves performance of `ActiveSupport::TimeZone` when `Numeric` or `ActiveSupport::Duration` objects are passed to `ActiveSupport::TimeZone[]`.

Previously, when `Numeric` or `ActiveSupport::Duration` objetcts are passed to `ActiveSupport::TimeZone`, it does the following fallback.

* Initialize all the registered TimeZone objects.
* Return the first object with the same utc_offset

The first one is not good from the perspective of performance overhead.
The second one is not a good fallback because the `TimeZone` object is selected based on the `utc_offset` when the method is called. Since most of the registered `TimeZone` have summer time, the returned object have different `utc_offset` when evaluating the object with different time. This is misleading because most developers expect deterministic and consistent `utc_offset` when passing `Numeric` or `ActiveSupport::Duration` objects.

In order to solve this, I changed the logic to the followings.

* Convert `Numeric` or `ActiveSupport::Duration` object to corresponding Etc/GMT based timezone.
* Initialize `TimeZone` as the same way when the `String` object is passed.