### PR TITLE
[ActiveStorage] Disable variant options when false or nil present

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Variant arguments of `false` or `nil` will no longer be passed to the
+    processor. For example, the following will not have the monochrome
+    variation applied:
+
+    ```ruby
+      avatar.variant(monochrome: false)
+    ```
+
+    *Jacob Smith*
+
 *   Generated attachment getter and setter methods are created
     within the model's `GeneratedAssociationMethods` module to
     allow overriding and composition using `super`.


### PR DESCRIPTION
#32917 

In response to https://github.com/rails/rails/issues/32917

In the current implementation, ActiveStorage passes all options to the underlying processor,
including when a key has a value of false.

For example, passing:

```
avatar.variant(resize: "100x100", monochrome: false, flip: "-90")
```

will return a monochrome image (or an error, pending on ImageMagick configuration) because
it passes `-monochrome false` to the command (but the command line does not allow disabling
flags this way, as usually a user would omit the flag entirely to disable that feature).

This fix only passes those keys forward to the underlying processor if the value responds to
`present?`. In practice, this means that `false` or `nil` will be filtered out before going
to the processor.

One possible use case would be for a user to be able to apply different filters to an avatar.
The code might look something like:

```
  variant_options = {
    monochrome: params[:monochrome],
    resize:     params[:resize]
  }

  avatar.variant(*variant_options)
```

Obviously some sanitization may be beneficial in a real-world scenario, but this type of
configuration object could be used in many other places as well.


( This is my first PR to Rails, so please let me know if I can update anything! Thanks! )