### PR TITLE
Add check that the status passed to Rack is valid when calling status on ActionDispatch response

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -222,7 +222,7 @@ module ActionDispatch # :nodoc:
     # Sets the HTTP status code.
     def status=(status)
       raise ArgumentError, "#{status} is not a valid response code identifier. See Rack::Utils::SYMBOL_TO_STATUS_CODE "\
-        "for valid values" unless !status.is_a?(Symbol) || Rack::Utils::SYMBOL_TO_STATUS_CODE.include?(status)
+        "for valid values" unless valid_http_status?(status)
       @status = Rack::Utils.status_code(status)
     end
 
@@ -406,6 +406,9 @@ module ActionDispatch # :nodoc:
     end
 
   private
+    def valid_http_status?(status)
+      !status.is_a?(Symbol) || Rack::Utils::SYMBOL_TO_STATUS_CODE.include?(status)
+    end
 
     ContentTypeHeader = Struct.new :mime_type, :charset
     NullContentTypeHeader = ContentTypeHeader.new nil, nil

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -221,6 +221,8 @@ module ActionDispatch # :nodoc:
 
     # Sets the HTTP status code.
     def status=(status)
+      raise ArgumentError, "#{status} is not a valid response code identifier. See Rack::Utils::SYMBOL_TO_STATUS_CODE "\
+        "for valid values" unless Rack::Utils::SYMBOL_TO_STATUS_CODE.include? status
       @status = Rack::Utils.status_code(status)
     end
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -221,8 +221,9 @@ module ActionDispatch # :nodoc:
 
     # Sets the HTTP status code.
     def status=(status)
-      raise ArgumentError, "#{status} is not a valid response code identifier. See Rack::Utils::SYMBOL_TO_STATUS_CODE "\
-        "for valid values" unless valid_http_status?(status)
+      raise ArgumentError, "#{status} is not a valid response code identifier. See " \
+      "http://guides.rubyonrails.org/layouts_and_rendering.html#the-status-option " \
+      "for valid values" unless valid_http_status?(status)
       @status = Rack::Utils.status_code(status)
     end
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -222,7 +222,7 @@ module ActionDispatch # :nodoc:
     # Sets the HTTP status code.
     def status=(status)
       raise ArgumentError, "#{status} is not a valid response code identifier. See Rack::Utils::SYMBOL_TO_STATUS_CODE "\
-        "for valid values" unless !status.is_a?(Symbol) || Rack::Utils::SYMBOL_TO_STATUS_CODE.include? status
+        "for valid values" unless !status.is_a?(Symbol) || Rack::Utils::SYMBOL_TO_STATUS_CODE.include?(status)
       @status = Rack::Utils.status_code(status)
     end
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -222,7 +222,7 @@ module ActionDispatch # :nodoc:
     # Sets the HTTP status code.
     def status=(status)
       raise ArgumentError, "#{status} is not a valid response code identifier. See Rack::Utils::SYMBOL_TO_STATUS_CODE "\
-        "for valid values" unless Rack::Utils::SYMBOL_TO_STATUS_CODE.include? status
+        "for valid values" unless !status.is_a?(Symbol) || Rack::Utils::SYMBOL_TO_STATUS_CODE.include? status
       @status = Rack::Utils.status_code(status)
     end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -117,6 +117,12 @@ class ResponseTest < ActiveSupport::TestCase
     assert_nil @response.content_type
   end
 
+  def test_set_invalid_status
+    assert_raises(ArgumentError) do
+      @response.status = :not_a_real_status_identifier
+    end
+  end
+
   test "simple output" do
     @response.body = "Hello, World!"
 


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/issues/33035 pointed out that Rails is pretty opaque when you set `self.status` as a symbol that is not valid (such as `:not_valid`), simply passing it through to Rake which then sets it to `500`: https://github.com/rack/rack/blob/master/lib/rack/utils.rb#L563. This PR improves the error checking by raising an ArgumentError when the status code is not correct.

### Other Information

I'm not sure what the best thing to do here would be around backwards-compatibility, as I'd imagine there's several apps which depend on this returning a 500 when the status is an invalid symbol. We could, for now, just log the message instead of raising. I'd love feedback on this.
