### PR TITLE
Inclusive Language in Documentation Examples

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -389,8 +389,8 @@ module ActionView
       # * Any other key creates standard HTML options for the tag.
       #
       # ==== Examples
-      #   radio_button_tag 'gender', 'male'
-      #   # => <input id="gender_male" name="gender" type="radio" value="male" />
+      #   radio_button_tag 'favorite_color', 'maroon'
+      #   # => <input id="favorite_color_maroon" name="favorite_color" type="radio" value="maroon" />
       #
       #   radio_button_tag 'receive_updates', 'no', true
       #   # => <input checked="checked" id="receive_updates_no" name="receive_updates" type="radio" value="no" />

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -63,7 +63,7 @@ module ActiveModel
       # and strings in shortcut form.
       #
       #   validates :email, format: /@/
-      #   validates :gender, inclusion: %w(male female)
+      #   validates :subscribed_to_newsletter, inclusion: [true, false]
       #   validates :password, length: 6..20
       #
       # When using shortcut form, ranges and arrays are passed to your

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -63,7 +63,7 @@ module ActiveModel
       # and strings in shortcut form.
       #
       #   validates :email, format: /@/
-      #   validates :subscribed_to_newsletter, inclusion: [true, false]
+      #   validates :role, inclusion: %(admin contributor)
       #   validates :password, length: 6..20
       #
       # When using shortcut form, ranges and arrays are passed to your

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -163,10 +163,10 @@ class Module
   # parent class. Similarly if parent class changes the value then that would
   # change the value of subclasses too.
   #
-  #   class Male < Person
+  #   class Citizen < Person
   #   end
   #
-  #   Male.new.hair_colors << :blue
+  #   Citizen.new.hair_colors << :blue
   #   Person.new.hair_colors # => [:brown, :black, :blonde, :red, :blue]
   #
   # To opt out of the instance writer method, pass <tt>instance_writer: false</tt>.

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1267,8 +1267,8 @@ password_field_tag 'pass'
 Creates a radio button; use groups of radio buttons named the same to allow users to select from a group of options.
 
 ```ruby
-radio_button_tag 'gender', 'male'
-# => <input id="gender_male" name="gender" type="radio" value="male" />
+radio_button_tag 'favorite_color', 'maroon'
+# => <input id="favorite_color_maroon" name="favorite_color" type="radio" value="maroon" />
 ```
 
 #### select_tag

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -857,12 +857,12 @@ In the event you need to access nested attributes within a given model, you shou
 en:
   activerecord:
     attributes:
-      user/subscribed_to_newsletter:
-        true: "True"
-        false: "False"
+      user/role:
+        admin: "Admin"
+        contributor: "Contributor"
 ```
 
-Then `User.human_attribute_name("subscribed_to_newsletter.true")` will return "True".
+Then `User.human_attribute_name("role.admin")` will return "Admin".
 
 NOTE: If you are using a class which includes `ActiveModel` and does not inherit from `ActiveRecord::Base`, replace `activerecord` with `activemodel` in the above key paths.
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -829,14 +829,14 @@ For example when you add the following translations:
 en:
   activerecord:
     models:
-      user: Dude
+      user: Customer
     attributes:
       user:
         login: "Handle"
       # will translate User attribute "login" as "Handle"
 ```
 
-Then `User.model_name.human` will return "Dude" and `User.human_attribute_name("login")` will return "Handle".
+Then `User.model_name.human` will return "Customer" and `User.human_attribute_name("login")` will return "Handle".
 
 You can also set a plural form for model names, adding as following:
 
@@ -845,11 +845,11 @@ en:
   activerecord:
     models:
       user:
-        one: Dude
-        other: Dudes
+        one: Customer
+        other: Customers
 ```
 
-Then `User.model_name.human(count: 2)` will return "Dudes". With `count: 1` or without params will return "Dude".
+Then `User.model_name.human(count: 2)` will return "Customers". With `count: 1` or without params will return "Customer".
 
 In the event you need to access nested attributes within a given model, you should nest these under `model/attribute` at the model level of your translation file:
 
@@ -857,12 +857,12 @@ In the event you need to access nested attributes within a given model, you shou
 en:
   activerecord:
     attributes:
-      user/gender:
-        female: "Female"
-        male: "Male"
+      user/subscribed_to_newsletter:
+        true: "True"
+        false: "False"
 ```
 
-Then `User.human_attribute_name("gender.female")` will return "Female".
+Then `User.human_attribute_name("subscribed_to_newsletter.true")` will return "True".
 
 NOTE: If you are using a class which includes `ActiveModel` and does not inherit from `ActiveRecord::Base`, replace `activerecord` with `activemodel` in the above key paths.
 


### PR DESCRIPTION
### Summary

I'd like to propose a couple of changes documentation to make it more inclusive of trans and non-binary individuals. I have changed examples that previously used a user's gender to use attributes like `favorite_color` or `subscribed_to_newsletter` instead.

### Other Information

The Rails Code of Conduct advises to use "welcoming and inclusive language" and this PR helps the documentation continue to evolve to be in line with the Code of Conduct. 
