### PR TITLE
Adding missing extension for `cattr_accessor` method

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -3,6 +3,7 @@
 require "openssl"
 require "base64"
 require "active_support/core_ext/array/extract_options"
+require "active_support/core_ext/module/attribute_accessors"
 require "active_support/message_verifier"
 require "active_support/messages/metadata"
 


### PR DESCRIPTION
Required for https://github.com/rails/rails/blob/90ebf3f90748fa77d7de4d9c358ba4eb57b91b6d/activesupport/lib/active_support/message_encryptor.rb#L84