### PR TITLE
Add autosave option to join table generated by has_and_belongs_to_many

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -129,6 +129,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
           rhs_options[:foreign_key] = options[:association_foreign_key]
         end
 
+        if options.key? :autosave
+          rhs_options[:autosave] = options[:autosave]
+        end
+
         rhs_options
       end
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -13,6 +13,7 @@ require "models/invoice"
 require "models/line_item"
 require "models/order"
 require "models/parrot"
+require "models/food"
 require "models/pirate"
 require "models/ship"
 require "models/ship_part"
@@ -1566,6 +1567,17 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::T
   end
 
   include AutosaveAssociationOnACollectionAssociationTests
+
+  def test_should_save_changed_grandchild_objects_if_grandparent_is_saved
+    @child_1.foods.create(name: "Apple")
+    @jack = Pirate.new(catchphrase: "Remember the day thou almost catch captain Jack Sparrow")
+    @jack.autosaved_parrots << @child_1
+    @grandchild = @child_1.foods[0]
+    @grandchild.name = "Banana"
+    @jack.save!
+    @grandchild.reload
+    assert_equal "Banana", @grandchild.name
+  end
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociationWithAcceptsNestedAttributes < ActiveRecord::TestCase

--- a/activerecord/test/models/food.rb
+++ b/activerecord/test/models/food.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Food < ActiveRecord::Base
+  belongs_to :parrot
+end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -6,6 +6,7 @@ class Parrot < ActiveRecord::Base
   has_and_belongs_to_many :pirates
   has_and_belongs_to_many :treasures
   has_many :loots, as: :looter
+  has_many :foods, autosave: true
   alias_attribute :title, :name
 
   validates_presence_of :name

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -615,6 +615,11 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :foods, force: true do |t|
+    t.column :name, :string
+    t.column :parrot_id, :integer
+  end
+
   create_table :parrots_pirates, id: false, force: true do |t|
     t.column :parrot_id, :integer
     t.column :pirate_id, :integer


### PR DESCRIPTION
Fix issues #32476

### Summary
This PR adds `autosave` options the join model generated by `has_and_belongs_to_many`. It fixes the
problems in #32476 but introduces a new regression as it breaks [this test](https://github.com/rails/rails/blob/76c9498eb1a83ad2da17044e850eb7bab212d399/activerecord/test/cases/autosave_association_test.rb#L1471). I'm still not sure whether this is the correct way to fix this problem, so I'm open for suggestions.
