### PR TITLE
2.6 warning: passing splat keyword arguments as a single Hash

### DIFF
--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -200,7 +200,7 @@ module ActionCable::StreamTests
       end
 
       def receive(connection, command:, identifiers:, channel: "ActionCable::StreamTests::ChatChannel")
-        identifier = JSON.generate(channel: channel, **identifiers)
+        identifier = JSON.generate(identifiers.merge(channel: channel))
         connection.dispatch_websocket_message JSON.generate(command: command, identifier: identifier)
         wait_for_async
       end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -454,8 +454,8 @@ module CacheStoreBehavior
 
     def assert_compression(should_compress, value, **options)
       freeze_time do
-        @cache.write("actual", value, **options)
-        @cache.write("uncompressed", value, **options, compress: false)
+        @cache.write("actual", value, options)
+        @cache.write("uncompressed", value, options.merge(compress: false))
       end
 
       if value.nil?


### PR DESCRIPTION
Ruby 2.6.0 warns about this.

``` ruby -v
ruby 2.6.0dev (2018-04-04 trunk 63085) [x86_64-linux]
```

Before, see:
https://travis-ci.org/rails/rails/jobs/365740163#L1262-L1264
https://travis-ci.org/rails/rails/jobs/365944863#L2121-L2174