### PR TITLE
[ci skip] Added instructions for using base64 private keys in Active Storage

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -171,6 +171,16 @@ google:
   bucket: ""
 ```
 
+Optionally provide a Base64 encoded private key:
+
+```yaml
+google:
+  service: GCS
+  credentials: <%= Base64.decode64(Rails.application.credentials.dig(:gcs, :private_key)) %>
+  project: ""
+  bucket: ""
+```
+
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:
 
 ```ruby


### PR DESCRIPTION
### Summary

Needing a way to to use ActiveStorage with GCS on Heroku, and not wanting to store my service account private key in source control, I tried building the hash of credentials ([as described here](http://edgeguides.rubyonrails.org/active_storage_overview.html#google-cloud-storage-service)) but kept running into yaml formatting issues (probably related to the key itself). I then Base64 encoded my private key, added it to my Rails Credentials, and it worked. This change documents the setup.