### PR TITLE
Delete files if they exist not the opposite:

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -153,11 +153,11 @@ module Rails
       end
 
       if options[:api]
-        unless cookie_serializer_config_exist
+        if cookie_serializer_config_exist
           remove_file "config/initializers/cookies_serializer.rb"
         end
 
-        unless csp_config_exist
+        if csp_config_exist
           remove_file "config/initializers/content_security_policy.rb"
         end
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -330,6 +330,32 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_cookies_serializer_initializer_when_api_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { api: true }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+
+      assert_no_file "#{app_root}/config/initializers/cookies_serializer.rb"
+    end
+  end
+
+  def test_app_update_does_not_generate_csp_initializer_when_api_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { api: true }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+
+      assert_no_file "#{app_root}/config/initializers/content_security_policy.rb"
+    end
+  end
+
   def test_app_update_does_not_generate_spring_contents_when_skip_spring_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-spring"]


### PR DESCRIPTION
Delete files if they exist not the opposite:

- We were removing file if they **don't** exist, which doesn't really
  make sense. Should be a `if` instead of an `unless`. Added test
  coverage as well
