### PR TITLE
[ci skip] Update README and RDOC_MAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Welcome to Rails
 
-Rails is a web-application framework that includes everything needed to
+## What's Rails
+
+**Rails** is a web-application framework that includes everything needed to
 create database-backed web applications according to the
 [Model-View-Controller (MVC)](http://en.wikipedia.org/wiki/Model-view-controller)
 pattern.
@@ -8,41 +10,46 @@ pattern.
 Understanding the MVC pattern is key to understanding Rails. MVC divides your
 application into three layers: Model, View, and Controller, each with a specific responsibility.
 
-The _Model layer_ represents the domain model (such as Account, Product,
+## Model layer
+
+The _**Model layer**_ represents the domain model (such as Account, Product,
 Person, Post, etc.) and encapsulates the business logic specific to
 your application. In Rails, database-backed model classes are derived from
-`ActiveRecord::Base`. Active Record allows you to present the data from
+`ActiveRecord::Base`. [Active Record](activerecord/README.rdoc) allows you to present the data from
 database rows as objects and embellish these data objects with business logic
-methods. You can read more about Active Record in its [README](activerecord/README.rdoc).
+methods.
 Although most Rails models are backed by a database, models can also be ordinary
 Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the Active Model module. You can read more about Active Model in its [README](activemodel/README.rdoc).
+the [Active Model](activemodel/README.rdoc) module.
 
-The _Controller layer_ is responsible for handling incoming HTTP requests and
+## Controller layer
+
+The _**Controller layer**_ is responsible for handling incoming HTTP requests and
 providing a suitable response. Usually this means returning HTML, but Rails controllers
 can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
 manipulate models, and render view templates in order to generate the appropriate HTTP response.
 In Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
 controller classes are derived from `ActionController::Base`. Action Dispatch and Action Controller
-are bundled together in Action Pack. You can read more about Action Pack in its
-[README](actionpack/README.rdoc).
+are bundled together in [Action Pack](actionpack/README.rdoc).
 
-The _View layer_ is composed of "templates" that are responsible for providing
+## View layer
+
+The _**View layer**_ is composed of "templates" that are responsible for providing
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are HTML with embedded
 Ruby code (ERB files). Views are typically rendered to generate a controller response,
-or to generate the body of an email. In Rails, View generation is handled by Action View.
-You can read more about Action View in its [README](actionview/README.rdoc).
+or to generate the body of an email. In Rails, View generation is handled by [Action View](actionview/README.rdoc).
 
-Active Record, Active Model, Action Pack, and Action View can each be used independently outside Rails.
-In addition to that, Rails also comes with Action Mailer ([README](actionmailer/README.rdoc)), a library
-to generate and send emails; Active Job ([README](activejob/README.md)), a
+## Frameworks and libraries
+
+[Active Record](activerecord/README.rdoc), [Active Model](activemodel/README.rdoc), [Action Pack](actionpack/README.rdoc), and [Action View](actionview/README.rdoc) can each be used independently outside Rails.
+In addition to that, Rails also comes with [Action Mailer](actionmailer/README.rdoc), a library
+to generate and send emails; [Active Job](activejob/README.md), a
 framework for declaring jobs and making them run on a variety of queueing
-backends; Action Cable ([README](actioncable/README.md)), a framework to
-integrate WebSockets with a Rails application;
-Active Storage ([README](activestorage/README.md)), a library to attach cloud
+backends; [Action Cable](actioncable/README.md), a framework to
+integrate WebSockets with a Rails application; [Active Storage](activestorage/README.md), a library to attach cloud
 and local files to Rails applications;
-and Active Support ([README](activesupport/README.rdoc)), a collection
+and [Active Support](activesupport/README.rdoc), a collection
 of utility classes and standard library extensions that are useful for Rails,
 and may also be used independently outside Rails.
 

--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -2,7 +2,7 @@
 
 == What's \Rails
 
-<b>\Rails</b> is a web-application framework that includes everything needed to
+\Rails is a web-application framework that includes everything needed to
 create database-backed web applications according to the
 {Model-View-Controller (MVC)}[http://en.wikipedia.org/wiki/Model-view-controller]
 pattern.

--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -1,6 +1,8 @@
-== Welcome to \Rails
+= Welcome to \Rails
 
-\Rails is a web-application framework that includes everything needed to
+== What's Rails
+
+<b>\Rails</b> is a web-application framework that includes everything needed to
 create database-backed web applications according to the
 {Model-View-Controller (MVC)}[http://en.wikipedia.org/wiki/Model-view-controller]
 pattern.
@@ -8,41 +10,46 @@ pattern.
 Understanding the MVC pattern is key to understanding \Rails. MVC divides your
 application into three layers: Model, View, and Controller, each with a specific responsibility.
 
-The <em>Model layer</em> represents the domain model (such as Account, Product,
-Person, Post, etc.) and encapsulates the business logic that is specific to
-your application. In \Rails, database-backed model classes are derived from
-ActiveRecord::Base. Active Record allows you to present the data from
-database rows as objects and embellish these data objects with business logic
-methods. You can read more about Active Record in its {README}[link:files/activerecord/README_rdoc.html].
-Although most \Rails models are backed by a database, models can also be ordinary
-Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the Active Model module. You can read more about Active Model in its {README}[link:files/activemodel/README_rdoc.html].
+== Model layer
 
-The <em>Controller layer</em> is responsible for handling incoming HTTP requests and
+The <em><b>Model layer</b></em> represents the domain model (such as Account, Product,
+Person, Post, etc.) and encapsulates the business logic specific to
+your application. In \Rails, database-backed model classes are derived from
+<tt>ActiveRecord::Base</tt>. {Active Record}[link:../activerecord/README.rdoc] allows you to present the data from
+database rows as objects and embellish these data objects with business logic
+methods. Although most \Rails models are backed by a database, models can also be ordinary
+Ruby classes, or Ruby classes that implement a set of interfaces as provided by
+the {Active Model}[link:../activemodel/README.rdoc] module.
+
+== Controller layer
+
+The <em><b>Controller layer</b></em> is responsible for handling incoming HTTP requests and
 providing a suitable response. Usually this means returning \HTML, but \Rails controllers
 can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
 manipulate models, and render view templates in order to generate the appropriate HTTP response.
 In \Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
-controller classes are derived from ActionController::Base. Action Dispatch and Action Controller
-are bundled together in Action Pack. You can read more about Action Pack in its
-{README}[link:files/actionpack/README_rdoc.html].
+controller classes are derived from <tt>ActionController::Base</tt>. Action Dispatch and Action Controller
+are bundled together in {Action Pack}[link:../actionpack/README.rdoc].
 
-The <em>View layer</em> is composed of "templates" that are responsible for providing
+== View layer
+
+The <em><b>View layer</b></em> is composed of "templates" that are responsible for providing
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are \HTML with embedded
 Ruby code (ERB files). Views are typically rendered to generate a controller response,
-or to generate the body of an email. In \Rails, View generation is handled by Action View.
-You can read more about Action View in its {README}[link:files/actionview/README_rdoc.html].
+or to generate the body of an email. In \Rails, View generation is handled by {Action View}[link:../actionview/README.rdoc].
 
-Active Record, Active Model, Action Pack, and Action View can each be used independently outside \Rails.
-In addition to that, \Rails also comes with Action Mailer ({README}[link:files/actionmailer/README_rdoc.html]), a library
-to generate and send emails; Active Job ({README}[link:files/activejob/README_md.html]), a
+== Frameworks and libraries
+
+{Active Record}[link:../activerecord/README.rdoc], {Active Model}[link:../activemodel/README.rdoc],
+{Action Pack}[link:../actionpack/README.rdoc], and {Action View}[link:../actionview/README.rdoc] can each be used independently outside \Rails.
+In addition to that, \Rails also comes with {Action Mailer}[link:../actionmailer/README.rdoc], a library
+to generate and send emails; {Active Job}[link:../activejob/README.md], a
 framework for declaring jobs and making them run on a variety of queueing
-backends; Action Cable ({README}[link:files/actioncable/README_md.html]), a framework to
-integrate WebSockets with a \Rails application;
-Active Storage ({README}[link:files/activestorage/README_md.html]), a library to attach cloud
-and local files to \Rails applications;
-and Active Support ({README}[link:files/activesupport/README_rdoc.html]), a collection
+backends; {Action Cable}[link:../actioncable/README.md], a framework to
+integrate WebSockets with a \Rails application; {Active Storage}[link:../activestorage/README.md],
+a library to attach cloud and local files to \Rails applications;
+and {Active Support}[link:../activesupport/README.rdoc], a collection
 of utility classes and standard library extensions that are useful for \Rails,
 and may also be used independently outside \Rails.
 

--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -1,6 +1,8 @@
-== Welcome to \Rails
+= Welcome to \Rails
 
-\Rails is a web-application framework that includes everything needed to
+== What's \Rails
+
+<b>\Rails</b> is a web-application framework that includes everything needed to
 create database-backed web applications according to the
 {Model-View-Controller (MVC)}[http://en.wikipedia.org/wiki/Model-view-controller]
 pattern.
@@ -8,41 +10,46 @@ pattern.
 Understanding the MVC pattern is key to understanding \Rails. MVC divides your
 application into three layers: Model, View, and Controller, each with a specific responsibility.
 
-The <em>Model layer</em> represents the domain model (such as Account, Product,
-Person, Post, etc.) and encapsulates the business logic that is specific to
-your application. In \Rails, database-backed model classes are derived from
-ActiveRecord::Base. Active Record allows you to present the data from
-database rows as objects and embellish these data objects with business logic
-methods. You can read more about Active Record in its {README}[link:files/activerecord/README_rdoc.html].
-Although most \Rails models are backed by a database, models can also be ordinary
-Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the Active Model module. You can read more about Active Model in its {README}[link:files/activemodel/README_rdoc.html].
+== Model layer
 
-The <em>Controller layer</em> is responsible for handling incoming HTTP requests and
+The <em><b>Model layer</b></em> represents the domain model (such as Account, Product,
+Person, Post, etc.) and encapsulates the business logic specific to
+your application. In \Rails, database-backed model classes are derived from
+<tt>ActiveRecord::Base</tt>. {Active Record}[link:../activerecord/README.rdoc] allows you to present the data from
+database rows as objects and embellish these data objects with business logic
+methods. Although most \Rails models are backed by a database, models can also be ordinary
+Ruby classes, or Ruby classes that implement a set of interfaces as provided by
+the {Active Model}[link:../activemodel/README.rdoc] module.
+
+== Controller layer
+
+The <em><b>Controller layer</b></em> is responsible for handling incoming HTTP requests and
 providing a suitable response. Usually this means returning \HTML, but \Rails controllers
 can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
 manipulate models, and render view templates in order to generate the appropriate HTTP response.
 In \Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
-controller classes are derived from ActionController::Base. Action Dispatch and Action Controller
-are bundled together in Action Pack. You can read more about Action Pack in its
-{README}[link:files/actionpack/README_rdoc.html].
+controller classes are derived from <tt>ActionController::Base</tt>. Action Dispatch and Action Controller
+are bundled together in {Action Pack}[link:../actionpack/README.rdoc].
 
-The <em>View layer</em> is composed of "templates" that are responsible for providing
+== View layer
+
+The <em><b>View layer</b></em> is composed of "templates" that are responsible for providing
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are \HTML with embedded
 Ruby code (ERB files). Views are typically rendered to generate a controller response,
-or to generate the body of an email. In \Rails, View generation is handled by Action View.
-You can read more about Action View in its {README}[link:files/actionview/README_rdoc.html].
+or to generate the body of an email. In \Rails, View generation is handled by {Action View}[link:../actionview/README.rdoc].
 
-Active Record, Active Model, Action Pack, and Action View can each be used independently outside \Rails.
-In addition to that, \Rails also comes with Action Mailer ({README}[link:files/actionmailer/README_rdoc.html]), a library
-to generate and send emails; Active Job ({README}[link:files/activejob/README_md.html]), a
+== Frameworks and libraries
+
+{Active Record}[link:../activerecord/README.rdoc], {Active Model}[link:../activemodel/README.rdoc],
+{Action Pack}[link:../actionpack/README.rdoc], and {Action View}[link:../actionview/README.rdoc] can each be used independently outside \Rails.
+In addition to that, \Rails also comes with {Action Mailer}[link:../actionmailer/README.rdoc], a library
+to generate and send emails; {Active Job}[link:../activejob/README.md], a
 framework for declaring jobs and making them run on a variety of queueing
-backends; Action Cable ({README}[link:files/actioncable/README_md.html]), a framework to
-integrate WebSockets with a \Rails application;
-Active Storage ({README}[link:files/activestorage/README_md.html]), a library to attach cloud
-and local files to \Rails applications;
-and Active Support ({README}[link:files/activesupport/README_rdoc.html]), a collection
+backends; {Action Cable}[link:../actioncable/README.md], a framework to
+integrate WebSockets with a \Rails application; {Active Storage}[link:../activestorage/README.md],
+a library to attach cloud and local files to \Rails applications;
+and {Active Support}[link:../activesupport/README.rdoc], a collection
 of utility classes and standard library extensions that are useful for \Rails,
 and may also be used independently outside \Rails.
 


### PR DESCRIPTION
This is just an update of the README, more about styling than in content, is easier to read now

RDOC_MAIN.rdoc has a fix of broken links too.

Here are some screenshots of how it looks with the changes:

![image](https://user-images.githubusercontent.com/4805305/39005752-a4ca8d00-43c6-11e8-8ae0-4c2b64a60b9d.png)


![image](https://user-images.githubusercontent.com/4805305/39004487-0e660a18-43c3-11e8-869e-9b4b33dc44e0.png)




🚀 