### PR TITLE
Fix ActionMailer assert_enqueued_email_with

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -301,7 +301,7 @@ module ActiveJob
       original_enqueued_jobs_count = enqueued_jobs.count
       expected = { job: job, args: args, at: at, queue: queue }.compact
       serialized_args = serialize_args_for_assertion(expected)
-      yield
+      yield if block_given?
       in_block_jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
       matching_job = in_block_jobs.find do |in_block_job|
         serialized_args.all? { |key, value| value == in_block_job[key] }


### PR DESCRIPTION
### Summary

The documentation for [`assert_enqueued_email_with`](https://github.com/rails/rails/blob/41e9a671d6fbb7ed7f98ef1b6b46ee4ac3db27a9/actionmailer/lib/action_mailer/test_helper.rb#L126) states that it's supposed to work without a block yet it calls [`assert_enqueued_with`](https://github.com/rails/rails/blob/af08044d6a6aa87d3b389f63c78564be2f60b1ab/activejob/lib/active_job/test_helper.rb#L300) which doesn't check whether a block was passed before calling `yield`.
