### PR TITLE
Enable warnings in all test tasks

### DIFF
--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -38,7 +38,7 @@ namespace :test do
       t.libs << "test"
       t.test_files = FileList["test/cases/**/*_test.rb"]
       t.verbose = true
-      t.warning = false
+      t.warning = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -56,7 +56,7 @@ namespace :test do
         t.libs << "test"
         t.test_files = FileList["test/integration/**/*_test.rb"]
         t.verbose = true
-        t.warning = false
+        t.warning = true
         t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
       end
     end

--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -4,12 +4,12 @@ require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new do |test|
-  test.libs << "app/controllers"
-  test.libs << "test"
-  test.test_files = FileList["test/**/*_test.rb"]
-  test.verbose = true
-  test.warning = false
+Rake::TestTask.new do |t|
+  t.libs << "app/controllers"
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.verbose = true
+  t.warning = true
 end
 
 task :package

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -73,7 +73,7 @@ end
 Rake::TestTask.new("test:regular") do |t|
   t.libs << "test" << "#{__dir__}/../activesupport/lib"
   t.pattern = "test/**/*_test.rb"
-  t.warning = false
+  t.warning = true
   t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end


### PR DESCRIPTION
Also normalize AJ task use t, like all other Rails test tasks.

We can't heed what we silence.