### PR TITLE
has_secure_password: use `recovery_password` instead of `activation_token`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -6,13 +6,13 @@
     Example:
 
         class User < ActiveRecord::Base
-            has_secure_password :activation_token, validations: false
+          has_secure_password :recovery_password, validations: false
         end
 
         user = User.new()
-        user.activation_token = "a_new_token"
-        user.activation_token_digest                        # => "$2a$10$0Budk0Fi/k2CDm2PEwa3Be..."
-        user.authenticate_activation_token('a_new_token')   # => user
+        user.recovery_password = "42password"
+        user.recovery_password_digest # => "$2a$04$iOfhwahFymCs5weB3BNH/uX..."
+        user.authenticate_recovery_password('42password') # => user
 
      *Unathi Chonco*
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -17,7 +17,7 @@ module ActiveModel
     module ClassMethods
       # Adds methods to set and authenticate against a BCrypt password.
       # This mechanism requires you to have a +XXX_digest+ attribute.
-      # Where +XXX+ is the attribute name of your desired password/token or defaults to +password+
+      # Where +XXX+ is the attribute name of your desired password.
       #
       # The following validations are added automatically:
       # * Password must be present on creation
@@ -38,10 +38,10 @@ module ActiveModel
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
-      #   # Schema: User(name:string, password_digest:string, activation_token_digest:string)
+      #   # Schema: User(name:string, password_digest:string, recovery_password_digest:string)
       #   class User < ActiveRecord::Base
       #     has_secure_password
-      #     has_secure_password :activation_token, validations: false
+      #     has_secure_password :recovery_password, validations: false
       #   end
       #
       #   user = User.new(name: 'david', password: '', password_confirmation: 'nomatch')
@@ -50,12 +50,12 @@ module ActiveModel
       #   user.save                                                       # => false, confirmation doesn't match
       #   user.password_confirmation = 'mUc3m00RsqyRe'
       #   user.save                                                       # => true
-      #   user.activation_token = "a_new_token"
-      #   user.activation_token_digest                                    # => "$2a$10$0Budk0Fi/k2CDm2PEwa3BeXO5tPOA85b6xazE9rp8nF2MIJlsUik."
+      #   user.recovery_password = "42password"
+      #   user.recovery_password_digest                                   # => "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
       #   user.save                                                       # => true
       #   user.authenticate('notright')                                   # => false
       #   user.authenticate('mUc3m00RsqyRe')                              # => user
-      #   user.authenticate_activation_token('a_new_token')               # => user
+      #   user.authenticate_recovery_password('42password')               # => user
       #   User.find_by(name: 'david').try(:authenticate, 'notright')      # => false
       #   User.find_by(name: 'david').try(:authenticate, 'mUc3m00RsqyRe') # => user
       def has_secure_password(attribute = :password, validations: true)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -186,7 +186,7 @@ class SecurePasswordTest < ActiveModel::TestCase
 
   test "authenticate" do
     @user.password = "secret"
-    @user.activation_token = "new_token"
+    @user.recovery_password = "42password"
 
     assert_equal false, @user.authenticate("wrong")
     assert_equal @user, @user.authenticate("secret")
@@ -194,8 +194,8 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal false, @user.authenticate_password("wrong")
     assert_equal @user, @user.authenticate_password("secret")
 
-    assert_equal false, @user.authenticate_activation_token("wrong")
-    assert_equal @user, @user.authenticate_activation_token("new_token")
+    assert_equal false, @user.authenticate_recovery_password("wrong")
+    assert_equal @user, @user.authenticate_recovery_password("42password")
   end
 
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -7,7 +7,7 @@ class User
   define_model_callbacks :create
 
   has_secure_password
-  has_secure_password :activation_token, validations: false
+  has_secure_password :recovery_password, validations: false
 
-  attr_accessor :password_digest, :activation_token_digest
+  attr_accessor :password_digest, :recovery_password_digest
 end

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -466,7 +466,7 @@ a `password` accessor with certain validations on it by default.
 `ActiveModel::SecurePassword` depends on [`bcrypt`](https://github.com/codahale/bcrypt-ruby 'BCrypt'),
 so include this gem in your `Gemfile` to use `ActiveModel::SecurePassword` correctly.
 In order to make this work, the model must have an accessor named `XXX_digest`.
-Where `XXX` is the attribute name of your desired password/token or defaults to `password`.
+Where `XXX` is the attribute name of your desired password.
 The following validations are added automatically:
 
 1. Password should be present.
@@ -479,9 +479,9 @@ The following validations are added automatically:
 class Person
   include ActiveModel::SecurePassword
   has_secure_password
-  has_secure_password :activation_token, validations: false
+  has_secure_password :recovery_password, validations: false
 
-  attr_accessor :password_digest, :activation_token_digest
+  attr_accessor :password_digest, :recovery_password_digest
 end
 
 person = Person.new
@@ -506,16 +506,16 @@ person.valid? # => true
 person.password = person.password_confirmation = 'aditya'
 person.valid? # => true
 
-person.activation_token = "a_new_token"
+person.recovery_password = "42password"
 
 person.authenticate('aditya') # => person
 person.authenticate('notright') # => false
 person.authenticate_password('aditya') # => person
 person.authenticate_password('notright') # => false
 
-person.authenticate_activation_token('a_new_token') # => person
-person.authenticate_activation_token('notright') # => false
+person.authenticate_recovery_password('42password') # => person
+person.authenticate_recovery_password('notright') # => false
 
-person.password_digest # => "$2a$04$l4yYxoUPibMXcvvu.Lq8M.T/rtjdLOA78LN2XHEzMovf7hWVGzgXC"
-person.activation_token_digest # => "$2a$10$0Budk0Fi/k2CDm2PEwa3BeXO5tPOA85b6xazE9rp8nF2MIJlsUik."
+person.password_digest # => "$2a$04$gF8RfZdoXHvyTjHhiU4ZsO.kQqV9oonYZu31PRE4hLQn3xM2qkpIy"
+person.recovery_password_digest # => "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
 ```


### PR DESCRIPTION
Since we have `has_secure_token`, it is too confusing to use `_token`
suffix with `has_secure_password`.
Context https://github.com/rails/rails/pull/33307#discussion_r200807185

r? @kaspth 