### PR TITLE
Fix broken nodocs

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -73,7 +73,7 @@ module ActionDispatch
         end
       end
 
-      def reset_session # :nodoc
+      def reset_session # :nodoc:
         super
         self.flash = nil
       end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -241,7 +241,7 @@ module ActiveRecord
       association
     end
 
-    def association_cached?(name) # :nodoc
+    def association_cached?(name) # :nodoc:
       @association_cache.key?(name)
     end
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -69,7 +69,7 @@ module ActiveRecord
       if defined?(JRUBY_VERSION)
         # This form is significantly faster on JRuby, and this is one of our biggest hotspots.
         # https://github.com/jruby/jruby/pull/2562
-        def _read_attribute(attr_name, &block) # :nodoc
+        def _read_attribute(attr_name, &block) # :nodoc:
           @attributes.fetch_value(attr_name.to_s, &block)
         end
       else


### PR DESCRIPTION
This commit fixes all references in the codebase missing a trailing colon, which causes the nodoc not to actually work.

One example of something that shouldn't show up in the docs but currently does:

![](http://screenshots.chrisarcand.com/pf65t.jpg)