### PR TITLE
Remove superfluous `ActionController::`

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -22,7 +22,7 @@ module ActionController
     end
   end
 
-  class ActionController::UrlGenerationError < ActionControllerError #:nodoc:
+  class UrlGenerationError < ActionControllerError #:nodoc:
   end
 
   class MethodNotAllowed < ActionControllerError #:nodoc:


### PR DESCRIPTION
### Summary

This simply removes the superfluous `ActionController::` prefix for this class definition. In this context `ActionController` resolves to the `ActionController` module that is opened on line 3, so `class UrlGenerationError` on line 25 is equivalent, but slightly less confusing.

### Other Information

There is no functional change, both ways of declaring this class produce the same runtime behavior.

Just a note, though this will probably never happen: if someone accidentally defined a constant in their app like this
```
module ActionController::ActionController
end
```
then the class defined on line 25 would end up incorrectly defined as `ActionController ::ActionController::UrlGenerationError`