### PR TITLE
Fix rubocop offense introduced in 161ed37

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -276,7 +276,7 @@ module Rails
               option instead.
             MSG
 
-            original_options.concat [ '-u', using ]
+            original_options.concat [ "-u", using ]
           else
             # Use positional internally to get around Thor's immutable options.
             # TODO: Replace `using` occurences with `options[:using]` after deprecation removal.


### PR DESCRIPTION
We prefer double quotes over single quotes.

Fixes:
```
railties/lib/rails/commands/server/server_command.rb:279:39:
C: Style/StringLiterals: Prefer double-quoted strings unless you need
single quotes to avoi d extra backslashes for escaping.
            original_options.concat [ '-u', using ]
```

Related to 161ed37d7120e1f391eed19e49a3390e53e4fe91

See https://codeclimate.com/github/rails/rails/issues