### PR TITLE
Add a removal in ActionPack changelog for Rails 5.2

### DIFF
--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -212,6 +212,9 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 *   Remove deprecated `ActionController::ParamsParser::ParseError`.
     ([Commit](https://github.com/rails/rails/commit/e16c765ac6dcff068ff2e5554d69ff345c003de1))
 
+*   Remove deprecated `ActionController::UnknownController`.
+    ([Commit](https://github.com/rails/rails/commit/b1c8610fca6d8a59246e190bfaed1aa445480b07))
+
 ### Deprecations
 
 *   Deprecate `#success?`, `#missing?` and `#error?` aliases of


### PR DESCRIPTION
### Summary

The controller exception `ActionController:: UnknownController` has been [removed from Rails 5.2](https://github.com/rails/rails/commit/b1c8610fca6d8a59246e190bfaed1aa445480b07), but that change has not been written in the [changelog](http://guides.rubyonrails.org/5_2_release_notes.html#action-pack)