### PR TITLE
Stop mutating body response

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -35,9 +35,9 @@ module Rails
           instrumenter = ActiveSupport::Notifications.instrumenter
           instrumenter.start "request.action_dispatch", request: request
           logger.info { started_request_message(request) }
-          resp = @app.call(env)
-          resp[2] = ::Rack::BodyProxy.new(resp[2]) { finish(request) }
-          resp
+          status, headers, body = @app.call(env)
+          body = ::Rack::BodyProxy.new(body) { finish(request) }
+          [status, headers, body]
         rescue Exception
           finish(request)
           raise

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -14,12 +14,19 @@ module Rails
 
         attr_reader :logger
 
-        def initialize(logger = NULL, taggers = nil, &block)
-          super(->(_) { block.call; [200, {}, []] }, taggers)
+        def initialize(logger = NULL, app: nil, taggers: nil, &block)
+          app ||= ->(_) { block.call; [200, {}, []] }
+          super(app, taggers)
           @logger = logger
         end
 
         def development?; false; end
+      end
+
+      class TestApp < Struct.new(:response)
+        def call(_env)
+          response
+        end
       end
 
       Subscriber = Struct.new(:starts, :finishes) do
@@ -70,6 +77,15 @@ module Rails
               logger.call "REQUEST_METHOD" => "GET"
             end
           end
+        end
+      end
+
+      def test_logger_does_not_mutate_app_return
+        response = []
+        app = TestApp.new(response)
+        logger = TestLogger.new(app: app)
+        assert_no_changes('response') do
+          logger.call('REQUEST_METHOD' => 'GET')
         end
       end
     end


### PR DESCRIPTION
If @app.call returns an object that is saved (for e.g., in a constant), the mutation results in a continuing cycle of wrapping the body in `Rack::BodyProxy`, eventually leading to `SystemStackError`. Here's an example to reproduce:

```ruby
class HealthcheckApp
  SUCCESS_RESPONSE = [200, { 'Content-Type' => 'text/plain' }, ['success']].freeze

  def initialize(app)
    @app = app
  end

  def call(env)
    return SUCCESS_RESPONSE if env['PATH_INFO'] == '/heartbeat'
    @app.call(env)
  end
end

app = HealthcheckApp.new(-> (_x) { [200, {}, nil] })
logger = Rails::Rack::Logger.new(app)

logger.call('REQUEST_METHOD' => 'GET')
```