### PR TITLE
Add/Remove `require`

### DIFF
--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -5,6 +5,7 @@ require "multibyte_test_helpers"
 require "stringio"
 require "fileutils"
 require "tempfile"
+require "tmpdir"
 require "concurrent/atomics"
 
 class LoggerTest < ActiveSupport::TestCase

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -3,15 +3,10 @@
 require "abstract_unit"
 require "multibyte_test_helpers"
 
-require "fileutils"
-require "open-uri"
-require "tmpdir"
-
 class MultibyteConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
   UNIDATA_FILE = "/NormalizationTest.txt"
-  FileUtils.mkdir_p(CACHE_DIR)
   RUN_P = begin
             Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)
           rescue

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -3,10 +3,6 @@
 require "abstract_unit"
 require "multibyte_test_helpers"
 
-require "fileutils"
-require "open-uri"
-require "tmpdir"
-
 class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -3,10 +3,6 @@
 require "abstract_unit"
 require "multibyte_test_helpers"
 
-require "fileutils"
-require "open-uri"
-require "tmpdir"
-
 class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "fileutils"
+require "open-uri"
+require "tmpdir"
+
 module MultibyteTestHelpers
   class Downloader
     def self.download(from, to)


### PR DESCRIPTION
Remove unused `require`

- `activesupport/multibyte_normalization_conformance_test.rb`
  `fileutils`, `tmpdir`, and `open-uri` are unused since c245ca3, c245ca3, and 7d7c2d1 in accordance.

- `activesupport/test/multibyte_conformance_test.rb`
  `tmpdir`, and `open-uri` are unused since c245ca3, and 7d7c2d1 in accordance.
  Remove using of `fileutils` since c245ca3.

- `activesupport/test/multibyte_grapheme_break_conformance_test.rb`
  `fileutils`, `tmpdir`, and `open-uri` are unused since c245ca3, c245ca3, and 7d7c2d1 in accordance.


Add missing `require` 

`activesupport/test/logger_test.rb` requires `tmpdir`.
`activesupport/test/multibyte_test_helpers.rb` requires `filutils`, `open-uri`, and `tmpdir`.