### PR TITLE
Make get_value public again

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -909,11 +909,12 @@ module ActiveRecord
       @arel ||= build_arel(aliases)
     end
 
+    # Returns a relation value with a given name
+    def get_value(name) # :nodoc:
+      @values.fetch(name, DEFAULT_VALUES[name])
+    end
+
     protected
-      # Returns a relation value with a given name
-      def get_value(name) # :nodoc:
-        @values.fetch(name, DEFAULT_VALUES[name])
-      end
 
       # Sets the relation value with the given name
       def set_value(name, value) # :nodoc:

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -126,5 +126,12 @@ module ActiveRecord
       expected = Author.find(1).posts + Post.where(title: "I don't have any comments")
       assert_equal expected.sort_by(&:id), actual.sort_by(&:id)
     end
+
+    def test_or_with_scope_on_association
+      author = Author.first
+      assert_nothing_raised do
+        author.top_posts.or(author.other_top_posts)
+      end
+    end
   end
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -162,6 +162,9 @@ class Author < ActiveRecord::Base
     def extension_method; end
   end
 
+  has_many :top_posts, -> { order(id: :asc) }, class_name: "Post"
+  has_many :other_top_posts, -> { order(id: :asc) }, class_name: "Post"
+
   attr_accessor :post_log
   after_initialize :set_post_log
 


### PR DESCRIPTION
As a part of this PR https://github.com/rails/rails/pull/29914 the `get_value` method was moved from public methods to protected methods.

This broke some behavior with the `Merger` class, where Rails was incorrectly reporting two relations to be structurally incompatible in `or` queries.

I also added a test case to guard against this failure in the future.

Fixes https://github.com/rails/rails/issues/32709