### PR TITLE
Add changelog entry for 3110cae [ci skip]

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow passing multiple exceptions to `retry_on`, and `discard_on`.
+
+    *George Claghorn*
+
 *   Pass the error instance as the second parameter of block executed by `discard_on`.
 
     Fixes #32853.


### PR DESCRIPTION
Since it is changes of the public API, it seems valuable to add a mention
about it to the changelog file.

Follow up 3110caecbebdad7300daaf26bfdff39efda99e25