### PR TITLE
Remove old TODO comment

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -21,7 +21,6 @@ module Rails
         RUBY
       end
 
-      # TODO: Remove once this is fully in place
       def method_missing(meth, *args, &block)
         @generator.send(meth, *args, &block)
       end


### PR DESCRIPTION
### Summary
This TODO comment has been here more than 7 years. I can't find out what should be in place by looking to the TODO message or history. If you prefer and alternative implementation or you can remember what it was, please comment it here and I would be happy yo implement it, otherwise I would remove the TODO comment since this doesn't seem to be a temporary implementation anymore.

At a first moment I tried removing the `method_missing` fallback and moving the necessary methods to the list above. Adding some methods like `keep_file` or `run` to the list seemed to be OK, but then others like `skip_spring?`, `mountable?`, etc. seemed to be more generator specific and I preferred to leave the `method_missing` fallback instead.