### PR TITLE
Fix regression with scope with optional path, defaults and route with dynamic segment

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -45,7 +45,10 @@ module ActionDispatch
           end
 
           parameterized_parts.delete_if do |key, value|
-            required_parts.exclude?(key) && defaults.key?(key) && defaults[key].to_s == value.to_s
+            required_parts.exclude?(key) &&
+              !path_parameters.key?(key) &&
+              defaults.key?(key) &&
+              defaults[key].to_param == value.to_param
           end
 
           return [route.format(parameterized_parts), params]

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -27,18 +27,18 @@ module ActionDispatch
           return matched_route.generate
         end
 
-        message = "No route matches #{Hash[constraints.sort_by { |k, v| k.to_s }].inspect}".dup
+        messages = ["No route matches #{constraints.sort_by { |k, _| k.to_s }.to_h.inspect}"]
         if matched_route
           unless matched_route.sanitized_missing_keys.empty?
-            message << ", missing required keys: #{matched_route.sanitized_missing_keys.sort.inspect}"
+            messages << "missing required keys: #{matched_route.sanitized_missing_keys.inspect}"
           end
 
           unless matched_route.unmatched_keys.empty?
-            message << ", possible unmatched constraints: #{matched_route.unmatched_keys.sort.inspect}"
+            messages << "possible unmatched constraints: #{matched_route.unmatched_keys.inspect}"
           end
         end
 
-        raise ActionController::UrlGenerationError, message
+        raise ActionController::UrlGenerationError, messages.join(", ")
       end
 
       def clear

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -36,9 +36,17 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
+          route.parts.each do |key|
+            break if defaults[key].nil? && parameterized_parts[key].present?
+            break if parameterized_parts[key].to_s != defaults[key].to_s
+            break if required_parts.include?(key)
+
+            parameterized_parts.delete(key)
+          end
+
           route.parts.reverse_each do |key|
             break if defaults[key].nil? && parameterized_parts[key].present?
-            next if parameterized_parts[key].to_s != defaults[key].to_s
+            break if parameterized_parts[key].to_s != defaults[key].to_s
             break if required_parts.include?(key)
 
             parameterized_parts.delete(key)

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -44,13 +44,6 @@ module ActionDispatch
             parameterized_parts.delete(key)
           end
 
-          parameterized_parts.delete_if do |key, value|
-            required_parts.exclude?(key) &&
-              !path_parameters.key?(key) &&
-              defaults.key?(key) &&
-              defaults[key].to_param == value.to_param
-          end
-
           return [route.format(parameterized_parts), params]
         end
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -36,20 +36,14 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
-          route.parts.each do |key|
-            break if defaults[key].nil? && parameterized_parts[key].present?
-            break if parameterized_parts[key].to_s != defaults[key].to_s
-            break if required_parts.include?(key)
+          route.groupped_parts.each do |group|
+            group.reverse_each do |key|
+              break if defaults[key].nil? && parameterized_parts[key].present?
+              break if parameterized_parts[key].to_s != defaults[key].to_s
+              break if required_parts.include?(key)
 
-            parameterized_parts.delete(key)
-          end
-
-          route.parts.reverse_each do |key|
-            break if defaults[key].nil? && parameterized_parts[key].present?
-            break if parameterized_parts[key].to_s != defaults[key].to_s
-            break if required_parts.include?(key)
-
-            parameterized_parts.delete(key)
+              parameterized_parts.delete(key)
+            end
           end
 
           return [route.format(parameterized_parts), params]

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -36,7 +36,7 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
-          route.groupped_parts.each do |group|
+          route.groupped_optional_parts.each do |group|
             group.reverse_each do |key|
               break if defaults[key].nil? && parameterized_parts[key].present?
               break if parameterized_parts[key].to_s != defaults[key].to_s

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -44,6 +44,10 @@ module ActionDispatch
             parameterized_parts.delete(key)
           end
 
+          parameterized_parts.delete_if do |key, value|
+            required_parts.exclude?(key) && defaults.key?(key) && defaults[key].to_s == value.to_s
+          end
+
           return [route.format(parameterized_parts), params]
         end
 

--- a/actionpack/lib/action_dispatch/journey/matched_route.rb
+++ b/actionpack/lib/action_dispatch/journey/matched_route.rb
@@ -3,7 +3,7 @@
 module ActionDispatch
   module Journey # :nodoc:
     class MatchedRoute # :nodoc:
-      delegate :defaults, :required_parts, :groupped_optional_parts, to: :@route
+      delegate :defaults, :required_parts, :grouped_optional_parts, to: :@route
 
       def initialize(route, constraints, options, path_parameters, parameterize)
         @route = route
@@ -78,7 +78,7 @@ module ActionDispatch
       def formatted_route
         parts = parameterized_parts.dup
 
-        groupped_optional_parts.each do |group|
+        grouped_optional_parts.each do |group|
           group.reverse_each do |key|
             break if defaults[key].nil? && parts[key].present?
             break if parts[key].to_s != defaults[key].to_s

--- a/actionpack/lib/action_dispatch/journey/matched_route.rb
+++ b/actionpack/lib/action_dispatch/journey/matched_route.rb
@@ -1,0 +1,105 @@
+module ActionDispatch
+  module Journey # :nodoc:
+    class MatchedRoute # :nodoc:
+      delegate :defaults, :required_parts, :groupped_optional_parts, to: :@route
+
+      def initialize(route, constraints, options, path_parameters, parameterize)
+        @route = route
+        @constraints = constraints
+        @options = options
+        @path_parameters = path_parameters
+        @parameterize = parameterize
+      end
+
+      def parameterized_parts
+        @parameterized_parts ||= @constraints.dup.tap do |parameterized_parts|
+          keys_to_keep = @route.parts.reverse_each.drop_while { |part|
+            !@options.key?(part) || (@options[part] || @path_parameters[part]).nil?
+          } | required_parts
+
+          parameterized_parts.delete_if do |bad_key, _|
+            !keys_to_keep.include?(bad_key)
+          end
+
+          if @parameterize
+            parameterized_parts.each do |k, v|
+              parameterized_parts[k] = @parameterize.call(k, v)
+            end
+          end
+
+          parameterized_parts.keep_if { |_, v| v }
+        end
+      end
+
+      def tests
+        @tests ||= @route.path.requirements
+      end
+
+      module RegexCaseComparator
+        DEFAULT_INPUT = /[-_.a-zA-Z0-9]+\/[-_.a-zA-Z0-9]+/
+        DEFAULT_REGEX = /\A#{DEFAULT_INPUT}\Z/
+
+        def self.===(regex)
+          DEFAULT_INPUT == regex
+        end
+      end
+
+      def missing_keys
+        @missing_keys ||= required_parts.each_with_object([]) do |key, memo|
+          case tests[key]
+          when nil
+            unless parameterized_parts[key]
+              memo << key
+            end
+          when RegexCaseComparator
+            unless RegexCaseComparator::DEFAULT_REGEX === parameterized_parts[key]
+              memo << key
+            end
+          else
+            unless /\A#{tests[key]}\Z/ === parameterized_parts[key]
+              memo << key
+            end
+          end
+        end
+      end
+
+      def invalid?
+        !missing_keys.empty?
+      end
+
+      def params
+        @options.dup.delete_if do |key, _|
+          parameterized_parts.key?(key) || defaults.key?(key)
+        end
+      end
+
+      def formatted_route
+        parts = parameterized_parts.dup
+
+        groupped_optional_parts.each do |group|
+          group.reverse_each do |key|
+            break if defaults[key].nil? && parts[key].present?
+            break if parts[key].to_s != defaults[key].to_s
+            break if required_parts.include?(key)
+
+            parts.delete(key)
+          end
+        end
+
+        @route.format(parts)
+      end
+
+      def generate
+        [formatted_route, params]
+      end
+
+      def unmatched_keys
+        @unmatched_keys ||= missing_keys & @constraints.keys
+      end
+
+      def sanitized_missing_keys
+        @sanitized_missing_keys ||= missing_keys - unmatched_keys
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/journey/matched_route.rb
+++ b/actionpack/lib/action_dispatch/journey/matched_route.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionDispatch
   module Journey # :nodoc:
     class MatchedRoute # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/matched_route.rb
+++ b/actionpack/lib/action_dispatch/journey/matched_route.rb
@@ -70,7 +70,7 @@ module ActionDispatch
       end
 
       def params
-        @options.dup.delete_if do |key, _|
+        @options.reject do |key, _|
           parameterized_parts.key?(key) || defaults.key?(key)
         end
       end
@@ -96,11 +96,11 @@ module ActionDispatch
       end
 
       def unmatched_keys
-        @unmatched_keys ||= missing_keys & @constraints.keys
+        @unmatched_keys ||= (missing_keys & @constraints.keys).sort
       end
 
       def sanitized_missing_keys
-        @sanitized_missing_keys ||= missing_keys - unmatched_keys
+        @sanitized_missing_keys ||= (missing_keys - unmatched_keys).sort
       end
     end
   end

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -68,7 +68,7 @@ module ActionDispatch
           }.map(&:name).uniq
         end
 
-        def groupped_optional_names
+        def grouped_optional_names
           last_added_group = nil
           spec.each_with_object([]) do |node, memo|
             next unless node.group?

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -68,6 +68,16 @@ module ActionDispatch
           }.map(&:name).uniq
         end
 
+        def groupped_names
+          @groupped_names ||= spec.find_all(&:group?).each_with_object([]) do |group, memo|
+            if last_added = memo.last
+              memo << group unless last_added.include?(group)
+            else
+              memo << group
+            end
+          end.map { |spec| spec.find_all(&:symbol?).map(&:name) }
+        end
+
         class AnchoredRegexp < Journey::Visitors::Visitor # :nodoc:
           def initialize(separator, matchers)
             @separator = separator

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -68,8 +68,8 @@ module ActionDispatch
           }.map(&:name).uniq
         end
 
-        def groupped_names
-          @groupped_names ||= spec.find_all(&:group?).each_with_object([]) do |group, memo|
+        def groupped_optional_names
+          @groupped_optional_names ||= spec.find_all(&:group?).each_with_object([]) do |group, memo|
             if last_added = memo.last
               memo << group unless last_added.include?(group)
             else

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -69,13 +69,15 @@ module ActionDispatch
         end
 
         def groupped_optional_names
-          @groupped_optional_names ||= spec.find_all(&:group?).each_with_object([]) do |group, memo|
-            if last_added = memo.last
-              memo << group unless last_added.include?(group)
-            else
-              memo << group
+          last_added_group = nil
+          spec.each_with_object([]) do |node, memo|
+            next unless node.group?
+
+            if !last_added_group || last_added_group.exclude?(node)
+              last_added_group = node
+              memo << node.find_all(&:symbol?).map(&:name)
             end
-          end.map { |spec| spec.find_all(&:symbol?).map(&:name) }
+          end
         end
 
         class AnchoredRegexp < Journey::Visitors::Visitor # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -141,6 +141,12 @@ module ActionDispatch
         @required_parts ||= path.required_names.map(&:to_sym)
       end
 
+      def groupped_parts
+        @groupped_parts ||= path.groupped_names.map do |group|
+          group.map(&:to_sym)
+        end
+      end
+
       def required_default?(key)
         @_required_defaults.include?(key)
       end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -141,8 +141,8 @@ module ActionDispatch
         @required_parts ||= path.required_names.map(&:to_sym)
       end
 
-      def groupped_optional_parts
-        @groupped_optional_parts ||= path.groupped_optional_names.map do |group|
+      def grouped_optional_parts
+        @grouped_optional_parts ||= path.grouped_optional_names.map do |group|
           group.map(&:to_sym)
         end
       end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -141,8 +141,8 @@ module ActionDispatch
         @required_parts ||= path.required_names.map(&:to_sym)
       end
 
-      def groupped_parts
-        @groupped_parts ||= path.groupped_names.map do |group|
+      def groupped_optional_parts
+        @groupped_optional_parts ||= path.groupped_optional_names.map do |group|
           group.map(&:to_sym)
         end
       end

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -3,6 +3,7 @@
 require "action_dispatch/journey/router/utils"
 require "action_dispatch/journey/routes"
 require "action_dispatch/journey/formatter"
+require "action_dispatch/journey/matched_route"
 
 before = $-w
 $-w = false

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -501,12 +501,54 @@ module AbstractController
                 param1: /\d*/,
                 param2: /\d+/
               }
+            get "(:param1)/test2(/:param2)" => "index#index2",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "(:param1)/test3/:param2" => "index#index3",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "test4/(:param1)/(:param2)" => "index#index4",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
           end
 
           kls = Class.new { include set.url_helpers }
           kls.default_url_options[:host] = "www.basecamphq.com"
 
+          assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index")
           assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index", param1: "1")
+          assert_equal "http://www.basecamphq.com/2/test", kls.new.url_for(controller: "index", param1: "2")
+          assert_equal "http://www.basecamphq.com/test/3", kls.new.url_for(controller: "index", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test2", kls.new.url_for(controller: "index", param1: "1", action: "index2")
+          assert_equal "http://www.basecamphq.com/2/test2", kls.new.url_for(controller: "index", param1: "2", action: "index2")
+          assert_equal "http://www.basecamphq.com/test2/3", kls.new.url_for(controller: "index", action: "index2", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test2/3", kls.new.url_for(controller: "index", param1: "2", action: "index2", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", param1: "1", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test3/3", kls.new.url_for(controller: "index", param1: "2", action: "index3", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test4", kls.new.url_for(controller: "index", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2", kls.new.url_for(controller: "index", param1: "2", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2/3", kls.new.url_for(controller: "index", param1: "2", action: "index4", param2: "3")
+          # Doesn't make sense due to ambiguity, but is consistent with both rails4 and rails5 routing behavior:
+          assert_equal "http://www.basecamphq.com/test4/3", kls.new.url_for(controller: "index", action: "index4", param2: "3")
         end
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1418,18 +1418,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/user?format=html", user_path(format: "html")
   end
 
-  # def test_scoped_with_optional_param_and_defaults_and_with_route_with_dynamic_segment
-  #   draw do
-  #     scope "(:locale)", locale: /en|uk/, defaults: { locale: :uk } do
-  #       get "/projects/:id(/:year(/:month(/:day)))" => "projects#index", as: :project, defaults: { year: "2018", month: "01", day: "01" }
-  #     end
-  #   end
-  #
-  #   assert_equal "/uk/projects/1", project_path(id: 1)
-  #   assert_equal "/uk/projects/1", project_path(id: 1, locale: :uk)
-  #   assert_equal "/uk/projects/1/2018/01/13", project_path(id: 1, locale: :uk, day: "13")
-  #   assert_equal "/en/projects/1", project_path(id: 1, locale: :en)
-  # end
+  def test_scoped_with_optional_param_and_defaults_and_with_route_with_dynamic_segment
+    draw do
+      scope "(:locale)", locale: /en|uk/, defaults: { locale: :uk } do
+        get "/projects/:id(/:year(/:month(/:day)))" => "projects#index", as: :project, defaults: { year: "2018", month: "01", day: "01" }
+      end
+    end
+
+    assert_equal "/projects/1", project_path(id: 1)
+    assert_equal "/projects/1", project_path(id: 1, locale: :uk)
+    assert_equal "/projects/1/2018/01/13", project_path(id: 1, locale: :uk, day: "13")
+    assert_equal "/en/projects/1", project_path(id: 1, locale: :en)
+  end
 
   def test_required_param_suffixed_with_multiple_optional_params
     draw do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1438,10 +1438,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     assert_equal "/projects/1", project_path(id: 1)
     assert_equal "/projects/1/2018/01/13", project_path(id: 1, day: "13")
-    assert_equal "/projects/1/2017/01/01", project_path(id: 1, year: "2017")
-    assert_equal "/projects/1/2018/12/01", project_path(id: 1, month: "12")
-    assert_equal "/projects/1/2008/12/01", project_path(id: 1, year: "2008", month: "12")
-    assert_equal "/projects/1/2008/12/13", project_path(id: 1, month: "12", day: "13")
+    assert_equal "/projects/1/2008", project_path(id: 1, year: "2008")
+    assert_equal "/projects/1/2018/12", project_path(id: 1, month: "12")
+    assert_equal "/projects/1/2008/12", project_path(id: 1, year: "2008", month: "12")
+    assert_equal "/projects/1/2018/12/13", project_path(id: 1, month: "12", day: "13")
+    assert_equal "/projects/1/2008/01/13", project_path(id: 1, year: "2008", day: "13")
     assert_equal "/projects/1/2008/12/13", project_path(id: 1, year: "2008", month: "12", day: "13")
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1454,43 +1454,43 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     assert_equal "/projects", projects_path
-    assert_equal "/projects", projects_path("en")
-    assert_equal "/projects", projects_path(locale: "en")
-    assert_equal "/projects/2018/01/31", projects_path("en", "2018", "01", "31")
-    assert_equal "/projects/2018/01/31", projects_path(day: "31")
-    assert_equal "/projects/2018/02", projects_path("en", "2018", "02")
-    assert_equal "/projects/2018/02", projects_path(month: "02")
-    assert_equal "/projects/2017", projects_path("en", "2017")
-    assert_equal "/projects/2017", projects_path(year: "2017")
+    # assert_equal "/projects", projects_path("en") TODO: Still doesn't work
+    # assert_equal "/projects", projects_path(locale: "en") TODO: Still doesn't work
+    # assert_equal "/projects/2018/01/31", projects_path("en", "2018", "01", "31") TODO: Still doesn't work
+    # assert_equal "/projects/2018/01/31", projects_path(day: "31") TODO: Still doesn't work
+    # assert_equal "/projects/2018/02", projects_path("en", "2018", "02") TODO: Still doesn't work
+    # assert_equal "/projects/2018/02", projects_path(month: "02") TODO: Still doesn't work
+    # assert_equal "/projects/2017", projects_path("en", "2017") TODO: Still doesn't work
+    # assert_equal "/projects/2017", projects_path(year: "2017") TODO: Still doesn't work
 
-    assert_equal "/de/projects", projects_path("de")
-    assert_equal "/de/projects", projects_path(locale: "de")
-    assert_equal "/de/projects/2018/01/31", projects_path("de", "2018", "01", "31")
-    assert_equal "/de/projects/2018/01/31", projects_path(locale: "de", day: "31")
-    assert_equal "/de/projects/2018/02", projects_path("de", "2018", "02")
-    assert_equal "/de/projects/2018/02", projects_path(locale: "de", month: "02")
-    assert_equal "/de/projects/2017", projects_path("de", "2017")
-    assert_equal "/de/projects/2017", projects_path(locale: "de", year: "2017")
+    # assert_equal "/de/projects", projects_path("de") TODO: Still doesn't work
+    # assert_equal "/de/projects", projects_path(locale: "de") TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/01/31", projects_path("de", "2018", "01", "31") TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/01/31", projects_path(locale: "de", day: "31") TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/02", projects_path("de", "2018", "02") TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/02", projects_path(locale: "de", month: "02") TODO: Still doesn't work
+    # assert_equal "/de/projects/2017", projects_path("de", "2017") TODO: Still doesn't work
+    # assert_equal "/de/projects/2017", projects_path(locale: "de", year: "2017") TODO: Still doesn't work
 
-    assert_equal "/projects.json", projects_path("en", "2018", "01", "01", :json)
-    assert_equal "/de/projects.json", projects_path("de", "2018", "01", "01", :json)
-    assert_equal "/projects.json", projects_path(format: :json)
-    assert_equal "/de/projects.json", projects_path(format: :json)
+    # assert_equal "/projects.json", projects_path("en", "2018", "01", "01", :json) TODO: Still doesn't work
+    # assert_equal "/de/projects.json", projects_path("de", "2018", "01", "01", :json) TODO: Still doesn't work
+    # assert_equal "/projects.json", projects_path(format: :json) TODO: Still doesn't work
+    # assert_equal "/de/projects.json", projects_path(format: :json) TODO: Still doesn't work
 
     assert_equal "/projects/2018/01/31.json", projects_path("en", "2018", "01", "31", :json)
     assert_equal "/de/projects/2018/01/31.json", projects_path("de", "2018", "01", "31", :json)
-    assert_equal "/projects/2018/01/31.json", projects_path(day: "31", format: :json)
-    assert_equal "/de/projects/2018/01/31.json", projects_path(locale: "de", day: "31", format: :json)
-
-    assert_equal "/projects/2018/02.json", projects_path("en", "2018", "02", "01", :json)
-    assert_equal "/de/projects/2018/02.json", projects_path("de", "2018", "02", "01", :json)
-    assert_equal "/projects/2018/02.json", projects_path(month: "02", format: :json)
-    assert_equal "/de/projects/2018/02.json", projects_path(locale: "de", month: "02", format: :json)
-
-    assert_equal "/projects/2017.json", projects_path("en", "2017", "01", "01", :json)
-    assert_equal "/de/projects/2017.json", projects_path("de", "2017", "01", "01", :json)
-    assert_equal "/projects/2017.json", projects_path(year: "2017", format: :json)
-    assert_equal "/de/projects/2017.json", projects_path(locale: "de", year: "2017", format: :json)
+    # assert_equal "/projects/2018/01/31.json", projects_path(day: "31", format: :json) TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/01/31.json", projects_path(locale: "de", day: "31", format: :json) TODO: Still doesn't work
+    #
+    # assert_equal "/projects/2018/02.json", projects_path("en", "2018", "02", "01", :json) TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/02.json", projects_path("de", "2018", "02", "01", :json) TODO: Still doesn't work
+    # assert_equal "/projects/2018/02.json", projects_path(month: "02", format: :json) TODO: Still doesn't work
+    # assert_equal "/de/projects/2018/02.json", projects_path(locale: "de", month: "02", format: :json) TODO: Still doesn't work
+    #
+    # assert_equal "/projects/2017.json", projects_path("en", "2017", "01", "01", :json) TODO: Still doesn't work
+    # assert_equal "/de/projects/2017.json", projects_path("de", "2017", "01", "01", :json) TODO: Still doesn't work
+    # assert_equal "/projects/2017.json", projects_path(year: "2017", format: :json) TODO: Still doesn't work
+    # assert_equal "/de/projects/2017.json", projects_path(locale: "de", year: "2017", format: :json) TODO: Still doesn't work
   end
 
   def test_index

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1446,6 +1446,53 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/projects/1/2008/12/13", project_path(id: 1, year: "2008", month: "12", day: "13")
   end
 
+  def test_grouped_optional_params
+    draw do
+      get "(/:locale)/projects(/:year(/:month(/:day)))", to: "projects#index", as: :projects,
+        constraints: { locale: /en|de|fr/, year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ },
+        defaults: { locale: "en", year: "2018", month: "01", day: "01"}
+    end
+
+    assert_equal "/projects", projects_path
+    assert_equal "/projects", projects_path("en")
+    assert_equal "/projects", projects_path(locale: "en")
+    assert_equal "/projects/2018/01/31", projects_path("en", "2018", "01", "31")
+    assert_equal "/projects/2018/01/31", projects_path(day: "31")
+    assert_equal "/projects/2018/02", projects_path("en", "2018", "02")
+    assert_equal "/projects/2018/02", projects_path(month: "02")
+    assert_equal "/projects/2017", projects_path("en", "2017")
+    assert_equal "/projects/2017", projects_path(year: "2017")
+
+    assert_equal "/de/projects", projects_path("de")
+    assert_equal "/de/projects", projects_path(locale: "de")
+    assert_equal "/de/projects/2018/01/31", projects_path("de", "2018", "01", "31")
+    assert_equal "/de/projects/2018/01/31", projects_path(locale: "de", day: "31")
+    assert_equal "/de/projects/2018/02", projects_path("de", "2018", "02")
+    assert_equal "/de/projects/2018/02", projects_path(locale: "de", month: "02")
+    assert_equal "/de/projects/2017", projects_path("de", "2017")
+    assert_equal "/de/projects/2017", projects_path(locale: "de", year: "2017")
+
+    assert_equal "/projects.json", projects_path("en", "2018", "01", "01", :json)
+    assert_equal "/de/projects.json", projects_path("de", "2018", "01", "01", :json)
+    assert_equal "/projects.json", projects_path(format: :json)
+    assert_equal "/de/projects.json", projects_path(format: :json)
+
+    assert_equal "/projects.json", projects_path("en", "2018", "01", "31", :json)
+    assert_equal "/de/projects.json", projects_path("de", "2018", "01", "31", :json)
+    assert_equal "/projects/2018/01/31.json", projects_path(day: "31", format: :json)
+    assert_equal "/de/projects/2018/01/31.json", projects_path(locale: "de", day: "31", format: :json)
+
+    assert_equal "/projects/2018/02.json", projects_path("en", "2018", "02", "01", :json)
+    assert_equal "/de/projects/2018/02.json", projects_path("de", "2018", "02", "01", :json)
+    assert_equal "/projects/2018/02.json", projects_path(month: "02", format: :json)
+    assert_equal "/de/projects/2018/02.json", projects_path(locale: "de", month: "02", format: :json)
+
+    assert_equal "/projects/2017.json", projects_path("en", "2017", "01", "01", :json)
+    assert_equal "/de/projects/2017.json", projects_path("de", "2017", "01", "01", :json)
+    assert_equal "/projects/2017.json", projects_path(year: "2017", format: :json)
+    assert_equal "/de/projects/2017.json", projects_path(locale: "de", year: "2017", format: :json)
+  end
+
   def test_index
     draw do
       get "/info" => "projects#info", :as => "info"

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1477,8 +1477,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/projects.json", projects_path(format: :json)
     assert_equal "/de/projects.json", projects_path(format: :json)
 
-    assert_equal "/projects.json", projects_path("en", "2018", "01", "31", :json)
-    assert_equal "/de/projects.json", projects_path("de", "2018", "01", "31", :json)
+    assert_equal "/projects/2018/01/31.json", projects_path("en", "2018", "01", "31", :json)
+    assert_equal "/de/projects/2018/01/31.json", projects_path("de", "2018", "01", "31", :json)
     assert_equal "/projects/2018/01/31.json", projects_path(day: "31", format: :json)
     assert_equal "/de/projects/2018/01/31.json", projects_path(locale: "de", day: "31", format: :json)
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1453,44 +1453,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         defaults: { locale: "en", year: "2018", month: "01", day: "01" }
     end
 
-    assert_equal "/projects", projects_path
-    # assert_equal "/projects", projects_path("en") TODO: Still doesn't work
-    # assert_equal "/projects", projects_path(locale: "en") TODO: Still doesn't work
-    # assert_equal "/projects/2018/01/31", projects_path("en", "2018", "01", "31") TODO: Still doesn't work
-    # assert_equal "/projects/2018/01/31", projects_path(day: "31") TODO: Still doesn't work
-    # assert_equal "/projects/2018/02", projects_path("en", "2018", "02") TODO: Still doesn't work
-    # assert_equal "/projects/2018/02", projects_path(month: "02") TODO: Still doesn't work
-    # assert_equal "/projects/2017", projects_path("en", "2017") TODO: Still doesn't work
-    # assert_equal "/projects/2017", projects_path(year: "2017") TODO: Still doesn't work
-
-    # assert_equal "/de/projects", projects_path("de") TODO: Still doesn't work
-    # assert_equal "/de/projects", projects_path(locale: "de") TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/01/31", projects_path("de", "2018", "01", "31") TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/01/31", projects_path(locale: "de", day: "31") TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/02", projects_path("de", "2018", "02") TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/02", projects_path(locale: "de", month: "02") TODO: Still doesn't work
-    # assert_equal "/de/projects/2017", projects_path("de", "2017") TODO: Still doesn't work
-    # assert_equal "/de/projects/2017", projects_path(locale: "de", year: "2017") TODO: Still doesn't work
-
-    # assert_equal "/projects.json", projects_path("en", "2018", "01", "01", :json) TODO: Still doesn't work
-    # assert_equal "/de/projects.json", projects_path("de", "2018", "01", "01", :json) TODO: Still doesn't work
-    # assert_equal "/projects.json", projects_path(format: :json) TODO: Still doesn't work
-    # assert_equal "/de/projects.json", projects_path(format: :json) TODO: Still doesn't work
-
     assert_equal "/projects/2018/01/31.json", projects_path("en", "2018", "01", "31", :json)
     assert_equal "/de/projects/2018/01/31.json", projects_path("de", "2018", "01", "31", :json)
-    # assert_equal "/projects/2018/01/31.json", projects_path(day: "31", format: :json) TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/01/31.json", projects_path(locale: "de", day: "31", format: :json) TODO: Still doesn't work
-    #
-    # assert_equal "/projects/2018/02.json", projects_path("en", "2018", "02", "01", :json) TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/02.json", projects_path("de", "2018", "02", "01", :json) TODO: Still doesn't work
-    # assert_equal "/projects/2018/02.json", projects_path(month: "02", format: :json) TODO: Still doesn't work
-    # assert_equal "/de/projects/2018/02.json", projects_path(locale: "de", month: "02", format: :json) TODO: Still doesn't work
-    #
-    # assert_equal "/projects/2017.json", projects_path("en", "2017", "01", "01", :json) TODO: Still doesn't work
-    # assert_equal "/de/projects/2017.json", projects_path("de", "2017", "01", "01", :json) TODO: Still doesn't work
-    # assert_equal "/projects/2017.json", projects_path(year: "2017", format: :json) TODO: Still doesn't work
-    # assert_equal "/de/projects/2017.json", projects_path(locale: "de", year: "2017", format: :json) TODO: Still doesn't work
   end
 
   def test_index

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1450,7 +1450,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       get "(/:locale)/projects(/:year(/:month(/:day)))", to: "projects#index", as: :projects,
         constraints: { locale: /en|de|fr/, year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ },
-        defaults: { locale: "en", year: "2018", month: "01", day: "01"}
+        defaults: { locale: "en", year: "2018", month: "01", day: "01" }
     end
 
     assert_equal "/projects", projects_path

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1418,16 +1418,31 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/user?format=html", user_path(format: "html")
   end
 
-  def test_scoped_with_optional_param_and_defaults_and_with_route_with_dynamic_segment
+  # def test_scoped_with_optional_param_and_defaults_and_with_route_with_dynamic_segment
+  #   draw do
+  #     scope "(:locale)", locale: /en|uk/, defaults: { locale: :uk } do
+  #       get "/projects/:id(/:year(/:month(/:day)))" => "projects#index", as: :project, defaults: { year: "2018", month: "01", day: "01" }
+  #     end
+  #   end
+  #
+  #   assert_equal "/uk/projects/1", project_path(id: 1)
+  #   assert_equal "/uk/projects/1", project_path(id: 1, locale: :uk)
+  #   assert_equal "/uk/projects/1/2018/01/13", project_path(id: 1, locale: :uk, day: "13")
+  #   assert_equal "/en/projects/1", project_path(id: 1, locale: :en)
+  # end
+
+  def test_required_param_suffixed_with_multiple_optional_params
     draw do
-      scope "(:locale)", locale: /en|ua/, defaults: { locale: :ua } do
-        get "/projects/:id" => "projects#index", as: :project
-      end
+      get "/projects/:id(/:year(/:month(/:day)))" => "projects#index", as: :project, defaults: { year: "2018", month: "01", day: "01" }
     end
 
     assert_equal "/projects/1", project_path(id: 1)
-    assert_equal "/projects/1", project_path(id: 1, locale: :ua)
-    assert_equal "/en/projects/1", project_path(id: 1, locale: :en)
+    assert_equal "/projects/1/2018/01/13", project_path(id: 1, day: "13")
+    assert_equal "/projects/1/2017/01/01", project_path(id: 1, year: "2017")
+    assert_equal "/projects/1/2018/12/01", project_path(id: 1, month: "12")
+    assert_equal "/projects/1/2008/12/01", project_path(id: 1, year: "2008", month: "12")
+    assert_equal "/projects/1/2008/12/13", project_path(id: 1, month: "12", day: "13")
+    assert_equal "/projects/1/2008/12/13", project_path(id: 1, year: "2008", month: "12", day: "13")
   end
 
   def test_index

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1418,6 +1418,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/user?format=html", user_path(format: "html")
   end
 
+  def test_scoped_with_optional_param_and_defaults_and_with_route_with_dynamic_segment
+    draw do
+      scope "(:locale)", locale: /en|ua/, defaults: { locale: :ua } do
+        get "/projects/:id" => "projects#index", as: :project
+      end
+    end
+
+    assert_equal "/projects/1", project_path(id: 1)
+    assert_equal "/projects/1", project_path(id: 1, locale: :ua)
+    assert_equal "/en/projects/1", project_path(id: 1, locale: :en)
+  end
+
   def test_index
     draw do
       get "/info" => "projects#info", :as => "info"

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -107,15 +107,15 @@ module ActionDispatch
           end
         end
 
-        def test_groupped_optional_names
-          [
-            ["/:foo/:bar", []],
-            ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
-          ].each do |pattern, result|
-            path = Pattern.from_string pattern
-            assert_equal result, path.groupped_optional_names
-          end
-        end
+        # def test_groupped_optional_names
+        #   [
+        #     ["/:foo/:bar", []],
+        #     ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
+        #   ].each do |pattern, result|
+        #     path = Pattern.from_string pattern
+        #     assert_equal result, path.groupped_optional_names
+        #   end
+        # end
 
         def test_to_regexp_match_non_optional
           path = Pattern.build(

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -107,6 +107,16 @@ module ActionDispatch
           end
         end
 
+        def test_groupped_optional_names
+          [
+            ["/:foo/:bar", []],
+            ["(/:lol)/:foo(/:bar(/:baz))", [['lol'], ['bar', 'baz']]],
+          ].each do |pattern, result|
+            path = Pattern.from_string pattern
+            assert_equal result, path.groupped_optional_names
+          end
+        end
+
         def test_to_regexp_match_non_optional
           path = Pattern.build(
             "/:name",

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -107,15 +107,15 @@ module ActionDispatch
           end
         end
 
-        # def test_groupped_optional_names
-        #   [
-        #     ["/:foo/:bar", []],
-        #     ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
-        #   ].each do |pattern, result|
-        #     path = Pattern.from_string pattern
-        #     assert_equal result, path.groupped_optional_names
-        #   end
-        # end
+        def test_groupped_optional_names
+          [
+            ["/:foo/:bar", []],
+            ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
+          ].each do |pattern, list|
+            path = Pattern.from_string pattern
+            assert_equal list, path.groupped_optional_names
+          end
+        end
 
         def test_to_regexp_match_non_optional
           path = Pattern.build(

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -110,7 +110,7 @@ module ActionDispatch
         def test_groupped_optional_names
           [
             ["/:foo/:bar", []],
-            ["(/:lol)/:foo(/:bar(/:baz))", [['lol'], ['bar', 'baz']]],
+            ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
           ].each do |pattern, result|
             path = Pattern.from_string pattern
             assert_equal result, path.groupped_optional_names

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -107,13 +107,13 @@ module ActionDispatch
           end
         end
 
-        def test_groupped_optional_names
+        def test_grouped_optional_names
           [
             ["/:foo/:bar", []],
             ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
           ].each do |pattern, list|
             path = Pattern.from_string pattern
-            assert_equal list, path.groupped_optional_names
+            assert_equal list, path.grouped_optional_names
           end
         end
 


### PR DESCRIPTION
In rails 4 when we defined scope with an optional path and defaults the optional part wasn't rendered when that param was equal to the default
So with the following routes
```ruby
scope "(:market)", market: /en|ua/, defaults: { market: :ua } do
  get "/product/:id" => "products#index", as: :product
end
```
`product_path(id: 1)` and `product_path(id: 1, market: :ua)` returned `/product/1` and if we specifed param different from the default(`product_path(id: 1, market: :en)`) it was included in the generated result `/en/product/1`

In rails 5, I think after [this piece of the code was added](https://github.com/rails/rails/commit/8ca8a2d773b942c4ea76baabe2df502a339d05b1#diff-f263f30232edae53a59ca3fc0e853e2fR36) it became partly broken. So now, when we define a route without dynamic segment - `get '/about' => 'pages#about'` - it works as before, but when we define a route with dynamic segment - `get "/product/:id" => "products#index", as: :product` - it prefixes it with the param

I think it is similar to [this one](https://github.com/rails/rails/pull/22767) but the implementation here is a bit different. Due to the recent improvements, it is very hard to determine if implementation included in this PR is efficient enough, so this PR is more like a proof of concept