### PR TITLE
[5-2-0] Restore Capybara's dependencies in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,12 @@ GEM
       amq-protocol (~> 2.3.0)
     byebug (10.0.2)
     capybara (3.0.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.1.0)
@@ -476,6 +482,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   java


### PR DESCRIPTION
These went missing in https://github.com/rails/rails/commit/b5d26248973e76dc154d9e599c75b6ff90fd715e, which was causing `bundle install` to fail with:

    Downloading capybara-3.0.1 revealed dependencies not in the API or the lockfile (addressable (>= 0), mini_mime (>= 0.1.3), nokogiri (~> 1.8), rack (>= 1.6.0), rack-test (>= 0.6.3), xpath (~> 3.0)).
    Either installing with `--full-index` or running `bundle update capybara` should fix the problem.

    In Gemfile:
      capybara

r? @rafaelfranca 