### PR TITLE
fix fail ActiveSupport::Cache::FileStore when cache key ended with dots

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -131,6 +131,7 @@ module ActiveSupport
 
           # Make sure file name doesn't exceed file system limits.
           begin
+            fname = ActiveSupport::Digest.hexdigest(key) if EXCLUDED_DIRS.include?(fname)
             fname_paths << fname[0, FILENAME_MAX_SIZE]
             fname = fname[FILENAME_MAX_SIZE..-1]
           end until fname.blank?

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -84,6 +84,17 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal "B", File.basename(path)
   end
 
+  # '.' and '..' are invalid filename.
+  def test_key_transformation_with_dot
+    key = ".."
+    path = @cache.send(:normalize_key, key, {})
+    assert_not_equal "..", File.basename(path)
+
+    key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}."
+    path = @cache.send(:normalize_key, key, {})
+    assert_not_equal ".", File.basename(path)
+  end
+
   # If nothing has been stored in the cache, there is a chance the cache directory does not yet exist
   # Ensure delete_matched gracefully handles this case
   def test_delete_matched_when_cache_directory_does_not_exist


### PR DESCRIPTION
### Summary

`ActiveSupport::Cache::FileStore` fail that cache key is `"."`, `".."` or normalized key ended with single/double dots.

```
> cache = ActiveSupport::Cache::FileStore.new("tmp/cache")
> cache.write ".", 1
Errno::EBUSY: Device or resource busy @ rb_file_s_rename - (tmp/cache/..20180511-21748-1na13iq, tmp/cache/02F/2F0/.)

> cache.write "."*229, 1
Errno::EBUSY: Device or resource busy @ rb_file_s_rename - (tmp/cache/..20180511-21748-kt8yr6, tmp/cache/927/052/..................................................................................................................................................................................................................................../.)
```
