### PR TITLE
Reset RAW_POST_DATA between test requests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -460,10 +460,6 @@ module ActionController
       def process(action, method: "GET", params: {}, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
         check_required_ivars
 
-        if body
-          @request.set_header "RAW_POST_DATA", body
-        end
-
         http_method = method.to_s.upcase
 
         @html_document = nil
@@ -477,6 +473,10 @@ module ActionController
         @response         = build_response @response_klass
         @response.request = @request
         @controller.recycle!
+
+        if body
+          @request.set_header "RAW_POST_DATA", body
+        end
 
         @request.set_header "REQUEST_METHOD", http_method
 
@@ -604,6 +604,7 @@ module ActionController
           env.delete "action_dispatch.request.query_parameters"
           env.delete "action_dispatch.request.request_parameters"
           env["rack.input"] = StringIO.new
+          env.delete "RAW_POST_DATA"
           env
         end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -681,6 +681,14 @@ XML
     assert_equal "baz", @request.filtered_parameters[:foo]
   end
 
+  def test_raw_post_reset_between_post_requests
+    post :no_op, params: { foo: "bar" }
+    assert_equal "foo=bar", @request.raw_post
+
+    post :no_op, params: { foo: "baz" }
+    assert_equal "foo=baz", @request.raw_post
+  end
+
   def test_path_is_kept_after_the_request
     get :test_params, params: { id: "foo" }
     assert_equal "/test_case_test/test/test_params/foo", @request.path


### PR DESCRIPTION
`RAW_POST_DATA` is derived from the `rack.input` header, which changes with each test request. It needs to be cleared in `scrub_env!`, or all requests in the same test will see the value from the first request.