### PR TITLE
[skip ci] Add changelog about bumping minimum SQLite version to 3.8

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump minimum SQLite version to 3.8
+
+    *Yasuo Honda*
+
 *   Fix parent record should not get saved with duplicate children records.
 
     Fixes #32940.


### PR DESCRIPTION
### Summary

This pull request adds changelog about bumping minimum SQLite version to 3.8
Related to #32923

Thanks @y-yagi for the suggestion. I should have included this entry with #32923