### PR TITLE
Autoload Activejob::Arguments

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -31,6 +31,7 @@ require "global_id"
 module ActiveJob
   extend ActiveSupport::Autoload
 
+  autoload :Arguments
   autoload :Base
   autoload :QueueAdapters
   autoload :Serializers

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_job/arguments"
-
 module ActiveJob
   # Provides behavior for enqueuing jobs.
   module Enqueuing

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/rescuable"
-require "active_job/arguments"
 
 module ActiveJob
   module Execution


### PR DESCRIPTION
### Summary

Currently, initial rails console can't load `ActiveJob::Arguments`.

```sh
$ ./bin/rails console
> ActiveJob::Arguments.serialize(...)
NameError: uninitialized constant ActiveJob::Arguments
```

It is inconvenient for me because I want to check the behavior from the console.