### PR TITLE
Disable ActionView::Template finalizers in test environment

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Disable `ActionView::Template` finalizers in test environment
+
+    Template finalization can be expensive in large view test suites.
+    Add a configuration option,
+    `action_view.finalize_compiled_template_methods`, and turn it off in
+    the test environment.
+
+    *Simon Coffey*
+
 *   Extract the `confirm` call in its own, overridable method in `rails_ujs`.
     Example :
         Rails.confirm = function(message, element) {

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -10,6 +10,7 @@ module ActionView
     config.action_view.embed_authenticity_token_in_remote_forms = nil
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
+    config.action_view.finalize_compiled_template_methods = true
 
     config.eager_load_namespaces << ActionView
 
@@ -42,6 +43,13 @@ module ActionView
         unless default_enforce_utf8.nil?
           ActionView::Helpers::FormTagHelper.default_enforce_utf8 = default_enforce_utf8
         end
+      end
+    end
+
+    initializer "action_view.finalize_compiled_template_methods" do |app|
+      ActiveSupport.on_load(:action_view) do
+        ActionView::Template.finalize_compiled_template_methods =
+          app.config.action_view.delete(:finalize_compiled_template_methods)
       end
     end
 

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -9,6 +9,9 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
+    mattr_accessor :finalize_compiled_template_methods
+    self.finalize_compiled_template_methods = true
+
     # === Encodings in ActionView::Template
     #
     # ActionView::Template is one of a few sources of potential
@@ -307,7 +310,9 @@ module ActionView
         end
 
         mod.module_eval(source, identifier, 0)
-        ObjectSpace.define_finalizer(self, Finalizer[method_name, mod])
+        if finalize_compiled_template_methods
+          ObjectSpace.define_finalizer(self, Finalizer[method_name, mod])
+        end
       end
 
       def handle_render_error(view, e)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -600,6 +600,13 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.default_enforce_utf8` determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8. This defaults to `false`.
 
+* `config.action_view.finalize_compiled_template_methods` determines
+  whether the methods on `ActionView::CompiledTemplates` that templates
+  compile themselves to are removed when template instances are
+  destroyed by the garbage collector. This helps prevent memory leaks in
+  development mode, but for large test suites, disabling this option in
+  the test environment can improve performance. This defaults to `true`.
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -47,4 +47,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Prevent expensive template finalization at end of test suite runs.
+  config.action_view.finalize_compiled_template_methods = false
 end


### PR DESCRIPTION
### Summary

To avoid expensive finalization of `ActionView::Template` instances at the end of large test suites, this adds a configuration option to disable the finalizers, and uses it to disable them in the test environment.

### Description

ActionView::Template instances compile their source to methods on the ActionView::CompiledTemplates module. To prevent leaks in development mode, where templates can frequently change, a finalizer is added that [undefines these methods](https://github.com/rails/rails/blob/09b2348f7fc8d4e7191e70e06608c5909067e2aa/actionview/lib/action_view/template.rb#L118-L126) when the templates are garbage-collected.

This is undesirable in the test environment, however, as templates don't change during the life of the test, so there's no leak to be avoided. Moreover, the cost of undefining a method is proportional to the number of descendants a class or module has, since the method cache must be cleared for [all descendant classes](https://github.com/ruby/ruby/blob/753aa75319282297c41a02d9932b5d88ba575112/vm_method.c#L80).

As `ActionView::CompiledTemplates` is mixed into `ActionView::TestCase` (or in RSpec suites, every view example group), it can end up with a very large number of descendants, and undefining its methods can become very expensive. In large test suites, this results in a long delay at the end of the test suite as all template finalizers are run, only for the process to then exit.

To avoid this unnecessary cost, this change adds a config option, `action_view.finalize_compiled_template_methods`, defaulting to true, and sets it to false in the test environment only.

### Other Information

I've built a small [reproduction of this issue](https://github.com/urbanautomaton/stub_template_perf/tree/finalizing-cost-at-end) using RSpec, illustrating a test suite that has 1,000 templates. For this suite the finalization cost at the end of the run is approximately 30 seconds, which is comparable to the delay seen in the app I'm currently working on (~45s).

```ruby
# spec/views/repro.html.erb_spec.rb
require 'rails_helper'

(1..1000).each do |i|
  RSpec.describe "many/#{i}.html.erb" do
    it 'renders the template' do
      render

      expect(rendered).to include("some-contents-#{i}")
    end
  end
end
```

```
$ time rspec spec/views/repro.html.erb_spec.rb
..... [many examples snipped] ....

Finished in 32.51 seconds (files took 2.17 seconds to load)
1000 examples, 0 failures


real    1m7.304s
user    1m6.304s
sys     0m0.841s
```

### Feedback

I've confirmed that this patch addresses the performance issue. However, I'm not entirely sure that exposing a configuration option is the best thing in this instance, since it's inevitably a rather obscure flag that the vast majority of users probably won't want to touch.

Any and all feedback is obviously welcome, but in particular if anyone has a better idea for making this environment-specific change, I'd be very open to suggestions.