### PR TITLE
Fix redis store clear keys outside the namespace

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -286,7 +286,7 @@ module ActiveSupport
       # Failsafe: Raises errors.
       def clear(options = nil)
         failsafe :clear do
-          if namespace = merged_options(options)[namespace]
+          if namespace = merged_options(options)[:namespace]
             delete_matched "*", namespace: namespace
           else
             redis.with { |c| c.flushdb }

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -221,4 +221,22 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
   end
+
+  class ClearTest < StoreTest
+    test "clear all cache key" do
+      @cache.write("foo", "bar")
+      @cache.write("fu", "baz")
+      @cache.clear
+      assert !@cache.exist?("foo")
+      assert !@cache.exist?("fu")
+    end
+
+    test "only clear namespace cache key" do
+      @cache.write("foo", "bar")
+      @cache.redis.set("fu", "baz")
+      @cache.clear
+      assert !@cache.exist?("foo")
+      assert @cache.redis.exists("fu")
+    end
+  end
 end


### PR DESCRIPTION
Namespace not working in RedisCacheStore#clear method. Bacause

    namespace = merged_options(options)[namespace]

is always nil, Correct is

    namespace = merged_options(options)[:namespace]
