### PR TITLE
Use assert_no_match for test_order_to_unscope_reordering

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -193,7 +193,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
 
   def test_order_to_unscope_reordering
     scope = DeveloperOrderedBySalary.order("salary DESC, name ASC").reverse_order.unscope(:order)
-    assert_not /order/i.match?(scope.to_sql)
+    assert_no_match(/order/i, scope.to_sql)
   end
 
   def test_unscope_reverse_order


### PR DESCRIPTION

### Summary

This pull request suppresses the "warning: ambiguous first argument; put parentheses or a space even after `/' operator" warning at default_scoping_test.rb

```ruby
$ bundle exec ruby -w -Itest test/cases/scoping/default_scoping_test.rb -n test_order_to_unscope_reordering
test/cases/scoping/default_scoping_test.rb:196: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Using sqlite3
Run options: -n test_order_to_unscope_reordering --seed 61444

.

Finished in 0.032895s, 30.3995 runs/s, 30.3995 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
```

