### PR TITLE
Make mutating params#dig return value mutate underlying params

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -590,7 +590,8 @@ module ActionController
     #   params2 = ActionController::Parameters.new(foo: [10, 11, 12])
     #   params2.dig(:foo, 1) # => 11
     def dig(*keys)
-      convert_value_to_parameters(@parameters.dig(*keys))
+      convert_hashes_to_parameters(keys.first, @parameters[keys.first])
+      @parameters.dig(*keys)
     end
 
     # Returns a new <tt>ActionController::Parameters</tt> instance that

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -284,4 +284,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
       value.is_a?(ActionController::Parameters)
     end
   end
+
+  test "mutating #dig return value mutates underlying parameters" do
+    @params.dig(:person, :name)[:first] = "Bill"
+    assert_equal "Bill", @params.dig(:person, :name, :first)
+
+    @params.dig(:person, :addresses)[0] = { city: "Boston", state: "Massachusetts" }
+    assert_equal "Boston", @params.dig(:person, :addresses, 0, :city)
+  end
 end


### PR DESCRIPTION
### Summary

When `#dig` was called on a params object and return either a Hash or an Array, and that value was subsquently mutated, it would not mutate the containing params object. 

That means that the behavior of `params.dig(:a, :b)[:c] = 1` did not match that of either `params[:a][:b][:c] = 1` or `hash.dig(:a, :b)[:c] = 1`. 

Similarly to `ActionController::Parameters#[]`, use `#convert_hashes_to_parameters` to pre-convert values and insert them in the receiving params object prior to returning them.

Old Behavior:
```ruby
params = ActionController::Parameters.new(a: { b: { c: 1 } })
params.dig(:a, :b)[:c] = 2
params # => <ActionController::Parameters {"a"=>{"b"=>{"c"=>1}}} permitted: false>

params = ActionController::Parameters.new(a: { b: [1] })
params.dig(:a, :b)[0] = 2
params # => <ActionController::Parameters {"a"=>{"b"=>[1]}} permitted: false>
```

New Behavior:
```ruby
params = ActionController::Parameters.new(a: { b: { c: 1 } })
params.dig(:a, :b)[:c] = 2
params # => <ActionController::Parameters {"a"=><ActionController::Parameters {"b"=><ActionController::Parameters {"c"=>2} permitted: false>} permitted: false>} permitted: false>

params = ActionController::Parameters.new(a: { b: [1] })
params.dig(:a, :b)[0] = 2
params # => <ActionController::Parameters {"a"=><ActionController::Parameters {"b"=>[2]} permitted: false>} permitted: false>
```

Fixes #32335 