### PR TITLE
Don't allocate unnecessary array in translation helper

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -59,15 +59,9 @@ module ActionView
       # they can provide HTML values for.
       def translate(key, options = {})
         options = options.dup
-        has_default = options.has_key?(:default)
-        if has_default
+        if options.has_key?(:default)
           remaining_defaults = Array(options.delete(:default)).compact
-        else
-          remaining_defaults = []
-        end
-
-        if has_default && !remaining_defaults.first.kind_of?(Symbol)
-          options[:default] = remaining_defaults
+          options[:default] = remaining_defaults unless remaining_defaults.first.kind_of?(Symbol)
         end
 
         # If the user has explicitly decided to NOT raise errors, pass that option to I18n.


### PR DESCRIPTION
Following https://github.com/rails/rails/pull/32326

Remove one more unnecessary allocation and cleaned up unused variable.