### PR TITLE
Clean up changelogs on master [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,9 +1,3 @@
-*   Output only one Content-Security-Policy nonce header value per request.
-
-    Fixes #32597.
-
-    *Andrey Novikov*, *Andrew White*
-
 *   Move default headers configuration into their own module that can be included in controllers.
 
     *Kevin Deisz*

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,16 +1,3 @@
-*   Fix JavaScript views rendering does not work with Firefox when using
-    Content Security Policy.
-
-    Fixes #32577.
-
-    *Yuji Yaginuma*
-
-*   Add the `nonce: true` option for `javascript_include_tag` helper to
-    support automatic nonce generation for Content Security Policy.
-    Works the same way as `javascript_tag nonce: true` does.
-
-    *Yaroslav Markin*
-
 *   Remove `ActionView::Helpers::RecordTagHelper`.
 
     *Yoshiyuki Hirano*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,20 +1,3 @@
-*   Fix bug where `ActiveSupport::Timezone.all` would fail when tzinfo data for
-    any timezone defined in `ActiveSupport::MAPPING` is missing.
-
-    *Dominik Sander*
-
-*   Redis cache store: `delete_matched` no longer blocks the Redis server.
-    (Switches from evaled Lua to a batched SCAN + DEL loop.)
-
-    *Gleb Mazovetskiy*
-
-*   Fix bug where `ActiveSupport::Cache` will massively inflate the storage
-    size when compression is enabled (which is true by default). This patch
-    does not attempt to repair existing data: please manually flush the cache
-    to clear out the problematic entries.
-
-    *Godfrey Chan*
-
 *   Fix bug where `URI.unscape` would fail with mixed Unicode/escaped character input:
 
         URI.unescape("\xe3\x83\x90")  # => "バ"

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,20 +1,3 @@
-*   Make the master.key file read-only for the owner upon generation on
-    POSIX-compliant systems.
-
-    Previously:
-
-        $ ls -l config/master.key
-        -rw-r--r--   1 owner  group      32 Jan 1 00:00 master.key
-
-    Now:
-
-        $ ls -l config/master.key
-        -rw-------   1 owner  group      32 Jan 1 00:00 master.key
-
-    Fixes #32604.
-
-    *Jose Luis Duran*
-
 *   Deprecate support for using the `HOST` environment to specify the server IP.
 
     The `BINDING` environment should be used instead.


### PR DESCRIPTION
Remove
```
*   Output only one Content-Security-Policy nonce header value per request.

    Fixes #32597.

    *Andrey Novikov*, *Andrew White*
```
since it was backported to `5-2-stable` in
4f8765f.

Remove
```
*   Add the `nonce: true` option for `javascript_include_tag` helper to
    support automatic nonce generation for Content Security Policy.
    Works the same way as `javascript_tag nonce: true` does.

    *Yaroslav Markin*
```
since it was backported to `5-2-stable` in
8cca042.

Remove
```
*   Fix JavaScript views rendering does not work with Firefox when using
    Content Security Policy.

    Fixes #32577.

    *Yuji Yaginuma*
```
since it was backported to `5-2-stable` in
744a506.

Remove
```
*   Fix bug where `ActiveSupport::Cache` will massively inflate the storage
    size when compression is enabled (which is true by default). This patch
    does not attempt to repair existing data: please manually flush the cache
    to clear out the problematic entries.

    *Godfrey Chan*
```
since it was backported to `5-2-stable` in
276fa9d.

Remove
```
*   Fix bug where `ActiveSupport::Timezone.all` would fail when tzinfo data for
    any timezone defined in `ActiveSupport::MAPPING` is missing.

    *Dominik Sander*
```
since it was backported to `5-2-stable` in
3084e9c.

Remove
```
*   Redis cache store: `delete_matched` no longer blocks the Redis server.
    (Switches from evaled Lua to a batched SCAN + DEL loop.)

    *Gleb Mazovetskiy*
```
since it was backported to `5-2-stable` in
6bc0f8d.

Remove
```
*   Make the master.key file read-only for the owner upon generation on
    POSIX-compliant systems.

    Previously:

        $ ls -l config/master.key
        -rw-r--r--   1 owner  group      32 Jan 1 00:00 master.key

    Now:

        $ ls -l config/master.key
        -rw-------   1 owner  group      32 Jan 1 00:00 master.key

    Fixes #32604.

    *Jose Luis Duran*
```
since it was backported to `5-2-stable` in
5411796.

Related to https://github.com/rails/rails/pull/32652#issuecomment-382956920

r? @rafaelfranca 