### PR TITLE
[ci skip] Use Oxford comma style in guide

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -23,6 +23,6 @@ The guides for earlier releases:
 <a href="http://guides.rubyonrails.org/v4.0/">Rails 4.0</a>,
 <a href="http://guides.rubyonrails.org/v3.2/">Rails 3.2</a>,
 <a href="http://guides.rubyonrails.org/v3.1/">Rails 3.1</a>,
-<a href="http://guides.rubyonrails.org/v3.0/">Rails 3.0</a> and
+<a href="http://guides.rubyonrails.org/v3.0/">Rails 3.0</a>, and
 <a href="http://guides.rubyonrails.org/v2.3/">Rails 2.3</a>.
 </p>


### PR DESCRIPTION
## Summary

Follow up #32389. Sorry it's my mistake. I should use the Oxford comma ("red, white, and blue", instead of "red, white and blue")