### PR TITLE
Add CSP nonce to `style-src` directive

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -132,7 +132,7 @@ module ActionDispatch #:nodoc:
       worker_src:      "worker-src"
     }.freeze
 
-    NONCE_DIRECTIVES = %w[script-src].freeze
+    NONCE_DIRECTIVES = %w[script-src style-src].freeze
 
     private_constant :MAPPINGS, :DIRECTIVES, :NONCE_DIRECTIVES
 

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -339,6 +339,11 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       p.script_src :self
     end
 
+    content_security_policy only: :style_src do |p|
+      p.default_src false
+      p.style_src :self
+    end
+
     content_security_policy(false, only: :no_policy)
 
     content_security_policy_report_only only: :report_only
@@ -363,6 +368,10 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def style_src
+      head :ok
+    end
+
     def no_policy
       head :ok
     end
@@ -381,6 +390,7 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       get "/conditional", to: "policy#conditional"
       get "/report-only", to: "policy#report_only"
       get "/script-src", to: "policy#script_src"
+      get "/style-src", to: "policy#style_src"
       get "/no-policy", to: "policy#no_policy"
     end
   end
@@ -439,6 +449,11 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
   def test_adds_nonce_to_script_src_content_security_policy
     get "/script-src"
     assert_policy "script-src 'self' 'nonce-iyhD0Yc0W+c='"
+  end
+
+  def test_adds_nonce_to_style_src_content_security_policy
+    get "/style-src"
+    assert_policy "style-src 'self' 'nonce-iyhD0Yc0W+c='"
   end
 
   def test_generates_no_content_security_policy


### PR DESCRIPTION
For nonce, only `script-src` and` style-src` are meaningful in the definition of Content Security Policy Level 2.

https://www.w3.org/TR/CSP2/#script-src-nonce-usage
https://www.w3.org/TR/CSP2/#style-src-nonce-usage

Therefore, I think that customization function not needs and it is enough to enable both directives inside the framework.

Fixes #32920
