### PR TITLE
Make JS views rendered work with content security policy

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix JavaScript views rendering does not work with Firefox when using
+    Content Security Policy.
+
+    Fixes #32577.
+
+    *Yuji Yaginuma*
+
 *   Add the `nonce: true` option for `javascript_include_tag` helper to
     support automatic nonce generation for Content Security Policy.
     Works the same way as `javascript_tag nonce: true` does.

--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -66,7 +66,7 @@ processResponse = (response, type) ->
       try response = JSON.parse(response)
     else if type.match(/\b(?:java|ecma)script\b/)
       script = document.createElement('script')
-      script.nonce = cspNonce()
+      script.setAttribute('nonce', cspNonce())
       script.text = response
       document.head.appendChild(script).parentNode.removeChild(script)
     else if type.match(/\bxml\b/)


### PR DESCRIPTION
As of now,  `HTMLElement.nonce` seems to work only in Chrome. So, it should not be used now.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/nonce#Browser_compatibility

Fixes #32577.
