### PR TITLE
Fix docs of `assert_no_emails` [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -60,7 +60,7 @@ module ActionMailer
     #
     # Note: This assertion is simply a shortcut for:
     #
-    #   assert_emails 0
+    #   assert_emails 0, &block
     def assert_no_emails(&block)
       assert_emails 0, &block
     end


### PR DESCRIPTION
`assert_no_emails` is shortcut for `assert_emails 0, &block`.