### PR TITLE
Fix typos related to ActionDispatch::Http::FilterParameters

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -9,8 +9,8 @@ module ActionDispatch
     # sub-hashes of the params hash to filter. Filtering only certain sub-keys
     # from a hash is possible by using the dot notation: 'credit_card.number'.
     # If a block is given, each key and value of the params hash and all
-    # sub-hashes is passed to it, where the value or the key can be replaced using
-    # String#replace or similar method.
+    # sub-hashes are passed to it, where the value or the key can be replaced using
+    # String#replace or similar methods.
     #
     #   env["action_dispatch.parameter_filter"] = [:password]
     #   => replaces the value to all keys matching /password/i with "[FILTERED]"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1417,7 +1417,7 @@ module ApplicationTests
       assert_equal "XML", last_response.body
     end
 
-    test "Rails.application#env_config exists and include some existing parameters" do
+    test "Rails.application#env_config exists and includes some existing parameters" do
       make_basic_app
 
       assert_equal app.env_config["action_dispatch.parameter_filter"],  app.config.filter_parameters


### PR DESCRIPTION
### Summary
This patch:
* Fixes two documentation typos found at `ActionDispatch::Http::FilterParameters` while reading this class.
* Fixes one test method name typo.

### Additional information
First commit has [ci skip] because it didn't need to pass CI for documentation, but second commit (issue found later) doesn't skip CI to be safe against the possibility (although very low) of repeating the same test method name.