### PR TITLE
Bump minimum SQLite version to 3.8

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1062,13 +1062,7 @@ module ActiveRecord
           if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          if supports_multi_insert?
-            execute insert_versions_sql(inserting)
-          else
-            inserting.each do |v|
-              execute insert_versions_sql(v)
-            end
-          end
+          execute insert_versions_sql(inserting)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -137,6 +137,10 @@ module ActiveRecord
         def <=>(version_string)
           @version <=> version_string.split(".").map(&:to_i)
         end
+
+        def to_s
+          @version.join(".")
+        end
       end
 
       def valid_type?(type) # :nodoc:
@@ -320,6 +324,7 @@ module ActiveRecord
       def supports_multi_insert?
         true
       end
+      deprecate :supports_multi_insert?
 
       # Does this adapter support virtual columns?
       def supports_virtual_columns?

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -104,6 +104,10 @@ module ActiveRecord
         @active     = true
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
+        if sqlite_version < "3.8.0"
+          raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."
+        end
+
         configure_connection
       end
 
@@ -116,7 +120,7 @@ module ActiveRecord
       end
 
       def supports_partial_index?
-        sqlite_version >= "3.8.0"
+        true
       end
 
       def requires_reloading?
@@ -124,7 +128,7 @@ module ActiveRecord
       end
 
       def supports_foreign_keys_in_create?
-        sqlite_version >= "3.6.19"
+        true
       end
 
       def supports_views?
@@ -137,10 +141,6 @@ module ActiveRecord
 
       def supports_json?
         true
-      end
-
-      def supports_multi_insert?
-        sqlite_version >= "3.7.11"
       end
 
       def active?

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -295,6 +295,10 @@ module ActiveRecord
         assert_equal "ы", error.message
       end
     end
+
+    def test_supports_multi_insert_is_deprecated
+      assert_deprecated { @connection.supports_multi_insert? }
+    end
   end
 
   class AdapterForeignKeyTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

These OS versions have SQLite 3.8 or higher by default.

- macOS 10.10 (Yosemite) or higher
- Ubuntu 14.04 LTS or higher

Raising the minimum version of SQLite 3.8 introduces these changes:

- All of the bundled adapters support `supports_multi_insert?`
- SQLite 3.8 always satisifies `supports_foreign_keys_in_create?` and `supports_partial_index?`
- sqlite adapter can support `alter_table` method for foreign key referenced tables by #32865

