### PR TITLE
Fix exception in AS::Timezone.all when any tzinfo data is missing

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug where `ActiveSupport::Timezone.all` would fail when tzinfo data for
+    any timezone defined in `ActiveSupport::MAPPING` is missing.
+
+    *Dominik Sander*
+
 *   Fix bug where `ActiveSupport::Cache` will massively inflate the storage
     size when compression is enabled (which is true by default). This patch
     does not attempt to repair existing data: please manually flush the cache

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -279,7 +279,8 @@ module ActiveSupport
 
         def zones_map
           @zones_map ||= MAPPING.each_with_object({}) do |(name, _), zones|
-            zones[name] = self[name]
+            timezone = self[name]
+            zones[name] = timezone if timezone
           end
         end
     end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -725,6 +725,21 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_not_includes all_zones, galapagos
   end
 
+  def test_all_not_raises_exception_with_mizzing_tzinfo_data
+    mappings = {
+      "Puerto Rico" => "America/Unknown",
+      "Pittsburgh"  => "America/New_York"
+    }
+
+    with_tz_mappings(mappings) do
+      assert_nil ActiveSupport::TimeZone["Puerto Rico"]
+      assert_nil ActiveSupport::TimeZone[-9]
+      assert_nothing_raised do
+        ActiveSupport::TimeZone.all
+      end
+    end
+  end
+
   def test_index
     assert_nil ActiveSupport::TimeZone["bogus"]
     assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone["Central Time (US & Canada)"]

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -23,4 +23,17 @@ module TimeZoneTestHelpers
   ensure
     ActiveSupport.to_time_preserves_timezone = old_preserve_tz
   end
+
+  def with_tz_mappings(mappings)
+    old_mappings = ActiveSupport::TimeZone::MAPPING.dup
+    ActiveSupport::TimeZone.clear
+    ActiveSupport::TimeZone::MAPPING.clear
+    ActiveSupport::TimeZone::MAPPING.merge!(mappings)
+
+    yield
+  ensure
+    ActiveSupport::TimeZone.clear
+    ActiveSupport::TimeZone::MAPPING.clear
+    ActiveSupport::TimeZone::MAPPING.merge!(old_mappings)
+  end
 end


### PR DESCRIPTION
Before this change missing timezone data for any of the time zones defined in `ActiveSupport::Timezone::MAPPING` caused a `comparison of NilClass with ActiveSupport::TimeZone failed` exception.

Attempting to get a timezone by passing a number/duration to `[]` or calling `all` directly will try to sort sort the values of `zones_map`. Those values are initialized by the return value of `create(zonename)` which returns `nil` if `TZInfo` is unable to find the timezone information.

In our case the exception was triggered by an outdated tzdata package which did not include information for the "recently" added time zones.

Before 078421bacba178eac6a8e607b16f3f4511c5d72f `zones_map` only returned the information that have been loaded into `@lazy_zone_map` which ignored time zones for which the data could not be loaded, this change restores the previous behaviour.

