### PR TITLE
[5-0-stable] Add support for Minitest 5.11

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -54,7 +54,8 @@ module ActiveSupport
                   end
                 }
               end
-              result = Marshal.dump(self.dup)
+              test_result = defined?(Minitest::Result) ? Minitest::Result.from(self) : dup
+              result = Marshal.dump(test_result)
             end
 
             write.puts [result].pack("m")
@@ -78,8 +79,9 @@ module ActiveSupport
 
           if ENV["ISOLATION_TEST"]
             yield
+            test_result = defined?(Minitest::Result) ? Minitest::Result.from(self) : dup
             File.open(ENV["ISOLATION_OUTPUT"], "w") do |file|
-              file.puts [Marshal.dump(self.dup)].pack("m")
+              file.puts [Marshal.dump(test_result)].pack("m")
             end
             exit!
           else

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -63,12 +63,18 @@ module Rails
       end
 
       def format_line(result)
-        "%s#%s = %.2f s = %s" % [result.class, result.name, result.time, result.result_code]
+        klass = result.respond_to?(:klass) ? result.klass : result.class
+        "%s#%s = %.2f s = %s" % [klass, result.name, result.time, result.result_code]
       end
 
       def format_rerun_snippet(result)
-        location, line = result.method(result.name).source_location
-        "#{self.executable} #{relative_path_for(location)}:#{line}"
+        location, line = if result.respond_to?(:source_location)
+          result.source_location
+        else
+          result.method(result.name).source_location
+        end
+
+        "#{executable} #{relative_path_for(location)}:#{line}"
       end
 
       def app_root


### PR DESCRIPTION
Merge pull request #31624 from y-yagi/fix_minitest_511
Add support for Minitest 5.11
cherry-pick 0552bcab646de4b8bdacf37823449a7c58431c2c

`Minitest::Result` can't use in 5-0-stable
Because Minitest is locked by 5.3.3.
cherry-pick f7e5f19fb38d298132f27500a354e0638e4ce762

Fixes
```
rails/railties/lib/rails/test_unit/reporter.rb:70:in `method':
undefined method `test_the_truth' for class `Minitest::Result' (NameError)
```

Related to https://github.com/seattlerb/minitest/issues/730
