### PR TITLE
Reset CONTENT_LENGTH between test requests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -604,6 +604,7 @@ module ActionController
           env.delete "action_dispatch.request.query_parameters"
           env.delete "action_dispatch.request.request_parameters"
           env["rack.input"] = StringIO.new
+          env.delete "CONTENT_LENGTH"
           env.delete "RAW_POST_DATA"
           env
         end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -689,6 +689,14 @@ XML
     assert_equal "foo=baz", @request.raw_post
   end
 
+  def test_content_length_reset_after_post_request
+    post :no_op, params: { foo: "bar" }
+    assert_not_equal 0, @request.content_length
+
+    get :no_op
+    assert_equal 0, @request.content_length
+  end
+
   def test_path_is_kept_after_the_request
     get :test_params, params: { id: "foo" }
     assert_equal "/test_case_test/test/test_params/foo", @request.path


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/32673.
Fixes https://github.com/rails/rails/issues/32767.

https://github.com/rails/rails/blob/ee6a431bb9071151d9d546856a6451b861907202/actionpack/lib/action_controller/test_case.rb#L120-L121

If a POST request is followed by a GET request in a controller test, the `rack.input` and `RAW_POST_DATA` headers from the first request will be reset but the `CONTENT_LENGTH` header will leak, leading the request object in the second request to incorrectly believe it has a body.

r? @georgeclaghorn 