### PR TITLE
Better compatibility with SPEC.

### DIFF
--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -98,8 +98,10 @@ module ActionCable
       def hijack_rack_socket
         return unless @socket_object.env["rack.hijack"]
 
-        @socket_object.env["rack.hijack"].call
-        @rack_hijack_io = @socket_object.env["rack.hijack_io"]
+        # This should return the underlying io according to the SPEC:
+        @rack_hijack_io = @socket_object.env["rack.hijack"].call
+        # Retain existing behaviour if required:
+        @rack_hijack_io ||= @socket_object.env["rack.hijack_io"]
 
         @event_loop.attach(@rack_hijack_io, self)
       end


### PR DESCRIPTION
If `env` is duped or otherwise not the same as the original `env` that was
generated at the top of rack middleware, it is impossible for the server hijack
proc to update the right `env` instance. Therefore, capturing the return value
is more reliable. This is the recommendation of the rack SPEC.