### PR TITLE
Updating Thor in response to #32955 and #32726

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Updates Thor to minimum release 0.20.0
+
+    Fixes #32955 and #32726
+
+    *James Griffin*
+
 *   Don't generate unused files in `app:update` task
 
      Skip the assets' initializer when sprockets isn't loaded.

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack",    version
 
   s.add_dependency "rake", ">= 0.8.7"
-  s.add_dependency "thor", ">= 0.18.1", "< 2.0"
+  s.add_dependency "thor", ">= 0.20.0", "< 2.0"
   s.add_dependency "method_source"
 
   s.add_development_dependency "actionview", version


### PR DESCRIPTION
### Summary
Updates `railties` to depend upon [thor](https://rubygems.org/gems/thor/versions/0.20.0) releases 0.20.0 or later in response to #32955 and #32726
