### PR TITLE
Rollback transaction if incorrect isolation level is passed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -240,6 +240,8 @@ module ActiveRecord
             if transaction
               rollback_transaction
               after_failure_actions(transaction, error)
+            elsif error.is_a? KeyError
+              @connection.exec_rollback_db_transaction
             end
             raise
           ensure

--- a/activerecord/test/cases/adapters/postgresql/transaction_isolation_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_isolation_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgresqlTransactionTest < ActiveRecord::PostgreSQLTestCase
+  self.use_transactional_tests = false
+
+  class Sample < ActiveRecord::Base
+    self.table_name = "samples"
+  end
+
+  setup do
+    connection = ActiveRecord::Base.connection
+    connection.drop_table "samples", if_exists: true
+    connection.create_table("samples") do |t|
+      t.integer "value"
+    end
+    Sample.establish_connection :arunit
+  end
+
+  teardown do
+    ActiveRecord::Base.connection.drop_table "samples", if_exists: true
+  end
+
+  test "setting incorrect isolation raises an error and closes transaction" do
+    assert_no_idle_transactions do
+      assert_raises(KeyError) do
+        Sample.transaction(isolation: "foobar") {}
+      end
+    end
+  end
+
+  private
+
+    def assert_no_idle_transactions
+      before = idle_transaction_count
+      yield
+      after = idle_transaction_count
+      assert_equal before, after
+    end
+
+    def idle_transaction_count
+      ActiveRecord::Base.connection.execute(
+        "SELECT COUNT(*) FROM pg_stat_activity WHERE state='idle in transaction' AND xact_start IS NOT NULL"
+      ).values
+    end
+end


### PR DESCRIPTION
### Summary
This fixes an issue where a transaction is left open if an incorrect
isolation level is passed as an option. eg:
```ruby
Table.transaction(isolation: "foobar") do
  # ...
end
```
This behaviour can have the side effect of unknowingly leaving lock
entries in the database until another transaction is committed or rolled
back.

This solution rescues the `KeyError`, executes a transaction rollback, then
re-raises the `KeyError`, leaving behaviour the way it currently is,
except rolling back the failed transaction.


### Other Information
This is an issue only for postgresql databases since setting transaction
isolation levels *must* happen inside transactions. In mysql, however,
specifying isolation levels outside transactions will apply it to the
next transaction that is opened; so we don't need to change the mysql
adapter.
