### PR TITLE
Support readonly option in SQLite3Adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -29,9 +29,11 @@ module ActiveRecord
         Dir.mkdir(dirname) unless File.directory?(dirname)
       end
 
+      db_opts = config.symbolize_keys.merge(results_as_hash: true)
+
       db = SQLite3::Database.new(
         config[:database].to_s,
-        results_as_hash: true
+        db_opts
       )
 
       db.busy_timeout(ConnectionAdapters::SQLite3Adapter.type_cast_config_to_integer(config[:timeout])) if config[:timeout]


### PR DESCRIPTION
### Summary

Readonly sqlite database files are very useful as a data format for storing configuration/lookup data that is too complicated for YAML files.  But since such files would typically be committed to a source
control repository, it's important to ensure that they are truly safe from being inadvertently modified.  Unfortunately using unix permissions isn't enough, as sqlite will "helpfully" add the write bit to a database file whenever it's written to.

sqlite3-ruby has supported a `:readonly` option since version 1.3.2 (see https://github.com/sparklemotion/sqlite3-ruby/commit/c20c9f5dd2990042)

This simply passes that option through to the sqlite adapter if present in the config hash.  I think this is best considered an adapter-specific option since no other supported database has an identical concept.