### PR TITLE
return nil when model has never any locking columns

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -140,8 +140,15 @@ module ActiveRecord
 
           # The version column used for optimistic locking. Defaults to +lock_version+.
           def locking_column
-            @locking_column = DEFAULT_LOCKING_COLUMN unless defined?(@locking_column)
-            @locking_column
+            if defined?(@locking_column)
+              @locking_column
+            else
+              if column_names.include? DEFAULT_LOCKING_COLUMN
+                DEFAULT_LOCKING_COLUMN
+              else
+                nil
+              end
+            end
           end
 
           # Reset the column used for optimistic locking back to the +lock_version+ default.

--- a/activerecord/test/cases/schema_loading_test.rb
+++ b/activerecord/test/cases/schema_loading_test.rb
@@ -36,10 +36,25 @@ class SchemaLoadingTest < ActiveRecord::TestCase
     klass = define_model do |c|
       c.table_name = :lock_without_defaults_cust
     end
+    custom_lock_version = :custom_lock_version
     klass.new
-    klass.locking_column = :custom_lock_version
+    klass.locking_column = custom_lock_version
     klass.new
     assert_equal 2, klass.load_schema_calls
+    assert_equal klass.locking_column, custom_lock_version.to_s
+  end
+
+  def test_model_has_lock_version_column_returns_lock_version
+    klass = define_model
+    assert klass.column_names.include? ActiveRecord::Locking::Optimistic::ClassMethods::DEFAULT_LOCKING_COLUMN
+    assert_equal klass.locking_column, ActiveRecord::Locking::Optimistic::ClassMethods::DEFAULT_LOCKING_COLUMN
+  end
+
+  def test_return_nil_when_model_have_not_locking_column
+    klass = define_model do |c|
+      c.table_name = :lions
+    end
+    assert_nil klass.locking_column
   end
 
   private


### PR DESCRIPTION
### Summary
return nil when model has never any locking columns.
`ActiveRecord.locking_column` method returned the string "lock_version" if there was no locking column. But if I do not have a `lock_version` column, I thought it would be natural to return `nil`, so I edited it

### Example
```ruby
class User < ActiveRecord::Base
  # This models column
  # name string
  # email string
  # lock_version integer <== locking_column
end
puts User.locking_column
# => 'lock_version'

class User < ActiveRecord::Base
  # This models column
  # name string
  # email string
  # other_locking_column integer <== locking_column
  self.locking_column = :other_locking_column
end
puts User.locking_column
# => 'other_locking_column'

class User < ActiveRecord::Base
  # This models column
  # name string
  # email string
  # <= nothing locking column
end
puts User.locking_column
# => nil
```
Thanks to read!
