### PR TITLE
Make the master.key readable only by the owner

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Make the master.key file read-only for the owner upon generation on
+    POSIX-compliant systems.
+
+    Previously:
+
+        $ ls -l config/master.key
+        -rw-r--r--   1 owner  group      32 Jan 1 00:00 master.key
+
+    Now:
+
+        $ ls -l config/master.key
+        -rw-------   1 owner  group      32 Jan 1 00:00 master.key
+
+    Fixes #32604.
+
+    *Jose Luis Duran*
+
 *   Deprecate support for using the `HOST` environment to specify the server IP.
 
     The `BINDING` environment should be used instead.

--- a/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
@@ -27,6 +27,7 @@ module Rails
 
       def add_key_file_silently(key_path, key = nil)
         create_file key_path, key || ActiveSupport::EncryptedFile.generate_key
+        key_path.chmod 0600
       end
 
       def ignore_key_file(key_path, ignore: key_ignore(key_path))

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -941,6 +941,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_directory("test/system")
   end
 
+  unless Gem.win_platform?
+    def test_master_key_is_only_readable_by_the_owner
+      run_generator
+
+      stat = File.stat("config/master.key")
+      assert_equal "100600", sprintf("%o", stat.mode)
+    end
+  end
+
   private
     def stub_rails_application(root)
       Rails.application.config.root = root


### PR DESCRIPTION
This change may only apply to POSIX-compliant systems.

Previously:

    $ ls -l config/master.key
    -rw-r--r--   1 owner  group      32 Jan 1 00:00 master.key

Now:

    $ ls -l config/master.key
    -rw-------   1 owner  group      32 Jan 1 00:00 master.key

Fixes #32604.