### PR TITLE
Allow disabling of authentication token for `button_to`, fix bug for `form_with`

### DIFF
--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -14,6 +14,10 @@ module RequestForgeryProtectionActions
     render inline: "<%= button_to('New', '/') %>"
   end
 
+  def show_button_without_authenticity_token
+    render inline: "<%= button_to('New', '/', form: {authenticity_token: false}) %>"
+  end
+
   def unsafe
     render plain: "pwn"
   end
@@ -200,6 +204,15 @@ module RequestForgeryProtectionTests
         get :show_button
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
+    end
+  end
+
+  def test_should_render_button_to_without_token_tag
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked do
+        get :show_button_without_authenticity_token
+      end
+      assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token, count: 0
     end
   end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -26,6 +26,14 @@ module RequestForgeryProtectionActions
     render inline: "<%= csrf_meta_tags %>"
   end
 
+  def form_for
+    render inline: "<%= form_for(:some_resource) {} %>"
+  end
+
+  def form_for_without_token
+    render inline: "<%= form_for(:some_resource, :authenticity_token => false) {} %>"
+  end
+
   def form_for_remote
     render inline: "<%= form_for(:some_resource, :remote => true ) {} %>"
   end
@@ -220,11 +228,18 @@ module RequestForgeryProtectionTests
     end
   end
 
-  def test_should_render_form_without_token_tag_if_remote
+  def test_should_render_form_for_with_token_tag
     assert_not_blocked do
-      get :form_for_remote
+      get :form_for
     end
-    assert_no_match(/authenticity_token/, response.body)
+    assert_match(/authenticity_token/, response.body)
+  end
+
+  def test_should_render_form_for_without_token_tag_if_refused
+    assert_not_blocked do
+      get :form_for_without_token
+    end
+    refute_match(/authenticity_token/, response.body)
   end
 
   def test_should_render_form_with_token_tag_if_remote_and_embedding_token_is_on

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -239,7 +239,7 @@ module RequestForgeryProtectionTests
     assert_not_blocked do
       get :form_for_without_token
     end
-    refute_match(/authenticity_token/, response.body)
+    assert_no_match(/authenticity_token/, response.body)
   end
 
   def test_should_render_form_with_token_tag_if_remote_and_embedding_token_is_on

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1534,7 +1534,7 @@ module ActionView
 
           html_options[:authenticity_token] = options.delete(:authenticity_token)
 
-          if !local && html_options[:authenticity_token].blank?
+          if !local && html_options[:authenticity_token].nil?
             html_options[:authenticity_token] = embed_authenticity_token_in_remote_forms
           end
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -319,7 +319,7 @@ module ActionView
 
         request_token_tag = if form_method == "post"
           request_method = method.empty? ? "post" : method
-          token_tag(nil, form_options: { action: url, method: request_method })
+          token_tag(form_options.delete(:authenticity_token), form_options: { action: url, method: request_method })
         else
           "".freeze
         end


### PR DESCRIPTION
### Summary

`button_to` should allow authenticity token to be disabled. After digging, I assumed that it probably was meant to be allowed in the same way it is allowed for [`form_with`](https://github.com/rails/rails/blob/76acaf6eb9ef3635e4c6f2ca9dba34edb50f541d/actionview/lib/action_view/helpers/form_helper.rb#L601). Then I discovered that it was broken for `form_for`. So I fixed that as well as added/fixed the functionality for `button_to`. And for good measure, I added tests to ensure it works for `form_for`.

### Other Information

I was using version 5.1.6 when I discovered the issue. I tested it in 5.2.0. I merged it into master also confirming that it is still an issue there too.