### PR TITLE
Not generate needless files in guides

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -141,32 +141,34 @@ module RailsGuides
         puts "Generating #{guide} as #{output_file}"
         layout = @kindle ? "kindle/layout" : "layout"
 
+        view = ActionView::Base.new(
+          @source_dir,
+          edge:     @edge,
+          version:  @version,
+          mobi:     "kindle/#{mobi}",
+          language: @language
+        )
+        view.extend(Helpers)
+
+        if guide =~ /\.(\w+)\.erb$/
+          return if %w[_license _welcome layout].include?($`)
+
+          # Generate the special pages like the home.
+          # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
+          result = view.render(layout: layout, formats: [$1], file: $`)
+        else
+          body = File.read("#{@source_dir}/#{guide}")
+          result = RailsGuides::Markdown.new(
+            view:    view,
+            layout:  layout,
+            edge:    @edge,
+            version: @version
+          ).render(body)
+
+          warn_about_broken_links(result)
+        end
+
         File.open(output_path, "w") do |f|
-          view = ActionView::Base.new(
-            @source_dir,
-            edge:     @edge,
-            version:  @version,
-            mobi:     "kindle/#{mobi}",
-            language: @language
-          )
-          view.extend(Helpers)
-
-          if guide =~ /\.(\w+)\.erb$/
-            # Generate the special pages like the home.
-            # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
-            result = view.render(layout: layout, formats: [$1], file: $`)
-          else
-            body = File.read("#{@source_dir}/#{guide}")
-            result = RailsGuides::Markdown.new(
-              view:    view,
-              layout:  layout,
-              edge:    @edge,
-              version: @version
-            ).render(body)
-
-            warn_about_broken_links(result)
-          end
-
           f.write(result)
         end
       end


### PR DESCRIPTION
### Summary

Not generate needless files:

* [_license.html.erb](http://edgeguides.rubyonrails.org/_license.html), [_welcome.html.erb](http://edgeguides.rubyonrails.org/_welcome.html) are partial files.
* [layout.html.erb](http://edgeguides.rubyonrails.org/layout.html) is the layout file.

I thought we don't need to generate these files.