### PR TITLE
Add AR::Base.base_class? predicate

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `AR::Base.base_class?` predicate
+
+    *Bogdan Gusiev*
+
 *   Add custom prefix option to ActiveRecord::Store.store_accessor.
 
     *Tan Huynh*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -59,7 +59,7 @@ module ActiveRecord
         # attribute methods.
         generated_attribute_methods.synchronize do
           return false if @attribute_methods_generated
-          superclass.define_attribute_methods unless self == base_class
+          superclass.define_attribute_methods unless base_class?
           super(attribute_names)
           @attribute_methods_generated = true
         end

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -83,7 +83,7 @@ module ActiveRecord
           end
 
           def reset_primary_key #:nodoc:
-            if self == base_class
+            if base_class?
               self.primary_key = get_primary_key(base_class.name)
             else
               self.primary_key = base_class.primary_key

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -55,7 +55,7 @@ module ActiveRecord
         if has_attribute?(inheritance_column)
           subclass = subclass_from_attributes(attributes)
 
-          if subclass.nil? && base_class == self
+          if subclass.nil? && base_class?
             subclass = subclass_from_attributes(column_defaults)
           end
         end
@@ -102,6 +102,12 @@ module ActiveRecord
         else
           superclass.base_class
         end
+      end
+
+      # Returns whether the class is a base class.
+      # See #base_class for more information.
+      def base_class?
+        base_class == self
       end
 
       # Set this to +true+ if this is an abstract class (see

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -276,7 +276,7 @@ module ActiveRecord
       end
 
       def sequence_name
-        if base_class == self
+        if base_class?
           @sequence_name ||= reset_sequence_name
         else
           (@sequence_name ||= nil) || base_class.sequence_name
@@ -501,8 +501,7 @@ module ActiveRecord
 
         # Computes and returns a table name according to default conventions.
         def compute_table_name
-          base = base_class
-          if self == base
+          if base_class?
             # Nested classes are prefixed with singular parent table name.
             if parent < Base && !parent.abstract_class?
               contained = parent.table_name
@@ -513,7 +512,7 @@ module ActiveRecord
             "#{full_table_name_prefix}#{contained}#{undecorated_table_name(name)}#{full_table_name_suffix}"
           else
             # STI subclasses always use their superclass' table.
-            base.table_name
+            base_class.table_name
           end
         end
     end

--- a/activerecord/lib/active_record/translation.rb
+++ b/activerecord/lib/active_record/translation.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       classes = [klass]
       return classes if klass == ActiveRecord::Base
 
-      while klass != klass.base_class
+      while !klass.base_class?
         classes << klass = klass.superclass
       end
       classes

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       def setup
         @klass = Class.new(Class.new { def self.initialize_generated_modules; end }) do
           def self.superclass; Base; end
-          def self.base_class; self; end
+          def self.base_class?; true; end
           def self.decorate_matching_attribute_types(*); end
 
           include ActiveRecord::DefineCallbacks

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -174,17 +174,26 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_inheritance_base_class
     assert_equal Post, Post.base_class
+    assert_predicate Post, :base_class?
     assert_equal Post, SpecialPost.base_class
+    assert_not_predicate SpecialPost, :base_class?
     assert_equal Post, StiPost.base_class
+    assert_not_predicate StiPost, :base_class?
     assert_equal Post, SubStiPost.base_class
+    assert_not_predicate SubStiPost, :base_class?
     assert_equal SubAbstractStiPost, SubAbstractStiPost.base_class
+    assert_predicate SubAbstractStiPost, :base_class?
   end
 
   def test_abstract_inheritance_base_class
     assert_equal LoosePerson, LoosePerson.base_class
+    assert_predicate LoosePerson, :base_class?
     assert_equal LooseDescendant, LooseDescendant.base_class
+    assert_predicate LooseDescendant, :base_class?
     assert_equal TightPerson, TightPerson.base_class
+    assert_predicate TightPerson, :base_class?
     assert_equal TightPerson, TightDescendant.base_class
+    assert_not_predicate TightDescendant, :base_class?
   end
 
   def test_base_class_activerecord_error


### PR DESCRIPTION
### Summary

`base_class?` can be handy addition to the `base_class` which is the same as `self == base_class`.
In my project `klass.base_class == klass` is 50% the case of the `base_class`. The same is actual for AR internally.
