### PR TITLE
Ensure to run initializers that extend Active Record before `load_config_initializers`

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -57,7 +57,7 @@ module ActiveStorage
       end
     end
 
-    initializer "active_storage.attached" do
+    initializer "active_storage.attached", before: :load_config_initializers do
       require "active_storage/attached"
 
       ActiveSupport.on_load(:active_record) do
@@ -98,7 +98,7 @@ module ActiveStorage
       end
     end
 
-    initializer "active_storage.reflection" do
+    initializer "active_storage.reflection", before: :load_config_initializers do
       ActiveSupport.on_load(:active_record) do
         include Reflection::ActiveRecordExtensions
         ActiveRecord::Reflection.singleton_class.prepend(Reflection::ReflectionExtension)

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -268,5 +268,23 @@ module ApplicationTests
       require "#{app_path}/config/environment"
       assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
     end
+
+    # ASt
+    test "active storage's initializers run before 'load_config_initializers'" do
+      rails %w(generate model user email:string)
+      rails %w(db:migrate)
+
+      app_file "app/models/user.rb", <<-RUBY
+        class User < ApplicationRecord
+          has_one_attached :avatar
+        end
+      RUBY
+
+      app_file "config/initializers/load_models.rb", <<-RUBY
+        User.to_s
+      RUBY
+
+      assert_nothing_raised { app "development" }
+    end
   end
 end


### PR DESCRIPTION
Currently, initializers which extend Active Record are executed after `load_config_initializers`.

Therefore, when loading files under `config/initializers`, macro methods are not defined and loading the model in which those methods are used will raise `NoMethodError`.

To fix this, make necessary initializers run before `load_config_initializers`.

Fixes #32933

