### PR TITLE
Fix invalid basic auth TypeError and add tests

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -101,7 +101,7 @@ module ActionController
       end
 
       def has_basic_credentials?(request)
-        request.authorization.present? && (auth_scheme(request).downcase == "basic")
+        request.authorization.present? && (auth_scheme(request).downcase == "basic") && !user_name_and_password(request).second.nil?
       end
 
       def user_name_and_password(request)

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -101,7 +101,7 @@ module ActionController
       end
 
       def has_basic_credentials?(request)
-        request.authorization.present? && (auth_scheme(request).downcase == "basic") && !user_name_and_password(request).second.nil?
+        request.authorization.present? && (auth_scheme(request).downcase == "basic") && user_name_and_password(request).second
       end
 
       def user_name_and_password(request)

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -171,6 +171,13 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
+  test "authentication request with invalid Base64 encoded basic auth" do
+    header = "Basic aW52YWxpZA==" # Base64 for "invalid"
+    @request.env["HTTP_AUTHORIZATION"] = header
+    get :search
+    assert_response :unauthorized
+  end
+
   private
 
     def encode_credentials(username, password)


### PR DESCRIPTION
### Summary

This PR fixes a bug causing a TypeError when using `http_basic_authenticate_with` and having sent a header with invalid format after `Basic` part, such as `Basic aW52YWxpZA==` (which is Base64 for "invalid")

Fixed by ensuring the password isn't nil before checking for length using `ActiveSupport::SecurityUtils.secure_compare`