### PR TITLE
Stop reaper when a connection pool is discarded.

### DIFF
--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -24,6 +24,10 @@ module ActiveRecord
           @reaped = false
         end
 
+        def connections
+          []
+        end
+
         def reap
           @reaped = true
         end


### PR DESCRIPTION
### Summary

Removing a connection pool via `ActiveRecord::Base.connection_handler.remove_connection` disconnects the pool but the connection pool's reaper continues to run forever.

## Script to reproduce

```
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'pg'
  gem 'activesupport', '5.2'
  gem 'activerecord', '5.2'
  gem 'activemodel', '5.2'
end

require 'active_record'

class ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper
  attr_reader :pool, :frequency

  def initialize(pool, frequency)
    @pool      = pool
    @frequency = frequency
  end

  def run
    puts "called"
    return unless frequency && frequency > 0

    Thread.new(1, pool) { |t, p|
      loop do
        puts "I'm still reaping"
        sleep t
        p.reap
        p.flush
      end
    }
  end
end

ActiveRecord::Base.establish_connection(
  :adapter => "postgresql",
  :database => "test_db"
)

pg = ActiveRecord::Base.connection.raw_connection

pg.async_exec <<SQL
drop table if exists topics
SQL

pg.async_exec <<SQL
CREATE TABLE topics (
    id integer NOT NULL,
    title character varying NOT NULL
)
SQL

class Topic < ActiveRecord::Base
end

ActiveRecord::Base.connection_handler.remove_connection(
  ActiveRecord::Base.connection_pool.spec.name
)

loop { sleep }
```
