### PR TITLE
Child joins should be aliased when merging relations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -88,7 +88,7 @@ module ActiveRecord
             walk join_root, oj.join_root
           else
             oj.join_root.children.flat_map { |child|
-              make_join_constraints(oj.join_root, child, join_type)
+              make_join_constraints(oj.join_root, child, join_type, true)
             }
           end
         }


### PR DESCRIPTION
Related to #33063

Rails 5.2 does not alias child joins anymore, possibly causing an error about duplicated table/fields:

Example:

Using some code like:
`Post.joins(:author, :categorizations).merge(Author.select(:id)).merge(Categorization.joins(:author))`

*Before this fix:*
`
SELECT ... FROM "posts" INNER JOIN "authors" ON ... INNER JOIN "authors" ON ...
`

*After this fix:*
`
SELECT ... FROM "posts" INNER JOIN "authors" ON ... INNER JOIN "authors" "authors_categorizations" ON ...
`

Before 5.2, Rails aliased the joins, but wrongfully transformed them into a LEFT OUTER JOIN.
This fix will keep them as INNER JOINS, but make sure child joins are aliased, to avoid errors.