### PR TITLE
guides/testing: Pluralize controller and helper class names.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1484,7 +1484,7 @@ located under the `test/helpers` directory.
 Given we have the following helper:
 
 ```ruby
-module UserHelper
+module UsersHelper
   def link_to_user(user)
     link_to "#{user.first_name} #{user.last_name}", user
   end
@@ -1494,7 +1494,7 @@ end
 We can test the output of this method like this:
 
 ```ruby
-class UserHelperTest < ActionView::TestCase
+class UsersHelperTest < ActionView::TestCase
   test "should return the user's full name" do
     user = users(:david)
 
@@ -1600,7 +1600,7 @@ Functional testing for mailers involves more than just checking that the email b
 ```ruby
 require 'test_helper'
 
-class UserControllerTest < ActionDispatch::IntegrationTest
+class UsersControllerTest < ActionDispatch::IntegrationTest
   test "invite friend" do
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post invite_friend_url, params: { email: 'friend@example.com' }


### PR DESCRIPTION
The Rails convention for controllers and helpers is plural, except where
intentionally singular. Pluralize the controller and helper class names,
to match convention.

### Summary

Minor change to guides/testing.md: pluralizing `UserHelper`, `UserHelperTest`, and `UserControllerTest`.

Thanks for all things Rails!
