### PR TITLE
Fix segmentation fault in EventedFileUpdateChecker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :storage do
   gem "azure-storage", require: false
 
   gem "image_processing", "~> 1.2"
+  gem "ffi", "<= 1.9.21"
 end
 
 group :ujs do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,10 +229,10 @@ GEM
     faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.9.23)
-    ffi (1.9.23-java)
-    ffi (1.9.23-x64-mingw32)
-    ffi (1.9.23-x86-mingw32)
+    ffi (1.9.21)
+    ffi (1.9.21-java)
+    ffi (1.9.21-x64-mingw32)
+    ffi (1.9.21-x86-mingw32)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.17.3)
@@ -518,6 +518,7 @@ DEPENDENCIES
   dalli
   delayed_job
   delayed_job_active_record
+  ffi (<= 1.9.21)
   google-cloud-storage (~> 1.8)
   hiredis
   image_processing (~> 1.2)


### PR DESCRIPTION
resolves #32705

Force updates ffi to the latest version which does not make us crash like this, currently 1.9.21