### PR TITLE
Handle pid collisions safely in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1020,14 +1020,12 @@ module ActiveRecord
       # can be used as an argument for #establish_connection, for easily
       # re-establishing the connection.
       def remove_connection(spec_name)
-        pool = owner_to_pool.delete(spec_name)
-        if ancestor_owner_to_pool = owner_to_pool_from_any_process_for(spec_name)
-          ancestor_owner_to_pool.delete(spec_name).discard!
-        end
-        if pool
+        if pool = owner_to_pool.delete(spec_name)
           pool.automatic_reconnect = false
           pool.disconnect!
           pool.spec.config
+        elsif ancestor_owner_to_pool = owner_to_pool_from_any_process_for(spec_name)
+          ancestor_owner_to_pool.delete(spec_name).discard!
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -919,7 +919,7 @@ module ActiveRecord
         end
       end
 
-      def self.discard_unowned_pools(pid_map , ancestor_map) # :nodoc:
+      def self.discard_unowned_pools(pid_map, ancestor_map) # :nodoc:
         ancestor_pids = []
         pid_map.each do |pid, pools|
           next if pid == Process.pid

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1022,7 +1022,7 @@ module ActiveRecord
       def remove_connection(spec_name)
         pool = owner_to_pool.delete(spec_name)
         if ancestor_owner_to_pool = owner_to_pool_from_any_process_for(spec_name)
-          ancestor_owner_to_pool.delete(spec_name)
+          ancestor_owner_to_pool.delete(spec_name).discard!
         end
         if pool
           pool.automatic_reconnect = false
@@ -1040,6 +1040,7 @@ module ActiveRecord
           # which may have been forked.
           if ancestor_owner_to_pool = owner_to_pool_from_any_process_for(spec_name)
             ancestor_pool = ancestor_owner_to_pool[spec_name]
+            ancestor_pool.discard!
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
             # the specification and establish a new connection with it.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -920,9 +920,13 @@ module ActiveRecord
       end
 
       def self.discard_unowned_pools(pid_map) # :nodoc:
+        ancestor_pids = []
         pid_map.each do |pid, pools|
-          pools.values.compact.each(&:discard!) unless pid == Process.pid
+          next unless pid == Process.pid
+          pools.values.compact.each(&:discard!)
+          ancestor_pids << pid
         end
+        ancestor_pids.each { |pid| pid_map.delete(pid) }
       end
 
       def initialize

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -56,11 +56,11 @@ class QueryCacheTest < ActiveRecord::TestCase
   private def with_temporary_connection_pool
     old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
     new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec
-    ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
+    ActiveRecord::Base.connection_handler.send(:pools)["primary"] = new_pool
 
     yield
   ensure
-    ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
+    ActiveRecord::Base.connection_handler.send(:pools)["primary"] = old_pool
   end
 
   def test_query_cache_across_threads

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -56,11 +56,11 @@ class QueryCacheTest < ActiveRecord::TestCase
   private def with_temporary_connection_pool
     old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
     new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec
-    ActiveRecord::Base.connection_handler.send(:pools)["primary"] = new_pool
+    ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
 
     yield
   ensure
-    ActiveRecord::Base.connection_handler.send(:pools)["primary"] = old_pool
+    ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
   end
 
   def test_query_cache_across_threads


### PR DESCRIPTION
### Summary

Due to pid recycling, it is possible for a process to have the same pid as its
grandparent's. A map from pid to connection pools is kept in
`ActiveRecord::ConnectionAdapters::ConnectionHandler`. If a process has the
same pid as its grandparent, then we might fetch a connection pool from this
map that has already been discarded. This can lead to errors when
`#establish_connection` is called in a process whose pid is the same as its
grandparent's.

In addition to discarding the connection pools belonging to an ancestor
process, we should also delete them from the pid map to avoid the pid collision
danger in descendant processes.

Fixes #33022.