### PR TITLE
Remove lock from method model

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -93,7 +93,7 @@ module ActionController
       end
 
       def model
-        super || synchronize { super || self.model = _default_wrap_model }
+        super || self.model = _default_wrap_model
       end
 
       def include


### PR DESCRIPTION
### Summary

There is a deadlock between `safe_constantize` and `synchronize`, reported at https://github.com/rails/rails/issues/32451. The [PR 32453](https://github.com/rails/rails/pull/32453) replaces `mutex_m` by `ActiveSupport::Concurrency::LoadInterlockAwareMonitor`, and this new PR is another approach only removing `mutex_m` lock from method `model`.

Fixes #32451 