### PR TITLE
Wrap ActiveJob::Enqueue in evented ActiveSupport::Notification

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Move `enqueue`/`enqueue_at` notifications to an around callback (was previously an after callback).
+
+    *Zach Kemp*
+
 *   Allow `queue` option to `assert_no_enqueued_jobs`.
 
     Example:

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -27,13 +27,13 @@ module ActiveJob
         end
       end
 
-      after_enqueue do |job|
+      around_enqueue do |job, block|
         if job.scheduled_at
           ActiveSupport::Notifications.instrument "enqueue_at.active_job",
-            adapter: job.class.queue_adapter, job: job
+            adapter: job.class.queue_adapter, job: job, &block
         else
           ActiveSupport::Notifications.instrument "enqueue.active_job",
-            adapter: job.class.queue_adapter, job: job
+            adapter: job.class.queue_adapter, job: job, &block
         end
       end
     end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -45,6 +45,14 @@ class LoggingTest < ActiveSupport::TestCase
     ActiveJob::Base.logger = logger
   end
 
+  def subscribed
+    [].tap do |events|
+      ActiveSupport::Notifications.subscribed(-> (*args) { events << args }, /enqueue.*\.active_job/) do
+        yield
+      end
+    end
+  end
+
   def test_uses_active_job_as_tag
     HelloJob.perform_later "Cristian"
     assert_match(/\[ActiveJob\]/, @logger.messages)
@@ -86,8 +94,11 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_enqueue_job_logging
-    HelloJob.perform_later "Cristian"
+    events = subscribed { HelloJob.perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
+    assert_equal(events.count, 1)
+    key, * = events.first
+    assert_equal(key, "enqueue.active_job")
   end
 
   def test_perform_job_logging
@@ -110,15 +121,21 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_enqueue_at_job_logging
-    HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian"
+    events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
+    assert_equal(events.count, 1)
+    key, * = events.first
+    assert_equal(key, "enqueue_at.active_job")
   rescue NotImplementedError
     skip
   end
 
   def test_enqueue_in_job_logging
-    HelloJob.set(wait: 2.seconds).perform_later "Cristian"
+    events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
+    assert_equal(events.count, 1)
+    key, * = events.first
+    assert_equal(key, "enqueue_at.active_job")
   rescue NotImplementedError
     skip
   end


### PR DESCRIPTION
### Summary

Instead of firing an event after enqueuing a job, wrap the enqueue in an `ActiveSupport::Notifications` instrumentation block.

### Other Information

 Enables more accurate timing, as it includes time spent writing jobs to the adapter's IO implementation.