### PR TITLE
Add the reference to Rails Guides 5.2 from the Edge Guides

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -16,6 +16,7 @@
 <% end %>
 <p>
 The guides for earlier releases:
+<a href="http://guides.rubyonrails.org/v5.2/">Rails 5.2</a>,
 <a href="http://guides.rubyonrails.org/v5.1/">Rails 5.1</a>,
 <a href="http://guides.rubyonrails.org/v5.0/">Rails 5.0</a>,
 <a href="http://guides.rubyonrails.org/v4.2/">Rails 4.2</a>,


### PR DESCRIPTION
This PR adds the link to http://guides.rubyonrails.org/v5.2/ from http://edgeguides.rubyonrails.org/.