### PR TITLE
Rollback parent transaction when children fails to update

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -401,7 +401,10 @@ module ActiveRecord
                 if autosave
                   saved = association.insert_record(record, false)
                 else
-                  association.insert_record(record) unless reflection.nested?
+                  association_saved = association.insert_record(record) unless reflection.nested?
+                  if reflection.options.fetch(:validate, true)
+                    saved = association_saved
+                  end
                 end
               elsif autosave
                 saved = record.save(validate: false)

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -400,9 +400,9 @@ module ActiveRecord
               if autosave != false && (@new_record_before_save || record.new_record?)
                 if autosave
                   saved = association.insert_record(record, false)
-                else
-                  association_saved = association.insert_record(record) unless reflection.nested?
-                  if reflection.options.fetch(:validate, true)
+                elsif !reflection.nested?
+                  association_saved = association.insert_record(record)
+                  if reflection.validate?
                     saved = association_saved
                   end
                 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -517,6 +517,24 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_not_predicate new_firm, :persisted?
   end
 
+  def test_adding_unsavable_association
+    new_firm = Firm.new("name" => "A New Firm, Inc")
+    client = new_firm.clients.new("name" => "Apple")
+    # Stub the save method of the client to simulate aborting the insert
+    class << client
+      def save(*)
+        false
+      end
+    end
+
+    assert_predicate client, :valid?
+    assert_predicate new_firm, :valid?
+    assert_not new_firm.save
+    assert new_firm, :persisted?
+    assert_not Firm.exists?(new_firm.id)
+    assert_not_predicate client, :persisted?
+  end
+
   def test_invalid_adding_with_validate_false
     firm = Firm.first
     client = Client.new

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -520,18 +520,12 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   def test_adding_unsavable_association
     new_firm = Firm.new("name" => "A New Firm, Inc")
     client = new_firm.clients.new("name" => "Apple")
-    # Stub the save method of the client to simulate aborting the insert
-    class << client
-      def save(*)
-        false
-      end
-    end
+    client.throw_on_save = true
 
     assert_predicate client, :valid?
     assert_predicate new_firm, :valid?
     assert_not new_firm.save
     assert_not_predicate new_firm, :persisted?
-    assert_not Firm.exists?(new_firm.id)
     assert_not_predicate client, :persisted?
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -530,7 +530,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_predicate client, :valid?
     assert_predicate new_firm, :valid?
     assert_not new_firm.save
-    assert new_firm, :persisted?
+    assert_not_predicate new_firm, :persisted?
     assert_not Firm.exists?(new_firm.id)
     assert_not_predicate client, :persisted?
   end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -145,6 +145,11 @@ class Client < Company
     raise RaisedOnSave if raise_on_save
   end
 
+  attr_accessor :throw_on_save
+  before_save do
+    throw :abort if throw_on_save
+  end
+
   class RaisedOnDestroy < RuntimeError; end
   attr_accessor :raise_on_destroy
   before_destroy do


### PR DESCRIPTION
## Summary

Rails supports autosave associations on the owner of a `has_many`
relationship. In certain situation, if the children of the association
fail to save, the parent is not rolled back. This PR starts making it rollback.

## Details

```ruby
class Employee < ActiveRecord::Base
end

class Company < ActiveRecord::Base
  has_many(:employees)
end

company = Company.new
employee = company.employees.new
company.save
```

In the previous example, if the Employee failed to save, the Company
will not be rolled back. It will remain in the database with no
associated Employee.

I expect the `company.save` call to be atomic, and either create all or
none of the records.

The persistence of the Company already starts a transaction that nests
it's associated record updates. However, it didn't track the success or failure of it's
associations in this very situation, and the outermost transaction is not
rolled back.

This PR makes the change to track the success of the child insertion and
rollback the parent if any of the children fail.
