### PR TITLE
[WIP] Enum maps values to string in the database from symbol array

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -3,8 +3,8 @@
 require "active_support/core_ext/object/deep_dup"
 
 module ActiveRecord
-  # Declare an enum attribute where the values map to integers in the database,
-  # but can be queried by name. Example:
+  # Declare an enum attribute where the values map to integers or strings in
+  # the database, but can be queried by name. Lets start with integer enums:
   #
   #   class Conversation < ActiveRecord::Base
   #     enum status: [ :active, :archived ]
@@ -75,6 +75,37 @@ module ActiveRecord
   # For example, you can use that when manually building SQL strings:
   #
   #   Conversation.where("status <> ?", Conversation.statuses[:archived])
+  #
+  # String enums on the other hand are mapped by default to their equivalent string
+  # value:
+  #
+  #   class Book < ApplicationRecord
+  #     enum cover: [ :hard, :soft ]
+  #   end
+  #
+  #   # book.update! cover: "hard"
+  #   book.hard!
+  #   book.hard? # => true
+  #   book.cover # => "hard"
+  #
+  #   # book.update! cover: "soft"
+  #   book.soft!
+  #   book.soft? # => true
+  #   book.cover # => "soft"
+  #
+  #   # book.cover = "hard"
+  #   book.cover = "hard"
+  #
+  #   book.cover = nil
+  #   book.cover.nil? # => true
+  #   book.cover      # => nil
+  #
+  # Of course you can also provide a hash to explicitly map the relation between
+  # attribute and database string:
+  #
+  #   class Book < ApplicationRecord
+  #     enum cover: { hard: "strong", soft: "weak" }
+  #   end
   #
   # You can use the +:_prefix+ or +:_suffix+ options when you need to define
   # multiple enums with same values. If the passed value is +true+, the methods

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -168,7 +168,15 @@ module ActiveRecord
         end
 
         _enum_methods_module.module_eval do
-          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+          pairs =
+            if values.respond_to?(:each_pair)
+              values.each_pair
+            elsif klass.columns_hash[name]&.type == :string
+              values.lazy.map { |value| [value, value.to_s] }
+            else
+              values.each_with_index
+            end
+
           pairs.each do |label, value|
             if enum_prefix == true
               prefix = "#{name}_"

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -75,6 +75,26 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal books(:ddd), Book.where(read_status: "forgotten").first
   end
 
+  test "string enums can be defined providing a mapping hash" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum cover: { hard: "hard", soft: "soft" }
+    end
+
+    assert_equal "hard", klass.covers["hard"]
+    assert_equal "soft", klass.covers["soft"]
+  end
+
+  test "string enums can be defined providing an array of symbols" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum cover: [:hard, :soft]
+    end
+
+    assert_equal "hard", klass.covers["hard"]
+    assert_equal "soft", klass.covers["soft"]
+  end
+
   test "build from scope" do
     assert_predicate Book.written.build, :written?
     assert_not_predicate Book.written.build, :proposed?


### PR DESCRIPTION
### Summary

This PR implements the proposal discussed in Ruby on Rails: Core Google Group https://groups.google.com/forum/#!topic/rubyonrails-core/HfTKqlHTWz8

It allows you to map string enums directly from a symbol array in the following manner:
```ruby
class Book < ApplicationRecord
  enum cover: [ :hard, :soft ]
end

# book.update! cover: "hard"
book.hard!
book.hard? # => true
book.cover # => "hard"

# book.update! cover: "soft"
book.soft!
book.soft? # => true
book.cover # => "soft"

# book.cover = "hard"
book.cover = "hard"

book.cover = nil
book.cover.nil? # => true
book.cover      # => nil
```
 Of course you can also provide a hash to explicitly map the relation between attribute and database string:

```ruby
class Book < ApplicationRecord
   enum cover: { hard: "strong", soft: "weak" }
end
```

I hope you like it.

Thanks in advance for your reviews! ❤️ 