### PR TITLE
Clarify activejob/lib/active_job/test_helper.rb

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -322,8 +322,8 @@ module ActiveJob
         jobs = enqueued_jobs
       end
 
-      matching_job = jobs.find do |in_block_job|
-        serialized_args.all? { |key, value| value == in_block_job[key] }
+      matching_job = jobs.find do |enqueued_job|
+        serialized_args.all? { |key, value| value == enqueued_job[key] }
       end
 
       assert matching_job, "No enqueued job found with #{expected}"

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -471,6 +471,12 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_with_with_at_option
+    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon) do
+      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+    end
+  end
+
   def test_assert_enqueued_with_with_no_block_with_at_option
     HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
     assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
@@ -501,7 +507,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
   end
 
-  def test_assert_enqueued_with_with_failure_with_no_block_with_global_id_args
+  def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
     ricardo = Person.new(9)
     wilma = Person.new(11)
     error = assert_raise ActiveSupport::TestCase::Assertion do
@@ -512,7 +518,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
   end
 
-  def test_assert_enqueued_job_does_not_change_jobs_count
+  def test_assert_enqueued_with_does_not_change_jobs_count
     HelloJob.perform_later
     assert_enqueued_with(job: HelloJob) do
       HelloJob.perform_later


### PR DESCRIPTION
Rename `in_block_job` to `enqueued_job` since this variable can refer not only
to jobs that were created in the block.
See #33258.

Return back accidentally removed test to activejob/test/cases/test_helper_test.rb
See #33258.

Fix name of tests.