### PR TITLE
Fix: FileStoreTest#test_filename_max_size fails in Ruby 2.5.1

### DIFF
--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -69,7 +69,7 @@ class FileStoreTest < ActiveSupport::TestCase
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}"
     path = @cache.send(:normalize_key, key, {})
     Dir::Tmpname.create(path) do |tmpname, n, opts|
-      assert File.basename(tmpname + ".lock").length <= 255, "Temp filename too long: #{File.basename(tmpname + '.lock').length}"
+      assert File.basename(key + tmpname.split(key).last + ".lock").length <= 255, "Temp filename too long: #{File.basename(tmpname + '.lock').length}"
     end
   end
 


### PR DESCRIPTION
### Summary

As of `Tmpname.create` was changed in [ruby/ruby@10b9690](https://github.com/ruby/ruby/commit/10b96900b90914b0cc1dba36f9736c038db2859d) to return a 'path' purged of file separators. The result is a test failure, even though the actual basename respects the constraint:

```
FileStoreTest#test_filename_max_size [/rails/activesupport/test/cache/stores/file_store_test.rb:72]:
Temp filename too long: 297
```

### Other Information

```
$ ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
```
