### PR TITLE
Add symbol to serialized arguments list

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -67,8 +67,10 @@ module ActiveJob
           result = serialize_hash(argument)
           result[SYMBOL_KEYS_KEY] = symbol_keys
           result
+        when Symbol
+          argument.to_s
         else
-          raise SerializationError.new("Unsupported argument type: #{argument.class.name}")
+          raise SerializationError.new("Unsupported argument #{argument} of type: #{argument.class.name}")
         end
       end
 


### PR DESCRIPTION
### Summary

recently I was using the `mandrill_mailer` gem, which creates an `ActiveJob::Base`-derived class instance for sending my emails. `mandrill_mailer` takes my hash of merge vars i give it for the email, and sends both the keys and values. So, if I send it a ruby hash with symbols as keys, they are serialized as individual `Symbol`s. So, when tested in rspec, `ActiveJob` was telling me:

```
ActiveJob::SerializationError:
       Unsupported argument type: Symbol
```

with no additional trace. This `Arguments` module already turns `Symbol`s within hashes to strings (in `serialize_hash_key`) but for individual `Symbol`s,  it just breaks. I propose with this change that if we get into a situation where a symbol is passed as an individual argument (not in a hash), we simply turn it into a string. I could also make it so that it's marked for being turned back into a symbol in deserialization (like we do with the `result[SYMBOL_KEYS_KEY]`) but I'll let y'all decide if that's necessary.

### Other Information

I also added the content of the bad argument to the error message, because when sending a large object for deserialization it's a little confusing if we only tell the user about the argument type.