### PR TITLE
Improve grammar for DateAndTime before? and after? calculations [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -60,12 +60,12 @@ module DateAndTime
       !WEEKEND_DAYS.include?(wday)
     end
 
-    # Returns true if the date/time before <tt>date_or_time</tt>.
+    # Returns true if the date/time falls before <tt>date_or_time</tt>.
     def before?(date_or_time)
       self < date_or_time
     end
 
-    # Returns true if the date/time after <tt>date_or_time</tt>.
+    # Returns true if the date/time falls after <tt>date_or_time</tt>.
     def after?(date_or_time)
       self > date_or_time
     end


### PR DESCRIPTION
This is a small grammatical improvement to documentation for a couple of
methods in ActiveSupport's DateAndTime calculations.