### PR TITLE
Introduce `restore_attributes_on` to Active Job

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Introduce `restore_attributes_on` to Active Job
+
+    User will be able to define a class (or classes) that Active Job should
+    preserve its attributes between when the job is enqueued and when the job
+    gets deserialized and ready to be executed. This is useful when using with
+    a subclass of `ActiveSupport::CurrentAttributes` as it will save and restore
+    those attributes on `Current` class automatically.
+
+    User can activate this functionality by putting this into their
+    `ApplicationJob`:
+
+        class ApplicationJob < ActiveJob::Base
+          restore_attributes_on Current
+        end
+
+    *Prem Sichanugrist*
+
 *   Remove support for Qu gem.
 
     Reasons are that the Qu gem wasn't compatible since Rails 5.1,

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -9,6 +9,7 @@ require "active_job/execution"
 require "active_job/callbacks"
 require "active_job/exceptions"
 require "active_job/logging"
+require "active_job/restore_attributes"
 require "active_job/timezones"
 require "active_job/translation"
 
@@ -40,6 +41,13 @@ module ActiveJob #:nodoc:
   # Records that are passed in are serialized/deserialized using Global
   # ID. More information can be found in Arguments.
   #
+  # You can also define that Active Job should preserve attributes on a given
+  # class such as your Current class:
+  #
+  #   class ApplicationJob < ActiveJob::Base
+  #     restore_attributes_on Current
+  #   end
+  #
   # To enqueue a job to be performed as soon as the queueing system is free:
   #
   #   ProcessPhotoJob.perform_later(photo)
@@ -52,7 +60,7 @@ module ActiveJob #:nodoc:
   #
   # A job can also be processed immediately without sending to the queue:
   #
-  #  ProcessPhotoJob.perform_now(photo)
+  #   ProcessPhotoJob.perform_now(photo)
   #
   # == Exceptions
   #
@@ -69,6 +77,7 @@ module ActiveJob #:nodoc:
     include Callbacks
     include Exceptions
     include Logging
+    include RestoreAttributes
     include Timezones
     include Translation
 

--- a/activejob/lib/active_job/restore_attributes.rb
+++ b/activejob/lib/active_job/restore_attributes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  # Provides a helper to define which classes Active Job should try to preserve
+  # its attributes before the job gets executed.
+  module RestoreAttributes
+    extend ActiveSupport::Concern
+
+    included do
+      mattr_accessor :shared_attributes_classes
+    end
+
+    module ClassMethods
+      # Specify classes that this job should preserve their attributes when
+      # enqueuing the job and restoring them upon the job execution. The given
+      # classes can be a descendant of <tt>ActiveSupport::CurrentAttributes</tt>
+      # or any class that respond to +attributes+ and +attributes=+.
+      def restore_attributes_on(*klasses)
+        self.shared_attributes_classes = klasses
+      end
+    end
+  end
+end

--- a/activejob/test/cases/restore_attributes_test.rb
+++ b/activejob/test/cases/restore_attributes_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "helper"
+require "jobs/hello_job"
+require "models/person"
+require "json"
+
+class RestoreAttributesTest < ActiveSupport::TestCase
+  setup do
+    JobBuffer.clear
+  end
+
+  class ExampleStorage
+    mattr_accessor :attributes
+  end
+
+  class AnotherExampleStorage
+    mattr_accessor :attributes
+  end
+
+  class TestCurrent < ActiveSupport::CurrentAttributes
+    attribute :person
+  end
+
+  test "restore_attributes_on saves attributes data from a given class" do
+    shared_attributes = { person: Person.new(27110), to_be_teased: "Takagi-san" }
+    ExampleStorage.attributes = shared_attributes
+    HelloJob.restore_attributes_on ExampleStorage
+
+    job_data = HelloJob.new.serialize
+    expected = ActiveJob::Arguments.serialize(
+      "restore_attributes_test/example_storage" => shared_attributes
+    )
+
+    assert_equal expected, job_data["shared_attributes"]
+  end
+
+  test "restore_attributes_on restores data back to a given class" do
+    shared_attributes = { person: Person.new(27110), to_be_teased: "Takagi-san" }
+    ExampleStorage.attributes = shared_attributes
+    HelloJob.restore_attributes_on ExampleStorage
+
+    # Serialize data and reset the attributes storage
+    job_data = HelloJob.new.serialize
+    ExampleStorage.attributes = {}
+
+    # Deserialize data and test that that the storage class get re-set.
+    HelloJob.new.deserialize(job_data)
+
+    assert_equal shared_attributes, ExampleStorage.attributes
+  end
+
+  test "restore_attributes_on works with ActiveSupport::CurrentAttributes" do
+    TestCurrent.person = Person.new(27110)
+    HelloJob.restore_attributes_on TestCurrent
+
+    job_data = HelloJob.new.serialize
+    TestCurrent.person = nil
+
+    assert_nil TestCurrent.person
+
+    HelloJob.new.deserialize(job_data)
+    assert_equal Person.new(27110), TestCurrent.person
+  end
+
+  test "restore_attributes_on supports multiple classes" do
+    HelloJob.restore_attributes_on ExampleStorage, AnotherExampleStorage
+
+    job_data = HelloJob.new.serialize
+    expected = [
+      "restore_attributes_test/example_storage",
+      "restore_attributes_test/another_example_storage"
+    ]
+
+    assert_equal expected, job_data["shared_attributes"].map(&:first)
+  end
+end


### PR DESCRIPTION
User will be able to define a class (or classes) that Active Job should preserve its attributes between when the job is enqueued and when the job gets deserialized and ready to be executed. This is useful when using with a subclass of `ActiveSupport::CurrentAttributes` as it will save and restore those attributes on `Current` class automatically.

User can activate this functionality by putting this into their `ApplicationJob`:

    class ApplicationJob < ActiveJob::Base
      restore_attributes_on Current
    end