### PR TITLE
Remove leftover requires

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "concurrent/map"
 require "action_view/dependency_tracker"
-require "monitor"
 
 module ActionView
   class Digestor


### PR DESCRIPTION
* `Concurrent::Map` usage was removed from this file in 3239ed48d28f3c0baf4445e6c279107e892b7cab

* `Monitor` usage was removed in f233598d2da773c2024cbe62a199ddc70d9fd7a1
