### PR TITLE
Fix relation merging with skip_query_cache!

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,8 @@
-*   Add `ActiveRecord::Base.base_class?` predicate.
+*   Fix relation merging with skip_query_cache!
+
+    *James Williams*
+
+*    Add `ActiveRecord::Base.base_class?` predicate.
 
     *Bogdan Gusiev*
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -894,8 +894,8 @@ module ActiveRecord
       self
     end
 
-    def skip_query_cache! # :nodoc:
-      self.skip_query_cache_value = true
+    def skip_query_cache!(value = true) # :nodoc:
+      self.skip_query_cache_value = value
       self
     end
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -78,6 +78,10 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal 1, comments.count
   end
 
+  def test_relation_merging_with_skip_query_cache
+    assert_equal Post.all.merge(Post.all.skip_query_cache!).skip_query_cache_value, true
+  end
+
   def test_relation_merging_with_association
     assert_queries(2) do  # one for loading post, and another one merged query
       post = Post.where(body: "Such a lovely day").first


### PR DESCRIPTION
### Summary

Allow skip_query_cache to receive an argument, similar to other methods (e.g. `distinct!`)

Fixes an issue where `ActiveRecord::Relation::Merger` tries to send the value to the other relation when it's set https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/merger.rb#L76

Fixes #32640 