### PR TITLE
Handle SocketError in RedisCacheStore

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -436,7 +436,7 @@ module ActiveSupport
 
         def failsafe(method, returning: nil)
           yield
-        rescue ::Redis::BaseConnectionError => e
+        rescue ::Redis::BaseConnectionError, SocketError => e
           handle_exception exception: e, method: method, returning: returning
           returning
         end


### PR DESCRIPTION
### Summary

Overall the Redis does a good job of encapsulating lower level network exception and re-raise them as `Redis::BaseConnectionError`, however it's missing one: https://github.com/redis/redis-rb/pull/631

Hopefully this will be fixed upstream one day, but for now I think `RedisStore` should handle such cases.

Here's a production backtrace of the issue this aim to handle:

```
SocketError - getaddrinfo: Try again
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/connection/ruby.rb:210getaddrinfo	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/connection/ruby.rb:210connect	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/connection/ruby.rb:293connect	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:334establish_connection	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:99block in connect	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:291with_reconnect	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:98connect	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:363ensure_connected	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:219block in process	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:304logging	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:218process	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis/client.rb:118call	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis.rb:889block in get	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis.rb:45block in synchronize	
/usr/lib/ruby/2.4.0/monitor.rb:214mon_synchronize	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis.rb:45synchronize	
/bundle/ruby/2.4.0/gems/redis-4.0.1/lib/redis.rb:888get	
/bundle/ruby/2.4.0/gems/activesupport-5.2.0.rc2/lib/active_support/cache/redis_cache_store.rb:324block (2 levels) in read_entry
```

This kind of things happen on a regular basis on some environments (cloud mostly).

cc @rafaelfranca @Edouard-chin @wvanbergen 