### PR TITLE
Address `NameError: uninitialized constant Arel::Collectors::Bind`

### DIFF
--- a/activerecord/test/cases/arel/collectors/bind_test.rb
+++ b/activerecord/test/cases/arel/collectors/bind_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../helper"
+require "arel/collectors/bind"
 
 module Arel
   module Collectors


### PR DESCRIPTION
### Summary

This pull request addresses `NameError: uninitialized constant Arel::Collectors::Bind` when tested with Ruby 2.5 or higher reported at https://travis-ci.org/rails/rails/jobs/370812855

```ruby
$ ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
$ bundle exec ruby -w -Itest test/cases/arel/collectors/bind_test.rb -n test_compile_gathers_all_bind_params
Run options: -n test_compile_gathers_all_bind_params --seed 24420

E

Error:
Arel::Collectors::TestBind#test_compile_gathers_all_bind_params:
NameError: uninitialized constant Arel::Collectors::Bind
Did you mean?  Binding
    test/cases/arel/collectors/bind_test.rb:15:in `collect'
    test/cases/arel/collectors/bind_test.rb:19:in `compile'
    test/cases/arel/collectors/bind_test.rb:31:in `test_compile_gathers_all_bind_params'

bin/rails test test/cases/arel/collectors/bind_test.rb:30

Finished in 0.002343s, 426.8559 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

It is likely due to Ruby 2.5 does not look up top level constant.
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/
"Top-level constant look-up is no longer available."


