### PR TITLE
Add support for prefetch-src directive

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -126,6 +126,7 @@ module ActionDispatch #:nodoc:
       manifest_src:    "manifest-src",
       media_src:       "media-src",
       object_src:      "object-src",
+      prefetch_src:    "prefetch-src",
       script_src:      "script-src",
       style_src:       "style-src",
       worker_src:      "worker-src"

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -116,6 +116,12 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.object_src false
     assert_no_match %r{object-src}, @policy.build
 
+    @policy.prefetch_src :self
+    assert_match %r{prefetch-src 'self'}, @policy.build
+
+    @policy.prefetch_src false
+    assert_no_match %r{prefetch-src}, @policy.build
+
     @policy.script_src :self
     assert_match %r{script-src 'self'}, @policy.build
 


### PR DESCRIPTION
Specification: https://w3c.github.io/webappsec-csp/#directive-prefetch-src

This directive can already be used as an experimental feature in Chrome.
Ref: https://bugs.chromium.org/p/chromium/issues/detail?id=801561
