### PR TITLE
Correct default value of `unknown_asset_fallback`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -165,7 +165,7 @@ pipeline is enabled. It is set to `true` by default.
 
 * `config.assets.precompile` allows you to specify additional assets (other than `application.css` and `application.js`) which are to be precompiled when `rake assets:precompile` is run.
 
-* `config.assets.unknown_asset_fallback` allows you to modify the behavior of the asset pipeline when an asset is not in the pipeline, if you use sprockets-rails 3.2.0 or newer. Defaults to `true`.
+* `config.assets.unknown_asset_fallback` allows you to modify the behavior of the asset pipeline when an asset is not in the pipeline, if you use sprockets-rails 3.2.0 or newer. Defaults to `false`.
 
 * `config.assets.prefix` defines the prefix where assets are served from. Defaults to `/assets`.
 


### PR DESCRIPTION
`Rails.application.config.assets.unknown_asset_fallback` now defaults to `false` in an unmodified Rails application, but the guides say it defaults to `true`. This commit fixes the guide.

### Summary

The default value of this configuration option is `false`; I believe this is true as of Rails 5.1, and certainly is in Rails 5.2; this was verified by generating a new Rails application, and running the following in a development console:

```ruby
Rails.application.config.assets.unknown_asset_fallback => false
Sprockets::Railtie.config.assets.unknown_asset_fallback # => false
ActionView::Base.unknown_asset_fallback # => false
```

The setting of this value can be seen here: https://github.com/rails/rails/blob/0ec23effa74e8e9da6ebb14afbd335bea470ab3e/railties/lib/rails/application/configuration.rb#L84