### PR TITLE
Add exculude condition in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - '**/templates/**/*'
     - '**/vendor/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
+    - 'railties/test/fixtures/tmp/**/*'
 
 # Prefer assert_not_x over refute_x
 CustomCops/RefuteNot:


### PR DESCRIPTION
### Summary

* Excluded `railties/test/fixtures/tmp/**/*` from rubocop inspect files (many warnings are shown)
* These files are generated after running test in railties.