### PR TITLE
Generate spring binstubs when `rails app:update`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -98,6 +98,7 @@ module Rails
       bin_yarn_exist = File.exist?("bin/yarn")
 
       bin
+      generate_spring_binstubs unless options[:skip_spring]
 
       if options[:api] && !bin_yarn_exist
         remove_file "bin/yarn"


### PR DESCRIPTION
After running `bin/rails app:update` in Rails 5.1 app,
spring binstub code is removed from  `bin/*`.

I'm not sure this PR is a right way to fix it
since Thor's diff is not what we'll get after `app:update`
and `app:update` does not accept `--skip-spring` nor `--no-skip-spring` option.

Adding note on `display_upgrade_guide_info` may be sufficient.

Example with this patch:
```
$ bundle exec bin/rails app:update
    conflict  config/boot.rb
Overwrite /Users/yskkin/projects/myapp/config/boot.rb? (enter "h" for help) [Ynaqdh] n
        skip  config/boot.rb
       exist  config
    conflict  config/routes.rb
Overwrite /Users/yskkin/projects/myapp/config/routes.rb? (enter "h" for help) [Ynaqdh] n
        skip  config/routes.rb
    conflict  config/application.rb
Overwrite /Users/yskkin/projects/myapp/config/application.rb? (enter "h" for help) [Ynaqdh] n
        skip  config/application.rb
[...snip...]
       exist  bin
   identical  bin/bundle
    conflict  bin/rails
Overwrite /Users/yskkin/projects/myapp/bin/rails? (enter "h" for help) [Ynaqdh] d
--- /Users/yskkin/projects/myapp/bin/rails	2018-04-11 08:02:15.000000000 +0900
+++ /Users/yskkin/projects/myapp/bin/rails20180411-78477-z1laa7	2018-04-11 15:48:52.000000000 +0900
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'
Retrying...
Overwrite /Users/yskkin/projects/myapp/bin/rails? (enter "h" for help) [Ynaqdh] y
       force  bin/rails
    conflict  bin/rake
Overwrite /Users/yskkin/projects/myapp/bin/rake? (enter "h" for help) [Ynaqdh] n
        skip  bin/rake
   identical  bin/setup
   identical  bin/update
   identical  bin/yarn
         run  bundle exec spring binstub --all
* bin/rake: spring already present
* bin/rails: spring inserted

After this, check Rails upgrade guide at http://guides.rubyonrails.org/upgrading_ruby_on_rails.html for more details about upgrading your app.
```
```
$ cat bin/rails
#!/usr/bin/env ruby
begin
  load File.expand_path('../spring', __FILE__)
rescue LoadError => e
  raise unless e.message.include?('spring')
end
APP_PATH = File.expand_path('../config/application', __dir__)
require_relative '../config/boot'
require 'rails/commands'
```
