### PR TITLE
Deprecate support for using `HOST` environment to specify server IP

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate support for using the `HOST` environment to specify the server IP.
+
+    The `BINDING` environment should be used instead.
+
+    Fixes #29516.
+
+    *Yuji Yaginuma*
+
 *   Deprecate passing Rack server name as a regular argument to `rails server`.
 
     Previously:

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -219,7 +219,7 @@ module Rails
                 user_supplied_options << name
               end
             end
-            user_supplied_options << :Host if ENV["HOST"]
+            user_supplied_options << :Host if ENV["HOST"] || ENV["BINDING"]
             user_supplied_options << :Port if ENV["PORT"]
             user_supplied_options.uniq
           end
@@ -234,7 +234,17 @@ module Rails
             options[:binding]
           else
             default_host = environment == "development" ? "localhost" : "0.0.0.0"
-            ENV.fetch("HOST", default_host)
+
+            if ENV["HOST"] && !ENV["BINDING"]
+              ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                Using the `HOST` environment to specify the IP is deprecated and will be removed in Rails 6.1.
+                Please use `BINDING` environment instead.
+              MSG
+
+              return ENV["HOST"]
+            end
+
+            ENV.fetch("BINDING", default_host)
           end
         end
 

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -90,6 +90,15 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
 
   def test_environment_with_host
     switch_env "HOST", "1.2.3.4" do
+      assert_deprecated do
+        options = parse_arguments
+        assert_equal "1.2.3.4", options[:Host]
+      end
+    end
+  end
+
+  def test_environment_with_binding
+    switch_env "BINDING", "1.2.3.4" do
       options = parse_arguments
       assert_equal "1.2.3.4", options[:Host]
     end
@@ -196,7 +205,7 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
       assert_equal 3000, options[:Port]
     end
 
-    switch_env "HOST", "1.2.3.4" do
+    switch_env "BINDING", "1.2.3.4" do
       args = ["-b", "127.0.0.1"]
       options = parse_arguments(args)
       assert_equal "127.0.0.1", options[:Host]
@@ -215,6 +224,11 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
 
     server_options = parse_arguments(["--port=3001"])
     assert_equal [:Port], server_options[:user_supplied_options]
+
+    switch_env "BINDING", "1.2.3.4" do
+      server_options = parse_arguments
+      assert_equal [:Host], server_options[:user_supplied_options]
+    end
   end
 
   def test_default_options


### PR DESCRIPTION
At SuSE, `$HOST` is set by default and is equal to `$HOSTNAME`.
https://www.suse.com/documentation/sled11/book_sle_admin/data/sec_adm_variables.html

Therefore, by default, it binds to hostname instead of `localhost`. This seems not to be appropriate as default behavior.

In order to avoid the name of the environment variable being used, changed the environment variable from `HOST` to `BINDING`.

Fixes #29516.
