### PR TITLE
Add test case for the `|` token in Journey scanner

### DIFF
--- a/actionpack/test/journey/route/definition/scanner_test.rb
+++ b/actionpack/test/journey/route/definition/scanner_test.rb
@@ -30,6 +30,12 @@ module ActionDispatch
           ["/~page",  [[:SLASH, "/"], [:LITERAL, "~page"]]],
           ["/pa-ge",  [[:SLASH, "/"], [:LITERAL, "pa-ge"]]],
           ["/:page",  [[:SLASH, "/"], [:SYMBOL, ":page"]]],
+          ["/:page|*foo", [
+                            [:SLASH, "/"],
+                            [:SYMBOL, ":page"],
+                            [:OR, "|"],
+                            [:STAR, "*foo"]
+                          ]],
           ["/(:page)", [
                         [:SLASH, "/"],
                         [:LPAREN, "("],


### PR DESCRIPTION
I noticed that Journey's scanner actually tokenizes the `|` (:OR) operator when scanning route urls.
For example, it handles routes [such as](https://github.com/rails/rails/blob/master/actionpack/test/journey/path/pattern_test.rb#L23) `"/:foo|*bar"`. 

However, while looking at the specs, I also noticed that there is currently no test case for the `|` operator for Journey's scanner. 

This PR adds a test case for the `|` operator:
```
"/:page|*foo"
```
which tokenizes to:
```
[[:SLASH, "/"],  [:SYMBOL, ":page"], [:OR, "|"], [:STAR, "*foo"]]
```

Hopefully, this will make it a little easier to see exactly which tokens are recognized by the routing engine by simply looking at the scanner test file.