### PR TITLE
Add .keep exception for storage folder

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -24,8 +24,11 @@
 <% unless skip_active_storage? -%>
 # Ignore uploaded files in development
 /storage/*
-
+<% if keeps? -%>
+!/storage/.keep
 <% end -%>
+<% end -%>
+
 <% unless options.skip_yarn? -%>
 /node_modules
 /yarn-error.log


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/32546 by including the `.keep` file in the .gitignore template, bringing the `storage` folder in line with the `tmp` and `log` folders.