### PR TITLE
Fix user_input_in_time_zone to coerce non valid string into nil

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/string/zones"
 require "active_support/core_ext/time/zones"
 
 module ActiveModel

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -18,6 +18,8 @@ module ActiveModel
         case value
         when ::String
           value = "2000-01-01 #{value}"
+          time_hash = ::Date._parse(value)
+          return if time_hash[:hour].nil?
         when ::Time
           value = value.change(year: 2000, day: 1, month: 1)
         end

--- a/activemodel/test/cases/type/time_test.rb
+++ b/activemodel/test/cases/type/time_test.rb
@@ -17,6 +17,21 @@ module ActiveModel
         assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast("2015-06-13T19:45:54+03:00")
         assert_equal ::Time.utc(1999, 12, 31, 21,  7,  8), type.cast("06:07:08+09:00")
       end
+
+      def test_user_input_in_time_zone
+        ::Time.use_zone("Pacific Time (US & Canada)") do
+          type = Type::Time.new
+          assert_nil type.user_input_in_time_zone(nil)
+          assert_nil type.user_input_in_time_zone("")
+          assert_nil type.user_input_in_time_zone("ABC")
+
+          offset = ::Time.zone.formatted_offset
+          time_string = "2015-02-09T19:45:54#{offset}"
+
+          assert_equal 19, type.user_input_in_time_zone(time_string).hour
+          assert_equal offset, type.user_input_in_time_zone(time_string).formatted_offset
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -736,6 +736,16 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  test "setting invalid string to a zone-aware time attribute" do
+    in_time_zone "Pacific Time (US & Canada)" do
+      record = @target.new
+      time_string = "ABC"
+
+      record.bonus_time = time_string
+      assert_nil record.bonus_time
+    end
+  end
+
   test "removing time zone-aware types" do
     with_time_zone_aware_types(:datetime) do
       in_time_zone "Pacific Time (US & Canada)" do


### PR DESCRIPTION
### Summary
There is a current bug where coercing an invalid string value for a time attribute into `2000-01-01 00:00:00` time object instead of `nil`.

```ruby
user = User.new
user.time_of_birth = "ABC"
# => "2000-01-01 00:00:00"
```

It is fixed by checking that the `hour` value of our parsed string is present similarly to what is done in [`cast_value`](https://github.com/rails/rails/blob/bfe4248c78ce6e93ebba8c7b9ada1c68cd79bb85/activemodel/lib/active_model/type/time.rb#L30) method of the same class.