### PR TITLE
Extract the confirm call in its own, overridable method in rails_ujs

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Extract the `confirm` call in its own, overridable method in `rails_ujs`.
+    Example :
+        Rails.confirm = function(message, element) {
+          return (my_bootstrap_modal_confirm(message));
+        }
+
+    *Mathieu Mahé*
+
 *   Enable select tag helper to mark `prompt` option as `selected` and/or `disabled` for `required`
     field. Example:
 

--- a/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
@@ -5,6 +5,10 @@
 Rails.handleConfirm = (e) ->
   stopEverything(e) unless allowAction(this)
 
+# Default confirm dialog, may be overridden with custom confirm dialog in Rails.confirm
+Rails.confirm = (message, element) ->
+  confirm(message)
+
 # For 'data-confirm' attribute:
 # - Fires `confirm` event
 # - Shows the confirmation dialog
@@ -20,7 +24,7 @@ allowAction = (element) ->
 
   answer = false
   if fire(element, 'confirm')
-    try answer = confirm(message)
+    try answer = Rails.confirm(message, element)
     callback = fire(element, 'confirm:complete', [answer])
 
   answer and callback

--- a/actionview/test/ujs/public/test/data-confirm.js
+++ b/actionview/test/ujs/public/test/data-confirm.js
@@ -314,3 +314,29 @@ asyncTest('clicking on the children of a disabled button should not trigger a co
     start()
   }, 50)
 })
+
+asyncTest('clicking on a link with data-confirm attribute with custom confirm handler. Confirm yes.', 7, function() {
+  var message, element
+  // redefine confirm function so we can make sure it's not called
+  window.confirm = function(msg) {
+    ok(false, 'confirm dialog should not be called')
+  }
+  // custom auto-confirm:
+  Rails.confirm = function(msg, elem) { message = msg; element = elem; return true }
+
+  $('a[data-confirm]')
+    .bindNative('confirm:complete', function(e, data) {
+      App.assertCallbackInvoked('confirm:complete')
+      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+    })
+    .bindNative('ajax:success', function(e, data, status, xhr) {
+      App.assertCallbackInvoked('ajax:success')
+      App.assertRequestPath(data, '/echo')
+      App.assertGetRequest(data)
+
+      equal(message, 'Are you absolutely sure?')
+      equal(element, $('a[data-confirm]').get(0))
+      start()
+    })
+    .triggerNative('click')
+})


### PR DESCRIPTION
Following the discussion in #32402 and the inactivity of #29965, I added the possibility to override the `confirm` call in rails_ujs. This feature can be useful to anyone who want to customize the confirm dialog for example.

The behaviour was possible with `jquery_ujs` but was missing from `rails_ujs`.