### PR TITLE
Loaded associations should not run a new query when size is called

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure `Associations::CollectionAssociation#size` and `Associations::CollectionAssociation#empty?`
+    use loaded association ids if present.
+
+    *Graham Turner*
+
 *   Add support to preload associations of polymorphic associations when not all the records have the requested associations.
 
     *Dana Sherson*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -212,6 +212,8 @@ module ActiveRecord
       def size
         if !find_target? || loaded?
           target.size
+        elsif @association_ids && target.empty?
+          @association_ids.size
         elsif !association_scope.group_values.empty?
           load_target.size
         elsif !association_scope.distinct_value && !target.empty?
@@ -231,7 +233,7 @@ module ActiveRecord
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        if loaded?
+        if loaded? || @association_ids
           size.zero?
         else
           target.empty? && !scope.exists?


### PR DESCRIPTION
Already loaded associations were running an extra query when `size` was called on the association.
This fix ensures that an extra query is no longer run.

This addresses #32569 