### PR TITLE
Avoid blocking the server in `RedisCacheStore#delete_matched`

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -236,14 +236,13 @@ module ActiveSupport
             raise ArgumentError, "Only Redis glob strings are supported: #{matcher.inspect}"
           end
           redis.with do |c|
-            start = "0"
             pattern = namespace_key(matcher, options)
+            start = "0"
             # Fetch keys in batches using SCAN to avoid blocking the Redis server.
-            while true
+            begin
               start, keys = c.scan(start, match: pattern, count: SCAN_BATCH_SIZE)
               c.del(*keys) unless keys.empty?
-              break if start == "0"
-            end
+            end until start == "0"
           end
         end
       end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -237,12 +237,12 @@ module ActiveSupport
           end
           redis.with do |c|
             pattern = namespace_key(matcher, options)
-            start = "0"
+            cursor = "0"
             # Fetch keys in batches using SCAN to avoid blocking the Redis server.
             begin
-              start, keys = c.scan(start, match: pattern, count: SCAN_BATCH_SIZE)
+              cursor, keys = c.scan(cursor, match: pattern, count: SCAN_BATCH_SIZE)
               c.del(*keys) unless keys.empty?
-            end until start == "0"
+            end until cursor == "0"
           end
         end
       end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -62,8 +62,9 @@ module ActiveSupport
         end
       end
 
-      DELETE_GLOB_LUA = "for i, name in ipairs(redis.call('KEYS', ARGV[1])) do redis.call('DEL', name); end"
-      private_constant :DELETE_GLOB_LUA
+      # The maximum number of entries to receive per SCAN call.
+      SCAN_BATCH_SIZE = 1000
+      private_constant :SCAN_BATCH_SIZE
 
       # Support raw values in the local cache strategy.
       module LocalCacheWithRaw # :nodoc:
@@ -231,11 +232,18 @@ module ActiveSupport
       # Failsafe: Raises errors.
       def delete_matched(matcher, options = nil)
         instrument :delete_matched, matcher do
-          case matcher
-          when String
-            redis.with { |c| c.eval DELETE_GLOB_LUA, [], [namespace_key(matcher, options)] }
-          else
+          unless String === matcher
             raise ArgumentError, "Only Redis glob strings are supported: #{matcher.inspect}"
+          end
+          redis.with do |c|
+            start = "0"
+            pattern = namespace_key(matcher, options)
+            # Fetch keys in batches using SCAN to avoid blocking the Redis server.
+            while true
+              start, keys = c.scan(start, match: pattern, count: SCAN_BATCH_SIZE)
+              c.del(*keys) unless keys.empty?
+              break if start == "0"
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes #32610

Lua scripts in redis are *blocking*, meaning that no other client can execute any commands while the script is running. See https://redis.io/commands/eval#atomicity-of-scripts.

This results in the following exceptions once the number of keys is sufficiently large:

    BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.

This commit replaces the lua-based implementation with one that uses `SCAN` and `DEL` in batches. This doesn't block the server.

The primary limitation of `SCAN`, i.e. potential duplicate keys, is of no consequence here, because `DEL` ignores keys that do not exist.