### PR TITLE
Create a .ruby-version compatible with MRI/JRuby by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= RUBY_VERSION -%>
+<%= "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -851,7 +851,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/ruby '#{RUBY_VERSION}'/, content)
     end
     assert_file ".ruby-version" do |content|
-      assert_match(/#{RUBY_VERSION}/, content)
+      assert_match(/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}/, content)
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/32639