### PR TITLE
Fix order of passed arguments to assert_equal

### DIFF
--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -79,7 +79,7 @@ class RelationMergingTest < ActiveRecord::TestCase
   end
 
   def test_relation_merging_with_skip_query_cache
-    assert_equal Post.all.merge(Post.all.skip_query_cache!).skip_query_cache_value, true
+    assert Post.all.merge(Post.all.skip_query_cache!).skip_query_cache_value
   end
 
   def test_relation_merging_with_association


### PR DESCRIPTION
First argument to `assert_equal` should be expected value,
second - actual value.

Use `assert` in order to assert that `skip_query_cache_value` is truly
object since we rely on Ruby semantics.

Related to #32645
