### PR TITLE
Update Rails minor version from 5.1 to 5.2 [ci skip]

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -10,7 +10,7 @@
 </p>
 <% else %>
 <p>
-  These are the new guides for Rails 5.1 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
+  These are the new guides for Rails 5.2 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>


### PR DESCRIPTION
### Summary

Update of Rails minor version on the guides welcome page to maintain consistency with the full Rails version ie 5.2.x