### PR TITLE
"brethen" is misspelled and could be clearer

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -20,7 +20,7 @@
         %i( title body ).index_with(nil)
         # => { title: nil, body: nil }
 
-    Closely linked with its brethen `index_by`.
+    Closely linked with `index_by`, which creates a hash where the keys are extracted from a block.
 
     *Kasper Timm Hansen*
 


### PR DESCRIPTION
I think @kaspth meant "brethren", which is a plural for "brother". We don't need plurality or gender here.