### PR TITLE
Lazily add `Aggregations` to `composed_of` models

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -225,6 +225,10 @@ module ActiveRecord
         def composed_of(part_id, options = {})
           options.assert_valid_keys(:class_name, :mapping, :allow_nil, :constructor, :converter)
 
+          unless self < Aggregations
+            include Aggregations
+          end
+
           name        = part_id.id2name
           class_name  = options[:class_name]  || name.camelize
           mapping     = options[:mapping]     || [ name, name ]

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -288,6 +288,7 @@ module ActiveRecord #:nodoc:
     extend Enum
     extend Delegation::DelegateCache
     extend CollectionCacheKey
+    extend Aggregations::ClassMethods
 
     include Core
     include DatabaseConfigurations
@@ -314,7 +315,6 @@ module ActiveRecord #:nodoc:
     include ActiveModel::SecurePassword
     include AutosaveAssociation
     include NestedAttributes
-    include Aggregations
     include Transactions
     include TouchLater
     include NoTouching


### PR DESCRIPTION
`composed_of` is a fairly rare method to call on models.  This commit
adds the `Aggregations` module to models that call `composed_of` so that
models that *don't* call `composed_of` don't need to instantiate the
`aggregation_cache` hash.  This saves one hash allocation per model
instance that doesn't use `composed_of`

Benchmark:

```
require 'active_record'

ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"

ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name
    t.timestamps null: false
  end
end


class User < ActiveRecord::Base; end

2000.times do
  User.create!(name: "Gorby")
end

users = User.limit(2000).to_a
GC.start
p ObjectSpace.count_objects[:T_HASH]

```

Result:

```
[aaron@TC activerecord (lazy-aggregate)]$ be ruby -I lib:~/git/allocation_tracer/lib count_objs.rb 
9163
[aaron@TC activerecord (lazy-aggregate)]$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
[aaron@TC activerecord (master)]$ be ruby -I lib:~/git/allocation_tracer/lib count_objs.rb 
11164
```
