### PR TITLE
Handle mutated values in assert_changes

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -160,6 +160,7 @@ module ActiveSupport
         exp = expression.respond_to?(:call) ? expression : -> { eval(expression.to_s, block.binding) }
 
         before = exp.call
+        before_mutation = before.dup
         retval = yield
 
         unless from == UNTRACKED
@@ -173,7 +174,7 @@ module ActiveSupport
         error = "#{expression.inspect} didn't change"
         error = "#{error}. It was already #{to}" if before == to
         error = "#{message}.\n#{error}" if message
-        assert before != after, error
+        assert (before != after) || (before_mutation != after), error
 
         unless to == UNTRACKED
           error = "#{expression.inspect} didn't change to #{to}"

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -185,6 +185,14 @@ class AssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_changes_with_to_option_and_mutable_value
+    value = []
+
+    assert_changes "value", to: [1] do
+      value << 1
+    end
+  end
+
   def test_assert_changes_with_to_option_but_no_change_has_special_message
     error = assert_raises Minitest::Assertion do
       assert_changes "@object.num", to: 0 do


### PR DESCRIPTION
Take the following assertion:

```ruby
assert_changes 'TestingPublisher.events', to: [event] do
  event.publish(time)
end
```

`TestingPublisher.events` is an array that is mutated every time
`event.publish` is executed. The assertion always fails in this case
because `assert_changes` cannot figure out that
`TestingPublisher.events` has not changed its reference but has been
mutated.

I'm not exactly sure whether we should try to handle this case as
testing the reference preservation is also useful, but here is a simple
fix that handles the example above well.