### PR TITLE
Allow `queue` option to `assert_no_enqueued_jobs`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow `queue` option to `assert_no_enqueued_jobs`.
+
+    Example:
+    ```
+    def test_no_logging
+      assert_no_enqueued_jobs queue: 'default' do
+        LoggingJob.set(queue: :some_queue).perform_later
+      end
+    end
+    ```
+
+    *bogdanvlviv*
+
 *   Allow call `assert_enqueued_with` with no block.
 
     Example:

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -159,11 +159,19 @@ module ActiveJob
     #     end
     #   end
     #
+    # It can be asserted that no jobs are enqueued to a specific queue:
+    #
+    #   def test_no_logging
+    #     assert_no_enqueued_jobs queue: 'default' do
+    #       LoggingJob.set(queue: :some_queue).perform_later
+    #     end
+    #   end
+    #
     # Note: This assertion is simply a shortcut for:
     #
     #   assert_enqueued_jobs 0, &block
-    def assert_no_enqueued_jobs(only: nil, except: nil, &block)
-      assert_enqueued_jobs 0, only: only, except: except, &block
+    def assert_no_enqueued_jobs(only: nil, except: nil, queue: nil, &block)
+      assert_enqueued_jobs 0, only: only, except: except, queue: queue, &block
     end
 
     # Asserts that the number of performed jobs matches the given number.


### PR DESCRIPTION
It can be asserted that no jobs are enqueued to a specific queue:
```ruby
def test_no_logging
  assert_no_enqueued_jobs queue: 'default' do
    LoggingJob.set(queue: :some_queue).perform_later
  end
end
```