### PR TITLE
Add example for no_touching? for api docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/no_touching.rb
+++ b/activerecord/lib/active_record/no_touching.rb
@@ -43,6 +43,13 @@ module ActiveRecord
         end
     end
 
+    # Returns +true+ if the class has +no_touching+ set, +false+ otherwise.
+    #
+    #   Project.no_touching do
+    #     Project.first.no_touching? # true
+    #     Message.first.no_touching? # false
+    #   end
+    #
     def no_touching?
       NoTouching.applied_to?(self.class)
     end


### PR DESCRIPTION
There was no example code for ActiveRecord::NoTouching#no_touching?.
This PR adds an example for the API docs.