### PR TITLE
Adds DigitalOceanService to ActiveStorage

### DIFF
--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -4,4 +4,5 @@ module ActiveStorage
   class InvariableError < StandardError; end
   class UnpreviewableError < StandardError; end
   class UnrepresentableError < StandardError; end
+  class UnavailableConfigurationError < StandardError; end
 end

--- a/activestorage/lib/active_storage/service/digital_ocean_service.rb
+++ b/activestorage/lib/active_storage/service/digital_ocean_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "active_storage/service/s3_service"
+
+module ActiveStorage
+  # Wraps the DigitalOcean Spaces as an Active Storage service.
+  # See ActiveStorage::Service for the generic API documentation that applies to all services.
+  class Service::DigitalOceanService < Service::S3Service
+    def initialize(bucket:, upload: {}, **options)
+      options[:access_key_id] = options.delete(:spaces_access_key)
+      options[:secret_access_key] = options.delete(:spaces_secret_key)
+
+      raise ActiveStorage::UnavailableConfigurationError if upload[:server_side_encryption]
+
+      super
+    end
+  end
+end

--- a/activestorage/test/service/digital_ocean_service_test.rb
+++ b/activestorage/test/service/digital_ocean_service_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "service/shared_service_tests"
+require "net/http"
+
+if SERVICE_CONFIGURATIONS[:digital_ocean]
+  class ActiveStorage::Service::DigitalOceanServiceTest < ActiveSupport::TestCase
+    SERVICE = ActiveStorage::Service.configure(:digital_ocean, SERVICE_CONFIGURATIONS)
+
+    include ActiveStorage::Service::SharedServiceTests
+
+    test "direct upload" do
+      begin
+        key      = SecureRandom.base58(24)
+        data     = "Something else entirely!"
+        checksum = Digest::MD5.base64digest(data)
+        url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+        uri = URI.parse url
+        request = Net::HTTP::Put.new uri.request_uri
+        request.body = data
+        request.add_field "Content-Type", "text/plain"
+        request.add_field "Content-MD5", checksum
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.request request
+        end
+
+        assert_equal data, @service.download(key)
+      ensure
+        @service.delete key
+      end
+    end
+
+    test "signed URL generation" do
+      url = @service.url(FIXTURE_KEY, expires_in: 5.minutes,
+        disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+
+      assert_match(/(-[-a-z0-9]+)?\.(\S+)?digitaloceanspaces.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url)
+      assert_match SERVICE_CONFIGURATIONS[:digital_ocean][:bucket], url
+    end
+
+    test "configuring upload with server-side encryption" do
+      config = SERVICE_CONFIGURATIONS.deep_merge(digital_ocean: { upload: { server_side_encryption: "AES256" } })
+
+      assert_raise ActiveStorage::UnavailableConfigurationError do
+        service = ActiveStorage::Service.configure(:digital_ocean, config)
+      end
+    end
+  end
+else
+  puts "Skipping DigitalOcean Service tests because no DigitalOcean configuration was supplied"
+end


### PR DESCRIPTION
While at RailsConf I overheard someone mention that DigitalOcean spaces were compatible with the `aws-sdk-s3` gem. I then saw an article, https://fedible.org/2017/11/26/integrate-activestorage-with-digitalocean-spaces.html, that discussed how DigitalOcean Spaces could be used with the current implementation of `ActiveStorage`. 

I thought, given the compatibly, it might be nice to make it easier for people to setup `ActiveStorage` with DigitalOcean Spaces by officially supporting them.

The only feature from  Amazon S3 that was is not supported by Spaces (that I can find) is the `server_side_encryption` on uploads.

I'm not sure if this is something that Rails Team would want to support, so I wanted to submit this WIP to see if there was any interest for adding more services. Obviously this isn't finished, but I wanted to get some feedback before I continued.

Let me know what you think, and if this is something you would like me to continue working on!

**sidenote, I am not affiliated with DigitalOcean, just thought this might be interesting to work on.