### PR TITLE
Add quotes to code in rdoc comment in ActionController [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -78,7 +78,7 @@ module ActionController
   #
   # You can retrieve it again through the same hash:
   #
-  #   Hello #{session[:person]}
+  #   "Hello #{session[:person]}"
   #
   # For removing objects from the session, you can either assign a single key to +nil+:
   #


### PR DESCRIPTION
Adds quotation marks to a string expression in an rdoc comment. The lack of quotes interfered with the syntax highlighting in the generated documentation (http://api.rubyonrails.org/classes/ActionController/Base.html).