### PR TITLE
Make Railties CI log for Ruby 2.6 accessible again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,8 @@ group :test do
   platforms :mri do
     gem "stackprof"
     gem "byebug"
+    # FIXME: Remove this when thor 0.21 is release
+    gem "thor", git: "https://github.com/erikhuda/thor.git", ref: "006832ea32480618791f89bb7d9e67b22fc814b9"
   end
 
   gem "benchmark-ips"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/erikhuda/thor.git
+  revision: 006832ea32480618791f89bb7d9e67b22fc814b9
+  ref: 006832ea32480618791f89bb7d9e67b22fc814b9
+  specs:
+    thor (0.20.0)
+
+GIT
   remote: https://github.com/matthewd/rb-inotify.git
   revision: 856730aad4b285969e8dd621e44808a7c5af4242
   branch: close-handling
@@ -458,7 +465,6 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (0.20.0)
     thread (0.1.7)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
@@ -554,6 +560,7 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
   stackprof
   sucker_punch
+  thor!
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Pending the next release of Thor which [fixes](https://github.com/erikhuda/thor/commit/006832ea32480618791f89bb7d9e67b22fc814b9) calls to `ERB.new`, Railties CI log for Ruby 2.6 is flooded with so many warnings (`> 37k`) it is too long for Travis to handle:
![log_too_log_to_display](https://user-images.githubusercontent.com/6261109/39405304-57c622be-4ba3-11e8-831c-d08d1f69b35c.png)
https://travis-ci.org/rails/rails/jobs/372623604#L10000

Raw:
```
...
/home/travis/.rvm/gems/ruby-head/gems/thor-0.20.0/lib/thor/actions/file_manipulation.rb:120: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/travis/.rvm/gems/ruby-head/gems/thor-0.20.0/lib/thor/actions/file_manipulation.rb:120: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/home/travis/.rvm/gems/ruby-head/gems/thor-0.20.0/lib/thor/actions/file_manipulation.rb:120: warning: Passing eoutvar with the 4th argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, eoutvar: ...) instead.

The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).

The job has been terminated
```

https://api.travis-ci.org/v3/job/372623604/log.txt

This patch forces installation of fixed Thor, and enables us to look at the the log.