### PR TITLE
Add comma to example in guides/source/active_storage_overview.md [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -326,7 +326,7 @@ You can bypass the content type inference from the data by passing in
 @message.image.attach(
   io: File.open('/path/to/file'),
   filename: 'file.pdf',
-  content_type: 'application/pdf'
+  content_type: 'application/pdf',
   identify: false
 )
 ```


### PR DESCRIPTION
In the Active Storage Overview Rails Guide, the third code example under '3.3 Attaching File/IO Objects' is missing a comma between the last two parameters. This pull requests adds that comma. [ci skip]