### PR TITLE
Use frozen string literal

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 tap "homebrew/core"
 tap "homebrew/bundle"
 tap "homebrew/services"


### PR DESCRIPTION
### Summary

This PR fixes rubocop warning "Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true."

### Command

```sh
$ bundle exec rubocop Brewfile                                                                                                                                                                                            17:35:45
Inspecting 1 file
C

Offenses:

Brewfile:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
tap "homebrew/core"
^

1 file inspected, 1 offense detected
```
