### PR TITLE
Display link to contributors as credits in guides

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -34,6 +34,7 @@
         <li class="more-info"><a href="http://api.rubyonrails.org/">API</a></li>
         <li class="more-info"><a href="https://stackoverflow.com/questions/tagged/ruby-on-rails">Ask for help</a></li>
         <li class="more-info"><a href="https://github.com/rails/rails">Contribute on GitHub</a></li>
+        <li class="more-info"><a href="http://contributors.rubyonrails.org/">Credits</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
### Summary

* Since #32429, credits doesn't display in guides.
* It's not easy for newbies to recognize website of rails contributors.
* I felt It's good that we pay tribute to all contributors

/cc @fxn 

### Screenshot

![](https://user-images.githubusercontent.com/15371677/39088981-7482dce6-45f7-11e8-9c4b-2f969adc6bab.png)

![](https://user-images.githubusercontent.com/15371677/39088991-90d0bc2e-45f7-11e8-89df-d7ecd221766e.png)