### PR TITLE
Eager loading won't mutate owner record

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         end
       end
 
-      def target=(record)
+      def inversed_from(record)
         replace_keys(record)
         super
       end
@@ -52,6 +52,8 @@ module ActiveRecord
           else
             decrement_counters
           end
+
+          replace_keys(record)
 
           self.target = record
         end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -44,6 +44,14 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_raise(frozen_error_class) { client.firm = Firm.new(name: "Firm") }
   end
 
+  def test_eager_loading_wont_mutate_owner_record
+    client = Client.eager_load(:firm_with_basic_id).first
+    assert_not_predicate client, :firm_id_came_from_user?
+
+    client = Client.preload(:firm_with_basic_id).first
+    assert_not_predicate client, :firm_id_came_from_user?
+  end
+
   def test_missing_attribute_error_is_raised_when_no_foreign_key_attribute
     assert_raises(ActiveModel::MissingAttributeError) { Client.select(:id).first.firm }
   end


### PR DESCRIPTION
Since #31575, `BelongsToAssociation#target=` replaces owner record's
foreign key to fix an inverse association bug.

But the method is not only used for inverse association but also used
for eager loading/preloading, it caused some public behavior changes
(#32338, #32375).

To avoid any side-effect in loading associations, I reverted the
overriding `#target=`, then introduced `#inversed_from` to replace
foreign key in `set_inverse_instance`.

Closes #32375.