### PR TITLE
Add deprecation warning when String#first and String#last receive neg…

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate using negative limits in `String#first` and `String#last`.
+
+    *Gannon McGibbon*, *Eric Turner*
+
 *   Fix bug where `#without` for `ActiveSupport::HashWithIndifferentAccess` would fail
     with symbol arguments
 

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -75,6 +75,10 @@ class String
   #   str.first(0) # => ""
   #   str.first(6) # => "hello"
   def first(limit = 1)
+    ActiveSupport::Deprecation.warn(
+      "Calling String#first with a negative integer limit " \
+      "will raise an ArgumentError in Rails 6.1."
+    ) if limit < 0
     if limit == 0
       ""
     elsif limit >= size
@@ -95,6 +99,10 @@ class String
   #   str.last(0) # => ""
   #   str.last(6) # => "hello"
   def last(limit = 1)
+    ActiveSupport::Deprecation.warn(
+      "Calling String#last with a negative integer limit " \
+      "will raise an ArgumentError in Rails 6.1."
+    ) if limit < 0
     if limit == 0
       ""
     elsif limit >= size

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -469,6 +469,15 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_not_same different_string, string
   end
 
+  test "#first with negative Integer is deprecated" do
+    string = "hello"
+    message = "Calling String#first with a negative integer limit " \
+              "will raise an ArgumentError in Rails 6.1."
+    assert_deprecated(message) do
+      string.first(-1)
+    end
+  end
+
   test "#last returns the last character" do
     assert_equal "o", "hello".last
     assert_equal "x", "x".last
@@ -485,6 +494,15 @@ class StringAccessTest < ActiveSupport::TestCase
     string = "hello"
     different_string = string.last(5)
     assert_not_same different_string, string
+  end
+
+  test "#last with negative Integer is deprecated" do
+    string = "hello"
+    message = "Calling String#last with a negative integer limit " \
+              "will raise an ArgumentError in Rails 6.1."
+    assert_deprecated(message) do
+      string.last(-1)
+    end
   end
 
   test "access returns a real string" do


### PR DESCRIPTION
…ative integers

### Summary

This adds a deprecation warning when calling`String#first` and `String#last` with negative integer arguments. The current behaviour is the following:
```
"hello".last(-1) #=> "ello"
"hello".first(-1) #=> "hell"
"hello".last(-6) #=> nil
"hello".first(-6) #=> ""
```
As you can see, it doesn't really line up with `Array`'s behaviour:
```
["h", "e", "l", "l", "o"].last(-1) #=> ArgumentError (negative array size)
["h", "e", "l", "l", "o"].first(-1) #=> ArgumentError (negative array size)
```

See https://github.com/rails/rails/pull/29105 for the discussion.
