### PR TITLE
Backport a845ffd to 5-2-stable [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -211,6 +211,8 @@ production:
 
 NOTE: Files are served from the primary service.
 
+NOTE: This is not compatible with the [direct uploads](#direct-uploads) feature.
+
 Attaching Files to Records
 --------------------------
 


### PR DESCRIPTION
Incompatibility of Direct Uploads & Mirror Service

Since #32732 might be fixed only for Rails 6.0, #33255 should be
backported to 5-2-stable directly.

cherry-pick a845ffdbd6d02f2166c24524e85ed67598b11938