### PR TITLE
Shadowing outer variable - spec_name

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -46,8 +46,8 @@ module ActiveRecord
       if config["database"] || env_name == "default"
         DatabaseConfig.new(env_name, spec_name, config)
       else
-        config.each_pair.map do |spec_name, sub_config|
-          walk_configs(env_name, spec_name, sub_config)
+        config.each_pair.map do |sub_name, sub_config|
+          walk_configs(env_name, sub_name, sub_config)
         end
       end
     end


### PR DESCRIPTION
Ruby >= 2.5 warns about this. 248 warnings in the test suite output...