### PR TITLE
[ci skip] belongs_to in self join association needs optional: true, if it's over 5.0 ver of rails

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -505,7 +505,7 @@ class Employee < ApplicationRecord
   has_many :subordinates, class_name: "Employee",
                           foreign_key: "manager_id"
 
-  belongs_to :manager, class_name: "Employee"
+  belongs_to :manager, class_name: "Employee", optional: true
 end
 ```
 


### PR DESCRIPTION
### Summary

[The sample code](http://edgeguides.rubyonrails.org/association_basics.html#self-joins) doesn't work, because of [the change of belongs_to that triggers a validation error by default](http://edgeguides.rubyonrails.org/5_0_release_notes.html#active-record-notable-changes). The pull request is [this](https://github.com/rails/rails/pull/18937). Thanks.
