### PR TITLE
Consider reinstating `ActiveSupport::Dependencies` logging

### DIFF
--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -502,7 +502,12 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
   include InheritanceTestHelper
   fixtures :companies
 
+  def setup
+    ActiveSupport::Dependencies.log_activity = true
+  end
+
   teardown do
+    ActiveSupport::Dependencies.log_activity = false
     self.class.const_remove :FirmOnTheFly rescue nil
     Firm.const_remove :FirmOnTheFly rescue nil
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -580,6 +580,8 @@ module ActiveSupport
     mattr_accessor :load_once_paths
     mattr_accessor :autoloaded_constants
     mattr_accessor :explicitly_unloadable_constants
+    mattr_accessor :logger
+    mattr_accessor :log_activity
     mattr_accessor :constant_watch_stack
     mattr_accessor :constant_watch_stack_mutex
   end


### PR DESCRIPTION
### Summary

This reverts commit 798dc5a92537ba4202a1a8e127a5ebdae87bc78d, reinstating the `ActiveSupport::Dependencies` logging removed in #24198. It is not intended for merge as-is, but as a prompt for discussion.

### Discussion

`ActiveSupport::Dependencies` used to have an optional logger, which was removed in #24198 on the basis that it's no longer useful. The logger would print output when missing constants were encountered, and display details of the resolution and loading process.

I'd like to argue that this logging was very useful indeed, and make the case for its reinstatement.

The logging may not be a huge benefit to maintainers, who (as @fxn says in #24198) can freely add their own tracing when they need to debug an issue with the loader, or use an interactive debugger. However, users also sometimes need to understand how the loader operates on their own code, and are less likely to know where to add tracing/breakpoints, or which are the most interesting aspects of the algorithm to trace.

For this purpose, having maintainer-curated tracing built in was really valuable. Anecdotally, the logging was the first thing I would reach for when trying to help colleagues with autoloading issues, because it's often hard to intuit what the loader is up to. Debug-level logging isn't that uncommon in library code, and while for the most part autoloading is completely transparent, it's the edge cases that really benefit from this aid to comprehension.

Several high-ranking blog posts on autoloading mention using the logger, and a handful of workarounds for its removal have sprung up in its place ([1](https://gist.github.com/glebm/d63b36768bbc7f83127df7803cd321c5), [2](https://makandracards.com/makandra/48754-how-to-debug-rails-autoloading)), suggesting there's still demand for it. Would you consider reinstating it?

As a final note: I'm not a maintainer, and I don't experience the pain of keeping the logging in working order. None of the above is intended as a criticism of the original change, and I'll completely understand if the cost/benefit tradeoff is different than the one I perceive!

Cheers,
Simon
