### PR TITLE
Only disable headless chrome gpu on Windows

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -33,7 +33,7 @@ module ActionDispatch
         def headless_chrome_browser_options
           options = Selenium::WebDriver::Chrome::Options.new
           options.args << "--headless"
-          options.args << "--disable-gpu"
+          options.args << "--disable-gpu" if Gem.win_platform?
 
           options
         end


### PR DESCRIPTION
Per Chromium team this has not been necessary on other platforms for quite some time: https://bugs.chromium.org/p/chromium/issues/detail?id=737678#c1

IMHO, this should be backported to 5-2-stable