### PR TITLE
Remove erroneous remove_column option from example

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -560,7 +560,7 @@ argument. Provide the original column options too, otherwise Rails can't
 recreate the column exactly when rolling back:
 
 ```ruby
-remove_column :posts, :slug, :string, null: false, default: '', index: true
+remove_column :posts, :slug, :string, null: false, default: ''
 ```
 
 If you're going to need to use any other methods, you should use `reversible`


### PR DESCRIPTION
### Summary

Hello, [Active Record Migrations](http://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method) has wrong example for `remove_column`. Currently it shows that `remove_column` accepts `index: true` option but in fact it doesn't. See documentation of [add_column](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column) and [remove_column](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_column). This pull request fixes the issue.