### PR TITLE
Add core extension Enumerable index_grouped_by.

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -53,6 +53,24 @@ module Enumerable
     end
   end
 
+  # Convert an enumerable to a hash, putting items with the same key in a list.
+  #
+  #   fruits.index_by(&:color)
+  #   # => { "yellow" => [<Fruit ...>, <Fruit ...>], "red" => [<Fruit ...>], ...}
+  def index_grouped_by
+    if block_given?
+      result = {}
+      each do |elem|
+        key = yield(elem)
+        result[key] ||= []
+        result[key] << elem
+      end
+      result
+    else
+      to_enum(:index_grouped_by) { size if respond_to?(:size) }
+    end
+  end
+
   # Returns +true+ if the enumerable has more than 1 element. Functionally
   # equivalent to <tt>enum.to_a.size > 1</tt>. Can be called with a block too,
   # much like any?, so <tt>people.many? { |p| p.age > 26 }</tt> returns +true+

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -179,6 +179,17 @@ class EnumerableTests < ActiveSupport::TestCase
                  payments.index_by.each(&:price))
   end
 
+  def test_index_grouped_by
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(10), Payment.new(10) ])
+    assert_equal({ 5 => [Payment.new(5)], 10 => [ Payment.new(10), Payment.new(10) ]},
+                 payments.index_grouped_by(&:price))
+    assert_equal Enumerator, payments.index_grouped_by.class
+    assert_nil payments.index_grouped_by.size
+    assert_equal 42, (1..42).index_grouped_by.size
+    assert_equal({ 5 => [Payment.new(5)], 10 => [ Payment.new(10), Payment.new(10) ]},
+                 payments.index_grouped_by.each(&:price))
+  end
+
   def test_many
     assert_equal false, GenericEnumerable.new([]).many?
     assert_equal false, GenericEnumerable.new([ 1 ]).many?


### PR DESCRIPTION
### Summary

Updates the core extensions to include a new method for Enumerable called
index_grouped_by. The behaviour of this method is almost the same as
that of the index_by method. The difference is that index_grouped_by
makes lists of all hash values, and appends items with the same key to
the same list. This allows for indexing an enumerable by a key that is
not unique.

I found myself using this pattern in many projects, abstracted it as an extension of Enumerable and finally decided that it might be worth including in the Active Support Core Extensions. I am looking forward to your thoughts on this!

### Example

```ruby
> fruits
[
  <Fruit name="banana" color="yellow">,
  <Fruit name="lemon" color="yellow">,
  <Fruit name="strawberry" color="red">
]

> fruits.index_grouped_by(&:color)
{
  "yellow" => [
    <Fruit name="banana" color="yellow">,
    <Fruit name="lemon" color="yellow">
  ],
  "red" => [ <Fruit name="strawberry" color="red"> ]
}
```
