### PR TITLE
Fix Ruby version in `.ruby-version`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" -%>
+<%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -891,7 +891,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/ruby '#{RUBY_VERSION}'/, content)
     end
     assert_file ".ruby-version" do |content|
-      assert_match(/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}/, content)
+      if ENV["RBENV_VERSION"]
+        assert_match(/#{ENV["RBENV_VERSION"]}/, content)
+      elsif ENV["rvm_ruby_string"]
+        assert_match(/#{ENV["rvm_ruby_string"]}/, content)
+      else
+        assert_match(/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}/, content)
+      end
     end
   end
 


### PR DESCRIPTION
Since #30016 Rails generates `.ruby-version` file
in order to help Ruby version manager tools like `rbenv`, `rvm`
determine which Ruby version should be used for the current Rails
project.

Since #32649 Rails sets Ruby version to the file compatible with MRI/JRuby
by default.

Pull Request #31496 reports that `.ruby-version` doesn't match ruby version other
than stable version and recommends to use `ENV["RBENV_VERSION"]`, and
`ENV["rvm_ruby_string"]` in order to set correct Ruby version to the file
that `rbenv` or `rvm` can understand.
Also, there is another similar issue that reports the same case if use
JRuby https://github.com/jruby/jruby/issues/5144.

Closes #31496, https://github.com/jruby/jruby/issues/5144.
