### PR TITLE
Avoid type casting in uniqueness validator

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -32,6 +32,7 @@ module ActiveRecord
 
           record.errors.add(attribute, :taken, error_options)
         end
+      rescue RangeError
       end
 
     protected
@@ -65,8 +66,6 @@ module ActiveRecord
 
         column = klass.columns_hash[attribute_name]
         cast_type = klass.type_for_attribute(attribute_name)
-        value = cast_type.serialize(value)
-        value = klass.connection.type_cast(value)
 
         comparison = if !options[:case_sensitive] && !value.nil?
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
@@ -77,11 +76,9 @@ module ActiveRecord
         if value.nil?
           klass.unscoped.where(comparison)
         else
-          bind = Relation::QueryAttribute.new(attribute_name, value, Type::Value.new)
+          bind = Relation::QueryAttribute.new(attribute_name, value, cast_type)
           klass.unscoped.where(comparison, bind)
         end
-      rescue RangeError
-        klass.none
       end
 
       def scope_relation(record, table, relation)


### PR DESCRIPTION
Type casting in uniqueness validator is for a string value truncation.
It was removed at #23523.