### PR TITLE
Allow fstring as a safe raw SQL string

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -73,7 +73,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   def test_pluck_with_type_cast
     @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (1, '123.45'::money)")
 
-    assert_equal [BigDecimal("123.45")], PostgresqlMoney.pluck(Arel.sql("id * wealth"))
+    assert_equal [BigDecimal("123.45")], PostgresqlMoney.pluck("id * wealth")
   end
 
   def test_schema_dumping

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -305,7 +305,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_distinct_count_all_with_custom_select_and_order
-    accounts = Account.distinct.select("credit_limit % 10").order(Arel.sql("credit_limit % 10"))
+    accounts = Account.distinct.select("credit_limit % 10").order("credit_limit % 10")
     assert_queries(1) { assert_equal 3, accounts.count(:all) }
     assert_queries(1) { assert_equal 3, accounts.load.size }
   end
@@ -834,10 +834,10 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_with_selection_clause
-    assert_equal [50, 53, 55, 60], Account.pluck(Arel.sql("DISTINCT credit_limit")).sort
-    assert_equal [50, 53, 55, 60], Account.pluck(Arel.sql("DISTINCT accounts.credit_limit")).sort
-    assert_equal [50, 53, 55, 60], Account.pluck(Arel.sql("DISTINCT(credit_limit)")).sort
-    assert_equal [50 + 53 + 55 + 60], Account.pluck(Arel.sql("SUM(DISTINCT(credit_limit))"))
+    assert_equal [50, 53, 55, 60], Account.pluck("DISTINCT credit_limit").sort
+    assert_equal [50, 53, 55, 60], Account.pluck("DISTINCT accounts.credit_limit").sort
+    assert_equal [50, 53, 55, 60], Account.pluck("DISTINCT(credit_limit)").sort
+    assert_equal [50 + 53 + 55 + 60], Account.pluck("SUM(DISTINCT(credit_limit))")
   end
 
   def test_plucks_with_ids
@@ -998,7 +998,7 @@ class CalculationsTest < ActiveRecord::TestCase
     companies = Company.order(:name).limit(3).load
 
     assert_queries(1) do
-      assert_equal ["37signals", "Apex", "Ex Nihilo"], companies.pluck(Arel.sql("DISTINCT name"))
+      assert_equal ["37signals", "Apex", "Ex Nihilo"], companies.pluck("DISTINCT name")
     end
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -302,7 +302,7 @@ class FinderTest < ActiveRecord::TestCase
 
   # Ensure +exists?+ runs without an error by excluding order value.
   def test_exists_with_order
-    assert_equal true, Topic.order(Arel.sql("invalid sql here")).exists?
+    assert_equal true, Topic.order("invalid sql here").exists?
   end
 
   def test_exists_with_large_number
@@ -892,7 +892,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_last_with_irreversible_order
     assert_raises(ActiveRecord::IrreversibleOrderError) do
-      Topic.order(Arel.sql("coalesce(author_name, title)")).last
+      Topic.order("coalesce(author_name, title)").last
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -325,16 +325,16 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_reverse_order_with_multiargument_function
     assert_raises(ActiveRecord::IrreversibleOrderError) do
-      Topic.order(Arel.sql("concat(author_name, title)")).reverse_order
+      Topic.order("concat(author_name, title)").reverse_order
     end
     assert_raises(ActiveRecord::IrreversibleOrderError) do
-      Topic.order(Arel.sql("concat(lower(author_name), title)")).reverse_order
+      Topic.order("concat(lower(author_name), title)").reverse_order
     end
     assert_raises(ActiveRecord::IrreversibleOrderError) do
-      Topic.order(Arel.sql("concat(author_name, lower(title))")).reverse_order
+      Topic.order("concat(author_name, lower(title))").reverse_order
     end
     assert_raises(ActiveRecord::IrreversibleOrderError) do
-      Topic.order(Arel.sql("concat(lower(author_name), title, length(title)")).reverse_order
+      Topic.order("concat(lower(author_name), title, length(title)").reverse_order
     end
   end
 
@@ -456,29 +456,29 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_cross_table_order_and_limit
     tags = Tag.includes(:taggings).
-              order("tags.name asc", "taggings.taggable_id asc", Arel.sql("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)")).
+              order("tags.name asc", "taggings.taggable_id asc", "REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").
               limit(1).to_a
     assert_equal 1, tags.length
   end
 
   def test_finding_with_complex_order_and_limit
-    tags = Tag.includes(:taggings).references(:taggings).order(Arel.sql("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)")).limit(1).to_a
+    tags = Tag.includes(:taggings).references(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").limit(1).to_a
     assert_equal 1, tags.length
   end
 
   def test_finding_with_complex_order
-    tags = Tag.includes(:taggings).references(:taggings).order(Arel.sql("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)")).to_a
+    tags = Tag.includes(:taggings).references(:taggings).order("REPLACE('abc', taggings.taggable_type, taggings.taggable_type)").to_a
     assert_equal 3, tags.length
   end
 
   def test_finding_with_sanitized_order
-    query = Tag.order([Arel.sql("field(id, ?)"), [1, 3, 2]]).to_sql
+    query = Tag.order(["field(id, ?)", [1, 3, 2]]).to_sql
     assert_match(/field\(id, 1,3,2\)/, query)
 
-    query = Tag.order([Arel.sql("field(id, ?)"), []]).to_sql
+    query = Tag.order(["field(id, ?)", []]).to_sql
     assert_match(/field\(id, NULL\)/, query)
 
-    query = Tag.order([Arel.sql("field(id, ?)"), nil]).to_sql
+    query = Tag.order(["field(id, ?)", nil]).to_sql
     assert_match(/field\(id, NULL\)/, query)
   end
 

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -10,7 +10,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows string column name" do
     ids_expected = Post.order(Arel.sql("title")).pluck(:id)
 
-    ids = Post.order("title").pluck(:id)
+    ids = Post.order(params("title")).pluck(:id)
 
     assert_equal ids_expected, ids
   end
@@ -66,7 +66,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows table and column names" do
     ids_expected = Post.order(Arel.sql("title")).pluck(:id)
 
-    ids = Post.order("posts.title").pluck(:id)
+    ids = Post.order(params("posts.title")).pluck(:id)
 
     assert_equal ids_expected, ids
   end
@@ -74,7 +74,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows quoted table and column names" do
     ids_expected = Post.order(Arel.sql("title")).pluck(:id)
 
-    quoted_title = Post.connection.quote_table_name("posts.title")
+    quoted_title = Post.connection.quote_table_name(params("posts.title"))
     ids = Post.order(quoted_title).pluck(:id)
 
     assert_equal ids_expected, ids
@@ -83,7 +83,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows column name and direction in string" do
     ids_expected = Post.order(Arel.sql("title desc")).pluck(:id)
 
-    ids = Post.order("title desc").pluck(:id)
+    ids = Post.order(params("title desc")).pluck(:id)
 
     assert_equal ids_expected, ids
   end
@@ -91,7 +91,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows table name, column name and direction in string" do
     ids_expected = Post.order(Arel.sql("title desc")).pluck(:id)
 
-    ids = Post.order("posts.title desc").pluck(:id)
+    ids = Post.order(params("posts.title desc")).pluck(:id)
 
     assert_equal ids_expected, ids
   end
@@ -107,7 +107,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
       %w(first last).each do |position|
         ids_expected = Post.order(Arel.sql("type::text #{direction} nulls #{position}")).pluck(:id)
 
-        ids = Post.order("type::text #{direction} nulls #{position}").pluck(:id)
+        ids = Post.order(params("type::text #{direction} nulls #{position}")).pluck(:id)
 
         assert_equal ids_expected, ids
       end
@@ -116,7 +116,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "order: disallows invalid column name" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.order("REPLACE(title, 'misc', 'zzzz') asc").pluck(:id)
+      Post.order(params("REPLACE(title, 'misc', 'zzzz') asc")).pluck(:id)
     end
   end
 
@@ -128,12 +128,12 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "order: disallows invalid column with direction" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.order("REPLACE(title, 'misc', 'zzzz')" => :asc).pluck(:id)
+      Post.order(params("REPLACE(title, 'misc', 'zzzz')") => :asc).pluck(:id)
     end
   end
 
   test "order: always allows Arel" do
-    titles = Post.order(Arel.sql("length(title)")).pluck(:title)
+    titles = Post.order(Arel.sql(params("length(title)"))).pluck(:title)
 
     assert_not_empty titles
   end
@@ -141,34 +141,34 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows Arel.sql with binds" do
     ids_expected = Post.order(Arel.sql("REPLACE(title, 'misc', 'zzzz'), id")).pluck(:id)
 
-    ids = Post.order([Arel.sql("REPLACE(title, ?, ?), id"), "misc", "zzzz"]).pluck(:id)
+    ids = Post.order([Arel.sql(params("REPLACE(title, ?, ?), id")), "misc", "zzzz"]).pluck(:id)
 
     assert_equal ids_expected, ids
   end
 
   test "order: disallows invalid bind statement" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.order(["REPLACE(title, ?, ?), id", "misc", "zzzz"]).pluck(:id)
+      Post.order([params("REPLACE(title, ?, ?), id", "misc", "zzzz")]).pluck(:id)
     end
   end
 
   test "order: disallows invalid Array arguments" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.order(["author_id", "REPLACE(title, 'misc', 'zzzz')"]).pluck(:id)
+      Post.order([params("author_id"), params("REPLACE(title, 'misc', 'zzzz')")]).pluck(:id)
     end
   end
 
   test "order: allows valid Array arguments" do
     ids_expected = Post.order(Arel.sql("author_id, length(title)")).pluck(:id)
 
-    ids = Post.order(["author_id", "length(title)"]).pluck(:id)
+    ids = Post.order([params("author_id"), params("length(title)")]).pluck(:id)
 
     assert_equal ids_expected, ids
   end
 
   test "order: logs deprecation warning for unrecognized column" do
     e = assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.order("REPLACE(title, 'misc', 'zzzz')")
+      Post.order(params("REPLACE(title, 'misc', 'zzzz')"))
     end
 
     assert_match(/Query method called with non-attribute argument\(s\):/, e.message)
@@ -177,7 +177,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "pluck: allows string column name" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles = Post.pluck("title")
+    titles = Post.pluck(params("title"))
 
     assert_equal titles_expected, titles
   end
@@ -225,7 +225,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "pluck: allows table and column names" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles = Post.pluck("posts.title")
+    titles = Post.pluck(params("posts.title"))
 
     assert_equal titles_expected, titles
   end
@@ -233,7 +233,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "pluck: allows quoted table and column names" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    quoted_title = Post.connection.quote_table_name("posts.title")
+    quoted_title = Post.connection.quote_table_name(params("posts.title"))
     titles = Post.pluck(quoted_title)
 
     assert_equal titles_expected, titles
@@ -241,19 +241,19 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "pluck: disallows invalid column name" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.pluck("REPLACE(title, 'misc', 'zzzz')")
+      Post.pluck(params("REPLACE(title, 'misc', 'zzzz')"))
     end
   end
 
   test "pluck: disallows invalid column name amongst valid names" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.pluck(:title, "REPLACE(title, 'misc', 'zzzz')")
+      Post.pluck(:title, params("REPLACE(title, 'misc', 'zzzz')"))
     end
   end
 
   test "pluck: disallows invalid column names with includes" do
     assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.includes(:comments).pluck(:title, "REPLACE(title, 'misc', 'zzzz')")
+      Post.includes(:comments).pluck(:title, params("REPLACE(title, 'misc', 'zzzz')"))
     end
   end
 
@@ -266,9 +266,14 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "pluck: logs deprecation warning" do
     e = assert_raises(ActiveRecord::UnknownAttributeReference) do
-      Post.includes(:comments).pluck(:title, "REPLACE(title, 'misc', 'zzzz')")
+      Post.includes(:comments).pluck(:title, params("REPLACE(title, 'misc', 'zzzz')"))
     end
 
     assert_match(/Query method called with non-attribute argument\(s\):/, e.message)
   end
+
+  private
+    def params(string)
+      +string
+    end
 end


### PR DESCRIPTION
#27947 was intended to address `Post.order(params[:order])` which
leading to SQL injection.

But the protection caused very annoying warnings, especially for calling
by a string literal which invoke a function like `Post.order("length(title)")`.

Calling by a string literal should be safe since it is not a user
input. So I'd like to allow string literals as a safe raw SQL string.

There is no reliable way to distinguish between `params[:order]` and
`"length(title)"`, but at least `params[:order]` as a user input is
always a mutable string, and `"length(title)"` will be a fstring if
`# frozen_string_literal: true`.

So I think that we can add fstring to the allowlist to mitigate the
annoying warnings without losing the original intention of #27947.

Resolves #32995.