### PR TITLE
has_(one/many)_attached absence validation

### DIFF
--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -17,6 +17,10 @@ module ActiveStorage
       attachment.blank?
     end
 
+    def present?
+      !blank?
+    end
+
     # Associates a given attachment with the current record, saving it to the database.
     #
     #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object

--- a/activestorage/test/models/absence_validation_test.rb
+++ b/activestorage/test/models/absence_validation_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::AbsenceValidationTest < ActiveSupport::TestCase
+  class Admin < User; end
+
+  teardown do
+    Admin.clear_validators!
+  end
+
+  test "validates_presence_of has_one_attached" do
+    Admin.validates_absence_of :avatar
+    a = Admin.new
+    assert_predicate a, :valid?
+
+    a.avatar.attach create_blob(filename: "funky.jpg")
+    assert_predicate a, :invalid?
+  end
+
+  test "validates_presence_of has_many_attached" do
+    Admin.validates_absence_of :highlights
+    a = Admin.new
+    assert_predicate a, :valid?
+
+    a.highlights.attach create_blob(filename: "funky.jpg")
+    assert_predicate a, :invalid?
+  end
+end

--- a/activestorage/test/models/absence_validation_test.rb
+++ b/activestorage/test/models/absence_validation_test.rb
@@ -10,7 +10,7 @@ class ActiveStorage::AbsenceValidationTest < ActiveSupport::TestCase
     Admin.clear_validators!
   end
 
-  test "validates_presence_of has_one_attached" do
+  test "validates_absence_of has_one_attached" do
     Admin.validates_absence_of :avatar
     a = Admin.new
     assert_predicate a, :valid?
@@ -19,7 +19,7 @@ class ActiveStorage::AbsenceValidationTest < ActiveSupport::TestCase
     assert_predicate a, :invalid?
   end
 
-  test "validates_presence_of has_many_attached" do
+  test "validates_absende_of has_many_attached" do
     Admin.validates_absence_of :highlights
     a = Admin.new
     assert_predicate a, :valid?


### PR DESCRIPTION
### Summary

Validator for attachment absence
`
class User < ActiveRecord::Base
  has_one_attached :avatar
  has_many_attached :highlights

  validates :avatar, presence: true
  validates :highlights, presence: true 
end
`
Is useful for conditional validation, in some case the attachments are not permitted.