### PR TITLE
Stop mutating body response

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -35,9 +35,9 @@ module Rails
         instrumenter = ActiveSupport::Notifications.instrumenter
         instrumenter.start 'request.action_dispatch', request: request
         logger.info { started_request_message(request) }
-        resp = @app.call(env)
-        resp[2] = ::Rack::BodyProxy.new(resp[2]) { finish(request) }
-        resp
+        status, headers, body = @app.call(env)
+        body = ::Rack::BodyProxy.new(body) { finish(request) }
+        [status, headers, body]
       rescue Exception
         finish(request)
         raise


### PR DESCRIPTION
If @app.call returns an object that is saved (for e.g., in a constant), the mutation results in a continuing cycle of wrapping the body in `Rack::BodyProxy`, eventually leading to `SystemStackError`. Here's an example to reproduce:

```ruby
class HealthcheckApp
  SUCCESS_RESPONSE = [200, { 'Content-Type' => 'text/plain' }, ['success']].freeze

  def initialize(app)
    @app = app
  end

  def call(env)
    return SUCCESS_RESPONSE if env['PATH_INFO'] == '/heartbeat'
    @app.call(env)
  end
end

app = HealthcheckApp.new(-> (_x) { [200, {}, nil] })
logger = Rails::Rack::Logger.new(app)

logger.call('REQUEST_METHOD' => 'GET')
```