### PR TITLE
Set belongs_to_required_by_default in AR bug report templates

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -27,6 +27,7 @@ Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.belongs_to_required_by_default = true
 
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
@@ -48,7 +49,7 @@ end
 class BugTest < Minitest::Test
   def test_association_stuff
     post = Post.create!
-    post.comments << Comment.create!
+    Comment.create!(post:post)
 
     assert_equal 1, post.comments.count
     assert_equal 1, Comment.count

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -23,6 +23,7 @@ require "logger"
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.belongs_to_required_by_default = true
 
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
@@ -44,7 +45,7 @@ end
 class BugTest < Minitest::Test
   def test_association_stuff
     post = Post.create!
-    post.comments << Comment.create!
+    Comment.create!(post: post)
 
     assert_equal 1, post.comments.count
     assert_equal 1, Comment.count


### PR DESCRIPTION
### Summary

`ActiveRecord::Base.belongs_to_required_by_default = true` is the generator default. As it is not present in the reproduction script templates, reproducing a problem from an app requires an extra step, and a little extra knowledge.

See #32953 and comments by @eugeneius and @matthewd 