### PR TITLE
autoload ActiveSupport::Notifications from ActiveSupport::Cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -10,6 +10,8 @@ require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/string/inflections"
 
 module ActiveSupport
+  autoload :Notifications, "active_support/notifications"
+
   # See ActiveSupport::Cache::Store for documentation.
   module Cache
     autoload :FileStore,        "active_support/cache/file_store"

--- a/activesupport/test/cache/cache_load_test.rb
+++ b/activesupport/test/cache/cache_load_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "active_support/testing/autorun"
+require "active_support/cache"
+
+# Ensures active_support/cache is loadable on its own without active_support.
+class CacheLoadTest < ::Minitest::Test
+  def test_load
+    assert_nil ActiveSupport::Cache::MemoryStore.new.read(nil)
+  end
+end


### PR DESCRIPTION
### Summary

This PR autoloads `ActiveSupport::Notifications` within `active_support/cache`, since it's used in the `ActiveSupport::Cache` implementation: https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/cache.rb#L664

Without this PR, `active_support/cache` currently depends on `active_support/notifications` already being loaded. In Rails 5.0.x, this raises a `NameError` when `ActiveSupport::Cache` is used on its own without loading all of `active_support` first:

```
$ bundle exec ruby -e "require 'active_support'; puts ActiveSupport::Cache::MemoryStore.new.fetch 'x'"

$ bundle exec ruby -e "require 'active_support/cache'; puts ActiveSupport::Cache::MemoryStore.new.fetch 'x'"
Traceback (most recent call last):
	3: from -e:1:in `<main>'
	2: from [GEMS]/activesupport-5.0.6/lib/active_support/cache.rb:305:in `fetch'
	1: from [GEMS]/activesupport-5.0.6/lib/active_support/cache.rb:317:in `read'
[GEMS]/activesupport-5.0.6/lib/active_support/cache.rb:562:in `instrument': uninitialized constant ActiveSupport::Notifications (NameError)
```

This bug was accidentally fixed in 5.1, since [#28204](https://github.com/rails/rails/pull/28204/files#diff-273d4ceedb426a237b07cb7146a074dfR4) indirectly loads `active_support/notifications` via a long require-chain through `active_support/deprecation`:

- https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/cache.rb#L8
- https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/core_ext/numeric/time.rb#L3
- https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/duration.rb#L7
- https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/deprecation.rb#L18
- https://github.com/rails/rails/blob/c31317bd16f14c868f7a3ffea9eee120880a7a4d/activesupport/lib/active_support/deprecation/behaviors.rb#L3

([#30782](https://github.com/rails/rails/pull/30782/files#diff-7981f69995a3750c52e68d1aa65d0c12R7) also loads `active_support/deprecation` through a slightly different require path.)

Instead of implicitly depending on this unintentional load-order, this PR explicitly autoloads `ActiveSupport::Notifications` and adds a test to ensure `ActiveSupport::Cache` can be used on its own.

### Other Information

This PR would be most useful if backported to the `5.0` branch where this test case is currently failing - I can create this additional backport PR if there's any interest in this.