### PR TITLE
Cache::Store#read: Fix fixed-width end tag in docs

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -333,8 +333,9 @@ module ActiveSupport
       # the cache with the given key, then that data is returned. Otherwise,
       # +nil+ is returned.
       #
-      # Note, if data was written with the <tt>:expires_in<tt> or <tt>:version</tt> options,
-      # both of these conditions are applied before the data is returned.
+      # Note, if data was written with the <tt>:expires_in</tt> or
+      # <tt>:version</tt> options, both of these conditions are applied before
+      # the data is returned.
       #
       # Options are passed to the underlying cache implementation.
       def read(name, options = nil)


### PR DESCRIPTION
* Fix the ending `</tt>` tag for `:expires_in`. Otherwise, the "or" is
  set in fixed-width also.
* Re-wrap paragraph to 80 columns.