### PR TITLE
Explicitly depend on the did_you_mean gem for 2.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ PATH
     railties (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)
       activesupport (= 6.0.0.alpha)
+      did_you_mean
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
@@ -204,6 +205,7 @@ GEM
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
+    did_you_mean (1.2.1)
     digest-crc (0.4.1)
     em-http-request (1.1.5)
       addressable (>= 2.3.4)

--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "did_you_mean"
+
 module Rails
   module Command
     module Spellchecker # :nodoc:

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rake", ">= 0.8.7"
   s.add_dependency "thor", ">= 0.18.1", "< 2.0"
   s.add_dependency "method_source"
+  s.add_dependency "did_you_mean"
 
   s.add_development_dependency "actionview", version
 end


### PR DESCRIPTION
Seeing that the tests are failing on 2.6.0-dev, we may as well
explicitly require `did_you_mean` if it's no longer included or
automatically required in future Ruby versions.

See https://github.com/rails/rails/issues/32779. Thanks to @utilum for finding and easily reproducing this.