### PR TITLE
Fix app:update when hyphenated name is given

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -490,7 +490,11 @@ module Rails
       end
 
       def app_name
-        @app_name ||= (defined_app_const_base? ? defined_app_name : File.basename(destination_root)).tr('\\', "").tr(". ", "_")
+        @app_name ||= original_app_name.tr("-", "_")
+      end
+
+      def original_app_name
+        @original_app_name ||= (defined_app_const_base? ? defined_app_name : File.basename(destination_root)).tr('\\', "").tr(". ", "_")
       end
 
       def defined_app_name
@@ -515,13 +519,13 @@ module Rails
 
       def valid_const?
         if app_const =~ /^\d/
-          raise Error, "Invalid application name #{app_name}. Please give a name which does not start with numbers."
-        elsif RESERVED_NAMES.include?(app_name)
-          raise Error, "Invalid application name #{app_name}. Please give a " \
+          raise Error, "Invalid application name #{original_app_name}. Please give a name which does not start with numbers."
+        elsif RESERVED_NAMES.include?(original_app_name)
+          raise Error, "Invalid application name #{original_app_name}. Please give a " \
                        "name which does not match one of the reserved rails " \
                        "words: #{RESERVED_NAMES.join(", ")}"
         elsif Object.const_defined?(app_const_base)
-          raise Error, "Invalid application name #{app_name}, constant #{app_const_base} is already in use. Please choose another application name."
+          raise Error, "Invalid application name #{original_app_name}, constant #{app_const_base} is already in use. Please choose another application name."
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -383,6 +383,30 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /\s+config\.load_defaults 5\.1/
   end
 
+  def test_app_update_does_not_change_app_name_when_app_name_is_hyphenated_name
+    app_root = File.join(destination_root, "hyphenated-app")
+    run_generator [app_root, "-d", "postgresql"]
+
+    assert_file "#{app_root}/config/database.yml" do |content|
+      assert_match(/hyphenated_app_development/, content)
+      assert_no_match(/hyphenated-app_development/, content)
+    end
+
+    assert_file "#{app_root}/config/cable.yml" do |content|
+      assert_match(/hyphenated_app/, content)
+      assert_no_match(/hyphenated-app/, content)
+    end
+
+    FileUtils.cd(app_root) do
+      quietly { system("bin/rails app:update") }
+    end
+
+    assert_file "#{app_root}/config/cable.yml" do |content|
+      assert_match(/hyphenated_app/, content)
+      assert_no_match(/hyphenated-app/, content)
+    end
+  end
+
   def test_application_names_are_not_singularized
     run_generator [File.join(destination_root, "hats")]
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/


### PR DESCRIPTION
### Summary

Fixed app_name's difference between `rails new` and `app:update`

#### Reproduce:

When app name is `sample-app` and it executes `bin/rails app:update`:

```diff
 development:
   adapter: async
 
 test:
   adapter: async
 
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-   channel_prefix: sample-app_production
+   channel_prefix: sample_app_production
```

I felt it's odd to change app name after update. So I've fixed this.

* Changed be prefer to const name than directory name.
* Kept original app name which use exception message.