### PR TITLE
Convert hashes into parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -640,19 +640,17 @@ module ActionController
     #   params.transform_values { |x| x * 2 }
     #   # => <ActionController::Parameters {"a"=>2, "b"=>4, "c"=>6} permitted: false>
     def transform_values(&block)
-      if block
-        new_instance_with_inherited_permitted_status(
-          @parameters.transform_values(&block)
-        )
-      else
-        @parameters.transform_values
-      end
+      return to_enum(:transform_values) unless block_given?
+      new_instance_with_inherited_permitted_status(
+        @parameters.transform_values { |v| yield convert_value_to_parameters(v) }
+      )
     end
 
     # Performs values transformation and returns the altered
     # <tt>ActionController::Parameters</tt> instance.
     def transform_values!(&block)
-      @parameters.transform_values!(&block)
+      return to_enum(:transform_values!) unless block_given?
+      @parameters.transform_values! { |v| yield convert_value_to_parameters(v) }
       self
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -639,7 +639,7 @@ module ActionController
     #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
     #   params.transform_values { |x| x * 2 }
     #   # => <ActionController::Parameters {"a"=>2, "b"=>4, "c"=>6} permitted: false>
-    def transform_values(&block)
+    def transform_values
       return to_enum(:transform_values) unless block_given?
       new_instance_with_inherited_permitted_status(
         @parameters.transform_values { |v| yield convert_value_to_parameters(v) }
@@ -648,7 +648,7 @@ module ActionController
 
     # Performs values transformation and returns the altered
     # <tt>ActionController::Parameters</tt> instance.
-    def transform_values!(&block)
+    def transform_values!
       return to_enum(:transform_values!) unless block_given?
       @parameters.transform_values! { |v| yield convert_value_to_parameters(v) }
       self

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -190,6 +190,27 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.transform_values { |v| v }, :permitted?
   end
 
+  test "transform_values converts hashes to parameters" do
+    @params.transform_values do |value|
+      assert_kind_of ActionController::Parameters, value
+      value
+    end
+  end
+
+  test "transform_values without block yieds an enumerator" do
+    assert_kind_of Enumerator, @params.transform_values
+  end
+
+  test "transform_values! converts hashes to parameters" do
+    @params.transform_values! do |value|
+      assert_kind_of ActionController::Parameters, value
+    end
+  end
+
+  test "transform_values! without block yields an enumerator" do
+    assert_kind_of Enumerator, @params.transform_values!
+  end
+
   test "value? returns true if the given value is present in the params" do
     params = ActionController::Parameters.new(city: "Chicago", state: "Illinois")
     assert params.value?("Chicago")


### PR DESCRIPTION
This is my first pull request to Rails, be gentle. 🙂 

### Summary

Ensure `ActionController::Parameters#transform_values` and
`ActionController::Parameters#transform_values!` converts hashes into
parameters.

Closes #33044.

### Other Information
