### PR TITLE
Update CoC to change a history of updates URL [ci skip]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,5 +8,5 @@ http://rubyonrails.org/conduct/
 
 For a history of updates, see the page history here:
 
-https://github.com/rails/rails.github.com/commits/master/conduct/index.html
+https://github.com/rails/homepage/commits/master/conduct.html
 


### PR DESCRIPTION
### Summary

A history of updates suggested archived URL, so changed new one:

* [NEW] https://github.com/rails/homepage/commits/master/conduct.html
* [OLD] https://github.com/rails/rails.github.com/commits/master/conduct/index.html