### PR TITLE
Remove unused `remove_file` method

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -159,10 +159,6 @@ module Rails
           remove_file "config/initializers/cookies_serializer.rb"
         end
 
-        unless assets_config_exist
-          remove_file "config/initializers/assets.rb"
-        end
-
         unless csp_config_exist
           remove_file "config/initializers/content_security_policy.rb"
         end


### PR DESCRIPTION
In #32780, We have supported the `--skip-sprockets` option in the `app:update` task. When `options[:api]` is truthy, `option[:skip_sprockets]` is also truthy. So we can remove this `remove_file` method.
https://github.com/rails/rails/blob/42b9e7e50c084e119a679cf155b70b5efc4d36ff/railties/lib/rails/generators/rails/app/app_generator.rb#L281-L283
