### PR TITLE
Add support for setting `s-maxage` in Cache-Control

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -238,6 +238,7 @@ module ActionController
     def expires_in(seconds, options = {})
       response.cache_control.merge!(
         max_age: seconds,
+        s_max_age: options.delete(:s_max_age),
         public: options.delete(:public),
         must_revalidate: options.delete(:must_revalidate),
         stale_while_revalidate: options.delete(:stale_while_revalidate),

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -206,11 +206,13 @@ module ActionDispatch
           else
             extras = control[:extras]
             max_age = control[:max_age]
+            s_max_age = control[:s_max_age]
             stale_while_revalidate = control[:stale_while_revalidate]
             stale_if_error = control[:stale_if_error]
 
             options = []
             options << "max-age=#{max_age.to_i}" if max_age
+            options << "s-maxage=#{s_max_age.to_i}" if s_max_age
             options << (control[:public] ? PUBLIC : PRIVATE)
             options << MUST_REVALIDATE if control[:must_revalidate]
             options << "stale-while-revalidate=#{stale_while_revalidate.to_i}" if stale_while_revalidate

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -131,6 +131,11 @@ class TestController < ActionController::Base
     render action: "hello_world"
   end
 
+  def conditional_hello_with_expires_in_with_s_maxage
+    expires_in 1.minute, public: true, s_max_age: 2.minutes
+    render action: "hello_world"
+  end
+
   def conditional_hello_with_expires_in_with_must_revalidate
     expires_in 1.minute, must_revalidate: true
     render action: "hello_world"
@@ -370,6 +375,11 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_expires_in_header_with_public
     get :conditional_hello_with_expires_in_with_public
     assert_equal "max-age=60, public", @response.headers["Cache-Control"]
+  end
+
+  def test_expires_in_header_with_s_maxage
+    get :conditional_hello_with_expires_in_with_s_maxage
+    assert_equal "max-age=60, s-maxage=120, public", @response.headers["Cache-Control"]
   end
 
   def test_expires_in_header_with_must_revalidate


### PR DESCRIPTION
Following #33134, this adds direct support for setting `s-maxage` in Cache-Control. I left this out of the first PR because it may warrant a different API altogether. This directive is specifically designed to allow HTTP servers to dictate that proxies cache the response for _x_ seconds and should be ignored by normal clients. So you could do `Cache-Control: public, max-age=0, s-maxage=120` to have just proxies do the caching. This is especially interesting if you use a CDN and can do further cache configurations there, such as varying by device type, authentication status, etc.

The simplest thing is to just add support for the directive, and I think that should be done no matter what, but we could additionally add a new API that directly supports the use case, e.g.

```ruby
proxy_cached_for 5.minutes
#=> Cache-Control: public, max-age=0, s-maxage=300
```

What say ye?

Also, I willing to write some docs for this if I can get some guidance – should they go in the Guides or in the API docs?