### PR TITLE
Eager autoload mail gem when eager load is true

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure mail gem is eager autoloaded when eager load is true to prevent thread deadlocks.
+
+    *Samuel Cochran*
+
 *   Perform email jobs in `assert_emails`.
 
     *Gannon McGibbon*

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -52,6 +52,13 @@ module ActionMailer
   autoload :TestHelper
   autoload :MessageDelivery
   autoload :DeliveryJob
+
+  def self.eager_load!
+    super
+
+    require "mail"
+    Mail.eager_autoload!
+  end
 end
 
 autoload :Mime, "action_dispatch/http/mime_type"

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -9,6 +9,7 @@ module ActionMailer
   class Railtie < Rails::Railtie # :nodoc:
     config.action_mailer = ActiveSupport::OrderedOptions.new
     config.eager_load_namespaces << ActionMailer
+    config.eager_load_namespaces << Mail
 
     initializer "action_mailer.logger" do
       ActiveSupport.on_load(:action_mailer) { self.logger ||= Rails.logger }

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -9,7 +9,10 @@ module ActionMailer
   class Railtie < Rails::Railtie # :nodoc:
     config.action_mailer = ActiveSupport::OrderedOptions.new
     config.eager_load_namespaces << ActionMailer
-    config.eager_load_namespaces << Mail
+
+    config.before_eager_load do
+      Mail.eager_autoload!
+    end
 
     initializer "action_mailer.logger" do
       ActiveSupport.on_load(:action_mailer) { self.logger ||= Rails.logger }

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -10,11 +10,6 @@ module ActionMailer
     config.action_mailer = ActiveSupport::OrderedOptions.new
     config.eager_load_namespaces << ActionMailer
 
-    config.before_eager_load do
-      require "mail"
-      Mail.eager_autoload!
-    end
-
     initializer "action_mailer.logger" do
       ActiveSupport.on_load(:action_mailer) { self.logger ||= Rails.logger }
     end

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -11,6 +11,7 @@ module ActionMailer
     config.eager_load_namespaces << ActionMailer
 
     config.before_eager_load do
+      require "mail"
       Mail.eager_autoload!
     end
 


### PR DESCRIPTION
We had a production issue where our Sidekiq worker threads all became deadlocked while autoloading a file within the mail gem, required via ActionMailer, despite setting `config.eager_load = true` for our Rails application. Mail uses ruby's native autoload instead of ActiveSupport, so ActiveSupport can't eager load it automatically. `Mail.eager_autoload!` exists and works great, ActionMailer just doesn't call it during eager loading. Adding it to the ActionMailer Railtie's `eager_load_namespaces` takes care of calling `Mail.eager_autoload!` during the `eager_load!` initializer.