### PR TITLE
Fix typo in rails-ujs HTML content test

### DIFF
--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -135,7 +135,7 @@ asyncTest('HTML content should be plain-text', 1, function() {
   $('form').append('<input type="text" name="content" value="<p>hello</p>">')
 
   submit(function(e, data, status, xhr) {
-    ok(data === '<p>hello</ps>', 'returned data should be a plain-text string')
+    ok(data === '<p>hello</p>', 'returned data should be a plain-text string')
   })
 })
 


### PR DESCRIPTION
### Summary

I made a typo...

`</ps>` is not a valid closing tag for `<p>`.