### PR TITLE
Preloading through polymorphic associations (still raises for typos on regular associations)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,5 @@
-*   Can preload through polymorphic associations (e.g. `Review.includes(media: [:author, :director])` where not all media records have an author or director)
+*   Add support to preload associations of polymorphic associations when not all the records have the requested associations.
+
     *Dana Sherson*
 
 *   Add `ActiveRecord::Base.base_class?` predicate.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Can preload through polymorphic associations (e.g. `Review.includes(media: [:author, :director])` where not all media records have an author or director)
+    *Dana Sherson*
+
 *   Add `ActiveRecord::Base.base_class?` predicate.
 
     *Bogdan Gusiev*

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -98,26 +98,33 @@ module ActiveRecord
       private
 
         # Loads all the given data into +records+ for the +association+.
-        def preloaders_on(association, records, scope)
+        def preloaders_on(association, records, scope, polymorphic_parent = false)
           case association
           when Hash
-            preloaders_for_hash(association, records, scope)
+            preloaders_for_hash(association, records, scope, polymorphic_parent)
           when Symbol
-            preloaders_for_one(association, records, scope)
+            preloaders_for_one(association, records, scope, polymorphic_parent)
           when String
-            preloaders_for_one(association.to_sym, records, scope)
+            preloaders_for_one(association.to_sym, records, scope, polymorphic_parent)
           else
             raise ArgumentError, "#{association.inspect} was not recognized for preload"
           end
         end
 
-        def preloaders_for_hash(association, records, scope)
+        def preloaders_for_hash(association, records, scope, polymorphic_parent)
           association.flat_map { |parent, child|
-            loaders = preloaders_for_one parent, records, scope
+            loaders = preloaders_for_one parent, records, scope, polymorphic_parent
 
             recs = loaders.flat_map(&:preloaded_records).uniq
+            polymorphic_parent = begin
+              records.first.association(parent).options[:polymorphic]
+            rescue ActiveRecord::AssociationNotFoundError
+              raise unless polymorphic_parent
+              false
+            end
+
             loaders.concat Array.wrap(child).flat_map { |assoc|
-              preloaders_on assoc, recs, scope
+              preloaders_on assoc, recs, scope, polymorphic_parent
             }
             loaders
           }
@@ -135,8 +142,8 @@ module ActiveRecord
         # Additionally, polymorphic belongs_to associations can have multiple associated
         # classes, depending on the polymorphic_type field. So we group by the classes as
         # well.
-        def preloaders_for_one(association, records, scope)
-          grouped_records(association, records).flat_map do |reflection, klasses|
+        def preloaders_for_one(association, records, scope, polymorphic_parent)
+          grouped_records(association, records, polymorphic_parent).flat_map do |reflection, klasses|
             klasses.map do |rhs_klass, rs|
               loader = preloader_for(reflection, rs).new(rhs_klass, rs, reflection, scope)
               loader.run self
@@ -145,11 +152,16 @@ module ActiveRecord
           end
         end
 
-        def grouped_records(association, records)
+        def grouped_records(association, records, polymorphic_parent)
           h = {}
           records.each do |record|
             next unless record
-            assoc = record.association(association)
+            begin
+              assoc = record.association(association)
+            rescue ActiveRecord::AssociationNotFoundError
+              raise unless polymorphic_parent
+              next
+            end
             next unless assoc.klass
             klasses = h[assoc.reflection] ||= {}
             (klasses[assoc.klass] ||= []) << record

--- a/activerecord/test/fixtures/sponsors.yml
+++ b/activerecord/test/fixtures/sponsors.yml
@@ -10,3 +10,6 @@ crazy_club_sponsor_for_groucho:
   sponsor_club: crazy_club
   sponsorable_id: 3
   sponsorable_type: Member
+sponsor_for_author_david:
+  sponsorable_id: 1
+  sponsorable_type: Author


### PR DESCRIPTION
given a structure like:
```
Review.has_many :media, polymorphic: true
# where media could be either
Movie.has_one :director
Book.has_one :author
``` 
Attempting to preload like `Review.includes(media: [:author, :director])` (might, depending on records returned) raise `ActiveRecord::AssociationNotFoundError`

This PR will only not raise `AssociationNotFoundError` if the parent association (`:media`) is polymorphic. A typo of `:media` itself, or `:studio` in `Review.includes(media: [:author, { director: :studio }])` it would still raise `AssociationNotFoundError`

This does mean if there was a typo in `:author` or `:director` then the `AssociationNotFoundError` wouldn't be raised, but currently this type of preload isn't possible at all (unless all the possible classes of the polymorphic association have the same further association).

### Other Information

There seems to be a lot of expectation that this should work:
https://stackoverflow.com/questions/42773318/eager-load-depending-on-type-of-association-in-ruby-on-rails
The suggested fixes are to deal with this by manually invoking the Preloader (internal API), or by adding scopes for each associated type (undoing the point of polymorphic association in the first place, and very difficult for polymorphic belongs_to)

There's a long open PR (with lots of +1's) that tries to solve this by just never raising: https://github.com/rails/rails/pull/17479

Resolves #8005