### PR TITLE
Enable TESTOPTS in railties tests

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -46,7 +46,7 @@ namespace :test do
       # We could run these in parallel, but pretty much all of the
       # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
       Process.waitpid fork {
-        ARGV.clear
+        ARGV.clear.push ENV["TESTOPTS"]
         Rake.application = nil
 
         load file


### PR DESCRIPTION
Unlike the other components' test suites, railties' currently
ignores such useful options as `"--verbose"`.

This patch allows us to use them.