### PR TITLE
ar connection pool: lazy start, eager quit of reaper thread

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -290,11 +290,13 @@ module ActiveRecord
         def initialize(pool, frequency)
           @pool      = pool
           @frequency = frequency
+          @thread    = nil
         end
 
         def run
           return unless frequency && frequency > 0
-          Thread.new(frequency, pool) { |t, p|
+          return if running?
+          @thread = Thread.new(frequency, pool) { |t, p|
             loop do
               sleep t
               p.reap
@@ -302,13 +304,23 @@ module ActiveRecord
             end
           }
         end
+
+        def running?
+          !!@thread && @thread.alive?
+        end
+
+        def stop
+          return unless running?
+          @thread.kill
+          @thread = nil
+        end
       end
 
       include MonitorMixin
       include QueryCache::ConnectionPoolConfiguration
 
       attr_accessor :automatic_reconnect, :checkout_timeout, :schema_cache
-      attr_reader :spec, :connections, :size, :reaper
+      attr_reader :spec, :connections, :size
 
       # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
       # object which describes database connection information (e.g. adapter,
@@ -358,9 +370,8 @@ module ActiveRecord
 
         # +reaping_frequency+ is configurable mostly for historical reasons, but it could
         # also be useful if someone wants a very low +idle_timeout+.
-        reaping_frequency = spec.config.fetch(:reaping_frequency, 60)
-        @reaper = Reaper.new(self, reaping_frequency && reaping_frequency.to_f)
-        @reaper.run
+        @reaping_frequency = spec.config.fetch(:reaping_frequency, 60)
+                              .yield_self { |rf| rf && rf.to_f }
       end
 
       def lock_thread=(lock_thread)
@@ -439,6 +450,7 @@ module ActiveRecord
             end
             @connections = []
             @available.clear
+            reaper_stop_if_needed
           end
         end
       end
@@ -465,6 +477,8 @@ module ActiveRecord
             conn.discard!
           end
           @connections = @available = @thread_cached_conns = nil
+          reaper.stop
+          @reaper = nil
         end
       end
 
@@ -487,6 +501,7 @@ module ActiveRecord
             end
             @connections.delete_if(&:requires_reloading?)
             @available.clear
+            
           end
         end
       end
@@ -550,6 +565,7 @@ module ActiveRecord
 
           @connections.delete conn
           @available.delete conn
+          reaper_stop_if_needed
 
           # @available.any_waiting? => true means that prior to removing this
           # conn, the pool was at its max size (@connections.size == @size).
@@ -607,6 +623,7 @@ module ActiveRecord
 
             @available.delete conn
             @connections.delete conn
+            reaper_stop_if_needed
           end
         end
 
@@ -642,6 +659,10 @@ module ActiveRecord
             checkout_timeout: checkout_timeout
           }
         end
+      end
+
+      def reaper
+        @reaper ||= Reaper.new(self, @reaping_frequency)
       end
 
       private
@@ -845,6 +866,7 @@ module ActiveRecord
 
         def adopt_connection(conn)
           conn.pool = self
+          reaper.run
           @connections << conn
         end
 
@@ -862,6 +884,10 @@ module ActiveRecord
           remove c
           c.disconnect!
           raise
+        end
+
+        def reaper_stop_if_needed
+          reaper.stop if @connections.empty?
         end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -501,7 +501,6 @@ module ActiveRecord
             end
             @connections.delete_if(&:requires_reloading?)
             @available.clear
-            
           end
         end
       end

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -33,6 +33,13 @@ module ActiveRecord
         end
       end
 
+      class FakeConnection
+        attr_accessor :pool, :owner
+
+        def close
+        end
+      end
+
       # A reaper with nil time should never reap connections
       def test_nil_time
         fp = FakePool.new
@@ -58,6 +65,20 @@ module ActiveRecord
       def test_pool_has_reaper
         assert pool.reaper
       end
+
+      def test_pool_empty_reaper_not_running
+        assert_not pool.reaper.running?
+      end
+
+      def test_pool_reaper_not_running_after_last_conn
+        conn = FakeConnection.new
+        pool.send :adopt_connection, conn
+        assert pool.reaper.running?
+
+        pool.remove(conn)
+        assert_not pool.reaper.running?
+      end
+
 
       def test_reaping_frequency_configuration
         spec = ActiveRecord::Base.connection_pool.spec.dup


### PR DESCRIPTION
Puma and likely other cluster forking apps don't like threads dangling around.

Tests added.