### PR TITLE
rubocop should ignore Brewfile [ci skip]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   Exclude:
     - '**/templates/**/*'
     - '**/vendor/**/*'
+    - 'Brewfile'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
 
 # Prefer assert_not_x over refute_x


### PR DESCRIPTION
```
rails$ bundle exec rubocop
Inspecting 2404 files
C....(snip)...

Offenses:

Brewfile:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
tap "homebrew/core"
^

2404 files inspected, 1 offense detected
```

Related to #32527