### PR TITLE
Fix loading issue of `ActionMailer::MessageDelivery`

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -37,6 +37,7 @@ module ActionMailer
 
   eager_autoload do
     autoload :Collector
+    autoload :MessageDelivery
   end
 
   autoload :Base
@@ -47,7 +48,6 @@ module ActionMailer
   autoload :Previews, 'action_mailer/preview'
   autoload :TestCase
   autoload :TestHelper
-  autoload :MessageDelivery
   autoload :DeliveryJob
 end
 


### PR DESCRIPTION
I had an error `NameError (uninitialized constant #<Class:ActionMailer::Base>::MessageDelivery)` that is difficult to reproduce.
I'm sending some mails in some action of ActionController using ActionMailer.

I think this is concurrency issue that is occurred when using thread-base app server like Puma.

This occurs in Rails 5.0.7 and earlier, but not occurs in Rails 5.1.0 and later.
I was using Rails 5.0.6 and Ruby 2.3.1 when this is occurred.

Before 5.0.7, `ActionMailer::MessageDelivery` is only used in `ActionMailer::Base#method_missing`.
So, `ActionMailer::MessageDelivery` will be loaded when mail method is called.
https://github.com/rails/rails/blob/v5.0.7/actionmailer/lib/action_mailer.rb#L50
https://github.com/rails/rails/blob/v5.0.7/actionmailer/lib/action_mailer/base.rb#L563

After 5.1.0, `ActionMailer::MessageDelivery` is used in the module definition of `ActionMailer::Parameterized` inclueded in `ActionMailer::Base`.
So, `ActionMailer::MessageDelivery` will be loaded when defining a class that inherited `ActionMailer::Base`.
https://github.com/rails/rails/blob/v5.1.0/actionmailer/lib/action_mailer.rb#L51
https://github.com/rails/rails/blob/v5.1.0/actionmailer/lib/action_mailer/base.rb#L438
https://github.com/rails/rails/blob/v5.1.0/actionmailer/lib/action_mailer/parameterized.rb#L122

I think this is similar to #27849.

Thanks.