### PR TITLE
new_framework_defaults_5_2.rb is incompatible with load_default "5.2"

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -33,3 +33,6 @@
 
 # Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
 # Rails.application.config.active_support.use_sha1_digests = true
+
+# Generates DOM id for `form_with` helper.
+# Rails.application.config.action_view.form_with_generates_ids = true


### PR DESCRIPTION
`load_default "5.2"` sets
`Rails.application.config.action_view.form_with_generates_ids` to true
but new_framework_defaults_5_2.rb does not mention about it.

refs 36ac675d2af5838c81afbd7c95b2e403e6366ba5