### PR TITLE
Active storage: Image variant options not correct in docs

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -42,7 +42,7 @@
 # You can combine any number of ImageMagick/libvips operations into a variant, as well as any macros provided by the
 # ImageProcessing gem (such as +resize_to_fit+):
 #
-#   avatar.variant(resize_to_fit: [800, 800], monochrome: true, flip: "-90")
+#   avatar.variant(resize_to_fit: [800, 800], monochrome: true, rotate: "-90")
 #
 # Visit the following links for a list of available ImageProcessing commands and ImageMagick/libvips operations:
 #


### PR DESCRIPTION
### Steps to reproduce

Using Rails 5.2.0

When following this example:

http://api.rubyonrails.org/classes/ActiveStorage/Variant.html

`avatar.variant(resize: "100x100", monochrome: true, flip: "-90")`

### Expected behavior

Image should be rendered as rotated.

### Actual behavior

I get an error:

> failed with error: gm mogrify: Unrecognized option (-90).

### Fix:

According to: https://github.com/minimagick/minimagick the option should be called rotate:

`avatar.variant(resize: "100x100", monochrome: true, rotate: "-90")`

So **flip** changed to **rotate**.

### System configuration
**Rails version**: 5.2.0

**Ruby version**: ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]


[ci skip]