### PR TITLE
Move the did_you_mean spellchecker to require-time

### DIFF
--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -5,11 +5,7 @@ module Rails
     module Spellchecker # :nodoc:
       class << self
         def suggest(word, from:)
-          if defined?(DidYouMean::SpellChecker)
-            DidYouMean::SpellChecker.new(dictionary: from.map(&:to_s)).correct(word).first
-          else
-            from.sort_by { |w| levenshtein_distance(word, w) }.first
-          end
+          from.sort_by { |w| levenshtein_distance(word, w) }.first
         end
 
         private


### PR DESCRIPTION
This change conditionally defines `Rails::Command::Spellchecker` based
on the `did_you_mean` presence in require time, so we don't have the
condition executing at runtime.