### PR TITLE
Fix assignment of TESTOPTS in railties test task

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -31,6 +31,8 @@ namespace :test do
     failing_files = []
 
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
+    test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
+
     test_files = dirs.map { |dir| "test/#{dir}/*_test.rb" }
     Dir[*test_files].each do |file|
       next true if file.start_with?("test/fixtures/")
@@ -46,7 +48,7 @@ namespace :test do
       # We could run these in parallel, but pretty much all of the
       # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
       Process.waitpid fork {
-        ARGV.clear.push ENV["TESTOPTS"]
+        ARGV.clear.concat test_options
         Rake.application = nil
 
         load file


### PR DESCRIPTION
The assignment of `ENV["TESTOPTS"]` to `ARGV`, introduced in
09f9a7a5b, did not take into account passing multiple options,
such as `--verbose --seed=1`. This patch fixes it.