### PR TITLE
Use fast ruby idioms

### DIFF
--- a/actioncable/lib/action_cable/channel/periodic_timers.rb
+++ b/actioncable/lib/action_cable/channel/periodic_timers.rb
@@ -70,7 +70,7 @@ module ActionCable
         end
 
         def stop_periodic_timers
-          active_periodic_timers.each { |timer| timer.shutdown }
+          active_periodic_timers.each(&:shutdown)
           active_periodic_timers.clear
         end
     end

--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -40,9 +40,7 @@ module ActionMailer
     end
 
     private
-      def message
-        @message
-      end
+      attr_reader :message
 
       def html_part
         @html_part ||= message.html_part

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -792,9 +792,7 @@ module ActionController
     protected
       attr_reader :parameters
 
-      def permitted=(new_permitted)
-        @permitted = new_permitted
-      end
+      attr_writer :permitted
 
       def fields_for_style?
         @parameters.all? { |k, v| k =~ /\A-?\d+\z/ && (v.is_a?(Hash) || v.is_a?(Parameters)) }

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -107,7 +107,7 @@ module ActionController
       }
 
       def rack_key_for(key)
-        RACK_KEY_TRANSLATION.fetch(key, key.to_s)
+        RACK_KEY_TRANSLATION.fetch(key) { key.to_s }
       end
 
       def rack_value_for(key, value)

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -52,7 +52,7 @@ module ActionDispatch
     # <tt>:httponly</tt>.
     class CookieStore < AbstractStore
       def initialize(app, options = {})
-        super(app, options.merge!(cookie_only: true))
+        super(app, options.tap { |o| o[:cookie_only] = true })
       end
 
       def delete_session(req, session_id, options)

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -123,10 +123,10 @@ module ActionDispatch
       end
 
       def redirect_to_https(request)
-        [ @redirect.fetch(:status, redirection_status(request)),
+        [ @redirect.fetch(:status) { redirection_status(request) },
           { "Content-Type" => "text/html",
             "Location" => https_location_for(request) },
-          @redirect.fetch(:body, []) ]
+          @redirect.fetch(:body) { [] } ]
       end
 
       def redirection_status(request)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1859,7 +1859,7 @@ module ActionDispatch
             options_constraints = options.delete(:constraints) || {}
 
             path_types = paths.group_by(&:class)
-            path_types.fetch(String, []).each do |_path|
+            path_types.fetch(String) { [] }.each do |_path|
               route_options = options.dup
               if _path && option_path
                 raise ArgumentError, "Ambiguous route definition. Both :path and the route path were specified as strings."
@@ -1868,7 +1868,7 @@ module ActionDispatch
               decomposed_match(_path, controller, route_options, _path, to, via, formatted, anchor, options_constraints)
             end
 
-            path_types.fetch(Symbol, []).each do |action|
+            path_types.fetch(Symbol) { [] }.each do |action|
               route_options = options.dup
               decomposed_match(action, controller, route_options, option_path, to, via, formatted, anchor, options_constraints)
             end

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -175,7 +175,7 @@ module ActionView
       def excerpt(text, phrase, options = {})
         return unless text && phrase
 
-        separator = options.fetch(:separator, nil) || ""
+        separator = options.dig(:separator) || ""
         case phrase
         when Regexp
           regex = phrase

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -49,7 +49,7 @@ module ActiveJob
     def after_teardown # :nodoc:
       super
 
-      queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
+      queue_adapter_changed_jobs.each(&:disable_test_adapter)
     end
 
     # Specifies the queue adapter to use with all active job test helpers.

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -121,9 +121,7 @@ module ActiveModel
         end
       end
 
-      def password_confirmation=(unencrypted_password)
-        @password_confirmation = unencrypted_password
-      end
+      attr_writer :password_confirmation
     end
   end
 end

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -12,7 +12,11 @@ module ActiveModel
         unless (confirmed = record.send("#{attribute}_confirmation")).nil?
           unless confirmation_value_equal?(record, attribute, value, confirmed)
             human_attribute_name = record.class.human_attribute_name(attribute)
-            record.errors.add(:"#{attribute}_confirmation", :confirmation, options.except(:case_sensitive).merge!(attribute: human_attribute_name))
+            record.errors.add(
+              :"#{attribute}_confirmation",
+              :confirmation,
+              options.except(:case_sensitive).tap { |o| o[:attribute] = human_attribute_name }
+            )
           end
         end
       end

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -9,7 +9,11 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         if include?(record, value)
-          record.errors.add(attribute, :exclusion, options.except(:in, :within).merge!(value: value))
+          record.errors.add(
+            attribute,
+            :exclusion,
+            options.except(:in, :within).tap { |o| o[:value] = value }
+          )
         end
       end
     end

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -30,7 +30,9 @@ module ActiveModel
         end
 
         def record_error(record, attribute, name, value)
-          record.errors.add(attribute, :invalid, options.except(name).merge!(value: value))
+          record.errors.add(
+            attribute, :invalid, options.except(name).tap { |o| o[:value] = value }
+          )
         end
 
         def check_options_validity(name)

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -9,7 +9,11 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         unless include?(record, value)
-          record.errors.add(attribute, :inclusion, options.except(:in, :within).merge!(value: value))
+          record.errors.add(
+            attribute,
+            :inclusion,
+            options.except(:in, :within).tap { |o| o[:value] = value }
+          )
         end
       end
     end

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -59,7 +59,11 @@ module ActiveModel
             end
 
             unless value.send(CHECKS[option], option_value)
-              record.errors.add(attr_name, option, filtered_options(value).merge!(count: option_value))
+              record.errors.add(
+                attr_name,
+                option,
+                filtered_options(value).tap { |o| o[:count] = option_value }
+              )
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -578,9 +578,7 @@ module ActiveRecord
         stale_connections = synchronize do
           @connections.select do |conn|
             conn.in_use? && !conn.owner.alive?
-          end.each do |conn|
-            conn.steal!
-          end
+          end.each(&:steal!)
         end
 
         stale_connections.each do |conn|

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -746,7 +746,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          variables = @config.fetch(:variables, {}).stringify_keys
+          variables = @config.fetch(:variables) { {} }.stringify_keys
 
           # By default, MySQL 'where id is null' selects the last inserted id; Turn this off.
           variables["sql_auto_is_null"] = 0

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -57,9 +57,7 @@ module ActiveRecord
 
         private
 
-          def uri
-            @uri
-          end
+          attr_reader :uri
 
           def uri_parser
             @uri_parser ||= URI::Parser.new

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -117,7 +117,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.query_options.merge!(as: :array)
+          @connection.query_options[:as] = :array
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -703,7 +703,7 @@ module ActiveRecord
           # Use standard-conforming strings so we don't have to do the E'...' dance.
           set_standard_conforming_strings
 
-          variables = @config.fetch(:variables, {}).stringify_keys
+          variables = @config.fetch(:variables) { {} }.stringify_keys
 
           # If using Active Record's time zone support configure the connection to return
           # TIMESTAMP WITH ZONE types in UTC.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -35,7 +35,9 @@ module ActiveRecord
     def self.add_reflection(ar, name, reflection)
       ar.clear_reflections_cache
       name = name.to_s
-      ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+      ar._reflections = ar._reflections.except(name).tap do |o|
+        o[name] = reflection
+      end
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -359,7 +359,7 @@ module ActiveRecord
         Hash[calculated_data.map do |row|
           key = group_columns.map { |aliaz, col_name|
             type = type_for(col_name) do
-              calculated_data.column_types.fetch(aliaz, Type.default_value)
+              calculated_data.column_types.fetch(aliaz) { Type.default_value }
             end
             type_cast_calculated_value(row[aliaz], type)
           }

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -912,7 +912,7 @@ module ActiveRecord
     protected
       # Returns a relation value with a given name
       def get_value(name) # :nodoc:
-        @values.fetch(name, DEFAULT_VALUES[name])
+        @values.fetch(name) { DEFAULT_VALUES[name] }
       end
 
       # Sets the relation value with the given name

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -116,7 +116,7 @@ module ActiveRecord
 
       def column_type(name, type_overrides = {})
         type_overrides.fetch(name) do
-          column_types.fetch(name, Type.default_value)
+          column_types.fetch(name) { Type.default_value }
         end
       end
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -68,9 +68,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
+        attr_reader :configuration
 
         def configuration_without_database
           configuration.merge("database" => nil)

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -90,9 +90,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
+        attr_reader :configuration
 
         def encoding
           configuration["encoding"] || DEFAULT_ENCODING

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -60,13 +60,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
-
-        def root
-          @root
-        end
+        attr_reader :configuration, :root
 
         def run_cmd(cmd, args, out)
           fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -497,9 +497,7 @@ module ActiveSupport
           arg.halted || !@user_conditions.all? { |c| c.call(arg.target, arg.value) }
         end
 
-        def nested
-          @nested
-        end
+        attr_reader :nested
 
         def final?
           !@call_template
@@ -578,7 +576,7 @@ module ActiveSupport
         end
 
         protected
-          def chain; @chain; end
+          attr_reader :chain
 
         private
 

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -89,7 +89,7 @@ class Class
     instance_reader    = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
     instance_writer    = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
     instance_predicate = options.fetch(:instance_predicate, true)
-    default_value      = options.fetch(:default, nil)
+    default_value      = options.dig(:default)
 
     attrs.each do |name|
       singleton_class.silence_redefinition_of_method(name)

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -53,7 +53,7 @@ class DateTime
       raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
       new_fraction = Rational(new_nsec, 1000000000)
     else
-      new_usec = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
+      new_usec = options.fetch(:usec) { (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000) }
       new_fraction = Rational(new_usec, 1000000)
     end
 

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -10,9 +10,11 @@ class Object
   # This will throw an +ArgumentError+ if the argument doesn't respond
   # to +#include?+.
   def in?(another_object)
-    another_object.include?(self)
-  rescue NoMethodError
-    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
+    if another_object.respond_to?(:include?)
+      another_object.include?(self)
+    else
+      raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
+    end
   end
 
   # Returns the receiver if it's included in the argument otherwise returns +nil+.

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -130,7 +130,7 @@ class Time
       raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
       new_usec = Rational(new_nsec, 1000)
     else
-      new_usec = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
+      new_usec = options.fetch(:usec) { (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000) }
     end
 
     raise ArgumentError, "argument out of range" if new_usec >= 1000000

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -113,7 +113,7 @@ module ActiveSupport
           ext = @ph.normalize_extension(file.extname)
 
           file.dirname.ascend do |dir|
-            if @dirs.fetch(dir, []).include?(ext)
+            if @dirs.fetch(dir) { [] }.include?(ext)
               break true
             elsif dir == @lcsp || dir.root?
               break false

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -343,7 +343,7 @@ module ActiveSupport
     def ordinal(number)
       abs_number = number.to_i.abs
 
-      if (11..13).include?(abs_number % 100)
+      if (11..13).cover?(abs_number % 100)
         "th"
       else
         case abs_number % 10

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -209,9 +209,7 @@ module ActiveSupport
         OpenSSL::Cipher.new(@cipher)
       end
 
-      def verifier
-        @verifier
-      end
+      attr_reader :verifier
 
       def aead_mode?
         @aead_mode ||= new_cipher.authenticated?

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -265,7 +265,7 @@ module ActiveSupport
       private
         def load_country_zones(code)
           country = TZInfo::Country.get(code)
-          country.zone_identifiers.map do |tz_id|
+          country.zone_identifiers.flat_map do |tz_id|
             if MAPPING.value?(tz_id)
               MAPPING.inject([]) do |memo, (key, value)|
                 memo << self[key] if value == tz_id
@@ -274,7 +274,7 @@ module ActiveSupport
             else
               create(tz_id, nil, TZInfo::Timezone.new(tz_id))
             end
-          end.flatten(1).sort!
+          end.sort!
         end
 
         def zones_map

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -373,9 +373,7 @@ module Rails
       @config ||= Application::Configuration.new(self.class.find_root(self.class.called_from))
     end
 
-    def config=(configuration) #:nodoc:
-      @config = configuration
-    end
+    attr_writer :config
 
     # Returns secrets added to config/secrets.yml.
     #
@@ -413,9 +411,7 @@ module Rails
       end
     end
 
-    def secrets=(secrets) #:nodoc:
-      @secrets = secrets
-    end
+    attr_writer :secrets
 
     # The secret_key_base is used as the input secret to the application's key generator, which in turn
     # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -146,9 +146,7 @@ module Rails
         @debug_exception_response_format || :default
       end
 
-      def debug_exception_response_format=(value)
-        @debug_exception_response_format = value
-      end
+      attr_writer :debug_exception_response_format
 
       def paths
         @paths ||= begin

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -79,13 +79,7 @@ module Rails
       end
 
       protected
-        def operations
-          @operations
-        end
-
-        def delete_operations
-          @delete_operations
-        end
+        attr_reader :operations, :delete_operations
     end
 
     class Generators #:nodoc:

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -126,7 +126,7 @@ module Rails
         )
 
         if ARGV.first == "mailer"
-          options[:rails].merge!(template_engine: :erb)
+          options[:rails][:template_engine] = :erb
         end
       end
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -298,7 +298,7 @@ module Rails
           sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
           config = { verbose: false }
 
-          config.merge!(capture: options[:capture]) if options[:capture]
+          config[:capture] = options[:capture] if options[:capture]
 
           in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", config) }
         end


### PR DESCRIPTION
### Summary

Based on https://github.com/JuanitoFatas/fast-ruby

Found by https://github.com/DamirSvrtan/fasterer

### Other Information

Changes made:

Use .each(&:method) instead of .each { |i| i.method }

Use attr_reader/attr_writer instead of methods
* method is 12% slower

Use fetch with block when result is a non-constant
* Without block is 45% slower and allocates unnecessary objects when the
key is found in the hash

Use hash[]= instead of hash.merge! with single arguments
* merge! is 166% slower

Use each_key instead of keys.each as keys.each allocates an extra array
* keys.each is 21% slower

Use dig(:key) over fetch(:key, nil)
* fetch version is 104% slower

Use cover? over include? for a range
* include? is way slower (scales with size of range)

Use flat_map over map.flatten(1)
* flatten is 66% slower