### PR TITLE
Remove reference to session_store.rb initializer

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -25,7 +25,7 @@ module ActionDispatch
     # goes a step further than signed cookies in that encrypted cookies cannot
     # be altered or read by users. This is the default starting in Rails 4.
     #
-    # Configure your session store in <tt>config/initializers/session_store.rb</tt>:
+    # Configure your session store in an initializer:
     #
     #   Rails.application.config.session_store :cookie_store, key: '_your_app_session'
     #


### PR DESCRIPTION
Rails no longer generates this file, but Google is still packed with results 
suggesting it should exist, so that the doc still pointed me to it threw me 
off (had I deleted it or something?). Probably be better to be vague and
prompt the user to stick it in a config file they own.

 cc/ @matthewd 

Resolves #33124