### PR TITLE
Correct docs on naming of sprockets manifest file

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -728,8 +728,8 @@ Rails.application.config.assets.precompile += %w( admin.js admin.css )
 NOTE. Always specify an expected compiled filename that ends with `.js` or `.css`,
 even if you want to add Sass or CoffeeScript files to the precompile array.
 
-The task also generates a `.sprockets-manifest-md5hash.json` (where `md5hash` is
-an MD5 hash) that contains a list with all your assets and their respective
+The task also generates a `.sprockets-manifest-randomhex.json` (where `randomhex` is
+a 16-byte random hex string) that contains a list with all your assets and their respective
 fingerprints. This is used by the Rails helper methods to avoid handing the
 mapping requests back to Sprockets. A typical manifest file looks like:
 


### PR DESCRIPTION
Calling this an MD5 implies that it is generated consistently based on some input.
However, this value is [completely random](https://github.com/rails/sprockets/blob/fbe6e450b6f25cf3ea494fcab0e34001d0b5a0b9/lib/sprockets/manifest_utils.rb#L11-L24).