### PR TITLE
Update sprockets to Security release for CVE-2018-3760

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
       concurrent-ruby (~> 1.0)
       serverengine (~> 2.0.5)
       thor
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-export (1.0.0)


### PR DESCRIPTION
See:

https://github.com/rails/sprockets/blob/v3.7.2/CHANGELOG.md
https://github.com/rails/sprockets/commit/9c34fa05900b968d74f08ccf40917848a7be9441
