### PR TITLE
Make `Arel::Test` subclass of `ActiveSupport::TestCase`

### DIFF
--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -978,7 +978,7 @@ module Arel
           table = Table.new(:foo)
           condition = table["id"].eq("1")
 
-          refute table.able_to_type_cast?
+          assert_not table.able_to_type_cast?
           condition.to_sql.must_equal %("foo"."id" = '1')
         end
 

--- a/activerecord/test/cases/arel/helper.rb
+++ b/activerecord/test/cases/arel/helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/test_case"
 require "rubygems"
 require "minitest/autorun"
 require "arel"
@@ -13,7 +14,7 @@ class Object
 end
 
 module Arel
-  class Test < Minitest::Test
+  class Test < ActiveSupport::TestCase
     def setup
       super
       @arel_engine = Arel::Table.engine
@@ -40,5 +41,11 @@ module Arel
     after do
       Arel::Table.engine = @arel_engine if defined? @arel_engine
     end
+    include ActiveSupport::Testing::Assertions
+
+    # test/unit backwards compatibility methods
+    alias :assert_no_match :refute_match
+    alias :assert_not_equal :refute_equal
+    alias :assert_not_same :refute_same
   end
 end

--- a/activerecord/test/cases/arel/nodes/ascending_test.rb
+++ b/activerecord/test/cases/arel/nodes/ascending_test.rb
@@ -29,7 +29,7 @@ module Arel
 
       def test_descending?
         ascending = Ascending.new "zomg"
-        assert !ascending.descending?
+        assert_not ascending.descending?
       end
 
       def test_equality_with_same_ivars

--- a/activerecord/test/cases/arel/nodes/binary_test.rb
+++ b/activerecord/test/cases/arel/nodes/binary_test.rb
@@ -4,22 +4,24 @@ require_relative "../helper"
 
 module Arel
   module Nodes
-    describe "Binary" do
-      describe "#hash" do
-        it "generates a hash based on its value" do
-          eq = Equality.new("foo", "bar")
-          eq2 = Equality.new("foo", "bar")
-          eq3 = Equality.new("bar", "baz")
+    class NodesTest < Arel::Spec
+      describe "Binary" do
+        describe "#hash" do
+          it "generates a hash based on its value" do
+            eq = Equality.new("foo", "bar")
+            eq2 = Equality.new("foo", "bar")
+            eq3 = Equality.new("bar", "baz")
 
-          assert_equal eq.hash, eq2.hash
-          refute_equal eq.hash, eq3.hash
-        end
+            assert_equal eq.hash, eq2.hash
+            assert_not_equal eq.hash, eq3.hash
+          end
 
-        it "generates a hash specific to its class" do
-          eq = Equality.new("foo", "bar")
-          neq = NotEqual.new("foo", "bar")
+          it "generates a hash specific to its class" do
+            eq = Equality.new("foo", "bar")
+            neq = NotEqual.new("foo", "bar")
 
-          refute_equal eq.hash, neq.hash
+            assert_not_equal eq.hash, neq.hash
+          end
         end
       end
     end

--- a/activerecord/test/cases/arel/nodes/case_test.rb
+++ b/activerecord/test/cases/arel/nodes/case_test.rb
@@ -4,79 +4,81 @@ require_relative "../helper"
 
 module Arel
   module Nodes
-    describe "Case" do
-      describe "#initialize" do
-        it "sets case expression from first argument" do
-          node = Case.new "foo"
+    class NodesTest < Arel::Spec
+      describe "Case" do
+        describe "#initialize" do
+          it "sets case expression from first argument" do
+            node = Case.new "foo"
 
-          assert_equal "foo", node.case
+            assert_equal "foo", node.case
+          end
+
+          it "sets default case from second argument" do
+            node = Case.new nil, "bar"
+
+            assert_equal "bar", node.default
+          end
         end
 
-        it "sets default case from second argument" do
-          node = Case.new nil, "bar"
+        describe "#clone" do
+          it "clones case, conditions and default" do
+            foo = Nodes.build_quoted "foo"
 
-          assert_equal "bar", node.default
-        end
-      end
+            node = Case.new
+            node.case = foo
+            node.conditions = [When.new(foo, foo)]
+            node.default = foo
 
-      describe "#clone" do
-        it "clones case, conditions and default" do
-          foo = Nodes.build_quoted "foo"
+            dolly = node.clone
 
-          node = Case.new
-          node.case = foo
-          node.conditions = [When.new(foo, foo)]
-          node.default = foo
+            assert_equal dolly.case, node.case
+            assert_not_same dolly.case, node.case
 
-          dolly = node.clone
+            assert_equal dolly.conditions, node.conditions
+            assert_not_same dolly.conditions, node.conditions
 
-          assert_equal dolly.case, node.case
-          refute_same  dolly.case, node.case
-
-          assert_equal dolly.conditions, node.conditions
-          refute_same  dolly.conditions, node.conditions
-
-          assert_equal dolly.default, node.default
-          refute_same  dolly.default, node.default
-        end
-      end
-
-      describe "equality" do
-        it "is equal with equal ivars" do
-          foo = Nodes.build_quoted "foo"
-          one = Nodes.build_quoted 1
-          zero = Nodes.build_quoted 0
-
-          case1 = Case.new foo
-          case1.conditions = [When.new(foo, one)]
-          case1.default = Else.new zero
-
-          case2 = Case.new foo
-          case2.conditions = [When.new(foo, one)]
-          case2.default = Else.new zero
-
-          array = [case1, case2]
-
-          assert_equal 1, array.uniq.size
+            assert_equal dolly.default, node.default
+            assert_not_same dolly.default, node.default
+          end
         end
 
-        it "is not equal with different ivars" do
-          foo = Nodes.build_quoted "foo"
-          bar = Nodes.build_quoted "bar"
-          one = Nodes.build_quoted 1
-          zero = Nodes.build_quoted 0
+        describe "equality" do
+          it "is equal with equal ivars" do
+            foo = Nodes.build_quoted "foo"
+            one = Nodes.build_quoted 1
+            zero = Nodes.build_quoted 0
 
-          case1 = Case.new foo
-          case1.conditions = [When.new(foo, one)]
-          case1.default = Else.new zero
+            case1 = Case.new foo
+            case1.conditions = [When.new(foo, one)]
+            case1.default = Else.new zero
 
-          case2 = Case.new foo
-          case2.conditions = [When.new(bar, one)]
-          case2.default = Else.new zero
+            case2 = Case.new foo
+            case2.conditions = [When.new(foo, one)]
+            case2.default = Else.new zero
 
-          array = [case1, case2]
+            array = [case1, case2]
 
-          assert_equal 2, array.uniq.size
+            assert_equal 1, array.uniq.size
+          end
+
+          it "is not equal with different ivars" do
+            foo = Nodes.build_quoted "foo"
+            bar = Nodes.build_quoted "bar"
+            one = Nodes.build_quoted 1
+            zero = Nodes.build_quoted 0
+
+            case1 = Case.new foo
+            case1.conditions = [When.new(foo, one)]
+            case1.default = Else.new zero
+
+            case2 = Case.new foo
+            case2.conditions = [When.new(bar, one)]
+            case2.default = Else.new zero
+
+            array = [case1, case2]
+
+            assert_equal 2, array.uniq.size
+          end
         end
       end
     end

--- a/activerecord/test/cases/arel/nodes/descending_test.rb
+++ b/activerecord/test/cases/arel/nodes/descending_test.rb
@@ -24,7 +24,7 @@ module Arel
 
       def test_ascending?
         descending = Descending.new "zomg"
-        assert !descending.ascending?
+        assert_not descending.ascending?
       end
 
       def test_descending?

--- a/activerecord/test/cases/arel/nodes/select_core_test.rb
+++ b/activerecord/test/cases/arel/nodes/select_core_test.rb
@@ -17,9 +17,9 @@ module Arel
         assert_equal core.projections, dolly.projections
         assert_equal core.wheres, dolly.wheres
 
-        refute_same core.froms, dolly.froms
-        refute_same core.projections, dolly.projections
-        refute_same core.wheres, dolly.wheres
+        assert_not_same core.froms, dolly.froms
+        assert_not_same core.projections, dolly.projections
+        assert_not_same core.wheres, dolly.wheres
       end
 
       def test_set_quantifier

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -1144,7 +1144,7 @@ module Arel
         assert_match("LIMIT", manager.to_sql)
 
         manager.limit = nil
-        refute_match("LIMIT", manager.to_sql)
+        assert_no_match("LIMIT", manager.to_sql)
       end
     end
 


### PR DESCRIPTION
### Summary

This pull request makes `Arel::Test` subclass of `ActiveSupport::TestCase` not `Minitest::Test`
to address #32720 . since `ActiveSupport::TestCase` has its own assertion methods which adresses RuboCop offenses.

`Arel::Spec`  is still a subclass of `Minitest::Spec` since there is no equivalent class in ActiveSupport
then including `ActiveSupport::Testing::Assertions` to `Arel::Spec` and add test/unit backwards compatibility methods.