### PR TITLE
prevent counter cache to update counter twice on belongs_to_association

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -54,6 +54,7 @@ module ActiveRecord
             set_inverse_instance(record)
             @updated = true
           else
+            owner.instance_variable_set :@_after_replace_counter_called, true
             decrement_counters
           end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -25,6 +25,7 @@ require "models/admin/user"
 require "models/ship"
 require "models/treasure"
 require "models/parrot"
+require "models/node"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -461,6 +462,20 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     comment.post = nil
 
     assert_equal 1, Post.find(post.id).comments.size
+  end
+
+  def test_belongs_to_counter_with_updating_to_nil
+    root = Node.create(name: 'parent')
+
+    Node.create(name: 'child1', parent: root)
+    Node.create(name: 'child2', parent: root)
+
+    assert_equal 2, root.children_count
+
+    root.children.last.update(parent: nil)
+    root.reload
+
+    assert_equal 1, root.children_count
   end
 
   def test_belongs_to_with_primary_key_counter

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -465,10 +465,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_counter_with_updating_to_nil
-    root = Node.create(name: 'parent')
+    root = Node.create(name: "parent")
 
-    Node.create(name: 'child1', parent: root)
-    Node.create(name: 'child2', parent: root)
+    Node.create(name: "child1", parent: root)
+    Node.create(name: "child2", parent: root)
 
     assert_equal 2, root.children_count
 

--- a/activerecord/test/models/node.rb
+++ b/activerecord/test/models/node.rb
@@ -2,6 +2,6 @@
 
 class Node < ActiveRecord::Base
   belongs_to :tree, touch: true
-  belongs_to :parent,   class_name: "Node", touch: true, optional: true
+  belongs_to :parent, class_name: "Node", touch: true, optional: true, counter_cache: 'children_count'
   has_many   :children, class_name: "Node", foreign_key: :parent_id, dependent: :destroy
 end

--- a/activerecord/test/models/node.rb
+++ b/activerecord/test/models/node.rb
@@ -2,6 +2,6 @@
 
 class Node < ActiveRecord::Base
   belongs_to :tree, touch: true
-  belongs_to :parent, class_name: "Node", touch: true, optional: true, counter_cache: 'children_count'
+  belongs_to :parent, class_name: "Node", touch: true, optional: true, counter_cache: "children_count"
   has_many   :children, class_name: "Node", foreign_key: :parent_id, dependent: :destroy
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
@@ -1012,6 +1013,7 @@ ActiveRecord::Schema.define do
   create_table :nodes, force: true do |t|
     t.integer :tree_id
     t.integer :parent_id
+    t.integer :children_count, default: 0, null: false
     t.string :name
     t.datetime :updated_at
   end


### PR DESCRIPTION
prevent counter cache to update counter twice on belongs to association #33117 