### PR TITLE
Change Active Storage’s video preview format from PNG to JPG

### DIFF
--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -9,15 +9,14 @@ module ActiveStorage
     def preview
       download_blob_to_tempfile do |input|
         draw_relevant_frame_from input do |output|
-          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+          yield io: output, filename: "#{blob.filename.base}.jpg", content_type: "image/jpeg"
         end
       end
     end
 
     private
       def draw_relevant_frame_from(file, &block)
-        draw ffmpeg_path, "-i", file.path, "-y", "-vcodec", "png",
-          "-vf", "thumbnail", "-vframes", "1", "-f", "image2", "-", &block
+        draw ffmpeg_path, "-i", file.path, "-y", "-vframes", "1", "-f", "image2", "-", &block
       end
 
       def ffmpeg_path

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -22,8 +22,8 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     preview = blob.preview(resize: "640x280").processed
 
     assert_predicate preview.image, :attached?
-    assert_equal "video.png", preview.image.filename.to_s
-    assert_equal "image/png", preview.image.content_type
+    assert_equal "video.jpg", preview.image.filename.to_s
+    assert_equal "image/jpeg", preview.image.content_type
 
     image = read_image(preview.image)
     assert_equal 640, image.width

--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -12,12 +12,13 @@ class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
 
   test "previewing an MP4 video" do
     ActiveStorage::Previewer::VideoPreviewer.new(@blob).preview do |attachable|
-      assert_equal "image/png", attachable[:content_type]
-      assert_equal "video.png", attachable[:filename]
+      assert_equal "image/jpeg", attachable[:content_type]
+      assert_equal "video.jpg", attachable[:filename]
 
       image = MiniMagick::Image.read(attachable[:io])
       assert_equal 640, image.width
       assert_equal 480, image.height
+      assert_equal "image/jpeg", image.mime_type
     end
   end
 end


### PR DESCRIPTION
PNG is not an ideal format for storing video previews for the same reason it’s not ideal for storing photos. We don’t need lossless compression or the associated extra bytes. Switching to JPG results in files that are ~90% smaller and have a negligible difference in image quality.

#### Before

<pre>
$ ffmpeg -i beach.m4v -y -vcodec png -vf thumbnail -vframes 1 -f image2 beach.png

$ mediainfo <a href="https://user-images.githubusercontent.com/5355/40445217-7c07f7d4-5e99-11e8-9f23-7bb20f20ee6a.png">beach.png</a>
Format      : PNG
File size   : <strong>1.78 MiB</strong>
Width       : 1 920 pixels
Height      : 1 080 pixels
Bit depth   : 24 bits
Compression : Lossless
</pre>

#### After

<pre>
$ ffmpeg -i beach.m4v -y -vframes 1 -f image2 beach.jpg

$ mediainfo <a href="https://user-images.githubusercontent.com/5355/40445506-4aca6764-5e9a-11e8-91d1-65e9544a3572.jpg">beach.jpg</a>
Format      : JPEG
File size   : <strong>82.2 KiB</strong>
Width       : 1 920 pixels
Height      : 1 080 pixels
Bit depth   : 8 bits
Compression : Lossy
</pre>

---

<details>
<summary>beach.m4v details</summary>
<pre>
$ mediainfo beach.m4v
Format    : MPEG-4
Codec ID  : M4V  (M4V /M4A /mp42/isom)
File size : 37.4 MiB
Duration  : 20 s 860 ms
Width     : 1 920 pixels
Height    : 1 080 pixels
</pre>
</details>