### PR TITLE
Fix #29632 - nil #path leads to NoMethodError in LoadError#is_missing?

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -4,6 +4,6 @@ class LoadError
   # Returns true if the given path name (except perhaps for the ".rb"
   # extension) is the missing file which caused the exception to be raised.
   def is_missing?(location)
-    location.sub(/\.rb$/, "".freeze) == path.sub(/\.rb$/, "".freeze)
+    location.sub(/\.rb$/, "".freeze) == path.to_s.sub(/\.rb$/, "".freeze)
   end
 end

--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -7,13 +7,20 @@ class TestLoadError < ActiveSupport::TestCase
   def test_with_require
     assert_raise(LoadError) { require "no_this_file_don't_exist" }
   end
+
   def test_with_load
     assert_raise(LoadError) { load "nor_does_this_one" }
   end
+
   def test_path
     begin load "nor/this/one.rb"
     rescue LoadError => e
       assert_equal "nor/this/one.rb", e.path
     end
+  end
+
+  def test_is_missing_with_nil_path
+    error = LoadError.new(nil)
+    assert_nothing_raised { error.is_missing?("anything") }
   end
 end


### PR DESCRIPTION
### Summary

Test added to https://github.com/rails/rails/pull/29957. See https://github.com/rails/rails/issues/29632 for the full story. This is just an extra precaution to make sure `LoadError#is_missing?` accounts for a potentially `nil` path.

CC @eileencodes @sgrif @nrser
