### PR TITLE
Remove redundant accessors in AC test stub

### DIFF
--- a/actioncable/test/stubs/test_adapter.rb
+++ b/actioncable/test/stubs/test_adapter.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
-  class << self; attr_accessor :subscribe_called, :unsubscribe_called end
-
   def broadcast(channel, payload)
   end
 


### PR DESCRIPTION
introduced in a0ea528b61.