### PR TITLE
Call initialize after allocate

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -139,11 +139,6 @@ module ActiveRecord
     end
 
     module ClassMethods # :nodoc:
-      def allocate
-        define_attribute_methods
-        super
-      end
-
       def initialize_find_by_cache # :nodoc:
         @find_by_statement_cache = { true => Concurrent::Map.new, false => Concurrent::Map.new }
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -163,19 +163,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "10", keyboard.read_attribute_before_type_cast(:key_number)
   end
 
-  # Syck calls respond_to? before actually calling initialize.
-  test "respond_to? with an allocated object" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "topics"
-    end
-
-    topic = klass.allocate
-    assert_not_respond_to topic, "nothingness"
-    assert_not_respond_to topic, :nothingness
-    assert_respond_to topic, "title"
-    assert_respond_to topic, :title
-  end
-
   # IRB inspects the return value of MyModel.allocate.
   test "allocated objects can be inspected" do
     topic = Topic.allocate


### PR DESCRIPTION
If someone calls allocate on the object, they'd better also call an
initialization routine too (you can't expect allocate to do any
initialization work).  Before this commit, AR objects that are
instantiated from the database would call `define_attribute_methods`
twice.
