### PR TITLE
Update et-orbi to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
     erubi (1.7.0)
-    et-orbi (1.0.8)
+    et-orbi (1.1.2)
       tzinfo
     event_emitter (0.2.6)
     eventmachine (1.2.5)
@@ -472,7 +472,7 @@ GEM
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.2)
       tzinfo (>= 1.0.0)


### PR DESCRIPTION
avoids 
> `warning: assigned but unused variable - tu`