### PR TITLE
Fix Aliasing for Associated Tables in Rails

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -50,7 +50,7 @@ module ActiveRecord
         return self
       elsif association && !association.polymorphic?
         association_klass = association.klass
-        arel_table = association_klass.arel_table.alias(table_name)
+        arel_table = association_klass.arel_table
       else
         type_caster = TypeCaster::Connection.new(klass, table_name)
         association_klass = nil


### PR DESCRIPTION
### Summary

When associated tables are created for queries (like joins), an Arel TablAlias is created instead of a Table. This means certain information in the model (like table_name) is omitted and the passed in model identifier is used. This change allows models with custom table_names to be passed in to joins statements. 

### Other Information

Resolves #32374