### PR TITLE
Note deliver_later_queue_name gotcha in ActionMailer guide

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -217,6 +217,8 @@ pending jobs on restart.
 If you need a persistent backend, you will need to use an Active Job adapter
 that has a persistent backend (Sidekiq, Resque, etc).
 
+NOTE: When calling `deliver_later` the job will be placed under `mailers` queue. Make sure Active Job adapter support it otherwise the job may be silently ignored preventing email delivery. You can change that by specifying `config.action_mailer.deliver_later_queue_name` option.
+
 If you want to send emails right away (from a cronjob for example) just call
 `deliver_now`:
 


### PR DESCRIPTION
Mention a "gotcha" when using Action Mailer with Active Job's in the guides.