### PR TITLE
Make NotesCommand tests more performant by getting rid of unnecessary map

### DIFF
--- a/railties/test/commands/notes_test.rb
+++ b/railties/test/commands/notes_test.rb
@@ -8,51 +8,51 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
   setup :build_app
   teardown :teardown_app
 
-  test "`rails notes` displays results for default directories and default annotations" do
+  test "`rails notes` displays results for default directories and default annotations with aligned line number and annotation tag" do
     app_file "app/controllers/some_controller.rb", "# OPTIMIZE: note in app directory"
     app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
     app_file "db/some_seeds.rb", "# FIXME: note in db directory"
     app_file "lib/some_file.rb", "# TODO: note in lib directory"
-    app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# FIXME: note in test directory"
+    app_file "test/some_test.rb", "\n" * 100 + "# FIXME: note in test directory"
 
     app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
     assert_equal <<~OUTPUT, run_notes_command
       app/controllers/some_controller.rb:
-        * [   1] [OPTIMIZE] note in app directory
+        * [  1] [OPTIMIZE] note in app directory
 
       config/initializers/some_initializer.rb:
-        * [   1] [TODO] note in config directory
+        * [  1] [TODO] note in config directory
 
       db/some_seeds.rb:
-        * [   1] [FIXME] note in db directory
+        * [  1] [FIXME] note in db directory
 
       lib/some_file.rb:
-        * [   1] [TODO] note in lib directory
+        * [  1] [TODO] note in lib directory
 
       test/some_test.rb:
-        * [1000] [FIXME] note in test directory
+        * [101] [FIXME] note in test directory
 
     OUTPUT
   end
 
-  test "`rails notes` displays an empty array when no results were found" do
+  test "`rails notes` displays an empty string when no results were found" do
     assert_equal "", run_notes_command
   end
 
   test "`rails notes --annotations` displays results for a single annotation without being prefixed by a tag" do
     app_file "db/some_seeds.rb", "# FIXME: note in db directory"
-    app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# FIXME: note in test directory"
+    app_file "test/some_test.rb", "# FIXME: note in test directory"
 
     app_file "app/controllers/some_controller.rb", "# OPTIMIZE: note in app directory"
     app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
 
     assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FIXME"])
       db/some_seeds.rb:
-        * [   1] note in db directory
+        * [1] note in db directory
 
       test/some_test.rb:
-        * [1000] note in test directory
+        * [1] note in test directory
 
     OUTPUT
   end
@@ -62,7 +62,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
     app_file "lib/some_file.rb", "# TODO: note in lib directory"
 
-    app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# FIXME: note in test directory"
+    app_file "test/some_test.rb", "# FIXME: note in test directory"
 
     assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FOOBAR", "TODO"])
       app/controllers/some_controller.rb:


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/pull/33220#discussion_r200271054 with @kaspth 

This PR:

* Gets rid of map and replace it with a multiplication of `\n` to generate document with multiple lines preceding the annotation
* Reduce number from 1000 to 100 since it achieves the same goal with a smaller number (I tried a 2 digits number but the indentation was not as visually clear for the reader in my opinion)
* Only keep one test for the multiple lines document since it's unnecessary to test multiple times
* Update some language in tests names to make it clearer what we are testing