### PR TITLE
perform_enqueued_jobs should still enqueue filtered jobs

### DIFF
--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -26,15 +26,11 @@ module ActiveJob
       end
 
       def enqueue(job) #:nodoc:
-        return if filtered?(job)
-
         job_data = job_to_hash(job)
         enqueue_or_perform(perform_enqueued_jobs, job, job_data)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        return if filtered?(job)
-
         job_data = job_to_hash(job, at: timestamp)
         enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
       end
@@ -45,7 +41,7 @@ module ActiveJob
         end
 
         def enqueue_or_perform(perform, job, job_data)
-          if perform
+          if perform && !filtered?(job)
             performed_jobs << job_data
             Base.execute job.serialize
           else

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -482,6 +482,17 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_nil queue_adapter.reject
   end
 
+  def test_performed_enqueue_jobs_still_enqueue_unfiltered_jobs
+    perform_enqueued_jobs only: HelloJob do
+      HelloJob.perform_later("jeremy")
+      LoggingJob.perform_later("stewie")
+      RescueJob.perform_later("david")
+
+      assert_enqueued_jobs 2
+      assert_performed_jobs 1
+    end
+  end
+
   def test_assert_performed_jobs
     assert_nothing_raised do
       assert_performed_jobs 1 do


### PR DESCRIPTION
### Summary

Current behavior of `perform_enqueued_jobs` will discard filtered jobs, this PR changes it to enqueue the jobs instead of discarding.

### Other Information

I found current behavior confusing and non-intuitive.. The updated behavior feels more intuitive and is especially useful when working with test while refactoring, or adding extra behavior to existing codes..

For example, let's say that request to a certain endpoint are currently registering X number of jobs and we already have some integration test to make sure that those jobs are registered (enqueued) correctly.. Now let's say that we want to add 1 more job to be run, but we want to actually perform it and check its side effect.. wrapping the request with `perform_enqueued_jobs` without filter will run all the jobs failing existing test, similarly, adding `only: TheNewJob` before this PR will also fails existing test..

PS: hopefully it can also be backported to 5.2--stable at least :grin: 