### PR TITLE
Documentation and some tests for `assert_no_difference`

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -113,9 +113,21 @@ module ActiveSupport
       #     post :create, params: { article: invalid_attributes }
       #   end
       #
+      # A lambda can be passed in and evaluated.
+      #
+      #   assert_no_difference -> { Article.count } do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      #
       # An error message can be specified.
       #
       #   assert_no_difference 'Article.count', 'An Article should not be created' do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      #
+      # An array of expressions can also be passed in and evaluated.
+      #
+      #   assert_no_difference [ 'Article.count', -> { Post.count } ] do
       #     post :create, params: { article: invalid_attributes }
       #   end
       def assert_no_difference(expression, message = nil, &block)

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -52,6 +52,22 @@ class AssertionsTest < ActiveSupport::TestCase
     assert_equal "Object Changed.\n\"@object.num\" didn't change by 0.\nExpected: 0\n  Actual: 1", error.message
   end
 
+  def test_assert_no_difference_with_multiple_expressions_pass
+    another_object = @object.dup
+    assert_no_difference ["@object.num", -> { another_object.num }] do
+      # ...
+    end
+  end
+
+  def test_assert_no_difference_with_multiple_expressions_fail
+    another_object = @object.dup
+    assert_raises(Minitest::Assertion) do
+      assert_no_difference ["@object.num", -> { another_object.num }], "Another Object Changed" do
+        another_object.increment
+      end
+    end
+  end
+
   def test_assert_difference
     assert_difference "@object.num", +1 do
       @object.increment


### PR DESCRIPTION
I noticed that the documentation for `assert_no_difference` does not explicitly tell that you can pass a lambda or multiple expressions to the assertion.

This PR adds that documentation and it also adds tests for it.

Not sure if the tests make much sense, because `assert_no_difference` simply calls `assert_difference` with `difference: 0`, and `assert_difference` has all these test cases already.


