### PR TITLE
Add available transformations to docs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -497,6 +497,9 @@ module ActiveRecord
     #     t.date
     #     t.binary
     #     t.boolean
+    #     t.foreign_key
+    #     t.json
+    #     t.virtual
     #     t.remove
     #     t.remove_references
     #     t.remove_belongs_to


### PR DESCRIPTION
Hi, Rails team. Thank you for the great work!

I noticed that the newly added transformation was not added to the documentation when investigating the behavior of `ActiveRecord::ConnectionAdapters::SchemaDefinitions#chage_table`. The `foreign_key`, `json` and `virtual` are also available.
