### PR TITLE
Fix test: threads being nil in ensure

### DIFF
--- a/activesupport/test/cache/behaviors/connection_pool_behavior.rb
+++ b/activesupport/test/cache/behaviors/connection_pool_behavior.rb
@@ -4,12 +4,12 @@ module ConnectionPoolBehavior
   def test_connection_pool
     Thread.report_on_exception, original_report_on_exception = false, Thread.report_on_exception
 
+    threads = []
+
     emulating_latency do
       begin
         cache = ActiveSupport::Cache.lookup_store(store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
         cache.clear
-
-        threads = []
 
         assert_raises Timeout::Error do
           # One of the three threads will fail in 1 second because our pool size
@@ -31,12 +31,12 @@ module ConnectionPoolBehavior
   end
 
   def test_no_connection_pool
+    threads = []
+
     emulating_latency do
       begin
         cache = ActiveSupport::Cache.lookup_store(store, store_options)
         cache.clear
-
-        threads = []
 
         assert_nothing_raised do
           # Default connection pool size is 5, assuming 10 will make sure that


### PR DESCRIPTION
### Summary
If `connection_pool` is not installed, then `ActiveSupport::Cache.lookup_store(...)` fails. The failure gets however overriden by `ensure` section, with:

```
MemCacheStoreTest#test_connection_pool:
NoMethodError: undefined method `each' for nil:NilClass
    /builddir/build/BUILD/activesupport-5.2.0/usr/share/gems/gems/activesupport-5.2.0/test/cache/behaviors/connection_pool_behavior.rb:26:in `ensure in block in test_connection$
    /builddir/build/BUILD/activesupport-5.2.0/usr/share/gems/gems/activesupport-5.2.0/test/cache/behaviors/connection_pool_behavior.rb:26:in `block in test_connection_pool'
    /builddir/build/BUILD/activesupport-5.2.0/usr/share/gems/gems/activesupport-5.2.0/test/cache/stores/mem_cache_store_test.rb:124:in `emulating_latency'
    /builddir/build/BUILD/activesupport-5.2.0/usr/share/gems/gems/activesupport-5.2.0/test/cache/behaviors/connection_pool_behavior.rb:7:in `test_connection_pool'
```

as `threads` were not declared at that point.