### PR TITLE
Remove unused attr_writer :joinable on Transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -75,7 +75,6 @@ module ActiveRecord
 
     class Transaction #:nodoc:
       attr_reader :connection, :state, :records, :savepoint_name
-      attr_writer :joinable
 
       def initialize(connection, options, run_commit_callbacks: false)
         @connection = connection


### PR DESCRIPTION
This was added in 280587588aba6ce13717cd6679e3f2b43d287443, but has been unused since 392eeecc11a291e406db927a18b75f41b2658253.