### PR TITLE
Change location for running copy migrations command

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -695,7 +695,7 @@ pre-defined path which may be customizable.
 The engine contains migrations for the `blorgh_articles` and `blorgh_comments`
 table which need to be created in the application's database so that the
 engine's models can query them correctly. To copy these migrations into the
-application run the following command from the `test/dummy` directory of your Rails engine:
+application run the following command from the application's root:
 
 ```bash
 $ bin/rails blorgh:install:migrations


### PR DESCRIPTION

### Summary

This fixes the location from where the command to copy migrations from the engine to the application should be run

To copy migrations to the main app, the `bin/rails blorgh:install:migrations` command should be run from the application's root rather than the `test/dummy` directory of the Rails engine

Later on in the guides, it is mentioned that: 
> Notice that only one migration was copied over here. This is because the first two migrations were copied over the first time this command was run.

This makes sure that the first 2 migrations are copied over the first time
