### PR TITLE
Don't generate yarn's contents in `app:update` task if it's skipped

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -4,6 +4,8 @@
 
      Skip `config/spring.rb` when spring isn't loaded.
 
+     Skip yarn's contents when yarn integration isn't used.
+
     *Tsukuru Tanimichi*
 
 *   Make the master.key file read-only for the owner upon generation on

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -21,6 +21,7 @@ module Rails
       private
         def generator_options
           options = { api: !!Rails.application.config.api_only, update: true }
+          options[:skip_yarn] = !File.exist?(Rails.root.join("bin", "yarn"))
           options[:skip_active_record]  = !defined?(ActiveRecord::Railtie)
           options[:skip_active_storage] = !defined?(ActiveStorage::Engine) || !defined?(ActiveRecord::Railtie)
           options[:skip_action_mailer]  = !defined?(ActionMailer::Railtie)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -95,11 +95,9 @@ module Rails
     end
 
     def bin_when_updating
-      bin_yarn_exist = File.exist?("bin/yarn")
-
       bin
 
-      if options[:api] && !bin_yarn_exist
+      if options[:skip_yarn]
         remove_file "bin/yarn"
       end
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -296,6 +296,27 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_yarn_contents_when_bin_yarn_is_not_used
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "--skip-yarn"]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true, skip_yarn: true }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.send(:update_bin_files) }
+
+      assert_no_file "#{app_root}/bin/yarn"
+
+      assert_file "#{app_root}/bin/setup" do |content|
+        assert_no_match(/system\('bin\/yarn'\)/, content)
+      end
+
+      assert_file "#{app_root}/bin/update" do |content|
+        assert_no_match(/system\('bin\/yarn'\)/, content)
+      end
+    end
+  end
+
   def test_app_update_does_not_generate_assets_initializer_when_skip_sprockets_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-sprockets"]


### PR DESCRIPTION
Related to #32837, #32780, #29645 and #28825