### PR TITLE
Use an ActiveSupport::CurrentAttributes model to provide the host for service urls

### DIFF
--- a/activestorage/app/controllers/active_storage/base_controller.rb
+++ b/activestorage/app/controllers/active_storage/base_controller.rb
@@ -3,4 +3,8 @@
 # The base controller for all ActiveStorage controllers.
 class ActiveStorage::BaseController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action do
+    ActiveStorage::Current.host = request.base_url
+  end
 end

--- a/activestorage/app/models/active_storage/current.rb
+++ b/activestorage/app/models/active_storage/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ActiveStorage::Current < ActiveSupport::CurrentAttributes #:nodoc:
+  attribute :host
+end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -78,8 +78,9 @@ module ActiveStorage
         verified_key_with_expiration = ActiveStorage.verifier.generate(key, expires_in: expires_in, purpose: :blob_key)
 
         generated_url =
-          url_helpers.rails_disk_service_path(
+          url_helpers.rails_disk_service_url(
             verified_key_with_expiration,
+            host: current_host,
             filename: filename,
             disposition: content_disposition_with(type: disposition, filename: filename),
             content_type: content_type
@@ -104,7 +105,7 @@ module ActiveStorage
           purpose: :blob_token }
         )
 
-        generated_url = url_helpers.update_rails_disk_service_path(verified_token_with_expiration)
+        generated_url = url_helpers.update_rails_disk_service_url(verified_token_with_expiration, host: current_host)
 
         payload[:url] = generated_url
 
@@ -129,7 +130,6 @@ module ActiveStorage
         path_for(key).tap { |path| FileUtils.mkdir_p File.dirname(path) }
       end
 
-
       def ensure_integrity_of(key, checksum)
         unless Digest::MD5.file(path_for(key)).base64digest == checksum
           delete key
@@ -137,9 +137,12 @@ module ActiveStorage
         end
       end
 
-
       def url_helpers
         @url_helpers ||= Rails.application.routes.url_helpers
+      end
+
+      def current_host
+        ActiveStorage::Current.host
       end
   end
 end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -140,6 +140,6 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     def expected_url_for(blob, disposition: :inline, filename: nil)
       filename ||= blob.filename
       query_string = { content_type: blob.content_type, disposition: "#{disposition}; #{filename.parameters}" }.to_param
-      "/rails/active_storage/disk/#{ActiveStorage.verifier.generate(blob.key, expires_in: 5.minutes, purpose: :blob_key)}/#{filename}?#{query_string}"
+      "https://example.com/rails/active_storage/disk/#{ActiveStorage.verifier.generate(blob.key, expires_in: 5.minutes, purpose: :blob_key)}/#{filename}?#{query_string}"
     end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -8,7 +8,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "url generation" do
-    assert_match(/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
+    assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
       @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -41,6 +41,14 @@ ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 class ActiveSupport::TestCase
   self.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 
+  setup do
+    ActiveStorage::Current.host = "https://example.com"
+  end
+
+  teardown do
+    ActiveStorage::Current.reset
+  end
+
   private
     def create_blob(data: "Hello world!", filename: "hello.txt", content_type: "text/plain")
       ActiveStorage::Blob.create_after_upload! io: StringIO.new(data), filename: filename, content_type: content_type


### PR DESCRIPTION
Trying to pass the current request down to the service so that it can create full urls instead of paths makes the API messy so use a model based on ActiveSupport::CurrentAttributes to provide the current host to services that need it (primarily the disk service).
