### PR TITLE
Fix integer division of ActiveSupport::Duration

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug where integer division of `ActiveSupport::Duration` would
+    result in zero seconds in cases like `1.day / 24` or `1.hour / 60`.
+
+    *Aaron Gough*
+
 *   Allow Range#=== and Range#cover? on Range
 
     `Range#cover?` can now accept a range argument like `Range#include?` and

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -266,11 +266,11 @@ module ActiveSupport
     # Divides this Duration by a Numeric and returns a new Duration.
     def /(other)
       if Scalar === other
-        Duration.new(value / other.value, parts.map { |type, number| [type, number / other.value] })
+        Duration.new(value / other.value, parts.map { |type, number| [type, number.fdiv(other.value)] })
       elsif Duration === other
         value / other.value
       elsif Numeric === other
-        Duration.new(value / other, parts.map { |type, number| [type, number / other] })
+        Duration.new(value / other, parts.map { |type, number| [type, number.fidv(other)] })
       else
         raise_type_error(other)
       end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -266,11 +266,11 @@ module ActiveSupport
     # Divides this Duration by a Numeric and returns a new Duration.
     def /(other)
       if Scalar === other
-        Duration.new(value / other.value, parts.map { |type, number| [type, number.fdiv(other.value)] })
+        Duration.new(value / other.value, parts.map { |type, number| [type, number / other.value] })
       elsif Duration === other
         value / other.value
       elsif Numeric === other
-        Duration.new(value / other, parts.map { |type, number| [type, number.fidv(other)] })
+        Duration.new(value / other, parts.map { |type, number| [type, number / other] })
       else
         raise_type_error(other)
       end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -96,6 +96,12 @@ class DurationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::Duration, 1.second + 1
   end
 
+  def test_plus_parts
+    assert_equal({ years: 1, days: 1 }, (1.year + 1.day).parts)
+    assert_equal({ months: 1, hours: 1.5 }, (1.month + 1.5.hours).parts)
+    assert_equal({ years: 1, days: -1 }, (1.year + -1.day).parts)
+  end
+
   def test_minus
     assert_equal 1.second, 2.seconds - 1.second
     assert_instance_of ActiveSupport::Duration, 2.seconds - 1.second
@@ -105,10 +111,22 @@ class DurationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::Duration, 2.seconds - 1
   end
 
+  def test_minus_parts
+    assert_equal({ years: 1, days: -1 }, (1.year - 1.day).parts)
+    assert_equal({ months: 1, hours: -1.5 }, (1.month - 1.5.hours).parts)
+    assert_equal({ years: 1, days: 1 }, (1.year - -1.day).parts)
+  end
+
   def test_multiply
     assert_equal 7.days, 1.day * 7
     assert_instance_of ActiveSupport::Duration, 1.day * 7
     assert_equal 86400, 1.day * 1.second
+  end
+
+  def test_multiply_parts
+    assert_equal({ years: 2 }, (1.year * 2).parts)
+    assert_equal({ months: 2.5 }, (1.month * 2.5).parts)
+    assert_equal({ years: -2 }, (1.year * -2).parts)
   end
 
   def test_divide
@@ -126,6 +144,12 @@ class DurationTest < ActiveSupport::TestCase
 
     assert_equal 1, 1.day / 1.day
     assert_kind_of Integer, 1.day / 1.hour
+  end
+
+  def test_divide_parts
+    assert_equal({ years: 0.5 }, (1.year / 2).parts)
+    assert_equal({ months: 0.4 }, (1.month / 2.5).parts)
+    assert_equal({ years: -0.5 }, (1.year / -2).parts)
   end
 
   def test_modulo
@@ -154,6 +178,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::Duration, 13.months % 1.year
   end
 
+  def test_modulo_parts
+    assert_equal({ months: 1 }, (13.months % 1.year).parts)
+    assert_equal({ days: 1 }, (36.days % 7.days).parts)
+  end
+
   def test_date_added_with_multiplied_duration
     assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 1.day * 2
   end
@@ -168,6 +197,10 @@ class DurationTest < ActiveSupport::TestCase
 
   def test_date_added_with_divided_duration_larger_than_one_month
     assert_equal Date.civil(2017, 2, 15), Date.civil(2017, 1, 1) + 90.days / 2
+  end
+
+  def test_date_minused_by_divided_duration
+    assert_equal Date.civil(2017, 12, 31), Date.civil(2018, 1, 1) - (1.week / 7)
   end
 
   def test_plus_with_time
@@ -471,6 +504,17 @@ class DurationTest < ActiveSupport::TestCase
     end
 
     assert_equal "no implicit conversion of String into ActiveSupport::Duration::Scalar", exception.message
+  end
+
+  def test_scalar_divide_parts
+    scalar = ActiveSupport::Duration::Scalar.new(2)
+
+    assert_equal({ years: 0.5 }, (1.year / scalar).parts)
+    assert_equal({ years: -0.5 }, (1.year / -scalar).parts)
+  end
+
+  def test_date_minused_by_divided_duration_by_scalar
+    assert_equal Date.civil(2017, 12, 31), Date.civil(2018, 1, 1) - (1.week / ActiveSupport::Duration::Scalar.new(7))
   end
 
   def test_scalar_modulo


### PR DESCRIPTION
### Summary

Fixes issue: https://github.com/rails/rails/issues/33179

In the case where an `ActiveSupport::Duration` object was divided by an integer, it would often return `0 seconds` as the result incorrectly. This is because it was performing integer division on the `#parts` of the original duration. So 1 year divided by 2 would result in zero:

```ruby
1.year / 2
 => 0 seconds
```

The `#value` of the resulting duration was correct, but the `#parts` was not and this would cause issues in any case that used the parts like when performing math against a date or time object, eg:

```ruby
> Time.new(2018, 1, 1, 0, 0, 0, "+00:00") - (1.day / 24)
=> 2018-01-01 00:00:00 +0000
# should be 2017-12-31 23:00:00 +0000
```