### PR TITLE
Rdoc 6.0.4 fixes a regression with sdoc.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       loofah (~> 2.2, >= 2.2.2)
     rake (12.3.1)
     rb-fsevent (0.10.3)
-    rdoc (6.0.3)
+    rdoc (6.0.4)
     redcarpet (3.2.3)
     redis (3.3.5)
     redis-namespace (1.6.0)


### PR DESCRIPTION
### Summary

RDoc 6.0.3 has a regression and 6.0.4 fixed it. ruby/rdoc/pull/614

### Steps to reproduce

- checkout 5-0-stable
- bundle install
- bundle exec rake rdoc

```
$ bundle exec rake rdoc
Parsing sources...
100% [944/944]  railties/lib/rails/welcome_controller.rb

......

rake aborted!
RDoc::Error: Error while evaluating /Users/kenchan/.rbenv/versions/2.6.0-preview1/lib/ruby/gems/2.6.0/gems/sdoc-1.0.0/lib/rdoc/generator/template/rails/_context.rhtml: undefined method `rdoc' for nil:NilClass (at "pan class=\"type\">MODULE</span>\n          <a href=\"")
(eval):1:in `include_template'
/Users/kenchan/.rbenv/versions/2.6.0-preview1/bin/bundle:23:in `load'
/Users/kenchan/.rbenv/versions/2.6.0-preview1/bin/bundle:23:in `<main>'

Caused by:
NoMethodError: undefined method `rdoc' for nil:NilClass
(eval):1:in `include_template'
/Users/kenchan/.rbenv/versions/2.6.0-preview1/bin/bundle:23:in `load'
/Users/kenchan/.rbenv/versions/2.6.0-preview1/bin/bundle:23:in `<main>'
Tasks: TOP => rdoc => html/created.rid
(See full trace by running task with --trace)
```
