### PR TITLE
Allow to override the full_message error format

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -62,6 +62,11 @@ module ActiveModel
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
     MESSAGE_OPTIONS = [:message]
 
+    class << self
+      attr_accessor :i18n_full_message # :nodoc:
+    end
+    self.i18n_full_message = false
+
     attr_reader :messages, :details
 
     # Pass in the instance of the object that is using the errors object.
@@ -375,7 +380,7 @@ module ActiveModel
     def full_message(attribute, message)
       return message if attribute == :base
 
-      if @base.class.respond_to?(:i18n_scope)
+      if self.class.i18n_full_message && @base.class.respond_to?(:i18n_scope)
         parts = attribute.to_s.split(".")
         attribute_name = parts.pop
         namespace = parts.join("/") unless parts.empty?

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -364,12 +364,51 @@ module ActiveModel
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
+    #
+    #   The `"%{attribute} %{message}"` error format can be overridden with either
+    #
+    # * <tt>activemodel.errors.models.person/contacts/addresses.attributes.street.format</tt>
+    # * <tt>activemodel.errors.models.person/contacts/addresses.format</tt>
+    # * <tt>activemodel.errors.models.person.attributes.name.format</tt>
+    # * <tt>activemodel.errors.models.person.format</tt>
+    # * <tt>errors.format</tt>
     def full_message(attribute, message)
       return message if attribute == :base
+
+      if @base.class.respond_to?(:i18n_scope)
+        parts = attribute.to_s.split(".")
+        attribute_name = parts.pop
+        namespace = parts.join("/") unless parts.empty?
+        attributes_scope = "#{@base.class.i18n_scope}.errors.models"
+
+        if namespace
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
+            ]
+          end
+        else
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
+            ]
+          end
+        end
+
+        defaults.flatten!
+      else
+        defaults = []
+      end
+
+      defaults << :"errors.format"
+      defaults << "%{attribute} %{message}"
+
       attr_name = attribute.to_s.tr(".", "_").humanize
       attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
-      I18n.t(:"errors.format",
-        default:  "%{attribute} %{message}",
+      I18n.t(defaults.shift,
+        default:  defaults,
         attribute: attr_name,
         message:   message)
     end

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -7,8 +7,14 @@ module ActiveModel
   class Railtie < Rails::Railtie # :nodoc:
     config.eager_load_namespaces << ActiveModel
 
+    config.active_model = ActiveSupport::OrderedOptions.new
+
     initializer "active_model.secure_password" do
       ActiveModel::SecurePassword.min_cost = Rails.env.test?
+    end
+
+    initializer "active_model.i18n_full_message" do
+      ActiveModel::Errors.i18n_full_message = config.active_model.delete(:i18n_full_message) || false
     end
   end
 end

--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -31,4 +31,24 @@ class RailtieTest < ActiveModel::TestCase
 
     assert_equal true, ActiveModel::SecurePassword.min_cost
   end
+
+  test "i18n full message defaults to false" do
+    @app.initialize!
+
+    assert_equal false, ActiveModel::Errors.i18n_full_message
+  end
+
+  test "i18n full message can be disabled" do
+    @app.config.active_model.i18n_full_message = false
+    @app.initialize!
+
+    assert_equal false, ActiveModel::Errors.i18n_full_message
+  end
+
+  test "i18n full message can be enabled" do
+    @app.config.active_model.i18n_full_message = true
+    @app.initialize!
+
+    assert_equal true, ActiveModel::Errors.i18n_full_message
+  end
 end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -42,6 +42,42 @@ class I18nValidationTest < ActiveModel::TestCase
     assert_equal ["Field Name empty"], @person.errors.full_messages
   end
 
+  def test_errors_full_messages_uses_attribute_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { person: { attributes: { name: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank")
+    assert_equal "Name test cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_model_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { person: { format: "%{message}" } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank")
+    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_deeply_nested_model_attributes_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.street', "cannot be blank")
+    assert_equal "Contacts/addresses country cannot be blank", person.errors.full_message(:'contacts/addresses.country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_deeply_nested_model_model_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { format: "%{message}" } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.street', "cannot be blank")
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.country', "cannot be blank")
+  end
+
   # ActiveModel::Validations
 
   # A set of common cases for ActiveModel::Validations message generation that

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -305,6 +305,10 @@ All these configuration options are delegated to the `I18n` library.
     config.i18n.fallbacks.map = { az: :tr, da: [:de, :en] }
     ```
 
+### Configuring Active Model
+
+* `config.active_model.i18n_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files
+
 ### Configuring Active Record
 
 `config.active_record` includes a variety of configuration options:


### PR DESCRIPTION
### Summary

The goal of this PR is to make it easier for an app to transition from a `#{attribute} #{message}` to a `#{message}`, `full_message` error format.

`full_message` formats error messages with a `#{attribute} #{message}` format which generates error messages as “name cannot be nil”. 

It is possible to override the format with ``:"errors.format"`` but only language wide. https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L371 allows a language to define a custom format, but changing it forces to extract all messages, including the implicit ones as `:blank`

The `#{attribute} #{message}` format prevents languages to move the attribute name to somewhere else within the message, for example, in some cases it can be preferred to have error messages as `“The person's name cannot be blank”`, so changing the format to `#{message}` and including the attribute name in the message itself can be preferable.

To make such transition easier, this PR allows to override `errors.format` at the attribute or model level, so an app can use either:

```
en:
  errors:
    format: '%{message}'
```

```
en:
  activemodel:
    errors:
      models:
        person:
          format: '%{message}'
```

```
en:
  activemodel:
    errors:
      models:
        person:
          attributes:
            name:
              format: '%{message}'
```

### How

This is based on `active_model/translation.rb#human_attribute_name`
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/translation.rb#L44


And `active_model/errors.rb#generate_message`
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L401
- The `@base.class.respond_to?(:i18n_scope)` is needed for cases where `ActiveModel::Errors` is used without including the `Translation` module

### Benchmark

```
require "active_model"

module ActiveModel
  class Errors
    def full_message_i18n(attribute, message)
      return message if attribute == :base

      if @base.class.respond_to?(:i18n_scope)
        parts = attribute.to_s.split(".")
        attribute_name = parts.pop
        namespace = parts.join("/") unless parts.empty?
        attributes_scope = "#{@base.class.i18n_scope}.errors.models"

        if namespace
          defaults = @base.class.lookup_ancestors.map do |klass|
            [
              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
            ]
          end
        else
          defaults = @base.class.lookup_ancestors.map do |klass|
            [
              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
            ]
          end
        end

        defaults.flatten!
      else
        defaults = []
      end

      defaults << :"errors.format"
      defaults << "%{attribute} %{message}"

      attr_name = attribute.to_s.tr(".", "_").humanize
      attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
      I18n.t(defaults.shift,
        default:  defaults,
        attribute: attr_name,
        message:   message)
    end
  end
end

class Person
  include ActiveModel::Validations
  extend  ActiveModel::Translation

  attr_accessor :title, :karma, :salary, :gender

  def condition_is_true
    true
  end

  def condition_is_false
    false
  end
end

person = Person.new

# Enumerate some representative scenarios here.
#
# It is very easy to make an optimization that improves performance for a
# specific scenario you care about but regresses on other common cases.
# Therefore, you should test your change against a list of representative
# scenarios. Ideally, they should be based on real-world scenarios extracted
# from production applications.
SCENARIOS = {
  "Deeply nested model attributes" => {
    attribute: :'contacts/addresses.street',
    translations: { errors: { format: "%{attribute} %{message}" } }
  },
  "Attribute with base format" => {
    attribute: :name,
    translations: { errors: { format: "%{attribute} %{message}" } }
  },
  "Attribute with attribute format" => {
    attribute: :name,
    translations: { activemodel: { errors: { models: { person: { attributes: { name: { format: "%{message}" } } } } } } }
  }
}

SCENARIOS.each_pair do |name, value|
  attribute = value[:attribute]
  translations = value[:translations]

  I18n.load_path.clear
  I18n.backend = I18n::Backend::Simple.new
  I18n.backend.store_translations("en", translations)

  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("full_message_i18n") { person.errors.full_message_i18n(attribute, "cannot be blank") }
    x.report("full_message") { person.errors.full_message(attribute, "cannot be blank") }
    x.compare!
  end
end
```

### Results

The result with the variance between runs

```
======================== Deeply nested model attributes ========================

Warming up --------------------------------------
   full_message_i18n     1.011k i/100ms
        full_message     1.423k i/100ms
Calculating -------------------------------------
   full_message_i18n     10.145k (± 3.9%) i/s -     51.561k in   5.090447s
        full_message     14.456k (± 3.9%) i/s -     72.573k in   5.028127s

Comparison:
        full_message:    14456.1 i/s
   full_message_i18n:    10144.8 i/s - 1.38x - 1.44x  slower


========================== Attribute with base format ==========================

Warming up --------------------------------------
   full_message_i18n     1.203k i/100ms
        full_message     1.834k i/100ms
Calculating -------------------------------------
   full_message_i18n     12.047k (± 4.0%) i/s -     60.150k in   5.000757s
        full_message     17.978k (± 1.9%) i/s -     89.866k in   5.000616s

Comparison:
        full_message:    17977.9 i/s
   full_message_i18n:    12047.3 i/s - 1.49x - 1.65x  slower


======================= Attribute with attribute format ========================

Warming up --------------------------------------
   full_message_i18n     1.553k i/100ms
        full_message     1.772k i/100ms
Calculating -------------------------------------
   full_message_i18n     16.465k (± 3.9%) i/s -     82.309k in   5.006884s
        full_message     17.041k (± 2.7%) i/s -     86.828k in   5.099021s

Comparison:
        full_message:    17040.9 i/s
   full_message_i18n:    16464.7 i/s - same-ish: difference falls within error to  1.20x  slower
```
