### PR TITLE
Don't clear transaction state after manual rollback

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -382,13 +382,7 @@ module ActiveRecord
       status = nil
       self.class.transaction do
         add_to_transaction
-        begin
-          status = yield
-        rescue ActiveRecord::Rollback
-          clear_transaction_record_state
-          status = nil
-        end
-
+        status = yield
         raise ActiveRecord::Rollback unless status
       end
       status

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -292,6 +292,18 @@ class TransactionTest < ActiveRecord::TestCase
     assert_nil new_topic.id, "The topic should not have an ID"
   end
 
+  def test_callback_rollback_in_create_with_rollback_exception
+    topic = Class.new(Topic) {
+      def after_create_for_transaction
+        raise ActiveRecord::Rollback
+      end
+    }
+
+    new_topic = topic.create(title: "A new topic")
+    assert !new_topic.persisted?, "The topic should not be persisted"
+    assert_nil new_topic.id, "The topic should not have an ID"
+  end
+
   def test_nested_explicit_transactions
     Topic.transaction do
       Topic.transaction do


### PR DESCRIPTION
See https://github.com/rails/rails/pull/32796#discussion_r185630054.

If an `ActiveRecord::Rollback` error was raised by a persistence method (e.g. in an `after_save` callback), this logic would potentially discard the original state of the record from before the transaction, preventing it from being restored later when the transaction was rolled back.

---

This code was originally added in https://github.com/rails/rails/pull/5535, ironically to address the same problem being fixed here!

The transaction wrapped around a `save` call is itself wrapped with [`rollback_active_record_state!`](https://github.com/rails/rails/blob/f507085fa2a7625324e6f4e3ecef9b27dabefb4f/activerecord/lib/active_record/transactions.rb#L309-L311), which restores the record's original state if `save` raises an error. Raising `ActiveRecord::Rollback` rolls back the transaction _without_ raising an error, so `rollback_active_record_state!` would incorrectly discard the record's original state instead of restoring it, as if the transaction had been committed.

https://github.com/rails/rails/pull/5535 solved this by decrementing the `level` counter that ensures only the outermost nested block restores the original state, letting the transaction restore it instead of `rollback_active_record_state!`.

(Incidentally, a better fix would have been to delete `rollback_active_record_state!`; it's vestigial.)

The tests added with the original fix used an observer instead of a callback to demonstrate the problem, and were removed in https://github.com/rails/rails/commit/ccecab3ba950a288b61a516bf9b6962e384aae0b when observers were extracted to a separate gem.

Later when https://github.com/rails/rails/pull/9068 was merged, the behaviour regressed, because the record's original state is now lazily restored the first time it's accessed after the transaction, instead of immediately when a rollback occurs. So instead of the state being restored when the transaction rolled back, it was discarded by `rollback_active_record_state!` before the application had a chance to trigger the restore.