### PR TITLE
Remove math module from count

### DIFF
--- a/activerecord/lib/arel/nodes/count.rb
+++ b/activerecord/lib/arel/nodes/count.rb
@@ -3,8 +3,6 @@
 module Arel # :nodoc: all
   module Nodes
     class Count < Arel::Nodes::Function
-      include Math
-
       def initialize(expr, distinct = false, aliaz = nil)
         super(expr, aliaz)
         @distinct = distinct


### PR DESCRIPTION
Not required after https://github.com/rails/arel/pull/449

There is a test showing it isn't needed here:
https://github.com/rails/rails/blob/master/activerecord/test/cases/arel/nodes/count_test.rb#L36-L42

Copied over from https://github.com/rails/arel/pull/525