### PR TITLE
Save a hash allocation in MySQL statement pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         private def dealloc(stmt)
-          stmt[:stmt].close
+          stmt.close
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -71,10 +71,7 @@ module ActiveRecord
 
             log(sql, name, binds, type_casted_binds) do
               if cache_stmt
-                cache = @statements[sql] ||= {
-                  stmt: @connection.prepare(sql)
-                }
-                stmt = cache[:stmt]
+                stmt = @statements[sql] ||= @connection.prepare(sql)
               else
                 stmt = @connection.prepare(sql)
               end


### PR DESCRIPTION
There's no need to wrap the statement in a hash with a single key.

r? @kamipo 