### PR TITLE
Use MethodCallAssertions instead of mocha expects

### DIFF
--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/method_call_assertions"
 require "stubs/test_connection"
 require "stubs/room"
 
@@ -143,6 +144,8 @@ module ActionCable::StreamTests
   end
 
   class StreamFromTest < ActionCable::TestCase
+    include ActiveSupport::Testing::MethodCallAssertions
+
     setup do
       @server = TestServer.new(subscription_adapter: ActionCable::SubscriptionAdapter::Async)
       @server.config.allowed_request_origins = %w( http://rubyonrails.com )
@@ -153,10 +156,11 @@ module ActionCable::StreamTests
         connection = open_connection
         subscribe_to connection, identifiers: { id: 1 }
 
-        connection.websocket.expects(:transmit)
-        @server.broadcast "test_room_1", { foo: "bar" }, { coder: DummyEncoder }
-        wait_for_async
-        wait_for_executor connection.server.worker_pool.executor
+        assert_called(connection.websocket, :transmit) do
+          @server.broadcast "test_room_1", { foo: "bar" }, { coder: DummyEncoder }
+          wait_for_async
+          wait_for_executor connection.server.worker_pool.executor
+        end
       end
     end
 
@@ -175,10 +179,10 @@ module ActionCable::StreamTests
       run_in_eventmachine do
         connection = open_connection
         expected = { "identifier" => { "channel" => MultiChatChannel.name }.to_json, "type" => "confirm_subscription" }
-        connection.websocket.expects(:transmit).with(expected.to_json)
-        receive(connection, command: "subscribe", channel: MultiChatChannel.name, identifiers: {})
-
-        wait_for_async
+        assert_called(connection.websocket, :transmit, [expected.to_json]) do
+          receive(connection, command: "subscribe", channel: MultiChatChannel.name, identifiers: {})
+          wait_for_async
+        end
       end
     end
 

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -7,6 +7,7 @@ require "websocket-client-simple"
 require "json"
 
 require "active_support/hash_with_indifferent_access"
+require "active_support/testing/method_call_assertions"
 
 ####
 # 😷 Warning suppression 😷
@@ -27,6 +28,8 @@ WebSocket::Frame::Data.prepend Module.new {
 ####
 
 class ClientTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   WAIT_WHEN_EXPECTING_EVENT = 2
   WAIT_WHEN_NOT_EXPECTING_EVENT = 0.5
 
@@ -289,9 +292,10 @@ class ClientTest < ActionCable::TestCase
       subscriptions = app.connections.first.subscriptions.send(:subscriptions)
       assert_not_equal 0, subscriptions.size, "Missing EchoChannel subscription"
       channel = subscriptions.first[1]
-      channel.expects(:unsubscribed)
-      c.close
-      sleep 0.1 # Data takes a moment to process
+      assert_called(channel, :unsubscribed) do
+        c.close
+        sleep 0.1 # Data takes a moment to process
+      end
 
       # All data is removed: No more connection or subscription information!
       assert_equal(0, app.connections.count)

--- a/actioncable/test/connection/authorization_test.rb
+++ b/actioncable/test/connection/authorization_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/method_call_assertions"
 require "stubs/test_server"
 
 class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   class Connection < ActionCable::Connection::Base
     attr_reader :websocket
 
@@ -25,9 +28,9 @@ class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
         "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
 
       connection = Connection.new(server, env)
-      connection.websocket.expects(:close)
-
-      connection.process
+      assert_called(connection.websocket, :close) do
+        connection.process
+      end
     end
   end
 end

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -62,10 +62,11 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
     run_in_eventmachine do
       connection = open_connection
 
-      connection.websocket.expects(:transmit).with({ type: "welcome" }.to_json)
-      assert_called(connection.message_buffer, :process!) do
-        connection.process
-        wait_for_async
+      assert_called_with(connection.websocket, :transmit, [{ type: "welcome" }.to_json]) do
+        assert_called(connection.message_buffer, :process!) do
+          connection.process
+          wait_for_async
+        end
       end
 
       assert_equal [ connection ], @server.connections

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -2,8 +2,11 @@
 
 require "test_helper"
 require "stubs/test_server"
+require "active_support/testing/method_call_assertions"
 
 class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   class Connection < ActionCable::Connection::Base
     attr_reader :connected, :websocket, :errors
 
@@ -41,9 +44,10 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
       # Internal hax = :(
       client = connection.websocket.send(:websocket)
       client.instance_variable_get("@stream").expects(:write).raises("foo")
-      client.expects(:client_gone).never
 
-      client.write("boo")
+      assert_not_called(client, :client_gone) do
+        client.write("boo")
+      end
       assert_equal %w[ foo ], connection.errors
     end
   end

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -44,8 +44,9 @@ class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
     run_in_eventmachine do
       open_connection_with_stubbed_pubsub
 
-      @connection.websocket.expects(:close)
-      @connection.process_internal_message "type" => "disconnect"
+      assert_called(@connection.websocket, :close) do
+        @connection.process_internal_message "type" => "disconnect"
+      end
     end
   end
 

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/method_call_assertions"
 require "stubs/test_server"
 require "stubs/user"
 
 class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
     attr_reader :websocket
@@ -50,8 +53,9 @@ class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
     run_in_eventmachine do
       open_connection_with_stubbed_pubsub
 
-      @connection.websocket.expects(:close).never
-      @connection.process_internal_message "type" => "unknown"
+      assert_not_called(@connection.websocket, :close) do
+        @connection.process_internal_message "type" => "unknown"
+      end
     end
   end
 

--- a/actioncable/test/connection/stream_test.rb
+++ b/actioncable/test/connection/stream_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/method_call_assertions"
 require "stubs/test_server"
 
 class ActionCable::Connection::StreamTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   class Connection < ActionCable::Connection::Base
     attr_reader :connected, :websocket, :errors
 
@@ -42,9 +45,10 @@ class ActionCable::Connection::StreamTest < ActionCable::TestCase
         # Internal hax = :(
         client = connection.websocket.send(:websocket)
         client.instance_variable_get("@stream").instance_variable_get("@rack_hijack_io").expects(:write).raises(closed_exception, "foo")
-        client.expects(:client_gone)
 
-        client.write("boo")
+        assert_called(client, :client_gone) do
+          client.write("boo")
+        end
         assert_equal [], connection.errors
       end
     end

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/method_call_assertions"
 
 class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   class Connection < ActionCable::Connection::Base
     attr_reader :websocket
 
@@ -55,9 +58,11 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       subscribe_to_chat_channel
 
       channel = subscribe_to_chat_channel
-      channel.expects(:unsubscribe_from_channel)
 
-      @subscriptions.execute_command "command" => "unsubscribe", "identifier" => @chat_identifier
+      assert_called(channel, :unsubscribe_from_channel) do
+        @subscriptions.execute_command "command" => "unsubscribe", "identifier" => @chat_identifier
+      end
+
       assert_empty @subscriptions.identifiers
     end
   end
@@ -92,10 +97,11 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       channel2_id = ActiveSupport::JSON.encode(id: 2, channel: "ActionCable::Connection::SubscriptionsTest::ChatChannel")
       channel2 = subscribe_to_chat_channel(channel2_id)
 
-      channel1.expects(:unsubscribe_from_channel)
-      channel2.expects(:unsubscribe_from_channel)
-
-      @subscriptions.unsubscribe_from_all
+      assert_called(channel1, :unsubscribe_from_channel) do
+        assert_called(channel2, :unsubscribe_from_channel) do
+          @subscriptions.unsubscribe_from_all
+        end
+      end
     end
   end
 

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -3,8 +3,11 @@
 require "test_helper"
 require "stubs/test_server"
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/testing/method_call_assertions"
 
 class BaseTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   def setup
     @server = ActionCable::Server::Base.new
     @server.config.cable = { adapter: "async" }.with_indifferent_access
@@ -19,17 +22,20 @@ class BaseTest < ActiveSupport::TestCase
     conn = FakeConnection.new
     @server.add_connection(conn)
 
-    conn.expects(:close)
-    @server.restart
+    assert_called(conn, :close) do
+      @server.restart
+    end
   end
 
   test "#restart shuts down worker pool" do
-    @server.worker_pool.expects(:halt)
-    @server.restart
+    assert_called(@server.worker_pool, :halt) do
+      @server.restart
+    end
   end
 
   test "#restart shuts down pub/sub adapter" do
-    @server.pubsub.expects(:shutdown)
-    @server.restart
+    assert_called(@server.pubsub, :shutdown) do
+      @server.restart
+    end
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2105,9 +2105,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_association_proxy_transaction_method_starts_transaction_in_association_class
-    Comment.expects(:transaction)
-    Post.first.comments.transaction do
-      # nothing
+    assert_called(Comment, :transaction) do
+      Post.first.comments.transaction do
+        # nothing
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1986,8 +1986,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_many_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
     assert_queries(1) do
-      firm.clients.expects(:size).never
-      firm.clients.many? { true }
+      assert_not_called(firm.clients, :size) do
+        firm.clients.many? { true }
+      end
     end
     assert_predicate firm.clients, :loaded?
   end
@@ -2025,8 +2026,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_none_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
     assert_queries(1) do
-      firm.clients.expects(:size).never
-      firm.clients.none? { true }
+      assert_not_called(firm.clients, :size) do
+        firm.clients.none? { true }
+      end
     end
     assert_predicate firm.clients, :loaded?
   end
@@ -2060,8 +2062,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_one_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
     assert_queries(1) do
-      firm.clients.expects(:size).never
-      firm.clients.one? { true }
+      assert_not_called(firm.clients, :size) do
+        firm.clients.one? { true }
+      end
     end
     assert_predicate firm.clients, :loaded?
   end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -488,8 +488,9 @@ class NamedScopingTest < ActiveRecord::TestCase
 
     [:public_method, :protected_method, :private_method].each do |reserved_method|
       assert Topic.respond_to?(reserved_method, true)
-      ActiveRecord::Base.logger.expects(:warn)
-      silence_warnings { Topic.scope(reserved_method, -> {}) }
+      assert_called(ActiveRecord::Base.logger, :warn) do
+        silence_warnings { Topic.scope(reserved_method, -> {}) }
+      end
     end
   end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -127,18 +127,18 @@ module ActiveRecord
     def test_ignores_configurations_without_databases
       @configurations["development"].merge!("database" => nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).never
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
 
     def test_ignores_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
       $stderr.stubs(:puts).returns(nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).never
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
 
     def test_warning_for_remote_databases
@@ -343,18 +343,18 @@ module ActiveRecord
     def test_ignores_configurations_without_databases
       @configurations[:development].merge!("database" => nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).never
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
 
     def test_ignores_remote_databases
       @configurations[:development].merge!("host" => "my.server.tld")
       $stderr.stubs(:puts).returns(nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).never
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
 
     def test_warning_for_remote_databases

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -80,10 +80,11 @@ module ActiveRecord
       instance = klazz.new
 
       klazz.stubs(:new).returns instance
-      instance.expects(:structure_dump).with("awesome-file.sql", nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
-      ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :foo }, "awesome-file.sql")
+      assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil]) do
+        ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :foo }, "awesome-file.sql")
+      end
     end
 
     def test_unregistered_task
@@ -144,9 +145,9 @@ module ActiveRecord
     def test_warning_for_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
 
-      $stderr.expects(:puts).with("This task only modifies local databases. my-db is on a remote host.")
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_called_with($stderr, :puts, ["This task only modifies local databases. my-db is on a remote host."]) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
 
     def test_creates_configurations_with_local_ip
@@ -187,21 +188,27 @@ module ActiveRecord
     end
 
     def test_creates_current_environment_database
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
-        with("database" => "test-db")
-
-      ActiveRecord::Tasks::DatabaseTasks.create_current(
-        ActiveSupport::StringInquirer.new("test")
-      )
+      assert_called_with(
+        ActiveRecord::Tasks::DatabaseTasks,
+        :create,
+        ["database" => "test-db"],
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.create_current(
+          ActiveSupport::StringInquirer.new("test")
+        )
+      end
     end
 
     def test_creates_current_environment_database_with_url
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
-        with("url" => "prod-db-url")
-
-      ActiveRecord::Tasks::DatabaseTasks.create_current(
-        ActiveSupport::StringInquirer.new("production")
-      )
+      assert_called_with(
+        ActiveRecord::Tasks::DatabaseTasks,
+        :create,
+        ["url" => "prod-db-url"],
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.create_current(
+          ActiveSupport::StringInquirer.new("production")
+        )
+      end
     end
 
     def test_creates_test_and_development_databases_when_env_was_not_specified
@@ -360,9 +367,13 @@ module ActiveRecord
     def test_warning_for_remote_databases
       @configurations[:development].merge!("host" => "my.server.tld")
 
-      $stderr.expects(:puts).with("This task only modifies local databases. my-db is on a remote host.")
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_called_with(
+        $stderr,
+        :puts,
+        ["This task only modifies local databases. my-db is on a remote host."],
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
 
     def test_drops_configurations_with_local_ip
@@ -673,9 +684,10 @@ module ActiveRecord
 
       ActiveRecord::Tasks::DatabaseTasks.expects(:purge).
         with("database" => "prod-db")
-      ActiveRecord::Base.expects(:establish_connection).with(:production)
 
-      ActiveRecord::Tasks::DatabaseTasks.purge_current("production")
+      assert_called_with(ActiveRecord::Base, :establish_connection, [:production]) do
+        ActiveRecord::Tasks::DatabaseTasks.purge_current("production")
+      end
     end
   end
 
@@ -839,8 +851,9 @@ module ActiveRecord
 
   class DatabaseTasksCheckSchemaFileTest < ActiveRecord::TestCase
     def test_check_schema_file
-      Kernel.expects(:abort).with(regexp_matches(/awesome-file.sql/))
-      ActiveRecord::Tasks::DatabaseTasks.check_schema_file("awesome-file.sql")
+      assert_called_with(Kernel, :abort, [/awesome-file.sql/]) do
+        ActiveRecord::Tasks::DatabaseTasks.check_schema_file("awesome-file.sql")
+      end
     end
   end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -152,25 +152,25 @@ module ActiveRecord
     def test_creates_configurations_with_local_ip
       @configurations["development"].merge!("host" => "127.0.0.1")
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
 
     def test_creates_configurations_with_local_host
       @configurations["development"].merge!("host" => "localhost")
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
 
     def test_creates_configurations_with_blank_hosts
       @configurations["development"].merge!("host" => nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:create)
-
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
+      end
     end
   end
 
@@ -368,25 +368,25 @@ module ActiveRecord
     def test_drops_configurations_with_local_ip
       @configurations[:development].merge!("host" => "127.0.0.1")
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
 
     def test_drops_configurations_with_local_host
       @configurations[:development].merge!("host" => "localhost")
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
 
     def test_drops_configurations_with_blank_hosts
       @configurations[:development].merge!("host" => nil)
 
-      ActiveRecord::Tasks::DatabaseTasks.expects(:drop)
-
-      ActiveRecord::Tasks::DatabaseTasks.drop_all
+      assert_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
+        ActiveRecord::Tasks::DatabaseTasks.drop_all
+      end
     end
   end
 
@@ -645,8 +645,9 @@ module ActiveRecord
     end
 
     def test_migrate_clears_schema_cache_afterward
-      ActiveRecord::Base.expects(:clear_cache!)
-      ActiveRecord::Tasks::DatabaseTasks.migrate
+      assert_called(ActiveRecord::Base, :clear_cache!) do
+        ActiveRecord::Tasks::DatabaseTasks.migrate
+      end
     end
   end
 

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -222,9 +222,14 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_structure_dump
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
       end
 
       def test_structure_dump_with_extra_flags
@@ -242,39 +247,57 @@ if current_adapter?(:Mysql2Adapter)
         filename = "awesome-file.sql"
         ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo", "bar"])
 
-        Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.foo", "--ignore-table=test-db.bar", "test-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.foo", "--ignore-table=test-db.bar", "test-db"],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
       end
 
       def test_warn_when_external_structure_dump_command_execution_fails
         filename = "awesome-file.sql"
-        Kernel.expects(:system)
-          .with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db")
-          .returns(false)
-
-        e = assert_raise(RuntimeError) {
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
-        }
-        assert_match(/^failed to execute: `mysqldump`$/, e.message)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+          returns: false
+        ) do
+          e = assert_raise(RuntimeError) {
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+          }
+          assert_match(/^failed to execute: `mysqldump`$/, e.message)
+        end
       end
 
       def test_structure_dump_with_port_number
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(
-          @configuration.merge("port" => 10000),
-          filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+            @configuration.merge("port" => 10000),
+            filename)
+        end
       end
 
       def test_structure_dump_with_ssl
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(
-          @configuration.merge("sslca" => "ca.crt"),
-          filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+          returns: true
+        ) do
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+              @configuration.merge("sslca" => "ca.crt"),
+              filename)
+          end
       end
 
       private

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -236,9 +236,14 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_structure_dump
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "my-app-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "my-app-db"],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        end
       end
 
       def test_structure_dump_header_comments_removed
@@ -261,47 +266,76 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_structure_dump_with_ignore_tables
-        ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo", "bar"])
-
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        assert_called(
+          ActiveRecord::SchemaDumper,
+          :ignore_tables,
+          returns: ["foo", "bar"]
+        ) do
+          assert_called_with(
+            Kernel,
+            :system,
+            ["pg_dump", "-s", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db"],
+            returns: true
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+          end
+        end
       end
 
       def test_structure_dump_with_schema_search_path
         @configuration["schema_search_path"] = "foo,bar"
 
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        end
       end
 
       def test_structure_dump_with_schema_search_path_and_dump_schemas_all
         @configuration["schema_search_path"] = "foo,bar"
 
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename,  "my-app-db").returns(true)
-
-        with_dump_schemas(:all) do
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename,  "my-app-db"],
+          returns: true
+        ) do
+          with_dump_schemas(:all) do
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+          end
         end
       end
 
       def test_structure_dump_with_dump_schemas_string
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db").returns(true)
-
-        with_dump_schemas("foo,bar") do
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
+          returns: true
+        ) do
+          with_dump_schemas("foo,bar") do
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+          end
         end
       end
 
       def test_structure_dump_execution_fails
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", filename, "my-app-db").returns(nil)
-
-        e = assert_raise(RuntimeError) do
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["pg_dump", "-s", "-x", "-O", "-f", filename, "my-app-db"],
+          returns: nil
+        ) do
+          e = assert_raise(RuntimeError) do
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+          end
+          assert_match("failed to execute:", e.message)
         end
-        assert_match("failed to execute:", e.message)
       end
 
       private
@@ -336,9 +370,14 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_structure_load
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("psql", "-v", "ON_ERROR_STOP=1", "-q", "-f", filename, @configuration["database"]).returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["psql", "-v", "ON_ERROR_STOP=1", "-q", "-f", filename, @configuration["database"]],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
       end
 
       def test_structure_load_with_extra_flags
@@ -354,9 +393,14 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_structure_load_accepts_path_with_spaces
         filename = "awesome file.sql"
-        Kernel.expects(:system).with("psql", "-v", "ON_ERROR_STOP=1", "-q", "-f", filename, @configuration["database"]).returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        assert_called_with(
+          Kernel,
+          :system,
+          ["psql", "-v", "ON_ERROR_STOP=1", "-q", "-f", filename, @configuration["database"]],
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
       end
 
       private

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -219,14 +219,19 @@ if current_adapter?(:SQLite3Adapter)
       def test_structure_dump_execution_fails
         dbfile   = @database
         filename = "awesome-file.sql"
-        Kernel.expects(:system).with("sqlite3", "--noop", "db_create.sqlite3", ".schema", out: "awesome-file.sql").returns(nil)
-
-        e = assert_raise(RuntimeError) do
-          with_structure_dump_flags(["--noop"]) do
-            quietly { ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root") }
+        assert_called_with(
+          Kernel,
+          :system,
+          ["sqlite3", "--noop", "db_create.sqlite3", ".schema", out: "awesome-file.sql"],
+          returns: nil
+        ) do
+          e = assert_raise(RuntimeError) do
+            with_structure_dump_flags(["--noop"]) do
+              quietly { ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root") }
+            end
           end
+          assert_match("failed to execute:", e.message)
         end
-        assert_match("failed to execute:", e.message)
       ensure
         FileUtils.rm_f(filename)
         FileUtils.rm_f(dbfile)

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -204,9 +204,9 @@ if current_adapter?(:SQLite3Adapter)
       def test_structure_dump_with_ignore_tables
         dbfile   = @database
         filename = "awesome-file.sql"
-        ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo"])
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root")
+        assert_called(ActiveRecord::SchemaDumper, :ignore_tables, returns: ["foo"]) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root")
+        end
         assert File.exist?(dbfile)
         assert File.exist?(filename)
         assert_match(/bar/, File.read(filename))


### PR DESCRIPTION
Remaining `expects` calls are entangled with mocha's mocks, and will require more work.
