### PR TITLE
2.6 warning: ambiguous first argument

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -366,7 +366,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     process :redirect_external
     assert_predicate @response, :redirect?
     assert_match(/rubyonrails/, @response.redirect_url)
-    assert_not /perloffrails/.match(@response.redirect_url)
+    assert_no_match(/perloffrails/, @response.redirect_url)
   end
 
   def test_redirection


### PR DESCRIPTION
```warning: ambiguous first argument; put parentheses or a space even after `/' operator```

See:
https://travis-ci.org/rails/rails/jobs/368956453#L1179
https://travis-ci.org/rails/rails/jobs/368956453#L1232