### PR TITLE
`SetupAndTeardown#teardown` should call any subsequent after_teardown:

### DIFF
--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -44,8 +44,15 @@ module ActiveSupport
       end
 
       def after_teardown # :nodoc:
-        run_callbacks :teardown
+        begin
+          run_callbacks :teardown
+        rescue => e
+          error = e
+        end
+
         super
+      ensure
+        raise error if error
       end
     end
   end

--- a/activesupport/test/testing/after_teardown_test.rb
+++ b/activesupport/test/testing/after_teardown_test.rb
@@ -8,7 +8,7 @@ module OtherAfterTeardown
   end
 end
 
-class SetupAndTeardownTest < Minitest::Test
+class AfterTeardownTest < Minitest::Test
   include OtherAfterTeardown
   include ActiveSupport::Testing::SetupAndTeardown
 

--- a/activesupport/test/testing/setup_and_teardown_test.rb
+++ b/activesupport/test/testing/setup_and_teardown_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module OtherAfterTeardown
+  def after_teardown
+    @witness = true
+  end
+end
+
+class SetupAndTeardownTest < Minitest::Test
+  include OtherAfterTeardown
+  include ActiveSupport::Testing::SetupAndTeardown
+
+  attr_writer :witness
+
+  MyError = Class.new(StandardError)
+
+  teardown do
+    raise MyError, "Test raises an error, all after_teardown should still get called"
+  end
+
+  def after_teardown
+    assert_raises MyError do
+      super
+    end
+
+    assert_equal true, @witness
+  end
+
+  def test_teardown_raise_but_all_after_teardown_method_are_called
+    assert true
+  end
+end


### PR DESCRIPTION
`SetupAndTeardown#teardown` should call any subsequent after_teardown:

  If you have a regular test that have a teardown block, and for any reason an exception get raised, 
  ActiveSupport will not run subsequent after_teardown method provided by other module or gems.
  One of them being the ActiveRecord::TestFixtures which won't rollback the transation when the test 
  ends making all subsequent test to be in a weird state.

  The default implementation of minitest is to run all teardown methods from the user's test, rescue all 
  exceptions, run all after_teardown methods provided by libraries and finally re-raise the exception 
  that happened in the user's teardown method.
  Rails should do the same.