### PR TITLE
cherry-pick 561aad0 to 5-2-stable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Exclude JSON root from `active_storage/direct_uploads#create` response.
+
+    *Javan Makhmali*
+
+
 ## Rails 5.2.0 (April 09, 2018) ##
 
 *   Allow full use of the AWS S3 SDK options for authentication. If an

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -15,7 +15,7 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
     end
 
     def direct_upload_json(blob)
-      blob.as_json(methods: :signed_id).merge(direct_upload: {
+      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
         url: blob.service_url_for_direct_upload,
         headers: blob.service_headers_for_direct_upload
       })

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -121,4 +121,27 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       assert_equal({ "Content-Type" => "text/plain" }, details["direct_upload"]["headers"])
     end
   end
+
+  test "creating new direct upload does not include root in json" do
+    checksum = Digest::MD5.base64digest("Hello")
+
+    set_include_root_in_json(true) do
+      post rails_direct_uploads_url, params: { blob: {
+        filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
+    end
+
+    @response.parsed_body.tap do |details|
+      assert_nil details["blob"]
+      assert_not_nil details["id"]
+    end
+  end
+
+  private
+    def set_include_root_in_json(value)
+      original = ActiveRecord::Base.include_root_in_json
+      ActiveRecord::Base.include_root_in_json = value
+      yield
+    ensure
+      ActiveRecord::Base.include_root_in_json = original
+    end
 end


### PR DESCRIPTION
Active Storage: Always exclude JSON root from direct_uploads#create response

cherry-pick 561aad0c186103232c094e38d4d3fe4ea4c083f3 to `5-2-stable`
in order to get this behavior in 5.2.1.

Add changelog entry.

r? @javan 