### PR TITLE
Fix typo in ActiveRecord test method name

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -982,7 +982,7 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_clear_cash_when_setting_table_name
+  def test_clear_cache_when_setting_table_name
     original_table_name = Joke.table_name
 
     Joke.table_name = "funny_jokes"


### PR DESCRIPTION
Fix typo in ActiveRecord test method name. 
- `cash` to `cache`
