### PR TITLE
Fix av-ujs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"
-  - "[[ $GEM != 'av:ujs' ]] || nvm install node"
+  - "[[ $GEM != 'av:ujs' ]] || nvm install v10.3.0" # FIXME: Remove version lock.
   - "[[ $GEM != 'av:ujs' ]] || node --version"
   - "[[ $GEM != 'av:ujs' ]] || (cd actionview && npm install)"
 


### PR DESCRIPTION
Although the cause is not clear, apparently when using Node.js v10.4.0 it seems that the ujs's test does not work well with headless chrome and it gets an error.
https://travis-ci.org/rails/rails/jobs/389960856 

In order to avoid build error, fixed the version temporarily to use the previous version.
