### PR TITLE
Remove unnecessary anonymous functions

### DIFF
--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -18,8 +18,8 @@ export class BlobRecord {
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
     this.xhr.setRequestHeader("X-CSRF-Token", getMetaValue("csrf-token"))
-    this.xhr.addEventListener("load", event => this.requestDidLoad(event))
-    this.xhr.addEventListener("error", event => this.requestDidError(event))
+    this.xhr.addEventListener("load", this.requestDidLoad)
+    this.xhr.addEventListener("error", this.requestDidError)
   }
 
   get status() {

--- a/activestorage/app/javascript/activestorage/blob_upload.js
+++ b/activestorage/app/javascript/activestorage/blob_upload.js
@@ -11,8 +11,8 @@ export class BlobUpload {
     for (const key in headers) {
       this.xhr.setRequestHeader(key, headers[key])
     }
-    this.xhr.addEventListener("load", event => this.requestDidLoad(event))
-    this.xhr.addEventListener("error", event => this.requestDidError(event))
+    this.xhr.addEventListener("load", this.requestDidLoad)
+    this.xhr.addEventListener("error", this.requestDidError)
   }
 
   create(callback) {

--- a/activestorage/app/javascript/activestorage/direct_upload_controller.js
+++ b/activestorage/app/javascript/activestorage/direct_upload_controller.js
@@ -62,6 +62,6 @@ export class DirectUploadController {
 
   directUploadWillStoreFileWithXHR(xhr) {
     this.dispatch("before-storage-request", { xhr })
-    xhr.upload.addEventListener("progress", event => this.uploadRequestDidProgress(event))
+    xhr.upload.addEventListener("progress", this.uploadRequestDidProgress)
   }
 }

--- a/activestorage/app/javascript/activestorage/file_checksum.js
+++ b/activestorage/app/javascript/activestorage/file_checksum.js
@@ -19,8 +19,8 @@ export class FileChecksum {
     this.callback = callback
     this.md5Buffer = new SparkMD5.ArrayBuffer
     this.fileReader = new FileReader
-    this.fileReader.addEventListener("load", event => this.fileReaderDidLoad(event))
-    this.fileReader.addEventListener("error", event => this.fileReaderDidError(event))
+    this.fileReader.addEventListener("load", this.fileReaderDidLoad)
+    this.fileReader.addEventListener("error", this.fileReaderDidError)
     this.readNextChunk()
   }
 


### PR DESCRIPTION
### Summary

Callback functions for some events were wrapped with an unnecessary anonymous function, when passing the original definition is enough.