### PR TITLE
Add a convenience method for direct SQL queries

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -66,5 +66,9 @@ module ActiveRecord
     def count_by_sql(sql)
       connection.select_value(sanitize_sql(sql), "#{name} Count").to_i
     end
+
+    def sql(text, *params)
+      connection.execute sanitize_sql(text, *params)
+    end
   end
 end


### PR DESCRIPTION
### Summary

Adds an `sql` method to ActiveRecord::Base so you can conveniently do things like this:

```
DatabaseConnection.sql 'select * from my_table where foo = ?', foo_value
```
