### PR TITLE
Remove leftover blank sqlite3 file after in memory handler tests.

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -94,6 +94,7 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
           ActiveRecord::Base.establish_connection(:arunit)
+          FileUtils.rm_rf "db"
         end
 
         def test_establish_connection_using_2_level_config_defaults_to_default_env_primary_db
@@ -116,6 +117,7 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
           ActiveRecord::Base.establish_connection(:arunit)
+          FileUtils.rm_rf "db"
         end
       end
 


### PR DESCRIPTION
### Summary

Fixes a glitch introduced in 03929463192be49acfb3660160543e48b0960fd1 that leaves an empty file, `/activerecord/db/primary.sqlite3` in the fs.