### PR TITLE
Don't unset foreign key when preloading missing record

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -42,11 +42,11 @@ module ActiveRecord
 
           def associate_records_to_owner(owner, records)
             association = owner.association(reflection.name)
+            association.loaded!
             if reflection.collection?
-              association.loaded!
               association.target.concat(records)
             else
-              association.target = records.first
+              association.target = records.first unless records.empty?
             end
           end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1218,6 +1218,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     client = assert_queries(2) { Client.preload(:firm).find(c.id) }
     assert_no_queries { assert_nil client.firm }
+    assert_equal c.client_of, client.client_of
   end
 
   def test_preloading_empty_belongs_to_polymorphic
@@ -1225,6 +1226,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     tagging = assert_queries(2) { Tagging.preload(:taggable).find(t.id) }
     assert_no_queries { assert_nil tagging.taggable }
+    assert_equal t.taggable_id, tagging.taggable_id
   end
 
   def test_preloading_through_empty_belongs_to


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/31575, when a belongs to association's target is set, its foreign key is updated to match the new target. This is the correct behaviour when a new record is assigned, but not when the existing record is preloaded.

As long as we mark the association as loaded, we can skip setting the target when the record is missing and avoid clobbering the foreign key.