### PR TITLE
Warn when a scope returns non ActiveRecord::Relation

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -180,7 +180,7 @@ module ActiveRecord
 
           if body.respond_to?(:to_proc)
             singleton_class.send(:define_method, name) do |*args|
-              scope = all._exec_scope(*args, &body)
+              scope = all._exec_scope(name, *args, &body)
               scope = scope.extending(extension) if extension
               scope
             end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -103,6 +103,12 @@ module ActiveRecord
       assert_predicate relation, :empty_scope?
     end
 
+    def test_scope_not_returning_a_relation
+      assert_deprecated(/Post.one_comment returned a value of type Comment. Scopes are intended to return ActiveRecord::Relation objects; consider defining a class method instead/) do
+        assert_equal Comment.first, Post.one_comment
+      end
+    end
+
     def test_bad_constants_raise_errors
       assert_raises(NameError) do
         ActiveRecord::Relation::HelloWorld

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "models/comment"
+
 class Post < ActiveRecord::Base
   class CategoryPost < ActiveRecord::Base
     self.table_name = "categories_posts"
@@ -49,6 +51,8 @@ class Post < ActiveRecord::Base
   scope :tagged_with_comment, ->(comment) { joins(:taggings).where(taggings: { comment: comment }) }
 
   scope :typographically_interesting, -> { containing_the_letter_a.or(titled_with_an_apostrophe) }
+
+  scope :one_comment, -> { Comment.first }
 
   has_many :comments do
     def find_most_recent

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1353,6 +1353,9 @@ end
 
 However, there is one important caveat: A scope will always return an `ActiveRecord::Relation` object, even if the conditional evaluates to `false`, whereas a class method, will return `nil`. This can cause `NoMethodError` when chaining class methods with conditionals, if any of the conditionals return `false`.
 
+NOTE: Returning a single model from a scope is deprecated, because of the
+aforementioned caveat. Consider defining a class method instead.
+
 ### Applying a default scope
 
 If we wish for a scope to be applied across all queries to the model we can use the


### PR DESCRIPTION
`ActiveRecord::Base.scope` expects a returned value of
`ActiveRecord::Relation | nil`. However, if you missed this
bit in the docs and attempt to return, say a single value, you are in
for a surprise. Look at this example:

```ruby
class Event < ApplicationRecord
  scope :upcoming, -> {
    includes(location: :venue).order(time: :desc).where('time >= ?', Time.current).first
  }
end
```

I have defined this scope with the expectation that it will return
`Event | nil`. When `Event` is returned, everything is as I expect it to
behave, however, the problem comes when `nil` is returned. The scope
gives me the previous scope as a return value, which is `Event.all` instead of
the `nil`, which I expect.

```ruby
>> Event.upcoming
  Event Load (1.3ms)  SELECT  "events".* FROM "events" WHERE (time >= '2018-05-04 15:35:28.296722') ORDER BY "events"."time" DESC LIMIT $1  [["LIMIT", 1]]
  Event Load (0.4ms)  SELECT  "events".* FROM "events" LIMIT $1  [["LIMIT", 11]]
=> #<ActiveRecord::Relation [#<Event id: 1, time: "2017-02-27 05:00:00", description: "This will be our very first Ruby Banitsa, so hello...", created_at: "2017-05-05 11:38:01", updated_at: "2017-11-20 09:13:25", published_at: nil>, #<Event id: 2, time: "2017-03-15 14:30:00", description: "The second Ruby Banitsa. Exciting! Join us for som...", created_at: "2017-05-05 12:02:51", updated_at: "2017-11-20 09:13:07", published_at: nil>, #<Event id: 3, time: "2017-04-01 05:00:00", description: "Third time is the charm! Come listen to Radoslav S...", created_at: "2017-05-05 12:07:10", updated_at: "2017-11-20 09:11:48", published_at: nil>, #<Event id: 4, time: "2017-05-10 12:30:00", description: "After all the National Holidays in the world, let'...", created_at: "2017-05-05 12:09:59", updated_at: "2017-11-20 09:12:27", published_at: nil>, #<Event id: 5, time: "2017-11-20 15:30:00", description: "After a long summer break, we're back, friends! Th...", created_at: "2017-11-14 10:48:49", updated_at: "2017-11-20 08:51:33", published_at: nil>, #<Event id: 6, time: "2017-12-12 15:30:00", description: "The last Banitsa was great! We reconciled old frie...", created_at: "2017-12-01 12:25:36", updated_at: "2017-12-03 07:14:54", published_at: nil>, #<Event id: 7, time: "2018-01-22 15:30:00", description: "New year, new banitsa. This time, with fortunes. F...", created_at: "2018-01-04 08:59:11", updated_at: "2018-01-04 12:11:40", published_at: "2018-01-04 12:11:39">, #<Event id: 15, time: "2018-04-26 13:20:01", description: "asdasdasdasd", created_at: "2018-04-02 13:20:54", updated_at: "2018-04-02 13:20:54", published_at: nil>]>
```

This is extremely confusing.  Now, I do get that my expectation is
different than the one in `ActiveRecord::Base.scope` and we probably
can't change the "delegate the previous scope on nil" behavior,
but we can warn (even if in runtime) about it. We can tweak the
message, as I don't think it's expressive at the moment or think about
how to warn about it earlier.