### PR TITLE
[ci skip] Modify twitter api link in api guide

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -24,7 +24,7 @@ With the advent of client-side frameworks, more developers are using Rails to
 build a back-end that is shared between their web application and other native
 applications.
 
-For example, Twitter uses its [public API](https://dev.twitter.com) in its web
+For example, Twitter uses its [public API](https://developer.twitter.com/) in its web
 application, which is built as a static site that consumes JSON resources.
 
 Instead of using Rails to generate HTML that communicates with the server


### PR DESCRIPTION
### Summary

* The twitter developer site's url was changed.
* I've updated this link new one.