### PR TITLE
Test `CustomCops/AssertNot` with a failure message

### DIFF
--- a/ci/custom_cops/test/custom_cops/assert_not_test.rb
+++ b/ci/custom_cops/test/custom_cops/assert_not_test.rb
@@ -15,6 +15,11 @@ class AssertNotTest < ActiveSupport::TestCase
     assert_offense @cop, "^^^^^^^^^ Prefer `assert_not` over `assert !`"
   end
 
+  test "rejects 'assert !' with a failure message" do
+    inspect_source @cop, "assert !x, 'a failure message'"
+    assert_offense @cop, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`"
+  end
+
   test "rejects 'assert !' with a complex value" do
     inspect_source @cop, "assert !a.b(c)"
     assert_offense @cop, "^^^^^^^^^^^^^^ Prefer `assert_not` over `assert !`"
@@ -23,6 +28,11 @@ class AssertNotTest < ActiveSupport::TestCase
   test "autocorrects `assert !`" do
     corrected = autocorrect_source(@cop, "assert !false")
     assert_equal "assert_not false", corrected
+  end
+
+  test "autocorrects 'assert !' with a failure message" do
+    corrected = autocorrect_source(@cop, "assert !x, 'a failure message'")
+    assert_equal "assert_not x, 'a failure message'", corrected
   end
 
   test "autocorrects `assert !` with extra spaces" do


### PR DESCRIPTION
Since Rubocop 0.56.1 with `Rails/AssertNot`, and `Rails/RefuteMethods`
hasn't been released yet, and we haven't considered replacing of `CustomCops` yet,
it makes sense to add these tests.

Follow up 1dc17e7b2e6814c3a6b476f93df4e8983d0a3e42
r? @kamipo 