### PR TITLE
Scaffold index view render

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
@@ -15,6 +15,7 @@ module Erb # :nodoc:
       end
 
       def copy_view_files
+        template "_member_partial.html.erb", File.join("app/views", controller_file_path, "_#{file_name}.html.erb")
         available_views.each do |view|
           formats.each do |format|
             filename = filename_with_extensions(view, format)

--- a/railties/lib/rails/generators/erb/scaffold/templates/_member_partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_member_partial.html.erb.tt
@@ -1,0 +1,8 @@
+<tr>
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+  <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
+<% end -%>
+  <td><%%= link_to 'Show', <%= model_resource_name %> %></td>
+  <td><%%= link_to 'Edit', edit_<%= singular_route_name %>_path(<%= singular_table_name %>) %></td>
+  <td><%%= link_to 'Destroy', <%= model_resource_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+</tr>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
@@ -13,16 +13,7 @@
   </thead>
 
   <tbody>
-    <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
-      <tr>
-<% attributes.reject(&:password_digest?).each do |attribute| -%>
-        <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
-<% end -%>
-        <td><%%= link_to 'Show', <%= model_resource_name %> %></td>
-        <td><%%= link_to 'Edit', edit_<%= singular_route_name %>_path(<%= singular_table_name %>) %></td>
-        <td><%%= link_to 'Destroy', <%= model_resource_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <%% end %>
+    <%%= render @<%= plural_table_name %> %>
   </tbody>
 </table>
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -185,10 +185,14 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/admin/users/index.html.erb" do |content|
+      assert_match(/render @users/, content)
+      assert_match("'New User', new_admin_user_path", content)
+    end
+
+    assert_file "app/views/admin/users/_user.html.erb" do |content|
       assert_match("'Show', [:admin, user]", content)
       assert_match("'Edit', edit_admin_user_path(user)", content)
       assert_match("'Destroy', [:admin, user]", content)
-      assert_match("'New User', new_admin_user_path", content)
     end
 
     assert_file "app/views/admin/users/new.html.erb" do |content|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -83,6 +83,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_file "app/views/product_lines/#{view}.html.erb", /render 'form', product_line: @product_line/
     end
 
+    assert_file "app/views/product_lines/_product_line.html.erb"
+
     assert_file "app/views/product_lines/_form.html.erb" do |test|
       assert_match "product_line", test
       assert_no_match "@product_line", test

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -285,10 +285,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Views
     assert_file "app/views/admin/roles/index.html.erb" do |content|
+      assert_match("'New Admin Role', new_admin_role_path", content)
+    end
+
+    assert_file "app/views/admin/roles/_role.html.erb" do |content|
       assert_match("'Show', admin_role", content)
       assert_match("'Edit', edit_admin_role_path(admin_role)", content)
       assert_match("'Destroy', admin_role", content)
-      assert_match("'New Admin Role', new_admin_role_path", content)
     end
 
     %w(edit new show _form).each do |view|


### PR DESCRIPTION
### Summary

Currently when you use scaffold it creates an index view that uses '@cats.each' on the collection rather than using 
<%= render @cats %>
with a partial _cat.html.erb. 
I see this as a good opportunity for new users of the framework to learn the collection render feature.

This commit updates the scaffold generator to create the member partial and modifies the index view to use render instead of each.
