### PR TITLE
Fixed `reverse_order` Arel SQL literal issue.

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Back port Rails 5.2 `reverse_order` Arel SQL literal fix.
+
+    *Matt Jones*, *Brooke Kuhlmann*
+
 ## Rails 5.1.6 (March 29, 2018) ##
 
 *   No changes.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1079,7 +1079,7 @@ module ActiveRecord
             end
             o.split(",").map! do |s|
               s.strip!
-              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") || s.concat(" DESC")
+              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") || (s << " DESC")
             end
           else
             o

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -253,6 +253,20 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:fifth).title, topics.first.title
   end
 
+  def test_reverse_order_with_string
+    result = Topic.order("id").reverse_order
+    proof = [5, 4, 3, 2, 1]
+
+    assert_equal result.pluck(:id), proof
+  end
+
+  def test_reverse_order_with_arel_literal
+    result = Topic.order(Arel::Nodes::SqlLiteral.new("id")).reverse_order
+    proof = [5, 4, 3, 2, 1]
+
+    assert_equal result.pluck(:id), proof
+  end
+
   def test_reverse_order_with_multiargument_function
     assert_raises(ActiveRecord::IrreversibleOrderError) do
       Topic.order("concat(author_name, title)").reverse_order


### PR DESCRIPTION
### Summary

Fixed `reverse_order` Arel SQL literal issue.

Use `<<` instead of `concat` in `reverse_sql_order` as we can have an
Arel SQL literator which overrides `concat`.

This will help with the upgrade of a major, private, Rails project.

### Other Information

This is a back port for Rails 5.1. See this [Rails 5.2.0](https://github.com/rails/rails/commit/ab03eb9f576312c75e61caaf9705a8ac5175c769) commit for further details.

cc: @eileencodes, @al2o3cr