### PR TITLE
Added --editor (-e) option to open generated files in the user's editor

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -12,7 +12,7 @@ module Rails
       check_class_collision suffix: "Channel"
 
       def create_channel_file
-        template "channel.rb", File.join("app/channels", class_path, "#{file_name}_channel.rb")
+        primary_template "channel.rb", File.join("app/channels", class_path, "#{file_name}_channel.rb")
 
         if options[:assets]
           if behavior == :invoke

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -10,7 +10,7 @@ module Rails
       check_class_collision suffix: "Mailer"
 
       def create_mailer_file
-        template "mailer.rb", File.join("app/mailers", class_path, "#{file_name}_mailer.rb")
+        primary_template "mailer.rb", File.join("app/mailers", class_path, "#{file_name}_mailer.rb")
 
         in_root do
           if behavior == :invoke && !File.exist?(application_mailer_file_name)

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -18,7 +18,7 @@ module Rails # :nodoc:
       end
 
       def create_job_file
-        template "job.rb", File.join("app/jobs", class_path, "#{file_name}_job.rb")
+        primary_template "job.rb", File.join("app/jobs", class_path, "#{file_name}_job.rb")
 
         in_root do
           if behavior == :invoke && !File.exist?(application_job_file_name)

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "rails/generators/active_record"
+require "rails/generators/primary_file_helpers"
 
 module ActiveRecord
   module Generators # :nodoc:
     class MigrationGenerator < Base # :nodoc:
+      include Rails::Generators::PrimaryFileHelpers
+
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
@@ -12,7 +15,8 @@ module ActiveRecord
       def create_migration_file
         set_local_assigns!
         validate_file_name!
-        migration_template @migration_template, File.join(db_migrate_path, "#{file_name}.rb")
+        destination = migration_template @migration_template, File.join(db_migrate_path, "#{file_name}.rb")
+        primary_file(destination)
       end
 
       private
@@ -68,6 +72,10 @@ module ActiveRecord
 
         def normalize_table_name(_table_name)
           pluralize_table_names? ? _table_name.pluralize : _table_name.singularize
+        end
+
+        def primary_file?
+          shell.base.class.to_s == "Rails::Generators::MigrationGenerator"
         end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       end
 
       def create_model_file
-        template "model.rb", File.join("app/models", class_path, "#{file_name}.rb")
+        primary_template "model.rb", File.join("app/models", class_path, "#{file_name}.rb")
       end
 
       def create_module_file
@@ -42,6 +42,10 @@ module ActiveRecord
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
           options[:parent] || "ApplicationRecord"
+        end
+
+        def primary_file?
+          shell.base.class.to_s == "Rails::Generators::ModelGenerator"
         end
     end
   end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added --editor (-e) option to open the main generated files in the user's editor.
+
+    *Nathan Broadbent*, *Yuji Yaginuma*
+
 *   Deprecate `rails notes` subcommands in favor of passing an `annotations` argument to `rails notes`.
 
     The following subcommands are replaced by passing `--annotations` or `-a` to `rails notes`:

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -276,6 +276,13 @@ module Rails
         @after_bundle_callbacks << block
       end
 
+      # Opens the given file in the user's editor, if generator is run with the <tt>--editor</tt> option.
+      #
+      #   open_file_in_editor "app/models/account.rb"
+      def open_file_in_editor(path)
+        run("#{options["editor"]} #{path}")
+      end
+
       private
 
         # Define log for backwards compatibility. If just one argument is sent,

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -2,10 +2,13 @@
 
 require "rails/generators/base"
 require "rails/generators/generated_attribute"
+require "rails/generators/primary_file_helpers"
 
 module Rails
   module Generators
     class NamedBase < Base
+      include Rails::Generators::PrimaryFileHelpers
+
       argument :name, type: :string
 
       def initialize(args, *options) #:nodoc:
@@ -28,6 +31,11 @@ module Rails
 
         def js_template(source, destination)
           template(source + ".js", destination + ".js")
+        end
+
+        def primary_template(source, destination)
+          template(source, destination)
+          primary_file(destination)
         end
       end
 

--- a/railties/lib/rails/generators/primary_file_helpers.rb
+++ b/railties/lib/rails/generators/primary_file_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Rails
+  module Generators
+    module PrimaryFileHelpers # :nodoc:
+      extend ActiveSupport::Concern
+
+      included do
+        class_option :editor, type: :string, aliases: "-e", lazy_default: ENV["EDITOR"],
+                              required: false, banner: "editor",
+                              desc: "Open generated primary file in the specified editor (Default: $EDITOR)"
+      end
+
+      private
+        def primary_file(filename)
+          open_file_in_editor(filename) if primary_file? && options[:editor].present?
+        end
+
+        def primary_file?
+          self.instance_of?(shell.base.class)
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -11,7 +11,7 @@ module Rails
       check_class_collision suffix: "Controller"
 
       def create_controller_files
-        template "controller.rb", File.join("app/controllers", class_path, "#{file_name}_controller.rb")
+        primary_template "controller.rb", File.join("app/controllers", class_path, "#{file_name}_controller.rb")
       end
 
       def add_routes

--- a/railties/lib/rails/generators/rails/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/rails/helper/helper_generator.rb
@@ -6,7 +6,7 @@ module Rails
       check_class_collision suffix: "Helper"
 
       def create_helper_files
-        template "helper.rb", File.join("app/helpers", class_path, "#{file_name}_helper.rb")
+        primary_template "helper.rb", File.join("app/helpers", class_path, "#{file_name}_helper.rb")
       end
 
       hook_for :test_framework

--- a/railties/lib/rails/generators/rails/task/task_generator.rb
+++ b/railties/lib/rails/generators/rails/task/task_generator.rb
@@ -6,7 +6,7 @@ module Rails
       argument :actions, type: :array, default: [], banner: "action action"
 
       def create_task_files
-        template "task.rb", File.join("lib/tasks", "#{file_name}.rake")
+        primary_template "task.rb", File.join("lib/tasks", "#{file_name}.rake")
       end
     end
   end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -457,6 +457,14 @@ F
     assert_equal("", action(:log, :yes, "YES"))
   end
 
+  def test_open_file_in_editor
+    generator(default_arguments, editor: "cat")
+
+    assert_called_with(generator, :run, ["cat Gemfile"]) do
+      action :open_file_in_editor, "Gemfile"
+    end
+  end
+
   private
 
     def action(*args, &block)

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -86,4 +86,12 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/javascripts/channels/chat_channel.js"
     assert_file "app/assets/javascripts/channels/chat.js"
   end
+
+  def test_file_is_opened_in_editor
+    generator ["chat"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat app/channels/chat_channel.rb"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -138,4 +138,12 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/stylesheets/account_controller.css"
     assert_file "app/assets/stylesheets/account.css"
   end
+
+  def test_file_is_opened_in_editor
+    generator ["account"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat app/controllers/account_controller.rb"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -38,4 +38,12 @@ class HelperGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_file_is_opened_in_editor
+    generator ["products"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat app/helpers/products_helper.rb"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -45,4 +45,12 @@ class JobGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/jobs/notifier_job_job_test.rb"
     assert_file "test/jobs/notifier_job_test.rb"
   end
+
+  def test_file_is_opened_in_editor
+    generator ["notifier"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat app/jobs/notifier_job.rb"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -176,4 +176,12 @@ class MailerGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/mailers/previews/notifier_mailer_mailer_preview.rb"
     assert_file "test/mailers/previews/notifier_mailer_preview.rb"
   end
+
+  def test_file_is_opened_in_editor
+    generator ["notifier"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat app/mailers/notifier_mailer.rb"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -2,6 +2,7 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/model/model_generator"
+require "rails/generators/active_record/model/model_generator"
 
 class ModelGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
@@ -458,6 +459,22 @@ class ModelGeneratorTest < Rails::Generators::TestCase
       end
     FILE
     assert_file "app/models/user.rb", expected_file
+  end
+
+  def test_file_is_opened_in_editor
+    model = "account"
+    editor = "cat"
+
+    generator [model], editor: editor
+    model_generator = ActiveRecord::Generators::ModelGenerator.new(
+      [model], ["-e", editor], shell: generator.shell, destination_root: generator.destination_root
+    )
+
+    stub_any_instance(ActiveRecord::Generators::ModelGenerator, instance: model_generator) do |instance|
+      assert_called_with(instance, :run, ["cat app/models/account.rb"]) do
+        quietly { generator.invoke_all }
+      end
+    end
   end
 
   private

--- a/railties/test/generators/task_generator_test.rb
+++ b/railties/test/generators/task_generator_test.rb
@@ -23,4 +23,12 @@ class TaskGeneratorTest < Rails::Generators::TestCase
     run_generator ["feeds"], behavior: :revoke
     assert_no_file task_path
   end
+
+  def test_file_is_opened_in_editor
+    generator ["feeds"], editor: "cat"
+
+    assert_called_with(generator, :run, ["cat lib/tasks/feeds.rake"]) do
+      quietly { generator.invoke_all }
+    end
+  end
 end


### PR DESCRIPTION
This is a retry of #8553.

Added support for generators added later from the original PR, and extract the function on the primary file into method.

Also avoied adding the `editor` option to `Generators::Base`.
If add it to `Generators::Base`, `editor` option will be output to the help of generator which does not support it. This confuses the user.