### PR TITLE
Remove extra `include ActiveSupport::Testing::MethodCallAssertions`

### DIFF
--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "active_support/testing/method_call_assertions"
 
 class MethodCallAssertionsTest < ActiveSupport::TestCase
-  include ActiveSupport::Testing::MethodCallAssertions
-
   class Level
     def increment; 1; end
     def decrement; end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -5,11 +5,9 @@ require "rack/test"
 require "minitest/mock"
 
 require "action_view"
-require "active_support/testing/method_call_assertions"
 
 class PerRequestDigestCacheTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
-  include ActiveSupport::Testing::MethodCallAssertions
   include Rack::Test::Methods
 
   setup do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -14,6 +14,7 @@ require "bundler/setup" unless defined?(Bundler)
 require "active_support"
 require "active_support/testing/autorun"
 require "active_support/testing/stream"
+require "active_support/testing/method_call_assertions"
 require "active_support/test_case"
 
 RAILS_FRAMEWORK_ROOT = File.expand_path("../../..", __dir__)
@@ -430,6 +431,7 @@ class ActiveSupport::TestCase
   include TestHelpers::Rack
   include TestHelpers::Generation
   include ActiveSupport::Testing::Stream
+  include ActiveSupport::Testing::MethodCallAssertions
 
   def frozen_error_class
     Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError


### PR DESCRIPTION
Remove extra `include ActiveSupport::Testing::MethodCallAssertions`
It includes via `require "abstract_unit"`.

Include `ActiveSupport::Testing::MethodCallAssertions` in `railties/test/isolation/abstract_unit.rb`
Related to #33102
