### PR TITLE
ActiveJob::Base no longer dependents on ActiveJob::Serializers

### DIFF
--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -60,7 +60,6 @@ module ActiveJob #:nodoc:
   # * SerializationError - Error class for serialization errors.
   class Base
     include Core
-    include Serializers
     include QueueAdapter
     include QueueName
     include QueuePriority

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -7,7 +7,6 @@ module ActiveJob
   # and to add new ones. It also has helpers to serialize/deserialize objects.
   module Serializers # :nodoc:
     extend ActiveSupport::Autoload
-    extend ActiveSupport::Concern
 
     autoload :ObjectSerializer
     autoload :SymbolSerializer


### PR DESCRIPTION
### Summary

I removed `ActiveJob::Serializers` from the ancestors of `ActiveJob::Base`.
Currently, `ActiveJob::Serializers` provides class methods. [commit](https://github.com/alpaca-tc/rails/commit/ec686a471e0a54194fc9ec72e639785606597704)