### PR TITLE
[ci skip] Add :private option to delegation doc

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -22,8 +22,9 @@ class Module
   # ==== Options
   # * <tt>:to</tt> - Specifies the target object
   # * <tt>:prefix</tt> - Prefixes the new method with the target name or a custom prefix
-  # * <tt>:allow_nil</tt> - if set to true, prevents a +Module::DelegationError+
+  # * <tt>:allow_nil</tt> - If set to true, prevents a +Module::DelegationError+
   #   from being raised
+  # * <tt>:private</tt> - If set to true, changes method visibility to private
   #
   # The macro receives one or more method names (specified as symbols or
   # strings) and the name of the target object via the <tt>:to</tt> option


### PR DESCRIPTION
### Summary

I found missing of description about `:private` option for ActiveSupport delegate method.