### PR TITLE
Display db:drop description in ActiveRecord

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -41,9 +41,11 @@ namespace :test do
   end
 end
 
-desc "Build MySQL and PostgreSQL test databases"
 namespace :db do
+  desc "Build MySQL and PostgreSQL test databases"
   task create: ["db:mysql:build", "db:postgresql:build"]
+
+  desc "Drop MySQL and PostgreSQL test databases"
   task drop: ["db:mysql:drop", "db:postgresql:drop"]
 end
 


### PR DESCRIPTION
### Summary

Added `db:drop` description:

```diff
   $ bundle exec rake -T
   rake db:create              # Build MySQL and PostgreSQL test databases
+  rake db:drop                # Drop MySQL and PostgreSQL test databases
   rake db:mysql:build         # Build the MySQL test databases
   rake db:mysql:drop          # Drop the MySQL test databases
   rake db:mysql:rebuild       # Rebuild the MySQL test databases
   rake db:postgresql:build    # Build the PostgreSQL test databases
   rake db:postgresql:drop     # Drop the PostgreSQL test databases
   rake db:postgresql:rebuild  # Rebuild the PostgreSQL test databases
   rake default                # Run mysql2, sqlite, and postgresql tests by default
   rake test                   # Run mysql2, sqlite, and postgresql tests
   rake test:db2               # Run tests for {"db2"=>"db2:env"}
   rake test:jdbcderby         # Run tests for {"jdbcderby"=>"jdbcderby:env"}
   rake test:jdbch2            # Run tests for {"jdbch2"=>"jdbch2:env"}
   rake test:jdbchsqldb        # Run tests for {"jdbchsqldb"=>"jdbchsqldb:env"}
   rake test:jdbcmysql         # Run tests for {"jdbcmysql"=>"jdbcmysql:env"}
   rake test:jdbcpostgresql    # Run tests for {"jdbcpostgresql"=>"jdbcpostgresql:env"}
   rake test:jdbcsqlite3       # Run tests for {"jdbcsqlite3"=>"jdbcsqlite3:env"}
   rake test:mysql2            # Run tests for {"mysql2"=>"mysql2:env"}
   rake test:oracle            # Run tests for {"oracle"=>"oracle:env"}
   rake test:postgresql        # Run tests for {"postgresql"=>"postgresql:env"}
   rake test:sqlite3           # Run tests for {"sqlite3"=>"sqlite3:env"}
   rake test:sqlite3_mem       # Run tests for {"sqlite3_mem"=>"sqlite3_mem:env"}
```