### PR TITLE
The attributes= alias in ActiveModel doesn't work

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -35,8 +35,6 @@ module ActiveModel
       _assign_attributes(sanitize_for_mass_assignment(attributes))
     end
 
-    alias attributes= assign_attributes
-
     private
 
       def _assign_attributes(attributes)

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -68,14 +68,6 @@ class AttributeAssignmentTest < ActiveModel::TestCase
     assert_equal "world", model.description
   end
 
-  test "simple assignment alias" do
-    model = Model.new
-
-    model.attributes = { name: "hello", description: "world" }
-    assert_equal "hello", model.name
-    assert_equal "world", model.description
-  end
-
   test "assign non-existing attribute" do
     model = Model.new
     error = assert_raises(ActiveModel::UnknownAttributeError) do


### PR DESCRIPTION
### Summary

`attributes=` in the ActiveModel doesn't work unless the alias is defined explicitly in the new class being made. Here's an example from a simple program:

```ruby
require 'active_model'

class Person
  include ActiveModel::Model

  attr_accessor :name, :age
  validates_presence_of :name
end

person = Person.new(name: "Bob", age: 23)
p person

person.attributes = { name: "Eric", age: 32 }
p person
```

This code raises the following error:
![2018-04-18 17 57 42](https://user-images.githubusercontent.com/10546292/38921980-0d88c2fc-4332-11e8-8f10-80a8c353bd1d.png)

Putting the alias explicitly in the class being made will work
```ruby
require 'active_model'

class Person
  include ActiveModel::Model

  attr_accessor :name, :age
  validates_presence_of :name

  alias attributes= assign_attributes
end

person = Person.new(name: "Bob", age: 23)
p person

person.attributes = { name: "Eric", age: 32 }
p person
```

![2018-04-18 17 58 24](https://user-images.githubusercontent.com/10546292/38922010-21bbf956-4332-11e8-88d2-a4d0b0f80284.png)

Because the test was failing I decided to delete the alias from the module and the test itself.