### PR TITLE
Reduce Memory Allocation when using .pluck

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -642,6 +642,18 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [ topic.written_on ], relation.pluck(:written_on)
   end
 
+  def test_pluck_with_type_cast_does_not_corrupt_the_query_cache
+    topic = topics(:first)
+    relation = Topic.where(id: topic.id)
+    assert_queries 1 do
+      Topic.cache do
+        kind = relation.select(:written_on).load.first.read_attribute_before_type_cast(:written_on).class
+        relation.pluck(:written_on)
+        assert_kind_of kind, relation.select(:written_on).load.first.read_attribute_before_type_cast(:written_on)
+      end
+    end
+  end
+
   def test_pluck_and_distinct
     assert_equal [50, 53, 55, 60], Account.order(:credit_limit).distinct.pluck(:credit_limit)
   end


### PR DESCRIPTION
In https://samsaffron.com/archive/2018/06/01/an-analysis-of-memory-bloat-in-active-record-5-2, it was shown that using `ActiveRecord::Relation#pluck` would allocate 5 objects per row retrieved.

This PR optimises `ActiveRecord::Result#cast_values` to avoid creating temporary arrays, reducing the number of objects allocated to 1 per row retrieved.

Benchmark script is at https://github.com/lsylvester/rails/blob/pluck-optimize-bench/activerecord/bench.rb (pluck! is the new optimised version in that branch).

The new version is up to 1.5 times faster depending on the database.

Result

```
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Using concurrent-ruby 1.0.5
Using i18n 1.0.1
Using minitest 5.11.3
Using thread_safe 0.3.6
Using tzinfo 1.2.5
Using activesupport 6.0.0.alpha from source at `../activesupport`
Using activemodel 6.0.0.alpha from source at `../activemodel`
Using activerecord 6.0.0.alpha from source at `.`
Using benchmark-ips 2.7.2
Using bundler 1.16.1
Using memory_profiler 0.9.10
Using mysql2 0.5.1
Using pg 1.0.0
Using sqlite3 1.3.13

==================================== MySQL =====================================

Warming up --------------------------------------
               pluck     8.000  i/100ms
              pluck!     9.000  i/100ms
Calculating -------------------------------------
               pluck     80.451  (± 3.7%) i/s -    408.000  in   5.077212s
              pluck!     83.794  (± 3.6%) i/s -    423.000  in   5.056341s

Comparison:
              pluck!:       83.8 i/s
               pluck:       80.5 i/s - same-ish: difference falls within error

==================================== PLUCK =====================================
Total allocated: 1146280 bytes (25100 objects)
Total retained:  560 bytes (2 objects)


==================================== PLUCK! ====================================
Total allocated: 306240 bytes (5099 objects)
Total retained:  560 bytes (2 objects)



================================== PostreSQL ===================================

Warming up --------------------------------------
               pluck    19.000  i/100ms
              pluck!    29.000  i/100ms
Calculating -------------------------------------
               pluck    192.043  (± 5.2%) i/s -    969.000  in   5.058218s
              pluck!    291.951  (± 5.8%) i/s -      1.479k in   5.082570s

Comparison:
              pluck!:      292.0 i/s
               pluck:      192.0 i/s - 1.52x  slower

==================================== PLUCK =====================================
Total allocated: 1084976 bytes (25093 objects)
Total retained:  80 bytes (1 objects)


==================================== PLUCK! ====================================
Total allocated: 244936 bytes (5092 objects)
Total retained:  80 bytes (1 objects)



==================================== SQLite ====================================

Warming up --------------------------------------
               pluck    14.000  i/100ms
              pluck!    19.000  i/100ms
Calculating -------------------------------------
               pluck    146.033  (± 4.8%) i/s -    742.000  in   5.093060s
              pluck!    186.104  (± 8.1%) i/s -    931.000  in   5.040595s

Comparison:
              pluck!:      186.1 i/s
               pluck:      146.0 i/s - 1.27x  slower

==================================== PLUCK =====================================
Total allocated: 1104480 bytes (25090 objects)
Total retained:  80 bytes (1 objects)


==================================== PLUCK! ====================================
Total allocated: 264440 bytes (5089 objects)
Total retained:  80 bytes (1 objects)

```




