### PR TITLE
Fix duplicated suffix for JobGenerator

### DIFF
--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -28,6 +28,10 @@ module Rails # :nodoc:
       end
 
       private
+        def file_name
+          @_file_name ||= super.gsub(/_job/i, "")
+        end
+
         def application_job_file_name
           @application_job_file_name ||= if mountable_engine?
             "app/jobs/#{namespaced_path}/application_job.rb"

--- a/railties/lib/rails/generators/test_unit/job/job_generator.rb
+++ b/railties/lib/rails/generators/test_unit/job/job_generator.rb
@@ -10,6 +10,11 @@ module TestUnit # :nodoc:
       def create_test_file
         template "unit_test.rb", File.join("test/jobs", class_path, "#{file_name}_job_test.rb")
       end
+
+      private
+        def file_name
+          @_file_name ||= super.gsub(/_job/i, "")
+        end
     end
   end
 end

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -35,4 +35,14 @@ class JobGeneratorTest < Rails::Generators::TestCase
       assert_match(/class ApplicationJob < ActiveJob::Base/, job)
     end
   end
+
+  def test_job_suffix_is_not_duplicated
+    run_generator ["notifier_job"]
+
+    assert_no_file "app/jobs/notifier_job_job.rb"
+    assert_file "app/jobs/notifier_job.rb"
+
+    assert_no_file "test/jobs/notifier_job_job_test.rb"
+    assert_file "test/jobs/notifier_job_test.rb"
+  end
 end


### PR DESCRIPTION
### Summary

I've fixed duplicated suffix for `Rails::Generators::JobGenerator`.

#### Before:

```
% bin/rails g job notifier_job
      invoke  test_unit
      create    test/jobs/notifier_job_job_test.rb
      create  app/jobs/notifier_job_job.rb
```

#### After:

```
% bin/rails g job notifier_job
      invoke  test_unit
      create    test/jobs/notifier_job_test.rb
      create  app/jobs/notifier_job.rb
```