### PR TITLE
Fix unloading `unloadable` constants which were autoloaded 

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -723,6 +723,10 @@ module ActiveSupport #:nodoc:
       # call from a class or module that were not autoloaded, as in the
       # example above with Object, accessing to that constant must err.
       unless parent.autoload?(to_remove)
+        # Don't try to unload a non-existent constant
+        if !parent.const_defined?(to_remove)
+          return
+        end
         begin
           constantized = parent.const_get(to_remove, false)
         rescue NameError

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -723,10 +723,10 @@ module ActiveSupport #:nodoc:
       # call from a class or module that were not autoloaded, as in the
       # example above with Object, accessing to that constant must err.
       unless parent.autoload?(to_remove)
-        # Don't try to unload a non-existent constant
-        if !parent.const_defined?(to_remove)
-          return
-        end
+        # Don't try to unload a non-existent constant,
+        # `const_get` below may trigger an ActiveSupport autoload
+        # if the constant isn't defined
+        return unless parent.const_defined?(to_remove)
         begin
           constantized = parent.const_get(to_remove, false)
         rescue NameError

--- a/activesupport/test/autoloading_fixtures/explicit_unloadable/unloadable_example.rb
+++ b/activesupport/test/autoloading_fixtures/explicit_unloadable/unloadable_example.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module UnloadableExample
+  unloadable
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -240,6 +240,7 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
+  # Regression see https://github.com/rails/rails/issues/32359
   def test_explicit_unloadable_constants_can_be_unloaded_and_reloaded
     with_loading "autoloading_fixtures/explicit_unloadable" do
       # autoload this constant:
@@ -258,6 +259,7 @@ class DependenciesTest < ActiveSupport::TestCase
     end
   end
 
+  # Regression see https://github.com/rails/rails/issues/32359
   def test_explicit_unloadable_constants_can_are_cleanly_unloaded
     with_loading "autoloading_fixtures/explicit_unloadable" do
       # autoload this constant:

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -273,7 +273,7 @@ class DependenciesTest < ActiveSupport::TestCase
 
       # Unload it, and do a reality check that Ruby's state and AS::D's state match
       ActiveSupport::Dependencies.remove_unloadable_constants!
-      refute defined?(UnloadableExample), "The constant was actually removed"
+      assert_not defined?(UnloadableExample), "The constant was actually removed"
       assert_equal ["UnloadableExample"], ActiveSupport::Dependencies.explicitly_unloadable_constants, "This array stays the same"
       assert_equal [], ActiveSupport::Dependencies.autoloaded_constants, "AS::D also knows there are no constants"
       assert_equal 0, ActiveSupport::Dependencies.loaded.size, "No files were loaded"


### PR DESCRIPTION
Fixes #32359, see that issue for a detailed description.

Is this a desirable solution to that problem? Or is there another approach to try? 