### PR TITLE
Fix logic on disabling afer_commit callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix logic on disabling commit callbacks so they are not called unexpectedly when errors occur.
+
+    *Brian Durand*
+
 *   Ensure `Associations::CollectionAssociation#size` and `Associations::CollectionAssociation#empty?`
     use loaded association ids if present.
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -340,7 +340,7 @@ module ActiveRecord
     # Ensure that it is not called if the object was never persisted (failed create),
     # but call it after the commit of a destroyed object.
     def committed!(should_run_callbacks: true) #:nodoc:
-      if should_run_callbacks && destroyed? || persisted?
+      if should_run_callbacks && (destroyed? || persisted?)
         _run_commit_without_transaction_enrollment_callbacks
         _run_commit_callbacks
       end


### PR DESCRIPTION
Commit callbacks are intentionally disabled when errors occur when calling the callback chain in order to reset the internal record state. However, the implicit order of operations on the logic for checking if callbacks are disabled is wrong. The result is that callbacks can be unexpectedly when errors occur in transactions.

### Summary

The flag to disable running `after_commit` callbacks is broken and will be ignored if a record is persisted to the database resulting in callbacks being run in all cases. The current logic to decide if callbacks should be run is:

`should_run_callbacks && destroyed? || persisted?`

Which is interpreted as:

`(should_run_callbacks && destroyed?) || persisted?`

But it should be:

`should_run_callbacks && (destroyed? || persisted?)`

This bug comes up in a case where there is an error during an `after_commit` call and was reported in #29747.