### PR TITLE
Fix ActiveRecord::ImmutableRelation is raised when collection caching and HTTP caching are used together

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -8,8 +8,8 @@ module ActiveRecord
                             :extending, :unscope]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering,
-                            :reverse_order, :distinct, :create_with, :skip_query_cache,
-                            :skip_preloading]
+                            :reverse_order, :distinct, :create_with, :skip_query_cache]
+
     CLAUSE_METHODS = [:where, :having, :from]
     INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :group, :having]
 
@@ -19,6 +19,7 @@ module ActiveRecord
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
 
     attr_reader :table, :klass, :loaded, :predicate_builder
+    attr_accessor :skip_preloading_value
     alias :model :klass
     alias :loaded? :loaded
     alias :locked? :lock_value

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       assert_equal [], relation.extending_values
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :skip_preloading]).each do |method|
+    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with, :skip_query_cache]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -315,6 +315,14 @@ module ActiveRecord
       assert_equal "type cast from database", UpdateAllTestModel.first.body
     end
 
+    def test_skip_preloading_after_arel_has_been_generated
+      assert_nothing_raised do
+        relation = Comment.all
+        relation.arel
+        relation.skip_preloading!
+      end
+    end
+
     private
 
       def skip_if_sqlite3_version_includes_quoting_bug


### PR DESCRIPTION
`skip_preloading!` was asserting immutability, but the arel may have already been defined by using `fresh_when` in the controller. 

As `skip_preloading!` has no effect on the sql being generated it should be safe to skip this check when setting this value.

This PR removes `skip_preloading` from the `SINGLE_VALUE_METHODS` that are used to define setters that use the `assert_immutability` check, and replaces it a attribute accessor on the relation.

Fixes #32534

/cc @georgeclaghorn 