### PR TITLE
Fix indentation manually

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -822,7 +822,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
         assert_match(/require 'bootsnap\/setup'/, content)
       end
     else
-       assert_file "Gemfile" do |content|
+      assert_file "Gemfile" do |content|
         assert_no_match(/bootsnap/, content)
       end
       assert_file "config/boot.rb" do |content|


### PR DESCRIPTION
### Summary

Rubocop auto-correct doesn't work well, so I fixed indentation manually.

```
Offenses:

railties/test/generators/app_generator_test.rb:825:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 3) spaces for indentation.
       assert_file "Gemfile" do |content|
    ^^^
railties/test/generators/app_generator_test.rb:828:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      assert_file "config/boot.rb" do |content| ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
railties/test/generators/app_generator_test.rb:828:8: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
       assert_file "config/boot.rb" do |content| ...
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```