### PR TITLE
Fix stubbed methods in test cases

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -842,7 +842,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
     end.new
 
     connection.pool = Class.new do
-      def lock_thread=(lock_thread); false; end
+      def lock_thread=(lock_thread); end
     end.new
 
     connection.expects(:begin_transaction).with(joinable: false)
@@ -863,7 +863,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
     end.new
 
     connection.pool = Class.new do
-      def lock_thread=(lock_thread); false; end
+      def lock_thread=(lock_thread); end
     end.new
 
     fire_connection_notification(connection)

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -104,7 +104,7 @@ if current_adapter?(:Mysql2Adapter)
 
     class MySQLDBDropTest < ActiveRecord::TestCase
       def setup
-        @connection    = Class.new { def drop_database(name); true end }.new
+        @connection    = Class.new { def drop_database(name); end }.new
         @configuration = {
           "adapter"  => "mysql2",
           "database" => "my-app-db"


### PR DESCRIPTION
Remove returning of `false` value for stubbed `lock_thread=` methods
since there aren't any needs in it.

Remove unnecessary returning of `true` for stubbed `drop_database` method.
Follow up #33309.

Related to #33162, #33326.