### PR TITLE
Correct Maintenance Policy for Rails 5.2

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -44,7 +44,7 @@ from.
 In special situations, where someone from the Core Team agrees to support more series,
 they are included in the list of supported series.
 
-**Currently included series:** `5.1.Z`.
+**Currently included series:** `5.2.Z`.
 
 Security Issues
 ---------------
@@ -59,7 +59,7 @@ be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.
 
-**Currently included series:** `5.1.Z`, `5.0.Z`.
+**Currently included series:** `5.2.Z`, `5.1.Z`.
 
 Severe Security Issues
 ----------------------
@@ -68,7 +68,7 @@ For severe security issues we will provide new versions as above, and also the
 last major release series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
 
-**Currently included series:** `5.1.Z`, `5.0.Z`, `4.2.Z`.
+**Currently included series:** `5.2.Z`, `5.1.Z`, `5.0.Z`.
 
 Unsupported Release Series
 --------------------------


### PR DESCRIPTION
Now that Rails 5.2 has been released, I think this policy should be updated as well.