### PR TITLE
Add `ActiveSupport::CompareWithRange` to API docs

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  module CompareWithRange #:nodoc:
+  module CompareWithRange
     # Extends the default Range#=== to support range comparisons.
     #  (1..5) === (1..5) # => true
     #  (1..5) === (2..3) # => true


### PR DESCRIPTION
Since it is documented in the guides
http://edgeguides.rubyonrails.org/active_support_core_extensions.html#include-questionmark-and-cover-questionmark
we can add it to API docs http://edgeapi.rubyonrails.org too.

[ci skip]
