### PR TITLE
Mocha updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,7 @@ gemspec
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"
 
-# This needs to be with require false to ensure correct loading order, as it has to
-# be loaded after loading the test library.
-gem "mocha", require: false
+gem "mocha"
 
 gem "capybara", ">= 2.15", "< 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
       path_expander (~> 1.0)
     minitest-server (1.0.5)
       minitest (~> 5.0)
-    mocha (1.3.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
     msgpack (1.2.4)

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -4,7 +4,7 @@ require "action_cable"
 require "active_support/testing/autorun"
 
 require "puma"
-require "mocha/setup"
+require "mocha/minitest"
 require "rack/mock"
 
 begin

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -184,4 +184,4 @@ module InTimeZone
     end
 end
 
-require "mocha/setup" # FIXME: stop using mocha
+require "mocha/minitest" # FIXME: stop using mocha


### PR DESCRIPTION
* Simplify declaration of mocha dependency in Gemfile
* Make Mocha setup explicitly Minitest-specific
* Upgrade Mocha from v1.3.0 to v1.5.0
