### PR TITLE
Update "Active Support Core Extensions" Guide

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2935,34 +2935,6 @@ Extensions to `Date`
 
 ### Calculations
 
-NOTE: All the following methods are defined in `active_support/core_ext/date/calculations.rb`.
-
-```ruby
-yesterday
-tomorrow
-beginning_of_week (at_beginning_of_week)
-end_of_week (at_end_of_week)
-monday
-sunday
-weeks_ago
-prev_week (last_week)
-next_week
-months_ago
-months_since
-beginning_of_month (at_beginning_of_month)
-end_of_month (at_end_of_month)
-last_month
-beginning_of_quarter (at_beginning_of_quarter)
-end_of_quarter (at_end_of_quarter)
-beginning_of_year (at_beginning_of_year)
-end_of_year (at_end_of_year)
-years_ago
-years_since
-last_year
-on_weekday?
-on_weekend?
-```
-
 INFO: The following calculation methods have edge cases in October 1582, since days 5..14 just do not exist. This guide does not document their behavior around those days for brevity, but it is enough to say that they do what you would expect. That is, `Date.new(1582, 10, 4).tomorrow` returns `Date.new(1582, 10, 15)` and so on. Please check `test/core_ext/date_ext_test.rb` in the Active Support test suite for expected behavior.
 
 #### `Date.current`
@@ -2970,6 +2942,8 @@ INFO: The following calculation methods have edge cases in October 1582, since d
 Active Support defines `Date.current` to be today in the current time zone. That's like `Date.today`, except that it honors the user time zone, if defined. It also defines `Date.yesterday` and `Date.tomorrow`, and the instance predicates `past?`, `today?`, `future?`, `on_weekday?` and `on_weekend?`, all of them relative to `Date.current`.
 
 When making Date comparisons using methods which honor the user time zone, make sure to use `Date.current` and not `Date.today`. There are cases where the user time zone might be in the future compared to the system time zone, which `Date.today` uses by default. This means `Date.today` may equal `Date.yesterday`.
+
+NOTE: Defined in `active_support/core_ext/date/calculations.rb`.
 
 #### Named dates
 
@@ -2990,6 +2964,8 @@ d.end_of_week(:sunday)       # => Sat, 08 May 2010
 
 `beginning_of_week` is aliased to `at_beginning_of_week` and `end_of_week` is aliased to `at_end_of_week`.
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `monday`, `sunday`
 
 The methods `monday` and `sunday` return the dates for the previous Monday and
@@ -3006,6 +2982,8 @@ d.monday                     # => Mon, 10 Sep 2012
 d = Date.new(2012, 9, 16)    # => Sun, 16 Sep 2012
 d.sunday                     # => Sun, 16 Sep 2012
 ```
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 ##### `prev_week`, `next_week`
 
@@ -3029,6 +3007,8 @@ d.prev_week(:friday)     # => Fri, 30 Apr 2010
 
 Both `next_week` and `prev_week` work as expected when `Date.beginning_of_week` or `config.beginning_of_week` are set.
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `beginning_of_month`, `end_of_month`
 
 The methods `beginning_of_month` and `end_of_month` return the dates for the beginning and end of the month:
@@ -3040,6 +3020,8 @@ d.end_of_month           # => Mon, 31 May 2010
 ```
 
 `beginning_of_month` is aliased to `at_beginning_of_month`, and `end_of_month` is aliased to `at_end_of_month`.
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 ##### `beginning_of_quarter`, `end_of_quarter`
 
@@ -3053,6 +3035,8 @@ d.end_of_quarter         # => Wed, 30 Jun 2010
 
 `beginning_of_quarter` is aliased to `at_beginning_of_quarter`, and `end_of_quarter` is aliased to `at_end_of_quarter`.
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `beginning_of_year`, `end_of_year`
 
 The methods `beginning_of_year` and `end_of_year` return the dates for the beginning and end of the year:
@@ -3064,6 +3048,8 @@ d.end_of_year            # => Fri, 31 Dec 2010
 ```
 
 `beginning_of_year` is aliased to `at_beginning_of_year`, and `end_of_year` is aliased to `at_end_of_year`.
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 #### Other Date Computations
 
@@ -3092,6 +3078,8 @@ Date.new(2012, 2, 29).years_since(3)   # => Sat, 28 Feb 2015
 
 `last_year` is short-hand for `#years_ago(1)`.
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `months_ago`, `months_since`
 
 The methods `months_ago` and `months_since` work analogously for months:
@@ -3110,6 +3098,8 @@ Date.new(2009, 12, 31).months_since(2) # => Sun, 28 Feb 2010
 
 `last_month` is short-hand for `#months_ago(1)`.
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `weeks_ago`
 
 The method `weeks_ago` works analogously for weeks:
@@ -3118,6 +3108,8 @@ The method `weeks_ago` works analogously for weeks:
 Date.new(2010, 5, 24).weeks_ago(1)    # => Mon, 17 May 2010
 Date.new(2010, 5, 24).weeks_ago(2)    # => Mon, 10 May 2010
 ```
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 ##### `advance`
 
@@ -3147,6 +3139,8 @@ Date.new(2010, 2, 28).advance(days: 1).advance(months: 1)
 # => Thu, 01 Apr 2010
 ```
 
+NOTE: Defined in `active_support/core_ext/date/calculations.rb`.
+
 #### Changing Components
 
 The method `change` allows you to get a new date which is the same as the receiver except for the given year, month, or day:
@@ -3162,6 +3156,8 @@ This method is not tolerant to non-existing dates, if the change is invalid `Arg
 Date.new(2010, 1, 31).change(month: 2)
 # => ArgumentError: invalid date
 ```
+
+NOTE: Defined in `active_support/core_ext/date/calculations.rb`.
 
 #### Durations
 
@@ -3205,6 +3201,8 @@ date.end_of_day # => Mon Jun 07 23:59:59 +0200 2010
 
 `beginning_of_day` is aliased to `at_beginning_of_day`, `midnight`, `at_midnight`.
 
+NOTE: Defined in `active_support/core_ext/date/calculations.rb`.
+
 ##### `beginning_of_hour`, `end_of_hour`
 
 The method `beginning_of_hour` returns a timestamp at the beginning of the hour (hh:00:00):
@@ -3222,6 +3220,8 @@ date.end_of_hour # => Mon Jun 07 19:59:59 +0200 2010
 ```
 
 `beginning_of_hour` is aliased to `at_beginning_of_hour`.
+
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
 
 ##### `beginning_of_minute`, `end_of_minute`
 
@@ -3243,6 +3243,8 @@ date.end_of_minute # => Mon Jun 07 19:55:59 +0200 2010
 
 INFO: `beginning_of_hour`, `end_of_hour`, `beginning_of_minute` and `end_of_minute` are implemented for `Time` and `DateTime` but **not** `Date` as it does not make sense to request the beginning or end of an hour or minute on a `Date` instance.
 
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
+
 ##### `ago`, `since`
 
 The method `ago` receives a number of seconds as argument and returns a timestamp those many seconds ago from midnight:
@@ -3259,6 +3261,8 @@ date = Date.current # => Fri, 11 Jun 2010
 date.since(1)       # => Fri, 11 Jun 2010 00:00:01 EDT -04:00
 ```
 
+NOTE: Defined in `active_support/core_ext/date/calculations.rb`.
+
 #### Other Time Computations
 
 ### Conversions
@@ -3269,8 +3273,6 @@ Extensions to `DateTime`
 WARNING: `DateTime` is not aware of DST rules and so some of these methods have edge cases when a DST change is going on. For example `seconds_since_midnight` might not return the real amount in such a day.
 
 ### Calculations
-
-NOTE: All the following methods are defined in `active_support/core_ext/date_time/calculations.rb`.
 
 The class `DateTime` is a subclass of `Date` so by loading `active_support/core_ext/date/calculations.rb` you inherit these methods and their aliases, except that they will always return datetimes.
 
@@ -3298,6 +3300,8 @@ end_of_hour
 
 Active Support defines `DateTime.current` to be like `Time.now.to_datetime`, except that it honors the user time zone, if defined. It also defines `DateTime.yesterday` and `DateTime.tomorrow`, and the instance predicates `past?`, and `future?` relative to `DateTime.current`.
 
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
+
 #### Other Extensions
 
 ##### `seconds_since_midnight`
@@ -3308,6 +3312,8 @@ The method `seconds_since_midnight` returns the number of seconds since midnight
 now = DateTime.current     # => Mon, 07 Jun 2010 20:26:36 +0000
 now.seconds_since_midnight # => 73596
 ```
+
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
 
 ##### `utc`
 
@@ -3320,6 +3326,8 @@ now.utc                # => Mon, 07 Jun 2010 23:27:52 +0000
 
 This method is also aliased as `getutc`.
 
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
+
 ##### `utc?`
 
 The predicate `utc?` says whether the receiver has UTC as its time zone:
@@ -3329,6 +3337,8 @@ now = DateTime.now # => Mon, 07 Jun 2010 19:30:47 -0400
 now.utc?           # => false
 now.utc.utc?       # => true
 ```
+
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
 
 ##### `advance`
 
@@ -3360,6 +3370,8 @@ d.advance(seconds: 1).advance(months: 1)
 ```
 
 WARNING: Since `DateTime` is not DST-aware you can end up in a non-existing point in time with no warning or error telling you so.
+
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
 
 #### Changing Components
 
@@ -3393,6 +3405,8 @@ DateTime.current.change(month: 2, day: 30)
 # => ArgumentError: invalid date
 ```
 
+NOTE: Defined in `active_support/core_ext/date_time/calculations.rb`.
+
 #### Durations
 
 Durations can be added to and subtracted from datetimes:
@@ -3418,52 +3432,6 @@ Extensions to `Time`
 
 ### Calculations
 
-NOTE: All the following methods are defined in `active_support/core_ext/time/calculations.rb`.
-
-```ruby
-past?
-today?
-future?
-yesterday
-tomorrow
-seconds_since_midnight
-change
-advance
-ago
-since (in)
-prev_day
-next_day
-beginning_of_day (midnight, at_midnight, at_beginning_of_day)
-end_of_day
-beginning_of_hour (at_beginning_of_hour)
-end_of_hour
-beginning_of_week (at_beginning_of_week)
-end_of_week (at_end_of_week)
-monday
-sunday
-weeks_ago
-prev_week (last_week)
-next_week
-months_ago
-months_since
-beginning_of_month (at_beginning_of_month)
-end_of_month (at_end_of_month)
-prev_month
-next_month
-last_month
-beginning_of_quarter (at_beginning_of_quarter)
-end_of_quarter (at_end_of_quarter)
-beginning_of_year (at_beginning_of_year)
-end_of_year (at_end_of_year)
-years_ago
-years_since
-prev_year
-last_year
-next_year
-on_weekday?
-on_weekend?
-```
-
 They are analogous. Please refer to their documentation above and take into account the following differences:
 
 * `change` accepts an additional `:usec` option.
@@ -3487,6 +3455,8 @@ t.advance(seconds: 1)
 Active Support defines `Time.current` to be today in the current time zone. That's like `Time.now`, except that it honors the user time zone, if defined. It also defines the instance predicates `past?`, `today?`, and `future?`, all of them relative to `Time.current`.
 
 When making Time comparisons using methods which honor the user time zone, make sure to use `Time.current` instead of `Time.now`. There are cases where the user time zone might be in the future compared to the system time zone, which `Time.now` uses by default. This means `Time.now.to_date` may equal `Date.yesterday`.
+
+NOTE: Defined in `active_support/core_ext/time/calculations.rb`.
 
 #### `all_day`, `all_week`, `all_month`, `all_quarter` and `all_year`
 
@@ -3516,6 +3486,8 @@ now.all_year
 # => Fri, 01 Jan 2010 00:00:00 UTC +00:00..Fri, 31 Dec 2010 23:59:59 UTC +00:00
 ```
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 #### `prev_day`, `next_day`
 
 In Ruby 1.9 `prev_day` and `next_day` return the date in the last or next day:
@@ -3525,6 +3497,8 @@ d = Date.new(2010, 5, 8) # => Sat, 08 May 2010
 d.prev_day               # => Fri, 07 May 2010
 d.next_day               # => Sun, 09 May 2010
 ```
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 #### `prev_month`, `next_month`
 
@@ -3545,6 +3519,8 @@ Date.new(2000, 5, 31).next_month # => Fri, 30 Jun 2000
 Date.new(2000, 1, 31).next_month # => Tue, 29 Feb 2000
 ```
 
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 #### `prev_year`, `next_year`
 
 In Ruby 1.9 `prev_year` and `next_year` return a date with the same day/month in the last or next year:
@@ -3562,6 +3538,8 @@ d = Date.new(2000, 2, 29) # => Tue, 29 Feb 2000
 d.prev_year               # => Sun, 28 Feb 1999
 d.next_year               # => Wed, 28 Feb 2001
 ```
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 #### `prev_quarter`, `next_quarter`
 
@@ -3583,6 +3561,8 @@ Time.local(2000, 11, 31).next_quarter # => 2001-03-01 00:00:00 +0200
 ```
 
 `prev_quarter` is aliased to `last_quarter`.
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
 ### Time Constructors
 


### PR DESCRIPTION
Remove general sentence that explains that all methods that Active Support
brings to `Date` `Time`, `DateTime` are defined in
`active_support/core_ext/date/calculations.rb` since it isn't true.
Add a references to an appropriate file where methods are defined
like it is done with the other methods in this guide.

Context https://github.com/rails/rails/pull/32552#discussion_r181216246

Related to #32543, #32552 

[ci skip]