### PR TITLE
Allow `primary_key` argument to  `empty_insert_statement_value`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -385,7 +385,7 @@ module ActiveRecord
         end
       end
 
-      def empty_insert_statement_value
+      def empty_insert_statement_value(primary_key = nil)
         "DEFAULT VALUES"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -223,7 +223,7 @@ module ActiveRecord
         end
       end
 
-      def empty_insert_statement_value
+      def empty_insert_statement_value(primary_key = nil)
         "VALUES ()"
       end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -178,7 +178,7 @@ module ActiveRecord
         end
 
         if values.empty?
-          im = arel_table.compile_insert(connection.empty_insert_statement_value)
+          im = arel_table.compile_insert(connection.empty_insert_statement_value(primary_key))
           im.into arel_table
         else
           im = arel_table.compile_insert(_substitute_values(values))


### PR DESCRIPTION
### Summary

Allow `primary_key` argument to  `empty_insert_statement_value` to support Oracle database support identity data type

Oracle database does not support `INSERT .. DEFAULT VALUES` then every insert statement needs at least one column name specified.

When `prefetch_primary_key?` returns `true` insert statement always have the primary key name since the primary key value is selected from the associated sequence. However, supporting identity data type will make `prefetch_primary_key?` returns `false` then no primary key column name added.
As a result, `empty_insert_statement_value` raises `NotImplementedError`.

To address this error `empty_insert_statement_value` can take one argument `primary_key` to generate insert statement like this.

`INSERT INTO "POSTS" ("ID") VALUES(DEFAULT)`

It needs arity change for the public method but no actual behavior changes for the bundled adapters.

### Other Information

Oracle enhanced adapter `empty_insert_statement_value` implementation will be like this:

```ruby
def empty_insert_statement_value(primary_key)
  raise NotImplementedError unless primary_key
  "(#{quote_column_name(primary_key)}) VALUES(DEFAULT)"
end
```

[Raise NotImplementedError when using empty_insert_statement_value with Oracle](https://github.com/rails/rails/pull/28029)
[Add support for INSERT .. DEFAULT VALUES](https://community.oracle.com/ideas/13845)
