### PR TITLE
fix with_timezone_config caching issue

### DIFF
--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -7,6 +7,14 @@ require "models/task"
 class DateTimeTest < ActiveRecord::TestCase
   include InTimeZone
 
+  def test_with_timezone_config_sets_aware_attributes
+    assert_not ActiveRecord::Base.time_zone_aware_attributes
+    with_timezone_config aware_attributes: true do
+      assert ActiveRecord::Base.time_zone_aware_attributes
+      assert Task.time_zone_aware_attributes
+    end
+  end
+
   def test_saves_both_date_and_time
     with_env_tz "America/New_York" do
       with_timezone_config default: :utc do

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -75,6 +75,7 @@ def with_timezone_config(cfg)
   if cfg.has_key?(:zone)
     Time.zone = cfg[:zone]
   end
+  ActiveRecord::Base.connection.clear_cache!
   yield
 ensure
   ActiveRecord::Base.default_timezone = old_default_zone


### PR DESCRIPTION
### Summary

`with_timezone_config` in the test suite didn't bust the cache and because of this, it didn't change the 
`time_zone_aware_attributes` config on the model level.