### PR TITLE
Fix title for example of removing data from `session` [ci skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -450,7 +450,7 @@ class LoginsController < ApplicationController
 end
 ```
 
-To remove something from the session, assign that key to be `nil`:
+To remove something from the session, delete the key/value pair:
 
 ```ruby
 class LoginsController < ApplicationController
@@ -478,7 +478,7 @@ Let's use the act of logging out as an example. The controller can send a messag
 ```ruby
 class LoginsController < ApplicationController
   def destroy
-    session[:current_user_id] = nil
+    session.delete(:current_user_id)
     flash[:notice] = "You have successfully logged out."
     redirect_to root_url
   end


### PR DESCRIPTION
After #31685 the description says different what
we expect to see in the example. Change `assign that key to be nil` to
`or delete the key/value pair` in order to highlight what is shown in the example.

Fix one more example of removing data from the session in favour of using
`delete` since assigning to `nil` doesn't delete key from it.
