### PR TITLE
Bring back private class methods accessibility in named scope

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -30,6 +30,7 @@ module ActiveRecord
       @offsets = {}
       @loaded = false
       @predicate_builder = predicate_builder
+      @delegate_to_klass = false
     end
 
     def initialize_copy(other)
@@ -453,6 +454,7 @@ module ActiveRecord
     end
 
     def reset
+      @delegate_to_klass = false
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @records = [].freeze
       @offsets = {}

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -313,6 +313,13 @@ module ActiveRecord
       klass.current_scope = previous
     end
 
+    def _exec_scope(*args, &block) # :nodoc:
+      @delegate_to_klass = true
+      instance_exec(*args, &block) || self
+    ensure
+      @delegate_to_klass = false
+    end
+
     # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
     # statement and sends it straight to the database. It does not instantiate the involved models and it does not
     # trigger Active Record callbacks or validations. However, values passed to #update_all will still go through

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -82,6 +82,9 @@ module ActiveRecord
           if @klass.respond_to?(method)
             self.class.delegate_to_scoped_klass(method)
             scoping { @klass.public_send(method, *args, &block) }
+          elsif defined?(@delegate_to_klass) &&
+            @delegate_to_klass && @klass.respond_to?(method, true)
+            @klass.send(method, *args, &block)
           elsif arel.respond_to?(method)
             ActiveSupport::Deprecation.warn \
               "Delegating #{method} to arel is deprecated and will be removed in Rails 6.0."

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -82,8 +82,10 @@ module ActiveRecord
           if @klass.respond_to?(method)
             self.class.delegate_to_scoped_klass(method)
             scoping { @klass.public_send(method, *args, &block) }
-          elsif defined?(@delegate_to_klass) &&
-            @delegate_to_klass && @klass.respond_to?(method, true)
+          elsif @delegate_to_klass && @klass.respond_to?(method, true)
+            ActiveSupport::Deprecation.warn \
+              "Delegating missing #{method} method to #{@klass}. " \
+              "Accessibility of private/protected class methods in :scope is deprecated and will be removed in Rails 6.0."
             @klass.send(method, *args, &block)
           elsif arel.respond_to?(method)
             ActiveSupport::Deprecation.warn \

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -183,7 +183,7 @@ module ActiveRecord
           if body.respond_to?(:to_proc)
             singleton_class.send(:define_method, name) do |*args|
               scope = all
-              scope = scope.instance_exec(*args, &body) || scope
+              scope = scope._exec_scope(*args, &body)
               scope = scope.extending(extension) if extension
               scope
             end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -303,6 +303,13 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal "lifo", topic.author_name
   end
 
+  def test_deprecated_delegating_private_method
+    assert_deprecated do
+      scope = Topic.all.by_private_lifo
+      assert_not scope.instance_variable_get(:@delegate_to_klass)
+    end
+  end
+
   def test_reserved_scope_names
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "topics"

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -12,12 +12,13 @@ class Topic < ActiveRecord::Base
 
   scope :scope_with_lambda, lambda { all }
 
-  scope :by_lifo, -> { where(author_name: author_name) }
+  scope :by_private_lifo, -> { where(author_name: private_lifo) }
+  scope :by_lifo, -> { where(author_name: "lifo") }
   scope :replied, -> { where "replies_count > 0" }
 
   class << self
     private
-      def author_name
+      def private_lifo
         "lifo"
       end
   end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -12,8 +12,15 @@ class Topic < ActiveRecord::Base
 
   scope :scope_with_lambda, lambda { all }
 
-  scope :by_lifo, -> { where(author_name: "lifo") }
+  scope :by_lifo, -> { where(author_name: author_name) }
   scope :replied, -> { where "replies_count > 0" }
+
+  class << self
+    private
+      def author_name
+        "lifo"
+      end
+  end
 
   scope "approved_as_string", -> { where(approved: true) }
   scope :anonymous_extension, -> {} do


### PR DESCRIPTION
The receiver in a scope was changed from `klass` to `relation` itself
for all scopes (named scope, default_scope, and association scope)
behaves consistently in #29301.

In addition. Before 5.2, if both an AR model class and a Relation
instance have same named methods (e.g. `arel_attribute`,
`predicate_builder`, etc), named scope doesn't respect relation instance
information.

For example:

```ruby
class Post < ActiveRecord::Base
  has_many :comments1, class_name: "RecentComment1"
  has_many :comments2, class_name: "RecentComment2"
end

class RecentComment1 < ActiveRecord::Base
  self.table_name = "comments"
  default_scope { where(arel_attribute(:created_at).gteq(2.weeks.ago)) }
end

class RecentComment2 < ActiveRecord::Base
  self.table_name = "comments"
  default_scope { recent_updated }
  scope :recent_updated, -> { where(arel_attribute(:updated_at).gteq(2.weeks.ago)) }
end
```

If eager loading `Post.eager_load(:comments1, :comments2).to_a`,
`:comments1` (default_scope) respects aliased table name, but
`:comments2` (using named scope) may not work correctly since named
scope doesn't respect relation instance information. See also 801ccab.

But this is a breaking change between releases without deprecation.
I decided to bring back private class methods accessibility in named
scope.

Fixes #31740.
Fixes #32331.