### PR TITLE
Replace shallow mocks with Ruby classes

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -6,7 +6,17 @@ require "active_record/tasks/database_tasks"
 module ActiveRecord
   module DatabaseTasksSetupper
     def setup
-      @mysql_tasks, @postgresql_tasks, @sqlite_tasks = stub, stub, stub
+      @mysql_tasks, @postgresql_tasks, @sqlite_tasks = Array.new(
+        3,
+        Class.new do
+          def create; end
+          def drop; end
+          def purge; end
+          def charset; end
+          def collation; end
+          def structure_dump(*); end
+        end.new
+      )
       ActiveRecord::Tasks::MySQLDatabaseTasks.stubs(:new).returns @mysql_tasks
       ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stubs(:new).returns @postgresql_tasks
       ActiveRecord::Tasks::SQLiteDatabaseTasks.stubs(:new).returns @sqlite_tasks

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -7,7 +7,7 @@ if current_adapter?(:Mysql2Adapter)
   module ActiveRecord
     class MysqlDBCreateTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def create_database(*); end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "my-app-db"
@@ -96,7 +96,7 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_raises_error
-        assert_raises(Mysql2::Error) do
+        assert_raises(Mysql2::Error, "Invalid permissions") do
           ActiveRecord::Tasks::DatabaseTasks.create @configuration
         end
       end
@@ -104,7 +104,7 @@ if current_adapter?(:Mysql2Adapter)
 
     class MySQLDBDropTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(drop_database: true)
+        @connection    = Class.new { def drop_database(name); true end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "my-app-db"
@@ -142,7 +142,7 @@ if current_adapter?(:Mysql2Adapter)
 
     class MySQLPurgeTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(recreate_database: true)
+        @connection    = Class.new { def recreate_database(*); end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "test-db"
@@ -176,7 +176,7 @@ if current_adapter?(:Mysql2Adapter)
 
     class MysqlDBCharsetTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def charset; end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "my-app-db"
@@ -193,7 +193,7 @@ if current_adapter?(:Mysql2Adapter)
 
     class MysqlDBCollationTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def collation; end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "my-app-db"

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -7,7 +7,7 @@ if current_adapter?(:PostgreSQLAdapter)
   module ActiveRecord
     class PostgreSQLDBCreateTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def create_database(*); end }.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -89,7 +89,7 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLDBDropTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(drop_database: true)
+        @connection    = Class.new { def drop_database(*); end }.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -131,7 +131,10 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLPurgeTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true, drop_database: true)
+        @connection = Class.new do
+          def create_database(*); end
+          def drop_database(*); end
+        end.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -179,7 +182,7 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLDBCharsetTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def create_database(*); end }.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -197,7 +200,7 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLDBCollationTest < ActiveRecord::TestCase
       def setup
-        @connection    = stub(create_database: true)
+        @connection    = Class.new { def create_database(*); end }.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -69,11 +69,14 @@ if current_adapter?(:SQLite3Adapter)
     class SqliteDBDropTest < ActiveRecord::TestCase
       def setup
         @database      = "db_create.sqlite3"
-        @path          = stub(to_s: "/absolute/path", absolute?: true)
         @configuration = {
           "adapter"  => "sqlite3",
           "database" => @database
         }
+        @path = Class.new do
+          def to_s; "/absolute/path" end
+          def absolute?; true end
+        end.new
 
         Pathname.stubs(:new).returns(@path)
         File.stubs(:join).returns("/former/relative/path")
@@ -126,7 +129,7 @@ if current_adapter?(:SQLite3Adapter)
     class SqliteDBCharsetTest < ActiveRecord::TestCase
       def setup
         @database      = "db_create.sqlite3"
-        @connection    = stub :connection
+        @connection    = Class.new { def encoding; end }.new
         @configuration = {
           "adapter"  => "sqlite3",
           "database" => @database


### PR DESCRIPTION
While preparing this I realised that some stubbed returns values
serve no purpose, so this patch drops those as well.

Step 3 in #33162