### PR TITLE
Break up Journey's scanner test

### DIFF
--- a/actionpack/test/journey/route/definition/scanner_test.rb
+++ b/actionpack/test/journey/route/definition/scanner_test.rb
@@ -10,61 +10,64 @@ module ActionDispatch
           @scanner = Scanner.new
         end
 
-        # /page/:id(/:action)(.:format)
-        def test_tokens
-          [
-            ["/",       [[:SLASH, "/"]]],
-            ["*omg",    [[:STAR, "*omg"]]],
-            ["/page",   [[:SLASH, "/"], [:LITERAL, "page"]]],
-            ["/page!",  [[:SLASH, "/"], [:LITERAL, "page!"]]],
-            ["/page$",  [[:SLASH, "/"], [:LITERAL, "page$"]]],
-            ["/page&",  [[:SLASH, "/"], [:LITERAL, "page&"]]],
-            ["/page'",  [[:SLASH, "/"], [:LITERAL, "page'"]]],
-            ["/page*",  [[:SLASH, "/"], [:LITERAL, "page*"]]],
-            ["/page+",  [[:SLASH, "/"], [:LITERAL, "page+"]]],
-            ["/page,",  [[:SLASH, "/"], [:LITERAL, "page,"]]],
-            ["/page;",  [[:SLASH, "/"], [:LITERAL, "page;"]]],
-            ["/page=",  [[:SLASH, "/"], [:LITERAL, "page="]]],
-            ["/page@",  [[:SLASH, "/"], [:LITERAL, "page@"]]],
-            ['/page\:', [[:SLASH, "/"], [:LITERAL, "page:"]]],
-            ['/page\(', [[:SLASH, "/"], [:LITERAL, "page("]]],
-            ['/page\)', [[:SLASH, "/"], [:LITERAL, "page)"]]],
-            ["/~page",  [[:SLASH, "/"], [:LITERAL, "~page"]]],
-            ["/pa-ge",  [[:SLASH, "/"], [:LITERAL, "pa-ge"]]],
-            ["/:page",  [[:SLASH, "/"], [:SYMBOL, ":page"]]],
-            ["/(:page)", [
-                          [:SLASH, "/"],
+        CASES = [
+          ["/",       [[:SLASH, "/"]]],
+          ["*omg",    [[:STAR, "*omg"]]],
+          ["/page",   [[:SLASH, "/"], [:LITERAL, "page"]]],
+          ["/page!",  [[:SLASH, "/"], [:LITERAL, "page!"]]],
+          ["/page$",  [[:SLASH, "/"], [:LITERAL, "page$"]]],
+          ["/page&",  [[:SLASH, "/"], [:LITERAL, "page&"]]],
+          ["/page'",  [[:SLASH, "/"], [:LITERAL, "page'"]]],
+          ["/page*",  [[:SLASH, "/"], [:LITERAL, "page*"]]],
+          ["/page+",  [[:SLASH, "/"], [:LITERAL, "page+"]]],
+          ["/page,",  [[:SLASH, "/"], [:LITERAL, "page,"]]],
+          ["/page;",  [[:SLASH, "/"], [:LITERAL, "page;"]]],
+          ["/page=",  [[:SLASH, "/"], [:LITERAL, "page="]]],
+          ["/page@",  [[:SLASH, "/"], [:LITERAL, "page@"]]],
+          ['/page\:', [[:SLASH, "/"], [:LITERAL, "page:"]]],
+          ['/page\(', [[:SLASH, "/"], [:LITERAL, "page("]]],
+          ['/page\)', [[:SLASH, "/"], [:LITERAL, "page)"]]],
+          ["/~page",  [[:SLASH, "/"], [:LITERAL, "~page"]]],
+          ["/pa-ge",  [[:SLASH, "/"], [:LITERAL, "pa-ge"]]],
+          ["/:page",  [[:SLASH, "/"], [:SYMBOL, ":page"]]],
+          ["/(:page)", [
+                        [:SLASH, "/"],
+                        [:LPAREN, "("],
+                        [:SYMBOL, ":page"],
+                        [:RPAREN, ")"],
+                      ]],
+          ["(/:action)", [
                           [:LPAREN, "("],
-                          [:SYMBOL, ":page"],
+                          [:SLASH, "/"],
+                          [:SYMBOL, ":action"],
+                          [:RPAREN, ")"],
+                         ]],
+          ["(())", [[:LPAREN, "("],
+                   [:LPAREN, "("], [:RPAREN, ")"], [:RPAREN, ")"]]],
+          ["(.:format)", [
+                          [:LPAREN, "("],
+                          [:DOT, "."],
+                          [:SYMBOL, ":format"],
                           [:RPAREN, ")"],
                         ]],
-            ["(/:action)", [
-                            [:LPAREN, "("],
-                            [:SLASH, "/"],
-                            [:SYMBOL, ":action"],
-                            [:RPAREN, ")"],
-                           ]],
-            ["(())", [[:LPAREN, "("],
-                     [:LPAREN, "("], [:RPAREN, ")"], [:RPAREN, ")"]]],
-            ["(.:format)", [
-                            [:LPAREN, "("],
-                            [:DOT, "."],
-                            [:SYMBOL, ":format"],
-                            [:RPAREN, ")"],
-                          ]],
-          ].each do |str, expected|
-            @scanner.scan_setup str
-            assert_tokens expected, @scanner
+        ]
+
+        CASES.each do |pattern, expected_tokens|
+          test "Scanning `#{pattern}`" do
+            @scanner.scan_setup pattern
+            assert_tokens expected_tokens, @scanner, pattern
           end
         end
 
-        def assert_tokens(tokens, scanner)
-          toks = []
-          while tok = scanner.next_token
-            toks << tok
+        private
+
+          def assert_tokens(expected_tokens, scanner, pattern)
+            actual_tokens = []
+            while token = scanner.next_token
+              actual_tokens << token
+            end
+            assert_equal expected_tokens, actual_tokens, "Wrong tokens for `#{pattern}`"
           end
-          assert_equal tokens, toks
-        end
       end
     end
   end


### PR DESCRIPTION
This breaks up the one megatest for Journey's scanner into multiple test cases, which also provides better output when there is a failure in the scanner.

Before:

```
./bin/test test/journey/route/definition/scanner_test.rb
Run options: --seed 778

F

Failure:
ActionDispatch::Journey::Definition::TestScanner#test_tokens [/Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:57]:
--- expected
+++ actual
@@ -1 +1 @@
-[[:SLASH, "/"], [:LITERAL, "page!!"]]
+[[:SLASH, "/"], [:LITERAL, "page!"]]

bin/test Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:14

Finished in 0.090899s, 11.0012 runs/s, 44.0049 assertions/s.
1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```

After:

```
./bin/test test/journey/route/definition/scanner_test.rb
Run options: --seed 2230

....................F

Failure:
ActionDispatch::Journey::Definition::TestScanner#test_scanning_/page$ [/Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:58]:
Wrong tokens for `/page$`.
--- expected
+++ actual
@@ -1 +1 @@
-[[:SLASH, "/"], [:LITERAL, "page$$"]]
+[[:SLASH, "/"], [:LITERAL, "page$"]]

bin/test Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:56

F

Failure:
ActionDispatch::Journey::Definition::TestScanner#test_scanning_/page! [/Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:58]:
Wrong tokens for `/page!`.
--- expected
+++ actual
@@ -1 +1 @@
-[[:SLASH, "/"], [:LITERAL, "page!!"]]
+[[:SLASH, "/"], [:LITERAL, "page!"]]

bin/test Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:56

F

Failure:
ActionDispatch::Journey::Definition::TestScanner#test_scanning_/page& [/Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:58]:
Wrong tokens for `/page&`.
--- expected
+++ actual
@@ -1 +1 @@
-[[:SLASH, "/"], [:LITERAL, "page&&"]]
+[[:SLASH, "/"], [:LITERAL, "page&"]]

bin/test Users/vaidehijoshi/Code/tilde/rails/actionpack/test/journey/route/definition/scanner_test.rb:56

Finished in 0.126447s, 181.8944 runs/s, 181.8944 assertions/s.
23 runs, 23 assertions, 3 failures, 0 errors, 0 skips
```

I paired on this with @chancancode!