### PR TITLE
Add earlier releases v3.0, v3.1 in guides

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -21,6 +21,8 @@ The guides for earlier releases:
 <a href="http://guides.rubyonrails.org/v4.2/">Rails 4.2</a>,
 <a href="http://guides.rubyonrails.org/v4.1/">Rails 4.1</a>,
 <a href="http://guides.rubyonrails.org/v4.0/">Rails 4.0</a>,
-<a href="http://guides.rubyonrails.org/v3.2/">Rails 3.2</a>, and
+<a href="http://guides.rubyonrails.org/v3.2/">Rails 3.2</a>,
+<a href="http://guides.rubyonrails.org/v3.1/">Rails 3.1</a>,
+<a href="http://guides.rubyonrails.org/v3.0/">Rails 3.0</a> and
 <a href="http://guides.rubyonrails.org/v2.3/">Rails 2.3</a>.
 </p>


### PR DESCRIPTION
### Summary

I found lackness of earlier releases links about v3.0 and v3.1 in guides. So I've added them.

![image](https://user-images.githubusercontent.com/15371677/38162036-18dbf4f6-3515-11e8-91b0-651c2d222212.png)
