### PR TITLE
Fix database.yml merging

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     # Given an env, spec and config creates DatabaseConfig structs with
     # each attribute set.
     def self.walk_configs(env_name, spec_name, config) # :nodoc:
-      if config["database"] || config["url"] || env_name == "default"
+      if config["database"] || config["url"] || config["adapter"]
         DatabaseConfig.new(env_name, spec_name, config)
       else
         config.each_pair.map do |sub_spec_name, sub_config|


### PR DESCRIPTION
Ok so apparently you can not just have a `default:` that manually is
merged in with YAML but you can also have a special "shared" config that
is automatically merged.

Example:

```
shared:
  adapter: mysql2
  host: <%= ENV["DB_HOST"] || "localhost" %>
  username: root
  connect_timeout: 0
  pool: 100
  reconnect: true

development:
  database: development_db
  adapter: mysql2
```

To fix, only create a DatabaseConfig object when an adapter, database,
or URL are present.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
