### PR TITLE
Return back "/" to the end of RAILS_GEM_ROOT

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -125,7 +125,7 @@ module ActiveRecord
         ]
       end
 
-      RAILS_GEM_ROOT = File.expand_path("../../../..", __FILE__) + "/"
+      RAILS_GEM_ROOT = File.expand_path("../../..", __dir__) + "/"
 
       def ignored_callstack(path)
         path.start_with?(RAILS_GEM_ROOT) ||

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -104,7 +104,7 @@ module ActiveSupport
           end
         end
 
-        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__)
+        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/"
 
         def ignored_callstack(path)
           path.start_with?(RAILS_GEM_ROOT) || path.start_with?(RbConfig::CONFIG["rubylibdir"])


### PR DESCRIPTION
- The "/" was removed in 40bdbce191ad90dfea43dad51fac5c4726b89392 during
refactoring. It may cause regression since looks like was added
intentionaly because it is possible that a name of any another gem
can start with /rails/, so slash was added to ensure that it is "rails"
gem.
I would like to backport this to `5-2-stable` too.

- Use `__dir__` instead of `__FILE__`. Follow up #29176.
