### PR TITLE
Only replace association keys if they've changed [5.2 Regression]

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -76,6 +76,11 @@ module ActiveRecord
         loaded!
       end
 
+      def preloaded_target=(target) #:nodoc:
+        @target = target
+        loaded!
+      end
+
       def scope
         target_scope.merge!(association_scope)
       end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       end
 
       def target=(record)
-        replace_keys(record) if record.nil? || different_target?(record)
+        replace_keys(record)
         super
       end
 

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       end
 
       def target=(record)
-        replace_keys(record)
+        replace_keys(record) if record.nil? || different_target?(record)
         super
       end
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -46,7 +46,7 @@ module ActiveRecord
             if reflection.collection?
               association.target.concat(records)
             else
-              association.target = records.first unless records.empty?
+              association.preloaded_target = records.first unless records.empty?
             end
           end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -25,7 +25,6 @@ require "models/admin/user"
 require "models/ship"
 require "models/treasure"
 require "models/parrot"
-require "models/category"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -39,12 +38,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_assigning_belongs_to_on_destroyed_object
-    firm = Firm.create!(name: "Firm")
-    client = Client.create!(name: "Client", firm: firm)
+    client = Client.create!(name: "Client")
     client.destroy!
     assert_raise(frozen_error_class) { client.firm = nil }
-    assert_raise(frozen_error_class) { client.firm = Firm.new(name: "New Firm") }
-    assert_nothing_raised { client.firm = firm }
+    assert_raise(frozen_error_class) { client.firm = Firm.new(name: "Firm") }
   end
 
   def test_missing_attribute_error_is_raised_when_no_foreign_key_attribute


### PR DESCRIPTION
### Summary

This is a bit obscure but as of Rails 5.2.0 RC1 (when commit a84c76573fa776e377c087930dcbdc3a07eb8603 landed) the `ActiveRecord::Associations::Preloader` can no longer invoked on associations of a destroyed model. This worked fine in older versions of Rails.

This results in a stack trace something like the following:

```
RuntimeError: Can't modify frozen hash
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activemodel-5.2.0.rc2/lib/active_model/attribute_set/builder.rb:44:in `[]='
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activemodel-5.2.0.rc2/lib/active_model/attribute_set.rb:57:in `write_from_user'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/attribute_methods/write.rb:51:in `_write_attribute'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/attribute_methods/write.rb:45:in `write_attribute'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/attribute_methods.rb:410:in `[]='
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/belongs_to_association.rb:92:in `replace_keys'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/belongs_to_association.rb:33:in `target='
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader/association.rb:50:in `associate_records_to_owner'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader/association.rb:26:in `block in run'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader/association.rb:25:in `each'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader/association.rb:25:in `run'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:142:in `block (2 levels) in preloaders_for_one'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:140:in `each'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:140:in `map'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:140:in `block in preloaders_for_one'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:139:in `each'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:139:in `flat_map'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:139:in `preloaders_for_one'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:106:in `preloaders_on'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:93:in `block in preload'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:92:in `each'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:92:in `flat_map'
/Users/jturkel/.rvm/gems/ruby-2.4.3/gems/activerecord-5.2.0.rc2/lib/active_record/associations/preloader.rb:92:in `preload'
```

### Other Information

This was discovered while testing the [goldiloader](https://github.com/salsify/goldiloader) gem with Rails 5.2. More details on the goldiloader side can be found in https://github.com/salsify/goldiloader/issues/63 if you're interested.
