### PR TITLE
add quick fix for auto disconnect when cable client offline

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -116,12 +116,12 @@ module ActionCable
       end
 
       def beat
-        #transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
+        # transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
         if websocket.respond_to?(:ping)
           websocket.ping
         else
           transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
-        end       
+        end
       end
 
       def on_open # :nodoc:

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -116,7 +116,12 @@ module ActionCable
       end
 
       def beat
-        transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
+        #transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
+        if websocket.respond_to?(:ping)
+          websocket.ping
+        else
+          transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
+        end       
       end
 
       def on_open # :nodoc:

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -32,6 +32,7 @@ module ActionCable
       attr_reader :env, :url
 
       def initialize(env, event_target, event_loop, protocols)
+        @ping_times = 0
         @env          = env
         @event_target = event_target
         @event_loop   = event_loop
@@ -64,6 +65,15 @@ module ActionCable
 
         @driver_started = true
         @driver.start
+      end
+
+      def ping
+        return false if @ready_state > OPEN
+        @ping_times += 1
+        result = @driver.ping('pong') do
+          @ping_times = 0
+        end
+        client_gone if @ping_times > 5
       end
 
       def rack_response

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -70,7 +70,7 @@ module ActionCable
       def ping
         return false if @ready_state > OPEN
         @ping_times += 1
-        result = @driver.ping('pong') do
+        result = @driver.ping("pong") do
           @ping_times = 0
         end
         client_gone if @ping_times > 5

--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -10,6 +10,10 @@ module ActionCable
         @websocket = ::WebSocket::Driver.websocket?(env) ? ClientSocket.new(env, event_target, event_loop, protocols) : nil
       end
 
+      def ping
+        websocket.ping
+      end
+
       def possible?
         websocket
       end


### PR DESCRIPTION
### Summary

in the production environment on ubuntu server, when disconnect from client side, it's keeping as connected. after adding these code it's checking 5 pins and disconnect  the connection if those 5 pins failed.

### Other Information
-