### PR TITLE
Finalize transaction record state after real transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -17,11 +17,19 @@ module ActiveRecord
       end
 
       def committed?
-        @state == :committed
+        @state == :committed || @state == :fully_committed
+      end
+
+      def fully_committed?
+        @state == :fully_committed
       end
 
       def rolledback?
-        @state == :rolledback
+        @state == :rolledback || @state == :fully_rolledback
+      end
+
+      def fully_rolledback?
+        @state == :fully_rolledback
       end
 
       def fully_completed?
@@ -55,8 +63,17 @@ module ActiveRecord
         @state = :rolledback
       end
 
+      def full_rollback!
+        @children.each { |c| c.rollback! }
+        @state = :fully_rolledback
+      end
+
       def commit!
         @state = :committed
+      end
+
+      def full_commit!
+        @state = :fully_committed
       end
 
       def nullify!
@@ -88,10 +105,6 @@ module ActiveRecord
         records << record
       end
 
-      def rollback
-        @state.rollback!
-      end
-
       def rollback_records
         ite = records.uniq
         while record = ite.shift
@@ -101,10 +114,6 @@ module ActiveRecord
         ite.each do |i|
           i.rolledback!(force_restore_state: full_rollback?, should_run_callbacks: false)
         end
-      end
-
-      def commit
-        @state.commit!
       end
 
       def before_commit_records
@@ -145,12 +154,12 @@ module ActiveRecord
 
       def rollback
         connection.rollback_to_savepoint(savepoint_name)
-        super
+        @state.rollback!
       end
 
       def commit
         connection.release_savepoint(savepoint_name)
-        super
+        @state.commit!
       end
 
       def full_rollback?; false; end
@@ -168,12 +177,12 @@ module ActiveRecord
 
       def rollback
         connection.rollback_db_transaction
-        super
+        @state.full_rollback!
       end
 
       def commit
         connection.commit_db_transaction
-        super
+        @state.full_commit!
       end
     end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -472,7 +472,8 @@ module ActiveRecord
 
       def update_attributes_from_transaction_state(transaction_state)
         if transaction_state && transaction_state.finalized?
-          restore_transaction_record_state if transaction_state.rolledback?
+          restore_transaction_record_state(transaction_state.fully_rolledback?) if transaction_state.rolledback?
+          force_clear_transaction_record_state if transaction_state.fully_committed?
           clear_transaction_record_state if transaction_state.fully_completed?
         end
       end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/32847.
Fixes https://github.com/rails/rails/issues/22066.

After a real (non-savepoint) transaction has committed or rolled back, the original persistence-related state for all records modified in that transaction is discarded or restored, respectively.

When the model has transactional callbacks, this happens synchronously in the [`committed!`](https://github.com/rails/rails/blob/bfe4248c78ce6e93ebba8c7b9ada1c68cd79bb85/activerecord/lib/active_record/transactions.rb#L335) or [`rolled_back!`](https://github.com/rails/rails/blob/bfe4248c78ce6e93ebba8c7b9ada1c68cd79bb85/activerecord/lib/active_record/transactions.rb#L346-L347) methods; otherwise, it happens lazily the next time the record's persistence-related state is accessed.

The synchronous code path always finalizes the state of the record, but the lazy code path only pops one "level" from the transaction counter, assuming it will always reach zero immediately after a real transaction. As the test cases included here demonstrate, that isn't always the case.

By using the same logic as the synchronous code path, we ensure that the record's state is always updated after a real transaction has finished.