### PR TITLE
Return timezone offset with DST when applicable

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -303,7 +303,7 @@ module ActiveSupport
       if @utc_offset
         @utc_offset
       else
-        tzinfo.current_period.utc_offset if tzinfo && tzinfo.current_period
+        tzinfo.current_period.utc_total_offset if tzinfo && tzinfo.current_period
       end
     end
 


### PR DESCRIPTION
### Summary

`ActiveSupport::TimeZone['Timezone ID'].utc_offset` does not return correct information when DST is in operation, i.e. as for now `ActiveSupport::TimeZone['Europe/Dublin'].utc_offset` is zero even we it should be +1 (IST timezone). Also, it is different behaviour from `Time.now.in_time_zone('Europe/Dublin').utc_offset` which returns +1 hour 
