### PR TITLE
Use delete instead of gsub

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -80,7 +80,7 @@ module ActionDispatch
           end
 
           def inline_base64(path)
-            Base64.encode64(path).gsub("\n", "")
+            Base64.encode64(path).delete("\n")
           end
 
           def failed?


### PR DESCRIPTION
### Summary

```
require 'benchmark'

TIMES = 1_000_000

s = "oh\nmy\nstring\n"

Benchmark.bmbm do |x|
  x.report("delete") do
    TIMES.times { s.delete("\n") }
  end

  x.report("gsub with string") do
    TIMES.times { s.gsub("\n", "") }
  end
end

Rehearsal ----------------------------------------------------
delete             0.465423   0.001219   0.466642 (  0.468006)
gsub with string   1.293566   0.002449   1.296015 (  1.298087)
------------------------------------------- total: 1.762657sec

                       user     system      total        real
delete             0.459217   0.002126   0.461343 (  0.463790)
gsub with string   1.283116   0.002070   1.285186 (  1.287792)
```