### PR TITLE
Fix url_helper examples in testing guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1085,16 +1085,16 @@ The `get` method kicks off the web request and populates the results into the `@
 
 All of these keyword arguments are optional.
 
-Example: Calling the `:show` action, passing an `id` of 12 as the `params` and setting `HTTP_REFERER` header:
+Example: Calling the `:show` action for the first `Article`, passing in an `HTTP_REFERER` header:
 
 ```ruby
-get article_url, params: { id: 12 }, headers: { "HTTP_REFERER" => "http://example.com/home" }
+get article_url(Article.first), headers: { "HTTP_REFERER" => "http://example.com/home" }
 ```
 
-Another example: Calling the `:update` action, passing an `id` of 12 as the `params` as an Ajax request.
+Another example: Calling the `:update` action for the last `Article`, passing in new text for the `title` in `params`, as an Ajax request:
 
 ```ruby
-patch article_url, params: { id: 12 }, xhr: true
+patch article_url(Article.last), params: { article: { title: "updated" } }, xhr: true
 ```
 
 NOTE: If you try running `test_should_create_article` test from `articles_controller_test.rb` it will fail on account of the newly added model level validation and rightly so.


### PR DESCRIPTION
### Summary

The `article_url` helper doesn't generate URLs for `patch` or `get` requests unless it's called with the Article (or its id) as an argument, like `article_url(@article)`.

I noticed this when looking into issue #31472, where the reporter quoted a test from the railsguide on testing.  That reporter (@runephilosof) didn't mention having any trouble with the url_helper, though.

### Other Information

I wasn't able to create a file from the templates for running tests of this url_helper.  However, I've dropped tests for calling the helper via `patch` and `get` into sample rails apps: [6.0.0.alpha](https://github.com/houhoulis/rails_issue_31472_6alpha/commit/a6dd51787d6355c8d265487ce60f44f2783771d3), [5.2](https://github.com/houhoulis/rails_issue_31472_52/commit/92220e4a1dd25a26ab0f82f3e687d6f475e2afe7), and [5.0](https://github.com/houhoulis/rails_issue_31472_50/commit/9071ef3796fdc1330442a3bf1dfd46791a6bb43d).  For example:

```ruby
  test "test from issue #31472: `get article_url, params: { id: ..`" do
    assert_raises(ActionController::UrlGenerationError) {
      get article_url, params: { id: @article.id },
        headers: { 'HTTP_REFERER' => 'http://example.com/home' }
    }
  end
```