### PR TITLE
Specify location for engine-specific commands

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -313,6 +313,9 @@ The engine that this guide covers provides submitting articles and commenting
 functionality and follows a similar thread to the [Getting Started
 Guide](getting_started.html), with some new twists.
 
+NOTE: For this section, make sure to run the commands in the root of the
+`blorgh` engine's directory.
+
 ### Generating an Article Resource
 
 The first thing to generate for a blog engine is the `Article` model and related


### PR DESCRIPTION
Be more specific when pointing out where the commands relating to the engine should be run

### Summary
While following the Engines Guides, I found that it was not specified where to run the commands.
I mistakenly run some commands in the root directory instead of the engine's directory.

This is an attempt to ensure that the commands that should be run in the engine's directory are specified
