### PR TITLE
Generate description in guides

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -21,6 +21,7 @@ module RailsGuides
       extract_raw_header_and_body
       generate_header
       generate_title
+      generate_description
       generate_body
       generate_structure
       generate_index
@@ -147,6 +148,14 @@ module RailsGuides
         end
       end
 
+      def generate_description
+        if heading = Nokogiri::HTML.fragment(@header).at(:p)
+          @description = heading.text.tr("\n", " ")
+        else
+          @description = "This guide is designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together."
+        end
+      end
+
       def node_index(hierarchy)
         case hierarchy.size
         when 1
@@ -166,6 +175,7 @@ module RailsGuides
       def render_page
         @view.content_for(:header_section) { @header }
         @view.content_for(:page_title) { @title }
+        @view.content_for(:page_description) { @description }
         @view.content_for(:index_section) { @index }
         @view.render(layout: @layout, html: @body.html_safe)
       end

--- a/guides/source/index.html.erb
+++ b/guides/source/index.html.erb
@@ -1,12 +1,16 @@
-<% content_for :page_title do %>
+<% content_for :page_title do -%>
 Ruby on Rails Guides
-<% end %>
+<%- end %>
 
-<% content_for :header_section do %>
+<% content_for :page_description do -%>
+This guide is designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
+<%- end %>
+
+<% content_for :header_section do -%>
 <%= render 'welcome' %>
 <% end %>
 
-<% content_for :index_section do %>
+<% content_for :index_section do -%>
 <div id="subCol">
   <dl>
     <dt></dt>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -6,6 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
 <title><%= yield(:page_title) || 'Ruby on Rails Guides' %></title>
+<meta name="description" content="<%= yield(:page_description) || 'This guide is designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.' %>" />
 <link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
 <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print" />
 


### PR DESCRIPTION
### Summary

Seems page's description are not generated in all guide's pages. So I've fixed to generated them.

cc / @fxn 