### PR TITLE
[WIP] Introduce migration compatibility per database adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1185,6 +1185,10 @@ module ActiveRecord
         SchemaDumper.create(self, options)
       end
 
+      def find_migration_compatibility(version) # :nodoc:
+        ActiveRecord::Migration::Compatibility.find(version)
+      end
+
       private
         def column_options_keys
           [:limit, :precision, :scale, :default, :null, :collation, :comment]

--- a/activerecord/lib/active_record/connection_adapters/mysql/migration/compatibility.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/migration/compatibility.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class Migration
+        module Compatibility # :nodoc: all
+          def self.find(version)
+            version = version.to_s
+            name = "V#{version.tr('.', '_')}"
+            if const_defined?(name)
+              return const_get(name)
+            else
+              ActiveRecord::Migration::Compatibility.find(version)
+            end
+          end
+
+          class V5_1 < ActiveRecord::Migration::Compatibility::V5_1
+            def create_table(table_name, options = {})
+              super(table_name, options: "ENGINE=InnoDB", **options)
+            end
+          end
+
+          class V5_0 < ActiveRecord::Migration::Compatibility::V5_0
+            def create_table(table_name, options = {})
+              if (options[:id] != :bigint)
+                if [:integer, :bigint].include?(options[:id]) && !options.key?(:default)
+                  options[:default] = nil
+                end
+              end
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -67,6 +67,10 @@ module ActiveRecord
           MySQL::SchemaDumper.create(self, options)
         end
 
+        def find_migration_compatibility(version)
+          Migration::Compatibility.find(version)
+        end
+
         private
           CHARSETS_OF_4BYTES_MAXLEN = ["utf8mb4", "utf16", "utf16le", "utf32"]
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -2,6 +2,7 @@
 
 require "active_record/connection_adapters/abstract_mysql_adapter"
 require "active_record/connection_adapters/mysql/database_statements"
+require "active_record/connection_adapters/mysql/migration/compatibility"
 
 gem "mysql2", ">= 0.4.4", "< 0.6.0"
 require "mysql2"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/migration/compatibility.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/migration/compatibility.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class Migration
+        module Compatibility # :nodoc: all
+          def self.find(version)
+            version = version.to_s
+            name = "V#{version.tr('.', '_')}"
+            if const_defined?(name)
+              return const_get(name)
+            else
+              ActiveRecord::Migration::Compatibility.find(version)
+            end
+          end
+
+          class V5_1 < ActiveRecord::Migration::Compatibility::V5_1
+            def change_column(table_name, column_name, type, options = {})
+              clear_cache!
+              sql = connection.send(:change_column_sql, table_name, column_name, type, options)
+              execute "ALTER TABLE #{quote_table_name(table_name)} #{sql}"
+              change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
+              change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
+              change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+            end
+          end
+
+          class V5_0 < ActiveRecord::Migration::Compatibility::V5_0
+            def create_table(table_name, options = {})
+              if options[:id] == :uuid && !options.key?(:default)
+                options[:default] = "uuid_generate_v4()"
+              end
+
+              unless adapter_name == "Mysql2" && options[:id] == :bigint
+                if [:integer, :bigint].include?(options[:id]) && !options.key?(:default)
+                  options[:default] = nil
+                end
+              end
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -631,6 +631,10 @@ module ActiveRecord
           validate_constraint from_table, fk_name_to_validate
         end
 
+        def find_migration_compatibility(version)
+          Migration::Compatibility.find(version)
+        end
+
         private
           def schema_creation
             PostgreSQL::SchemaCreation.new(self)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -18,6 +18,7 @@ require "active_record/connection_adapters/postgresql/schema_dumper"
 require "active_record/connection_adapters/postgresql/schema_statements"
 require "active_record/connection_adapters/postgresql/type_metadata"
 require "active_record/connection_adapters/postgresql/utils"
+require "active_record/connection_adapters/postgresql/migration/compatibility"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -534,7 +534,7 @@ module ActiveRecord
     end
 
     def self.[](version)
-      Compatibility.find(version)
+      find_migration_compatibility(version)
     end
 
     def self.current_version

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -19,26 +19,6 @@ module ActiveRecord
       end
 
       class V5_1 < V5_2
-        def change_column(table_name, column_name, type, options = {})
-          if adapter_name == "PostgreSQL"
-            clear_cache!
-            sql = connection.send(:change_column_sql, table_name, column_name, type, options)
-            execute "ALTER TABLE #{quote_table_name(table_name)} #{sql}"
-            change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
-            change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
-            change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
-          else
-            super
-          end
-        end
-
-        def create_table(table_name, options = {})
-          if adapter_name == "Mysql2"
-            super(table_name, options: "ENGINE=InnoDB", **options)
-          else
-            super
-          end
-        end
       end
 
       class V5_0 < V5_1
@@ -55,13 +35,8 @@ module ActiveRecord
         end
 
         def create_table(table_name, options = {})
-          if adapter_name == "PostgreSQL"
-            if options[:id] == :uuid && !options.key?(:default)
-              options[:default] = "uuid_generate_v4()"
-            end
-          end
-
-          unless adapter_name == "Mysql2" && options[:id] == :bigint
+          # TODO: Need to remove adapter_name condition here
+          if (adapter_name != "Mysql2") || (options[:id] != :bigint)
             if [:integer, :bigint].include?(options[:id]) && !options.key?(:default)
               options[:default] = nil
             end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1157,6 +1157,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def test_unknown_migration_version_should_raise_an_argument_error
+    # TODO: Need to suppress `-- find_migration_compatibility(1.0)` message here
     assert_raise(ArgumentError) { ActiveRecord::Migration[1.0] }
   end
 end


### PR DESCRIPTION
### Summary

This pull request introduces migration compatibility per database adapters.

`ActiveRecord::Migration::Compatibility` handles database migration differences per Active Record versions. It also manages database adapter differences by adding `if adapter_name` statements, which is a little bit hard to maintain and I wanted these if statements disappeared by separating migration compatibility per database adapters as Active Record connection adapter does.

It will also allow 3rd party database adapters to implement their own migration differences per Active Record version.

### Other Information

This commit message has [WIP] tag since there are still some TODO things:

* Remove `adapter_name != "Mysql2")` condition
  from `ActiveRecord::Migration::Compatibility::V5_0#create_table`
* Suppress `-- find_migration_compatibility(1.0)` message
from `test_unknown_migration_version_should_raise_an_argument_error`
