### PR TITLE
Use `:default` option in order to set default value of `finalize_compiled_template_methods`

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -9,8 +9,7 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
-    mattr_accessor :finalize_compiled_template_methods
-    self.finalize_compiled_template_methods = true
+    mattr_accessor :finalize_compiled_template_methods, default: true
 
     # === Encodings in ActionView::Template
     #


### PR DESCRIPTION
Since we introduced default option for `class_attribute` and
`mattr_accessor` family of methods and changed all occurrences of setting
default values by using of `:default` option I think it would be fine to use
`:default` option in order to set default value of `finalize_compiled_template_methods`
since it expresses itself very well.

Related to #29294, #32418
