### PR TITLE
Don't generate assets' initializer in `app:update` task if sprockets is skipped

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't generate assets' initializer in `app:update` task if sprockets is skipped
+
+    *Tsukuru Tanimichi*
+
 *   Make the master.key file read-only for the owner upon generation on
     POSIX-compliant systems.
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -146,6 +146,10 @@ module Rails
         template "config/storage.yml"
       end
 
+      if options[:skip_sprockets] && !assets_config_exist
+        remove_file "config/initializers/assets.rb"
+      end
+
       unless rack_cors_config_exist
         remove_file "config/initializers/cors.rb"
       end

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -40,7 +40,7 @@ namespace :app do
   namespace :update do
     require "rails/app_updater"
 
-    # desc "Update config/boot.rb from your current rails install"
+    # desc "Update config files from your current rails install"
     task :configs do
       Rails::AppUpdater.invoke_from_app_generator :create_boot_file
       Rails::AppUpdater.invoke_from_app_generator :update_config_files

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -296,6 +296,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_assets_initializer_when_skip_sprockets_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "--skip-sprockets"]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true, skip_sprockets: true }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+
+      assert_no_file "#{app_root}/config/initializers/assets.rb"
+    end
+  end
+
   def test_app_update_does_not_generate_action_cable_contents_when_skip_action_cable_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-action-cable"]


### PR DESCRIPTION
Execute `rails new myapp -S` and then upgrade the app by using the `app:update` task, `bin/rails c` results in `NoMethodError`.

```sh
$ bin/rails app:update

$ bin/rails c
Traceback (most recent call last):
    44: from bin/rails:4:in `<main>'
(snip)
     1: from /Users/tanimichi.tsukuru/ghq/github.com/moneyforward/moneyplus/config/initializers/assets.rb:4:in `<top (required)>'
/Users/tanimichi.tsukuru/ghq/github.com/moneyforward/moneyplus/vendor/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/railtie/configuration.rb:97:in `method_missing': undefined method `assets' for #<Rails::Application::Configuration:0x00007fcb8d3697e0> (NoMethodError)
Did you mean?  asset_host
```

Related to #29645 and #28825