### PR TITLE
Remove unnecessary Mocha stubs

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -158,7 +158,6 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
 
   def test_indexes_in_create
     ActiveRecord::Base.connection.stubs(:data_source_exists?).with(:temp).returns(false)
-    ActiveRecord::Base.connection.stubs(:index_name_exists?).with(:index_temp_on_zip).returns(false)
 
     expected = "CREATE TEMPORARY TABLE `temp` ( INDEX `index_temp_on_zip`  (`zip`)) AS SELECT id, name, zip FROM a_really_complicated_query"
     actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -135,7 +135,7 @@ module ActiveRecord
 
     def test_ignores_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
-      $stderr.stubs(:puts).returns(nil)
+      $stderr.stubs(:puts)
 
       assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
         ActiveRecord::Tasks::DatabaseTasks.create_all
@@ -184,7 +184,7 @@ module ActiveRecord
       }
 
       ActiveRecord::Base.stubs(:configurations).returns(@configurations)
-      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+      ActiveRecord::Base.stubs(:establish_connection)
     end
 
     def test_creates_current_environment_database
@@ -238,7 +238,7 @@ module ActiveRecord
     end
 
     def test_establishes_connection_for_the_given_environments
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:create)
 
       ActiveRecord::Base.expects(:establish_connection).with(:development)
 
@@ -257,7 +257,7 @@ module ActiveRecord
       }
 
       ActiveRecord::Base.stubs(:configurations).returns(@configurations)
-      ActiveRecord::Base.stubs(:establish_connection).returns(true)
+      ActiveRecord::Base.stubs(:establish_connection)
     end
 
     def test_creates_current_environment_database
@@ -319,7 +319,7 @@ module ActiveRecord
     end
 
     def test_establishes_connection_for_the_given_environments_config
-      ActiveRecord::Tasks::DatabaseTasks.stubs(:create).returns true
+      ActiveRecord::Tasks::DatabaseTasks.stubs(:create)
 
       ActiveRecord::Base.expects(:establish_connection).with(:development)
 
@@ -357,7 +357,7 @@ module ActiveRecord
 
     def test_ignores_remote_databases
       @configurations[:development].merge!("host" => "my.server.tld")
-      $stderr.stubs(:puts).returns(nil)
+      $stderr.stubs(:puts)
 
       assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :drop) do
         ActiveRecord::Tasks::DatabaseTasks.drop_all

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -14,7 +14,7 @@ if current_adapter?(:Mysql2Adapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -77,7 +77,6 @@ if current_adapter?(:Mysql2Adapter)
 
     class MysqlDBCreateWithInvalidPermissionsTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub("Connection", create_database: true)
         @error         = Mysql2::Error.new("Invalid permissions")
         @configuration = {
           "adapter"  => "mysql2",
@@ -86,7 +85,6 @@ if current_adapter?(:Mysql2Adapter)
           "password" => "wossname"
         }
 
-        ActiveRecord::Base.stubs(:connection).returns(@connection)
         ActiveRecord::Base.stubs(:establish_connection).raises(@error)
 
         $stdout, @original_stdout = StringIO.new, $stdout
@@ -113,7 +111,7 @@ if current_adapter?(:Mysql2Adapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -151,7 +149,7 @@ if current_adapter?(:Mysql2Adapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
       end
 
       def test_establishes_connection_to_the_appropriate_database
@@ -185,7 +183,6 @@ if current_adapter?(:Mysql2Adapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_db_retrieves_charset
@@ -203,7 +200,6 @@ if current_adapter?(:Mysql2Adapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_db_retrieves_collation

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -14,7 +14,7 @@ if current_adapter?(:PostgreSQLAdapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -66,7 +66,7 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_db_create_with_error_prints_message
         ActiveRecord::Base.stubs(:establish_connection).raises(Exception)
 
-        $stderr.stubs(:puts).returns(true)
+        $stderr.stubs(:puts)
         $stderr.expects(:puts).
           with("Couldn't create database for #{@configuration.inspect}")
 
@@ -99,7 +99,7 @@ if current_adapter?(:PostgreSQLAdapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -141,8 +141,7 @@ if current_adapter?(:PostgreSQLAdapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:clear_active_connections!).returns(true)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
       end
 
       def test_clears_active_connections
@@ -190,7 +189,7 @@ if current_adapter?(:PostgreSQLAdapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
       end
 
       def test_db_retrieves_charset
@@ -208,7 +207,6 @@ if current_adapter?(:PostgreSQLAdapter)
         }
 
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_db_retrieves_collation
@@ -219,16 +217,12 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLStructureDumpTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(schema_search_path: nil, structure_dump: true)
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
         }
         @filename = "/tmp/awesome-file.sql"
         FileUtils.touch(@filename)
-
-        ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def teardown
@@ -358,14 +352,10 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLStructureLoadTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
         }
-
-        ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_structure_load

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -9,15 +9,12 @@ if current_adapter?(:SQLite3Adapter)
     class SqliteDBCreateTest < ActiveRecord::TestCase
       def setup
         @database      = "db_create.sqlite3"
-        @connection    = stub :connection
         @configuration = {
           "adapter"  => "sqlite3",
           "database" => @database
         }
 
-        File.stubs(:exist?).returns(false)
-        ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
+        ActiveRecord::Base.stubs(:establish_connection)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -49,7 +46,6 @@ if current_adapter?(:SQLite3Adapter)
 
       def test_db_create_with_file_does_nothing
         File.stubs(:exist?).returns(true)
-        $stderr.stubs(:puts).returns(nil)
 
         ActiveRecord::Base.expects(:establish_connection).never
 
@@ -84,7 +80,7 @@ if current_adapter?(:SQLite3Adapter)
 
         Pathname.stubs(:new).returns(@path)
         File.stubs(:join).returns("/former/relative/path")
-        FileUtils.stubs(:rm).returns(true)
+        FileUtils.stubs(:rm)
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -101,16 +97,13 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_removes_file_with_absolute_path
-        File.stubs(:exist?).returns(true)
-        @path.stubs(:absolute?).returns(true)
-
         FileUtils.expects(:rm).with("/absolute/path")
 
         ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
       end
 
       def test_generates_absolute_path_with_given_root
-        @path.stubs(:absolute?).returns(false)
+        @path.stubs(:absolute?)
 
         File.expects(:join).with("/rails/root", @path).
           returns("/former/relative/path")
@@ -119,8 +112,7 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_removes_file_with_relative_path
-        File.stubs(:exist?).returns(true)
-        @path.stubs(:absolute?).returns(false)
+        @path.stubs(:absolute?)
 
         FileUtils.expects(:rm).with("/former/relative/path")
 
@@ -143,9 +135,7 @@ if current_adapter?(:SQLite3Adapter)
           "database" => @database
         }
 
-        File.stubs(:exist?).returns(false)
         ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_db_retrieves_charset
@@ -157,15 +147,10 @@ if current_adapter?(:SQLite3Adapter)
     class SqliteDBCollationTest < ActiveRecord::TestCase
       def setup
         @database      = "db_create.sqlite3"
-        @connection    = stub :connection
         @configuration = {
           "adapter"  => "sqlite3",
           "database" => @database
         }
-
-        File.stubs(:exist?).returns(false)
-        ActiveRecord::Base.stubs(:connection).returns(@connection)
-        ActiveRecord::Base.stubs(:establish_connection).returns(true)
       end
 
       def test_db_retrieves_collation


### PR DESCRIPTION
Step 1 in #33162 

While modifying tests to replace use of Mocha it became evident that some calls to `Mocha#stub` and `Mocha#stubs` do not have any impact on the test case. The same is true of some calls to `returns` on such objects. This patch removes both.

I speculate that the setup for one test was sometimes copied from onto another without verifying necessity. Tracing each of these instances to its origins and determining the moment it became unnecessary is fascinating, but a lot of work.

For example, [`@connection    = stub("Connection", create_database: true)`](https://github.com/rails/rails/blob/master/activerecord/test/cases/tasks/mysql_rake_test.rb#L80) was introduced six years ago as part of [quite a refactoring](https://github.com/rails/rails/commit/d29727235ae967e1ae4880ddfa5fd37d726f779d#diff-93b789231e1c92cf1089f31be51d375eR50). I'd need a whole new stack to verify it was necessary at the time, and it's gone through several changes since.

So I did not complete the historical research.