### PR TITLE
Deallocate preexisting prepare statement identifiers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -202,7 +202,7 @@ module ActiveRecord
           def has_prepared_statement?(key)
             result = @connection.query "SELECT COUNT(name) AS key_count FROM pg_prepared_statements WHERE name = '#{key}'"
 
-            result.num_tuples > 0 && result[0]['key_count'].to_i > 0
+            result.num_tuples > 0 && result[0]["key_count"].to_i > 0
           rescue PG::Error
             false
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -182,7 +182,11 @@ module ActiveRecord
         end
 
         def next_key
-          "a#{@counter + 1}"
+          key = "a#{@counter + 1}"
+
+          dealloc(key)
+
+          key
         end
 
         def []=(sql, key)
@@ -191,8 +195,16 @@ module ActiveRecord
 
         private
           def dealloc(key)
-            @connection.query "DEALLOCATE #{key}" if connection_active?
+            @connection.query "DEALLOCATE #{key}" if connection_active? && has_prepared_statement?(key)
           rescue PG::Error
+          end
+
+          def has_prepared_statement?(key)
+            result = @connection.query "SELECT COUNT(name) AS key_count FROM pg_prepared_statements WHERE name = '#{key}'"
+
+            result.num_tuples > 0 && result[0]['key_count'].to_i > 0
+          rescue PG::Error
+            false
           end
 
           def connection_active?
@@ -664,15 +676,15 @@ module ActiveRecord
           @lock.synchronize do
             sql_key = sql_key(sql)
             unless @statements.key? sql_key
-              nextkey = @statements.next_key
+              next_key = @statements.next_key
               begin
-                @connection.prepare nextkey, sql
+                @connection.prepare next_key, sql
               rescue => e
                 raise translate_exception_class(e, sql)
               end
               # Clear the queue
               @connection.get_last_result
-              @statements[sql_key] = nextkey
+              @statements[sql_key] = next_key
             end
             @statements[sql_key]
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -191,7 +191,7 @@ module ActiveRecord
 
         private
           def dealloc(key)
-            @connection.query "DEALLOCATE #{key}"
+            @connection.query "DEALLOCATE #{key}" if connection_active?
           rescue PG::Error
           end
 

--- a/activerecord/test/cases/adapters/postgresql/deallocate_duplicate_prepared_statement_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/deallocate_duplicate_prepared_statement_test.rb
@@ -9,29 +9,27 @@ module ActiveRecord
 
       public :prepare_statement
 
-      class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
-        attr_accessor :counter
-      end
-
       class DeallocateDuplicatePreparedStatementTestWithTransactions < ActiveRecord::PostgreSQLTestCase
-        NOOP = "SELECT 1;"
+        NOOP_1 = "SELECT 1;"
+        NOOP_2 = "SELECT 2;"
 
         def setup
           @connection = ActiveRecord::Base.connection
         end
 
         def test_duplicate_prepared_statement
-          first_key, second_key = generate_keys
+          @connection.statements.stub :next_key, "a0" do
+            first_key, second_key = generate_keys
 
-          assert_equal first_key, second_key
+            assert_equal first_key, second_key
+          end
         end
 
         private
 
           def generate_keys
-            first_key = @connection.prepare_statement NOOP
-            @connection.statements.counter = 0
-            second_key = @connection.prepare_statement NOOP
+            first_key = @connection.prepare_statement NOOP_1
+            second_key = @connection.prepare_statement NOOP_2
 
             [first_key, second_key]
           end

--- a/activerecord/test/cases/deallocate_duplicate_prepared_statement_test.rb
+++ b/activerecord/test/cases/deallocate_duplicate_prepared_statement_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
+        attr_accessor :counter
+      end
+
+      class DeallocateDuplicatePreparedStatementTestWithTransactions < ActiveRecord::PostgreSQLTestCase
+        NOOP = "SELECT 1;"
+
+        def setup
+          @connection = ActiveRecord::Base.connection.raw_connection
+          @statement_pool = StatementPool.new(@connection, 10)
+        end
+
+        def test_duplicate_prepared_statement
+          first_key, second_key = generate_keys
+
+          assert_equal first_key, second_key
+        end
+
+        private
+
+        def generate_keys
+          first_key = @statement_pool.next_key
+          @connection.prepare first_key, NOOP
+
+          @statement_pool.counter = 0
+
+          second_key = @statement_pool.next_key
+          @connection.prepare second_key, NOOP
+
+          [first_key, second_key]
+        end
+      end
+
+      class DeallocatePreparedStatementTestWithoutTransactions < DeallocateDuplicatePreparedStatementTestWithTransactions
+        self.use_transactional_tests = false
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/deallocate_duplicate_prepared_statement_test.rb
+++ b/activerecord/test/cases/deallocate_duplicate_prepared_statement_test.rb
@@ -25,17 +25,17 @@ module ActiveRecord
 
         private
 
-        def generate_keys
-          first_key = @statement_pool.next_key
-          @connection.prepare first_key, NOOP
+          def generate_keys
+            first_key = @statement_pool.next_key
+            @connection.prepare first_key, NOOP
 
-          @statement_pool.counter = 0
+            @statement_pool.counter = 0
 
-          second_key = @statement_pool.next_key
-          @connection.prepare second_key, NOOP
+            second_key = @statement_pool.next_key
+            @connection.prepare second_key, NOOP
 
-          [first_key, second_key]
-        end
+            [first_key, second_key]
+          end
       end
 
       class DeallocatePreparedStatementTestWithoutTransactions < DeallocateDuplicatePreparedStatementTestWithTransactions


### PR DESCRIPTION
### Summary

This fixes a long running issue in active record relating to the preparation of SQL statements with identifiers already bound to existing prepared statements. This issue is best described in:

#1627
#17607
#25827

This patch resolves the solution suggested by @sgrif (https://github.com/rails/rails/pull/25827#issuecomment-233329194) of using `DEALLOCATE` rather than using UUIDs or any other approach.
