### PR TITLE
Use strict_encode64 instead of gsub newline for ScreenshotHelper

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -80,7 +80,7 @@ module ActionDispatch
           end
 
           def inline_base64(path)
-            Base64.encode64(path).gsub("\n", "")
+            Base64.strict_encode64(path)
           end
 
           def failed?


### PR DESCRIPTION
Per https://github.com/rails/rails/pull/32696 a more idiomatic approach.