### PR TITLE
Add :expires_in option support for RedisCacheStore increment/decrement method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -131,5 +131,16 @@
 
     *Eileen M. Uchitelle*, *Aaron Patterson*
 
+*   RedisCacheStore: Support expiring counters.
+    Pass `expires_in: [seconds]` to `#increment` and `#decrement` options
+    to set the Redis EXPIRE if the counter doesn't exist.
+    If the counter exists, Redis doesn't extend its expiry when it's exist.
+
+    ```
+    Rails.cache.increment("my_counter", 1, expires_in: 2.minutes)
+    ```
+
+    *Jason Lee*
+
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -141,6 +141,30 @@ module ActiveSupport::Cache::RedisCacheStoreTests
         end
       end
     end
+
+    def test_increment_expires_in
+      assert_called_with @cache.redis, :incrby, [ "#{@namespace}:foo", 1 ] do
+        assert_called_with @cache.redis, :expire, [ "#{@namespace}:foo", 60 ] do
+          @cache.increment("foo", 1, expires_in: 60)
+        end
+      end
+
+      assert_not_called @cache.redis, :expire do
+        @cache.decrement("foo", 1, expires_in: 60)
+      end
+    end
+
+    def test_decrement_expires_in
+      assert_called_with @cache.redis, :decrby, [ "#{@namespace}:foo", 1 ] do
+        assert_called_with @cache.redis, :expire, [ "#{@namespace}:foo", 60 ] do
+          @cache.decrement("foo", 1, expires_in: 60)
+        end
+      end
+
+      assert_not_called @cache.redis, :expire do
+        @cache.decrement("foo", 1, expires_in: 60)
+      end
+    end
   end
 
   class ConnectionPoolBehaviourTest < StoreTest


### PR DESCRIPTION
Redis not support `incry` with expire option, so call `expire`.

This fix is keep same behavior with the `:memcached` store.

```rb
irb> Rails.cache.increment("my_counter", 1, expires_in: 100)
1
irb> Rails.cache.data.ttl("my_counter")
=> 99
# skip set expire when "my_counter" has ttl
irb> Rails.cache.increment("my_counter", 1, expires_in: 200)
2
irb> Rails.cache.data.ttl("my_counter")
=> 98
```