### PR TITLE
Remove reference to old `:text` rendering option

### DIFF
--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -13,7 +13,6 @@ module ActionView
       # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt>.
       # * <tt>:file</tt> - Renders an explicit template file (this used to be the old default), add :locals to pass in those.
       # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
-      # * <tt>:text</tt> - Renders the text passed in out.
       # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
       #   type as <tt>text/plain</tt>.
       # * <tt>:html</tt> - Renders the HTML safe string passed in out, otherwise


### PR DESCRIPTION
Support for the `:text` option for rendering was removed in 79a5ea9eadb4d43b62afacedc0706cbe88c54496, but there's still a reference to it in the API documentation. Remove the reference so people are no longer confused why the option doesn't work.