### PR TITLE
use ProxyPattern to match for ActiveSupport::Notifications fanout/unsubscribe

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Revise `ActiveSupport::Notifications.unsubscribe` to correctly handle Regex or other multiple-pattern subscribers.
+
+    *Zach Kemp*
+
 *   Add `before_reset` callback to `CurrentAttributes` and define `after_reset` as an alias of `resets` for symmetry.
 
     *Rosa Gutierrez*

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -153,6 +153,15 @@ module ActiveSupport
   #
   #   ActiveSupport::Notifications.unsubscribe("render")
   #
+  # Subscribers using a regexp or other pattern-matching object will remain subscribed
+  # to all events that match their original pattern, unless those events match a string
+  # passed to `unsubscribe`:
+  #
+  #   subscriber = ActiveSupport::Notifications.subscribe(/render/) { }
+  #   ActiveSupport::Notifications.unsubscribe('render_template.action_view')
+  #   subscriber.matches?('render_template.action_view') # => false
+  #   subscriber.matches?('render_partial.action_view') # => true
+  #
   # == Default Queue
   #
   # Notifications ships with a queue implementation that consumes and publishes events

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -2,6 +2,7 @@
 
 require "mutex_m"
 require "concurrent/map"
+require "set"
 
 module ActiveSupport
   module Notifications
@@ -39,6 +40,7 @@ module ActiveSupport
           when String
             @string_subscribers[subscriber_or_name].clear
             @listeners_for.delete(subscriber_or_name)
+            @other_subscribers.each { |sub| sub.unsubscribe!(subscriber_or_name) }
           else
             pattern = subscriber_or_name.try(:pattern)
             if String === pattern
@@ -113,11 +115,33 @@ module ActiveSupport
           end
         end
 
+        class Matcher #:nodoc:
+          attr_reader :pattern, :exclusions
+
+          def self.wrap(pattern)
+            return pattern if String === pattern
+            new(pattern)
+          end
+
+          def initialize(pattern)
+            @pattern = pattern
+            @exclusions = Set.new
+          end
+
+          def unsubscribe!(name)
+            exclusions << -name if pattern === name
+          end
+
+          def ===(name)
+            pattern === name && !exclusions.include?(name)
+          end
+        end
+
         class Evented #:nodoc:
           attr_reader :pattern
 
           def initialize(pattern, delegate)
-            @pattern = pattern
+            @pattern = Matcher.wrap(pattern)
             @delegate = delegate
             @can_publish = delegate.respond_to?(:publish)
           end
@@ -137,11 +161,15 @@ module ActiveSupport
           end
 
           def subscribed_to?(name)
-            @pattern === name
+            pattern === name
           end
 
           def matches?(name)
-            @pattern && @pattern === name
+            pattern && pattern === name
+          end
+
+          def unsubscribe!(name)
+            pattern.unsubscribe!(name)
           end
         end
 
@@ -202,6 +230,10 @@ module ActiveSupport
 
           def subscribed_to?(name)
             true
+          end
+
+          def unsubscribe!(*)
+            false
           end
 
           alias :matches? :===

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -84,6 +84,39 @@ module ActiveSupport
           [:finish, "hi", 1, {}]
         ], listener.events
       end
+
+      def test_listen_to_regexp
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe(/[a-z]*.world/, listener)
+        notifier.start("hi.world", 1, {})
+        notifier.finish("hi.world", 2, {})
+        notifier.start("hello.world", 1, {})
+        notifier.finish("hello.world", 2, {})
+
+        assert_equal [
+          [:start, "hi.world", 1, {}],
+          [:finish, "hi.world", 2, {}],
+          [:start, "hello.world", 1, {}],
+          [:finish, "hello.world", 2, {}]
+        ], listener.events
+      end
+
+      def test_listen_to_regexp_with_exclusions
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe(/[a-z]*.world/, listener)
+        notifier.unsubscribe("hi.world")
+        notifier.start("hi.world", 1, {})
+        notifier.finish("hi.world", 2, {})
+        notifier.start("hello.world", 1, {})
+        notifier.finish("hello.world", 2, {})
+
+        assert_equal [
+          [:start, "hello.world", 1, {}],
+          [:finish, "hello.world", 2, {}]
+        ], listener.events
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Before this change, `ActiveSupport::Notifications.unsubscribe` would eagerly remove all subscribers for which `subscriber.matches?(string)` was true, which can cause some unintended behavior in the case of regexes or other compound matchers (in our case, we had a single listener subscribed to a few dozen event keys via a single pattern object that internally checked for inclusion within a set).

Unsubscribing to a single string should not negate any other potential matches for those subscriptions. After this change:

- [no change] unsubscribing via string for string-based subscriptions will reject the subscription from the array
- [no change] unsubscribing via subscriber reference removes that subscriber
- unsubscribing via string for subscriptions _with the potential to match multiple values_ will append that string to a blacklist. This will in turn prevent that pattern from matching that string in the future, so the listener won't be added under that key to the `listeners_for` map.