### PR TITLE
refactor: remove useless code

### DIFF
--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -50,12 +50,12 @@ module ActionView
             name_and_id["id"] = name_and_id["for"]
           else
             name_and_id.delete("id")
+            options["for"] = nil
           end
 
           add_default_name_and_id_for_value(tag_value, name_and_id)
           options.delete("index")
           options.delete("namespace")
-          options["for"] = name_and_id["id"] unless options.key?("for")
 
           builder = LabelBuilder.new(@template_object, @object_name, @method_name, @object, tag_value)
 


### PR DESCRIPTION
### Summary
I think `options["for"] = name_and_id["id"] unless options.key?("for")` is useless.
In this method `render`, value of key `for` in `option` and its copy `name_and_id` dosen't change.
When `option` has key `for`, `options["for"] = name_and_id["id"] unless options.key?("for")` dosen't work. When `option` dosen't has key `for`, `name_and_id["for"]` returns false and `name_and_id["id"] is deleted. `options.key?("for")` returns false, so `options["for"] = name_and_id["id"]` executed. But `name_and_id["id"]` is `nil`.

So I think `options["for"] = name_and_id["id"] unless options.key?("for")` is useless.