### PR TITLE
A safe_parse method for Date

### DIFF
--- a/activesupport/lib/active_support/core_ext/date.rb
+++ b/activesupport/lib/active_support/core_ext/date.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/date/acts_like"
 require "active_support/core_ext/date/blank"
+require "active_support/core_ext/date/safe_parse"
 require "active_support/core_ext/date/calculations"
 require "active_support/core_ext/date/conversions"
 require "active_support/core_ext/date/zones"

--- a/activesupport/lib/active_support/core_ext/date/safe_parse.rb
+++ b/activesupport/lib/active_support/core_ext/date/safe_parse.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "date"
+
+class Date #:nodoc:
+  # Safely parse a string without the need of rescuing possible exceptions
+  def self.safe_parse(string, fallback = nil)
+    parse(string)
+  rescue TypeError, ArgumentError
+    fallback
+  end
+end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -404,4 +404,25 @@ class DateExtBehaviorTest < ActiveSupport::TestCase
       Date.today.freeze.freeze
     end
   end
+
+  def test_can_safe_parse_nil
+    assert_nil Date.safe_parse(nil)
+  end
+
+  def test_can_safe_parse_empty_string
+    assert_nil Date.safe_parse("")
+  end
+
+  def test_can_safe_parse_and_fallback
+    fallback = 1.day.ago
+    assert_equal Date.safe_parse(nil, fallback), fallback
+  end
+
+  def test_can_safe_parse_an_invalid_string
+    assert_nil Date.safe_parse("i am so cool")
+  end
+
+  def test_can_safe_parse_a_valid_string
+    assert_equal Date.safe_parse("2018-01-01", "fallback"), Date.new(2018, 1, 1)
+  end
 end


### PR DESCRIPTION
### Summary

Too many times we had to parse a string into a Date object and we had to deal with the possible exceptions. 

This Pull Request introduces a wonderful `safe_parse` method with an optional `fallback` parameter to make our life easier from now on.