### PR TITLE
Refactor Previewer::PopplerPDFPreviewer#pdftoppm_exists?

### DIFF
--- a/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
@@ -12,7 +12,7 @@ module ActiveStorage
       end
 
       def pdftoppm_exists?
-        return @pdftoppm_exists unless @pdftoppm_exists.nil?
+        return @pdftoppm_exists if defined?(@pdftoppm_exists)
 
         @pdftoppm_exists = system(pdftoppm_path, "-v", out: File::NULL, err: File::NULL)
       end


### PR DESCRIPTION
So as not to emit: `warning: instance variable @pdftoppm_exists not initialized`.

See [CI](https://travis-ci.org/rails/rails/jobs/397717259#L1445)
