### PR TITLE
PostgreSQL: Use a specialized Result object to defer retrieval of values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "sqlite3", "~> 1.3.6"
 
   group :db do
-    gem "pg", ">= 0.18.0"
+    gem "pg", "~> 1.1"
     gem "mysql2", ">= 0.4.10"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,7 +550,7 @@ DEPENDENCIES
   minitest-retry
   mysql2 (>= 0.4.10)
   nokogiri (>= 1.8.1)
-  pg (>= 0.18.0)
+  pg (~> 1.1)
   psych (~> 3.0)
   puma
   que

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "pg", ">= 0.18", "< 2.0"
+gem "pg", "~> 1.1"
 require "pg"
 require "thread"
 require "digest/sha1"

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -71,13 +71,13 @@ module ActiveRecord
 
       # Returns a single value from a record
       def select_value(arel, name = nil, binds = [])
-        single_value_from_rows(select_rows(arel, name, binds))
+        single_value_from_result(select_all(arel, name, binds))
       end
 
       # Returns an array of the values of the first column in a select:
       #   select_values("SELECT id FROM companies LIMIT 3") => [1,2,3]
       def select_values(arel, name = nil, binds = [])
-        select_rows(arel, name, binds).map(&:first)
+        select_all(arel, name, binds).column_values(0)
       end
 
       # Returns an array of arrays containing the field values.
@@ -87,11 +87,11 @@ module ActiveRecord
       end
 
       def query_value(sql, name = nil) # :nodoc:
-        single_value_from_rows(query(sql, name))
+        single_value_from_result(exec_query(sql, name))
       end
 
       def query_values(sql, name = nil) # :nodoc:
-        query(sql, name).map(&:first)
+        exec_query(sql, name).column_values(0)
       end
 
       def query(sql, name = nil) # :nodoc:
@@ -450,12 +450,12 @@ module ActiveRecord
         end
 
         def last_inserted_id(result)
-          single_value_from_rows(result.rows)
+          single_value_from_result(result)
         end
 
-        def single_value_from_rows(rows)
-          row = rows.first
-          row && row.first
+        def single_value_from_result(result)
+          row = result.first
+          row && row.each_value.first
         end
 
         def arel_from_relation(relation)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/explain_pretty_printer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/explain_pretty_printer.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         #
         def pp(result)
           header = result.columns.first
-          lines  = result.rows.map(&:first)
+          lines  = result.column_values(0)
 
           # We add 2 because there's one char of padding at both sides, note
           # the extra hyphens in the example above.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/result.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/result.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module ActiveRecord::ConnectionAdapters::PostgreSQL
+  ###
+  # This class encapsulates a result returned from calling
+  # {#exec_query}[rdoc-ref:ConnectionAdapters::DatabaseStatements#exec_query]
+  # on the PostgreSQL connection adapter.
+  class Result < ActiveRecord::Result
+    include Enumerable
+
+    attr_reader :columns
+
+    def initialize(pg_result, adapter)
+      @pg_result = pg_result
+      @adapter = adapter
+      @field_map = nil
+      @length = nil
+      @columns = @pg_result.fields
+    end
+
+    def initialize_copy(other)
+    end
+
+    def each
+      return to_enum(:each) { length } unless block_given?
+
+      l = length
+      i = 0
+      while i < l
+        yield @pg_result.tuple(i)
+        i += 1
+      end
+    end
+
+    def [](i)
+      @pg_result.tuple(i)
+    end
+
+    def column_type(name)
+      if i = columns.index(name)
+        ftype = @pg_result.ftype i
+        fmod  = @pg_result.fmod i
+        @adapter.get_oid_type ftype, fmod, name
+      elsif block_given?
+        yield
+      else
+        Type.default_value
+      end
+    end
+
+    # Returns true if this result set includes the column named +name+
+    def includes_column?(name)
+      columns.include? name
+    end
+
+    def length
+      @length ||= @pg_result.ntuples
+    end
+
+    def cast_values(type_overrides = {}) # :nodoc:
+      if columns.one?
+        # Separated to avoid allocating an array per row
+        type = type_overrides.fetch(columns.first) { column_type(columns.first) }
+
+        column_values(0).map { |value| type.deserialize(value) }
+      else
+        types = columns.map do |name|
+          type_overrides.fetch(name) { column_type(name) }
+        end
+
+        @pg_result.values.map do |row|
+          Array.new(row.size) { |i| types[i].deserialize(row[i]) }
+        end
+      end
+    end
+
+    def column_values(i)
+      @pg_result.column_values(i)
+    end
+
+    def last
+      return nil if length == 0
+      self[length - 1]
+    end
+
+    def first
+      return nil if length == 0
+      self[0]
+    end
+
+    # Returns true if there are no records, otherwise false.
+    def empty?
+      length == 0
+    end
+
+    # Returns an array of hashes representing each row record.
+    #
+    # This method should be avoided, since it materializes the whole result set and is therefore slow.
+    def to_a
+      each.to_a.map(&:to_h)
+    end
+
+    alias :to_ary :to_a
+
+    # Returns an array of arrays representing each row record values.
+    #
+    # This method should be avoided, since materializes the whole result set and is therefore slow.
+    def rows
+      @pg_result.values
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -295,8 +295,8 @@ module ActiveRecord
 
         result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder, nil) }
         row    = result.first
-        value  = row && row.values.first
-        type   = result.column_types.fetch(column_alias) do
+        value  = row && row.each_value.first
+        type   = result.column_type(column_alias) do
           type_for(column_name)
         end
 
@@ -355,14 +355,14 @@ module ActiveRecord
         Hash[calculated_data.map do |row|
           key = group_columns.map { |aliaz, col_name|
             type = type_for(col_name) do
-              calculated_data.column_types.fetch(aliaz, Type.default_value)
+              calculated_data.column_type(aliaz)
             end
             type_cast_calculated_value(row[aliaz], type)
           }
           key = key.first if key.size == 1
           key = key_records[key] if associated
 
-          type = calculated_data.column_types.fetch(aggregate_alias) { type_for(column_name) }
+          type = calculated_data.column_type(aggregate_alias) { type_for(column_name) }
           [key, type_cast_calculated_value(row[aggregate_alias], type, operation)]
         end]
       end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -111,7 +111,7 @@ module ActiveRecord
 
     def test_exec_query_returns_an_empty_result
       result = @connection.exec_query "INSERT INTO subscribers(nick) VALUES('me')"
-      assert_instance_of(ActiveRecord::Result, result)
+      assert_kind_of(ActiveRecord::Result, result)
     end
 
     if current_adapter?(:Mysql2Adapter)
@@ -301,7 +301,7 @@ module ActiveRecord
 
         @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
-        assert_equal({ "id" => 1, "title" => "foo" }, result.first)
+        assert_equal({ "id" => 1, "title" => "foo" }, result.first.to_h)
 
         @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
@@ -317,7 +317,7 @@ module ActiveRecord
 
         @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
-        assert_equal({ "id" => 1, "title" => "foo" }, result.first)
+        assert_equal({ "id" => 1, "title" => "foo" }, result.first.to_h)
 
         @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
@@ -329,7 +329,7 @@ module ActiveRecord
       author = Author.create!(name: "john")
       Post.create!(author: author, title: "foo", body: "bar")
       query = author.posts.where(title: "foo").select(:title)
-      assert_equal({ "title" => "foo" }, @connection.select_one(query))
+      assert_equal({ "title" => "foo" }, @connection.select_one(query).to_h)
       assert @connection.select_all(query).is_a?(ActiveRecord::Result)
       assert_equal "foo", @connection.select_value(query)
       assert_equal ["foo"], @connection.select_values(query)
@@ -338,7 +338,7 @@ module ActiveRecord
     def test_select_methods_passing_a_relation
       Post.create!(title: "foo", body: "bar")
       query = Post.where(title: "foo").select(:title)
-      assert_equal({ "title" => "foo" }, @connection.select_one(query))
+      assert_equal({ "title" => "foo" }, @connection.select_one(query).to_h)
       assert @connection.select_all(query).is_a?(ActiveRecord::Result)
       assert_equal "foo", @connection.select_value(query)
       assert_equal ["foo"], @connection.select_values(query)

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -141,7 +141,7 @@ module ActiveRecord
         name = @subscriber.payloads.last[:statement_name]
         assert name
         res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(1)")
-        plan = res.column_types["QUERY PLAN"].deserialize res.rows.first.first
+        plan = res.column_type("QUERY PLAN").deserialize res.rows.first.first
         assert_operator plan.length, :>, 0
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -320,7 +320,7 @@ module ActiveRecord
         @connection.execute "CREATE TYPE feeling AS ENUM ('good', 'bad')"
         result = @connection.select_all "SELECT 'good'::feeling"
         assert_instance_of(PostgreSQLAdapter::OID::Enum,
-                           result.column_types["feeling"])
+                           result.column_type("feeling"))
       ensure
         @connection.execute "DROP TYPE IF EXISTS feeling"
         reset_connection
@@ -332,13 +332,13 @@ module ActiveRecord
 
         silence_warnings do
           assert_queries 2, ignore_none: true do
-            connection.select_all "select 'pg_catalog.pg_class'::regclass"
+            connection.select_all("select 'pg_catalog.pg_class'::regclass").cast_values
           end
           assert_queries 1, ignore_none: true do
-            connection.select_all "select 'pg_catalog.pg_class'::regclass"
+            connection.select_all("select 'pg_catalog.pg_class'::regclass").cast_values
           end
           assert_queries 2, ignore_none: true do
-            connection.select_all "SELECT NULL::anyarray"
+            connection.select_all("SELECT NULL::anyarray").cast_values
           end
         end
       ensure
@@ -350,9 +350,9 @@ module ActiveRecord
         connection = ActiveRecord::Base.connection
 
         warning = capture(:stderr) {
-          connection.select_all "select 'pg_catalog.pg_class'::regclass"
-          connection.select_all "select 'pg_catalog.pg_class'::regclass"
-          connection.select_all "select 'pg_catalog.pg_class'::regclass"
+          connection.select_all("select 'pg_catalog.pg_class'::regclass").cast_values
+          connection.select_all("select 'pg_catalog.pg_class'::regclass").cast_values
+          connection.select_all("select 'pg_catalog.pg_class'::regclass").cast_values
         }
         assert_match(/\Aunknown OID \d+: failed to recognize type of 'regclass'\. It will be treated as String\.\n\z/, warning)
       ensure

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -298,7 +298,7 @@ class FixturesTest < ActiveRecord::TestCase
       conn.insert_fixtures_set({ "aircraft" => fixtures }, ["aircraft"])
     end
     result = conn.select_all("SELECT name, wheels_count FROM aircraft ORDER BY id")
-    assert_equal fixtures, result.to_a
+    assert_equal fixtures, result.to_a.map(&:to_h)
   end
 
   def test_broken_yaml_exception

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -14,7 +14,7 @@ module Rails
       def gem_for_database(database = options[:database])
         case database
         when "mysql"          then ["mysql2", [">= 0.4.4"]]
-        when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
+        when "postgresql"     then ["pg", ["~> 1.1"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -551,7 +551,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcpostgresql-adapter"
     else
-      assert_gem "pg", "'>= 0.18', '< 2.0'"
+      assert_gem "pg", "'~> 1.1'"
     end
   end
 


### PR DESCRIPTION
PG::Result stores values received from the database internally in a compact memory format. When the value is accessed, it is converted to a ruby string or casted to another ruby object.

While ActiveRecord::Result enforces the conversion of all rows and columns to ruby objects, this implementation defers conversion to when the single value is accessed. Therefore ActiveRecord::ConnectionAdapters::PostgreSQL::Result and PG::Tuple store a reference to the PG::Result object.

PG::Tuple caches all values after being materialized. It detaches the PG::Result object, when all columns have been materialized or when the object is marshaled.

The new Result object is disabled for pg versions < 1.1. This is because PG::Tuple is not yet available in older versions and because keeping the PG::Result around can lead to [memory bloat with older pg versions](https://samsaffron.com/archive/2018/06/13/ruby-x27-s-external-malloc-problem). For the first issue I wrote a [lightweight ruby implementation](https://github.com/rails/rails/compare/master...larskanis:hyperrecord-v1#diff-03ff5d20e0d36954f6eb182511936923), but since it doesn't prevent memory bloat, I think it's best to make it pg-1.1 only.

This speedups wasteful queries (without explicit selecting required columns) by [up to 50%](https://gist.github.com/larskanis/cd40185b962c8aaec6d77b4740a9ae52). Calling column_type/get_oid_type only for necessary columns has another small performance advantage even if all columns are used.

pg-1.1.0 is not yet released, but I would like to get some feedback before. For now I patched the Gemfile to use pg from git.

cc @SamSaffron 
