### PR TITLE
fix .blank? method; we should use nil? for Object insted of empty?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -17,7 +17,7 @@ class Object
   #
   # @return [true, false]
   def blank?
-    respond_to?(:empty?) ? !!empty? : !self
+    respond_to?(:nil?) ? !!nil? : !self
   end
 
   # An object is present if it's not blank.


### PR DESCRIPTION
### Summary
In this PR fix `.blank?` method in activesupport
issue [33231](https://github.com/rails/rails/issues/33231)
![screen shot 2018-06-27 at 3 07 54 am](https://user-images.githubusercontent.com/8098344/41945764-5cb0c92c-79b7-11e8-9138-b8b899c01830.png)
method `.blank?` was broken in my project then I check source_location of method 
![screen shot 2018-06-27 at 3 09 40 am](https://user-images.githubusercontent.com/8098344/41945879-230f8860-79b8-11e8-8a33-d8d0f00e292b.png)
and for object there use `.empty?` method instead if `.nil?`

Full description in issue