### PR TITLE
Remove redundant else block

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -237,8 +237,6 @@ module ActionDispatch #:nodoc:
             end
           elsif sources
             directive
-          else
-            nil
           end
         end
       end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -16,9 +16,8 @@ module ActionDispatch
         fetch_header("action_dispatch.request.content_type") do |k|
           v = if get_header("CONTENT_TYPE") =~ /^([^,\;]*)/
             Mime::Type.lookup($1.strip.downcase)
-          else
-            nil
           end
+
           set_header k, v
         end
       end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -101,8 +101,6 @@ module ActionDispatch
                   "omg"
                 end
               when Nodes::Terminal then n.symbol
-              else
-                nil
               end
             }.compact.join
           end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1882,8 +1882,6 @@ module ActionDispatch
             path_without_format = path.sub(/\(\.:format\)$/, "")
             if using_match_shorthand?(path_without_format)
               path_without_format.gsub(%r{^/}, "").sub(%r{/([^/]*)$}, '#\1').tr("-", "_")
-            else
-              nil
             end
           end
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -239,10 +239,9 @@ module ActionView
       def compute_asset_extname(source, options = {})
         return if options[:extname] == false
         extname = options[:extname] || ASSET_EXTENSIONS[options[:type]]
+
         if extname && File.extname(source) != extname
           extname
-        else
-          nil
         end
       end
 

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -97,8 +97,6 @@ module ActiveRecord
               reflection_scope.merge(preload_scope)
             elsif reflection.scope
               reflection_scope
-            else
-              nil
             end
           end
       end

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -28,8 +28,6 @@ module ActiveStorage
           ActiveStorage::Blob.create_after_upload!(attachable)
         when String
           ActiveStorage::Blob.find_signed(attachable)
-        else
-          nil
         end
       end
   end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -33,8 +33,6 @@ module ActiveSupport
           value <=> other.value
         elsif Numeric === other
           value <=> other
-        else
-          nil
         end
       end
 

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -23,8 +23,6 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       params = ActionController::Parameters.new request.parameters
       if params[:t]
         klass.find_by_title(params[:t])
-      else
-        nil
       end
     }
 


### PR DESCRIPTION
### Summary

Remove redundant `else; nil; end` block. **if block** already returns nil in case it does not branch.