### PR TITLE
remove instance variables from index and create methods

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -8,9 +8,9 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   # GET <%= route_url %>
   def index
-    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+    <%= plural_table_name %> = <%= orm_class.all(class_name) %>
 
-    render json: <%= "@#{plural_table_name}" %>
+    render json: <%= "#{plural_table_name}" %>
   end
 
   # GET <%= route_url %>/1
@@ -20,12 +20,12 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   # POST <%= route_url %>
   def create
-    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+    <%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
-    if @<%= orm_instance.save %>
-      render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %>
+    if <%= orm_instance.save %>
+      render json: <%= "#{singular_table_name}" %>, status: :created, location: <%= "#{singular_table_name}" %>
     else
-      render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
+      render json: <%= "#{orm_instance.errors}" %>, status: :unprocessable_entity
     end
   end
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -19,7 +19,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/class UsersController < ApplicationController/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@users = User\.all/, m)
+        assert_match(/users = User\.all/, m)
       end
 
       assert_instance_method :show, content
@@ -31,8 +31,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :edit, content
 
       assert_instance_method :create, content do |m|
-        assert_match(/@user = User\.new\(user_params\)/, m)
-        assert_match(/@user\.save/, m)
+        assert_match(/user = User\.new\(user_params\)/, m)
+        assert_match(/user\.save/, m)
       end
 
       assert_instance_method :update, content do |m|
@@ -108,8 +108,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "test/controllers/users_controller_test.rb" do |content|
       assert_match(/class UsersControllerTest < ActionDispatch::IntegrationTest/, content)
       assert_match(/test "should get index"/, content)
-      assert_match(/post users_url, params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}/, content)
-      assert_match(/patch user_url\(@user\), params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}/, content)
+      assert_match(/post users_url, params: \{ user: \{ age: user\.age, name: user\.name, organization_id: user\.organization_id, organization_type: user\.organization_type \} \}/, content)
+      assert_match(/patch user_url\(user\), params: \{ user: \{ age: user\.age, name: user\.name, organization_id: user\.organization_id, organization_type: user\.organization_type \} \}/, content)
     end
   end
 
@@ -120,7 +120,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/class UsersControllerTest < ActionDispatch::IntegrationTest/, content)
       assert_match(/test "should get index"/, content)
       assert_match(/post users_url, params: \{ user: \{  \} \}/, content)
-      assert_match(/patch user_url\(@user\), params: \{ user: \{  \} \}/, content)
+      assert_match(/patch user_url\(user\), params: \{ user: \{  \} \}/, content)
     end
   end
 
@@ -141,7 +141,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/class UsersController < ApplicationController/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@users = User\.all/, m)
+        assert_match(/users = User\.all/, m)
       end
     end
   end
@@ -160,8 +160,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/class UsersController < ApplicationController/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@users = User\.find\(:all\)/, m)
-        assert_no_match(/@users = User\.all/, m)
+        assert_match(/users = User\.find\(:all\)/, m)
+        assert_no_match(/users = User\.all/, m)
       end
     end
   ensure
@@ -172,11 +172,11 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     run_generator ["Admin::User", "--model-name=User"]
     assert_file "app/controllers/admin/users_controller.rb" do |content|
       assert_instance_method :index, content do |m|
-        assert_match("@users = User.all", m)
+        assert_match("users = User.all", m)
       end
 
       assert_instance_method :create, content do |m|
-        assert_match("redirect_to [:admin, @user]", m)
+        assert_match("redirect_to [:admin, user]", m)
       end
 
       assert_instance_method :update, content do |m|
@@ -234,8 +234,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/before_action :set_user, only: \[:show, :update, :destroy\]/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@users = User\.all/, m)
-        assert_match(/render json: @users/, m)
+        assert_match(/users = User\.all/, m)
+        assert_match(/render json: users/, m)
       end
 
       assert_instance_method :show, content do |m|
@@ -243,9 +243,9 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :create, content do |m|
-        assert_match(/@user = User\.new\(user_params\)/, m)
-        assert_match(/@user\.save/, m)
-        assert_match(/@user\.errors/, m)
+        assert_match(/user = User\.new\(user_params\)/, m)
+        assert_match(/user\.save/, m)
+        assert_match(/user\.errors/, m)
       end
 
       assert_instance_method :update, content do |m|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -120,8 +120,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/before_action :set_product_line, only: \[:show, :update, :destroy\]/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@product_lines = ProductLine\.all/, m)
-        assert_match(/render json: @product_lines/, m)
+        assert_match(/product_lines = ProductLine\.all/, m)
+        assert_match(/render json: product_lines/, m)
       end
 
       assert_instance_method :show, content do |m|
@@ -129,9 +129,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :create, content do |m|
-        assert_match(/@product_line = ProductLine\.new\(product_line_params\)/, m)
-        assert_match(/@product_line\.save/, m)
-        assert_match(/@product_line\.errors/, m)
+        assert_match(/product_line = ProductLine\.new\(product_line_params\)/, m)
+        assert_match(/product_line\.save/, m)
+        assert_match(/product_line\.errors/, m)
       end
 
       assert_instance_method :update, content do |m|


### PR DESCRIPTION
Removed instance variables from create and index methods, these variables must be local variables because they are only used in the context of the methods.  This is basically for rails api generate controller.
