### PR TITLE
Refer to ApplicationRecord [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -219,7 +219,7 @@ module ActionController
     # Also, sets the +permitted+ attribute to the default value of
     # <tt>ActionController::Parameters.permit_all_parameters</tt>.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationRecord
     #   end
     #
     #   params = ActionController::Parameters.new(name: "Francesco")
@@ -363,7 +363,7 @@ module ActionController
     # Sets the +permitted+ attribute to +true+. This can be used to pass
     # mass assignment. Returns +self+.
     #
-    #   class Person < ActiveRecord::Base
+    #   class Person < ApplicationRecord
     #   end
     #
     #   params = ActionController::Parameters.new(name: "Francesco")

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -488,7 +488,7 @@ module ActionDispatch
         #   You can override <tt>ActiveRecord::Base#to_param</tt> of a related
         #   model to construct a URL:
         #
-        #      class User < ActiveRecord::Base
+        #      class User < ApplicationRecord
         #        def to_param
         #          name
         #        end

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -74,7 +74,7 @@ module ActionDispatch
     # to access this auto-generated method from other places (such as a model), then
     # you can do that by including Rails.application.routes.url_helpers in your class:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationRecord
     #     include Rails.application.routes.url_helpers
     #
     #     def base_uri

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -869,7 +869,7 @@ module ActionView
       # When address is already an association on a Person you can use
       # +accepts_nested_attributes_for+ to define the writer method for you:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_one :address
       #     accepts_nested_attributes_for :address
       #   end
@@ -878,7 +878,7 @@ module ActionView
       # to enable it first using the <tt>:allow_destroy</tt> option for
       # +accepts_nested_attributes_for+:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_one :address
       #     accepts_nested_attributes_for :address, allow_destroy: true
       #   end
@@ -919,7 +919,7 @@ module ActionView
       # When projects is already an association on Person you can use
       # +accepts_nested_attributes_for+ to define the writer method for you:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_many :projects
       #     accepts_nested_attributes_for :projects
       #   end
@@ -966,7 +966,7 @@ module ActionView
       # form, you have to enable it first using the <tt>:allow_destroy</tt>
       # option for +accepts_nested_attributes_for+:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_many :projects
       #     accepts_nested_attributes_for :projects, allow_destroy: true
       #   end
@@ -1794,7 +1794,7 @@ module ActionView
       # When address is already an association on a Person you can use
       # +accepts_nested_attributes_for+ to define the writer method for you:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_one :address
       #     accepts_nested_attributes_for :address
       #   end
@@ -1803,7 +1803,7 @@ module ActionView
       # to enable it first using the <tt>:allow_destroy</tt> option for
       # +accepts_nested_attributes_for+:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_one :address
       #     accepts_nested_attributes_for :address, allow_destroy: true
       #   end
@@ -1844,7 +1844,7 @@ module ActionView
       # When projects is already an association on Person you can use
       # +accepts_nested_attributes_for+ to define the writer method for you:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_many :projects
       #     accepts_nested_attributes_for :projects
       #   end
@@ -1891,7 +1891,7 @@ module ActionView
       # form, you have to enable it first using the <tt>:allow_destroy</tt>
       # option for +accepts_nested_attributes_for+:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     has_many :projects
       #     accepts_nested_attributes_for :projects, allow_destroy: true
       #   end

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -178,11 +178,11 @@ module ActionView
       #
       # Example object structure for use with this method:
       #
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationRecord
       #     belongs_to :author
       #   end
       #
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationRecord
       #     has_many :posts
       #     def name_with_initial
       #       "#{first_name.first}. #{last_name}"
@@ -228,17 +228,17 @@ module ActionView
       #
       # Example object structure for use with this method:
       #
-      #   class Continent < ActiveRecord::Base
+      #   class Continent < ApplicationRecord
       #     has_many :countries
       #     # attribs: id, name
       #   end
       #
-      #   class Country < ActiveRecord::Base
+      #   class Country < ApplicationRecord
       #     belongs_to :continent
       #     # attribs: id, name, continent_id
       #   end
       #
-      #   class City < ActiveRecord::Base
+      #   class City < ApplicationRecord
       #     belongs_to :country
       #     # attribs: id, name, country_id
       #   end
@@ -430,12 +430,12 @@ module ActionView
       #
       # Example object structure for use with this method:
       #
-      #   class Continent < ActiveRecord::Base
+      #   class Continent < ApplicationRecord
       #     has_many :countries
       #     # attribs: id, name
       #   end
       #
-      #   class Country < ActiveRecord::Base
+      #   class Country < ApplicationRecord
       #     belongs_to :continent
       #     # attribs: id, name, continent_id
       #   end
@@ -606,10 +606,10 @@ module ActionView
       # retrieve the value/text.
       #
       # Example object structure for use with this method:
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationRecord
       #     belongs_to :author
       #   end
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationRecord
       #     has_many :posts
       #     def name_with_initial
       #       "#{first_name.first}. #{last_name}"
@@ -686,10 +686,10 @@ module ActionView
       # retrieve the value/text.
       #
       # Example object structure for use with this method:
-      #   class Post < ActiveRecord::Base
+      #   class Post < ApplicationRecord
       #     has_and_belongs_to_many :authors
       #   end
-      #   class Author < ActiveRecord::Base
+      #   class Author < ApplicationRecord
       #     has_and_belongs_to_many :posts
       #     def name_with_initial
       #       "#{first_name.first}. #{last_name}"

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -5,7 +5,7 @@ require "concurrent/map"
 module ActiveModel
   # Raised when an attribute is not defined.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationRecord
   #     has_many :pets
   #   end
   #

--- a/activemodel/lib/active_model/forbidden_attributes_protection.rb
+++ b/activemodel/lib/active_model/forbidden_attributes_protection.rb
@@ -3,7 +3,7 @@
 module ActiveModel
   # Raised when forbidden attributes are used for mass assignment.
   #
-  #   class Person < ActiveRecord::Base
+  #   class Person < ApplicationRecord
   #   end
   #
   #   params = ActionController::Parameters.new(name: 'Bob')

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -39,7 +39,7 @@ module ActiveModel
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
       #   # Schema: User(name:string, password_digest:string, recovery_password_digest:string)
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     has_secure_password
       #     has_secure_password :recovery_password, validations: false
       #   end
@@ -87,7 +87,7 @@ module ActiveModel
 
         # Returns +self+ if the password is correct, otherwise +false+.
         #
-        #   class User < ActiveRecord::Base
+        #   class User < ApplicationRecord
         #     has_secure_password validations: false
         #   end
         #

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -13,7 +13,7 @@ module ActiveModel
       # Validates that the specified attributes are blank (as defined by
       # Object#blank?). Happens by default on save.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_absence_of :first_name
       #   end
       #

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -71,7 +71,7 @@ module ActiveModel
       # Encapsulates the pattern of wanting to validate the acceptance of a
       # terms of service check box (or similar agreement).
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_acceptance_of :terms_of_service
       #     validates_acceptance_of :eula, message: 'must be abided'
       #   end

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -42,7 +42,7 @@ module ActiveModel
       # address field with a confirmation.
       #
       #   Model:
-      #     class Person < ActiveRecord::Base
+      #     class Person < ApplicationRecord
       #       validates_confirmation_of :user_name, :password
       #       validates_confirmation_of :email_address,
       #                                 message: 'should match confirmation'

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -18,7 +18,7 @@ module ActiveModel
       # Validates that the value of the specified attribute is not in a
       # particular enumerable object.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_exclusion_of :username, in: %w( admin superuser ), message: "You don't belong here"
       #     validates_exclusion_of :age, in: 30..60, message: 'This site is only for under 30 and over 60'
       #     validates_exclusion_of :format, in: %w( mov avi ), message: "extension %{value} is not allowed"

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -58,21 +58,21 @@ module ActiveModel
       # form, going by the regular expression provided. You can require that the
       # attribute matches the regular expression:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create
       #   end
       #
       # Alternatively, you can require that the specified attribute does _not_
       # match the regular expression:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_format_of :email, without: /NOSPAM/
       #   end
       #
       # You can also provide a proc or lambda which will determine the regular
       # expression that will be used to validate the attribute.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     # Admin can have number as a first letter in their screen name
       #     validates_format_of :screen_name,
       #                         with: ->(person) { person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\z/i : /\A[a-z][a-z0-9_\-]*\z/i }

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -18,7 +18,7 @@ module ActiveModel
       # Validates whether the value of the specified attribute is available in a
       # particular enumerable object.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_inclusion_of :role, in: %w( admin contributor )
       #     validates_inclusion_of :age, in: 0..99
       #     validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -74,7 +74,7 @@ module ActiveModel
       # supplied. Only one constraint option can be used at a time apart from
       # +:minimum+ and +:maximum+ that can be combined together:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_length_of :first_name, maximum: 30
       #     validates_length_of :last_name, maximum: 30, message: "less than 30 if you don't mind"
       #     validates_length_of :fax, in: 7..32, allow_nil: true

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -113,7 +113,7 @@ module ActiveModel
       # is +false+) or applying it to the regular expression <tt>/\A[\+\-]?\d+\z/</tt>
       # (if <tt>only_integer</tt> is set to +true+).
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_numericality_of :value, on: :create
       #   end
       #
@@ -155,7 +155,7 @@ module ActiveModel
       #
       # For example:
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_numericality_of :width, less_than: ->(person) { person.height }
       #     validates_numericality_of :width, greater_than: :minimum_weight
       #   end

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -12,7 +12,7 @@ module ActiveModel
       # Validates that the specified attributes are not blank (as defined by
       # Object#blank?). Happens by default on save.
       #
-      #   class Person < ActiveRecord::Base
+      #   class Person < ApplicationRecord
       #     validates_presence_of :first_name
       #   end
       #

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -30,7 +30,7 @@ module ActiveStorage
 
     # Returns true if any attachments has been made.
     #
-    #   class Gallery < ActiveRecord::Base
+    #   class Gallery < ApplicationRecord
     #     has_many_attached :photos
     #   end
     #

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -8,7 +8,7 @@ module ActiveStorage
     class_methods do
       # Specifies the relation between a single attachment and the model.
       #
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     has_one_attached :avatar
       #   end
       #
@@ -62,7 +62,7 @@ module ActiveStorage
 
       # Specifies the relation between multiple attachments and the model.
       #
-      #   class Gallery < ActiveRecord::Base
+      #   class Gallery < ApplicationRecord
       #     has_many_attached :photos
       #   end
       #

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -33,7 +33,7 @@ module ActiveStorage
 
     # Returns +true+ if an attachment has been made.
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationRecord
     #     has_one_attached :avatar
     #   end
     #

--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -4,7 +4,7 @@ class Module
   # Allows you to make aliases for attributes, which includes
   # getter, setter, and a predicate.
   #
-  #   class Content < ActiveRecord::Base
+  #   class Content < ApplicationRecord
   #     # has a title attribute
   #   end
   #

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -32,7 +32,7 @@ class Module
   #
   # Delegation is particularly useful with Active Record associations:
   #
-  #   class Greeter < ActiveRecord::Base
+  #   class Greeter < ApplicationRecord
   #     def hello
   #       'hello'
   #     end
@@ -42,7 +42,7 @@ class Module
   #     end
   #   end
   #
-  #   class Foo < ActiveRecord::Base
+  #   class Foo < ApplicationRecord
   #     belongs_to :greeter
   #     delegate :hello, to: :greeter
   #   end
@@ -52,7 +52,7 @@ class Module
   #
   # Multiple delegates to the same target are allowed:
   #
-  #   class Foo < ActiveRecord::Base
+  #   class Foo < ApplicationRecord
   #     belongs_to :greeter
   #     delegate :hello, :goodbye, to: :greeter
   #   end
@@ -118,7 +118,7 @@ class Module
   # The delegated methods are public by default.
   # Pass <tt>private: true</tt> to change that.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationRecord
   #     has_one :profile
   #     delegate :first_name, to: :profile
   #     delegate :date_of_birth, to: :profile, private: true
@@ -136,7 +136,7 @@ class Module
   # +Module::DelegationError+ is raised. If you wish to instead return +nil+,
   # use the <tt>:allow_nil</tt> option.
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationRecord
   #     has_one :profile
   #     delegate :age, to: :profile
   #   end
@@ -147,7 +147,7 @@ class Module
   # But if not having a profile yet is fine and should not be an error
   # condition:
   #
-  #   class User < ActiveRecord::Base
+  #   class User < ApplicationRecord
   #     has_one :profile
   #     delegate :age, to: :profile, allow_nil: true
   #   end

--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -11,7 +11,7 @@ class Object
   #
   # Without <tt>with_options</tt>, this code contains duplication:
   #
-  #   class Account < ActiveRecord::Base
+  #   class Account < ApplicationRecord
   #     has_many :customers, dependent: :destroy
   #     has_many :products,  dependent: :destroy
   #     has_many :invoices,  dependent: :destroy
@@ -20,7 +20,7 @@ class Object
   #
   # Using <tt>with_options</tt>, we can remove the duplication:
   #
-  #   class Account < ActiveRecord::Base
+  #   class Account < ApplicationRecord
   #     with_options dependent: :destroy do |assoc|
   #       assoc.has_many :customers
   #       assoc.has_many :products
@@ -39,7 +39,7 @@ class Object
   # When you don't pass an explicit receiver, it executes the whole block
   # in merging options context:
   #
-  #   class Account < ActiveRecord::Base
+  #   class Account < ApplicationRecord
   #     with_options dependent: :destroy do
   #       has_many :customers
   #       has_many :products
@@ -52,7 +52,7 @@ class Object
   #
   # NOTE: Each nesting level will merge inherited defaults in addition to their own.
   #
-  #   class Post < ActiveRecord::Base
+  #   class Post < ApplicationRecord
   #     with_options if: :persisted?, length: { minimum: 50 } do
   #       validates :content, if: -> { content.present? }
   #     end
@@ -67,7 +67,7 @@ class Object
   # NOTE: You cannot call class methods implicitly inside of with_options.
   # You can access these methods using the class name instead:
   #
-  #   class Phone < ActiveRecord::Base
+  #   class Phone < ApplicationRecord
   #     enum phone_number_type: [home: 0, office: 1, mobile: 2]
   #
   #     with_options presence: true do

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -714,7 +714,7 @@ module ActiveSupport #:nodoc:
       #
       #   autoload :Foo, 'foo'
       #
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #   end
       #
       # we correctly register "Foo" as being autoloaded. But if the app does


### PR DESCRIPTION
### Summary
This PR changes all references from `ActiveRecord::Base` to `ApplicationRecord` for all Rails modules except `ActiveRecord`. `ActiveRecord` will keep referring to `ActiveRecord::Base` because examples should still be valid when used outside Rails. For the remaining modules, some examples where referring to `ActiveRecord::Base` while others to `ApplicationRecord`, as new models are created with `ApplicationRecord` I changed every examples to use it

If you consider that `ActiveRecord` examples should also be changed, please let me know.

Thanks!