### PR TITLE
strip group options from count select_values

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -292,7 +292,8 @@ module ActiveRecord
         if field.respond_to?(:as)
           field.as(aliaz)
         else
-          "#{field} AS #{aliaz}"
+          striped_field = field.split(' ').first
+          "#{striped_field} AS #{aliaz}"
         end
       }
 


### PR DESCRIPTION
### Summary

Strip group_by options that comes right after column name.

Issue: https://github.com/rails/rails/issues/32890