### PR TITLE
Fix: Arel Postgresql visitor generates invalid SQL for GROUPING SETS.

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -5,7 +5,7 @@ module Arel # :nodoc: all
     class PostgreSQL < Arel::Visitors::ToSql
       CUBE = "CUBE"
       ROLLUP = "ROLLUP"
-      GROUPING_SET = "GROUPING SET"
+      GROUPING_SETS = "GROUPING SETS"
       LATERAL = "LATERAL"
 
       private
@@ -67,7 +67,7 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_GroupingSet(o, collector)
-          collector << GROUPING_SET
+          collector << GROUPING_SETS
           grouping_array_or_grouping_element o, collector
         end
 

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -229,7 +229,7 @@ module Arel
         it "should know how to visit with array arguments" do
           node = Arel::Nodes::GroupingSet.new([@table[:name], @table[:bool]])
           compile(node).must_be_like %{
-            GROUPING SET( "users"."name", "users"."bool" )
+            GROUPING SETS( "users"."name", "users"."bool" )
           }
         end
 
@@ -237,7 +237,7 @@ module Arel
           group = Arel::Nodes::GroupingElement.new([@table[:name], @table[:bool]])
           node = Arel::Nodes::GroupingSet.new(group)
           compile(node).must_be_like %{
-            GROUPING SET( "users"."name", "users"."bool" )
+            GROUPING SETS( "users"."name", "users"."bool" )
           }
         end
 
@@ -246,7 +246,7 @@ module Arel
           group2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
           node = Arel::Nodes::GroupingSet.new([group1, group2])
           compile(node).must_be_like %{
-            GROUPING SET( ( "users"."name" ), ( "users"."bool", "users"."created_at" ) )
+            GROUPING SETS( ( "users"."name" ), ( "users"."bool", "users"."created_at" ) )
           }
         end
       end


### PR DESCRIPTION
### Summary

PostgreSQL visitor in Arel generates invalid SQL when a `GroupingSet` node is used.

The correct syntax for a grouping sets clause is `GROUPING SETS` according to the [PostgreSQL documentation](https://www.postgresql.org/docs/9.5/static/queries-table-expressions.html). The visitor was generating `GROUPING SET` instead.

I have renamed the constant `GROUPING_SET` to `GROUPING_SETS` and their value too. Other option is to change only the constant value, in case that someone is using it (unlikely, since the feature was not working). Not sure which option do you prefer, so I will be grateful if you can provide some feedback on this.

Regards.

### Other Information
Active record template that reproduces the issue (requires a postgresql database `grouping_sets_test`):

```ruby
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "pg"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "grouping_sets_test")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_grouping_sets
    post = Post.create!
    post.comments << Comment.create!

    grouping = Arel::Nodes::GroupingElement.new(Post.arel_table[:id])
    # PG::SyntaxError: ERROR:  syntax error at or near "SET"
    Post.group(Arel::Nodes::GroupingSet.new([grouping])).load
  end
end
```
