### PR TITLE
Compare ruby version with correct way

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if RUBY_VERSION < "2.4.1" && RUBY_ENGINE == "ruby"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.1") && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 


### PR DESCRIPTION
### Summary

Ruby version check has some bug with 2 digit minor version (i.e. [2.2.10](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/))
To make it work, compare ruby version using `Gem::Version`

### Other Information

If you think it's fine, please backport this to 5.x to let developer who uses rails with 2.2.10 ;)