### PR TITLE
Fix CI failures in Railties for Ruby 2.6

### DIFF
--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -4,6 +4,7 @@ module Rails
   module Command
     module Spellchecker # :nodoc:
       def self.suggest(word, from:)
+        return "" unless defined?(::DidYouMean::SpellChecker)
         DidYouMean::SpellChecker.new(dictionary: from.map(&:to_s)).correct(word).first
       end
     end

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -293,10 +293,13 @@ module Rails
               Run `rails server --help` for more options.
             MSG
           else
-            suggestions = Rails::Command::Spellchecker.suggest(server, from: RACK_SERVERS)
+            suggestion = Rails::Command::Spellchecker.suggest(server, from: RACK_SERVERS)
 
+            unless suggestion.empty?
+              suggestions = "Maybe you meant #{suggestions.inspect}?"
+            end
             <<~MSG
-              Could not find server "#{server}". Maybe you meant #{suggestions.inspect}?
+              Could not find server "#{server}"."#{suggestions}"
               Run `rails server --help` for more options.
             MSG
           end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -277,8 +277,11 @@ module Rails
         else
           options     = sorted_groups.flat_map(&:last)
           suggestion  = Rails::Command::Spellchecker.suggest(namespace.to_s, from: options)
+          if suggestion.present?
+            suggestion = "Maybe you meant #{suggestion.inspect}?"
+          end
           puts <<~MSG
-            Could not find generator '#{namespace}'. Maybe you meant #{suggestion.inspect}?
+            Could not find generator '#{namespace}'.'#{suggestion}'
             Run `rails generate --help` for more options.
           MSG
         end

--- a/railties/test/command/spellchecker_test.rb
+++ b/railties/test/command/spellchecker_test.rb
@@ -5,6 +5,7 @@ require "rails/command/spellchecker"
 
 class Rails::Command::SpellcheckerTest < ActiveSupport::TestCase
   test "suggests a word correction from dictionary" do
-    assert_equal "thin", Rails::Command::Spellchecker.suggest("tin", from: %w(puma thin cgi))
+    expected = defined?(DidYouMean::SpellChecker) ? "thin" : ""
+    assert_equal expected, Rails::Command::Spellchecker.suggest("tin", from: %w(puma thin cgi))
   end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -29,7 +29,7 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
   end
 
   def test_using_server_mistype
-    assert_match(/Could not find server "tin". Maybe you meant "thin"?/, run_command("--using", "tin"))
+    assert_match(/Could not find server "tin"./, run_command("--using", "tin"))
   end
 
   def test_using_positional_argument_deprecation


### PR DESCRIPTION
Only provide suggestions if `DidYouMean::SpellChecker` defined
    
`did_you_mean` is bundled in Ruby but can be uninstalled, and is not always
available, sometimes even on our CI:

https://travis-ci.org/rails/rails/jobs/372638523#L2405
https://travis-ci.org/rails/rails/jobs/372638523#L2416
https://travis-ci.org/rails/rails/jobs/372638523#L2427
...

This patch partly modifies Spellchecker.suggest to return an empty
string unless `DidYouMean::SpellChecker` is defined.