### PR TITLE
Allow call `assert_enqueued_with` and `assert_enqueued_email_with` with no block

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Allow call `assert_enqueued_email_with` with no block.
+
+    Example:
+    ```
+    def test_email
+      ContactMailer.welcome.deliver_later
+      assert_enqueued_email_with ContactMailer, :welcome
+    end
+
+    def test_email_with_arguments
+      ContactMailer.welcome("Hello", "Goodbye").deliver_later
+      assert_enqueued_email_with ContactMailer, :welcome, args: ["Hello", "Goodbye"]
+    end
+    ```
+
+    *bogdanvlviv*
+
 *   Ensure mail gem is eager autoloaded when eager load is true to prevent thread deadlocks.
 
     *Samuel Cochran*

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -252,7 +252,16 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
-  def test_assert_enqueued_email_with_args
+  def test_assert_enqueued_email_with_with_no_block
+    assert_nothing_raised do
+      silence_stream($stdout) do
+        TestHelperMailer.test.deliver_later
+        assert_enqueued_email_with TestHelperMailer, :test
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_with_args
     assert_nothing_raised do
       assert_enqueued_email_with TestHelperMailer, :test_args, args: ["some_email", "some_name"] do
         silence_stream($stdout) do
@@ -262,12 +271,30 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
-  def test_assert_enqueued_email_with_parameterized_args
+  def test_assert_enqueued_email_with_with_no_block_with_args
+    assert_nothing_raised do
+      silence_stream($stdout) do
+        TestHelperMailer.test_args("some_email", "some_name").deliver_later
+        assert_enqueued_email_with TestHelperMailer, :test_args, args: ["some_email", "some_name"]
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_with_parameterized_args
     assert_nothing_raised do
       assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" } do
         silence_stream($stdout) do
           TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
         end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_with_no_block_wiht_parameterized_args
+    assert_nothing_raised do
+      silence_stream($stdout) do
+        TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
+        assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" }
       end
     end
   end

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow call `assert_enqueued_with` with no block.
+
+    Example:
+    ```
+    def test_assert_enqueued_with
+      MyJob.perform_later(1,2,3)
+      assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low')
+
+      MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+      assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon)
+    end
+    ```
+
+    *bogdanvlviv*
+
 *   Allow passing multiple exceptions to `retry_on`, and `discard_on`.
 
     *George Claghorn*

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -286,7 +286,18 @@ module ActiveJob
       assert_performed_jobs 0, only: only, except: except, &block
     end
 
-    # Asserts that the job passed in the block has been enqueued with the given arguments.
+    # Asserts that the job has been enqueued with the given arguments.
+    #
+    #   def test_assert_enqueued_with
+    #     MyJob.perform_later(1,2,3)
+    #     assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low')
+    #
+    #     MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+    #     assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon)
+    #   end
+    #
+    # If a block is passed, that block should cause the job to be
+    # enqueued with the given arguments.
     #
     #   def test_assert_enqueued_with
     #     assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low') do
@@ -298,14 +309,23 @@ module ActiveJob
     #     end
     #   end
     def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
-      original_enqueued_jobs_count = enqueued_jobs.count
       expected = { job: job, args: args, at: at, queue: queue }.compact
       serialized_args = serialize_args_for_assertion(expected)
-      yield
-      in_block_jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
-      matching_job = in_block_jobs.find do |in_block_job|
+
+      if block_given?
+        original_enqueued_jobs_count = enqueued_jobs.count
+
+        yield
+
+        jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
+      else
+        jobs = enqueued_jobs
+      end
+
+      matching_job = jobs.find do |in_block_job|
         serialized_args.all? { |key, value| value == in_block_job[key] }
       end
+
       assert matching_job, "No enqueued job found with #{expected}"
       instantiate_job(matching_job)
     end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -389,13 +389,18 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/`:only` and `:except`/, error.message)
   end
 
-  def test_assert_enqueued_job
+  def test_assert_enqueued_with
     assert_enqueued_with(job: LoggingJob, queue: "default") do
       LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
     end
   end
 
-  def test_assert_enqueued_job_returns
+  def test_assert_enqueued_with_with_no_block
+    LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
+    assert_enqueued_with(job: LoggingJob, queue: "default")
+  end
+
+  def test_assert_enqueued_with_returns
     job = assert_enqueued_with(job: LoggingJob) do
       LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3)
     end
@@ -406,11 +411,26 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_equal [1, 2, 3], job.arguments
   end
 
-  def test_assert_enqueued_job_failure
+  def test_assert_enqueued_with_with_no_block_returns
+    LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3)
+    job = assert_enqueued_with(job: LoggingJob)
+
+    assert_instance_of LoggingJob, job
+    assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
+    assert_equal "default", job.queue_name
+    assert_equal [1, 2, 3], job.arguments
+  end
+
+  def test_assert_enqueued_with_failure
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_enqueued_with(job: LoggingJob, queue: "default") do
         NestedJob.perform_later
       end
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      LoggingJob.perform_later
+      assert_enqueued_with(job: LoggingJob) {}
     end
 
     error = assert_raise ActiveSupport::TestCase::Assertion do
@@ -422,7 +442,21 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_equal 'No enqueued job found with {:job=>NestedJob, :queue=>"low"}', error.message
   end
 
-  def test_assert_enqueued_job_args
+  def test_assert_enqueued_with_with_no_block_failure
+    assert_raise ActiveSupport::TestCase::Assertion do
+      NestedJob.perform_later
+      assert_enqueued_with(job: LoggingJob, queue: "default")
+    end
+
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      NestedJob.perform_later
+      assert_enqueued_with(job: NestedJob, queue: "low")
+    end
+
+    assert_equal 'No enqueued job found with {:job=>NestedJob, :queue=>"low"}', error.message
+  end
+
+  def test_assert_enqueued_with_args
     assert_raise ArgumentError do
       assert_enqueued_with(class: LoggingJob) do
         NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
@@ -430,20 +464,32 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
-  def test_assert_enqueued_job_with_at_option
-    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon) do
-      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+  def test_assert_enqueued_with_with_no_block_args
+    assert_raise ArgumentError do
+      NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
+      assert_enqueued_with(class: LoggingJob)
     end
   end
 
-  def test_assert_enqueued_job_with_global_id_args
+  def test_assert_enqueued_with_with_no_block_with_at_option
+    HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
+  end
+
+  def test_assert_enqueued_with_with_global_id_args
     ricardo = Person.new(9)
     assert_enqueued_with(job: HelloJob, args: [ricardo]) do
       HelloJob.perform_later(ricardo)
     end
   end
 
-  def test_assert_enqueued_job_failure_with_global_id_args
+  def test_assert_enqueued_with_with_no_block_with_global_id_args
+    ricardo = Person.new(9)
+    HelloJob.perform_later(ricardo)
+    assert_enqueued_with(job: HelloJob, args: [ricardo])
+  end
+
+  def test_assert_enqueued_with_failure_with_global_id_args
     ricardo = Person.new(9)
     wilma = Person.new(11)
     error = assert_raise ActiveSupport::TestCase::Assertion do
@@ -455,11 +501,30 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
   end
 
+  def test_assert_enqueued_with_with_failure_with_no_block_with_global_id_args
+    ricardo = Person.new(9)
+    wilma = Person.new(11)
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      HelloJob.perform_later(ricardo)
+      assert_enqueued_with(job: HelloJob, args: [wilma])
+    end
+
+    assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+  end
+
   def test_assert_enqueued_job_does_not_change_jobs_count
     HelloJob.perform_later
     assert_enqueued_with(job: HelloJob) do
       HelloJob.perform_later
     end
+
+    assert_equal 2, queue_adapter.enqueued_jobs.count
+  end
+
+  def test_assert_enqueued_with_with_no_block_does_not_change_jobs_count
+    HelloJob.perform_later
+    HelloJob.perform_later
+    assert_enqueued_with(job: HelloJob)
 
     assert_equal 2, queue_adapter.enqueued_jobs.count
   end


### PR DESCRIPTION
Example of `assert_enqueued_with` with no block
```ruby
def test_assert_enqueued_with
  MyJob.perform_later(1,2,3)
  assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low')

  MyJob.set(wait_until: Date.tomorrow.noon).perform_later
  assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon)
end
```

Example of `assert_enqueued_email_with` with no block:
```ruby
def test_email
  ContactMailer.welcome.deliver_later
  assert_enqueued_email_with ContactMailer, :welcome
end

def test_email_with_arguments
  ContactMailer.welcome("Hello", "Goodbye").deliver_later
  assert_enqueued_email_with ContactMailer, :welcome, args: ["Hello", "Goodbye"]
end
```

Related to #33243
