### PR TITLE
Support months and years in Numeric, not only Integer

### DIFF
--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "active_support/core_ext/integer/time"
 require "active_support/core_ext/numeric/time"
 
 class ConditionalGetApiController < ActionController::API

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -101,6 +101,16 @@
 
     *Jason Lee*
 
+*   Support months and years in Numeric, not only Integer
+
+    `.month(s)` and `.year(s)` now be added to Numeric, not only Integer.
+    e.g. `1.5.months`
+
+    *Requiring active_support/core_ext/integer/time is now deprecated.*
+    *Use `require "active_support/core_ext/numeric/time"` instead.*
+
+    *jychen7*
+
 *   Allow `Range#===` and `Range#cover?` on Range.
 
     `Range#cover?` can now accept a range argument like `Range#include?` and

--- a/activesupport/lib/active_support/core_ext/integer.rb
+++ b/activesupport/lib/active_support/core_ext/integer.rb
@@ -2,4 +2,3 @@
 
 require "active_support/core_ext/integer/multiple"
 require "active_support/core_ext/integer/inflections"
-require "active_support/core_ext/integer/time"

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -2,21 +2,8 @@
 
 require "active_support/duration"
 require "active_support/core_ext/numeric/time"
+require "active_support/deprecation"
 
-class Integer
-  # Returns a Duration instance matching the number of months provided.
-  #
-  #   2.months # => 2 months
-  def months
-    ActiveSupport::Duration.months(self)
-  end
-  alias :month :months
-
-  # Returns a Duration instance matching the number of years provided.
-  #
-  #   2.years # => 2 years
-  def years
-    ActiveSupport::Duration.years(self)
-  end
-  alias :year :years
-end
+ActiveSupport::Deprecation.warn "You have required `active_support/core_ext/integer/time`. " \
+"This file will be removed in Rails 6.1. You should require `active_support/core_ext/numeric/time` " \
+  "instead."

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -47,6 +47,22 @@ class Numeric
   end
   alias :week :weeks
 
+  # Returns a Duration instance matching the number of months provided.
+  #
+  #   2.months # => 2 months
+  def months
+    ActiveSupport::Duration.months(self)
+  end
+  alias :month :months
+
+  # Returns a Duration instance matching the number of years provided.
+  #
+  #   2.years # => 2 years
+  def years
+    ActiveSupport::Duration.years(self)
+  end
+  alias :year :years
+
   # Returns a Duration instance matching the number of fortnights provided.
   #
   #   2.fortnights # => 4 weeks

--- a/activesupport/lib/active_support/time.rb
+++ b/activesupport/lib/active_support/time.rb
@@ -13,7 +13,6 @@ require "active_support/core_ext/time"
 require "active_support/core_ext/date"
 require "active_support/core_ext/date_time"
 
-require "active_support/core_ext/integer/time"
 require "active_support/core_ext/numeric/time"
 
 require "active_support/core_ext/string/conversions"

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -10,8 +10,34 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
     @now = Time.local(2005, 2, 10, 15, 30, 45)
     @dtnow = DateTime.civil(2005, 2, 10, 15, 30, 45)
     @seconds = {
-      1.minute   => 60,
-      10.minutes => 600,
+      1.second     => ActiveSupport::Duration::PARTS_IN_SECONDS[:seconds],
+      1.minute     => ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes],
+      1.hour       => ActiveSupport::Duration::PARTS_IN_SECONDS[:hours],
+      1.day        => ActiveSupport::Duration::PARTS_IN_SECONDS[:days],
+      1.week       => ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks],
+      1.month      => ActiveSupport::Duration::PARTS_IN_SECONDS[:months],
+      1.year       => ActiveSupport::Duration::PARTS_IN_SECONDS[:years],
+      1.0.second   => ActiveSupport::Duration::PARTS_IN_SECONDS[:seconds],
+      1.0.minute   => ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes],
+      1.0.hour     => ActiveSupport::Duration::PARTS_IN_SECONDS[:hours],
+      1.0.day      => ActiveSupport::Duration::PARTS_IN_SECONDS[:days],
+      1.0.week     => ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks],
+      1.0.month    => ActiveSupport::Duration::PARTS_IN_SECONDS[:months],
+      1.0.year     => ActiveSupport::Duration::PARTS_IN_SECONDS[:years],
+      10.seconds   => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:seconds],
+      10.minutes   => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes],
+      10.hours     => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:hours],
+      10.days      => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:days],
+      10.weeks     => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks],
+      10.months    => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:months],
+      10.years     => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:years],
+      10.0.seconds => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:seconds],
+      10.0.minutes => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes],
+      10.0.hours   => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:hours],
+      10.0.days    => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:days],
+      10.0.weeks   => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks],
+      10.0.months  => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:months],
+      10.0.years   => 10 * ActiveSupport::Duration::PARTS_IN_SECONDS[:years],
       1.hour + 15.minutes => 4500,
       2.days + 4.hours + 30.minutes => 189000,
       5.years + 1.month + 1.fortnight => 161624106
@@ -22,6 +48,10 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
     @seconds.each do |actual, expected|
       assert_equal expected, actual
     end
+  end
+
+  def test_in_milliseconds
+    assert_equal 10_000, 10.seconds.in_milliseconds
   end
 
   def test_irregular_durations
@@ -400,10 +430,6 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_raises TypeError do
       1.to_s({})
     end
-  end
-
-  def test_in_milliseconds
-    assert_equal 10_000, 10.seconds.in_milliseconds
   end
 
   def test_requiring_inquiry_is_deprecated

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1958,7 +1958,7 @@ as well as adding or subtracting their results from a Time object. For example:
 
 WARNING. For other durations please refer to the time extensions to `Numeric`.
 
-NOTE: Defined in `active_support/core_ext/integer/time.rb`.
+NOTE: Defined in `active_support/core_ext/numeric/time.rb`.
 
 Extensions to `BigDecimal`
 --------------------------


### PR DESCRIPTION
https://github.com/rails/rails/issues/33200

### Summary

    Support months and years in Numeric, not only Integer

    `.month(s)` and `.year(s)` now be added to Numeric, not only Integer.
    e.g. `1.5.months`

    *Requiring active_support/core_ext/integer/time is now deprecated.*
    *Use `require "active_support/core_ext/numeric/time"` instead.*


### Other Information

`active_support/core_ext/integer/time` is marked as deprecated, and reuse the error message form other file, is it correct way?