### PR TITLE
Add missing changelog entry

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix strong parameters `permit!` with nested arrays.
+
+    Given:
+    ```
+    params = ActionController::Parameters.new(nested_arrays: [[{ x: 2, y: 3 }, { x: 21, y: 42 }]])
+    params.permit!
+    ```
+
+    `params[:nested_arrays][0][0].permitted?` will now return `true` instead of `false`.
+
+    *Steve Hull*
+
 *   Output only one Content-Security-Policy nonce header value per request.
 
     Fixes #32597.


### PR DESCRIPTION
https://github.com/rails/rails/pull/32593 was backported to
`5-2-stable` but since 5.2.0 is released the changelog entry should
be in Rails 6.0.0 too.

[ci skip]
