### PR TITLE
Ruby 2.6 warning: passing splat keyword arguments as a single Hash

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -71,11 +71,16 @@ module ActionView
 
       private
         def find_template(finder, *args)
+          name = args.first
+          prefixes = args[1] || []
+          partial = args[2] || false
+          keys = args[3] || []
+          options = args[4] || {}
           finder.disable_cache do
             if format = finder.rendered_format
-              finder.find_all(*args, formats: [format]).first || finder.find_all(*args).first
+              finder.find_all(name, prefixes, partial, keys, options.merge(formats: [format])).first || finder.find_all(name, prefixes, partial, keys, options).first
             else
-              finder.find_all(*args).first
+              finder.find_all(name, prefixes, partial, keys, options).first
             end
           end
         end


### PR DESCRIPTION
Before:

```
$ ruby -v
ruby 2.6.0dev (2018-04-04 trunk 63085) [x86_64-linux]

$ bundle exec rake test:template
...
/rails/actionview/lib/action_view/digestor.rb:76: warning: passing splat keyword arguments as a single Hash to `find_all'
```

See:
https://travis-ci.org/rails/rails/jobs/367493803#L1516-L1874