### PR TITLE
Add WebSocket URI support to CSP DSL mappings

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -113,7 +113,9 @@ module ActionDispatch #:nodoc:
       blob:           "blob:",
       filesystem:     "filesystem:",
       report_sample:  "'report-sample'",
-      strict_dynamic: "'strict-dynamic'"
+      strict_dynamic: "'strict-dynamic'",
+      ws:             "ws:",
+      wss:            "wss:"
     }.freeze
 
     DIRECTIVES = {

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -51,6 +51,12 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.script_src :strict_dynamic
     assert_equal "script-src 'strict-dynamic'", @policy.build
 
+    @policy.script_src :ws
+    assert_equal "script-src ws:", @policy.build
+
+    @policy.script_src :wss
+    assert_equal "script-src wss:", @policy.build
+
     @policy.script_src :none, :report_sample
     assert_equal "script-src 'none' 'report-sample'", @policy.build
   end


### PR DESCRIPTION
This allows specifying Websockets URIs in the CSP DSL, like for example:
```
content_security_policy do |p|
  p.connect_src :wss
end
```
