### PR TITLE
update README link: md instead rdoc

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -15,7 +15,7 @@ module ActiveJob
   # * {Sucker Punch}[https://github.com/brandonhilkert/sucker_punch]
   # * {Active Job Async Job}[http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html]
   # * {Active Job Inline}[http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html]
-  # * Please Note: We are not accepting pull requests for new adapters. See the {README}[link:files/activejob/README_rdoc.html] for more details.
+  # * Please Note: We are not accepting pull requests for new adapters. See the {README}[link:files/activejob/README_md.html] for more details.
   #
   # === Backends Features
   #


### PR DESCRIPTION
### Summary

Fix the documentation link. There is a broken link, activejob use md documentation instead rdoc.
Related to PR #32975
