### PR TITLE
Stop using Mocha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gemspec
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"
 
-gem "mocha"
-
 gem "capybara", ">= 2.15"
 
 gem "rack-cache", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,6 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     memoist (0.16.0)
-    metaclass (0.0.4)
     method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -324,8 +323,6 @@ GEM
       path_expander (~> 1.0)
     minitest-server (1.0.5)
       minitest (~> 5.0)
-    mocha (1.5.0)
-      metaclass (~> 0.0.1)
     mono_logger (1.1.0)
     msgpack (1.2.4)
     msgpack (1.2.4-java)
@@ -541,7 +538,6 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   minitest-bisect
-  mocha
   mysql2 (>= 0.4.10)
   nokogiri (>= 1.8.1)
   pg (>= 0.18.0)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1571,8 +1571,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   # CollectionProxy#reader is expensive, so the preloader avoids calling it.
   test "preloading has_many_through association avoids calling association.reader" do
-    ActiveRecord::Associations::HasManyAssociation.any_instance.expects(:reader).never
-    Author.preload(:readonly_comments).first!
+    assert_not_called_on_instance_of(ActiveRecord::Associations::HasManyAssociation, :reader) do
+      Author.preload(:readonly_comments).first!
+    end
   end
 
   test "preloading through a polymorphic association doesn't require the association to exist" do

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2134,21 +2134,29 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_defining_has_many_association_with_delete_all_dependency_lazily_evaluates_target_class
-    ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
-    class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class DeleteAllModel < ActiveRecord::Base
-        has_many :nonentities, :dependent => :delete_all
-      end
-    EOF
+    assert_not_called_on_instance_of(
+      ActiveRecord::Reflection::AssociationReflection,
+      :class_name,
+    ) do
+      class_eval(<<-EOF, __FILE__, __LINE__ + 1)
+        class DeleteAllModel < ActiveRecord::Base
+          has_many :nonentities, :dependent => :delete_all
+        end
+      EOF
+    end
   end
 
   def test_defining_has_many_association_with_nullify_dependency_lazily_evaluates_target_class
-    ActiveRecord::Reflection::AssociationReflection.any_instance.expects(:class_name).never
-    class_eval(<<-EOF, __FILE__, __LINE__ + 1)
-      class NullifyModel < ActiveRecord::Base
-        has_many :nonentities, :dependent => :nullify
-      end
-    EOF
+    assert_not_called_on_instance_of(
+      ActiveRecord::Reflection::AssociationReflection,
+      :class_name,
+    ) do
+      class_eval(<<-EOF, __FILE__, __LINE__ + 1)
+        class NullifyModel < ActiveRecord::Base
+          has_many :nonentities, :dependent => :nullify
+        end
+      EOF
+    end
   end
 
   def test_attributes_are_being_set_when_initialized_from_has_many_association_with_where_clause

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -183,5 +183,3 @@ module InTimeZone
       ActiveRecord::Base.time_zone_aware_attributes = old_tz
     end
 end
-
-require "mocha/minitest" # FIXME: stop using mocha

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -46,35 +46,46 @@ module ActiveRecord
 
   class DatabaseTasksUtilsTask < ActiveRecord::TestCase
     def test_raises_an_error_when_called_with_protected_environment
-      ActiveRecord::MigrationContext.any_instance.stubs(:current_version).returns(1)
-
       protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Base.connection.migration_context.current_environment
-      assert_not_includes protected_environments, current_env
-      # Assert no error
-      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
 
-      ActiveRecord::Base.protected_environments = [current_env]
-
-      assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+      assert_called_on_instance_of(
+        ActiveRecord::MigrationContext,
+        :current_version,
+        times: 6,
+        returns: 1
+      ) do
+        assert_not_includes protected_environments, current_env
+        # Assert no error
         ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+        ActiveRecord::Base.protected_environments = [current_env]
+
+        assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+          ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+        end
       end
     ensure
       ActiveRecord::Base.protected_environments = protected_environments
     end
 
     def test_raises_an_error_when_called_with_protected_environment_which_name_is_a_symbol
-      ActiveRecord::MigrationContext.any_instance.stubs(:current_version).returns(1)
-
       protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Base.connection.migration_context.current_environment
-      assert_not_includes protected_environments, current_env
-      # Assert no error
-      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
-
-      ActiveRecord::Base.protected_environments = [current_env.to_sym]
-      assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+      assert_called_on_instance_of(
+        ActiveRecord::MigrationContext,
+        :current_version,
+        times: 6,
+        returns: 1
+      ) do
+        assert_not_includes protected_environments, current_env
+        # Assert no error
         ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+        ActiveRecord::Base.protected_environments = [current_env.to_sym]
+        assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+          ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+        end
       end
     ensure
       ActiveRecord::Base.protected_environments = protected_environments
@@ -82,10 +93,14 @@ module ActiveRecord
 
     def test_raises_an_error_if_no_migrations_have_been_made
       ActiveRecord::InternalMetadata.stub(:table_exists?, false) do
-        ActiveRecord::MigrationContext.any_instance.stubs(:current_version).returns(1)
-
-        assert_raise(ActiveRecord::NoEnvironmentInSchemaError) do
-          ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+        assert_called_on_instance_of(
+          ActiveRecord::MigrationContext,
+          :current_version,
+          returns: 1
+        ) do
+          assert_raise(ActiveRecord::NoEnvironmentInSchemaError) do
+            ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+          end
         end
       end
     end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -152,10 +152,14 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_establishes_connection_to_mysql_database
-        with_stubbed_connection_establish_connection do
-          ActiveRecord::Base.expects(:establish_connection).with @configuration
-
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+        ActiveRecord::Base.stub(:connection, @connection) do
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [@configuration]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          end
         end
       end
 
@@ -196,10 +200,14 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_establishes_connection_to_the_appropriate_database
-        with_stubbed_connection_establish_connection do
-          ActiveRecord::Base.expects(:establish_connection).with(@configuration)
-
-          ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+        ActiveRecord::Base.stub(:connection, @connection) do
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [@configuration]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          end
         end
       end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -166,12 +166,17 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_establishes_connection_to_postgresql_database
         ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.expects(:establish_connection).with(
-            "adapter"            => "postgresql",
-            "database"           => "postgres",
-            "schema_search_path" => "public"
-          )
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              "adapter"            => "postgresql",
+              "database"           => "postgres",
+              "schema_search_path" => "public"
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          end
         end
       end
 

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -47,9 +47,9 @@ if current_adapter?(:SQLite3Adapter)
 
       def test_db_create_with_file_does_nothing
         File.stub(:exist?, true) do
-          ActiveRecord::Base.expects(:establish_connection).never
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
+          assert_not_called(ActiveRecord::Base, :establish_connection) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
+          end
         end
       end
 

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -35,6 +35,35 @@ module ActiveSupport
           assert_called(object, method_name, message, times: 0, &block)
         end
 
+        # TODO: No need to resort to #send once support for Ruby 2.4 is
+        # dropped.
+        def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
+          times_called = 0
+          klass.send(:define_method, "stubbed_#{method_name}") do |*|
+            times_called += 1
+
+            returns
+          end
+
+          klass.send(:alias_method, "original_#{method_name}", method_name)
+          klass.send(:alias_method, method_name, "stubbed_#{method_name}")
+
+          yield
+
+          error = "Expected #{method_name} to be called #{times} times, but was called #{times_called} times"
+          error = "#{message}.\n#{error}" if message
+
+          assert_equal times, times_called, error
+        ensure
+          klass.send(:alias_method, method_name, "original_#{method_name}")
+          klass.send(:undef_method, "original_#{method_name}")
+          klass.send(:undef_method, "stubbed_#{method_name}")
+        end
+
+        def assert_not_called_on_instance_of(klass, method_name, message = nil, &block)
+          assert_called_on_instance_of(klass, method_name, message, times: 0, &block)
+        end
+
         def stub_any_instance(klass, instance: klass.new)
           klass.stub(:new, instance) { yield instance }
         end

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -91,6 +91,65 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_called_on_instance_of_with_defaults_to_expect_once
+    assert_called_on_instance_of Level, :increment do
+      @object.increment
+    end
+  end
+
+  def test_assert_called_on_instance_of_more_than_once
+    assert_called_on_instance_of(Level, :increment, times: 2) do
+      @object.increment
+      @object.increment
+    end
+  end
+
+  def test_assert_called_on_instance_of_with_arguments
+    assert_called_on_instance_of(Level, :<<) do
+      @object << 2
+    end
+  end
+
+  def test_assert_called_on_instance_of_returns
+    assert_called_on_instance_of(Level, :increment, returns: 10) do
+      assert_equal 10, @object.increment
+    end
+
+    assert_equal 1, @object.increment
+  end
+
+  def test_assert_called_on_instance_of_failure
+    error = assert_raises(Minitest::Assertion) do
+      assert_called_on_instance_of(Level, :increment) do
+        # Call nothing...
+      end
+    end
+
+    assert_equal "Expected increment to be called 1 times, but was called 0 times.\nExpected: 1\n  Actual: 0", error.message
+  end
+
+  def test_assert_called_on_instance_of_with_message
+    error = assert_raises(Minitest::Assertion) do
+      assert_called_on_instance_of(Level, :increment, "dang it") do
+        # Call nothing...
+      end
+    end
+
+    assert_match(/dang it.\nExpected increment/, error.message)
+  end
+
+  def test_assert_called_on_instance_of_nesting
+    assert_called_on_instance_of(Level, :increment, times: 3) do
+      assert_called_on_instance_of(Level, :decrement, times: 2) do
+        @object.increment
+        @object.decrement
+        @object.increment
+        @object.decrement
+        @object.increment
+      end
+    end
+  end
+
   def test_assert_not_called
     assert_not_called(@object, :decrement) do
       @object.increment
@@ -105,6 +164,30 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
 
     assert_equal "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1", error.message
+  end
+
+  def test_assert_not_called_on_instance_of
+    assert_not_called_on_instance_of(Level, :decrement) do
+      @object.increment
+    end
+  end
+
+  def test_assert_not_called_on_instance_of_failure
+    error = assert_raises(Minitest::Assertion) do
+      assert_not_called_on_instance_of(Level, :increment) do
+        @object.increment
+      end
+    end
+
+    assert_equal "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1", error.message
+  end
+
+  def test_assert_not_called_on_instance_of_nesting
+    assert_not_called_on_instance_of(Level, :increment) do
+      assert_not_called_on_instance_of(Level, :decrement) do
+        # Call nothing...
+      end
+    end
   end
 
   def test_stub_any_instance


### PR DESCRIPTION
Following discussion with @bogdanvlviv I'm breaking this up into smaller manageable more review-friendly PRs, that will be submitted one by one.

From the lowest hanging fruit to deep embeded mocking.

- [x] Remove unnecessary mock objects (created with by `.stubs`) 8c1e1726d, 2af162c46, d2d7296
Working on these tests it became evident that some calls to `Mocha#stub` and `Mocha#stubs` do not serve the test case in any way. The same is true of some calls to `returns` on such objects. Remove both.
- [x] Reduce mocking by testing for value instead of method call 331cca175
Another low hanging fruit. When we can test for value, we do not need to test the setter method was called on a mock.
- [x] Replace shallow mocks with Ruby classes f7bfb3db2
Some mocks are simple to replace with a minimal class that responds to the needed methods.
- [x] Replace `Mocha#stubs` with `Minitest#stub 837d60317, 7afdc6c1a, a94d6ae81
- [x] Use MethodCallAssertions instead of Mocha part 1 d0743d026, d89937505
Replace simple instances of `Mocha#expect` with `MethodCallAssertions`.
- [x] Use MethodCallAssertions instead of Mocha part 2 82e42c1bd
Replace instances of `Mocha#expects` with `MethodCallAssertsions` where expecations need to be added to withstand Minitest's more stringent mocking.
- [x] Stub deeper mocks with new `MethodCallAssertions`
Remaining calls to `Mocha#stubs` and `Mocha#expects` cannot be replicated with plain Minitest. Stub and mock them with Ruby.
- [x] Remove mocha from Gemfile [_Q.E.F._] 