### PR TITLE
5-2-stable: cherry-pick dc8a66a

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Create the `.ruby-version` file compatible with MRI/JRuby by default.
+
+    Fixes #32639.
+
+    *Guillermo Iguaran*
+
 *   Make the master.key file read-only for the owner upon generation on
     POSIX-compliant systems.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't include `bootsnap` by default in apps generated under JRuby.
+
+    Fixes #32641.
+
+    *Guillermo Iguaran*
+
 *   Create the `.ruby-version` file compatible with MRI/JRuby by default.
 
     Fixes #32639.

--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= RUBY_VERSION -%>
+<%= "#{RUBY_ENGINE}-#{defined?(JRUBY_VERSION) ? JRUBY_VERSION : RUBY_VERSION}" -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -858,7 +858,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/ruby '#{RUBY_VERSION}'/, content)
     end
     assert_file ".ruby-version" do |content|
-      assert_match(/#{RUBY_VERSION}/, content)
+      if defined?(JRUBY_VERSION)
+        assert_match(/jruby-#{JRUBY_VERSION}/, content)
+      else
+        assert_match(/ruby-#{RUBY_VERSION}/, content)
+      end
     end
   end
 


### PR DESCRIPTION
- Create a .ruby-version compatible with MRI/JRuby by default

  cherry-pick dc8a66aa47318b3a6aaf4014b9f118c51edb67e8

  RUBY_ENGINE_VERSION isn't defined in CRuby 2.2.
  Use RUBY_VERSION/JRUBY_VERSION constants instead.

  Add changelog entry.

  Related to #32649, #32639


- Add changelog entry for 69b7c9fc1673606de32c8c5190cd4dfb48ac892a

r? @guilleiguaran