### PR TITLE
Allow a belonging to object to be created from a new record

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -107,6 +107,14 @@ module ActiveRecord
             yield
           end
         end
+
+        def _create_record(attributes, raise_error = false)
+          unless owner.persisted?
+            raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
+          end
+
+          super
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -63,10 +63,6 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false)
-          unless owner.persisted?
-            raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
-          end
-
           record = build_record(attributes)
           yield(record) if block_given?
           saved = record.save

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -272,6 +272,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal apple, citibank.firm
   end
 
+  def test_creating_the_belonging_object_from_new_record
+    citibank = Account.new("credit_limit" => 10)
+    apple    = citibank.create_firm("name" => "Apple")
+    assert_equal apple, citibank.firm
+    citibank.save
+    citibank.reload
+    assert_equal apple, citibank.firm
+  end
+
   def test_creating_the_belonging_object_with_primary_key
     client = Client.create(name: "Primary key client")
     apple  = client.create_firm_with_primary_key("name" => "Apple")


### PR DESCRIPTION
### Summary

If a 'has one' object is created from a new record, an `ActiveRecord::RecordNotSaved` error is raised with the message `You cannot call create unless the parent is saved`. This behavior (see https://github.com/rails/rails/pull/29392) also applies to the reverse scenario ie a 'belongs to' object created from a new record.

In this reverse case the error message is confusing since it is the child and not the parent object that is not saved. I've removed the error for the `belongs_to_association` so that the parent record can be created even though the child is not persisted.

