### PR TITLE
[ci skip] Add securing rails app guide link to credential section

### DIFF
--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -75,6 +75,9 @@ secrets introduced in Rails 5.1.
 Furthermore, Rails 5.2
 [opens API underlying Credentials](https://github.com/rails/rails/pull/30940),
 so you can easily deal with other encrypted configurations, keys, and files.
+You can read more about this in the
+[Securing Rails Applications](security.html#custom-credentials)
+guide.
 
 ### Content Security Policy
 


### PR DESCRIPTION
### Summary

* In 5.2 release note, added [securing rails app guide](http://edgeguides.rubyonrails.org/security.html#custom-credentials) link to [credentials section](http://edgeguides.rubyonrails.org/5_2_release_notes.html#credentials).