### PR TITLE
fix: allow empty content label

### DIFF
--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -61,7 +61,7 @@ module ActionView
 
           content = if block_given?
             @template_object.capture(builder, &block)
-          elsif @content.present?
+          elsif !@content.nil?
             @content.to_s
           else
             render_component(builder)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -188,6 +188,9 @@ class FormHelperTest < ActionView::TestCase
       '<label for="post_title">The title goes here</label>',
       label("post", "title", "The title goes here")
     )
+    assert_dom_equal('<label for="post_title">Title</label>', label("post", "title", nil))
+    assert_dom_equal('<label for="post_title">content</label>', label("post", "title", "content"))
+    assert_dom_equal('<label for="post_title"></label>', label("post", "title", ""))
     assert_dom_equal(
       '<label class="title_label" for="post_title">Title</label>',
       label("post", "title", nil, class: "title_label")


### PR DESCRIPTION
### Summary
Allow generate empty content `<label>` in form helper method `label` or `f.label`
 
### Other Information
In Recently Web front, to make rich web, sometimes write bellow code.So, empty content label tag is needed.But `f.label :hoge, ''` isn't realize it.

```application.css
.checkbox {
  display: hidden;
}

.label {
  background-color: #000;
}

.checkbox:checked + .label {
  background-color: #fff;
}
```

```index.html
  <input id="checkbox" class="checkbox" type="checkbox">
  <label for="checkbox" class="label"></label>
```