### PR TITLE
Failing test for AR::Calculations on PG datetime column not converting to time zone

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -77,6 +77,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 55, Account.where("companies.name != 'Summit'").references(:companies).includes(:firm).maximum(Account.arel_table[:credit_limit])
   end
 
+  def test_should_get_maximum_of_datetime_with_time_zone_conversion
+    with_timezone_config default: :utc, aware_attributes: true, zone: "Eastern Time (US & Canada)" do
+      Comment.reset_column_information
+
+      assert_equal ActiveSupport::TimeWithZone, Comment.maximum(:updated_at).class
+    end
+  end
+
   def test_should_get_minimum_of_field
     assert_equal 50, Account.minimum(:credit_limit)
   end


### PR DESCRIPTION
Calling something like `Model.maximum(:created_at)` returns an instance of `ActiveSupport::TimeWithZone` in the configured `Time.zone` in both MySQL and SQLite (ie. `2018-06-19 15:30:52 -0400`), however in PostgreSQL, it returns an instance of `Time` in UTC (ie. `2018-06-19 19:30:56 UTC`).

I've confirmed this on master as well as the latest patches on 5.2, 5.1, and 5.0.

I traced it to
https://github.com/rails/rails/blob/897946f2141662a072a8917946737218df82e204/activerecord/lib/active_record/relation/calculations.rb#L400
and discovered that for MySQL, `type` is an instance of `ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter` whereas for PostgreSQL, `type` is an instance of `ActiveRecord::ConnectionAdapaters::PostgreSQL::OID::DateTime` and I don't see `TimeZoneConverter` in the ancestors of that object. I wasn't sure where to go from here to attempt a fix.

Here is a simplified re-production:
```ruby
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  # gem "activerecord", "5.0.7"
  # gem "activerecord", "5.1.6"
  # gem "activerecord", "5.2.0"
  gem "rails", github: "rails/rails"
  gem "mysql2"
  gem "pg", "0.21.0"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# Ensure backward compatibility with Minitest 4
Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)

# This connection will do for database-independent bug reports.
config = { adapter: ENV.fetch('DB'), database: "test" }
if ENV.fetch('DB') == 'mysql2'
  config[:username] = 'root'
end
ActiveRecord::Base.establish_connection(config)
ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.time_zone_aware_attributes = true

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.timestamps
  end
end

Time.zone = 'Eastern Time (US & Canada)'

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_calculation_time_zone
    post = Post.create!

    assert_equal ActiveSupport::TimeWithZone, Post.maximum(:created_at).class
  end
end
```

A similar issue was raised previously (#13711) and it was stated then that the problem was fixed, however it seems the fix didn't apply to PostgreSQL.