### PR TITLE
Active Storage: Explicit form field in basic example

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -230,6 +230,10 @@ end
 
 You can create a user with an avatar:
 
+```erb
+<%= form.file_field :avatar %>
+```
+
 ```ruby
 class SignupController < ApplicationController
   def create
@@ -479,7 +483,7 @@ directly from the client to the cloud.
 
 2. Annotate file inputs with the direct upload URL.
 
-    ```ruby
+    ```erb
     <%= form.file_field :attachments, multiple: true, direct_upload: true %>
     ```
 3. That's it! Uploads begin upon form submission.


### PR DESCRIPTION
There was an example of the controller code but not the view code. This also made me uncertain whether Active Storage supported to-server uploads or just direct-to-S3. Turns out to-server works.

Also fix syntax highlighting in the more advanced JS example.