### PR TITLE
Improve model attribute accessor method names for backtraces

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -22,15 +22,6 @@ module ActiveRecord
       delegate :column_for_attribute, to: :class
     end
 
-    AttrNames = Module.new {
-      def self.set_name_cache(name, value)
-        const_name = "ATTR_#{name}"
-        unless const_defined? const_name
-          const_set const_name, -value
-        end
-      end
-    }
-
     RESTRICTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
 
     class GeneratedAttributeMethods < Module #:nodoc:

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -13,19 +13,19 @@ module ActiveRecord
         private
 
           def define_method_attribute=(name)
-            safe_name = name.unpack1("h*")
-            ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
             sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
 
-            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-              def __temp__#{safe_name}=(value)
-                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-                #{sync_with_transaction_state}
-                _write_attribute(name, value)
-              end
-              alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
-              undef_method :__temp__#{safe_name}=
-            STR
+            ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
+              generated_attribute_methods, name, writer: true,
+            ) do |temp_method_name, attr_name_expr|
+              generated_attribute_methods.module_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def #{temp_method_name}(value)
+                  name = #{attr_name_expr}
+                  #{sync_with_transaction_state}
+                  _write_attribute(name, value)
+                end
+              RUBY
+            end
           end
       end
 


### PR DESCRIPTION
## Problem

Attribute accessor method names use a temp name like `__temp__36f657e6472797` when defining the method then alias the method to the attribute name.  This was done so it could support arbitrary attribute names while still defining the methods with the `def` keyword for performance reasons.  However, ruby uses the method name given when the method is defined in Exception#backtrace, Kernel#caller, Kernel#caller_locations and TracePoint#method_id.

This can be demonstrated with the simple ruby script

```ruby
class Address
  def __temp__36f657e6472797
    raise 'demo'
  end
  alias_method :country, :__temp__36f657e6472797
end
Address.new.country
```

which outputs

```
main.rb:3:in `__temp__36f657e6472797': demo exception (RuntimeError)
	from main.rb:7:in `<main>'
```

This is unnecessary obscure in the common case where the method name is compatible with `def`.

## Solution

Define the method using the attribute name directly if it is compatible with the `def` keyword syntax.

To reduce duplication, I've moved this conditional logic to ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method so it can be re-used for attribute readers and writers for active record and active model.