### PR TITLE
Include the changelogs when generating the release post.

### DIFF
--- a/tasks/release_announcement_draft.erb
+++ b/tasks/release_announcement_draft.erb
@@ -11,16 +11,14 @@ If you find one, please open an [issue on GitHub](https://github.com/rails/rails
 
 ## CHANGES since <%= version.previous %>
 
-To view the changes for each gem, please read the changelogs on GitHub:
-  <% FRAMEWORKS.sort.each do |framework| %>
-<%= "* [#{FRAMEWORK_NAMES[framework]} CHANGELOG](https://github.com/rails/rails/blob/v#{version}/#{framework}/CHANGELOG.md)" %>
-  <% end %>
+<%= fetch_changes(version) %>
 
-*Full listing*
+### Full listing
 
 To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v<%= "#{version.previous}...v#{version}" %>).
-  <% end %>
+<% end %>
+
 ## SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,


### PR DESCRIPTION
### Summary

We included the changelogs for each frameworks in the release post instead of clicking on github links.

### Other Information

Here is a sample release post generated for the 5.1.6 version: https://gist.github.com/francois2metz/b82a82cc200093c853d569fda52f8bef
