### PR TITLE
Add `Array#extract!`

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/object/duplicable"
+require "active_support/core_ext/array/extract"
 
 module ActionDispatch
   module Http
@@ -38,8 +39,8 @@ module ActionDispatch
             end
           end
 
-          deep_regexps, regexps = regexps.partition { |r| r.to_s.include?("\\.".freeze) }
-          deep_strings, strings = strings.partition { |s| s.include?("\\.".freeze) }
+          deep_regexps = regexps.extract! { |r| r.to_s.include?("\\.".freeze) }
+          deep_strings = strings.extract! { |s| s.include?("\\.".freeze) }
 
           regexps << Regexp.new(strings.join("|".freeze), true) unless strings.empty?
           deep_regexps << Regexp.new(deep_strings.join("|".freeze), true) unless deep_strings.empty?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/array/extract"
+
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -16,12 +18,12 @@ module ActiveRecord
 
           def run(records)
             nodes = records.reject { |row| @store.key? row["oid"].to_i }
-            mapped, nodes = nodes.partition { |row| @store.key? row["typname"] }
-            ranges, nodes = nodes.partition { |row| row["typtype"] == "r".freeze }
-            enums, nodes = nodes.partition { |row| row["typtype"] == "e".freeze }
-            domains, nodes = nodes.partition { |row| row["typtype"] == "d".freeze }
-            arrays, nodes = nodes.partition { |row| row["typinput"] == "array_in".freeze }
-            composites, nodes = nodes.partition { |row| row["typelem"].to_i != 0 }
+            mapped = nodes.extract! { |row| @store.key? row["typname"] }
+            ranges = nodes.extract! { |row| row["typtype"] == "r".freeze }
+            enums = nodes.extract! { |row| row["typtype"] == "e".freeze }
+            domains = nodes.extract! { |row| row["typtype"] == "d".freeze }
+            arrays = nodes.extract! { |row| row["typinput"] == "array_in".freeze }
+            composites = nodes.extract! { |row| row["typelem"].to_i != 0 }
 
             mapped.each     { |row| register_mapped_type(row)    }
             enums.each      { |row| register_enum_type(row)      }

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/array/extract"
+
 module ActiveRecord
   class PredicateBuilder
     class ArrayHandler # :nodoc:
@@ -11,8 +13,8 @@ module ActiveRecord
         return attribute.in([]) if value.empty?
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
-        nils, values = values.partition(&:nil?)
-        ranges, values = values.partition { |v| v.is_a?(Range) }
+        nils = values.extract!(&:nil?)
+        ranges = values.extract! { |v| v.is_a?(Range) }
 
         values_predicate =
           case values.length

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `Array#extract!`.
+
+    The method removes and returns the elements for which the block returns a true value.
+    If no block is given, an Enumerator is returned instead.
+
+        numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
+        numbers # => [0, 2, 4, 6, 8]
+
+    *bogdanvlviv*
+
 *   Support not to cache `nil` for `ActiveSupport::Cache#fetch`.
 
         cache.fetch('bar', skip_nil: true) { nil }

--- a/activesupport/lib/active_support/core_ext/array.rb
+++ b/activesupport/lib/active_support/core_ext/array.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/array/conversions"
+require "active_support/core_ext/array/extract"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/array/grouping"
 require "active_support/core_ext/array/prepend_and_append"

--- a/activesupport/lib/active_support/core_ext/array/extract.rb
+++ b/activesupport/lib/active_support/core_ext/array/extract.rb
@@ -7,15 +7,15 @@ class Array
   #   numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   #   odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
   #   numbers # => [0, 2, 4, 6, 8]
-  def extract!(&block)
-    unless block_given?
-      to_enum(:extract!) { size }
-    else
-      extracted_elements, other_elements = partition(&block)
+  def extract!
+    return to_enum(:extract!) { size } unless block_given?
 
-      replace(other_elements)
+    extracted_elements = []
 
-      extracted_elements
+    reject! do |element|
+      extracted_elements << element if yield(element)
     end
+
+    extracted_elements
   end
 end

--- a/activesupport/lib/active_support/core_ext/array/extract.rb
+++ b/activesupport/lib/active_support/core_ext/array/extract.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Array
+  # Removes and returns the elements for which the block returns a true value.
+  # If no block is given, an Enumerator is returned instead.
+  #
+  #   numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  #   odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
+  #   numbers # => [0, 2, 4, 6, 8]
+  def extract!(&block)
+    unless block_given?
+      to_enum(:extract!) { size }
+    else
+      extracted_elements, other_elements = partition(&block)
+
+      replace(other_elements)
+
+      extracted_elements
+    end
+  end
+end

--- a/activesupport/test/core_ext/array/extract_test.rb
+++ b/activesupport/test/core_ext/array/extract_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/array"
+
+class ExtractTest < ActiveSupport::TestCase
+  def test_extract
+    numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    array_id = numbers.object_id
+
+    odd_numbers = numbers.extract!(&:odd?)
+
+    assert_equal [1, 3, 5, 7, 9], odd_numbers
+    assert_equal [0, 2, 4, 6, 8], numbers
+    assert_equal array_id, numbers.object_id
+  end
+
+  def test_extract_without_block
+    numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    array_id = numbers.object_id
+
+    extract_enumerator = numbers.extract!
+
+    assert_instance_of Enumerator, extract_enumerator
+    assert_equal numbers.size, extract_enumerator.size
+
+    odd_numbers = extract_enumerator.each(&:odd?)
+
+    assert_equal [1, 3, 5, 7, 9], odd_numbers
+    assert_equal [0, 2, 4, 6, 8], numbers
+    assert_equal array_id, numbers.object_id
+  end
+
+  def test_extract_on_empty_array
+    empty_array = []
+    array_id = empty_array.object_id
+
+    new_empty_array = empty_array.extract! {}
+
+    assert_equal [], new_empty_array
+    assert_equal [], empty_array
+    assert_equal array_id, empty_array.object_id
+  end
+end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2156,6 +2156,19 @@ This method is an alias of `Array#<<`.
 
 NOTE: Defined in `active_support/core_ext/array/prepend_and_append.rb`.
 
+### Extracting
+
+The method `extract!` removes and returns the elements for which the block returns a true value.
+If no block is given, an Enumerator is returned instead.
+
+```ruby
+numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
+numbers # => [0, 2, 4, 6, 8]
+```
+
+NOTE: Defined in `active_support/core_ext/array/extract.rb`.
+
 ### Options Extraction
 
 When the last argument in a method call is a hash, except perhaps for a `&block` argument, Ruby allows you to omit the brackets:

--- a/railties/lib/rails/api/generator.rb
+++ b/railties/lib/rails/api/generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sdoc"
+require "active_support/core_ext/array/extract"
 
 class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
   RDoc::RDoc.add_generator self
@@ -11,7 +12,7 @@ class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
     # since they aren't nested under a definition of the `ActiveStorage` module.
     if visited.empty?
       classes = classes.reject { |klass| active_storage?(klass) }
-      core_exts, classes = classes.partition { |klass| core_extension?(klass) }
+      core_exts = classes.extract! { |klass| core_extension?(klass) }
 
       super.unshift([ "Core extensions", "", "", build_core_ext_subtree(core_exts, visited) ])
     else


### PR DESCRIPTION
The method removes and returns the elements for which the block returns a true value.
If no block is given, an Enumerator is returned instead.

```ruby
numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
numbers # => [0, 2, 4, 6, 8]
```

Also, I added commit [Use `Array#extract!` where possible](https://github.com/rails/rails/commit/2f7d607cf8966c1dc226a422c639f965bfb019b6) in order to show that we can improve Rails code base by this method.

```diff
- nils, values = values.partition(&:nil?)
- ranges, values = values.partition { |v| v.is_a?(Range) }
+ nils = values.extract!(&:nil?)
+ ranges = values.extract! { |v| v.is_a?(Range) }
```
Looks more readable if use `Array#extract!`, doesn't it?

I know we try to omit adding new methods to ActiveSupport, but I think this one has a good chance to be added since we can apply it in Rails code base.
By the way, we already added `Hash#extract!`
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/hash/slice.rb#L41-L47

Post: https://gitlab.com/bogdanvlviv/posts/-/issues/14, https://bogdanvlviv.com/posts/ruby/rails/array-extract-to-activesupport-6-0.html

 I have tried to add Active Support's `Array#extract!` as `Array#extract` to Ruby, see [Feature #15831: "Add `Array#extract`, `Hash#extract`, and `ENV.extract`"](https://bugs.ruby-lang.org/issues/15831).

Thanks!