### PR TITLE
[5-0-stable] Don't mutate parameters in test request helpers

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -516,11 +516,11 @@ module ActionController
           format ||= as
         end
 
+        parameters = parameters.symbolize_keys
+
         if format
           parameters[:format] = format
         end
-
-        parameters = parameters.symbolize_keys
 
         generated_extras = @routes.generate_extras(parameters.merge(controller: controller_class_name, action: action.to_s))
         generated_path = generated_path(generated_extras)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -889,6 +889,12 @@ XML
     assert_equal 'application/json', @response.body
   end
 
+  def test_request_format_kwarg_doesnt_mutate_params
+    params = { foo: 'bar' }
+    get :test_format, format: 'json', params: params
+    assert_equal({ foo: 'bar' }, params)
+  end
+
   def test_deprecated_request_format_params_with_session
     assert_deprecated { get :test_format, { format: 'json' }, { 'string': 'value1' } }
     assert_equal 'application/json', @response.body


### PR DESCRIPTION
Mutating the value passed as `params` when making a request in a controller test is surprising behaviour. We can avoid it by calling `symbolize_keys` first, which will make a copy of the hash.

This matches the behaviour on 5.1 and later, which was introduced in 98b8309569a326910a723f521911e54994b112fb. On 4.2 and earlier, passing `format` separately wasn't supported, so this fix is only needed on 5.0.