### PR TITLE
Allow rubocop check more files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,12 +14,12 @@ AllCops:
 # Prefer assert_not_x over refute_x
 CustomCops/RefuteNot:
   Include:
-    - '**/*_test.rb'
+    - '**/test/**/*'
 
 # Prefer assert_not over assert !
 CustomCops/AssertNot:
   Include:
-    - '**/*_test.rb'
+    - '**/test/**/*'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:

--- a/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
@@ -7,9 +7,9 @@ module CacheDeleteMatchedBehavior
     @cache.write("foo/bar", "baz")
     @cache.write("fu/baz", "bar")
     @cache.delete_matched(/oo/)
-    assert !@cache.exist?("foo")
+    assert_not @cache.exist?("foo")
     assert @cache.exist?("fu")
-    assert !@cache.exist?("foo/bar")
+    assert_not @cache.exist?("foo/bar")
     assert @cache.exist?("fu/baz")
   end
 end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -33,7 +33,7 @@ module CacheStoreBehavior
 
     cache_miss = false
     assert_equal 3, @cache.fetch("foo") { |key| cache_miss = true; key.length }
-    assert !cache_miss
+    assert_not cache_miss
   end
 
   def test_fetch_with_forced_cache_miss
@@ -308,7 +308,7 @@ module CacheStoreBehavior
     @cache.write("foo", "bar")
     assert @cache.exist?("foo")
     assert @cache.delete("foo")
-    assert !@cache.exist?("foo")
+    assert_not @cache.exist?("foo")
   end
 
   def test_original_store_objects_should_not_be_immutable

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -30,7 +30,7 @@ module CacheStoreVersionBehavior
 
   def test_exist_with_wrong_version_should_be_false
     @cache.write("foo", "bar", version: 1)
-    assert !@cache.exist?("foo", version: 2)
+    assert_not @cache.exist?("foo", version: 2)
   end
 
   def test_reading_and_writing_with_model_supporting_cache_version

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -63,7 +63,7 @@ module FailureSafetyBehavior
     @cache.write("foo", "bar")
 
     emulating_unavailability do |cache|
-      assert !cache.exist?("foo")
+      assert_not cache.exist?("foo")
     end
   end
 

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -30,7 +30,7 @@ module FileUpdateCheckerSharedTests
 
     checker = new_checker { i += 1 }
 
-    assert !checker.execute_if_updated
+    assert_not checker.execute_if_updated
     assert_equal 0, i
   end
 
@@ -41,7 +41,7 @@ module FileUpdateCheckerSharedTests
 
     checker = new_checker(tmpfiles) { i += 1 }
 
-    assert !checker.execute_if_updated
+    assert_not checker.execute_if_updated
     assert_equal 0, i
   end
 
@@ -212,7 +212,7 @@ module FileUpdateCheckerSharedTests
     touch(tmpfile("foo.rb"))
     wait
 
-    assert !checker.execute_if_updated
+    assert_not checker.execute_if_updated
     assert_equal 0, i
   end
 
@@ -238,7 +238,7 @@ module FileUpdateCheckerSharedTests
     mkdir(subdir)
     wait
 
-    assert !checker.execute_if_updated
+    assert_not checker.execute_if_updated
     assert_equal 0, i
 
     touch(File.join(subdir, "nested.rb"))
@@ -259,7 +259,7 @@ module FileUpdateCheckerSharedTests
     touch(tmpfile("new.txt"))
     wait
 
-    assert !checker.execute_if_updated
+    assert_not checker.execute_if_updated
     assert_equal 0, i
 
     # subdir does not look for Ruby files, but its parent tmpdir does.


### PR DESCRIPTION
This commit fix pattern of filenames for `CustomCops/AssertNot` and
`CustomCops/RefuteNot`.

rubocop should check every file under `test/`.

Related to #32441, #32605
