### PR TITLE
Add missing `require "benchmark"`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "benchmark"
 require "set"
 require "zlib"
 require "active_support/core_ext/module/attribute_accessors"


### PR DESCRIPTION
## Summary

Added `require "benchmark"` at the head of lib/active_record/migration.rb. This is because it may raise NameError if we use ActiveRecord::Migration before (auto-)loading lib/active_record/base.rb.

## Details

### Steps to reproduce

```ruby
begin
  require "bundler/inline"
rescue LoadError
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_schema_definition_without_connection
    assert_raises(ActiveRecord::ConnectionNotEstablished) do
      ActiveRecord::Schema.define do
        create_table :users
      end
    end
  end
end
```

### Expected behavior

```
# Running:

-- create_table(:users)
.

Finished in 0.214005s, 4.6728 runs/s, 4.6728 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

### Actual behavior

```
# Running:

-- create_table(:users)
F

Failure:
BugTest#test_schema_definition_without_connection [/Users/r7kamura/Desktop/missing-benchmark.rb:22]:
[ActiveRecord::ConnectionNotEstablished] exception expected, not
Class: <NameError>
Message: <"uninitialized constant ActiveRecord::Migration::Benchmark">
---Backtrace---
/Users/r7kamura/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:841:in `say_with_time'
/Users/r7kamura/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:861:in `method_missing'
/Users/r7kamura/Desktop/missing-benchmark.rb:24:in `block (2 levels) in test_schema_definition_without_connection'
/Users/r7kamura/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:50:in `instance_eval'
/Users/r7kamura/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:50:in `define'
/Users/r7kamura/src/github.com/rails/rails/activerecord/lib/active_record/schema.rb:46:in `define'
/Users/r7kamura/Desktop/missing-benchmark.rb:23:in `block in test_schema_definition_without_connection'
---------------


bin/rails test Users/r7kamura/Desktop/missing-benchmark.rb:21



Finished in 0.003833s, 260.8922 runs/s, 260.8922 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```
