### PR TITLE
Fix test added in #32444

### DIFF
--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -81,11 +81,13 @@ module Rails
       end
 
       def test_logger_does_not_mutate_app_return
-        response = []
+        response = [].freeze
         app = TestApp.new(response)
         logger = TestLogger.new(app: app)
         assert_no_changes("response") do
-          logger.call("REQUEST_METHOD" => "GET")
+          assert_nothing_raised do
+            logger.call("REQUEST_METHOD" => "GET")
+          end
         end
       end
     end


### PR DESCRIPTION
Currently test `#test_logger_does_not_mutate_app_return` doesn't
test mutation of response and the test passes with and without changes
added in #32444. `#freeze` response in the test in order to
test mutation.

/cc @rafaelfranca, @matrinox