### PR TITLE
Dev-Dep guide: mention AST third party requirements

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -22,8 +22,8 @@
 # Outside of a Rails application, modify +ActiveStorage.previewers+ instead.
 #
 # The built-in previewers rely on third-party system libraries. Specifically, the built-in video previewer requires
-# {ffmpeg}[https://www.ffmpeg.org]. Two PDF previewers are provided: one requires {Poppler}[https://poppler.freedesktop.org],
-# and the other requires {mupdf}[https://mupdf.com] (version 1.8 or newer). To preview PDFs, install either Poppler or mupdf.
+# {FFmpeg}[https://www.ffmpeg.org]. Two PDF previewers are provided: one requires {Poppler}[https://poppler.freedesktop.org],
+# and the other requires {muPDF}[https://mupdf.com] (version 1.8 or newer). To preview PDFs, install either Poppler or muPDF.
 #
 # These libraries are not provided by Rails. You must install them yourself to use the built-in previewers. Before you
 # install and use third-party software, make sure you understand the licensing implications of doing so.

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -16,7 +16,7 @@ module ActiveStorage
   #
   # When a video's angle is 90 or 270 degrees, its width and height are automatically swapped for convenience.
   #
-  # This analyzer requires the {ffmpeg}[https://www.ffmpeg.org] system library, which is not provided by Rails.
+  # This analyzer requires the {FFmpeg}[https://www.ffmpeg.org] system library, which is not provided by Rails.
   class Analyzer::VideoAnalyzer < Analyzer
     def self.accept?(blob)
       blob.video?
@@ -107,7 +107,7 @@ module ActiveStorage
           JSON.parse(output.read)
         end
       rescue Errno::ENOENT
-        logger.info "Skipping video analysis because ffmpeg isn't installed"
+        logger.info "Skipping video analysis because FFmpeg isn't installed"
         {}
       end
 

--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -31,7 +31,7 @@ module ActiveStorage
 
       # Executes a system command, capturing its binary output in a tempfile. Yields the tempfile.
       #
-      # Use this method to shell out to a system library (e.g. mupdf or ffmpeg) for preview image
+      # Use this method to shell out to a system library (e.g. muPDF or FFmpeg) for preview image
       # generation. The resulting tempfile can be used as the +:io+ value in an attachable Hash:
       #
       #   def preview

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -446,11 +446,11 @@ the box, Active Storage supports previewing videos and PDF documents.
 </ul>
 ```
 
-WARNING: Extracting previews requires third-party applications, `ffmpeg` for
-video and `mutool` for PDFs. These libraries are not provided by Rails. You must
-install them yourself to use the built-in previewers. Before you install and use
-third-party software, make sure you understand the licensing implications of
-doing so.
+WARNING: Extracting previews requires third-party applications, `FFmpeg` for
+video and `muPDF` for PDFs, and on macOS also `XQuartz` and `Poppler`.
+These libraries are not provided by Rails. You must install them yourself to
+use the built-in previewers. Before you install and use third-party software,
+make sure you understand the licensing implications of doing so.
 
 Direct Uploads
 --------------

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -452,6 +452,7 @@ These libraries are not provided by Rails. You must install them yourself to
 use the built-in previewers. Before you install and use third-party software,
 make sure you understand the licensing implications of doing so.
 
+
 Direct Uploads
 --------------
 

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -376,3 +376,31 @@ command inside of the `activestorage` directory to install the dependencies:
 ```bash
 yarn install
 ```
+
+Extracting previews, tested in ActiveStorage's test suite requires third-party
+applications, `FFmpeg` for video and `muPDF` for PDFs, and on macOS also
+`XQuartz` and `Poppler`.. Without these applications installed, ActiveStorage
+tests will raise errors.
+
+On macOS you can run:
+
+```bash
+brew install ffmpeg
+brew cask install xquartz
+brew install mupdf-tools
+brew install poppler
+```
+
+On Ubuntu, you can run:
+
+```bash
+sudo apt-get update && install ffmpeg
+sudo apt-get update && install mupdf mupdf-tools
+```
+
+On Fedora or CentOS, just run:
+
+```bash
+sudo yum install ffmpeg
+sudo yum install mupdf
+```


### PR DESCRIPTION
Avoid the likes of:

```
Error:
ActiveStorage::RepresentationTest#test_representing_an_MP4_video:
Errno::ENOENT: No such file or directory - ffmpeg
    test/models/representation_test.rb:27:in `block in <class:RepresentationTest>'
```

While at it, update the library names: `FFmpeg`, and `muPDF` used elsewhere in the documentation.

[ci skip]