### PR TITLE
Use current_config in structure_dump

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -318,7 +318,7 @@ db_namespace = namespace :db do
         ActiveRecord::Base.establish_connection(config)
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(spec_name, :sql)
         current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, filename)
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
 
         if ActiveRecord::SchemaMigration.table_exists?
           File.open(filename, "a") do |f|


### PR DESCRIPTION
This looks like a typo from 0f0aa6a275876502e002c054896734d6536ba5cd . It warns about `assigned but unused variable - current_config`, and looks to me like it _should_ in fact be used.

Should add a test, it seems.