### PR TITLE
Add Graphiz as a requirement for running the routes visualizer

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -83,6 +83,7 @@ module ActionDispatch
           svg.join.sub(/width="[^"]*"/, "").sub(/height="[^"]*"/, "")
         end
 
+        # Requires Grahphiz to be installed
         def visualizer(paths, title = "FSM")
           viz_dir   = File.join __dir__, "..", "visualizer"
           fsm_js    = File.read File.join(viz_dir, "fsm.js")


### PR DESCRIPTION
### Summary

Related to #32692 

`Rails.application.routes.router.visualizer` doesn't work without Graphiz installed (and the recommendation to use the `dot` gem makes things worse because `dot` overwrites the `dot` executable.