### PR TITLE
Fix Collection cache key with limit and custom select 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix Collection cache key with limit and custom select
+
+    Fixes #33056.
+
+    *Federico Martinez*
+
 *   Add basic API for connection switching to support multiple databases.
 
     1) Adds a `connects_to` method for models to connect to multiple databases. Example:

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -20,9 +20,9 @@ module ActiveRecord
         select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
 
         if collection.has_limit_or_offset?
-          query = collection.select(column)
+          query = collection.select("#{column} AS collection_cache_key_timestamp")
           subquery_alias = "subquery_for_cache_key"
-          subquery_column = "#{subquery_alias}.#{timestamp_column}"
+          subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
           subquery = query.arel.as(subquery_alias)
           arel = Arel::SelectManager.new(subquery).project(select_values % subquery_column)
         else

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -42,6 +42,20 @@ module ActiveRecord
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
+    test "cache_key for relation with custom select and limit" do
+      developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5)
+      developers_with_select = developers.select("developers.*")
+      last_developer_timestamp = developers.first.updated_at
+
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers_with_select.cache_key)
+
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers_with_select.cache_key
+
+      assert_equal ActiveSupport::Digest.hexdigest(developers_with_select.to_sql), $1
+      assert_equal developers.count.to_s, $2
+      assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+    end
+
     test "cache_key for loaded relation" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5).load
       last_developer_timestamp = developers.first.updated_at


### PR DESCRIPTION
Fix Collection cache key with limit and custom select (PG:AmbigousColumn: Error)

Change query to use alias name for timestamp_column to avoid ambiguity problems when using timestamp from subquery.

It fixes https://github.com/rails/rails/issues/33056
