### PR TITLE
Update raabro to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,7 @@ GEM
     qunit-selenium (0.0.4)
       selenium-webdriver
       thor
-    raabro (1.1.5)
+    raabro (1.1.6)
     racc (1.4.14)
     rack (2.0.5)
     rack-cache (1.7.2)


### PR DESCRIPTION
[v 1.1.6](https://github.com/floraison/raabro/blob/master/CHANGELOG.md#raabro-116--released-2018-06-22) fixes a warning we see on [Rails CI](https://travis-ci.org/rails/rails/jobs/395177524#L3763).