### PR TITLE
Update fugit to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     ffi (1.9.21-java)
     ffi (1.9.21-x64-mingw32)
     ffi (1.9.21-x86-mingw32)
-    fugit (1.1.1)
+    fugit (1.1.3)
       et-orbi (~> 1.1, >= 1.1.1)
       raabro (~> 1.1)
     globalid (0.4.1)
@@ -575,4 +575,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
[fugit 1.1.3](https://github.com/floraison/fugit/commit/03a3ee86f3cd5d929442dd25896b99acbd151947)
fixes warnings that show up in ActiveJob tests.

See [CI](https://travis-ci.org/rails/rails/jobs/394107740#L3764-L3778).

Thanks to @jmettraux