### PR TITLE
Remove vestigial require on ActiveStorage GCSService

### DIFF
--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -6,7 +6,6 @@ require "google/cloud/storage"
 require "net/http"
 
 require "active_support/core_ext/object/to_query"
-require "active_storage/filename"
 
 module ActiveStorage
   # Wraps the Google Cloud Storage as an Active Storage service. See ActiveStorage::Service for the generic API


### PR DESCRIPTION
### Summary

The file `filename.rb` as mentioned in `require "active_storage/filename"`
belongs to the `app` folder while GCSService belongs to the `lib` folder.

Looking at the git blame, it was added in commit https://github.com/rails/rails/commit/ccac681122db9747fec9512076772bca345e24b9#diff-bda6a610ef1575b2c8458c96b7f12578
where ActiveStorage::Filename was actually used. But it is no longer
required on master and therefore can be removed.

This allows anyone to use GCSService directly without enabling
ActiveStorage engine.

Thanks for contributing to Rails!
