### PR TITLE
Include default headers by default in API mode

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Move default headers configuration into their own module that can be included in controllers.
+
+    *Kevin Deisz*
+
 *   Add method `dig` to `session`.
 
     *claudiob*, *Takumi Shotoku*

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -25,6 +25,7 @@ module ActionController
     autoload :ContentSecurityPolicy
     autoload :Cookies
     autoload :DataStreaming
+    autoload :DefaultHeaders
     autoload :EtagWithTemplateDigest
     autoload :EtagWithFlash
     autoload :Flash

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -122,6 +122,7 @@ module ActionController
 
       ForceSSL,
       DataStreaming,
+      DefaultHeaders,
 
       # Before callbacks should also be executed as early as possible, so
       # also include them at the bottom.

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -232,6 +232,7 @@ module ActionController
       HttpAuthentication::Basic::ControllerMethods,
       HttpAuthentication::Digest::ControllerMethods,
       HttpAuthentication::Token::ControllerMethods,
+      DefaultHeaders,
 
       # Before callbacks should also be executed as early as possible, so
       # also include them at the bottom.
@@ -262,12 +263,6 @@ module ActionController
 
     def _protected_ivars # :nodoc:
       PROTECTED_IVARS
-    end
-
-    def self.make_response!(request)
-      ActionDispatch::Response.create.tap do |res|
-        res.request = request
-      end
     end
 
     ActiveSupport.run_load_hooks(:action_controller_base, self)

--- a/actionpack/lib/action_controller/metal/default_headers.rb
+++ b/actionpack/lib/action_controller/metal/default_headers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActionController
+  # Allows configuring default headers that will be automatically merged into
+  # each response.
+  module DefaultHeaders
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def make_response!(request)
+        ActionDispatch::Response.create.tap do |res|
+          res.request = request
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ActionDispatch's default headers are now moved into their own module that are by default included in both Base and API. This allows API-mode applications to take advantage of the default security headers, as well as providing an easy way to add more.

Fixes #32483.