### PR TITLE
Add ujs desc to rakefile in actionview

### DIFF
--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -57,7 +57,7 @@ namespace :test do
   end
 
   namespace :integration do
-    desc "ActiveRecord Integration Tests"
+    # ActiveRecord Integration Tests
     Rake::TestTask.new(:active_record) do |t|
       t.libs << "test"
       t.test_files = Dir.glob("test/activerecord/*_test.rb")
@@ -66,7 +66,7 @@ namespace :test do
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
-    desc "ActionPack Integration Tests"
+    # ActionPack Integration Tests
     Rake::TestTask.new(:action_pack) do |t|
       t.libs << "test"
       t.test_files = Dir.glob("test/actionpack/**/*_test.rb")

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -29,6 +29,7 @@ namespace :test do
     t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
   end
 
+  desc "Run tests for rails-ujs"
   task :ujs do
     begin
       Dir.mkdir("log")


### PR DESCRIPTION
### Summary

* Added :ujs desc to Rakefile in actionview.
* Use comment instead of desc in actionview's Rakefile (Because each `desc` is not displayed )

#### After

```diff
   rake assets:compile                  # Compile Action View assets
   rake assets:verify                   # Verify compiled Action View assets
   rake default                         # Default Task
   rake test                            # Run all unit tests
   rake test:integration:action_pack    # Run tests for action_pack
   rake test:integration:active_record  # Run tests for active_record
   rake test:template                   # Run tests for template
+  rake test:ujs                        # Run tests for rails-ujs
   rake ujs:server                      # Starts the test server
```