### PR TITLE
Allow using capybara 3.0 + rspec-rails + system tests with 5.1 stable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*  Use Capybara registered `:puma` server config.
+
+    The Capybara registered `:puma` server ensures the puma server is run in process so
+    connection sharing and open request detection work correctly by default.
+
+    *Thomas Walpole*
+
 ## Rails 5.1.6 (March 29, 2018) ##
 
 *   Check exclude before flagging cookies as secure.

--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -1,5 +1,3 @@
-require "rack/handler/puma"
-
 module ActionDispatch
   module SystemTesting
     class Server # :nodoc:

--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -8,31 +8,17 @@ module ActionDispatch
       self.silence_puma = false
 
       def run
-        register
         setup
       end
 
       private
-        def register
-          Capybara.register_server :rails_puma do |app, port, host|
-            Rack::Handler::Puma.run(
-              app,
-              Port: port,
-              Threads: "0:1",
-              workers: 0,
-              daemon: false,
-              Silent: self.class.silence_puma
-            )
-          end
-        end
-
         def setup
           set_server
           set_port
         end
 
         def set_server
-          Capybara.server = :rails_puma
+          Capybara.server = :puma, { Silent: self.class.silence_puma }
         end
 
         def set_port

--- a/actionpack/test/dispatch/system_testing/server_test.rb
+++ b/actionpack/test/dispatch/system_testing/server_test.rb
@@ -7,10 +7,6 @@ class ServerTest < ActiveSupport::TestCase
     ActionDispatch::SystemTesting::Server.new.run
   end
 
-  test "initializing the server port" do
-    assert_includes Capybara.servers, :rails_puma
-  end
-
   test "port is always included" do
     assert Capybara.always_include_port, "expected Capybara.always_include_port to be true"
   end


### PR DESCRIPTION
### Summary

Backporting these two patches is the only way I've found to be able to use these libraries with rails 5.1. There's a very annoying problem with this combination of libraries that it's only fixed in `capybara 3.0` (see https://github.com/rspec/rspec-rails/issues/1887 and https://github.com/rspec/rspec-rails/issues/1887#issuecomment-375804167 in particular). It'd be nice to be able to upgrade to capybara 3.0 to fix this issue without having to attempt the full rails upgrade at the same time. @twalpole What do you think about this? Will it cause problems for older versions of `capybara`?
