### PR TITLE
Add tests for duration multiplication and division

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -158,6 +158,18 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 1.day * 2
   end
 
+  def test_date_added_with_multiplied_duration_larger_than_one_month
+    assert_equal Date.civil(2017, 2, 15), Date.civil(2017, 1, 1) + 1.day * 45
+  end
+
+  def test_date_added_with_divided_duration
+    assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 4.days / 2
+  end
+
+  def test_date_added_with_divided_duration_larger_than_one_month
+    assert_equal Date.civil(2017, 2, 15), Date.civil(2017, 1, 1) + 90.days / 2
+  end
+
   def test_plus_with_time
     assert_equal 1 + 1.second, 1.second + 1, "Duration + Numeric should == Numeric + Duration"
   end


### PR DESCRIPTION
When multiplying or dividing a duration by a scalar, it's tempting to operate directly on the duration's value in seconds and recompute the parts from the result. However this loses information, as there are multiple combinations of parts that map to any given number of seconds (e.g. `2.weeks` or `336.hours`). This is especially problematic when dealing with durations on the scale of months or years, as converting an exact number of seconds to one of those intervals and then using the resulting duration to modify a date will give the wrong result.

The implementation in https://github.com/rails/rails/pull/33183 had this problem, and the existing tests didn't catch it.

r? @pixeltrix 