### PR TITLE
Fix: Route generation regression with optionals with default values.

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -35,11 +35,22 @@ module ActionDispatch
 
           defaults       = route.defaults
           required_parts = route.required_parts
+          filter_action_part = true
 
           route.parts.reverse_each do |key|
-            break if defaults[key].nil? && parameterized_parts[key].present?
+            next if (key == :action) && !filter_action_part
+
+            if defaults[key].nil? && parameterized_parts[key].present?
+              filter_action_part = false
+              next
+            end
+
             next if parameterized_parts[key].to_s != defaults[key].to_s
-            break if required_parts.include?(key)
+
+            if required_parts.include?(key)
+              filter_action_part = false
+              next
+            end
 
             parameterized_parts.delete(key)
           end

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -501,12 +501,54 @@ module AbstractController
                 param1: /\d*/,
                 param2: /\d+/
               }
+            get "(:param1)/test2(/:param2)" => "index#index2",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "(:param1)/test3/:param2" => "index#index3",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "test4/(:param1)/(:param2)" => "index#index4",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
           end
 
           kls = Class.new { include set.url_helpers }
           kls.default_url_options[:host] = "www.basecamphq.com"
 
+          assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index")
           assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index", param1: "1")
+          assert_equal "http://www.basecamphq.com/2/test", kls.new.url_for(controller: "index", param1: "2")
+          assert_equal "http://www.basecamphq.com/test/3", kls.new.url_for(controller: "index", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test2", kls.new.url_for(controller: "index", param1: "1", action: "index2")
+          assert_equal "http://www.basecamphq.com/2/test2", kls.new.url_for(controller: "index", param1: "2", action: "index2")
+          assert_equal "http://www.basecamphq.com/test2/3", kls.new.url_for(controller: "index", action: "index2", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test2/3", kls.new.url_for(controller: "index", param1: "2", action: "index2", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", param1: "1", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test3/3", kls.new.url_for(controller: "index", param1: "2", action: "index3", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test4", kls.new.url_for(controller: "index", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2", kls.new.url_for(controller: "index", param1: "2", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2/3", kls.new.url_for(controller: "index", param1: "2", action: "index4", param2: "3")
+          # Doesn't make sense due to ambiguity, but is consistent with both rails4 and rails5 routing behavior:
+          assert_equal "http://www.basecamphq.com/test4/3", kls.new.url_for(controller: "index", action: "index4", param2: "3")
         end
       end
 


### PR DESCRIPTION
Rails4 and before supported leading segments of urls that were optional
and had default values. This could be used for example for having
locale in the url, and having a global default that was unspecified.
Rails5 with commit 8ca8a2d773b942c4ea broke this behaviour, and commit
0713265fd15f5ce0d6e fixes the case where all optionals have default
values but not the cases when some have it or when some are required.

Fixes #31413
