### PR TITLE
Separate min and max threads count environment variable for puma configuration

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -4,8 +4,9 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-threads threads_count, threads_count
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -4,8 +4,8 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { 5 }
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
Same environment variable RAILS_MAX_THREADS was being used
for setting the minimum and maximum thread count for puma.
This change makes it obvious and easy to decide which
environment variable to change for setting the min or max.

Don't feel like this is a breaking change as the same
default is maintained.