### PR TITLE
Model name for error message needs class

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -421,7 +421,7 @@ module ActiveModel
 
       options = {
         default: defaults,
-        model: @base.model_name.human,
+        model: @base.class.model_name.human,
         attribute: @base.class.human_attribute_name(attribute),
         value: value,
         object: @base


### PR DESCRIPTION
The error message in model name should build from the class, not the instance.  Have seen conflicts between the instance variable model_name and the class method.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
