### PR TITLE
Fix active_model/errors docs [ci skip]

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -370,7 +370,7 @@ module ActiveModel
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
     #
-    #   The `"%{attribute} %{message}"` error format can be overridden with either
+    # The `"%{attribute} %{message}"` error format can be overridden with either
     #
     # * <tt>activemodel.errors.models.person/contacts/addresses.attributes.street.format</tt>
     # * <tt>activemodel.errors.models.person/contacts/addresses.format</tt>

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -307,7 +307,7 @@ All these configuration options are delegated to the `I18n` library.
 
 ### Configuring Active Model
 
-* `config.active_model.i18n_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files
+* `config.active_model.i18n_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files.
 
 ### Configuring Active Record
 


### PR DESCRIPTION
- Fix indentation.
![screenshot from 2018-06-12 00-34-43](https://user-images.githubusercontent.com/6443532/41258372-8fe6d95c-6dd8-11e8-89d8-9608e03ae81a.png)

- Add a missing dot to the end of the sentence.

Related to #32956
