### PR TITLE
Fix example of `index_with`

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2045,10 +2045,10 @@ The method `index_with` generates a hash with the elements of an enumerable as k
 is either a passed default or returned in a block.
 
 ```ruby
-%i( title body created_at ).index_with { |attr_name| public_send(attr_name) }
+%i( title body created_at ).index_with { |attr_name| post.public_send(attr_name) }
 # => { title: "hey", body: "what's up?", … }
 
-WEEKDAYS.index_with([ Interval.all_day ])
+WEEKDAYS.index_with(Interval.all_day)
 # => { monday: [ 0, 1440 ], … }
 ```
 


### PR DESCRIPTION
- Clarify executor of `public_send`.
- Do not wrap `Interval.all_day` into [] since
  an array is expected as a returned value.

Related to #32523.

[ci skip]
