### PR TITLE
Turn on performance based cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,3 +179,12 @@ Style/Semicolon:
 # Prefer Foo.method over Foo::method
 Style/ColonMethodCall:
   Enabled: true
+
+Style/TrivialAccessors:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true

--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -40,9 +40,7 @@ module ActionMailer
     end
 
     private
-      def message
-        @message
-      end
+      attr_reader :message
 
       def html_part
         @html_part ||= message.html_part

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -793,9 +793,7 @@ module ActionController
     protected
       attr_reader :parameters
 
-      def permitted=(new_permitted)
-        @permitted = new_permitted
-      end
+      attr_writer :permitted
 
       def fields_for_style?
         @parameters.all? { |k, v| k =~ /\A-?\d+\z/ && (v.is_a?(Hash) || v.is_a?(Parameters)) }

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -272,7 +272,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
       credentials.merge!(options)
       path_info = @request.env["PATH_INFO"].to_s
       uri = options[:uri] || path_info
-      credentials.merge!(uri: uri)
+      credentials[:uri] = uri
       @request.env["ORIGINAL_FULLPATH"] = path_info
       ActionController::HttpAuthentication::Digest.encode_credentials(method, credentials, password, options[:password_is_ha1])
     end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -82,9 +82,7 @@ module Another
       @last_payload = payload
     end
 
-    def last_payload
-      @last_payload
-    end
+    attr_reader :last_payload
   end
 end
 

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1322,7 +1322,7 @@ class ResourcesTest < ActionController::TestCase
     def assert_resource_allowed_routes(controller, options, shallow_options, allowed, not_allowed, path = controller)
       shallow_path = "#{path}/#{shallow_options[:id]}"
       format = options[:format] && ".#{options[:format]}"
-      options.merge!(controller: controller)
+      options[:controller] = controller
       shallow_options.merge!(options)
 
       assert_whether_allowed(allowed, not_allowed, options,         "index",    "#{path}#{format}",               :get)
@@ -1336,7 +1336,7 @@ class ResourcesTest < ActionController::TestCase
 
     def assert_singleton_resource_allowed_routes(controller, options, allowed, not_allowed, path = controller.singularize)
       format = options[:format] && ".#{options[:format]}"
-      options.merge!(controller: controller)
+      options[:controller] = controller
 
       assert_whether_allowed(allowed, not_allowed, options, "new",      "#{path}/new#{format}",   :get)
       assert_whether_allowed(allowed, not_allowed, options, "create",   "#{path}#{format}",       :post)

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -105,16 +105,20 @@ class HeaderTest < ActiveSupport::TestCase
   end
 
   test "#merge! headers with mutation" do
+    # rubocop:disable Performance/RedundantMerge
     @headers.merge!("Host" => "http://example.test",
                     "Content-Type" => "text/html")
+    # rubocop:enable Performance/RedundantMerge
     assert_equal({ "HTTP_HOST" => "http://example.test",
                   "CONTENT_TYPE" => "text/html",
                   "HTTP_REFERER" => "/some/page" }, @headers.env)
   end
 
   test "#merge! env with mutation" do
+    # rubocop:disable Performance/RedundantMerge
     @headers.merge!("HTTP_HOST" => "http://first.com",
                     "CONTENT_TYPE" => "text/html")
+    # rubocop:enable Performance/RedundantMerge
     assert_equal({ "HTTP_HOST" => "http://first.com",
                   "CONTENT_TYPE" => "text/html",
                   "HTTP_REFERER" => "/some/page" }, @headers.env)
@@ -156,7 +160,7 @@ class HeaderTest < ActiveSupport::TestCase
     env = { "HTTP_REFERER" => "/" }
     headers = make_headers(env)
     headers["Referer"] = "http://example.com/"
-    headers.merge! "CONTENT_TYPE" => "text/plain"
+    headers["CONTENT_TYPE"] = "text/plain"
     assert_equal({ "HTTP_REFERER" => "http://example.com/",
                   "CONTENT_TYPE" => "text/plain" }, env)
   end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -318,7 +318,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     @url_for_options = object
 
     if object.is_a?(Hash) && object[:use_route].blank? && object[:controller].blank?
-      object.merge!(controller: "main", action: "index")
+      object[:controller] = "main"
+      object[:action] = "index"
     end
 
     super

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -168,7 +168,8 @@ class FormHelperTest < ActionView::TestCase
     @url_for_options = object
 
     if object.is_a?(Hash) && object[:use_route].blank? && object[:controller].blank?
-      object.merge!(controller: "main", action: "index")
+      object[:controller] = "main"
+      object[:action] = "index"
     end
 
     super

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -14,17 +14,11 @@ class DirtyTest < ActiveModel::TestCase
       @status = "initialized"
     end
 
-    def name
-      @name
-    end
+    attr_reader :name, :color, :size, :status
 
     def name=(val)
       name_will_change!
       @name = val
-    end
-
-    def color
-      @color
     end
 
     def color=(val)
@@ -32,17 +26,9 @@ class DirtyTest < ActiveModel::TestCase
       @color = val
     end
 
-    def size
-      @size
-    end
-
     def size=(val)
       attribute_will_change!(:size) unless val == @size
       @size = val
-    end
-
-    def status
-      @status
     end
 
     def status=(val)

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -57,9 +57,7 @@ module ActiveRecord
 
         private
 
-          def uri
-            @uri
-          end
+          attr_reader :uri
 
           def uri_parser
             @uri_parser ||= URI::Parser.new

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -36,7 +36,7 @@ module ActiveRecord
               end
 
               indexes.last[-2] << row[:Column_name]
-              indexes.last[-1][:lengths].merge!(row[:Column_name] => row[:Sub_part].to_i) if row[:Sub_part]
+              indexes.last[-1][:lengths][row[:Column_name]] = row[:Sub_part].to_i if row[:Sub_part]
               indexes.last[-1][:orders].merge!(row[:Column_name] => :desc) if row[:Collation] == "D"
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -117,7 +117,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.query_options.merge!(as: :array)
+          @connection.query_options[:as] = :array
           super
         end
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -68,9 +68,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
+        attr_reader :configuration
 
         def configuration_without_database
           configuration.merge("database" => nil)

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -90,9 +90,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
+        attr_reader :configuration
 
         def encoding
           configuration["encoding"] || DEFAULT_ENCODING

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -60,13 +60,7 @@ module ActiveRecord
 
       private
 
-        def configuration
-          @configuration
-        end
-
-        def root
-          @root
-        end
+        attr_reader :configuration, :root
 
         def run_cmd(cmd, args, out)
           fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -187,7 +187,7 @@ module ActiveRecord
       end
 
       relation = Relation.new(klass)
-      relation.merge!(where: ["foo = ?", "bar"])
+      relation.merge!(where: ["foo = ?", "bar"]) # rubocop:disable Performance/RedundantMerge
       assert_equal Relation::WhereClause.new(["foo = bar"]), relation.where_clause
     end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -152,7 +152,7 @@ module ActiveRecord
     end
 
     def test_ignores_configurations_without_databases
-      @configurations["development"].merge!("database" => nil)
+      @configurations["development"]["database"] = nil
 
       with_stubbed_configurations_establish_connection do
         assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
@@ -162,7 +162,7 @@ module ActiveRecord
     end
 
     def test_ignores_remote_databases
-      @configurations["development"].merge!("host" => "my.server.tld")
+      @configurations["development"]["host"] = "my.server.tld"
 
       with_stubbed_configurations_establish_connection do
         assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
@@ -172,7 +172,7 @@ module ActiveRecord
     end
 
     def test_warning_for_remote_databases
-      @configurations["development"].merge!("host" => "my.server.tld")
+      @configurations["development"]["host"] = "my.server.tld"
 
       with_stubbed_configurations_establish_connection do
         ActiveRecord::Tasks::DatabaseTasks.create_all
@@ -183,7 +183,7 @@ module ActiveRecord
     end
 
     def test_creates_configurations_with_local_ip
-      @configurations["development"].merge!("host" => "127.0.0.1")
+      @configurations["development"]["host"] = "127.0.0.1"
 
       with_stubbed_configurations_establish_connection do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
@@ -193,7 +193,7 @@ module ActiveRecord
     end
 
     def test_creates_configurations_with_local_host
-      @configurations["development"].merge!("host" => "localhost")
+      @configurations["development"]["host"] = "localhost"
 
       with_stubbed_configurations_establish_connection do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
@@ -203,7 +203,7 @@ module ActiveRecord
     end
 
     def test_creates_configurations_with_blank_hosts
-      @configurations["development"].merge!("host" => nil)
+      @configurations["development"]["host"] = nil
 
       with_stubbed_configurations_establish_connection do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
@@ -463,7 +463,7 @@ module ActiveRecord
     end
 
     def test_ignores_configurations_without_databases
-      @configurations[:development].merge!("database" => nil)
+      @configurations[:development]["database"] = nil
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
@@ -473,7 +473,7 @@ module ActiveRecord
     end
 
     def test_ignores_remote_databases
-      @configurations[:development].merge!("host" => "my.server.tld")
+      @configurations[:development]["host"] = "my.server.tld"
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
@@ -483,7 +483,7 @@ module ActiveRecord
     end
 
     def test_warning_for_remote_databases
-      @configurations[:development].merge!("host" => "my.server.tld")
+      @configurations[:development]["host"] = "my.server.tld"
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         ActiveRecord::Tasks::DatabaseTasks.drop_all
@@ -494,7 +494,7 @@ module ActiveRecord
     end
 
     def test_drops_configurations_with_local_ip
-      @configurations[:development].merge!("host" => "127.0.0.1")
+      @configurations[:development]["host"] = "127.0.0.1"
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
@@ -504,7 +504,7 @@ module ActiveRecord
     end
 
     def test_drops_configurations_with_local_host
-      @configurations[:development].merge!("host" => "localhost")
+      @configurations[:development]["host"] = "localhost"
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
@@ -514,7 +514,7 @@ module ActiveRecord
     end
 
     def test_drops_configurations_with_blank_hosts
-      @configurations[:development].merge!("host" => nil)
+      @configurations[:development]["host"] = nil
 
       ActiveRecord::Base.stub(:configurations, @configurations) do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -497,9 +497,7 @@ module ActiveSupport
           arg.halted || !@user_conditions.all? { |c| c.call(arg.target, arg.value) }
         end
 
-        def nested
-          @nested
-        end
+        attr_reader :nested
 
         def final?
           !@call_template
@@ -578,7 +576,7 @@ module ActiveSupport
         end
 
         protected
-          def chain; @chain; end
+          attr_reader :chain
 
         private
 

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -210,9 +210,7 @@ module ActiveSupport
         OpenSSL::Cipher.new(@cipher)
       end
 
-      def verifier
-        @verifier
-      end
+      attr_reader :verifier
 
       def aead_mode?
         @aead_mode ||= new_cipher.authenticated?

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -26,25 +26,21 @@ module ActiveSupport
         def pop; @queue.pop; end
       end
 
-      @after_fork_hooks = []
+      @@after_fork_hooks = []
 
       def self.after_fork_hook(&blk)
-        @after_fork_hooks << blk
+        @@after_fork_hooks << blk
       end
 
-      def self.after_fork_hooks
-        @after_fork_hooks
-      end
+      cattr_reader :after_fork_hooks
 
-      @run_cleanup_hooks = []
+      @@run_cleanup_hooks = []
 
       def self.run_cleanup_hook(&blk)
-        @run_cleanup_hooks << blk
+        @@run_cleanup_hooks << blk
       end
 
-      def self.run_cleanup_hooks
-        @run_cleanup_hooks
-      end
+      cattr_reader :run_cleanup_hooks
 
       def initialize(queue_size)
         @queue_size = queue_size

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -265,7 +265,7 @@ module ActiveSupport
       private
         def load_country_zones(code)
           country = TZInfo::Country.get(code)
-          country.zone_identifiers.map do |tz_id|
+          country.zone_identifiers.flat_map do |tz_id|
             if MAPPING.value?(tz_id)
               MAPPING.inject([]) do |memo, (key, value)|
                 memo << self[key] if value == tz_id
@@ -274,7 +274,7 @@ module ActiveSupport
             else
               create(tz_id, nil, TZInfo::Timezone.new(tz_id))
             end
-          end.flatten(1).sort!
+          end.sort!
         end
 
         def zones_map

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -103,9 +103,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     private
       def build(**kwargs)
-        ActiveSupport::Cache::RedisCacheStore.new(driver: DRIVER, **kwargs).tap do |cache|
-          cache.redis
-        end
+        ActiveSupport::Cache::RedisCacheStore.new(driver: DRIVER, **kwargs).tap(&:redis)
       end
   end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -373,9 +373,7 @@ module Rails
       @config ||= Application::Configuration.new(self.class.find_root(self.class.called_from))
     end
 
-    def config=(configuration) #:nodoc:
-      @config = configuration
-    end
+    attr_writer :config
 
     # Returns secrets added to config/secrets.yml.
     #
@@ -413,9 +411,7 @@ module Rails
       end
     end
 
-    def secrets=(secrets) #:nodoc:
-      @secrets = secrets
-    end
+    attr_writer :secrets
 
     # The secret_key_base is used as the input secret to the application's key generator, which in turn
     # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -146,9 +146,7 @@ module Rails
         @debug_exception_response_format || :default
       end
 
-      def debug_exception_response_format=(value)
-        @debug_exception_response_format = value
-      end
+      attr_writer :debug_exception_response_format
 
       def paths
         @paths ||= begin

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -79,13 +79,7 @@ module Rails
       end
 
       protected
-        def operations
-          @operations
-        end
-
-        def delete_operations
-          @delete_operations
-        end
+        attr_reader :operations, :delete_operations
     end
 
     class Generators #:nodoc:

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -126,7 +126,7 @@ module Rails
         )
 
         if ARGV.first == "mailer"
-          options[:rails].merge!(template_engine: :erb)
+          options[:rails][:template_engine] = :erb
         end
       end
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -298,7 +298,7 @@ module Rails
           sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
           config = { verbose: false }
 
-          config.merge!(capture: options[:capture]) if options[:capture]
+          config[:capture] = options[:capture] if options[:capture]
 
           in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", config) }
         end

--- a/railties/test/app_loader_test.rb
+++ b/railties/test/app_loader_test.rb
@@ -9,12 +9,12 @@ class AppLoaderTest < ActiveSupport::TestCase
     @loader ||= Class.new do
       extend Rails::AppLoader
 
-      def self.exec_arguments
-        @exec_arguments
-      end
+      class << self
+        attr_accessor :exec_arguments
 
-      def self.exec(*args)
-        @exec_arguments = args
+        def exec(*args)
+          self.exec_arguments = args
+        end
       end
     end
   end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -151,7 +151,8 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
     def build_app(console)
       mocked_console = Class.new do
-        attr_reader :sandbox, :console
+        attr_accessor :sandbox
+        attr_reader :console
 
         def initialize(console)
           @console = console
@@ -159,10 +160,6 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
         def config
           self
-        end
-
-        def sandbox=(arg)
-          @sandbox = arg
         end
 
         def load_console


### PR DESCRIPTION
### Summary

Use attr_reader/attr_writer instead of methods

method is 12% slower

Use flat_map over map.flatten(1)

flatten is 66% slower

Use hash[]= instead of hash.merge! with single arguments

merge! is 166% slower

See https://github.com/rails/rails/pull/32337 for more conversation
