### PR TITLE
Move implementation of `before?` and `after?` to `DateAndTime::Calculations`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -142,6 +142,4 @@ class Date
   end
   alias_method :compare_without_coercion, :<=>
   alias_method :<=>, :compare_with_coercion
-  alias_method :before?, :<
-  alias_method :after?, :>
 end

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -60,6 +60,16 @@ module DateAndTime
       !WEEKEND_DAYS.include?(wday)
     end
 
+    # Returns true if the date/time before <tt>date_or_time</tt>.
+    def before?(date_or_time)
+      self < date_or_time
+    end
+
+    # Returns true if the date/time after <tt>date_or_time</tt>.
+    def after?(date_or_time)
+      self > date_or_time
+    end
+
     # Returns a new date/time the specified number of days ago.
     def days_ago(days)
       advance(days: -days)

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -208,6 +208,4 @@ class DateTime
       super
     end
   end
-  alias_method :before?, :<
-  alias_method :after?, :>
 end

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -302,8 +302,6 @@ class Time
   end
   alias_method :compare_without_coercion, :<=>
   alias_method :<=>, :compare_with_coercion
-  alias_method :before?, :<
-  alias_method :after?, :>
 
   # Layers additional behavior on Time#eql? so that ActiveSupport::TimeWithZone instances
   # can be eql? to an equivalent Time

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -385,6 +385,18 @@ module DateAndTimeBehavior
     assert_predicate date_time_init(2015, 1, 5, 15, 15, 10), :on_weekday?
   end
 
+  def test_before
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
+  def test_after
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
   def with_bw_default(bw = :monday)
     old_bw = Date.beginning_of_week
     Date.beginning_of_week = bw

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -360,18 +360,6 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_before
-    assert_equal false, Date.new(2017, 3, 6).before?(Date.new(2017, 3, 5))
-    assert_equal false, Date.new(2017, 3, 6).before?(Date.new(2017, 3, 6))
-    assert_equal true, Date.new(2017, 3, 6).before?(Date.new(2017, 3, 7))
-  end
-
-  def test_after
-    assert_equal true, Date.new(2017, 3, 6).after?(Date.new(2017, 3, 5))
-    assert_equal false, Date.new(2017, 3, 6).after?(Date.new(2017, 3, 6))
-    assert_equal false, Date.new(2017, 3, 6).after?(Date.new(2017, 3, 7))
-  end
-
   def test_current_returns_date_today_when_zone_not_set
     with_env_tz "US/Central" do
       Time.stub(:now, Time.local(1999, 12, 31, 23)) do

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -285,18 +285,6 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_before
-    assert_equal false, DateTime.civil(2017, 3, 6, 12, 0, 0).before?(DateTime.civil(2017, 3, 6, 11, 59, 59))
-    assert_equal false, DateTime.civil(2017, 3, 6, 12, 0, 0).before?(DateTime.civil(2017, 3, 6, 12, 0, 0))
-    assert_equal true, DateTime.civil(2017, 3, 6, 12, 0, 0).before?(DateTime.civil(2017, 3, 6, 12, 00, 1))
-  end
-
-  def test_after
-    assert_equal true, DateTime.civil(2017, 3, 6, 12, 0, 0).after?(DateTime.civil(2017, 3, 6, 11, 59, 59))
-    assert_equal false, DateTime.civil(2017, 3, 6, 12, 0, 0).after?(DateTime.civil(2017, 3, 6, 12, 0, 0))
-    assert_equal false, DateTime.civil(2017, 3, 6, 12, 0, 0).after?(DateTime.civil(2017, 3, 6, 12, 00, 1))
-  end
-
   def test_current_returns_date_today_when_zone_is_not_set
     with_env_tz "US/Eastern" do
       Time.stub(:now, Time.local(1999, 12, 31, 23, 59, 59)) do

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -736,18 +736,6 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_before
-    assert_equal false, Time.utc(2017, 3, 6, 12, 0, 0).before?(Time.utc(2017, 3, 6, 11, 59, 59))
-    assert_equal false, Time.utc(2017, 3, 6, 12, 0, 0).before?(Time.utc(2017, 3, 6, 12, 0, 0))
-    assert_equal true, Time.utc(2017, 3, 6, 12, 0, 0).before?(Time.utc(2017, 3, 6, 12, 00, 1))
-  end
-
-  def test_after
-    assert_equal true, Time.utc(2017, 3, 6, 12, 0, 0).after?(Time.utc(2017, 3, 6, 11, 59, 59))
-    assert_equal false, Time.utc(2017, 3, 6, 12, 0, 0).after?(Time.utc(2017, 3, 6, 12, 0, 0))
-    assert_equal false, Time.utc(2017, 3, 6, 12, 0, 0).after?(Time.utc(2017, 3, 6, 12, 00, 1))
-  end
-
   def test_acts_like_time
     assert_predicate Time.new, :acts_like_time?
   end


### PR DESCRIPTION
This prevents duplication of code.

Prevent duplication of tests by moving them to `DateAndTimeBehavior`.

Related to #32185.
