### PR TITLE
fix spelling in docs for ActiveJob::Serializers::ObjectSerializer#deserialize

### DIFF
--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -38,7 +38,7 @@ module ActiveJob
         { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.merge!(hash)
       end
 
-      # Deserilizes an argument form a JSON primiteve type.
+      # Deserializes an argument from a JSON primitive type.
       def deserialize(_argument)
         raise NotImplementedError
       end


### PR DESCRIPTION
- "desirilize" should be "deserialize"
- "primiteve" should be "primitive"
- "form" should be "from"