### PR TITLE
Fix ActiveSupport::Cache compression

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix bug where `ActiveSupport::Cache` will massively inflate the storage
+    size when compression is enabled (which is true by default). This patch
+    does not attempt to repair existing data: please manually flush the cache
+    to clear out the problematic entries.
+
+    *Godfrey Chan*
+
 *   Fix bug where `URI.unscape` would fail with mixed Unicode/escaped character input:
 
         URI.unescape("\xe3\x83\x90")  # => "バ"

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -712,17 +712,14 @@ module ActiveSupport
       DEFAULT_COMPRESS_LIMIT = 1.kilobyte
 
       # Creates a new cache entry for the specified value. Options supported are
-      # +:compress+, +:compress_threshold+, and +:expires_in+.
-      def initialize(value, options = {})
-        @value = value
-        if should_compress?(options)
-          compress!
-        end
-
-        @version    = options[:version]
+      # +:compress+, +:compress_threshold+, +:version+ and +:expires_in+.
+      def initialize(value, compress: true, compress_threshold: DEFAULT_COMPRESS_LIMIT, version: nil, expires_in: nil, **)
+        @value      = value
+        @version    = version
         @created_at = Time.now.to_f
-        @expires_in = options[:expires_in]
-        @expires_in = @expires_in.to_f if @expires_in
+        @expires_in = expires_in && expires_in.to_f
+
+        compress!(compress_threshold) if compress
       end
 
       def value
@@ -754,17 +751,13 @@ module ActiveSupport
       # Returns the size of the cached value. This could be less than
       # <tt>value.size</tt> if the data is compressed.
       def size
-        if defined?(@s)
-          @s
+        case value
+        when NilClass
+          0
+        when String
+          @value.bytesize
         else
-          case value
-          when NilClass
-            0
-          when String
-            @value.bytesize
-          else
-            @s = Marshal.dump(@value).bytesize
-          end
+          @s ||= Marshal.dump(@value).bytesize
         end
       end
 
@@ -781,30 +774,34 @@ module ActiveSupport
       end
 
       private
-        def should_compress?(options)
-          if @value && options.fetch(:compress, true)
-            compress_threshold = options.fetch(:compress_threshold, DEFAULT_COMPRESS_LIMIT)
-            serialized_value_size = (@value.is_a?(String) ? @value : marshaled_value).bytesize
+        def compress!(compress_threshold)
+          case @value
+          when nil, true, false, Numeric
+            uncompressed_size = 0
+          when String
+            uncompressed_size = @value.bytesize
+          else
+            serialized = Marshal.dump(@value)
+            uncompressed_size = serialized.bytesize
+          end
 
-            serialized_value_size >= compress_threshold
+          if uncompressed_size >= compress_threshold
+            serialized ||= Marshal.dump(@value)
+            compressed = Zlib::Deflate.deflate(serialized)
+
+            if compressed.bytesize < uncompressed_size
+              @value = compressed
+              @compressed = true
+            end
           end
         end
 
         def compressed?
-          defined?(@compressed) ? @compressed : false
-        end
-
-        def compress!
-          @value = Zlib::Deflate.deflate(marshaled_value)
-          @compressed = true
+          defined?(@compressed)
         end
 
         def uncompress(value)
           Marshal.load(Zlib::Inflate.inflate(value))
-        end
-
-        def marshaled_value
-          @marshaled_value ||= Marshal.dump(@value)
         end
     end
   end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -162,7 +162,7 @@ module CacheStoreBehavior
   end
 
   def test_nil_with_compress_low_compress_threshold
-    assert_uncompressed(nil, compress: true, compress_threshold: 2)
+    assert_uncompressed(nil, compress: true, compress_threshold: 1)
   end
 
   def test_small_string_with_default_compression_settings
@@ -178,7 +178,7 @@ module CacheStoreBehavior
   end
 
   def test_small_string_with_low_compress_threshold
-    assert_compressed(SMALL_STRING, compress: true, compress_threshold: 2)
+    assert_compressed(SMALL_STRING, compress: true, compress_threshold: 1)
   end
 
   def test_small_object_with_default_compression_settings
@@ -227,6 +227,25 @@ module CacheStoreBehavior
 
   def test_large_object_with_high_compress_threshold
     assert_uncompressed(LARGE_OBJECT, compress: true, compress_threshold: 1.megabyte)
+  end
+
+  def test_incompressable_data
+    assert_uncompressed(nil, compress: true, compress_threshold: 1)
+    assert_uncompressed(true, compress: true, compress_threshold: 1)
+    assert_uncompressed(false, compress: true, compress_threshold: 1)
+    assert_uncompressed(0, compress: true, compress_threshold: 1)
+    assert_uncompressed(1.2345, compress: true, compress_threshold: 1)
+    assert_uncompressed("", compress: true, compress_threshold: 1)
+
+    incompressible = nil
+
+    # generate an incompressible string
+    loop do
+      incompressible = SecureRandom.bytes(1.kilobyte)
+      break if incompressible.bytesize < Zlib::Deflate.deflate(incompressible).bytesize
+    end
+
+    assert_uncompressed(incompressible, compress: true, compress_threshold: 1)
   end
 
   def test_cache_key

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -13,25 +13,4 @@ class CacheEntryTest < ActiveSupport::TestCase
       assert entry.expired?, "entry is expired"
     end
   end
-
-  def test_compressed_values
-    value = "value" * 100
-    entry = ActiveSupport::Cache::Entry.new(value, compress: true, compress_threshold: 1)
-    assert_equal value, entry.value
-    assert(value.bytesize > entry.size, "value is compressed")
-  end
-
-  def test_compressed_by_default
-    value = "value" * 100
-    entry = ActiveSupport::Cache::Entry.new(value, compress_threshold: 1)
-    assert_equal value, entry.value
-    assert(value.bytesize > entry.size, "value is compressed")
-  end
-
-  def test_uncompressed_values
-    value = "value" * 100
-    entry = ActiveSupport::Cache::Entry.new(value, compress: false)
-    assert_equal value, entry.value
-    assert_equal value.bytesize, entry.size
-  end
 end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -6,8 +6,7 @@ require_relative "../behaviors"
 
 class MemoryStoreTest < ActiveSupport::TestCase
   def setup
-    @record_size = ActiveSupport::Cache.lookup_store(:memory_store).send(:cached_size, 1, ActiveSupport::Cache::Entry.new("aaaaaaaaaa"))
-    @cache = ActiveSupport::Cache.lookup_store(:memory_store, expires_in: 60, size: @record_size * 10 + 1)
+    @cache = ActiveSupport::Cache.lookup_store(:memory_store, expires_in: 60)
   end
 
   include CacheStoreBehavior
@@ -15,6 +14,13 @@ class MemoryStoreTest < ActiveSupport::TestCase
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
+end
+
+class MemoryStorePruningTest < ActiveSupport::TestCase
+  def setup
+    @record_size = ActiveSupport::Cache.lookup_store(:memory_store).send(:cached_size, 1, ActiveSupport::Cache::Entry.new("aaaaaaaaaa"))
+    @cache = ActiveSupport::Cache.lookup_store(:memory_store, expires_in: 60, size: @record_size * 10 + 1)
+  end
 
   def test_prune_size
     @cache.write(1, "aaaaaaaaaa") && sleep(0.001)


### PR DESCRIPTION
On Rails 5.2, when compression is enabled (which it is by default), the actual value being written to the underlying storage is actually _bigger_ than the uncompressed raw value.

This is because the `@marshaled_value` instance variable (typically) gets serialized with the entry object, which is then written to the underlying storage, essentially double-storing every value (once uncompressed, once possibly compressed).

This regression was introduced in #32254.

Fix incoming.