### PR TITLE
Use `Kernel.require` in `DeprecationProxy`

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -124,7 +124,7 @@ module ActiveSupport
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
     class DeprecatedConstantProxy < DeprecationProxy
       def initialize(old_const, new_const, deprecator = ActiveSupport::Deprecation.instance, message: "#{old_const} is deprecated! Use #{new_const} instead.")
-        require "active_support/inflector/methods"
+        Kernel.require "active_support/inflector/methods"
 
         @old_const = old_const
         @new_const = new_const


### PR DESCRIPTION
This is necessary because `DeprecationProxy` undefines the `require` method. So when we try to call it it hits the `method_missing` instead of actually requiring.