### PR TITLE
[ci skip] Add :private option to delegate section in guide

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -779,6 +779,14 @@ delegate :size, to: :attachment, prefix: :avatar
 
 In the previous example the macro generates `avatar_size` rather than `size`.
 
+The option `:private` changes methods scope:
+
+```ruby
+delegate :date_of_birth, to: :profile, private: true
+```
+
+The delegated methods are public by default. Pass `private: true` to change that.
+
 NOTE: Defined in `active_support/core_ext/module/delegation.rb`
 
 #### `delegate_missing_to`


### PR DESCRIPTION
### Summary

* Added new [:private](https://github.com/rails/rails/pull/31944) option to delegate section in ActiveSupport Core Extension Guide