### PR TITLE
PostgreSQL: prepare for pg-1.1

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -33,7 +33,13 @@ module ActiveRecord
 
           def cast(value)
             if value.is_a?(::String)
-              value = @pg_decoder.decode(value)
+              value = begin
+                @pg_decoder.decode(value)
+              rescue TypeError
+                # malformed array string is treated as [], will raise in PG 2.0 gem
+                # this keeps a consistent implementation
+                []
+              end
             end
             type_cast_array(value, :cast)
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -4,6 +4,14 @@
 gem "pg", ">= 0.18", "< 2.0"
 require "pg"
 
+# Use async_exec instead of exec_params on pg versions before 1.1
+class ::PG::Connection
+  unless self.public_method_defined?(:async_exec_params)
+    remove_method :exec_params
+    alias exec_params async_exec
+  end
+end
+
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/postgresql/column"
@@ -600,7 +608,7 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.async_exec(sql, type_casted_binds)
+              @connection.exec_params(sql, type_casted_binds)
             end
           end
         end


### PR DESCRIPTION
pg-1.1 is planned to deprecate some behavior. I (tried to) discussed this [here](https://bitbucket.org/ged/ruby-pg/issues/277/deprecation-warnings-for-query-methods). It currently warns at every method invocation, but I plan to change it to warm only once and to add an environment variable to disable the warning entirely. I'm also open to disable the most prominent warning about async_exec vs. async_exec_params until the next rails-5.x releases are out.

Fixes #33185