### PR TITLE
Pass the error instance as the second parameter of block executed by `discard_on`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Pass the error instance as the second parameter of block executed by `discard_on`.
+
+    Fixes #32853.
+
+    *Yuji Yaginuma*
+
 *   Remove support for Qu gem.
 
     Reasons are that the Qu gem wasn't compatible since Rails 5.1,

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -79,7 +79,7 @@ module ActiveJob
       def discard_on(exception)
         rescue_from exception do |error|
           if block_given?
-            yield self, exception
+            yield self, error
           else
             logger.error "Discarded #{self.class} due to a #{exception}. The original exception was #{error.cause.inspect}."
           end

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -61,7 +61,7 @@ class ExceptionsTest < ActiveJob::TestCase
   test "custom handling of discarded job" do
     perform_enqueued_jobs do
       RetryJob.perform_later "CustomDiscardableError", 2
-      assert_equal "Dealt with a job that was discarded in a custom way", JobBuffer.last_value
+      assert_equal "Dealt with a job that was discarded in a custom way. Message: CustomDiscardableError", JobBuffer.last_value
     end
   end
 

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -20,7 +20,7 @@ class RetryJob < ActiveJob::Base
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
   retry_on(CustomCatchError) { |job, exception| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{exception.message}") }
   discard_on DiscardableError
-  discard_on(CustomDiscardableError) { |job, exception| JobBuffer.add("Dealt with a job that was discarded in a custom way") }
+  discard_on(CustomDiscardableError) { |job, exception| JobBuffer.add("Dealt with a job that was discarded in a custom way. Message: #{exception.message}") }
 
   def perform(raising, attempts)
     if executions < attempts


### PR DESCRIPTION
I'm not sure what originally wanted to pass to the argument.
However, as long as see the document added along with the commit, it seems just to be mistaken that trying to pass the error instance.
https://github.com/rails/rails/pull/30622/files#diff-59beb0189c8c6bc862edf7fdb84ff5a7R64

Fixes #32853

