### PR TITLE
For attributes that do not exist in the table

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -187,7 +187,7 @@ module ActiveRecord
 
             # def active?() status == "active" end
             klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-            define_method("#{value_method_name}?") { self[attr] == label }
+            define_method("#{value_method_name}?") { self.try(attr) == label }
 
             # def active!() update!(status: 0) end
             klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")


### PR DESCRIPTION
### Summary
I'd like to use helper by defining an enum for attributes not actually present in table defined by attr_accessor etc.

### For example
```ruby
class Book < ApplicationRecord
  has_many :lends
  has_one :lend, -> { last }
  enum :status, [:lending, :lendable]

  def status
    if self.lend.return_at.nil?
      :lendable
    else
      :lending
    end
  end
end
class Lend < ApplicationRecord
  belongs_to :book
end
Book.first.lendable?
#=> true/false
```

