### PR TITLE
Use ImageProcessing gem for ActiveStorage variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ group :storage do
   gem "google-cloud-storage", "~> 1.8", require: false
   gem "azure-storage", require: false
 
-  gem "mini_magick"
+  gem "image_processing", "~> 1.2"
 end
 
 group :ujs do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,10 +229,10 @@ GEM
     faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.9.18)
-    ffi (1.9.18-java)
-    ffi (1.9.18-x64-mingw32)
-    ffi (1.9.18-x86-mingw32)
+    ffi (1.9.23)
+    ffi (1.9.23-java)
+    ffi (1.9.23-x64-mingw32)
+    ffi (1.9.23-x86-mingw32)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.17.3)
@@ -265,6 +265,9 @@ GEM
     httpclient (2.8.3)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.2.0)
+      mini_magick (~> 4.0)
+      ruby-vips (>= 2.0.10, < 3)
     io-like (0.3.0)
     jdbc-mysql (5.1.44)
     jdbc-postgres (9.4.1206)
@@ -393,6 +396,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    ruby-vips (2.0.10)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
@@ -515,11 +520,11 @@ DEPENDENCIES
   delayed_job_active_record
   google-cloud-storage (~> 1.8)
   hiredis
+  image_processing (~> 1.2)
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
-  mini_magick
   minitest-bisect
   mocha
   mysql2 (>= 0.4.10)

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -325,9 +325,9 @@ module ActionView
       #
       #   image_tag(user.avatar)
       #   # => <img src="/rails/active_storage/blobs/.../tiger.jpg" />
-      #   image_tag(user.avatar.variant(resize: "100x100"))
+      #   image_tag(user.avatar.variant(resize_to_fit: [100, 100]))
       #   # => <img src="/rails/active_storage/variants/.../tiger.jpg" />
-      #   image_tag(user.avatar.variant(resize: "100x100"), size: '100')
+      #   image_tag(user.avatar.variant(resize_to_fit: [100, 100]), size: '100')
       #   # => <img width="100" height="100" src="/rails/active_storage/variants/.../tiger.jpg" />
       def image_tag(source, options = {})
         options = options.symbolize_keys

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Use the [ImageProcessing](https://github.com/janko-m/image_processing) gem
+    for Active Storage variants, and deprecate the MiniMagick backend.
+
+    This means that variants are now automatically oriented if the original
+    image was rotated. Also, in addition to the existing ImageMagick
+    operations, variants can now use `:resize_to_fit`, `:resize_to_fill`, and
+    other ImageProcessing macros. These are now recommended over raw `:resize`,
+    as they also sharpen the thumbnail after resizing.
+
+    The ImageProcessing gem also comes with a backend implemented on
+    [libvips](http://jcupitt.github.io/libvips/), an alternative to
+    ImageMagick which has significantly better performance than
+    ImageMagick in most cases, both in terms of speed and memory usage. In
+    Active Storage it's now possible to switch to the libvips backend by
+    changing `Rails.application.config.active_storage.variant_processor` to
+    `:vips`.
+
+    *Janko Marohnić*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -99,7 +99,7 @@ Variation of image attachment:
 
 ```erb
 <%# Hitting the variant URL will lazy transform the original blob and then redirect to its new service location %>
-<%= image_tag user.avatar.variant(resize: "100x100") %>
+<%= image_tag user.avatar.variant(resize_to_fit: [100, 100]) %>
 ```
 
 ## Direct uploads

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -4,7 +4,7 @@ Active Storage makes it simple to upload and reference files in cloud services l
 
 Files can be uploaded from the server to the cloud or directly from the client to the cloud.
 
-Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) supported transformation.
+Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) or [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image) supported transformation.
 
 ## Compared to other storage solutions
 

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -10,7 +10,7 @@ module ActiveStorage::Blob::Representable
   # Returns an ActiveStorage::Variant instance with the set of +transformations+ provided. This is only relevant for image
   # files, and it allows any image to be transformed for size, colors, and the like. Example:
   #
-  #   avatar.variant(resize: "100x100").processed.service_url
+  #   avatar.variant(resize_to_fit: [100, 100]).processed.service_url
   #
   # This will create and process a variant of the avatar blob that's constrained to a height and width of 100px.
   # Then it'll upload said variant to the service according to a derivative key of the blob and the transformations.
@@ -18,7 +18,7 @@ module ActiveStorage::Blob::Representable
   # Frequently, though, you don't actually want to transform the variant right away. But rather simply refer to a
   # specific variant that can be created by a controller on-demand. Like so:
   #
-  #   <%= image_tag Current.user.avatar.variant(resize: "100x100") %>
+  #   <%= image_tag Current.user.avatar.variant(resize_to_fit: [100, 100]) %>
   #
   # This will create a URL for that specific blob with that specific variant, which the ActiveStorage::RepresentationsController
   # can then produce on-demand.
@@ -43,13 +43,13 @@ module ActiveStorage::Blob::Representable
   # from a non-image blob. Active Storage comes with built-in previewers for videos and PDF documents. The video previewer
   # extracts the first frame from a video and the PDF previewer extracts the first page from a PDF document.
   #
-  #   blob.preview(resize: "100x100").processed.service_url
+  #   blob.preview(resize_to_fit: [100, 100]).processed.service_url
   #
   # Avoid processing previews synchronously in views. Instead, link to a controller action that processes them on demand.
   # Active Storage provides one, but you may want to create your own (for example, if you need authentication). Here’s
   # how to use the built-in version:
   #
-  #   <%= image_tag video.preview(resize: "100x100") %>
+  #   <%= image_tag video.preview(resize_to_fit: [100, 100]) %>
   #
   # This method raises ActiveStorage::UnpreviewableError if no previewer accepts the receiving blob. To determine
   # whether a blob is accepted by any previewer, call ActiveStorage::Blob#previewable?.
@@ -69,7 +69,7 @@ module ActiveStorage::Blob::Representable
 
   # Returns an ActiveStorage::Preview for a previewable blob or an ActiveStorage::Variant for a variable image blob.
   #
-  #   blob.representation(resize: "100x100").processed.service_url
+  #   blob.representation(resize_to_fit: [100, 100]).processed.service_url
   #
   # Raises ActiveStorage::UnrepresentableError if the receiving blob is neither variable nor previewable. Call
   # ActiveStorage::Blob#representable? to determine whether a blob is representable.

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -38,7 +38,7 @@ class ActiveStorage::Preview
 
   # Processes the preview if it has not been processed yet. Returns the receiving Preview instance for convenience:
   #
-  #   blob.preview(resize: "100x100").processed.service_url
+  #   blob.preview(resize_to_fit: [100, 100]).processed.service_url
   #
   # Processing a preview generates an image from its blob and attaches the preview image to the blob. Because the preview
   # image is stored with the blob, it is only generated once.

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -19,16 +19,15 @@ require "active_storage/downloading"
 #   Rails.application.config.active_storage.variant_processor = :vips
 #   # => :vips
 #
-# Note that to create a variant it's necessary to download the entire blob file from the service and load it
-# into memory. The larger the image, the more memory is used. Because of this process, you also want to be
-# considerate about when the variant is actually processed. You shouldn't be processing variants inline in a
-# template, for example. Delay the processing to an on-demand controller, like the one provided in
-# ActiveStorage::RepresentationsController.
+# Note that to create a variant it's necessary to download the entire blob file from the service. The larger
+# the image, the more memory is used. Because of this process, you also want to be considerate about when the variant
+# is actually processed. You shouldn't be processing variants inline in a template, for example. Delay the processing
+# to an on-demand controller, like the one provided in ActiveStorage::RepresentationsController.
 #
 # To refer to such a delayed on-demand variant, simply link to the variant through the resolved route provided
 # by Active Storage like so:
 #
-#   <%= image_tag Current.user.avatar.variant(resize_to_fit: [100, 100]) %>
+#   <%= image_tag Current.user.avatar.variant(resize: "100x100") %>
 #
 # This will create a URL for that specific blob with that specific variant, which the ActiveStorage::RepresentationsController
 # can then produce on-demand.
@@ -37,22 +36,22 @@ require "active_storage/downloading"
 # has already been processed and uploaded to the service, and, if so, just return that. Otherwise it will perform
 # the transformations, upload the variant to the service, and return itself again. Example:
 #
-#   avatar.variant(resize_to_fit: [100, 100]).processed.service_url
+#   avatar.variant(resize: "100x100").processed.service_url
 #
 # This will create and process a variant of the avatar blob that's constrained to a height and width of 100.
 # Then it'll upload said variant to the service according to a derivative key of the blob and the transformations.
 #
-# Variant options are forwarded directly to the ImageProcessing gem. Visit the following links for a list of
-# available ImageProcessing commands and processor operations:
+# You can combine any number of ImageMagick/libvips operations into a variant. In addition to that, you can also use
+# any macros provided by the ImageProcessing gem (such as +resize_to_limit+).
+#
+#   avatar.variant(resize_to_limit: [800, 800], monochrome: true, flip: "-90")
+#
+# Visit the following links for a list of available ImageProcessing commands and ImageMagick/libvips operations:
 #
 # * {ImageProcessing::MiniMagick}[https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#methods]
 # * {ImageMagick reference}[https://www.imagemagick.org/script/mogrify.php]
 # * {ImageProcessing::Vips}[https://github.com/janko-m/image_processing/blob/master/doc/vips.md#methods]
 # * {ruby-vips reference}[http://www.rubydoc.info/gems/ruby-vips/Vips/Image]
-#
-# You can combine as many of these options as you like freely:
-#
-#   avatar.variant(resize_to_fit: [100, 100], monochrome: true, flip: "-90")
 class ActiveStorage::Variant
   include ActiveStorage::Downloading
 

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -13,10 +13,10 @@ require "active_storage/downloading"
 # {libvips}[http://jcupitt.github.io/libvips/] processor operated by the {ruby-vips}[https://github.com/jcupitt/ruby-vips]
 # gem).
 #
-#   Rails.application.config.active_storage.processor
+#   Rails.application.config.active_storage.variant_processor
 #   # => :mini_magick
 #
-#   Rails.application.config.active_storage.processor = :vips
+#   Rails.application.config.active_storage.variant_processor = :vips
 #   # => :vips
 #
 # Note that to create a variant it's necessary to download the entire blob file from the service and load it

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -27,7 +27,7 @@ require "active_storage/downloading"
 # To refer to such a delayed on-demand variant, simply link to the variant through the resolved route provided
 # by Active Storage like so:
 #
-#   <%= image_tag Current.user.avatar.variant(resize: "100x100") %>
+#   <%= image_tag Current.user.avatar.variant(resize_to_fit: [100, 100]) %>
 #
 # This will create a URL for that specific blob with that specific variant, which the ActiveStorage::RepresentationsController
 # can then produce on-demand.
@@ -36,15 +36,15 @@ require "active_storage/downloading"
 # has already been processed and uploaded to the service, and, if so, just return that. Otherwise it will perform
 # the transformations, upload the variant to the service, and return itself again. Example:
 #
-#   avatar.variant(resize: "100x100").processed.service_url
+#   avatar.variant(resize_to_fit: [100, 100]).processed.service_url
 #
 # This will create and process a variant of the avatar blob that's constrained to a height and width of 100.
 # Then it'll upload said variant to the service according to a derivative key of the blob and the transformations.
 #
-# You can combine any number of ImageMagick/libvips operations into a variant. In addition to that, you can also use
-# any macros provided by the ImageProcessing gem (such as +resize_to_limit+).
+# You can combine any number of ImageMagick/libvips operations into a variant, as well as any macros provided by the
+# ImageProcessing gem (such as +resize_to_fit+):
 #
-#   avatar.variant(resize_to_limit: [800, 800], monochrome: true, flip: "-90")
+#   avatar.variant(resize_to_fit: [800, 800], monochrome: true, flip: "-90")
 #
 # Visit the following links for a list of available ImageProcessing commands and ImageMagick/libvips operations:
 #

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -19,10 +19,10 @@ require "active_storage/downloading"
 #   Rails.application.config.active_storage.variant_processor = :vips
 #   # => :vips
 #
-# Note that to create a variant it's necessary to download the entire blob file from the service. The larger
-# the image, the more memory is used. Because of this process, you also want to be considerate about when the variant
-# is actually processed. You shouldn't be processing variants inline in a template, for example. Delay the processing
-# to an on-demand controller, like the one provided in ActiveStorage::RepresentationsController.
+# Note that to create a variant it's necessary to download the entire blob file from the service. Because of this process,
+# you also want to be considerate about when the variant is actually processed. You shouldn't be processing variants inline
+# in a template, for example. Delay the processing to an on-demand controller, like the one provided in
+# ActiveStorage::RepresentationsController.
 #
 # To refer to such a delayed on-demand variant, simply link to the variant through the resolved route provided
 # by Active Storage like so:

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -100,9 +100,9 @@ class ActiveStorage::Variant
 
     def process
       download_blob_to_tempfile do |image|
-        variant = transform image
-        upload variant
-        variant.close!
+        transform image do |output|
+          upload output
+        end
       end
     end
 
@@ -121,7 +121,13 @@ class ActiveStorage::Variant
 
     def transform(image)
       format = "png" unless WEB_IMAGE_CONTENT_TYPES.include?(blob.content_type)
-      variation.transform(image, format: format)
+      result = variation.transform(image, format: format)
+
+      begin
+        yield result
+      ensure
+        result.close!
+      end
     end
 
     def upload(file)

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -6,7 +6,7 @@
 # In case you do need to use this directly, it's instantiated using a hash of transformations where
 # the key is the command and the value is the arguments. Example:
 #
-#   ActiveStorage::Variation.new(resize: "100x100", monochrome: true, trim: true, rotate: "-90")
+#   ActiveStorage::Variation.new(resize_to_fit: [100, 100], monochrome: true, trim: true, rotate: "-90")
 #
 # The options map directly to {ImageProcessing}[https://github.com/janko-m/image_processing] commands.
 class ActiveStorage::Variation

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -8,15 +8,7 @@
 #
 #   ActiveStorage::Variation.new(resize: "100x100", monochrome: true, trim: true, rotate: "-90")
 #
-# You can also combine multiple transformations in one step, e.g. for center-weighted cropping:
-#
-#   ActiveStorage::Variation.new(combine_options: {
-#     resize: "100x100^",
-#     gravity: "center",
-#     crop: "100x100+0+0",
-#   })
-#
-# A list of all possible transformations is available at https://www.imagemagick.org/script/mogrify.php.
+# The options map directly to {ImageProcessing}[https://github.com/janko-m/image_processing] commands.
 class ActiveStorage::Variation
   attr_reader :transformations
 
@@ -51,10 +43,49 @@ class ActiveStorage::Variation
     @transformations = transformations
   end
 
-  # Accepts an open MiniMagick image instance, like what's returned by <tt>MiniMagick::Image.read(io)</tt>,
-  # and performs the +transformations+ against it. The transformed image instance is then returned.
-  def transform(image)
+  # Accepts a File object, performs the +transformations+ against it, and
+  # saves the transformed image into a temporary file. If +format+ is specified
+  # it will be the format of the result image, otherwise the result image
+  # retains the source format.
+  def transform(file, format: nil)
     ActiveSupport::Notifications.instrument("transform.active_storage") do
+      if processor
+        image_processing_transform(file, format)
+      else
+        mini_magick_transform(file, format)
+      end
+    end
+  end
+
+  # Returns a signed key for all the +transformations+ that this variation was instantiated with.
+  def key
+    self.class.encode(transformations)
+  end
+
+  private
+    # Applies image transformations using the ImageProcessing gem.
+    def image_processing_transform(file, format)
+      operations = transformations.inject([]) do |list, (name, argument)|
+        if name.to_s == "combine_options"
+          ActiveSupport::Deprecation.warn("The ImageProcessing ActiveStorage variant backend doesn't need :combine_options, as it already generates a single MiniMagick command. In Rails 6.1 :combine_options will not be supported anymore.")
+          list.concat argument.to_a
+        else
+          list << [name, argument]
+        end
+      end
+
+      processor
+        .source(file)
+        .loader(page: 0)
+        .convert(format)
+        .apply(operations)
+        .call
+    end
+
+    # Applies image transformations using the MiniMagick gem.
+    def mini_magick_transform(file, format)
+      image = MiniMagick::Image.new(file.path, file)
+
       transformations.each do |name, argument_or_subtransformations|
         image.mogrify do |command|
           if name.to_s == "combine_options"
@@ -66,15 +97,20 @@ class ActiveStorage::Variation
           end
         end
       end
+
+      image.format(format) if format
+
+      image.tempfile.tap(&:open)
     end
-  end
 
-  # Returns a signed key for all the +transformations+ that this variation was instantiated with.
-  def key
-    self.class.encode(transformations)
-  end
+    # Returns the ImageProcessing processor class specified by `ActiveStorage.processor`.
+    def processor
+      require "image_processing"
+      ImageProcessing.const_get(ActiveStorage.processor.to_s.camelize) if ActiveStorage.processor
+    rescue LoadError
+      ActiveSupport::Deprecation.warn("Using mini_magick gem directly is deprecated and will be removed in Rails 6.1. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+    end
 
-  private
     def pass_transform_argument(command, method, argument)
       if eligible_argument?(argument)
         command.public_send(method, argument)

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -105,10 +105,14 @@ class ActiveStorage::Variation
 
     # Returns the ImageProcessing processor class specified by `ActiveStorage.variant_processor`.
     def processor
-      require "image_processing"
+      begin
+        require "image_processing"
+      rescue LoadError
+        ActiveSupport::Deprecation.warn("Using mini_magick gem directly is deprecated and will be removed in Rails 6.1. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+        return nil
+      end
+
       ImageProcessing.const_get(ActiveStorage.variant_processor.to_s.camelize) if ActiveStorage.variant_processor
-    rescue LoadError
-      ActiveSupport::Deprecation.warn("Using mini_magick gem directly is deprecated and will be removed in Rails 6.1. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
     end
 
     def pass_transform_argument(command, method, argument)

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -103,10 +103,10 @@ class ActiveStorage::Variation
       image.tempfile.tap(&:open)
     end
 
-    # Returns the ImageProcessing processor class specified by `ActiveStorage.processor`.
+    # Returns the ImageProcessing processor class specified by `ActiveStorage.variant_processor`.
     def processor
       require "image_processing"
-      ImageProcessing.const_get(ActiveStorage.processor.to_s.camelize) if ActiveStorage.processor
+      ImageProcessing.const_get(ActiveStorage.variant_processor.to_s.camelize) if ActiveStorage.variant_processor
     rescue LoadError
       ActiveSupport::Deprecation.warn("Using mini_magick gem directly is deprecated and will be removed in Rails 6.1. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
     end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -45,6 +45,7 @@ module ActiveStorage
   mattr_accessor :queue
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers, default: []
+  mattr_accessor :processor, default: :mini_magick
   mattr_accessor :paths, default: {}
   mattr_accessor :variable_content_types, default: []
   mattr_accessor :content_types_to_serve_as_binary, default: []

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -45,7 +45,7 @@ module ActiveStorage
   mattr_accessor :queue
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers, default: []
-  mattr_accessor :processor, default: :mini_magick
+  mattr_accessor :variant_processor, default: :mini_magick
   mattr_accessor :paths, default: {}
   mattr_accessor :variable_content_types, default: []
   mattr_accessor :content_types_to_serve_as_binary, default: []

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -45,6 +45,7 @@ module ActiveStorage
       config.after_initialize do |app|
         ActiveStorage.logger     = app.config.active_storage.logger || Rails.logger
         ActiveStorage.queue      = app.config.active_storage.queue
+        ActiveStorage.processor  = app.config.active_storage.processor || :mini_magick
         ActiveStorage.previewers = app.config.active_storage.previewers || []
         ActiveStorage.analyzers  = app.config.active_storage.analyzers || []
         ActiveStorage.paths      = app.config.active_storage.paths || {}

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -43,12 +43,12 @@ module ActiveStorage
 
     initializer "active_storage.configs" do
       config.after_initialize do |app|
-        ActiveStorage.logger     = app.config.active_storage.logger || Rails.logger
-        ActiveStorage.queue      = app.config.active_storage.queue
-        ActiveStorage.processor  = app.config.active_storage.processor || :mini_magick
-        ActiveStorage.previewers = app.config.active_storage.previewers || []
-        ActiveStorage.analyzers  = app.config.active_storage.analyzers || []
-        ActiveStorage.paths      = app.config.active_storage.paths || {}
+        ActiveStorage.logger            = app.config.active_storage.logger || Rails.logger
+        ActiveStorage.queue             = app.config.active_storage.queue
+        ActiveStorage.variant_processor = app.config.active_storage.variant_processor || :mini_magick
+        ActiveStorage.previewers        = app.config.active_storage.previewers || []
+        ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
+        ActiveStorage.paths             = app.config.active_storage.paths || {}
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -6,7 +6,7 @@ require "database/setup"
 class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize_to_fit: [100, 100]).processed
+    variant = blob.variant(resize: "100x100").processed
     assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image(variant)
@@ -16,7 +16,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized and monochrome variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize_to_fit: [100, 100], monochrome: true).processed
+    variant = blob.variant(resize: "100x100", monochrome: true).processed
     assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image(variant)
@@ -25,7 +25,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_match(/Gray/, image.colorspace)
   end
 
-  test "center-weighted crop of JPEG blob" do
+  test "center-weighted crop of JPEG blob using :combine_options" do
     begin
       ActiveStorage.variant_processor = nil
       blob = create_file_blob(filename: "racecar.jpg")
@@ -44,6 +44,16 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     ensure
       ActiveStorage.variant_processor = :mini_magick
     end
+  end
+
+  test "center-weighted crop of JPEG blob using :resize_to_fill" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(resize_to_fill: [100, 100]).processed
+    assert_match(/racecar\.jpg/, variant.service_url)
+
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 100, image.height
   end
 
   test "resized variation of PSD blob" do

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -27,7 +27,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "center-weighted crop of JPEG blob" do
     begin
-      ActiveStorage.processor = nil
+      ActiveStorage.variant_processor = nil
       blob = create_file_blob(filename: "racecar.jpg")
       variant = ActiveSupport::Deprecation.silence do
         blob.variant(combine_options: {
@@ -42,7 +42,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
       assert_equal 100, image.width
       assert_equal 100, image.height
     ensure
-      ActiveStorage.processor = :mini_magick
+      ActiveStorage.variant_processor = :mini_magick
     end
   end
 
@@ -90,7 +90,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "works for vips processor" do
     begin
-      ActiveStorage.processor = :vips
+      ActiveStorage.variant_processor = :vips
       blob = create_file_blob(filename: "racecar.jpg")
       variant = blob.variant(thumbnail_image: 100).processed
 
@@ -100,7 +100,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     rescue LoadError
       # libvips not installed
     ensure
-      ActiveStorage.processor = :mini_magick
+      ActiveStorage.variant_processor = :mini_magick
     end
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -7,7 +7,7 @@ require "bundler/setup"
 require "active_support"
 require "active_support/test_case"
 require "active_support/testing/autorun"
-require "mini_magick"
+require "image_processing/mini_magick"
 
 begin
   require "byebug"

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -337,14 +337,15 @@ rails_blob_path(user.avatar, disposition: "attachment")
 Transforming Images
 -------------------
 
-To create variation of the image, call `variant` on the Blob.
-You can pass any [MiniMagick](https://github.com/minimagick/minimagick)
-supported transformation to the method.
+To create variation of the image, call `variant` on the Blob. You can pass
+any transformation to the method supported by the procecssor. The default
+processor is [MiniMagick](https://github.com/minimagick/minimagick), but you
+can also use [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
-To enable variants, add `mini_magick` to your `Gemfile`:
+To enable variants, add `image_processing` gem to your `Gemfile`:
 
 ```ruby
-gem 'mini_magick'
+gem 'image_processing', '~> 1.2'
 ```
 
 When the browser hits the variant URL, Active Storage will lazy transform the
@@ -352,7 +353,15 @@ original blob into the format you specified and redirect to its new service
 location.
 
 ```erb
-<%= image_tag user.avatar.variant(resize: "100x100") %>
+<%= image_tag user.avatar.variant(resize_to_fit: [100, 100]) %>
+```
+
+To switch to the Vips processor, you would add the following to
+`config/application.rb`:
+
+```ruby
+# Use Vips for processing variants.
+config.active_storage.processor = :vips
 ```
 
 Previewing Files

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -353,7 +353,7 @@ original blob into the format you specified and redirect to its new service
 location.
 
 ```erb
-<%= image_tag user.avatar.variant(resize: "100x100") %>
+<%= image_tag user.avatar.variant(resize_to_fit: [100, 100]) %>
 ```
 
 To switch to the Vips processor, you would add the following to
@@ -375,7 +375,7 @@ the box, Active Storage supports previewing videos and PDF documents.
 <ul>
   <% @message.files.each do |file| %>
     <li>
-      <%= image_tag file.preview(resize: "100x100>") %>
+      <%= image_tag file.preview(resize_to_limit: [100, 100]) %>
     </li>
   <% end %>
 </ul>

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -361,7 +361,7 @@ To switch to the Vips processor, you would add the following to
 
 ```ruby
 # Use Vips for processing variants.
-config.active_storage.processor = :vips
+config.active_storage.variant_processor = :vips
 ```
 
 Previewing Files

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -338,11 +338,11 @@ Transforming Images
 -------------------
 
 To create variation of the image, call `variant` on the Blob. You can pass
-any transformation to the method supported by the procecssor. The default
+any transformation to the method supported by the processor. The default
 processor is [MiniMagick](https://github.com/minimagick/minimagick), but you
 can also use [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 
-To enable variants, add `image_processing` gem to your `Gemfile`:
+To enable variants, add the `image_processing` gem to your `Gemfile`:
 
 ```ruby
 gem 'image_processing', '~> 1.2'

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -353,7 +353,7 @@ original blob into the format you specified and redirect to its new service
 location.
 
 ```erb
-<%= image_tag user.avatar.variant(resize_to_fit: [100, 100]) %>
+<%= image_tag user.avatar.variant(resize: "100x100") %>
 ```
 
 To switch to the Vips processor, you would add the following to

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -778,6 +778,8 @@ normal Rails server.
 
 `config.active_storage` provides the following configuration options:
 
+* `config.active_storage.processor` accepts a symbol `:mini_magick` or `:vips`, specifying whether variant transformations will be performed with MiniMagick or ruby-vips. The default is `:mini_magick`.
+
 * `config.active_storage.analyzers` accepts an array of classes indicating the analyzers available for Active Storage blobs. The default is `[ActiveStorage::Analyzer::ImageAnalyzer, ActiveStorage::Analyzer::VideoAnalyzer]`. The former can extract width and height of an image blob; the latter can extract width, height, duration, angle, and aspect ratio of a video blob.
 
 * `config.active_storage.previewers` accepts an array of classes indicating the image previewers available in Active Storage blobs. The default is `[ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer]`. The former can generate a thumbnail from the first page of a PDF blob; the latter from the relevant frame of a video blob.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -778,7 +778,7 @@ normal Rails server.
 
 `config.active_storage` provides the following configuration options:
 
-* `config.active_storage.processor` accepts a symbol `:mini_magick` or `:vips`, specifying whether variant transformations will be performed with MiniMagick or ruby-vips. The default is `:mini_magick`.
+* `config.active_storage.variant_processor` accepts a symbol `:mini_magick` or `:vips`, specifying whether variant transformations will be performed with MiniMagick or ruby-vips. The default is `:mini_magick`.
 
 * `config.active_storage.analyzers` accepts an array of classes indicating the analyzers available for Active Storage blobs. The default is `[ActiveStorage::Analyzer::ImageAnalyzer, ActiveStorage::Analyzer::VideoAnalyzer]`. The former can extract width and height of an image blob; the latter can extract width, height, duration, angle, and aspect ratio of a video blob.
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -23,7 +23,7 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 <% unless skip_active_storage? -%>
 
 # Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+# gem 'image_processing', '~> 1.2'
 <% end -%>
 
 # Use Capistrano for deployment

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -312,7 +312,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_active_storage_mini_magick_gem
     run_generator
-    assert_file "Gemfile", /^# gem 'mini_magick'/
+    assert_file "Gemfile", /^# gem 'image_processing'/
   end
 
   def test_mini_magick_gem_when_skip_active_storage_is_given
@@ -320,7 +320,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root, "--skip-active-storage"]
 
     assert_file "#{app_root}/Gemfile" do |content|
-      assert_no_match(/gem 'mini_magick'/, content)
+      assert_no_match(/gem 'image_processing'/, content)
     end
   end
 


### PR DESCRIPTION
[ImageProcessing](https://github.com/janko-m/image_processing) gem is a wrapper around MiniMagick and [ruby-vips](https://github.com/jcupitt/ruby-vips), and implements an interface for common image resizing and processing. This is the canonical image processing gem recommended in [Shrine](https://github.com/shrinerb/shrine), and that's where it developed from. The initial implementation was extracted from Refile, which also implements on-the-fly transformations.

Some features that ImageProcessing gem adds on top of MiniMagick:

  * resizing macros
    - [#resize_to_limit](https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#resize_to_limit)
    - [#resize_to_fit](https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#resize_to_fit)
    - [#resize_to_fill](https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#resize_to_fill)
    - [#resize_and_pad](https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#resize_and_pad)
  * [automatic orientation](https://www.imagemagick.org/script/command-line-options.php#auto-orient)
  * [automatic thumbnail sharpening](https://github.com/janko-m/image_processing/blob/master/doc/minimagick.md#sharpening)
  * avoids the complex and inefficient `MiniMagick::Image` class
  * will use `magick` CLI instead of `convert` on ImageMagick 7 in the near future

However, maybe the biggest feature of the ImageProcessing gem is that it has an alternative implementation that uses **[libvips](http://jcupitt.github.io/libvips/)**. Libvips is an alternative to ImageMagick that can process images [very rapidly](https://github.com/jcupitt/libvips/wiki/Speed-and-memory-use) (we've seen **up to 10x faster processing** compared to ImageMagick).

What's great is that the ImageProcessing gem provides the same interface for both implementations. The macros are named the same, and the libvips implementation also does auto orientation and thumbnail sharpening; only the operations/options specific to ImageMagick/libvips differ. The integration provided by this PR should work for both implementations.

The PR should maintain almost 100% backwards compatibility; there are two incompatibilities:

* users would now have to include the `image_processing` gem into their Gemfiles instead of `mini_magick`
* `:combine_options` was removed because `ImageProcessing::MiniMagick` builds a single `convert` command, so it's not needed anymore

I know that Rails 5.2 is on feature freeze before the release, but I think if we agree we want ImageProcessing to be used for Active Storage, it's better to get it in now, due to the two mentioned backwards incompatibilities.

In short, Active Storage relying on ImageProcessing means it will have much better MiniMagick defaults, it will get **libvips** support *for free* (which is a big deal in terms of performance), it will get convenient resizing macros that work on both implementations, and it means the Active Storage project will have minimal maintenance in the image processing department.