### PR TITLE
add `storage` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.bundle
 /dist/
 /doc/
+/storage/
 /guides/output/
 debug.log
 node_modules/


### PR DESCRIPTION
Active::Storage suggest a local storage directory `Rails.root.join("storage")`; its content should never end up in git

### Summary

Small update to .gitignore; too small for bugreport.