### PR TITLE
Use Rack to generate query information under test

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -109,7 +109,7 @@ module ActionController
           when :xml
             data = non_path_parameters.to_xml
           when :url_encoded_form
-            data = non_path_parameters.to_query
+            data = Rack::Utils.build_nested_query(non_path_parameters)
           else
             @custom_param_parsers[content_mime_type.symbol] = ->(_) { non_path_parameters }
             data = non_path_parameters.to_query

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -220,7 +220,15 @@ XML
     params = Hash[:page, { name: "page name" }, "some key", 123]
     post :render_raw_post, params: params.dup
 
-    assert_equal params.to_query, @response.body
+    assert_equal Rack::Utils.build_nested_query(params), @response.body
+  end
+
+  def test_params_round_trip
+    params = {"foo"=>{"contents"=>[{"name"=>"gorby", "id"=>"123"}, {"name"=>"puff", "d"=>"true"}]}}
+    post :test_params, params: params.dup
+
+    controller_info = { "controller" => "test_case_test/test", "action" => "test_params" }
+    assert_equal params.merge(controller_info), JSON.parse(@response.body)
   end
 
   def test_body_stream
@@ -228,7 +236,7 @@ XML
 
     post :render_body, params: params.dup
 
-    assert_equal params.to_query, @response.body
+    assert_equal Rack::Utils.build_nested_query(params), @response.body
   end
 
   def test_document_body_and_params_with_post


### PR DESCRIPTION
`to_query` sorts parameters before encoding them.  This causes a round
tripping issue as noted here:

  https://github.com/rails/rails/issues/23997#issuecomment-328297933
  https://github.com/rails/rails/issues/10529#issuecomment-328298109
  https://github.com/rails/rails/pull/30558

Unfortunately, that method is being used to generate cache keys, so its
results need to be stable:

  https://github.com/rails/rails/commit/10dec0e65e1f4d87f411b4361045eba86b121be9

However, the test harness is only using `to_query` to encode parameters
before sending them to the controller so the "cache key" usecase doesn't
apply here.

This commit adds a test that demonstrates the round trip problems and
changes the serialization strategy to use Rack for encoding the
parameters rather than `to_query`.