### PR TITLE
Doc fix added missing quote

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -119,7 +119,7 @@ module ActionMailer
     #
     #   def test_parameterized_email
     #     assert_enqueued_email_with ContactMailer, :welcome,
-    #       args: {email: 'user@example.com} do
+    #       args: {email: 'user@example.com'} do
     #       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
     #     end
     #   end


### PR DESCRIPTION
### Summary
Just added a quote to the ```'user@example.com'``` on line 122.
