### PR TITLE
Optimize the code inside AR::QueryCache middleware

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -441,8 +441,9 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
 
       middleware {
-        assert ActiveRecord::Base.connection.query_cache_enabled, "QueryCache did not get lazily enabled"
+        assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
       }.call({})
+      assert_not_predicate ActiveRecord::Base.connection, :query_cache_enabled
     end
   end
 


### PR DESCRIPTION
### Summary

Reduce number of generated arrays from n+1 to 1 where n is the number of pools.
It can be important for applications that use a techniques like database sharding and can have a hundred of databases used by the same app.

In my project we use 6: 1 primary and 2 shards + a slave for each of them.

Follow up on https://github.com/rails/rails/pull/28869#discussion_r178390805

r? @matthewd

cc @eugeneius 