### PR TITLE
[5-2-stable] Remove upper bound on Capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "rake", ">= 11.1"
 # be loaded after loading the test library.
 gem "mocha", require: false
 
-gem "capybara", ">= 2.15", "< 4.0"
+gem "capybara", ">= 2.15"
 
 gem "rack-cache", "~> 1.2"
 gem "coffee-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,7 @@ DEPENDENCIES
   blade-sauce_labs_plugin
   bootsnap (>= 1.1.0)
   byebug
-  capybara (>= 2.15, < 4.0)
+  capybara (>= 2.15)
   chromedriver-helper
   coffee-rails
   connection_pool

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "capybara", ">= 2.15", "< 4.0"
+gem "capybara", ">= 2.15"
 
 require "capybara/dsl"
 require "capybara/minitest"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -69,7 +69,7 @@ end
 <%- if depends_on_system_test? -%>
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15', '< 4.0'
+  gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'


### PR DESCRIPTION
There's no reason to block future versions of Capybara since we don't
_know_ they are going to break. How will we know if we have a
conservative option set? This change prevents us from blocking users who
want to upgrade in the future.

cherry-pick 72f17d5

r? @eileencodes 