### PR TITLE
2.6 warnings: passing splat keyword arguments as a single Hash

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1970,7 +1970,7 @@ module ActionView
 
         convert_to_legacy_options(options)
 
-        fields_for(scope || model, model, **options, &block)
+        fields_for(scope || model, model, options, &block)
       end
 
       # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -305,7 +305,8 @@ module ActiveRecord
         yield td if block_given?
 
         if options[:force]
-          drop_table(table_name, **options, if_exists: true)
+          drop_opts = { if_exists: true }.merge(**options)
+          drop_table(table_name, drop_opts)
         end
 
         result = execute schema_creation.accept td
@@ -908,7 +909,7 @@ module ActiveRecord
             foreign_key_options = { to_table: reference_name }
           end
           foreign_key_options[:column] ||= "#{ref_name}_id"
-          remove_foreign_key(table_name, **foreign_key_options)
+          remove_foreign_key(table_name, foreign_key_options)
         end
 
         remove_column(table_name, "#{ref_name}_id")


### PR DESCRIPTION
Ruby 2.6.0 warns about this.

```
$ ruby -v
ruby 2.6.0dev (2018-04-04 trunk 63085) [x86_64-linux]
```

Before, see:
- https://travis-ci.org/rails/rails/jobs/361660080#L1189-L1374
- https://travis-ci.org/rails/rails/jobs/361660080#L1391-L1544
- https://travis-ci.org/rails/rails/jobs/361660077#L1330-L1397