### PR TITLE
ActiveStorage reflection

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -13,34 +13,37 @@ module ActiveRecord
       class_attribute :aggregate_reflections, instance_writer: false, default: {}
     end
 
-    def self.create(macro, name, scope, options, ar)
-      reflection = reflection_class_for(macro).new(name, scope, options, ar)
-      options[:through] ? ThroughReflection.new(reflection) : reflection
-    end
-
-    def self.reflection_class_for(macro)
-      case macro
-      when :composed_of
-        AggregateReflection
-      when :has_many
-        HasManyReflection
-      when :has_one
-        HasOneReflection
-      when :belongs_to
-        BelongsToReflection
-      else
-        raise "Unsupported Macro: #{macro}"
+    class << self
+      def create(macro, name, scope, options, ar)
+        reflection = reflection_class_for(macro).new(name, scope, options, ar)
+        options[:through] ? ThroughReflection.new(reflection) : reflection
       end
-    end
 
-    def self.add_reflection(ar, name, reflection)
-      ar.clear_reflections_cache
-      name = name.to_s
-      ar._reflections = ar._reflections.except(name).merge!(name => reflection)
-    end
+      def add_reflection(ar, name, reflection)
+        ar.clear_reflections_cache
+        name = name.to_s
+        ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+      end
 
-    def self.add_aggregate_reflection(ar, name, reflection)
-      ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
+      def add_aggregate_reflection(ar, name, reflection)
+        ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
+      end
+
+      private
+        def reflection_class_for(macro)
+          case macro
+          when :composed_of
+            AggregateReflection
+          when :has_many
+            HasManyReflection
+          when :has_one
+            HasOneReflection
+          when :belongs_to
+            BelongsToReflection
+          else
+            raise "Unsupported Macro: #{macro}"
+          end
+        end
     end
 
     # \Reflection enables the ability to examine the associations and aggregations of

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -11,7 +11,6 @@ module ActiveRecord
     included do
       class_attribute :_reflections, instance_writer: false, default: {}
       class_attribute :aggregate_reflections, instance_writer: false, default: {}
-      class_attribute :attachment_reflections, instance_writer: false, default: {}
     end
 
     def self.create(macro, name, scope, options, ar)
@@ -29,10 +28,6 @@ module ActiveRecord
         HasOneReflection
       when :belongs_to
         BelongsToReflection
-      when :has_one_attached
-        HasOneAttachedReflection
-      when :has_many_attached
-        HasManyAttachedReflection
       else
         raise "Unsupported Macro: #{macro}"
       end
@@ -48,18 +43,14 @@ module ActiveRecord
       ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
     end
 
-    def self.add_attachment_reflection(ar, name, reflection)
-      ar.attachment_reflections.merge!(name.to_s => reflection)
-    end
-
     # \Reflection enables the ability to examine the associations and aggregations of
     # Active Record classes and objects. This information, for example,
     # can be used in a form builder that takes an Active Record object
     # and creates input fields for all of the attributes depending on their type
     # and displays the associations to other objects.
     #
-    # MacroReflection class has info for the AggregateReflection and
-    # AssociationReflection classes.
+    # MacroReflection class has info for AggregateReflection and AssociationReflection
+    # classes.
     module ClassMethods
       # Returns an array of AggregateReflection objects for all the aggregations in the class.
       def reflect_on_all_aggregations
@@ -72,21 +63,6 @@ module ActiveRecord
       #
       def reflect_on_aggregation(aggregation)
         aggregate_reflections[aggregation.to_s]
-      end
-
-      # Returns an array of reflection objects for all the attachments in the
-      # class.
-      def reflect_on_all_attachments
-        attachment_reflections.values
-      end
-
-      # Returns the reflection object for the named +attachment+.
-      #
-      #    User.reflect_on_attachment(:avatar)
-      #    # => the avatar reflection
-      #
-      def reflect_on_attachment(attachment)
-        attachment_reflections[attachment.to_s]
       end
 
       # Returns a Hash of name of the reflection as the key and an AssociationReflection as the value.
@@ -161,8 +137,6 @@ module ActiveRecord
     #         HasOneReflection
     #         BelongsToReflection
     #         HasAndBelongsToManyReflection
-    #       HasOneAttachedReflection
-    #       HasManyAttachedReflection
     #     ThroughReflection
     #     PolymorphicReflection
     #     RuntimeReflection
@@ -436,22 +410,6 @@ module ActiveRecord
       def mapping
         mapping = options[:mapping] || [name, name]
         mapping.first.is_a?(Array) ? mapping : [mapping]
-      end
-    end
-
-    # Holds all the metadata about a has_one_attached attachment as it was
-    # specified in the Active Record class.
-    class HasOneAttachedReflection < MacroReflection #:nodoc:
-      def macro
-        :has_one_attached
-      end
-    end
-
-    # Holds all the metadata about a has_many_attached attachment as it was
-    # specified in the Active Record class.
-    class HasManyAttachedReflection < MacroReflection #:nodoc:
-      def macro
-        :has_many_attached
       end
     end
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add the ability to reflect on defined attachments using the existing
+    ActiveRecord reflection mechanism.
+
+    *Kevin Deisz*
+
 *   Variant arguments of `false` or `nil` will no longer be passed to the
     processor. For example, the following will not have the monochrome
     variation applied:

--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -48,6 +48,12 @@ module ActiveStorage
       else
         before_destroy { public_send(name).detach }
       end
+
+      ActiveRecord::Reflection.add_attachment_reflection(
+        self,
+        name,
+        ActiveRecord::Reflection.create(:has_one_attached, name, nil, { dependent: dependent }, self)
+      )
     end
 
     # Specifies the relation between multiple attachments and the model.
@@ -105,6 +111,12 @@ module ActiveStorage
       else
         before_destroy { public_send(name).detach }
       end
+
+      ActiveRecord::Reflection.add_attachment_reflection(
+        self,
+        name,
+        ActiveRecord::Reflection.create(:has_many_attached, name, nil, { dependent: dependent }, self)
+      )
     end
   end
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -10,6 +10,8 @@ require "active_storage/previewer/video_previewer"
 require "active_storage/analyzer/image_analyzer"
 require "active_storage/analyzer/video_analyzer"
 
+require "active_storage/reflection"
+
 module ActiveStorage
   class Engine < Rails::Engine # :nodoc:
     isolate_namespace ActiveStorage
@@ -93,6 +95,13 @@ module ActiveStorage
               raise e, "Cannot load `Rails.config.active_storage.service`:\n#{e.message}", e.backtrace
             end
         end
+      end
+    end
+
+    initializer "active_storage.reflection" do
+      ActiveSupport.on_load(:active_record) do
+        include Reflection::ActiveRecordExtensions
+        ActiveRecord::Reflection.singleton_class.prepend(Reflection::ReflectionExtension)
       end
     end
   end

--- a/activestorage/lib/active_storage/reflection.rb
+++ b/activestorage/lib/active_storage/reflection.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Reflection
+    # Holds all the metadata about a has_one_attached attachment as it was
+    # specified in the Active Record class.
+    class HasOneAttachedReflection < ActiveRecord::Reflection::MacroReflection #:nodoc:
+      def macro
+        :has_one_attached
+      end
+    end
+
+    # Holds all the metadata about a has_many_attached attachment as it was
+    # specified in the Active Record class.
+    class HasManyAttachedReflection < ActiveRecord::Reflection::MacroReflection #:nodoc:
+      def macro
+        :has_many_attached
+      end
+    end
+
+    module ReflectionExtension
+      def reflection_class_for(macro)
+        case macro
+        when :has_one_attached
+          HasOneAttachedReflection
+        when :has_many_attached
+          HasManyAttachedReflection
+        else
+          super
+        end
+      end
+
+      def add_attachment_reflection(ar, name, reflection)
+        ar.attachment_reflections.merge!(name.to_s => reflection)
+      end
+    end
+
+    module ActiveRecordExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :attachment_reflections, instance_writer: false, default: {}
+      end
+
+      module ClassMethods
+        # Returns an array of reflection objects for all the attachments in the
+        # class.
+        def reflect_on_all_attachments
+          attachment_reflections.values
+        end
+
+        # Returns the reflection object for the named +attachment+.
+        #
+        #    User.reflect_on_attachment(:avatar)
+        #    # => the avatar reflection
+        #
+        def reflect_on_attachment(attachment)
+          attachment_reflections[attachment.to_s]
+        end
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/reflection.rb
+++ b/activestorage/lib/active_storage/reflection.rb
@@ -18,21 +18,22 @@ module ActiveStorage
       end
     end
 
-    module ReflectionExtension
-      def reflection_class_for(macro)
-        case macro
-        when :has_one_attached
-          HasOneAttachedReflection
-        when :has_many_attached
-          HasManyAttachedReflection
-        else
-          super
-        end
-      end
-
+    module ReflectionExtension # :nodoc:
       def add_attachment_reflection(ar, name, reflection)
         ar.attachment_reflections.merge!(name.to_s => reflection)
       end
+
+      private
+        def reflection_class_for(macro)
+          case macro
+          when :has_one_attached
+            HasOneAttachedReflection
+          when :has_many_attached
+            HasManyAttachedReflection
+          else
+            super
+          end
+        end
     end
 
     module ActiveRecordExtensions

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
+  test "allows reflecting for all attachment" do
+    expected_classes =
+      User.reflect_on_all_attachments.all? do |reflection|
+        reflection.is_a?(ActiveRecord::Reflection::HasOneAttachedReflection) ||
+          reflection.is_a?(ActiveRecord::Reflection::HasManyAttachedReflection)
+      end
+
+    assert expected_classes
+  end
+
+  test "allows reflecting on a singular has_one_attached attachment" do
+    reflection = User.reflect_on_attachment(:avatar)
+
+    assert_equal :avatar, reflection.name
+    assert_equal :has_one_attached, reflection.macro
+  end
+
+  test "allows reflecting on a singular has_many_attached attachment" do
+    reflection = User.reflect_on_attachment(:highlights)
+
+    assert_equal :highlights, reflection.name
+    assert_equal :has_many_attached, reflection.macro
+  end
+end

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -6,8 +6,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "allows reflecting for all attachment" do
     expected_classes =
       User.reflect_on_all_attachments.all? do |reflection|
-        reflection.is_a?(ActiveRecord::Reflection::HasOneAttachedReflection) ||
-          reflection.is_a?(ActiveRecord::Reflection::HasManyAttachedReflection)
+        reflection.is_a?(ActiveStorage::Reflection::HasOneAttachedReflection) ||
+          reflection.is_a?(ActiveStorage::Reflection::HasManyAttachedReflection)
       end
 
     assert expected_classes


### PR DESCRIPTION
Add the ability to query for the attachments that have been defined on a model through the `ActiveRecord::Base::defined_attachments` method. 

Useful for writing things on top of ActiveStorage that can loop through models and their attachments to perform things in bulk.