### PR TITLE
respect path_only option when an array is passed into url_for

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Respect the `path_only` option passed to `url_for` when the options are passed in as an array
+    
+    Fixes #33237.
+
+    *Joel Ambass*
+
 *   Add `year_format` option to date_select tag. This option makes it possible to customize year
     names. Lambda should be passed to use this option.
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -10,6 +10,12 @@
 
     *Juan Broullon*
 
+*   Respect the `path_only` option passed to `url_for` when the options are passed in as an array
+    
+    Fixes #33237.
+
+    *Joel Ambass*
+
 *   Add `year_format` option to date_select tag. This option makes it possible to customize year
     names. Lambda should be passed to use this option.
 

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -84,25 +84,24 @@ module ActionView
         super(only_path: _generate_paths_by_default)
       when Hash
         options = options.symbolize_keys
-        unless options.key?(:only_path)
-          options[:only_path] = only_path?(options[:host])
-        end
+        ensure_only_path_option(options)
 
         super(options)
       when ActionController::Parameters
-        unless options.key?(:only_path)
-          options[:only_path] = only_path?(options[:host])
-        end
+        ensure_only_path_option(options)
 
         super(options)
       when :back
         _back_url
       when Array
         components = options.dup
-        if _generate_paths_by_default
-          polymorphic_path(components, components.extract_options!)
+        options = components.extract_options!
+        ensure_only_path_option(options)
+
+        if options[:only_path]
+          polymorphic_path(components, options)
         else
-          polymorphic_url(components, components.extract_options!)
+          polymorphic_url(components, options)
         end
       else
         method = _generate_paths_by_default ? :path : :url
@@ -138,8 +137,14 @@ module ActionView
         true
       end
 
-      def only_path?(host)
-        _generate_paths_by_default unless host
+      def ensure_only_path_option(options)
+        unless options.key?(:only_path)
+          options[:only_path] = _generate_paths_by_default unless host_option_set?(options)
+        end
+      end
+
+      def host_option_set?(options)
+        !!options[:host]
       end
   end
 end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -75,6 +75,15 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal "javascript:history.back()", url_for(:back)
   end
 
+  def test_url_for_defaults_to_only_path_true
+    assert_equal '/other', url_for(hash_for(action: 'other'))
+  end
+
+  def test_url_for_with_only_path_set_to_false
+    default_url_options[:host] = 'http://example.com'
+    assert_equal 'http://example.com/other', url_for(hash_for(action: 'other', only_path: false))
+  end
+
   def test_to_form_params_with_hash
     assert_equal(
       [{ name: :name, value: "David" }, { name: :nationality, value: "Danish" }],

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -76,12 +76,12 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_url_for_defaults_to_only_path_true
-    assert_equal '/other', url_for(hash_for(action: 'other'))
+    assert_equal "/other", url_for(hash_for(action: "other"))
   end
 
   def test_url_for_with_only_path_set_to_false
-    default_url_options[:host] = 'http://example.com'
-    assert_equal 'http://example.com/other', url_for(hash_for(action: 'other', only_path: false))
+    default_url_options[:host] = "http://example.com"
+    assert_equal "http://example.com/other", url_for(hash_for(action: "other", only_path: false))
   end
 
   def test_to_form_params_with_hash


### PR DESCRIPTION
The url_for method is now extracting the path_only option in order to determine if polymorphic_path or polymorphic_url should be called. 

If the path_only option is not set it will be set to true unless the host option is set. This behaviour is the same as when a Hash or Params object is passed.

To support this unifying the code responsible for setting this default value has been extracted into a private method

### Summary
Fixes: #33237

I couldn't find the right spot to put some test in for this behaviour. I could use some pointers there.
