### PR TITLE
Output only one nonce in CSP header per request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     Fixes [#35297](https://github.com/rails/rails/issues/32597).
 
-    *Andrey Novikov*
+    *Andrey Novikov*, *Andrew White*
 
 *   Move default headers configuration into their own module that can be included in controllers.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Output only one Content-Security-Policy nonce header value per request.
+
+    Fixes [#35297](https://github.com/rails/rails/issues/32597).
+
+    *Andrey Novikov*
+
 *   Move default headers configuration into their own module that can be included in controllers.
 
     *Kevin Deisz*


### PR DESCRIPTION
### Summary

Fixes #32597: nonces are accumulated infinetely and all accumulated nonces sent in every response, this occurs only when policy is not redefined on controller level.

Ensure that we're adding only one nonce value to the Content-Security-Policy header and does not accumulate them.

### Other Information

Instead of pushing the generated nonce value to the list policy's `script-src` directive values on every request, a special generator object is being pushed to this list on policy (re-)declaration and called on every request. This is for keeping current API intact where Procs are called in scope of controller instance and nonce generator is given a request argument.