### PR TITLE
Fixes StrongParameters `permit!` to work with nested arrays

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix strong parameters `permit!` with nested arrays
+
+    Strong parameters doesn't support nested arrays, take as example: `[[{ name: 'Leonardo', age: 26 }]]`.
+    This is separate from making `permit(something: [[:key]])` work properly, which is being addressed in #23650
+
+    *Steve Hull*
+
 *   Move default headers configuration into their own module that can be included in controllers.
 
     *Kevin Deisz*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -374,7 +374,7 @@ module ActionController
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def permit!
       each_pair do |key, value|
-        Array.wrap(value).each do |v|
+        Array.wrap(value).flatten.each do |v|
           v.permit! if v.respond_to? :permit!
         end
       end

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -353,12 +353,15 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "Jonas", @params[:person][:family][:brother]
   end
 
-  test "permit is recursive" do
+  test "permit! is recursive" do
+    @params[:nested_array] = [[{ x: 2, y: 3 }, { x: 21, y: 42 }]]
     @params.permit!
     assert_predicate @params, :permitted?
     assert_predicate @params[:person], :permitted?
     assert_predicate @params[:person][:name], :permitted?
     assert_predicate @params[:person][:addresses][0], :permitted?
+    assert_predicate @params[:nested_array][0][0], :permitted?
+    assert_predicate @params[:nested_array][0][1], :permitted?
   end
 
   test "permitted takes a default value when Parameters.permit_all_parameters is set" do


### PR DESCRIPTION
### Summary
`permit!` is intended to mark all instances of `ActionController::Parameters` as permitted, however nested arrays of params were not being marked permitted because the method did shallow iteration.
This fixes that by flattening the array before calling `permit!` on all each item.

A simple reproduction of the bug is:
```ruby
[1] pry(main)> params = ActionController::Parameters.new(name: "Steve", foo: [[{bar: 'baz'}]])
=> <ActionController::Parameters {"name"=>"Steve", "foo"=>[[{"bar"=>"baz"}]]} permitted: false>
[2] pry(main)> params.permit!
=> <ActionController::Parameters {"name"=>"Steve", "foo"=>[[<ActionController::Parameters {"bar"=>"baz"} permitted: false>]]} permitted: true>
```

### Other Information
This is related to #23650 however that PR does not fix the `permit!` method (as the entry point in that PR that was fixed was `each_element` but the `permit!` method uses `each_pair`.
