### PR TITLE
Incompatibility of Direct Uploads & Mirror Service

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -211,6 +211,8 @@ production:
 
 NOTE: Files are served from the primary service.
 
+NOTE: This is not compatible with the [direct uploads](#direct-uploads) feature.
+
 Attaching Files to Records
 --------------------------
 


### PR DESCRIPTION
### Summary

It adds a note to the Active Storage documentation regarding the use of Mirror Service not being compatible with the use of the Direct Uploads (mentioned later on in the documentation), as described in issue #32732.