### PR TITLE
CI against MariaDB 10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
-        mariadb: 10.2
+        mariadb: 10.3
     - rvm: 2.5.1
       env:
         - "GEM=ar:sqlite3_mem"

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -18,6 +18,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
         t.string  :name
         t.virtual :upper_name,  type: :string,  as: "UPPER(`name`)"
         t.virtual :name_length, type: :integer, as: "LENGTH(`name`)", stored: true
+        t.virtual :name_octet_length, type: :integer, as: "OCTET_LENGTH(`name`)", stored: true
       end
       VirtualColumn.create(name: "Rails")
     end
@@ -55,7 +56,8 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
     def test_schema_dumping
       output = dump_table_schema("virtual_columns")
       assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
-      assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "LENGTH\(`name`\)",\s+stored: true$/i, output)
+      assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
+      assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
     end
   end
 end


### PR DESCRIPTION
### Summary

This pull request changes the version of MariaDB to the latest GA release.

- MariaDB 10.3.7 is the first GA release
https://mariadb.com/kb/en/library/mariadb-1037-release-notes/

- MariaDB 10.3 translates `LENGTH()` to `OCTET_LENGTH()` function

https://mariadb.com/kb/en/library/sql_modeoracle-from-mariadb-103/
> MariaDB translates LENGTH() to OCTET_LENGTH()

- MySQL does NOT translate `LENGTH()` to `OCTET_LENGTH()`
However, it translates `OCTET_LENGTH()` to `LENGTH()`

Here are generated schema dumps of this test to show the differences between MySQL and MariaDB:

* MySQL 8.0 (Server version: 8.0.11 MySQL Community Server - GPL)

```ruby
  create_table \"virtual_columns\", options: \"ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci\", force: :cascade do |t|
    t.string \"name\"
    t.virtual \"upper_name\", type: :string, as: \"upper(`name`)\"
    t.virtual \"name_length\", type: :integer, as: \"length(`name`)\", stored: true
    t.virtual \"name_octet_length\", type: :integer, as: \"length(`name`)\", stored: true
  end
```

* Maria DB 10.3 (Server version: 10.3.7-MariaDB-1:10.3.7+maria~bionic-log mariadb.org binary distribution)

```ruby
  create_table \"virtual_columns\", options: \"ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci\", force: :cascade do |t|
    t.string \"name\"
    t.virtual \"upper_name\", type: :string, as: \"ucase(`name`)\"
    t.virtual \"name_length\", type: :integer, as: \"octet_length(`name`)\", stored: true
    t.virtual \"name_octet_length\", type: :integer, as: \"octet_length(`name`)\", stored: true
  end
```