### PR TITLE
Deriving `secret_key_base` breaks `key_generator` defined in 5.1.

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -427,7 +427,7 @@ module Rails
     # the correct place to store it is in the encrypted credentials file.
     def secret_key_base
       if Rails.env.test? || Rails.env.development?
-        Digest::MD5.hexdigest self.class.name
+        secrets.secret_key_base || Digest::MD5.hexdigest(self.class.name)
       else
         validate_secret_key_base(
           ENV["SECRET_KEY_BASE"] || credentials.secret_key_base || secrets.secret_key_base

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -576,6 +576,7 @@ module ApplicationTests
 
       app "development"
       assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
+      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 
     test "secret_key_base is copied from config to secrets when not set" do


### PR DESCRIPTION
# Summary 
If one created Rails 5.1 app and then updated to 5.2,
`secret_key_base` defined in `config/secrets.yml` is ignored for
`development` and `test` environment.
A change in `secret_key_base` in turn breaks
`Rails.application.key_generator`.

If one encrypt data in Rails 5.1, she cannot decrypt it in Rails 5.2
for `developemnt` and `test` environment.
