### PR TITLE
Add `TestCaseTest#test_request_format_kwarg_doesnt_mutate_params` to master

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -740,6 +740,14 @@ XML
     assert_equal "application/json", @response.body
   end
 
+  def test_request_format_kwarg_doesnt_mutate_params
+    params = { foo: "bar" }.freeze
+
+    assert_nothing_raised do
+      get :test_format, format: "json", params: params
+    end
+  end
+
   def test_should_have_knowledge_of_client_side_cookie_state_even_if_they_are_not_set
     cookies["foo"] = "bar"
     get :no_op


### PR DESCRIPTION
Initially, the test was added to 5-0-stable in #32492
and a bit modified in #32506. This test ensures that request(in tests)
doesn't mutate params. It was fixed since v5.1.0.beta1 by
98b8309569a326910a723f521911e54994b112fb and then on 5-0-stable by #32492.
This commit adds this test to master branch in order to prevent any
regressions.