### PR TITLE
Respect NODE_ENV when running `rails yarn:install`

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -3,7 +3,13 @@
 namespace :yarn do
   desc "Install all JavaScript dependencies as specified via Yarn"
   task :install do
-    system("./bin/yarn install --no-progress --frozen-lockfile --production")
+    # Install only production deps when for not usual envs.
+    valid_node_envs = %w[test development production]
+    node_env = ENV.fetch("NODE_ENV") do
+      rails_env = ENV["RAILS_ENV"]
+      valid_node_envs.include?(rails_env) ? rails_env : "production"
+    end
+    system({ "NODE_ENV" => node_env }, "./bin/yarn install --no-progress --frozen-lockfile")
   end
 end
 


### PR DESCRIPTION
`yarn install --prod` removes dev deps, so it's impossible to run `assets:precompile` with dev npm dependencies. This change makes rake task pass NODE_ENV to yarn when explicitly set.

Re: discussion in #29851

@lpil I've slightly modified proposed change to use `NODE_ENV=production` in not standard envs (like `staging`).
