### PR TITLE
Add safe html support to arrays of translations

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -85,8 +85,11 @@ module ActionView
             end
           end
           translation = I18n.translate(scope_key_by_partial(key), html_safe_options.merge(raise: i18n_raise))
-
-          translation.respond_to?(:html_safe) ? translation.html_safe : translation
+          if translation.respond_to?(:map)
+            translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
+          else
+            translation.respond_to?(:html_safe) ? translation.html_safe : translation
+          end
         else
           I18n.translate(scope_key_by_partial(key), options.merge(raise: i18n_raise))
         end

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -164,8 +164,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal "<a>Other &lt;One&gt;</a>", translate(:'translations.count_html', count: "<One>")
   end
 
-  def test_translation_returning_an_array_ignores_html_suffix
-    assert_equal ["foo", "bar"], translate(:'translations.array_html')
+  def test_translate_marks_array_of_translations_with_a_html_safe_suffix_as_safe_html
+    translate(:'translations.array_html').tap do |translated|
+      assert_equal %w( foo bar ), translated
+      assert translated.all?(&:html_safe?)
+    end
   end
 
   def test_translate_with_default_named_html


### PR DESCRIPTION
### Summary

The `translate` method ignores the `_html` suffix, which leads developers to overuse `html_safe` in places where it shouldn't be used. This PR adds safe html support to arrays of translations whose key includes the `_html` suffix.

