### PR TITLE
Fix default value for mysql time types with specified precision

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix default value for mysql time types with specified precision
+
+    *Nikolay Kondratyev*
+
 *   Fix `touch` option to behave consistently with `Persistence#touch` method.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -80,8 +80,8 @@ module ActiveRecord
 
           def new_column_from_field(table_name, field)
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
-            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\(\))?\z/i.match?(field[:Default])
-              default, default_function = nil, "CURRENT_TIMESTAMP"
+            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(field[:Default])
+              default, default_function = nil, field[:Default]
             else
               default, default_function = field[:Default], nil
             end

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -109,13 +109,23 @@ if current_adapter?(:Mysql2Adapter)
     if ActiveRecord::Base.connection.version >= "5.6.0"
       test "schema dump datetime includes default expression" do
         output = dump_table_schema("datetime_defaults")
-        assert_match %r/t\.datetime\s+"modified_datetime",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+        assert_match %r/t\.datetime\s+"modified_datetime",\s+default: -> { "CURRENT_TIMESTAMP(?:\(\))?" }/i, output
+      end
+
+      test "schema dump datetime includes precise default expression" do
+        output = dump_table_schema("datetime_defaults")
+        assert_match %r/t\.datetime\s+"precise_datetime",.+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
       end
     end
 
     test "schema dump timestamp includes default expression" do
       output = dump_table_schema("timestamp_defaults")
-      assert_match %r/t\.timestamp\s+"modified_timestamp",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      assert_match %r/t\.timestamp\s+"modified_timestamp",\s+default: -> { "CURRENT_TIMESTAMP(?:\(\))?" }/i, output
+    end
+
+    test "schema dump timestamp includes precise default expression" do
+      output = dump_table_schema("timestamp_defaults")
+      assert_match %r/t\.timestamp\s+"precise_timestamp",.+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
     end
 
     test "schema dump timestamp without default expression" do

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -5,12 +5,14 @@ ActiveRecord::Schema.define do
   if ActiveRecord::Base.connection.version >= "5.6.0"
     create_table :datetime_defaults, force: true do |t|
       t.datetime :modified_datetime, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :precise_datetime, precision: 6, default: -> { "CURRENT_TIMESTAMP(6)" }
     end
   end
 
   create_table :timestamp_defaults, force: true do |t|
     t.timestamp :nullable_timestamp
     t.timestamp :modified_timestamp, default: -> { "CURRENT_TIMESTAMP" }
+    t.timestamp :precise_timestamp, precision: 6, default: -> { "CURRENT_TIMESTAMP(6)" }
   end
 
   create_table :binary_fields, force: true do |t|


### PR DESCRIPTION
### Summary

The TIME, DATETIME, and TIMESTAMP types [have supported](https://mariadb.com/kb/en/library/microseconds-in-mariadb/)
a fractional seconds precision from 0 to 6.

Default values from time columns with specified precision is read
as `current_timestamp(n)` from information schema.

### Current behavior

rake `db:schema:dump` produces `schema.rb` **without** default values for time columns with the specified precision:

    t.datetime "last_message_at", precision: 6, null: false

### Expected behavior

rake `db:schema:dump` produces `schema.rb` **with** default values for time columns with the specified precision:

    t.datetime "last_message_at", precision: 6, default: -> { "current_timestamp(6)" }, null: false
