### PR TITLE
Fix .new with multiple through associations

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -28,7 +28,11 @@ module ActiveRecord
             end
 
             if through_record
-              through_record.update(attributes)
+              if through_record.new_record?
+                through_record.assign_attributes(attributes)
+              else
+                through_record.update(attributes)
+              end
             elsif owner.new_record? || !save
               through_proxy.build(attributes)
             else

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -22,6 +22,10 @@ require "models/customer"
 require "models/carrier"
 require "models/shop_account"
 require "models/customer_carrier"
+require "models/game"
+require "models/game_board"
+require "models/game_collection"
+require "models/game_owner"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
@@ -62,6 +66,24 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:moustache_club), new_member.club
     assert new_member.save
     assert_equal clubs(:moustache_club), new_member.club
+  end
+
+  def test_building_multiple_associations_builds_through_record
+    game_owner = GameOwner.create
+    game_collection = GameCollection.create
+    game_board_with_one_association = GameBoard.new(game_owner: game_owner)
+    assert_nil game_board_with_one_association.game.id
+    game_board_with_two_associations = GameBoard.new(game_owner: game_owner, game_collection: game_collection)
+    assert_nil game_board_with_two_associations.game.id
+  end
+
+  def test_creating_multiple_associations_creates_through_record
+    game_owner = GameOwner.create
+    game_collection = GameCollection.create
+    game_board_with_one_association = GameBoard.create(game_owner: game_owner)
+    assert_not_nil game_board_with_one_association.game.id
+    game_board_with_two_associations = GameBoard.create(game_owner: game_owner, game_collection: game_collection)
+    assert_not_nil game_board_with_two_associations.game.id
   end
 
   def test_creating_association_sets_both_parent_ids_for_new

--- a/activerecord/test/models/game.rb
+++ b/activerecord/test/models/game.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Game < ActiveRecord::Base
+  has_one :game_board
+  belongs_to :game_owner
+  belongs_to :game_collection
+end

--- a/activerecord/test/models/game_board.rb
+++ b/activerecord/test/models/game_board.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class GameBoard < ActiveRecord::Base
+  belongs_to :game
+  has_one :game_owner, through: :game
+  has_one :game_collection, through: :game
+end

--- a/activerecord/test/models/game_collection.rb
+++ b/activerecord/test/models/game_collection.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class GameCollection < ActiveRecord::Base
+  has_many :games
+end

--- a/activerecord/test/models/game_owner.rb
+++ b/activerecord/test/models/game_owner.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class GameOwner < ActiveRecord::Base
+  has_many :games
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -364,6 +364,19 @@ ActiveRecord::Schema.define do
     t.integer :follower_id
   end
 
+  create_table :games, force: true do |t|
+    t.integer :game_owner_id
+    t.integer :game_collection_id
+  end
+
+  create_table :game_boards, force: true do |t|
+    t.integer :game_id
+  end
+
+  create_table :game_collections, force: true
+
+  create_table :game_owners, force: true
+
   create_table :goofy_string_id, force: true, id: false do |t|
     t.string :id, null: false
     t.string :info


### PR DESCRIPTION
### Summary
This fixes a bug with building an object that has multiple `has_many :through` 
associations through the same object. 
Previously, when building the object via `.new`, the intermediate object 
would be created instead of just being built.

The associated issue is: #32511 

### Other information
Here's an example:
Given a `GameBoard`, that `has_one` `:owner` and `:collection` `through: game`.
The following line would cause a `Game` object to be created in the
database.

    GameBoard.new(owner: some_owner, collection: some_collection)

Whereas, if passing only one of those associations into `.new` would
cause the `game` object to be built and not created in the database.

Now the above code will only build the Game object, and not save it.