### PR TITLE
Fix: Model class method 'locking_enabled?' should return a boolean value.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix model class method 'locking_enabled?' should return a boolean value.
+
+    *Santosh Wadghule*
+
 *   Fix logic on disabling commit callbacks so they are not called unexpectedly when errors occur.
 
     *Brian Durand*

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -129,7 +129,7 @@ module ActiveRecord
           # (which it is, by default) and the table includes the
           # +locking_column+ column (defaults to +lock_version+).
           def locking_enabled?
-            lock_optimistically && columns_hash[locking_column]
+            lock_optimistically && columns_hash[locking_column].present?
           end
 
           # Set the column to use for optimistic locking. Defaults to +lock_version+.

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -32,6 +32,11 @@ end
 class OptimisticLockingTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
 
+  def test_locking_enabled_predicate_class_method_should_return_boolean_value
+    assert_equal false, Reader.locking_enabled?
+    assert_equal true, Person.locking_enabled?
+  end
+
   def test_quote_value_passed_lock_col
     p1 = Person.find(1)
     assert_equal 0, p1.lock_version


### PR DESCRIPTION
- Previously 'locking_enabled? method was returning non-boolean value
if the class is enabled for locking.
- Now we do return expected boolean value.