### PR TITLE
Add the `AR::Relation.where.exists` and `.not_exists` methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add the `AR::Relation.where.exists` and `.not_exists` methods.
+    The methods work as a more readable shortcut to the exists SQL where condition build manually.
+    Accepts the AR::Relation or as String argument.
+
+    Example:
+
+        User.where.exists(Project.where("projects.owner_id = users.id"))
+        # SELECT * FROM users WHERE EXISTS (SELECT * FROM projects WHERE users.id = projects.owner_id)
+
+        User.where.not_exists("SELECT 1 FROM projects p WHERE users.id = p.owner_id")
+        # SELECT * FROM users WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE users.id = p.owner_id)
+    
+    *Bogdan Gusiev*
+
 *   Added `index` option for `change_table` migration helpers.
     With this change you can create indexes while adding new
     columns into the existing tables.

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -103,5 +103,33 @@ module ActiveRecord
 
       assert_equal Post.where(comments_count: 3..5), relation
     end
+
+    def test_exists_with_relation
+      relation = Post.where.exists(Comment.where("posts.id = comments.post_id"))
+      post = Post.first
+      Comment.create!(post: post, body: "Nice!")
+      assert_equal [post], relation
+    end
+
+    def test_exists_with_string
+      relation = Post.where.exists("select * from comments c where posts.id = c.post_id")
+      post = Post.first
+      Comment.create!(post: post, body: "Nice!")
+      assert_equal [post], relation
+    end
+
+    def test_not_exists_with_relation
+      relation = Post.where.not_exists(Comment.where("posts.id = comments.post_id"))
+      post = Post.first
+      Comment.create!(post: post, body: "Nice!")
+      assert_equal Post.offset(1).to_a, relation
+    end
+
+    def test_not_exists_with_string
+      relation = Post.where.not_exists("select * from comments c where posts.id = c.post_id")
+      post = Post.first
+      Comment.create!(post: post, body: "Nice!")
+      assert_equal Post.offset(1).to_a, relation
+    end
   end
 end


### PR DESCRIPTION
Current way of constructing the `exists` SQL query condition looks pretty unreadable and requires to know arel presence:

``` ruby
Post.where(Comment.created_today.where("posts.id = comments.post_id").select(1).arel.exists)
# OR
Post.where("not exists (#{Comment.created_today.where("posts.id = comments.post_id").select(1).to_sql})")
```

Adding the `AR::Relation.where.exists` and `.not_exists` methods.                                     
The methods work as a more readable shortcut to the exists SQL where condition build manually.     
Accepts the AR::Relation or as String argument.                                                    
                                                                                                   
Example:                                                                                           
            
``` ruby                                                                                       
    User.where.exists(Project.where("projects.owner_id = users.id"))                               
    # SELECT * FROM users WHERE EXISTS (SELECT * FROM projects WHERE users.id = projects.owner_id) 
                                                                                                   
    User.where.not_exists("SELECT 1 FROM projects p WHERE users.id = p.owner_id")                  
    # SELECT * FROM users WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE users.id = p.owner_id)  
```