### PR TITLE
Relation values into their own instance vars

### DIFF
--- a/activerecord/lib/active_record/relation/relation_values.rb
+++ b/activerecord/lib/active_record/relation/relation_values.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class Relation
+    module RelationValues
+      EMPTY_FROM_CLAUSE = FromClause.empty
+      EMPTY_WHERE_CLAUSE = WhereClause.empty
+
+      FROZEN_EMPTY_ARRAY = [].freeze
+      FROZEN_EMPTY_HASH = {}.freeze
+
+      VALUES =
+        {}.tap do |values|
+          MULTI_VALUE_METHODS.each { |value| values[value] = :"#{value}_values" }
+          SINGLE_VALUE_METHODS.each { |value| values[value] = :"#{value}_value" }
+          CLAUSE_METHODS.each { |value| values[value] = :"#{value}_clause" }
+        end.freeze
+
+      def self.included(base)
+        base.attr_reader *(SINGLE_VALUE_METHODS - %i[create_with]).map { |value| :"#{value}_value" }
+        base.alias_method :extensions, :extending_values
+      end
+
+      def empty_scope?
+        VALUES.each_value.all? { |value| !instance_variable_defined?(value) }
+      end
+
+      def values
+        VALUES.each_with_object({}) do |(key, value), new_values|
+          next unless instance_variable_defined?(value)
+          new_values[key] = public_send(value)
+        end
+      end
+
+      def create_with_value
+        @create_with_value || FROZEN_EMPTY_HASH
+      end
+
+      def where_clause
+        @where_clause || EMPTY_WHERE_CLAUSE
+      end
+
+      def having_clause
+        @having_clause || EMPTY_WHERE_CLAUSE
+      end
+
+      def from_clause
+        @from_clause || EMPTY_FROM_CLAUSE
+      end
+
+      MULTI_VALUE_METHODS.each do |value|
+        class_eval <<-CODE, __FILE__, __LINE__ + 1
+          def #{value}_values
+            @#{value}_values || FROZEN_EMPTY_ARRAY
+          end
+        CODE
+      end
+
+      VALUES.each_value do |value|
+        class_eval <<-CODE, __FILE__, __LINE__ + 1
+          def #{value}=(value)
+            assert_mutability!
+            @#{value} = value
+          end
+        CODE
+      end
+
+      private
+
+      def initialize_values_from(values)
+        values.each do |key, value|
+          public_send(:"#{VALUES[key]}=", value)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Opening this PR as a follow up to #31598.

In profiling out application, I've found that a lot of time is spent in the `ActiveRecord::QueryMethods#get_value` method, mostly doing hash fetch method calls in order to pull out the previously set components of an AR relation. We can somewhat speed this up by putting each component into its own instance variable and accessing them through their own methods directly instead of through the intermediary of `includes_values` --> `get_value` --> `hash[]`.

This PR is not at all ready to go, as you can see it doesn't remove any of the existing code. I'm opening this PR to get more feedback and see if folks are down with moving in this direction. Here's the benchmark I've been using to measure: https://gist.github.com/kddeisz/670bc23215c8f29b390492010860b087. 

Here are the results of the last run on my machine:

```
Warming up --------------------------------------
                 old   509.000  i/100ms
Calculating -------------------------------------
                 old      5.196k (± 2.9%) i/s -    103.836k in  20.001285s
Warming up --------------------------------------
                 new   585.000  i/100ms
Calculating -------------------------------------
                 new      5.816k (± 3.8%) i/s -    116.415k in  20.050146s
```