### PR TITLE
Fix route eager loading

### DIFF
--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -56,6 +56,7 @@ module ActionDispatch
       end
 
       def simulator
+        return if ast.nil?
         @simulator ||= begin
           gtg = GTG::Builder.new(ast).transition_table
           GTG::Simulator.new(gtg)

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -127,7 +127,7 @@ module Rails
       initializer :set_routes_reloader_hook do |app|
         reloader = routes_reloader
         reloader.eager_load = app.config.eager_load
-        reloader.execute_if_updated
+        reloader.execute
         reloaders << reloader
         app.reloader.to_run do
           # We configure #execute rather than #execute_if_updated because if

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -7,7 +7,7 @@ module Rails
     class RoutesReloader
       attr_reader :route_sets, :paths
       attr_accessor :eager_load
-      delegate :updated?, to: :updater
+      delegate :execute_if_updated, :execute, :updated?, to: :updater
 
       def initialize
         @paths      = []
@@ -19,21 +19,9 @@ module Rails
         clear!
         load_paths
         finalize!
+        route_sets.each(&:eager_load!) if eager_load
       ensure
         revert
-      end
-
-      def execute
-        ret = updater.execute
-        route_sets.each(&:eager_load!) if eager_load
-        ret
-      end
-
-      def execute_if_updated
-        if updated = updater.execute_if_updated
-          route_sets.each(&:eager_load!) if eager_load
-        end
-        updated
       end
 
     private

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -27,11 +27,7 @@ module Rails
     private
 
       def updater
-        @updater ||= begin
-          updater = ActiveSupport::FileUpdateChecker.new(paths) { reload! }
-          updater.execute
-          updater
-        end
+        @updater ||= ActiveSupport::FileUpdateChecker.new(paths) { reload! }
       end
 
       def clear!


### PR DESCRIPTION
### Summary

My jRuby/Puma application is encountering issues #23699 & #33026 which were supposed to be fixed by #27647. 

I found that the routes were not being eager loaded when `config.eager_load = true` because RoutesReloader:33 `updater.execute_if_updated` returns false at application startup. Given that the only thing `RoutesReloader#execute` & `RoutesReloader#execute_if_updated` do is to execute the updater which reloads the routes, it made sense to just eager load whenever the routes are reloaded (and eager loading is enabled).

Fixing the first issue exposed another issue. The default behavior of lazily building the routes means that route sets with no anchored routes work because these routes are never visited or initialized. Eager loading the routes requires an extra check to avoid trying to build the routes simulator when there is no AST.

CC @rafaelfranca 
