### PR TITLE
Revert "Try to use Hash's native #[] for speed."

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -20,7 +20,7 @@ module ActiveSupport
       def self.compile_methods!(keys)
         keys.reject { |m| method_defined?(m) }.each do |key|
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{key}; _get(#{key.inspect}); end
+            def #{key}; self[#{key.inspect}]; end
           RUBY
         end
       end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -27,9 +27,6 @@ module ActiveSupport
   #   h.dog! # => raises KeyError: :dog is blank
   #
   class OrderedOptions < Hash
-    alias_method :_get, :[] # preserve the original #[] method
-    protected :_get # make it protected
-
     def []=(key, value)
       super(key.to_sym, value)
     end
@@ -68,11 +65,8 @@ module ActiveSupport
   #   h.boy  # => 'John'
   class InheritableOptions < OrderedOptions
     def initialize(parent = nil)
-      if parent.kind_of?(OrderedOptions)
-        # use the faster _get when dealing with OrderedOptions
-        super() { |h, k| parent._get(k) }
-      elsif parent
-        super() { |h, k| parent[k] }
+      if parent
+        super() { |h,k| parent[k] }
       else
         super()
       end


### PR DESCRIPTION
It reverts https://github.com/rails/rails/commit/5a518487fe66b11b81e21dc6c31d036057a410ed where `OrderedOptions#[]` was made protected. There is no description why it was made, just said that it was for speedup. Maybe this is related to older rubies behaviour or OrderedHash, which was used that time.

Having `#[]` protected is useless, because `#dig` &  `#fetch` are public. Also it's confusing  because `#[]=` is public.