### PR TITLE
[ci skip]Add the comment about webP to ActiveStorage::Analyzer::ImageAnalyzer

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer.rb
@@ -11,7 +11,8 @@ module ActiveStorage
   #   # => { width: 4104, height: 2736 }
   #
   # This analyzer relies on the third-party {MiniMagick}[https://github.com/minimagick/minimagick] gem. MiniMagick requires
-  # the {ImageMagick}[http://www.imagemagick.org] system library.
+  # the {ImageMagick}[http://www.imagemagick.org] system library and if you want to analyze webP images,
+  # the {dwebp}[https://developers.google.com/speed/webp/docs/dwebp] command is also required.
   class Analyzer::ImageAnalyzer < Analyzer
     def self.accept?(blob)
       blob.image?


### PR DESCRIPTION
### Summary

If you want to analyze webP images by using `ActiveStorage::Analyzer::ImageAnalyzer`,
MiniMagick requires the dwebp system library command.
If the dwebp command is not installed, `ActiveStorage::AnalyzeJob` will
raise `MiniMagick::Error` as below.

```
Error performing ActiveStorage::AnalyzeJob (Job ID: 5aa9db9a-0bea-4c43-ba17-e491786eab73) from Async(default) in 63.23ms: MiniMagick::Error (`identify -format %[orientation] /var/folders/0f/h8zh34wn75sgq060r86ftc0r0000gn/T/ActiveStorage20180608-14490-tc8u3r.webp[0]` failed with error:
identify: delegate failed `'dwebp' -pam '%i' -o '%o'' @ error/delegate.c/InvokeDelegate/1844.
identify: unable to open file '/var/folders/0f/h8zh34wn75sgq060r86ftc0r0000gn/T/magick-14529brafxkWfzyJA': No such file or directory @ error/constitute.c/ReadImage/552.
```

### Other Information

dwebp
https://developers.google.com/speed/webp/docs/dwebp