### PR TITLE
Refactor actioncable's tests

### DIFF
--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -5,7 +5,7 @@ require "minitest/mock"
 require "stubs/test_connection"
 require "stubs/room"
 
-class ActionCable::Channel::BaseTest < ActiveSupport::TestCase
+class ActionCable::Channel::BaseTest < ActionCable::TestCase
   class ActionCable::Channel::Base
     def kick
       @last_action = [ :kick ]

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -5,7 +5,7 @@ require "active_support/testing/method_call_assertions"
 require "stubs/test_connection"
 require "stubs/room"
 
-class ActionCable::Channel::BroadcastingTest < ActiveSupport::TestCase
+class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   class ChatChannel < ActionCable::Channel::Base

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 require "stubs/test_connection"
 require "stubs/room"
 
 class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class ChatChannel < ActionCable::Channel::Base
   end
 

--- a/actioncable/test/channel/naming_test.rb
+++ b/actioncable/test/channel/naming_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class ActionCable::Channel::NamingTest < ActiveSupport::TestCase
+class ActionCable::Channel::NamingTest < ActionCable::TestCase
   class ChatChannel < ActionCable::Channel::Base
   end
 

--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -6,7 +6,7 @@ require "stubs/room"
 require "active_support/time"
 require "active_support/testing/method_call_assertions"
 
-class ActionCable::Channel::PeriodicTimersTest < ActiveSupport::TestCase
+class ActionCable::Channel::PeriodicTimersTest < ActionCable::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   class ChatChannel < ActionCable::Channel::Base

--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -4,11 +4,8 @@ require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"
 require "active_support/time"
-require "active_support/testing/method_call_assertions"
 
 class ActionCable::Channel::PeriodicTimersTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class ChatChannel < ActionCable::Channel::Base
     # Method name arg
     periodically :send_updates, every: 1

--- a/actioncable/test/channel/rejection_test.rb
+++ b/actioncable/test/channel/rejection_test.rb
@@ -5,7 +5,7 @@ require "minitest/mock"
 require "stubs/test_connection"
 require "stubs/room"
 
-class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
+class ActionCable::Channel::RejectionTest < ActionCable::TestCase
   class SecretChannel < ActionCable::Channel::Base
     def subscribed
       reject if params[:id] > 0

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 require "minitest/mock"
 require "stubs/test_connection"
 require "stubs/room"
@@ -164,8 +163,6 @@ module ActionCable::StreamTests
   end
 
   class StreamFromTest < ActionCable::TestCase
-    include ActiveSupport::Testing::MethodCallAssertions
-
     setup do
       @server = TestServer.new(subscription_adapter: ActionCable::SubscriptionAdapter::Async)
       @server.config.allowed_request_origins = %w( http://rubyonrails.com )

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -7,7 +7,6 @@ require "websocket-client-simple"
 require "json"
 
 require "active_support/hash_with_indifferent_access"
-require "active_support/testing/method_call_assertions"
 
 ####
 # 😷 Warning suppression 😷
@@ -28,8 +27,6 @@ WebSocket::Frame::Data.prepend Module.new {
 ####
 
 class ClientTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   WAIT_WHEN_EXPECTING_EVENT = 2
   WAIT_WHEN_NOT_EXPECTING_EVENT = 0.5
 

--- a/actioncable/test/connection/authorization_test.rb
+++ b/actioncable/test/connection/authorization_test.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 require "stubs/test_server"
 
 class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     attr_reader :websocket
 

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -3,11 +3,8 @@
 require "test_helper"
 require "stubs/test_server"
 require "active_support/core_ext/object/json"
-require "active_support/testing/method_call_assertions"
 
 class ActionCable::Connection::BaseTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     attr_reader :websocket, :subscriptions, :message_buffer, :connected
 

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -2,11 +2,8 @@
 
 require "test_helper"
 require "stubs/test_server"
-require "active_support/testing/method_call_assertions"
 
 class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     attr_reader :connected, :websocket, :errors
 

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 require "stubs/test_server"
 require "stubs/user"
 
 class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
     attr_reader :websocket

--- a/actioncable/test/connection/stream_test.rb
+++ b/actioncable/test/connection/stream_test.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 require "minitest/mock"
 require "stubs/test_server"
 
 class ActionCable::Connection::StreamTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     attr_reader :connected, :websocket, :errors
 

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "active_support/testing/method_call_assertions"
 
 class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Connection < ActionCable::Connection::Base
     attr_reader :websocket
 

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -5,7 +5,7 @@ require "stubs/test_server"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/testing/method_call_assertions"
 
-class BaseTest < ActiveSupport::TestCase
+class BaseTest < ActionCable::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   def setup

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -3,11 +3,8 @@
 require "test_helper"
 require "stubs/test_server"
 require "active_support/core_ext/hash/indifferent_access"
-require "active_support/testing/method_call_assertions"
 
 class BaseTest < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   def setup
     @server = ActionCable::Server::Base.new
     @server.config.cable = { adapter: "async" }.with_indifferent_access

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "stubs/test_server"
 
-class BroadcastingTest < ActiveSupport::TestCase
+class BroadcastingTest < ActionCable::TestCase
   test "fetching a broadcaster converts the broadcasting queue to a string" do
     broadcasting = :test_queue
     server = TestServer.new

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 require_relative "common"
 require_relative "channel_prefix"
 
-require "active_support/testing/method_call_assertions"
 require "action_cable/subscription_adapter/redis"
 
 class RedisAdapterTest < ActionCable::TestCase
@@ -31,8 +30,6 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
 end
 
 class RedisAdapterTest::Connector < ActionCable::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   test "slices url, host, port, db, and password from config" do
     config = { url: 1, host: 2, port: 3, db: 4, password: 5 }
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -30,7 +30,7 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
   end
 end
 
-class RedisAdapterTest::Connector < ActiveSupport::TestCase
+class RedisAdapterTest::Connector < ActionCable::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   test "slices url, host, port, db, and password from config" do

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 require "action_cable"
 require "active_support/testing/autorun"
+require "active_support/testing/method_call_assertions"
 
 require "puma"
 require "rack/mock"
@@ -15,6 +16,8 @@ end
 Dir[File.expand_path("stubs/*.rb", __dir__)].each { |file| require file }
 
 class ActionCable::TestCase < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   def wait_for_async
     wait_for_executor Concurrent.global_io_executor
   end

--- a/actioncable/test/worker_test.rb
+++ b/actioncable/test/worker_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class WorkerTest < ActiveSupport::TestCase
+class WorkerTest < ActionCable::TestCase
   class Receiver
     attr_accessor :last_action
 


### PR DESCRIPTION
Inherit all actioncable's test classes from `ActionCable::TestCase`
We have defined `ActionCable::TestCase` in `actioncable/test/test_helper.rb`
that we can use in order to prevent code duplication and build common
interface for actioncable's test.


Include `ActiveSupport::Testing::MethodCallAssertions` to `ActionCable::TestCase`
Remove all `include ActiveSupport::Testing::MethodCallAssertions`
in actioncable's tests since we can do it only in `ActionCable::TestCase`
in order to prevent code duplication.
We use the same approach for other modules of Rails.