### PR TITLE
Swap assertion order

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -919,8 +919,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_system_tests_directory_generated
     run_generator
 
-    assert_file("test/system/.keep")
     assert_directory("test/system")
+    assert_file("test/system/.keep")
   end
 
   unless Gem.win_platform?


### PR DESCRIPTION
`assert_directory("test/system")` may pass even if `assert_file("test/system/.keep")` fails.