### PR TITLE
Prevent code duplication in ActiveStorage analyzers tests

### DIFF
--- a/activestorage/test/analyzer/image_analyzer_test.rb
+++ b/activestorage/test/analyzer/image_analyzer_test.rb
@@ -29,9 +29,4 @@ class ActiveStorage::Analyzer::ImageAnalyzerTest < ActiveSupport::TestCase
     assert_equal 792, metadata[:width]
     assert_equal 584, metadata[:height]
   end
-
-  private
-    def extract_metadata_from(blob)
-      blob.tap(&:analyze).metadata
-    end
 end

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -51,9 +51,4 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     metadata = extract_metadata_from(blob)
     assert_equal({ "analyzed" => true, "identified" => true }, metadata)
   end
-
-  private
-    def extract_metadata_from(blob)
-      blob.tap(&:analyze).metadata
-    end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -75,6 +75,10 @@ class ActiveSupport::TestCase
     def read_image(blob_or_variant)
       MiniMagick::Image.open blob_or_variant.service.send(:path_for, blob_or_variant.key)
     end
+
+    def extract_metadata_from(blob)
+      blob.tap(&:analyze).metadata
+    end
 end
 
 require "global_id"


### PR DESCRIPTION
### Summary

`ImageAnalyzerTest` and `VideoAnalyzerTest` cases are defining the same helper, since both use `#create_file_blob` that is defined in TestHelper, it would make sense to move `#extract_metadata_from` to that side.

