### PR TITLE
Don't lock the rails dependency version on plugin generation

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails"
 <% unless options[:skip_active_record] -%>
 
   s.add_development_dependency "<%= gem_for_database[0] %>"

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
+<%= '# ' if options.dev? || options.edge? -%>gem 'rails' %>'
 <% else -%>
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and


### PR DESCRIPTION
When you generate a plugin with `rails plugin new`, we lock the rails
version in the `gemspec` or the `Gemfile`. We want to avoid
the specific framework locks, to make it easier to upgrade Rails
versions in applications.