### PR TITLE
Check valid options in numericality validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Check options passed to the numericality validator.
+    Misspelled options as greather_than_or_equal_to will be ignored and allow
+    invalid values. Add a check to ensure provided options are valid.
+
+    *Robinson Rodriguez*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -13,12 +13,7 @@ module ActiveModel
 
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
-        options.each do |option, _|
-          unless VALID_OPTIONS.include?(option)
-            raise ArgumentError, ":#{option} is not a valid option"
-          end
-        end
-
+        options.assert_valid_keys(VALID_OPTIONS)
         options.slice(*keys).each do |option, value|
           unless value.is_a?(Numeric) || value.is_a?(Proc) || value.is_a?(Symbol)
             raise ArgumentError, ":#{option} must be a number, a symbol or a proc"

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -9,8 +9,16 @@ module ActiveModel
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
+      VALID_OPTIONS = RESERVED_OPTIONS + [:allow_blank, :allow_nil, :message]
+
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
+        options.each do |option, _|
+          unless VALID_OPTIONS.include?(option)
+            raise ArgumentError, ":#{option} is not a valid option"
+          end
+        end
+
         options.slice(*keys).each do |option, value|
           unless value.is_a?(Numeric) || value.is_a?(Proc) || value.is_a?(Symbol)
             raise ArgumentError, ":#{option} must be a number, a symbol or a proc"

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -279,6 +279,10 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, equal_to: "foo" }
   end
 
+  def test_validates_numericality_with_invalid_options
+    assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, invalid_option: "foo" }
+  end
+
   private
 
     def invalid!(values, error = nil)


### PR DESCRIPTION
Invalid options should not be ignored by the validator:

      class User
        include ActiveModel::Validations

        validates_numericality_of :argument, :greather_than_or_equal_to: 0
      end

The previous model would allow negative values because of the option misspelling.
Add a check to ensure valid options are passed to the validator.

