### PR TITLE
Refactor activestorage/test/models/attached_test.rb

### DIFF
--- a/activestorage/test/models/attached_test.rb
+++ b/activestorage/test/models/attached_test.rb
@@ -4,8 +4,6 @@ require "test_helper"
 require "database/setup"
 
 class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
   setup do
     @user = User.create!(name: "Josh")
   end
@@ -19,16 +17,18 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     # inherited only
     assert_equal "funky.jpg", @user.avatar.filename.to_s
 
-    User.class_eval do
-      def avatar
-        super.filename.to_s.reverse
+    begin
+      User.class_eval do
+        def avatar
+          super.filename.to_s.reverse
+        end
       end
+
+      # override with super
+      assert_equal "funky.jpg".reverse, @user.avatar
+    ensure
+      User.send(:remove_method, :avatar)
     end
-
-    # override with super
-    assert_equal "funky.jpg".reverse, @user.avatar
-
-    User.send(:remove_method, :avatar)
   end
 
   test "overriding has_many_attached methods works" do
@@ -39,16 +39,18 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
     assert_equal "wonky.jpg", @user.highlights.second.filename.to_s
 
-    User.class_eval do
-      def highlights
-        super.reverse
+    begin
+      User.class_eval do
+        def highlights
+          super.reverse
+        end
       end
+
+      # override with super
+      assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
+      assert_equal "funky.jpg", @user.highlights.second.filename.to_s
+    ensure
+      User.send(:remove_method, :highlights)
     end
-
-    # override with super
-    assert_equal "wonky.jpg", @user.highlights.first.filename.to_s
-    assert_equal "funky.jpg", @user.highlights.second.filename.to_s
-
-    User.send(:remove_method, :highlights)
   end
 end


### PR DESCRIPTION
Don't include `ActiveJob::TestHelper` since there is no test that uses it.

Ensure removing of overridden User's methods.

Related to https://github.com/rails/rails/pull/33085#issuecomment-395548563
`Module#remove_method` is private in Ruby 2.4.
r? @georgeclaghorn

Related to fd0bd1bf682622f064ac437ceee4e1b2a6b6d3b9
