### PR TITLE
A regression in `deprecate_methods` was introduced in a982a42:

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -54,23 +54,26 @@ module ActiveSupport
         deprecator = options.delete(:deprecator) || self
         method_names += options.keys
 
-        mod = Module.new do
-          method_names.each do |method_name|
-            define_method(method_name) do |*args, &block|
-              deprecator.deprecation_warning(method_name, options[method_name])
-              super(*args, &block)
-            end
+        method_names.each do |method_name|
+          aliased_method, punctuation = method_name.to_s.sub(/([?!=])$/, ""), $1
+          with_method = "#{aliased_method}_with_deprecation#{punctuation}"
+          without_method = "#{aliased_method}_without_deprecation#{punctuation}"
 
-            case
-            when target_module.protected_method_defined?(method_name)
-              protected method_name
-            when target_module.private_method_defined?(method_name)
-              private method_name
-            end
+          target_module.send(:define_method, with_method) do |*args, &block|
+            deprecator.deprecation_warning(method_name, options[method_name])
+            send(without_method, *args, &block)
+          end
+
+          target_module.send(:alias_method, without_method, method_name)
+          target_module.send(:alias_method, method_name, with_method)
+
+          case
+          when target_module.protected_method_defined?(without_method)
+            target_module.send(:protected, method_name)
+          when target_module.private_method_defined?(without_method)
+            target_module.send(:private, method_name)
           end
         end
-
-        target_module.prepend(mod)
       end
     end
   end


### PR DESCRIPTION
A regression in `deprecate_methods` was introduced in a982a42:

- Refactoring alias_chain to Module#prepend broke the possibility to deprecate class methods since the module
  generated was prepended to the target's instance.
  This patch uses `AS#redefine_method` instead and bind the unbound method to the class
- Fixes #33253
- Credit to @kamipo for the elegant solution
