### PR TITLE
Clarify warning about `after_commit` for both create & update

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -429,7 +429,7 @@ end
 
 WARNING. The `after_commit` and `after_rollback` callbacks are called for all models created, updated, or destroyed within a transaction block. However, if an exception is raised within one of these callbacks, the exception will bubble up and any remaining `after_commit` or `after_rollback` methods will _not_ be executed. As such, if your callback code could raise an exception, you'll need to rescue it and handle it within the callback in order to allow other callbacks to run.
 
-WARNING. Using both `after_create_commit` and `after_update_commit` in the same model will only allow the last callback defined to take effect, and will override all others.
+WARNING. Using both `after_create_commit` and `after_update_commit` with the same method in the same model will only allow the last callback defined to take effect, and will override all others.
 
 ```ruby
 class User < ApplicationRecord


### PR DESCRIPTION
### Summary

The docs have contained a warning that
> Using both `after_create_commit` and `after_update_commit` in the same model will only allow the last callback defined to take effect, and will override all others.

to this I suggest updating it to 

> with the same method in the same model

### Other Information

This is because that is what is accurate.

For example, if I have

```ruby
  after_create_commit :say_apple
  after_create_commit :say_banana
  after_update_commit :say_cherry
  after_update_commit :say_dragonfruit
  
  def say_apple
    puts "apple"
  end

  def say_banana
    puts "banana"
  end

  def say_cherry
    puts "cherry"
  end

  def say_dragonfruit
    puts "dragonfruit"
  end
```
then creating outputs both `apple` and `banana` and updating outputs both `cherry` and `dragonfruit`. However, when the same method is used, such as in the example provided already in the docs, that's when there is actually an override.