### PR TITLE
Backport "save attributes changed by callbacks after update_attribute"

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -261,7 +261,7 @@ module ActiveRecord
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
 
-      changed? ? save(validate: false) : true
+      save(validate: false)
     end
 
     # Updates the attributes of the model from the passed-in hash and saves the

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -493,6 +493,9 @@ class PersistenceTest < ActiveRecord::TestCase
 
     Topic.find(1).update_attribute(:approved, false)
     assert !Topic.find(1).approved?
+
+    Topic.find(1).update_attribute(:change_approved_before_save, true)
+    assert Topic.find(1).approved?
   end
 
   def test_update_attribute_for_readonly_attribute

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -63,6 +63,9 @@ class Topic < ActiveRecord::Base
 
   after_initialize :set_email_address
 
+  attr_accessor :change_approved_before_save
+  before_save :change_approved_callback
+
   class_attribute :after_initialize_called
   after_initialize do
     self.class.after_initialize_called = true
@@ -94,6 +97,10 @@ class Topic < ActiveRecord::Base
     def before_destroy_for_transaction; end
     def after_save_for_transaction; end
     def after_create_for_transaction; end
+
+    def change_approved_callback
+      self.approved = change_approved_before_save unless change_approved_before_save.nil?
+    end
 end
 
 class ImportantTopic < Topic


### PR DESCRIPTION
This backports https://github.com/rails/rails/pull/27780 to the 5.0.x series.

/cc @eileencodes & @tenderlove 