### PR TITLE
Revert "Avoid Node.js v10.4.0 for now"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"
-  - "[[ $GEM != 'av:ujs' ]] || nvm install v10.3.0" # FIXME: Remove version lock.
+  - "[[ $GEM != 'av:ujs' ]] || nvm install node"
   - "[[ $GEM != 'av:ujs' ]] || node --version"
   - "[[ $GEM != 'av:ujs' ]] || (cd actionview && npm install)"
 


### PR DESCRIPTION
This reverts commit 691addbffad10aa249d5fb1b0e47b46a086e5332.

Reason: v10.5.0 has been released, and it seems that the issue is fixed.
Ref: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.5.0