### PR TITLE
Relax assertions in connection config tests

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -89,7 +89,7 @@ module ActiveRecord
 
           ActiveRecord::Base.establish_connection
 
-          assert_equal "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
+          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
@@ -112,7 +112,7 @@ module ActiveRecord
 
           ActiveRecord::Base.establish_connection
 
-          assert_equal "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
+          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env


### PR DESCRIPTION
At the moment these two ActiveRecord tests pass with `rake test:sqlite3`,
but fail with `ARCONN=sqlite3 bin/test`.

`Rails.root` is defined when running `bin/test`, but not when running
the rake task. When `Rails.root` is defined, `config[:database]` will
look something like `vagrant/rails/activerecord/db/primary.sqlite3`
instead of just `db/primary.sqlite3`.
https://github.com/rails/rails/blob/00caf95e14b90782ab17fbd6d2b930844df99980/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L27

Relaxing `assert_equal` to `assert_match` will allow these tests to pass
regardless of how they are run.

I do have a question why we need both ways to run tests. I have been
using `bin/test` lately, but I see from #32426 that this is not the preferred
method.