### PR TITLE
Prevent changes_to_save from mutating attributes

### DIFF
--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -23,7 +23,7 @@ module ActiveModel
       attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
         change = change_to_attribute(attr_name)
         if change
-          result[attr_name] = change
+          result.merge!(attr_name => change)
         end
       end
     end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -473,6 +473,14 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
+  def test_changes_to_save_should_not_mutate_array_of_hashes
+    topic = Topic.new(author_name: "Bill", content: [{ a: "a" }])
+
+    topic.changes_to_save
+
+    assert_equal [{ a: "a" }], topic.content
+  end
+
   def test_previous_changes
     # original values should be in previous_changes
     pirate = Pirate.new


### PR DESCRIPTION
When an array of hashes is added to a `HashWithIndifferentAccess`, the hashes are replaced with HWIAs by [mutating the array in place](https://github.com/rails/rails/blob/v5.1.6/activesupport/lib/active_support/hash_with_indifferent_access.rb#L323).

If an attribute's value is an array of hashes, `changes_to_save` will convert it to an array of HWIAs as a side-effect of adding it to the changes hash. `changes_to_save` is [currently](https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/attribute_methods/dirty.rb#L293) [called](https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/attribute_methods/dirty.rb#L297) [every time](https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/attribute_methods/dirty.rb#L301) [a record is saved](https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/attribute_methods/dirty.rb#L207), so arrays of hashes stored in serialized attributes are always converted to arrays of HWIAs.

Using `merge!` instead of `[]=` fixes the problem, as `merge!` [copies any array values](https://github.com/rails/rails/blob/v5.1.6/activesupport/lib/active_support/hash_with_indifferent_access.rb#L321) in the provided hash instead of mutating them.

This fix will make `changes_to_save` slower, as `AttributeMutationTracker#changes` will allocate an extra single-element hash per attribute that the HWIA will [iterate over](https://github.com/rails/rails/blob/v5.1.6/activesupport/lib/active_support/hash_with_indifferent_access.rb#L125). If https://github.com/rails/rails/pull/32497 is merged however, the common case won't be affected, as `changes_to_save` will no longer be called internally on every save.

r? @sgrif 