### PR TITLE
Avoid generating full changes hash on every save

### DIFF
--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -11,6 +11,10 @@ module ActiveModel
       @forced_changes = Set.new
     end
 
+    def changed_attribute_names
+      attr_names.select { |attr_name| changed?(attr_name) }
+    end
+
     def changed_values
       attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
         if changed?(attr_name)
@@ -75,6 +79,10 @@ module ActiveModel
 
   class NullMutationTracker # :nodoc:
     include Singleton
+
+    def changed_attribute_names(*)
+      []
+    end
 
     def changed_values(*)
       {}

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -114,7 +114,7 @@ module ActiveRecord
 
       # Alias for +changed+
       def changed_attribute_names_to_save
-        changes_to_save.keys
+        mutations_from_database.changed_attribute_names
       end
 
       # Alias for +changed_attributes+


### PR DESCRIPTION
`changed_attribute_names_to_save` is called in `keys_for_partial_write`, which is called on every save when partial writes are enabled.

We can avoid generating the full changes hash by asking the mutation tracker for just the names of the changed attributes. At minimum this saves one array allocation per attribute, but will also avoid calling `Attribute#original_value` which is expensive for serialized attributes.

r? @sgrif 