### PR TITLE
Fix bug with eager_load in development environment

### DIFF
--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -51,7 +51,7 @@ module ActionDispatch
       def ast
         @ast ||= begin
           asts = anchored_routes.map(&:ast)
-          Nodes::Or.new(asts) unless asts.empty?
+          Nodes::Or.new(asts)
         end
       end
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -493,6 +493,15 @@ module ActionDispatch
         assert_not called
       end
 
+      def test_eager_load_with_routes
+        get "/foo-bar", to: "foo#bar"
+        assert_nil router.eager_load!
+      end
+
+      def test_eager_load_without_routes
+        assert_nil router.eager_load!
+      end
+
       private
 
         def get(*args)


### PR DESCRIPTION
### Summary

Fixes the "Development Environment Lockup" bug reported in Issue #30578, and adds test coverage to protect against any similar bug in the future.

### Problem

If `config.eager_load = true` in development, then any change to a model or controller will cause an `ArgumentError (unknown firstpos: NilClass)` on the next request.

The problem occurs when secondary Engines are loaded (the Rails application is the primary Engine).  In the case of a default Rails 5.1/5.2 install, the secondary Engine triggering the problem is ActiveStorage - [stop loading ActiveStorage](https://mikerogers.io/2018/04/13/remove-activestorage-from-rails-5-2.html) and the problem goes away.  This is because, for every secondary Engine, a new RouteSet is created.  These secondary RouteSets are apparently not used – routes are not added to them (only to the primary RouteSet).  In other words, when you have a secondary Engine, then you have an empty RouteSet.  But ActionDispatch::Journey::Routes chokes on empty RouteSets.  Specifically, the `#simulator` method expects the `#asts` method to return an instance of `Nodes::Or`, but when a RouteSet is empty the `#asts` method returns `nil` and triggers the exception.

This bug was apparently introduced in https://github.com/rails/rails/commit/5b1332bb4d3c3aa5215b43004d1e7f6a8d376dd0, which calls the routes simulator during the eager_load process.

### Solution
__I think routes simulation should not trigger an exception when there is an empty RouteSet.__  The most elegant solution seems to be removing the `unless asts.empty?` that was introduced in a refactor commit in 2013: https://github.com/rails/rails/commit/2467ec8b5ce1be8481283943e830c56d0c827040#diff-d72add3debad9b63513514835f2a70b7R44.  I'm reluctant to change something so well established, but I can't determine why it was added, and it seems to have been unnecessary.  With this change, the `#asts` method returns a `Nodes::Or` object when the RouteSet is empty (with its `@children` variable simply set to an empty array).  This results in the `#simulator` method receiving a `Nodes::Or` object as expected, thereby avoiding the `ArgumentError` exception.