### PR TITLE
Remove unused `assert_like` from `Arel::Test`

### DIFF
--- a/activerecord/test/cases/arel/helper.rb
+++ b/activerecord/test/cases/arel/helper.rb
@@ -24,11 +24,6 @@ module Arel
       Arel::Table.engine = @arel_engine if defined? @arel_engine
       super
     end
-
-    def assert_like(expected, actual)
-      assert_equal expected.gsub(/\s+/, " ").strip,
-                   actual.gsub(/\s+/, " ").strip
-    end
   end
 
   class Spec < Minitest::Spec


### PR DESCRIPTION
### Summary

This pull request removes unused `assert_like` from `Arel::Test`

It had been added at https://github.com/rails/arel/commit/05b5bb12270b32e094c1c879273e0978dabe5b3b and removed at https://github.com/rails/arel/commit/db1bb4e9a728a437d16f8bdb48c3b772c3e4edb0


