### PR TITLE
Implement change() to properly reflect the correct UTC time

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Normalize the date component to account for DST.
+*   Normalize the date component for `time` columns to the epoch date of 2000-01-01.
 
     *Sean Prashad*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Normalize the date component to account for DST.
+
+    *Sean Prashad*
+
 *   Fix logic on disabling commit callbacks so they are not called unexpectedly when errors occur.
 
     *Brian Durand*

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -131,7 +131,7 @@ module ActiveRecord
 
       def quoted_time(value) # :nodoc:
         value = value.change(year: 2000, month: 1, day: 1)
-        quoted_date(value).sub(/\A\d\d\d\d-\d\d-\d\d /, "")
+        quoted_date(value).slice(11..-1)
       end
 
       def quoted_binary(value) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -130,6 +130,7 @@ module ActiveRecord
       end
 
       def quoted_time(value) # :nodoc:
+        value = value.change(year: 2000, month: 1, day: 1)
         quoted_date(value).sub(/\A\d\d\d\d-\d\d-\d\d /, "")
       end
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -71,8 +71,19 @@ module ActiveRecord
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
 
-          expected = t.getutc.change(year: 2000, month: 1, day: 1)
-          expected = expected.to_s(:db).sub("2000-01-01 ", "")
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
+
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_dst
+        with_timezone_config default: :utc do
+          t = Time.now.change(usec: 0)
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
 
           assert_equal expected, @quoter.quoted_time(t)
         end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -71,20 +71,33 @@ module ActiveRecord
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
 
+          puts t
+
           expected = t.change(year: 2000, month: 1, day: 1)
-          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
+          expected = expected.getutc.to_s(:db).slice(11..-1)
 
           assert_equal expected, @quoter.quoted_time(t)
         end
       end
 
-      def test_quoted_time_dst
+      def test_quoted_time_utc_dst
         with_timezone_config default: :utc do
-          t = Time.now.change(usec: 0)
+          t = Time.new(2000, 7, 1)
 
-          expected = t.change(year: 2000, month: 1, day: 1)
-          expected = expected.getutc.to_s(:db).sub("2000-01-01 ", "")
+          puts t
 
+          expected = t.change(year: 2000, month: 7, day: 1)
+          expected = expected.getutc.to_s(:db).slice(11..-1)
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_utc_local
+        with_timezone_config default: :local do
+          t = Time.new(2000, 7, 1)
+
+          expected = t.change(year: 2000, month: 7, day: 1)
+          expected = expected.getlocal.to_s(:db).slice(11..-1)
           assert_equal expected, @quoter.quoted_time(t)
         end
       end


### PR DESCRIPTION
### Summary

Fixes #32550 - implemented `change()` to properly convert the value to UTC on the date component (_which may be different to the conversion_) to UTC on `2000-01-01`.

### Other Information

N/A