### PR TITLE
Halve memory allocation in S3Service#download

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -33,7 +33,7 @@ module ActiveStorage
         end
       else
         instrument :download, key: key do
-          object_for(key).get.body.read.force_encoding(Encoding::BINARY)
+          object_for(key).get.body.string.force_encoding(Encoding::BINARY)
         end
       end
     end


### PR DESCRIPTION
`Aws::S3::Object#get` returns a response with object content wrapped in an in-memory `StringIO` object. `StringIO#read` will return a copy of the content, which is not necessary because we can return the content directly using `StringIO#string`.

```rb
require "stringio"

content  = "foo"
stringio = StringIO.new(content)

content.object_id         # => 70113512953300
stringio.string.object_id # => 70113512953300
stringio.read.object_id   # => 70113512951780
```

This halves memory allocation of `S3Service#download`, because we remove the extra content duplication.