### PR TITLE
Add RuboCop for `assert_not` over `assert !`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,11 @@ CustomCops/RefuteNot:
   Include:
     - '**/*_test.rb'
 
+# Prefer assert_not over assert !
+CustomCops/AssertNot:
+  Include:
+    - '**/*_test.rb'
+
 # Prefer &&/|| over and/or.
 Style/AndOr:
   Enabled: true

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -83,7 +83,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
       connection.subscriptions.expects(:unsubscribe_from_all)
       connection.send :handle_close
 
-      assert ! connection.connected
+      assert_not connection.connected
       assert_equal [], @server.connections
     end
   end

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -40,14 +40,14 @@ class FragmentCachingTest < BaseCachingTest
   def test_fragment_exist_with_caching_enabled
     @store.write("views/name", "value")
     assert @mailer.fragment_exist?("name")
-    assert !@mailer.fragment_exist?("other_name")
+    assert_not @mailer.fragment_exist?("other_name")
   end
 
   def test_fragment_exist_with_caching_disabled
     @mailer.perform_caching = false
     @store.write("views/name", "value")
-    assert !@mailer.fragment_exist?("name")
-    assert !@mailer.fragment_exist?("other_name")
+    assert_not @mailer.fragment_exist?("name")
+    assert_not @mailer.fragment_exist?("other_name")
   end
 
   def test_write_fragment_with_caching_enabled
@@ -90,7 +90,7 @@ class FragmentCachingTest < BaseCachingTest
     buffer = "generated till now -> ".html_safe
     buffer << view_context.send(:fragment_for, "expensive") { fragment_computed = true }
 
-    assert !fragment_computed
+    assert_not fragment_computed
     assert_equal "generated till now -> fragment content", buffer
   end
 

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -154,7 +154,7 @@ module AbstractController
 
       test "when :except is specified, an after action is not triggered on that action" do
         @controller.process(:index)
-        assert !@controller.instance_variable_defined?("@authenticated")
+        assert_not @controller.instance_variable_defined?("@authenticated")
       end
     end
 
@@ -198,7 +198,7 @@ module AbstractController
 
       test "when :except is specified with an array, an after action is not triggered on that action" do
         @controller.process(:index)
-        assert !@controller.instance_variable_defined?("@authenticated")
+        assert_not @controller.instance_variable_defined?("@authenticated")
       end
     end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -290,13 +290,13 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
 
   def test_template_objects_exist
     process :assign_this
-    assert !@controller.instance_variable_defined?(:"@hi")
+    assert_not @controller.instance_variable_defined?(:"@hi")
     assert @controller.instance_variable_get(:"@howdy")
   end
 
   def test_template_objects_missing
     process :nothing
-    assert !@controller.instance_variable_defined?(:@howdy)
+    assert_not @controller.instance_variable_defined?(:@howdy)
   end
 
   def test_empty_flash
@@ -366,7 +366,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     process :redirect_external
     assert_predicate @response, :redirect?
     assert_match(/rubyonrails/, @response.redirect_url)
-    assert !/perloffrails/.match(@response.redirect_url)
+    assert_not /perloffrails/.match(@response.redirect_url)
   end
 
   def test_redirection

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -94,14 +94,14 @@ class FragmentCachingTest < ActionController::TestCase
   def test_fragment_exist_with_caching_enabled
     @store.write("views/name", "value")
     assert @controller.fragment_exist?("name")
-    assert !@controller.fragment_exist?("other_name")
+    assert_not @controller.fragment_exist?("other_name")
   end
 
   def test_fragment_exist_with_caching_disabled
     @controller.perform_caching = false
     @store.write("views/name", "value")
-    assert !@controller.fragment_exist?("name")
-    assert !@controller.fragment_exist?("other_name")
+    assert_not @controller.fragment_exist?("name")
+    assert_not @controller.fragment_exist?("other_name")
   end
 
   def test_write_fragment_with_caching_enabled
@@ -144,7 +144,7 @@ class FragmentCachingTest < ActionController::TestCase
     buffer = "generated till now -> ".html_safe
     buffer << view_context.send(:fragment_for, "expensive") { fragment_computed = true }
 
-    assert !fragment_computed
+    assert_not fragment_computed
     assert_equal "generated till now -> fragment content", buffer
   end
 

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -787,7 +787,7 @@ class FilterTest < ActionController::TestCase
     assert_equal %w( ensure_login find_user ), @controller.instance_variable_get(:@ran_filter)
 
     test_process(ConditionalSkippingController, "login")
-    assert !@controller.instance_variable_defined?("@ran_after_action")
+    assert_not @controller.instance_variable_defined?("@ran_after_action")
     test_process(ConditionalSkippingController, "change_password")
     assert_equal %w( clean_up ), @controller.instance_variable_get("@ran_after_action")
   end

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -44,7 +44,7 @@ module ActionDispatch
       @hash["foo"] = "bar"
       @hash.delete "foo"
 
-      assert !@hash.key?("foo")
+      assert_not @hash.key?("foo")
       assert_nil @hash["foo"]
     end
 
@@ -53,7 +53,7 @@ module ActionDispatch
       assert_equal({ "foo" => "bar" }, @hash.to_hash)
 
       @hash.to_hash["zomg"] = "aaron"
-      assert !@hash.key?("zomg")
+      assert_not @hash.key?("zomg")
       assert_equal({ "foo" => "bar" }, @hash.to_hash)
     end
 

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -202,7 +202,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
 
   test "validate_digest_response should fail with nil returning password_procedure" do
     @request.env["HTTP_AUTHORIZATION"] = encode_credentials(username: nil, password: nil)
-    assert !ActionController::HttpAuthentication::Digest.validate_digest_response(@request, "SuperSecret") { nil }
+    assert_not ActionController::HttpAuthentication::Digest.validate_digest_response(@request, "SuperSecret") { nil }
   end
 
   test "authentication request with request-uri ending in '/'" do

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -135,7 +135,7 @@ class IntegrationTestTest < ActiveSupport::TestCase
     session1 = @test.open_session { |sess| }
     session2 = @test.open_session # implicit session
 
-    assert !session1.equal?(session2)
+    assert_not session1.equal?(session2)
   end
 
   # RSpec mixes Matchers (which has a #method_missing) into

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -136,7 +136,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "key: it is not assigned if not present in params" do
     params = ActionController::Parameters.new(name: "Joe")
     permitted = params.permit(:id)
-    assert !permitted.has_key?(:id)
+    assert_not permitted.has_key?(:id)
   end
 
   test "key to empty array: empty arrays pass" do

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -65,8 +65,8 @@ class CookieJarTest < ActiveSupport::TestCase
   end
 
   def test_key_methods
-    assert !request.cookie_jar.key?(:foo)
-    assert !request.cookie_jar.has_key?("foo")
+    assert_not request.cookie_jar.key?(:foo)
+    assert_not request.cookie_jar.has_key?("foo")
 
     request.cookie_jar[:foo] = :bar
     assert request.cookie_jar.key?(:foo)

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -81,7 +81,7 @@ class ExecutorTest < ActiveSupport::TestCase
 
     running = false
     body.close
-    assert !running
+    assert_not running
   end
 
   def test_complete_callbacks_are_called_on_close
@@ -89,7 +89,7 @@ class ExecutorTest < ActiveSupport::TestCase
     executor.to_complete { completed = true }
 
     body = call_and_return_body
-    assert !completed
+    assert_not completed
 
     body.close
     assert completed
@@ -116,7 +116,7 @@ class ExecutorTest < ActiveSupport::TestCase
 
     call_and_return_body.close
     assert result
-    assert !defined?(@in_shared_context) # it's not in the test itself
+    assert_not defined?(@in_shared_context) # it's not in the test itself
   end
 
   private

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -180,8 +180,8 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert Mime[:js] =~ "text/javascript"
     assert Mime[:js] =~ "application/javascript"
     assert Mime[:js] !~ "text/html"
-    assert !(Mime[:js] !~ "text/javascript")
-    assert !(Mime[:js] !~ "application/javascript")
+    assert_not (Mime[:js] !~ "text/javascript")
+    assert_not (Mime[:js] !~ "application/javascript")
     assert Mime[:html] =~ "application/xhtml+xml"
   end
 end

--- a/actionpack/test/dispatch/reloader_test.rb
+++ b/actionpack/test/dispatch/reloader_test.rb
@@ -115,7 +115,7 @@ class ReloaderTest < ActiveSupport::TestCase
     reloader.to_complete { completed = true }
 
     body = call_and_return_body
-    assert !completed
+    assert_not completed
 
     body.close
     assert completed
@@ -129,7 +129,7 @@ class ReloaderTest < ActiveSupport::TestCase
     prepared = false
 
     body.close
-    assert !prepared
+    assert_not prepared
   end
 
   def test_complete_callbacks_are_called_on_exceptions

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -191,7 +191,7 @@ class ResponseTest < ActiveSupport::TestCase
   test "does not include Status header" do
     @response.status = "200 OK"
     _, headers, _ = @response.to_a
-    assert !headers.has_key?("Status")
+    assert_not headers.has_key?("Status")
   end
 
   test "response code" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3166,7 +3166,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       end
     end
 
-    assert !respond_to?(:routes_no_collision_path)
+    assert_not respond_to?(:routes_no_collision_path)
   end
 
   def test_controller_name_with_leading_slash_raise_error

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -49,21 +49,21 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_multiple_calls
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title, "bar"
     assert_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_multiple_calls_and_flush
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title, "bar", flush: true
     assert_equal "bar", content_for(:title)
   end
 
   def test_content_for_with_block
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title do
       output_buffer << "foo"
       output_buffer << "bar"
@@ -73,7 +73,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_block_and_multiple_calls_with_flush
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title do
       "foo"
     end
@@ -84,7 +84,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_block_and_multiple_calls_with_flush_nil_content
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title do
       "foo"
     end
@@ -95,7 +95,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_block_and_multiple_calls_without_flush
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title do
       "foo"
     end
@@ -106,7 +106,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_whitespace_block
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title do
       output_buffer << "  \n  "
@@ -117,7 +117,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_with_whitespace_block_and_flush
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title, flush: true do
       output_buffer << "  \n  "
@@ -128,7 +128,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_returns_nil_when_writing
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     assert_nil content_for(:title, "foo")
     assert_nil content_for(:title) { output_buffer << "bar"; nil }
     assert_nil content_for(:title) { output_buffer << "  \n  "; nil }
@@ -144,14 +144,14 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_content_for_question_mark
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title, "title"
     assert content_for?(:title)
-    assert ! content_for?(:something_else)
+    assert_not content_for?(:something_else)
   end
 
   def test_content_for_should_be_html_safe_after_flush_empty
-    assert ! content_for?(:title)
+    assert_not content_for?(:title)
     content_for :title do
       content_tag(:p, "title")
     end
@@ -164,7 +164,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_provide
-    assert !content_for?(:title)
+    assert_not content_for?(:title)
     provide :title, "hi"
     assert content_for?(:title)
     assert_equal "hi", content_for(:title)

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -195,7 +195,7 @@ class LookupContextTest < ActiveSupport::TestCase
 
     assert @lookup_context.cache
     template = @lookup_context.disable_cache do
-      assert !@lookup_context.cache
+      assert_not @lookup_context.cache
       @lookup_context.find("foo", %w(test), true)
     end
     assert @lookup_context.cache

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -192,7 +192,7 @@ module ActionView
     helper HelperThatInvokesProtectAgainstForgery
 
     test "protect_from_forgery? in any helpers returns false" do
-      assert !view.help_me
+      assert_not view.help_me
     end
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -508,16 +508,16 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_considering_params
     @request = request_for_url("/?order=desc&page=1")
 
-    assert !current_page?(url_hash, check_parameters: true)
-    assert !current_page?(url_hash.merge(check_parameters: true))
-    assert !current_page?(ActionController::Parameters.new(url_hash.merge(check_parameters: true)).permit!)
-    assert !current_page?("http://www.example.com/", check_parameters: true)
+    assert_not current_page?(url_hash, check_parameters: true)
+    assert_not current_page?(url_hash.merge(check_parameters: true))
+    assert_not current_page?(ActionController::Parameters.new(url_hash.merge(check_parameters: true)).permit!)
+    assert_not current_page?("http://www.example.com/", check_parameters: true)
   end
 
   def test_current_page_considering_params_when_options_does_not_respond_to_to_hash
     @request = request_for_url("/?order=desc&page=1")
 
-    assert !current_page?(:back, check_parameters: false)
+    assert_not current_page?(:back, check_parameters: false)
   end
 
   def test_current_page_with_params_that_match
@@ -562,7 +562,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_not_get_verb
     @request = request_for_url("/events", method: :post)
 
-    assert !current_page?("/events")
+    assert_not current_page?("/events")
   end
 
   def test_link_unless_current

--- a/activemodel/test/cases/attributes_dirty_test.rb
+++ b/activemodel/test/cases/attributes_dirty_test.rb
@@ -39,7 +39,7 @@ class AttributesDirtyTest < ActiveModel::TestCase
   end
 
   test "changes to attribute values" do
-    assert !@model.changes["name"]
+    assert_not @model.changes["name"]
     @model.name = "John"
     assert_equal [nil, "John"], @model.changes["name"]
   end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -78,7 +78,7 @@ class DirtyTest < ActiveModel::TestCase
   end
 
   test "changes to attribute values" do
-    assert !@model.changes["name"]
+    assert_not @model.changes["name"]
     @model.name = "John"
     assert_equal [nil, "John"], @model.changes["name"]
   end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -207,26 +207,26 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "added? returns false when no errors are present" do
     person = Person.new
-    assert !person.errors.added?(:name)
+    assert_not person.errors.added?(:name)
   end
 
   test "added? returns false when checking a nonexisting error and other errors are present for the given attribute" do
     person = Person.new
     person.errors.add(:name, "is invalid")
-    assert !person.errors.added?(:name, "cannot be blank")
+    assert_not person.errors.added?(:name, "cannot be blank")
   end
 
   test "added? returns false when checking for an error, but not providing message arguments" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")
-    assert !person.errors.added?(:name)
+    assert_not person.errors.added?(:name)
   end
 
   test "added? returns false when checking for an error by symbol and a different error with same message is present" do
     I18n.backend.store_translations("en", errors: { attributes: { name: { wrong: "is wrong", used: "is wrong" } } })
     person = Person.new
     person.errors.add(:name, :wrong)
-    assert !person.errors.added?(:name, :used)
+    assert_not person.errors.added?(:name, :used)
   end
 
   test "size calculates the number of error messages" do

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -187,7 +187,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "authenticate" do
     @user.password = "secret"
 
-    assert !@user.authenticate("wrong")
+    assert_not @user.authenticate("wrong")
     assert @user.authenticate("secret")
   end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       indexes = @connection.indexes("accounts")
       assert_equal "accounts", indexes.first.table
       assert_equal idx_name, indexes.first.name
-      assert !indexes.first.unique
+      assert_not indexes.first.unique
       assert_equal ["firm_id"], indexes.first.columns
     ensure
       @connection.remove_index(:accounts, name: idx_name) rescue nil

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -148,8 +148,8 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
           t.timestamps null: true
         end
         ActiveRecord::Base.connection.remove_timestamps :delete_me, null: true
-        assert !column_present?("delete_me", "updated_at", "datetime")
-        assert !column_present?("delete_me", "created_at", "datetime")
+        assert_not column_present?("delete_me", "updated_at", "datetime")
+        assert_not column_present?("delete_me", "created_at", "datetime")
       ensure
         ActiveRecord::Base.connection.drop_table :delete_me rescue nil
       end

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -116,8 +116,8 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
       end
     end
 
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
   end
 
   def test_timestamps_without_null_set_null_to_false_on_change_table
@@ -129,8 +129,8 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
       end
     end
 
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
   end
 
   def test_timestamps_without_null_set_null_to_false_on_add_timestamps
@@ -139,7 +139,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
       add_timestamps :has_timestamps, default: Time.now
     end
 
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert_not @connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
   end
 end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -569,7 +569,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     developer = Developer.create name: "Bryan", salary: 50_000
 
     assert_not_predicate project.developers, :loaded?
-    assert ! project.developers.include?(developer)
+    assert_not project.developers.include?(developer)
   end
 
   def test_find_with_merged_options

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2009,7 +2009,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_none_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
     firm.clients.load  # force load
-    assert_no_queries { assert ! firm.clients.none? }
+    assert_no_queries { assert_not firm.clients.none? }
   end
 
   def test_calling_none_should_defer_to_collection_if_using_a_block
@@ -2044,7 +2044,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_one_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
     firm.clients.load  # force load
-    assert_no_queries { assert ! firm.clients.one? }
+    assert_no_queries { assert_not firm.clients.one? }
   end
 
   def test_calling_one_should_defer_to_collection_if_using_a_block

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -866,7 +866,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     author   = authors(:mary)
     category = author.named_categories.create(name: "Primary")
     author.named_categories.delete(category)
-    assert !Categorization.exists?(author_id: author.id, named_category_name: category.name)
+    assert_not Categorization.exists?(author_id: author.id, named_category_name: category.name)
     assert_empty author.named_categories.reload
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -452,7 +452,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal new_ship, pirate.ship
     assert_predicate new_ship, :new_record?
     assert_nil orig_ship.pirate_id
-    assert !orig_ship.changed? # check it was saved
+    assert_not orig_ship.changed? # check it was saved
   end
 
   def test_creation_failure_with_dependent_option

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -732,7 +732,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     category = Category.create!(name: "Not Associated")
 
     assert_not_predicate david.categories, :loaded?
-    assert ! david.categories.include?(category)
+    assert_not david.categories.include?(category)
   end
 
   def test_has_many_through_goes_through_all_sti_classes

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -63,8 +63,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     t.author_name = ""
     assert t.attribute_present?("title")
     assert t.attribute_present?("written_on")
-    assert !t.attribute_present?("content")
-    assert !t.attribute_present?("author_name")
+    assert_not t.attribute_present?("content")
+    assert_not t.attribute_present?("author_name")
   end
 
   test "attribute_present with booleans" do
@@ -77,7 +77,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert b2.attribute_present?(:value)
 
     b3 = Boolean.new
-    assert !b3.attribute_present?(:value)
+    assert_not b3.attribute_present?(:value)
 
     b4 = Boolean.new
     b4.value = false
@@ -827,7 +827,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       self.table_name = "computers"
     end
 
-    assert !klass.instance_method_already_implemented?(:system)
+    assert_not klass.instance_method_already_implemented?(:system)
     computer = klass.new
     assert_nil computer.system
   end
@@ -841,8 +841,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       self.table_name = "computers"
     end
 
-    assert !klass.instance_method_already_implemented?(:system)
-    assert !subklass.instance_method_already_implemented?(:system)
+    assert_not klass.instance_method_already_implemented?(:system)
+    assert_not subklass.instance_method_already_implemented?(:system)
     computer = subklass.new
     assert_nil computer.system
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -116,7 +116,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
 
     assert_not_predicate firm.account, :valid?
     assert_not_predicate firm, :valid?
-    assert !firm.save
+    assert_not firm.save
     assert_equal ["is invalid"], firm.errors["account"]
   end
 
@@ -237,7 +237,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     log.developer = Developer.new
     assert_not_predicate log.developer, :valid?
     assert_not_predicate log, :valid?
-    assert !log.save
+    assert_not log.save
     assert_equal ["is invalid"], log.errors["developer"]
   end
 
@@ -499,10 +499,10 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
   def test_invalid_adding
     firm = Firm.find(1)
-    assert !(firm.clients_of_firm << c = Client.new)
+    assert_not (firm.clients_of_firm << c = Client.new)
     assert_not_predicate c, :persisted?
     assert_not_predicate firm, :valid?
-    assert !firm.save
+    assert_not firm.save
     assert_not_predicate c, :persisted?
   end
 
@@ -512,7 +512,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_not_predicate c, :persisted?
     assert_not_predicate c, :valid?
     assert_not_predicate new_firm, :valid?
-    assert !new_firm.save
+    assert_not new_firm.save
     assert_not_predicate c, :persisted?
     assert_not_predicate new_firm, :persisted?
   end
@@ -550,7 +550,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_not_predicate new_client, :persisted?
     assert_not_predicate new_client, :valid?
     assert_equal new_client, companies(:first_firm).clients_of_firm.last
-    assert !companies(:first_firm).save
+    assert_not companies(:first_firm).save
     assert_not_predicate new_client, :persisted?
     assert_equal 2, companies(:first_firm).clients_of_firm.reload.size
   end
@@ -795,7 +795,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     @ship.pirate.catchphrase = "Changed Catchphrase"
     @ship.name_will_change!
 
-    assert_raise(RuntimeError) { assert !@pirate.save }
+    assert_raise(RuntimeError) { assert_not @pirate.save }
     assert_not_nil @pirate.reload.ship
   end
 
@@ -855,7 +855,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
     @ship.pirate.catchphrase = "Changed Catchphrase"
 
-    assert_raise(RuntimeError) { assert !@ship.save }
+    assert_raise(RuntimeError) { assert_not @ship.save }
     assert_not_nil @ship.reload.pirate
   end
 
@@ -871,7 +871,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_destroy_has_many_as_part_of_the_save_transaction_if_they_were_marked_for_destruction
     2.times { |i| @pirate.birds.create!(name: "birds_#{i}") }
 
-    assert !@pirate.birds.any?(&:marked_for_destruction?)
+    assert_not @pirate.birds.any?(&:marked_for_destruction?)
 
     @pirate.birds.each(&:mark_for_destruction)
     klass = @pirate.birds.first.class
@@ -937,7 +937,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       end
     end
 
-    assert_raise(RuntimeError) { assert !@pirate.save }
+    assert_raise(RuntimeError) { assert_not @pirate.save }
     assert_equal before, @pirate.reload.birds
   end
 
@@ -1003,7 +1003,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_destroy_habtm_as_part_of_the_save_transaction_if_they_were_marked_for_destruction
     2.times { |i| @pirate.parrots.create!(name: "parrots_#{i}") }
 
-    assert !@pirate.parrots.any?(&:marked_for_destruction?)
+    assert_not @pirate.parrots.any?(&:marked_for_destruction?)
     @pirate.parrots.each(&:mark_for_destruction)
 
     assert_no_difference "Parrot.count" do
@@ -1065,7 +1065,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
       end
     end
 
-    assert_raise(RuntimeError) { assert !@pirate.save }
+    assert_raise(RuntimeError) { assert_not @pirate.save }
     assert_equal before, @pirate.reload.parrots
   end
 
@@ -1213,7 +1213,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
     assert_no_difference "Pirate.count" do
       assert_no_difference "Ship.count" do
-        assert !pirate.save
+        assert_not pirate.save
       end
     end
   end
@@ -1232,7 +1232,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
       end
     end
 
-    assert_raise(RuntimeError) { assert !@pirate.save }
+    assert_raise(RuntimeError) { assert_not @pirate.save }
     assert_equal before, [@pirate.reload.catchphrase, @pirate.ship.name]
   end
 
@@ -1337,7 +1337,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
 
     assert_no_difference "Ship.count" do
       assert_no_difference "Pirate.count" do
-        assert !ship.save
+        assert_not ship.save
       end
     end
   end
@@ -1356,7 +1356,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
       end
     end
 
-    assert_raise(RuntimeError) { assert !@ship.save }
+    assert_raise(RuntimeError) { assert_not @ship.save }
     assert_equal before, [@ship.pirate.reload.catchphrase, @ship.reload.name]
   end
 
@@ -1480,7 +1480,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @child_1.name = "Changed"
     @child_1.cancel_save_from_callback = true
 
-    assert !@pirate.save
+    assert_not @pirate.save
     assert_equal "Don' botharrr talkin' like one, savvy?", @pirate.reload.catchphrase
     assert_equal "Posideons Killer", @child_1.reload.name
 
@@ -1490,7 +1490,7 @@ module AutosaveAssociationOnACollectionAssociationTests
 
     assert_no_difference "Pirate.count" do
       assert_no_difference "#{new_child.class.name}.count" do
-        assert !new_pirate.save
+        assert_not new_pirate.save
       end
     end
   end
@@ -1510,7 +1510,7 @@ module AutosaveAssociationOnACollectionAssociationTests
       end
     end
 
-    assert_raise(RuntimeError) { assert !@pirate.save }
+    assert_raise(RuntimeError) { assert_not @pirate.save }
     assert_equal before, [@pirate.reload.catchphrase, *@pirate.send(@association_name).map(&:name)]
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -307,7 +307,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "Dude", cbs[0].name
     assert_equal "Bob", cbs[1].name
     assert cbs[0].frickinawesome
-    assert !cbs[1].frickinawesome
+    assert_not cbs[1].frickinawesome
   end
 
   def test_load
@@ -856,11 +856,11 @@ class BasicsTest < ActiveRecord::TestCase
   def test_clone_of_new_object_marks_as_dirty_only_changed_attributes
     developer = Developer.new name: "Bjorn"
     assert developer.name_changed?            # obviously
-    assert !developer.salary_changed?         # attribute has non-nil default value, so treated as not changed
+    assert_not developer.salary_changed?         # attribute has non-nil default value, so treated as not changed
 
     cloned_developer = developer.clone
     assert_predicate cloned_developer, :name_changed?
-    assert !cloned_developer.salary_changed?  # ... and cloned instance should behave same
+    assert_not cloned_developer.salary_changed?  # ... and cloned instance should behave same
   end
 
   def test_dup_of_saved_object_marks_attributes_as_dirty
@@ -875,12 +875,12 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_dup_of_saved_object_marks_as_dirty_only_changed_attributes
     developer = Developer.create! name: "Bjorn"
-    assert !developer.name_changed?           # both attributes of saved object should be treated as not changed
+    assert_not developer.name_changed?           # both attributes of saved object should be treated as not changed
     assert_not_predicate developer, :salary_changed?
 
     cloned_developer = developer.dup
     assert cloned_developer.name_changed?     # ... but on cloned object should be
-    assert !cloned_developer.salary_changed?  # ... BUT salary has non-nil default which should be treated as not changed on cloned instance
+    assert_not cloned_developer.salary_changed?  # ... BUT salary has non-nil default which should be treated as not changed on cloned instance
   end
 
   def test_bignum

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -385,9 +385,9 @@ class CallbacksTest < ActiveRecord::TestCase
   end
 
   def assert_save_callbacks_not_called(someone)
-    assert !someone.after_save_called
-    assert !someone.after_create_called
-    assert !someone.after_update_called
+    assert_not someone.after_save_called
+    assert_not someone.after_create_called
+    assert_not someone.after_update_called
   end
   private :assert_save_callbacks_not_called
 
@@ -395,27 +395,27 @@ class CallbacksTest < ActiveRecord::TestCase
     someone = CallbackHaltedDeveloper.new
     someone.cancel_before_create = true
     assert_predicate someone, :valid?
-    assert !someone.save
+    assert_not someone.save
     assert_save_callbacks_not_called(someone)
   end
 
   def test_before_save_throwing_abort
     david = DeveloperWithCanceledCallbacks.find(1)
     assert_predicate david, :valid?
-    assert !david.save
+    assert_not david.save
     exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
     assert_equal david, exc.record
 
     david = DeveloperWithCanceledCallbacks.find(1)
     david.salary = 10_000_000
     assert_not_predicate david, :valid?
-    assert !david.save
+    assert_not david.save
     assert_raise(ActiveRecord::RecordInvalid) { david.save! }
 
     someone = CallbackHaltedDeveloper.find(1)
     someone.cancel_before_save = true
     assert_predicate someone, :valid?
-    assert !someone.save
+    assert_not someone.save
     assert_save_callbacks_not_called(someone)
   end
 
@@ -423,22 +423,22 @@ class CallbacksTest < ActiveRecord::TestCase
     someone = CallbackHaltedDeveloper.find(1)
     someone.cancel_before_update = true
     assert_predicate someone, :valid?
-    assert !someone.save
+    assert_not someone.save
     assert_save_callbacks_not_called(someone)
   end
 
   def test_before_destroy_throwing_abort
     david = DeveloperWithCanceledCallbacks.find(1)
-    assert !david.destroy
+    assert_not david.destroy
     exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
     assert_equal david, exc.record
     assert_not_nil ImmutableDeveloper.find_by_id(1)
 
     someone = CallbackHaltedDeveloper.find(1)
     someone.cancel_before_destroy = true
-    assert !someone.destroy
+    assert_not someone.destroy
     assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
-    assert !someone.after_destroy_called
+    assert_not someone.after_destroy_called
   end
 
   def test_callback_throwing_abort
@@ -467,12 +467,12 @@ class CallbacksTest < ActiveRecord::TestCase
 
   def test_inheritance_of_callbacks
     parent = ParentDeveloper.new
-    assert !parent.after_save_called
+    assert_not parent.after_save_called
     parent.save
     assert parent.after_save_called
 
     child = ChildDeveloper.new
-    assert !child.after_save_called
+    assert_not child.after_save_called
     child.save
     assert child.after_save_called
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -366,7 +366,7 @@ class DirtyTest < ActiveRecord::TestCase
   def test_changed_attributes_should_be_preserved_if_save_failure
     pirate = Pirate.new
     pirate.parrot_id = 1
-    assert !pirate.save
+    assert_not pirate.save
     check_pirate_after_save_failure(pirate)
 
     pirate = Pirate.new
@@ -496,7 +496,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not_nil pirate.previous_changes["updated_on"][1]
     assert_nil pirate.previous_changes["created_on"][0]
     assert_not_nil pirate.previous_changes["created_on"][1]
-    assert !pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("parrot_id")
 
     # original values should be in previous_changes
     pirate = Pirate.new
@@ -510,7 +510,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal [nil, pirate.id], pirate.previous_changes["id"]
     assert_includes pirate.previous_changes, "updated_on"
     assert_includes pirate.previous_changes, "created_on"
-    assert !pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("parrot_id")
 
     pirate.catchphrase = "Yar!!"
     pirate.reload
@@ -527,8 +527,8 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["arrr", "Me Maties!"], pirate.previous_changes["catchphrase"]
     assert_not_nil pirate.previous_changes["updated_on"][0]
     assert_not_nil pirate.previous_changes["updated_on"][1]
-    assert !pirate.previous_changes.key?("parrot_id")
-    assert !pirate.previous_changes.key?("created_on")
+    assert_not pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("created_on")
 
     pirate = Pirate.find_by_catchphrase("Me Maties!")
 
@@ -541,8 +541,8 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["Me Maties!", "Thar She Blows!"], pirate.previous_changes["catchphrase"]
     assert_not_nil pirate.previous_changes["updated_on"][0]
     assert_not_nil pirate.previous_changes["updated_on"][1]
-    assert !pirate.previous_changes.key?("parrot_id")
-    assert !pirate.previous_changes.key?("created_on")
+    assert_not pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("created_on")
 
     travel(1.second)
 
@@ -553,8 +553,8 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["Thar She Blows!", "Ahoy!"], pirate.previous_changes["catchphrase"]
     assert_not_nil pirate.previous_changes["updated_on"][0]
     assert_not_nil pirate.previous_changes["updated_on"][1]
-    assert !pirate.previous_changes.key?("parrot_id")
-    assert !pirate.previous_changes.key?("created_on")
+    assert_not pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("created_on")
 
     travel(1.second)
 
@@ -565,8 +565,8 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["Ahoy!", "Ninjas suck!"], pirate.previous_changes["catchphrase"]
     assert_not_nil pirate.previous_changes["updated_on"][0]
     assert_not_nil pirate.previous_changes["updated_on"][1]
-    assert !pirate.previous_changes.key?("parrot_id")
-    assert !pirate.previous_changes.key?("created_on")
+    assert_not pirate.previous_changes.key?("parrot_id")
+    assert_not pirate.previous_changes.key?("created_on")
   ensure
     travel_back
   end

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -171,7 +171,7 @@ module ActiveRecord
         end
       end
 
-      assert !movie.persisted?
+      assert_not movie.persisted?
     end
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -727,8 +727,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_raise(ActiveModel::MissingAttributeError) { topic.title? }
     assert_nil topic.read_attribute("title")
     assert_equal "David", topic.author_name
-    assert !topic.attribute_present?("title")
-    assert !topic.attribute_present?(:title)
+    assert_not topic.attribute_present?("title")
+    assert_not topic.attribute_present?(:title)
     assert topic.attribute_present?("author_name")
     assert_respond_to topic, "author_name"
   end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -592,10 +592,10 @@ class FixturesWithoutInstantiationTest < ActiveRecord::TestCase
   fixtures :topics, :developers, :accounts
 
   def test_without_complete_instantiation
-    assert !defined?(@first)
-    assert !defined?(@topics)
-    assert !defined?(@developers)
-    assert !defined?(@accounts)
+    assert_not defined?(@first)
+    assert_not defined?(@topics)
+    assert_not defined?(@developers)
+    assert_not defined?(@accounts)
   end
 
   def test_fixtures_from_root_yml_without_instantiation
@@ -1082,13 +1082,13 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   def test_supports_inline_habtm
     assert(parrots(:george).treasures.include?(treasures(:diamond)))
     assert(parrots(:george).treasures.include?(treasures(:sapphire)))
-    assert(!parrots(:george).treasures.include?(treasures(:ruby)))
+    assert_not(parrots(:george).treasures.include?(treasures(:ruby)))
   end
 
   def test_supports_inline_habtm_with_specified_id
     assert(parrots(:polly).treasures.include?(treasures(:ruby)))
     assert(parrots(:polly).treasures.include?(treasures(:sapphire)))
-    assert(!parrots(:polly).treasures.include?(treasures(:diamond)))
+    assert_not(parrots(:polly).treasures.include?(treasures(:diamond)))
   end
 
   def test_supports_yaml_arrays

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -215,7 +215,7 @@ module ActiveRecord
       migration = InvertibleMigration.new
       migration.migrate :up
       migration.migrate :down
-      assert !migration.connection.table_exists?("horses")
+      assert_not migration.connection.table_exists?("horses")
     end
 
     def test_migrate_revert
@@ -223,11 +223,11 @@ module ActiveRecord
       revert = InvertibleRevertMigration.new
       migration.migrate :up
       revert.migrate :up
-      assert !migration.connection.table_exists?("horses")
+      assert_not migration.connection.table_exists?("horses")
       revert.migrate :down
       assert migration.connection.table_exists?("horses")
       migration.migrate :down
-      assert !migration.connection.table_exists?("horses")
+      assert_not migration.connection.table_exists?("horses")
     end
 
     def test_migrate_revert_by_part
@@ -241,12 +241,12 @@ module ActiveRecord
       }
       migration.migrate :up
       assert_equal [:both, :up], received
-      assert !migration.connection.table_exists?("horses")
+      assert_not migration.connection.table_exists?("horses")
       assert migration.connection.table_exists?("new_horses")
       migration.migrate :down
       assert_equal [:both, :up, :both, :down], received
       assert migration.connection.table_exists?("horses")
-      assert !migration.connection.table_exists?("new_horses")
+      assert_not migration.connection.table_exists?("new_horses")
     end
 
     def test_migrate_revert_whole_migration
@@ -255,11 +255,11 @@ module ActiveRecord
         revert = RevertWholeMigration.new(klass)
         migration.migrate :up
         revert.migrate :up
-        assert !migration.connection.table_exists?("horses")
+        assert_not migration.connection.table_exists?("horses")
         revert.migrate :down
         assert migration.connection.table_exists?("horses")
         migration.migrate :down
-        assert !migration.connection.table_exists?("horses")
+        assert_not migration.connection.table_exists?("horses")
       end
     end
 
@@ -268,7 +268,7 @@ module ActiveRecord
       revert.migrate :down
       assert revert.connection.table_exists?("horses")
       revert.migrate :up
-      assert !revert.connection.table_exists?("horses")
+      assert_not revert.connection.table_exists?("horses")
     end
 
     def test_migrate_revert_change_column_default
@@ -402,7 +402,7 @@ module ActiveRecord
 
       UpOnlyMigration.new.migrate(:down) # should be no error
       connection = ActiveRecord::Base.connection
-      assert !connection.column_exists?(:horses, :oldie)
+      assert_not connection.column_exists?(:horses, :oldie)
       Horse.reset_column_information
     end
   end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -205,8 +205,8 @@ module ActiveRecord
         created_at_column = created_columns.detect { |c| c.name == "created_at" }
         updated_at_column = created_columns.detect { |c| c.name == "updated_at" }
 
-        assert !created_at_column.null
-        assert !updated_at_column.null
+        assert_not created_at_column.null
+        assert_not updated_at_column.null
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns_with_options
@@ -408,7 +408,7 @@ module ActiveRecord
         end
         connection.change_table :testings do |t|
           assert t.column_exists?(:foo)
-          assert !(t.column_exists?(:bar))
+          assert_not (t.column_exists?(:bar))
         end
       end
 

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -95,42 +95,42 @@ module ActiveRecord
         connection.create_join_table :artists, :musics
         connection.drop_join_table :artists, :musics
 
-        assert !connection.table_exists?("artists_musics")
+        assert_not connection.table_exists?("artists_musics")
       end
 
       def test_drop_join_table_with_strings
         connection.create_join_table :artists, :musics
         connection.drop_join_table "artists", "musics"
 
-        assert !connection.table_exists?("artists_musics")
+        assert_not connection.table_exists?("artists_musics")
       end
 
       def test_drop_join_table_with_the_proper_order
         connection.create_join_table :videos, :musics
         connection.drop_join_table :videos, :musics
 
-        assert !connection.table_exists?("musics_videos")
+        assert_not connection.table_exists?("musics_videos")
       end
 
       def test_drop_join_table_with_the_table_name
         connection.create_join_table :artists, :musics, table_name: :catalog
         connection.drop_join_table :artists, :musics, table_name: :catalog
 
-        assert !connection.table_exists?("catalog")
+        assert_not connection.table_exists?("catalog")
       end
 
       def test_drop_join_table_with_the_table_name_as_string
         connection.create_join_table :artists, :musics, table_name: "catalog"
         connection.drop_join_table :artists, :musics, table_name: "catalog"
 
-        assert !connection.table_exists?("catalog")
+        assert_not connection.table_exists?("catalog")
       end
 
       def test_drop_join_table_with_column_options
         connection.create_join_table :artists, :musics, column_options: { null: true }
         connection.drop_join_table :artists, :musics, column_options: { null: true }
 
-        assert !connection.table_exists?("artists_musics")
+        assert_not connection.table_exists?("artists_musics")
       end
 
       def test_create_and_drop_join_table_with_common_prefix

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -99,7 +99,7 @@ module ActiveRecord
         connection.add_index :testings, :foo
 
         assert connection.index_exists?(:testings, :foo)
-        assert !connection.index_exists?(:testings, :bar)
+        assert_not connection.index_exists?(:testings, :bar)
       end
 
       def test_index_exists_on_multiple_columns
@@ -131,7 +131,7 @@ module ActiveRecord
 
         assert connection.index_exists?(:testings, :foo)
         assert connection.index_exists?(:testings, :foo, name: "custom_index_name")
-        assert !connection.index_exists?(:testings, :foo, name: "other_index_name")
+        assert_not connection.index_exists?(:testings, :foo, name: "other_index_name")
       end
 
       def test_remove_named_index
@@ -139,7 +139,7 @@ module ActiveRecord
 
         assert connection.index_exists?(:testings, :foo)
         connection.remove_index :testings, :foo
-        assert !connection.index_exists?(:testings, :foo)
+        assert_not connection.index_exists?(:testings, :foo)
       end
 
       def test_add_index_attribute_length_limit
@@ -203,7 +203,7 @@ module ActiveRecord
           assert connection.index_exists?("testings", "last_name")
 
           connection.remove_index("testings", "last_name")
-          assert !connection.index_exists?("testings", "last_name")
+          assert_not connection.index_exists?("testings", "last_name")
         end
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -548,7 +548,7 @@ class MigrationTest < ActiveRecord::TestCase
       end
       assert Person.connection.column_exists?(:something, :foo)
       assert_nothing_raised { Person.connection.remove_column :something, :foo, :bar }
-      assert !Person.connection.column_exists?(:something, :foo)
+      assert_not Person.connection.column_exists?(:something, :foo)
       assert Person.connection.column_exists?(:something, :name)
       assert Person.connection.column_exists?(:something, :number)
     ensure
@@ -822,7 +822,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         end
       end
 
-      [:qualification, :experience].each { |c| assert ! column(c) }
+      [:qualification, :experience].each { |c| assert_not column(c) }
       assert column(:qualification_experience)
     end
 
@@ -852,7 +852,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
       name_age_index = index(:index_delete_me_on_name_and_age)
       assert_equal ["name", "age"].sort, name_age_index.columns.sort
-      assert ! name_age_index.unique
+      assert_not name_age_index.unique
 
       assert index(:awesome_username_index).unique
     end
@@ -880,7 +880,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         end
       end
 
-      assert ! index(:index_delete_me_on_name)
+      assert_not index(:index_delete_me_on_name)
 
       new_name_index = index(:new_name_index)
       assert new_name_index.unique
@@ -892,7 +892,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         t.date :birthdate
       end
 
-      assert ! column(:name).default
+      assert_not column(:name).default
       assert_equal :date, column(:birthdate).type
 
       classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -83,7 +83,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
 
   def test_a_model_should_respond_to_underscore_destroy_and_return_if_it_is_marked_for_destruction
     ship = Ship.create!(name: "Nights Dirty Lightning")
-    assert !ship._destroy
+    assert_not ship._destroy
     ship.mark_for_destruction
     assert ship._destroy
   end
@@ -835,7 +835,7 @@ module NestedAttributesOnACollectionAssociationTests
       man = Man.create(name: "John")
       interest = man.interests.create(topic: "bar", zine_id: 0)
       assert interest.save
-      assert !man.update(interests_attributes: { id: interest.id, zine_id: "foo" })
+      assert_not man.update(interests_attributes: { id: interest.id, zine_id: "foo" })
     end
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -48,7 +48,7 @@ class PersistenceTest < ActiveRecord::TestCase
       end
 
       if test_update_with_order_succeeds.call("id DESC")
-        assert !test_update_with_order_succeeds.call("id ASC") # test that this wasn't a fluke and using an incorrect order results in an exception
+        assert_not test_update_with_order_succeeds.call("id ASC") # test that this wasn't a fluke and using an incorrect order results in an exception
       else
         # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
         assert_sql(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -518,19 +518,19 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
 
   def test_find
     assert_called(Task.connection, :clear_query_cache) do
-      assert !Task.connection.query_cache_enabled
+      assert_not Task.connection.query_cache_enabled
       Task.cache do
         assert Task.connection.query_cache_enabled
         Task.find(1)
 
         Task.uncached do
-          assert !Task.connection.query_cache_enabled
+          assert_not Task.connection.query_cache_enabled
           Task.find(1)
         end
 
         assert Task.connection.query_cache_enabled
       end
-      assert !Task.connection.query_cache_enabled
+      assert_not Task.connection.query_cache_enabled
     end
   end
 

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -23,7 +23,7 @@ class ReadOnlyTest < ActiveRecord::TestCase
 
     assert_nothing_raised do
       dev.name = "Luscious forbidden fruit."
-      assert !dev.save
+      assert_not dev.save
       dev.name = "Forbidden."
     end
 
@@ -38,8 +38,8 @@ class ReadOnlyTest < ActiveRecord::TestCase
   end
 
   def test_find_with_readonly_option
-    Developer.all.each { |d| assert !d.readonly? }
-    Developer.readonly(false).each { |d| assert !d.readonly? }
+    Developer.all.each { |d| assert_not d.readonly? }
+    Developer.readonly(false).each { |d| assert_not d.readonly? }
     Developer.readonly(true).each { |d| assert d.readonly? }
     Developer.readonly.each { |d| assert d.readonly? }
   end
@@ -55,14 +55,14 @@ class ReadOnlyTest < ActiveRecord::TestCase
   def test_has_many_find_readonly
     post = Post.find(1)
     assert_not_empty post.comments
-    assert !post.comments.any?(&:readonly?)
-    assert !post.comments.to_a.any?(&:readonly?)
+    assert_not post.comments.any?(&:readonly?)
+    assert_not post.comments.to_a.any?(&:readonly?)
     assert post.comments.readonly(true).all?(&:readonly?)
   end
 
   def test_has_many_with_through_is_not_implicitly_marked_readonly
     assert people = Post.find(1).people
-    assert !people.any?(&:readonly?)
+    assert_not people.any?(&:readonly?)
   end
 
   def test_has_many_with_through_is_not_implicitly_marked_readonly_while_finding_by_id

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -36,15 +36,15 @@ module ActiveRecord
       # A reaper with nil time should never reap connections
       def test_nil_time
         fp = FakePool.new
-        assert !fp.reaped
+        assert_not fp.reaped
         reaper = ConnectionPool::Reaper.new(fp, nil)
         reaper.run
-        assert !fp.reaped
+        assert_not fp.reaped
       end
 
       def test_some_time
         fp = FakePool.new
-        assert !fp.reaped
+        assert_not fp.reaped
 
         reaper = ConnectionPool::Reaper.new(fp, 0.0001)
         reaper.run

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -75,7 +75,7 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_column_null_not_null
     subscriber = Subscriber.first
     assert subscriber.column_for_attribute("name").null
-    assert !subscriber.column_for_attribute("nick").null
+    assert_not subscriber.column_for_attribute("nick").null
   end
 
   def test_human_name_for_column

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -511,7 +511,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_find_with_readonly_option
-    Developer.all.each { |d| assert !d.readonly? }
+    Developer.all.each { |d| assert_not d.readonly? }
     Developer.all.readonly.each { |d| assert d.readonly? }
   end
 
@@ -1097,7 +1097,7 @@ class RelationTest < ActiveRecord::TestCase
       assert_not_predicate posts.where(id: nil), :any?
 
       assert posts.any? { |p| p.id > 0 }
-      assert ! posts.any? { |p| p.id <= 0 }
+      assert_not posts.any? { |p| p.id <= 0 }
     end
 
     assert_predicate posts, :loaded?
@@ -1109,7 +1109,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_queries(2) do
       assert posts.many? # Uses COUNT()
       assert posts.many? { |p| p.id > 0 }
-      assert ! posts.many? { |p| p.id < 2 }
+      assert_not posts.many? { |p| p.id < 2 }
     end
 
     assert_predicate posts, :loaded?
@@ -1125,14 +1125,14 @@ class RelationTest < ActiveRecord::TestCase
   def test_none?
     posts = Post.all
     assert_queries(1) do
-      assert ! posts.none? # Uses COUNT()
+      assert_not posts.none? # Uses COUNT()
     end
 
     assert_not_predicate posts, :loaded?
 
     assert_queries(1) do
       assert posts.none? { |p| p.id < 0 }
-      assert ! posts.none? { |p| p.id == 1 }
+      assert_not posts.none? { |p| p.id == 1 }
     end
 
     assert_predicate posts, :loaded?
@@ -1141,13 +1141,13 @@ class RelationTest < ActiveRecord::TestCase
   def test_one
     posts = Post.all
     assert_queries(1) do
-      assert ! posts.one? # Uses COUNT()
+      assert_not posts.one? # Uses COUNT()
     end
 
     assert_not_predicate posts, :loaded?
 
     assert_queries(1) do
-      assert ! posts.one? { |p| p.id < 3 }
+      assert_not posts.one? { |p| p.id < 3 }
       assert posts.one? { |p| p.id == 1 }
     end
 
@@ -1696,7 +1696,7 @@ class RelationTest < ActiveRecord::TestCase
     # checking if there are topics is used before you actually display them,
     # thus it shouldn't invoke an extra count query.
     assert_no_queries { assert topics.present? }
-    assert_no_queries { assert !topics.blank? }
+    assert_no_queries { assert_not topics.blank? }
 
     # shows count of topics and loops after loading the query should not trigger extra queries either.
     assert_no_queries { topics.size }

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -193,7 +193,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
 
   def test_order_to_unscope_reordering
     scope = DeveloperOrderedBySalary.order("salary DESC, name ASC").reverse_order.unscope(:order)
-    assert !/order/i.match?(scope.to_sql)
+    assert_not /order/i.match?(scope.to_sql)
   end
 
   def test_unscope_reverse_order

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -86,7 +86,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_scopes_are_composable
     assert_equal((approved = Topic.all.merge!(where: { approved: true }).to_a), Topic.approved)
     assert_equal((replied = Topic.all.merge!(where: "replies_count > 0").to_a), Topic.replied)
-    assert !(approved == replied)
+    assert_not (approved == replied)
     assert_not_empty (approved & replied)
 
     assert_equal approved & replied, Topic.approved.replied

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -105,7 +105,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     Developer.select("id, name").scoping do
       developer = Developer.where("name = 'David'").first
       assert_equal "David", developer.name
-      assert !developer.has_attribute?(:salary)
+      assert_not developer.has_attribute?(:salary)
     end
   end
 

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -67,8 +67,8 @@ class SerializationTest < ActiveRecord::TestCase
 
     klazz.include_root_in_json = false
     assert ActiveRecord::Base.include_root_in_json
-    assert !klazz.include_root_in_json
-    assert !klazz.new.include_root_in_json
+    assert_not klazz.include_root_in_json
+    assert_not klazz.new.include_root_in_json
   ensure
     ActiveRecord::Base.include_root_in_json = original_root_in_json
   end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -159,7 +159,7 @@ class TransactionTest < ActiveRecord::TestCase
     def @first.before_save_for_transaction
       raise ActiveRecord::Rollback
     end
-    assert !@first.approved
+    assert_not @first.approved
 
     Topic.transaction do
       @first.approved = true
@@ -194,7 +194,7 @@ class TransactionTest < ActiveRecord::TestCase
     posts_count = author.posts.size
     assert posts_count > 0
     status = author.update(name: nil, post_ids: [])
-    assert !status
+    assert_not status
     assert_equal posts_count, author.posts.reload.size
   end
 
@@ -212,7 +212,7 @@ class TransactionTest < ActiveRecord::TestCase
     add_cancelling_before_destroy_with_db_side_effect_to_topic @first
     nbooks_before_destroy = Book.count
     status = @first.destroy
-    assert !status
+    assert_not status
     @first.reload
     assert_equal nbooks_before_destroy, Book.count
   end
@@ -224,7 +224,7 @@ class TransactionTest < ActiveRecord::TestCase
       original_author_name = @first.author_name
       @first.author_name += "_this_should_not_end_up_in_the_db"
       status = @first.save
-      assert !status
+      assert_not status
       assert_equal original_author_name, @first.reload.author_name
       assert_equal nbooks_before_save, Book.count
     end

--- a/activerecord/test/cases/validations/length_validation_test.rb
+++ b/activerecord/test/cases/validations/length_validation_test.rb
@@ -17,7 +17,7 @@ class LengthValidationTest < ActiveRecord::TestCase
   def test_validates_size_of_association
     assert_nothing_raised { @owner.validates_size_of :pets, minimum: 1 }
     o = @owner.new("name" => "nopets")
-    assert !o.save
+    assert_not o.save
     assert_predicate o.errors[:pets], :any?
     o.pets.build("name" => "apet")
     assert_predicate o, :valid?
@@ -26,21 +26,21 @@ class LengthValidationTest < ActiveRecord::TestCase
   def test_validates_size_of_association_using_within
     assert_nothing_raised { @owner.validates_size_of :pets, within: 1..2 }
     o = @owner.new("name" => "nopets")
-    assert !o.save
+    assert_not o.save
     assert_predicate o.errors[:pets], :any?
 
     o.pets.build("name" => "apet")
     assert_predicate o, :valid?
 
     2.times { o.pets.build("name" => "apet") }
-    assert !o.save
+    assert_not o.save
     assert_predicate o.errors[:pets], :any?
   end
 
   def test_validates_size_of_association_utf8
     @owner.validates_size_of :pets, minimum: 1
     o = @owner.new("name" => "あいうえおかきくけこ")
-    assert !o.save
+    assert_not o.save
     assert_predicate o.errors[:pets], :any?
     o.pets.build("name" => "あいうえおかきくけこ")
     assert_predicate o, :valid?

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -39,7 +39,7 @@ class ValidationsTest < ActiveRecord::TestCase
 
   def test_valid_using_special_context
     r = WrongReply.new(title: "Valid title")
-    assert !r.valid?(:special_case)
+    assert_not r.valid?(:special_case)
     assert_equal "Invalid", r.errors[:author_name].join
 
     r.author_name = "secret"
@@ -125,7 +125,7 @@ class ValidationsTest < ActiveRecord::TestCase
 
   def test_save_without_validation
     reply = WrongReply.new
-    assert !reply.save
+    assert_not reply.save
     assert reply.save(validate: false)
   end
 

--- a/activesupport/test/cache/cache_store_namespace_test.rb
+++ b/activesupport/test/cache/cache_store_namespace_test.rb
@@ -25,7 +25,7 @@ class CacheStoreNamespaceTest < ActiveSupport::TestCase
     cache.write("foo", "bar")
     cache.write("fu", "baz")
     cache.delete_matched(/^fo/)
-    assert !cache.exist?("foo")
+    assert_not cache.exist?("foo")
     assert cache.exist?("fu")
   end
 
@@ -34,7 +34,7 @@ class CacheStoreNamespaceTest < ActiveSupport::TestCase
     cache.write("foo", "bar")
     cache.write("fu", "baz")
     cache.delete_matched(/OO/i)
-    assert !cache.exist?("foo")
+    assert_not cache.exist?("foo")
     assert cache.exist?("fu")
   end
 end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -104,7 +104,7 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     assert @cache.exist?(4)
     assert @cache.exist?(3)
     assert @cache.exist?(2)
-    assert !@cache.exist?(1)
+    assert_not @cache.exist?(1)
   end
 
   def test_write_with_unless_exist

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -211,7 +211,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @cache.write("foo", "bar")
       @cache.write("fu", "baz")
       @cache.delete_matched("foo*")
-      assert !@cache.exist?("foo")
+      assert_not @cache.exist?("foo")
       assert @cache.exist?("fu")
     end
 
@@ -227,15 +227,15 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @cache.write("foo", "bar")
       @cache.write("fu", "baz")
       @cache.clear
-      assert !@cache.exist?("foo")
-      assert !@cache.exist?("fu")
+      assert_not @cache.exist?("foo")
+      assert_not @cache.exist?("fu")
     end
 
     test "only clear namespace cache key" do
       @cache.write("foo", "bar")
       @cache.redis.set("fu", "baz")
       @cache.clear
-      assert !@cache.exist?("foo")
+      assert_not @cache.exist?("foo")
       assert @cache.redis.exists("fu")
     end
   end

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -829,7 +829,7 @@ module CallbacksTest
     def test_block_never_called_if_terminated
       obj = CallbackTerminator.new
       obj.save
-      assert !obj.saved
+      assert_not obj.saved
     end
   end
 
@@ -857,7 +857,7 @@ module CallbacksTest
     def test_block_never_called_if_abort_is_thrown
       obj = CallbackDefaultTerminator.new
       obj.save
-      assert !obj.saved
+      assert_not obj.saved
     end
   end
 

--- a/activesupport/test/class_cache_test.rb
+++ b/activesupport/test/class_cache_test.rb
@@ -68,7 +68,7 @@ module ActiveSupport
 
       def test_new_rejects_strings
         @cache.store ClassCacheTest.name
-        assert !@cache.key?(ClassCacheTest.name)
+        assert_not @cache.key?(ClassCacheTest.name)
       end
 
       def test_store_returns_self

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -16,30 +16,30 @@ class DurationTest < ActiveSupport::TestCase
     assert_kind_of ActiveSupport::Duration, d
     assert_kind_of Numeric, d
     assert_kind_of Integer, d
-    assert !d.is_a?(Hash)
+    assert_not d.is_a?(Hash)
 
     k = Class.new
     class << k; undef_method :== end
-    assert !d.is_a?(k)
+    assert_not d.is_a?(k)
   end
 
   def test_instance_of
     assert 1.minute.instance_of?(Integer)
     assert 2.days.instance_of?(ActiveSupport::Duration)
-    assert !3.second.instance_of?(Numeric)
+    assert_not 3.second.instance_of?(Numeric)
   end
 
   def test_threequals
     assert ActiveSupport::Duration === 1.day
-    assert !(ActiveSupport::Duration === 1.day.to_i)
-    assert !(ActiveSupport::Duration === "foo")
+    assert_not (ActiveSupport::Duration === 1.day.to_i)
+    assert_not (ActiveSupport::Duration === "foo")
   end
 
   def test_equals
     assert 1.day == 1.day
     assert 1.day == 1.day.to_i
     assert 1.day.to_i == 1.day
-    assert !(1.day == "foo")
+    assert_not (1.day == "foo")
   end
 
   def test_to_s
@@ -53,11 +53,11 @@ class DurationTest < ActiveSupport::TestCase
     assert 1.minute.eql?(1.minute)
     assert 1.minute.eql?(60.seconds)
     assert 2.days.eql?(48.hours)
-    assert !1.second.eql?(1)
-    assert !1.eql?(1.second)
+    assert_not 1.second.eql?(1)
+    assert_not 1.eql?(1.second)
     assert 1.minute.eql?(180.seconds - 2.minutes)
-    assert !1.minute.eql?(60)
-    assert !1.minute.eql?("foo")
+    assert_not 1.minute.eql?(60)
+    assert_not 1.minute.eql?("foo")
   end
 
   def test_inspect

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -8,7 +8,7 @@ class AtomicWriteTest < ActiveSupport::TestCase
     contents = "Atomic Text"
     File.atomic_write(file_name, Dir.pwd) do |file|
       file.write(contents)
-      assert !File.exist?(file_name)
+      assert_not File.exist?(file_name)
     end
     assert File.exist?(file_name)
     assert_equal contents, File.read(file_name)
@@ -22,7 +22,7 @@ class AtomicWriteTest < ActiveSupport::TestCase
       raise "something bad"
     end
   rescue
-    assert !File.exist?(file_name)
+    assert_not File.exist?(file_name)
   end
 
   def test_atomic_write_preserves_file_permissions
@@ -50,7 +50,7 @@ class AtomicWriteTest < ActiveSupport::TestCase
     contents = "Atomic Text"
     File.atomic_write(file_name, Dir.pwd) do |file|
       file.write(contents)
-      assert !File.exist?(file_name)
+      assert_not File.exist?(file_name)
     end
     assert File.exist?(file_name)
     assert_equal File.probe_stat_in(Dir.pwd).mode, file_mode

--- a/activesupport/test/core_ext/integer_ext_test.rb
+++ b/activesupport/test/core_ext/integer_ext_test.rb
@@ -8,14 +8,14 @@ class IntegerExtTest < ActiveSupport::TestCase
 
   def test_multiple_of
     [ -7, 0, 7, 14 ].each { |i| assert i.multiple_of?(7) }
-    [ -7, 7, 14 ].each { |i| assert ! i.multiple_of?(6) }
+    [ -7, 7, 14 ].each { |i| assert_not i.multiple_of?(6) }
 
     # test the 0 edge case
     assert 0.multiple_of?(0)
-    assert !5.multiple_of?(0)
+    assert_not 5.multiple_of?(0)
 
     # test with a prime
-    [2, 3, 5, 7].each { |i| assert !PRIME.multiple_of?(i) }
+    [2, 3, 5, 7].each { |i| assert_not PRIME.multiple_of?(i) }
   end
 
   def test_ordinalize

--- a/activesupport/test/core_ext/module/attr_internal_test.rb
+++ b/activesupport/test/core_ext/module/attr_internal_test.rb
@@ -12,7 +12,7 @@ class AttrInternalTest < ActiveSupport::TestCase
   def test_reader
     assert_nothing_raised { @target.attr_internal_reader :foo }
 
-    assert !@instance.instance_variable_defined?("@_foo")
+    assert_not @instance.instance_variable_defined?("@_foo")
     assert_raise(NoMethodError) { @instance.foo = 1 }
 
     @instance.instance_variable_set("@_foo", 1)
@@ -22,7 +22,7 @@ class AttrInternalTest < ActiveSupport::TestCase
   def test_writer
     assert_nothing_raised { @target.attr_internal_writer :foo }
 
-    assert !@instance.instance_variable_defined?("@_foo")
+    assert_not @instance.instance_variable_defined?("@_foo")
     assert_nothing_raised { assert_equal 1, @instance.foo = 1 }
 
     assert_equal 1, @instance.instance_variable_get("@_foo")
@@ -32,7 +32,7 @@ class AttrInternalTest < ActiveSupport::TestCase
   def test_accessor
     assert_nothing_raised { @target.attr_internal :foo }
 
-    assert !@instance.instance_variable_defined?("@_foo")
+    assert_not @instance.instance_variable_defined?("@_foo")
     assert_nothing_raised { assert_equal 1, @instance.foo = 1 }
 
     assert_equal 1, @instance.instance_variable_get("@_foo")
@@ -44,10 +44,10 @@ class AttrInternalTest < ActiveSupport::TestCase
     assert_nothing_raised { Module.attr_internal_naming_format = "@abc%sdef" }
     @target.attr_internal :foo
 
-    assert !@instance.instance_variable_defined?("@_foo")
-    assert !@instance.instance_variable_defined?("@abcfoodef")
+    assert_not @instance.instance_variable_defined?("@_foo")
+    assert_not @instance.instance_variable_defined?("@abcfoodef")
     assert_nothing_raised { @instance.foo = 1 }
-    assert !@instance.instance_variable_defined?("@_foo")
+    assert_not @instance.instance_variable_defined?("@_foo")
     assert @instance.instance_variable_defined?("@abcfoodef")
   ensure
     Module.attr_internal_naming_format = "@_%s"

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -21,7 +21,7 @@ class ModuleConcernTest < ActiveSupport::TestCase
 
     # Declares a concern but doesn't include it
     assert klass.const_defined?(:Baz, false)
-    assert !ModuleConcernTest.const_defined?(:Baz)
+    assert_not ModuleConcernTest.const_defined?(:Baz)
     assert_kind_of ActiveSupport::Concern, klass::Baz
     assert_not_includes klass.ancestors, klass::Baz, klass.ancestors.inspect
 

--- a/activesupport/test/core_ext/name_error_test.rb
+++ b/activesupport/test/core_ext/name_error_test.rb
@@ -17,7 +17,7 @@ class NameErrorTest < ActiveSupport::TestCase
     exc = assert_raise NameError do
       some_method_that_does_not_exist
     end
-    assert !exc.missing_name?(:Foo)
+    assert_not exc.missing_name?(:Foo)
     assert_nil exc.missing_name
   end
 end

--- a/activesupport/test/core_ext/object/acts_like_test.rb
+++ b/activesupport/test/core_ext/object/acts_like_test.rb
@@ -17,19 +17,19 @@ class ObjectTests < ActiveSupport::TestCase
     dt     = DateTime.new
     duck   = DuckTime.new
 
-    assert !object.acts_like?(:time)
-    assert !object.acts_like?(:date)
+    assert_not object.acts_like?(:time)
+    assert_not object.acts_like?(:date)
 
     assert time.acts_like?(:time)
-    assert !time.acts_like?(:date)
+    assert_not time.acts_like?(:date)
 
-    assert !date.acts_like?(:time)
+    assert_not date.acts_like?(:time)
     assert date.acts_like?(:date)
 
     assert dt.acts_like?(:time)
     assert dt.acts_like?(:date)
 
     assert duck.acts_like?(:time)
-    assert !duck.acts_like?(:date)
+    assert_not duck.acts_like?(:date)
   end
 end

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -47,7 +47,7 @@ class DeepDupTest < ActiveSupport::TestCase
     object = Object.new
     dup = object.deep_dup
     dup.instance_variable_set(:@a, 1)
-    assert !object.instance_variable_defined?(:@a)
+    assert_not object.instance_variable_defined?(:@a)
     assert dup.instance_variable_defined?(:@a)
   end
 

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -6,30 +6,30 @@ require "active_support/core_ext/object/inclusion"
 class InTest < ActiveSupport::TestCase
   def test_in_array
     assert 1.in?([1, 2])
-    assert !3.in?([1, 2])
+    assert_not 3.in?([1, 2])
   end
 
   def test_in_hash
     h = { "a" => 100, "b" => 200 }
     assert "a".in?(h)
-    assert !"z".in?(h)
+    assert_not "z".in?(h)
   end
 
   def test_in_string
     assert "lo".in?("hello")
-    assert !"ol".in?("hello")
+    assert_not "ol".in?("hello")
     assert ?h.in?("hello")
   end
 
   def test_in_range
     assert 25.in?(1..50)
-    assert !75.in?(1..50)
+    assert_not 75.in?(1..50)
   end
 
   def test_in_set
     s = Set.new([1, 2])
     assert 1.in?(s)
-    assert !3.in?(s)
+    assert_not 3.in?(s)
   end
 
   module A
@@ -45,8 +45,8 @@ class InTest < ActiveSupport::TestCase
   def test_in_module
     assert A.in?(B)
     assert A.in?(C)
-    assert !A.in?(A)
-    assert !A.in?(D)
+    assert_not A.in?(A)
+    assert_not A.in?(D)
   end
 
   def test_no_method_catching

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -37,7 +37,7 @@ class RangeTest < ActiveSupport::TestCase
   end
 
   def test_overlaps_last_exclusive
-    assert !(1...5).overlaps?(5..10)
+    assert_not (1...5).overlaps?(5..10)
   end
 
   def test_overlaps_first_inclusive
@@ -45,7 +45,7 @@ class RangeTest < ActiveSupport::TestCase
   end
 
   def test_overlaps_first_exclusive
-    assert !(5..10).overlaps?(1...5)
+    assert_not (5..10).overlaps?(1...5)
   end
 
   def test_should_include_identical_inclusive
@@ -102,7 +102,7 @@ class RangeTest < ActiveSupport::TestCase
   def test_no_overlaps_on_time
     time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     time_range_2 = Time.utc(2005, 12, 10, 17, 31)..Time.utc(2005, 12, 10, 18, 00)
-    assert !time_range_1.overlaps?(time_range_2)
+    assert_not time_range_1.overlaps?(time_range_2)
   end
 
   def test_each_on_time_with_zone

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -237,11 +237,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
     s = "hello"
     assert s.starts_with?("h")
     assert s.starts_with?("hel")
-    assert !s.starts_with?("el")
+    assert_not s.starts_with?("el")
 
     assert s.ends_with?("o")
     assert s.ends_with?("lo")
-    assert !s.ends_with?("el")
+    assert_not s.ends_with?("el")
   end
 
   def test_string_squish

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -535,9 +535,9 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_qualified_const_defined_should_not_call_const_missing
     ModuleWithMissing.missing_count = 0
-    assert ! ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A")
+    assert_not ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A")
     assert_equal 0, ModuleWithMissing.missing_count
-    assert ! ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A::B")
+    assert_not ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A::B")
     assert_equal 0, ModuleWithMissing.missing_count
   end
 
@@ -547,13 +547,13 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_autoloaded?
     with_autoloading_fixtures do
-      assert ! ActiveSupport::Dependencies.autoloaded?("ModuleFolder")
-      assert ! ActiveSupport::Dependencies.autoloaded?("ModuleFolder::NestedClass")
+      assert_not ActiveSupport::Dependencies.autoloaded?("ModuleFolder")
+      assert_not ActiveSupport::Dependencies.autoloaded?("ModuleFolder::NestedClass")
 
       assert ActiveSupport::Dependencies.autoloaded?(ModuleFolder)
 
       assert ActiveSupport::Dependencies.autoloaded?("ModuleFolder")
-      assert ! ActiveSupport::Dependencies.autoloaded?("ModuleFolder::NestedClass")
+      assert_not ActiveSupport::Dependencies.autoloaded?("ModuleFolder::NestedClass")
 
       assert ActiveSupport::Dependencies.autoloaded?(ModuleFolder::NestedClass)
 
@@ -564,11 +564,11 @@ class DependenciesTest < ActiveSupport::TestCase
       assert ActiveSupport::Dependencies.autoloaded?(:ModuleFolder)
 
       # Anonymous modules aren't autoloaded.
-      assert !ActiveSupport::Dependencies.autoloaded?(Module.new)
+      assert_not ActiveSupport::Dependencies.autoloaded?(Module.new)
 
       nil_name = Module.new
       def nil_name.name() nil end
-      assert !ActiveSupport::Dependencies.autoloaded?(nil_name)
+      assert_not ActiveSupport::Dependencies.autoloaded?(nil_name)
     end
   ensure
     remove_constants(:ModuleFolder)
@@ -778,7 +778,7 @@ class DependenciesTest < ActiveSupport::TestCase
       M.unloadable
 
       ActiveSupport::Dependencies.clear
-      assert ! defined?(M)
+      assert_not defined?(M)
 
       Object.const_set :M, Module.new
       ActiveSupport::Dependencies.clear
@@ -809,7 +809,7 @@ class DependenciesTest < ActiveSupport::TestCase
     assert_called(C, :before_remove_const, times: 1) do
       assert_respond_to C, :before_remove_const
       ActiveSupport::Dependencies.clear
-      assert !defined?(C)
+      assert_not defined?(C)
     end
   ensure
     remove_constants(:C)
@@ -1023,7 +1023,7 @@ class DependenciesTest < ActiveSupport::TestCase
         assert !defined?(::RaisesNameError), "::RaisesNameError is defined but it should have failed!"
       end
 
-      assert !defined?(::RaisesNameError)
+      assert_not defined?(::RaisesNameError)
       2.times do
         assert_raise(NameError) { ::RaisesNameError }
         assert !defined?(::RaisesNameError), "::RaisesNameError is defined but it should have failed!"

--- a/activesupport/test/deprecation/proxy_wrappers_test.rb
+++ b/activesupport/test/deprecation/proxy_wrappers_test.rb
@@ -9,16 +9,16 @@ class ProxyWrappersTest < ActiveSupport::TestCase
 
   def test_deprecated_object_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(nil, "message")
-    assert !proxy
+    assert_not proxy
   end
 
   def test_deprecated_instance_variable_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(nil, :waffles)
-    assert !proxy
+    assert_not proxy
   end
 
   def test_deprecated_constant_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(Waffles, NewWaffles)
-    assert !proxy
+    assert_not proxy
   end
 end

--- a/activesupport/test/descendants_tracker_without_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_without_autoloading_test.rb
@@ -13,7 +13,7 @@ class DescendantsTrackerWithoutAutoloadingTest < ActiveSupport::TestCase
       parent_instance = Parent.new
       parent_instance.singleton_class.descendants
       ActiveSupport::DescendantsTracker.clear
-      assert !ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants).key?(parent_instance.singleton_class)
+      assert_not ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants).key?(parent_instance.singleton_class)
     end
   end
 end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -280,7 +280,7 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     replaced = hash.replace(b: 12)
 
     assert hash.key?("b")
-    assert !hash.key?(:a)
+    assert_not hash.key?(:a)
     assert_equal 12, hash[:b]
     assert_same hash, replaced
   end
@@ -292,7 +292,7 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     replaced = hash.replace(HashByConversion.new(b: 12))
 
     assert hash.key?("b")
-    assert !hash.key?(:a)
+    assert_not hash.key?(:a)
     assert_equal 12, hash[:b]
     assert_same hash, replaced
   end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -25,12 +25,12 @@ class MessageVerifierTest < ActiveSupport::TestCase
 
   def test_valid_message
     data, hash = @verifier.generate(@data).split("--")
-    assert !@verifier.valid_message?(nil)
-    assert !@verifier.valid_message?("")
-    assert !@verifier.valid_message?("\xff") # invalid encoding
-    assert !@verifier.valid_message?("#{data.reverse}--#{hash}")
-    assert !@verifier.valid_message?("#{data}--#{hash.reverse}")
-    assert !@verifier.valid_message?("purejunk")
+    assert_not @verifier.valid_message?(nil)
+    assert_not @verifier.valid_message?("")
+    assert_not @verifier.valid_message?("\xff") # invalid encoding
+    assert_not @verifier.valid_message?("#{data.reverse}--#{hash}")
+    assert_not @verifier.valid_message?("#{data}--#{hash.reverse}")
+    assert_not @verifier.valid_message?("purejunk")
   end
 
   def test_simple_round_tripping
@@ -40,7 +40,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
   end
 
   def test_verified_returns_false_on_invalid_message
-    assert !@verifier.verified("purejunk")
+    assert_not @verifier.verified("purejunk")
   end
 
   def test_verify_exception_on_invalid_message

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -75,7 +75,7 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   def test_consumes_utf8_strings
     assert @proxy_class.consumes?(UNICODE_STRING)
     assert @proxy_class.consumes?(ASCII_STRING)
-    assert !@proxy_class.consumes?(BYTE_STRING)
+    assert_not @proxy_class.consumes?(BYTE_STRING)
   end
 
   def test_concatenation_should_return_a_proxy_class_instance
@@ -148,7 +148,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   def test_identity
     assert_equal @chars, @chars
     assert @chars.eql?(@chars)
-    assert !@chars.eql?(UNICODE_STRING)
+    assert_not @chars.eql?(UNICODE_STRING)
   end
 
   def test_string_methods_are_chainable

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -270,9 +270,9 @@ module Notifications
       parent.children << child
 
       assert parent.parent_of?(child)
-      assert !child.parent_of?(parent)
-      assert !parent.parent_of?(not_child)
-      assert !not_child.parent_of?(parent)
+      assert_not child.parent_of?(parent)
+      assert_not parent.parent_of?(not_child)
+      assert_not not_child.parent_of?(parent)
     end
 
     private

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -15,7 +15,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     a[:allow_concurrency] = false
     assert_equal 1, a.size
-    assert !a[:allow_concurrency]
+    assert_not a[:allow_concurrency]
 
     a["else_where"] = 56
     assert_equal 2, a.size
@@ -47,7 +47,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     a.allow_concurrency = false
     assert_equal 1, a.size
-    assert !a.allow_concurrency
+    assert_not a.allow_concurrency
 
     a.else_where = 56
     assert_equal 2, a.size

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -8,18 +8,18 @@ class ReloaderTest < ActiveSupport::TestCase
     reloader.to_prepare { prepared = true }
     reloader.to_complete { completed = true }
 
-    assert !prepared
-    assert !completed
+    assert_not prepared
+    assert_not completed
     reloader.prepare!
     assert prepared
-    assert !completed
+    assert_not completed
 
     prepared = false
     reloader.wrap do
       assert prepared
       prepared = false
     end
-    assert !prepared
+    assert_not prepared
   end
 
   def test_prepend_prepare_callback
@@ -42,7 +42,7 @@ class ReloaderTest < ActiveSupport::TestCase
     invoked = false
     r.to_run { invoked = true }
     r.wrap {}
-    assert !invoked
+    assert_not invoked
   end
 
   def test_full_reload_sequence

--- a/activesupport/test/security_utils_test.rb
+++ b/activesupport/test/security_utils_test.rb
@@ -11,7 +11,7 @@ class SecurityUtilsTest < ActiveSupport::TestCase
 
   def test_fixed_length_secure_compare_should_perform_string_comparison
     assert ActiveSupport::SecurityUtils.fixed_length_secure_compare("a", "a")
-    assert !ActiveSupport::SecurityUtils.fixed_length_secure_compare("a", "b")
+    assert_not ActiveSupport::SecurityUtils.fixed_length_secure_compare("a", "b")
   end
 
   def test_fixed_length_secure_compare_raise_on_length_mismatch

--- a/ci/custom_cops/lib/custom_cops.rb
+++ b/ci/custom_cops/lib/custom_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "custom_cops/refute_not"
+require_relative "custom_cops/assert_not"

--- a/ci/custom_cops/lib/custom_cops/assert_not.rb
+++ b/ci/custom_cops/lib/custom_cops/assert_not.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module CustomCops
+  # Enforces the use of `assert_not` over `assert !`.
+  #
+  # @example
+  #   # bad
+  #   assert !x
+  #   assert ! x
+  #
+  #   # good
+  #   assert_not x
+  #
+  class AssertNot < RuboCop::Cop::Cop
+    MSG = "Prefer `assert_not` over `assert !`"
+
+    def_node_matcher :offensive?, "(send nil? :assert (send ... :!))"
+
+    def on_send(node)
+      add_offense(node) if offensive?(node)
+    end
+
+    def autocorrect(node)
+      expression = node.loc.expression
+
+      ->(corrector) do
+        corrector.replace(
+          expression,
+          corrected_source(expression.source)
+        )
+      end
+    end
+
+    private
+
+      def corrected_source(source)
+        source.gsub(/^assert(\(| ) *! */, "assert_not\\1")
+      end
+  end
+end

--- a/ci/custom_cops/test/custom_cops/assert_not_test.rb
+++ b/ci/custom_cops/test/custom_cops/assert_not_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "support/cop_helper"
+require_relative "../../lib/custom_cops/assert_not"
+
+class AssertNotTest < ActiveSupport::TestCase
+  include CopHelper
+
+  setup do
+    @cop = CustomCops::AssertNot.new
+  end
+
+  test "rejects 'assert !'" do
+    inspect_source @cop, "assert !x"
+    assert_offense @cop, "^^^^^^^^^ Prefer `assert_not` over `assert !`"
+  end
+
+  test "rejects 'assert !' with a complex value" do
+    inspect_source @cop, "assert !a.b(c)"
+    assert_offense @cop, "^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`"
+  end
+
+  test "autocorrects `assert !`" do
+    corrected = autocorrect_source(@cop, "assert !false")
+    assert_equal "assert_not false", corrected
+  end
+
+  test "autocorrects `assert !` with extra spaces" do
+    corrected = autocorrect_source(@cop, "assert   !  false")
+    assert_equal "assert_not false", corrected
+  end
+
+  test "autocorrects `assert !` with parentheses" do
+    corrected = autocorrect_source(@cop, "assert(!false)")
+    assert_equal "assert_not(false)", corrected
+  end
+
+  test "accepts `assert_not`" do
+    inspect_source @cop, "assert_not x"
+    assert_empty @cop.offenses
+  end
+end

--- a/ci/custom_cops/test/custom_cops/refute_not_test.rb
+++ b/ci/custom_cops/test/custom_cops/refute_not_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "support/cop_helper"
-require "./lib/custom_cops/refute_not"
+require_relative "../../lib/custom_cops/refute_not"
 
 class RefuteNotTest < ActiveSupport::TestCase
   include CopHelper
@@ -58,15 +58,6 @@ class RefuteNotTest < ActiveSupport::TestCase
   end
 
   private
-
-    def assert_offense(cop, expected_message)
-      assert_not_empty cop.offenses
-
-      offense = cop.offenses.first
-      carets = "^" * offense.column_length
-
-      assert_equal expected_message, "#{carets} #{offense.message}"
-    end
 
     def offense_message(refute_method, assert_method)
       carets = "^" * refute_method.to_s.length

--- a/ci/custom_cops/test/support/cop_helper.rb
+++ b/ci/custom_cops/test/support/cop_helper.rb
@@ -16,6 +16,18 @@ module CopHelper
     rewrite(cop, processed_source)
   end
 
+  def assert_offense(cop, expected_message)
+    assert_not_empty(
+      cop.offenses,
+      "Expected offense with message \"#{expected_message}\", but got no offense"
+    )
+
+    offense = cop.offenses.first
+    carets = "^" * offense.column_length
+
+    assert_equal expected_message, "#{carets} #{offense.message}"
+  end
+
   private
     TARGET_RUBY_VERSION = 2.4
 

--- a/railties/test/app_loader_test.rb
+++ b/railties/test/app_loader_test.rb
@@ -40,13 +40,13 @@ class AppLoaderTest < ActiveSupport::TestCase
     test "is not in a Rails application if #{exe} is not found in the current or parent directories" do
       def loader.find_executables; end
 
-      assert !loader.exec_app
+      assert_not loader.exec_app
     end
 
     test "is not in a Rails application if #{exe} exists but is a folder" do
       FileUtils.mkdir_p(exe)
 
-      assert !loader.exec_app
+      assert_not loader.exec_app
     end
 
     ["APP_PATH", "ENGINE_PATH"].each do |keyword|
@@ -61,7 +61,7 @@ class AppLoaderTest < ActiveSupport::TestCase
       test "is not in a Rails application if #{exe} exists but doesn't contain #{keyword}" do
         write exe
 
-        assert !loader.exec_app
+        assert_not loader.exec_app
       end
 
       test "is in a Rails application if parent directory has #{exe} containing #{keyword} and chdirs to the root directory" do

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -76,7 +76,7 @@ module ApplicationTests
       # Load app env
       app "production"
 
-      assert !defined?(Uglifier)
+      assert_not defined?(Uglifier)
       get "/assets/demo.js"
       assert_match "alert()", last_response.body
       assert defined?(Uglifier)
@@ -270,10 +270,10 @@ module ApplicationTests
       app "production"
 
       # Checking if Uglifier is defined we can know if Sprockets was reached or not
-      assert !defined?(Uglifier)
+      assert_not defined?(Uglifier)
       get "/assets/#{asset_path}"
       assert_match "alert()", last_response.body
-      assert !defined?(Uglifier)
+      assert_not defined?(Uglifier)
     end
 
     test "precompile properly refers files referenced with asset_path" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -361,7 +361,7 @@ module ApplicationTests
         end
       RUBY
 
-      assert !$prepared
+      assert_not $prepared
 
       app "development"
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -226,7 +226,7 @@ module ApplicationTests
       rails %w(generate model post title:string)
       rails %w(db:migrate db:schema:cache:dump db:rollback)
       require "#{app_path}/config/environment"
-      assert !ActiveRecord::Base.connection.schema_cache.data_sources("posts")
+      assert_not ActiveRecord::Base.connection.schema_cache.data_sources("posts")
     end
 
     test "active record establish_connection uses Rails.env if DATABASE_URL is not set" do

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -29,7 +29,7 @@ module ApplicationTests
       simple_controller
 
       get "/"
-      assert !last_response.headers["X-Sendfile"]
+      assert_not last_response.headers["X-Sendfile"]
       assert_equal File.read(__FILE__), last_response.body
     end
 

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -31,7 +31,7 @@ module ApplicationTests
       add_to_config "config.force_ssl = true"
       add_to_config "config.ssl_options = { secure_cookies: false }"
       require "#{app_path}/config/environment"
-      assert !app.config.session_options[:secure]
+      assert_not app.config.session_options[:secure]
     end
 
     test "session is not loaded if it's not used" do
@@ -51,7 +51,7 @@ module ApplicationTests
       get "/"
 
       assert last_request.env["HTTP_COOKIE"]
-      assert !last_response.headers["Set-Cookie"]
+      assert_not last_response.headers["Set-Cookie"]
     end
 
     test "session is empty and isn't saved on unverified request when using :null_session protect method" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -34,7 +34,7 @@ module ApplicationTests
           assert_equal expected_database, ActiveRecord::Base.connection_config[:database] if environment_loaded
           output = rails("db:drop")
           assert_match(/Dropped database/, output)
-          assert !File.exist?(expected_database)
+          assert_not File.exist?(expected_database)
         end
       end
 

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -26,7 +26,7 @@ module ApplicationTests
           output = rails("db:drop")
           assert_match(/Dropped database/, output)
           assert_match_namespace(namespace, output)
-          assert !File.exist?(expected_database)
+          assert_not File.exist?(expected_database)
         end
       end
 
@@ -40,7 +40,7 @@ module ApplicationTests
           output = rails("db:drop:#{namespace}")
           assert_match(/Dropped database/, output)
           assert_match_namespace(namespace, output)
-          assert !File.exist?(expected_database)
+          assert_not File.exist?(expected_database)
         end
       end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -229,7 +229,7 @@ module ApplicationTests
 
     def test_rake_clear_schema_cache
       rails "db:schema:cache:dump", "db:schema:cache:clear"
-      assert !File.exist?(File.join(app_path, "db", "schema_cache.yml"))
+      assert_not File.exist?(File.join(app_path, "db", "schema_cache.yml"))
     end
 
     def test_copy_templates

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -123,31 +123,31 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_mysql
     start(adapter: "mysql2", database: "db")
-    assert !aborted
+    assert_not aborted
     assert_equal [%w[mysql mysql5], "db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_mysql_full
     start(adapter: "mysql2", database: "db", host: "locahost", port: 1234, socket: "socket", username: "user", password: "qwerty", encoding: "UTF-8")
-    assert !aborted
+    assert_not aborted
     assert_equal [%w[mysql mysql5], "--host=locahost", "--port=1234", "--socket=socket", "--user=user", "--default-character-set=UTF-8", "-p", "db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_mysql_include_password
     start({ adapter: "mysql2", database: "db", username: "user", password: "qwerty" }, ["-p"])
-    assert !aborted
+    assert_not aborted
     assert_equal [%w[mysql mysql5], "--user=user", "--password=qwerty", "db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_postgresql
     start(adapter: "postgresql", database: "db")
-    assert !aborted
+    assert_not aborted
     assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_postgresql_full
     start(adapter: "postgresql", database: "db", username: "user", password: "q1w2e3", host: "host", port: 5432)
-    assert !aborted
+    assert_not aborted
     assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
     assert_equal "user", ENV["PGUSER"]
     assert_equal "host", ENV["PGHOST"]
@@ -157,7 +157,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_postgresql_include_password
     start({ adapter: "postgresql", database: "db", username: "user", password: "q1w2e3" }, ["-p"])
-    assert !aborted
+    assert_not aborted
     assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
     assert_equal "user", ENV["PGUSER"]
     assert_equal "q1w2e3", ENV["PGPASSWORD"]
@@ -165,13 +165,13 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_sqlite3
     start(adapter: "sqlite3", database: "db.sqlite3")
-    assert !aborted
+    assert_not aborted
     assert_equal ["sqlite3", Rails.root.join("db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
   end
 
   def test_sqlite3_mode
     start({ adapter: "sqlite3", database: "db.sqlite3" }, ["--mode", "html"])
-    assert !aborted
+    assert_not aborted
     assert_equal ["sqlite3", "-html", Rails.root.join("db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
   end
 
@@ -182,27 +182,27 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_sqlite3_db_absolute_path
     start(adapter: "sqlite3", database: "/tmp/db.sqlite3")
-    assert !aborted
+    assert_not aborted
     assert_equal ["sqlite3", "/tmp/db.sqlite3"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_sqlite3_db_without_defined_rails_root
     Rails.stub(:respond_to?, false) do
       start(adapter: "sqlite3", database: "config/db.sqlite3")
-      assert !aborted
+      assert_not aborted
       assert_equal ["sqlite3", Rails.root.join("../config/db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
     end
   end
 
   def test_oracle
     start(adapter: "oracle", database: "db", username: "user", password: "secret")
-    assert !aborted
+    assert_not aborted
     assert_equal ["sqlplus", "user@db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_oracle_include_password
     start({ adapter: "oracle", database: "db", username: "user", password: "secret" }, ["-p"])
-    assert !aborted
+    assert_not aborted
     assert_equal ["sqlplus", "user/secret@db"], dbconsole.find_cmd_and_exec_args
   end
 

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -9,7 +9,7 @@ class InfoTest < ActiveSupport::TestCase
         property("Bogus") { raise }
       end
     end
-    assert !property_defined?("Bogus")
+    assert_not property_defined?("Bogus")
   end
 
   def test_property_with_string

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -226,7 +226,7 @@ module RailtiesTest
       require "rdoc/task"
       require "rake/testtask"
       Rails.application.load_tasks
-      assert !Rake::Task.task_defined?("bukkits:install:migrations")
+      assert_not Rake::Task.task_defined?("bukkits:install:migrations")
     end
 
     test "puts its lib directory on load path" do
@@ -745,7 +745,7 @@ YAML
       assert_equal "bukkits", Bukkits::Engine.engine_name
       assert_equal Bukkits.railtie_namespace, Bukkits::Engine
       assert ::Bukkits::MyMailer.method_defined?(:foo_url)
-      assert !::Bukkits::MyMailer.method_defined?(:bar_url)
+      assert_not ::Bukkits::MyMailer.method_defined?(:bar_url)
 
       get("/bukkits/from_app")
       assert_equal "false", last_response.body

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -65,7 +65,7 @@ module RailtiesTest
     test "railtie can add to_prepare callbacks" do
       $to_prepare = false
       class Foo < Rails::Railtie ; config.to_prepare { $to_prepare = true } ; end
-      assert !$to_prepare
+      assert_not $to_prepare
       require "#{app_path}/config/environment"
       require "rack/test"
       extend Rack::Test::Methods
@@ -91,7 +91,7 @@ module RailtiesTest
     test "railtie can add after_initialize callbacks" do
       $after_initialize = false
       class Foo < Rails::Railtie ; config.after_initialize { $after_initialize = true } ; end
-      assert !$after_initialize
+      assert_not $after_initialize
       require "#{app_path}/config/environment"
       assert $after_initialize
     end
@@ -107,7 +107,7 @@ module RailtiesTest
 
       require "#{app_path}/config/environment"
 
-      assert !$ran_block
+      assert_not $ran_block
       require "rake"
       require "rake/testtask"
       require "rdoc/task"
@@ -151,7 +151,7 @@ module RailtiesTest
 
       require "#{app_path}/config/environment"
 
-      assert !$ran_block
+      assert_not $ran_block
       Rails.application.load_generators
       assert $ran_block
     end
@@ -167,7 +167,7 @@ module RailtiesTest
 
       require "#{app_path}/config/environment"
 
-      assert !$ran_block
+      assert_not $ran_block
       Rails.application.load_console
       assert $ran_block
     end
@@ -183,7 +183,7 @@ module RailtiesTest
 
       require "#{app_path}/config/environment"
 
-      assert !$ran_block
+      assert_not $ran_block
       Rails.application.load_runner
       assert $ran_block
     end
@@ -197,7 +197,7 @@ module RailtiesTest
         end
       end
 
-      assert !$ran_block
+      assert_not $ran_block
       require "#{app_path}/config/environment"
       assert $ran_block
     end


### PR DESCRIPTION
We added `assert_not` in f75addd "to replace warty 'assert !foo'".
fa8d35b agrees that it is warty, and so do I. This custom Rubocop rule
turns the wart into a violation.

~~As with my last custom cop, https://github.com/rails/rails/pull/32441,
I want to make sure this looks right on code climate before pushing
another commit to autocorrect everything.~~ seems to have worked as expected

@toshimaru I just noticed
https://github.com/toshimaru/rubocop-rails/pull/26
Needing to copy over all the code for these is definitely not great.
At one point I had thought to put them in a gem.
Is there a better way to add these custom cops, or were you saying we
shouldn't have custom cops at all? 