### PR TITLE
Remove ActiveRecord::Transactions#rollback_active_record_state!

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -306,9 +306,7 @@ module ActiveRecord
     end
 
     def save(*) #:nodoc:
-      rollback_active_record_state! do
-        with_transaction_returning_status { super }
-      end
+      with_transaction_returning_status { super }
     end
 
     def save!(*) #:nodoc:
@@ -317,17 +315,6 @@ module ActiveRecord
 
     def touch(*) #:nodoc:
       with_transaction_returning_status { super }
-    end
-
-    # Reset id and @new_record if the transaction rolls back.
-    def rollback_active_record_state!
-      remember_transaction_record_state
-      yield
-    rescue Exception
-      restore_transaction_record_state
-      raise
-    ensure
-      clear_transaction_record_state
     end
 
     def before_committed! # :nodoc:


### PR DESCRIPTION
See https://github.com/rails/rails/pull/32862#issuecomment-388158209.
Closes https://github.com/rails/rails/pull/28302.

`rollback_active_record_state!` was removed from `save!` but not `save` in da840d13da865331297d5287391231b1ed39721b. I believe that leaving it in `save` was a mistake, since that commit was intended to move the rollback logic from the `save`/`save!` call to the transaction stack.

As of https://github.com/rails/rails/pull/9068 the record's original state is lazily restored the first time it's accessed after the transaction instead of when a rollback occurs. This means that the call to `restore_transaction_record_state` has no effect: the record's "transaction level" is incremented twice (in `rollback_active_record_state!` and `with_transaction_returning_status`), isn't decremented again until the the `ensure` block runs, and won't hit zero until the next time `sync_with_transaction_state` is called.