### PR TITLE
File updater checker no longer feezes file list

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -44,7 +44,7 @@ module ActiveSupport
         raise ArgumentError, "A block is required to initialize a FileUpdateChecker"
       end
 
-      @files = files.freeze
+      @files = files.dup.freeze
       @glob  = compile_glob(dirs)
       @block = block
 

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -24,6 +24,13 @@ module FileUpdateCheckerSharedTests
     end
   end
 
+  test "must not freeze file list" do
+    list = []
+    refute list.frozen?
+    new_checker(list) {}
+    refute list.frozen?
+  end
+
   test "should not execute the block if no paths are given" do
     silence_warnings { require "listen" }
     i = 0


### PR DESCRIPTION
FileUpdateChecker initializer modifies input parameter `files` by calling `freeze`. This can lead to unexpected behaviour when things are set to initialize in different than standard order in Rails. This patch makes sure FileUpdateChecker has it's own frozen copy of files to watch.



More details about the problems we have can be found at:

https://github.com/Shopify/bootsnap/issues/106#issuecomment-381254534