### PR TITLE
Don't generate `config/spring.rb` in `app:update` task when spring isn't loaded

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,8 @@
-*   Don't generate assets' initializer in `app:update` task if sprockets is skipped
+*   Don't generate unused files in `app:update` task
+
+     Skip the assets' initializer when sprockets isn't loaded.
+
+     Skip `config/spring.rb` when spring isn't loaded.
 
     *Tsukuru Tanimichi*
 

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -28,6 +28,7 @@ module Rails
           options[:skip_sprockets]      = !defined?(Sprockets::Railtie)
           options[:skip_puma]           = !defined?(Puma)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
+          options[:skip_spring]         = !defined?(Spring)
           options
         end
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -309,6 +309,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_spring_contents_when_skip_spring_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "--skip-spring"]
+
+    FileUtils.cd(app_root) do
+      quietly { system("bin/rails app:update") }
+    end
+
+    assert_no_file "#{app_root}/config/spring.rb"
+  end
+
   def test_app_update_does_not_generate_action_cable_contents_when_skip_action_cable_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-action-cable"]


### PR DESCRIPTION
Related to #32780, #29645 and #28825