### PR TITLE
[ci skip] `sanitizer_vendor` will be removed in Rails 6

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -126,7 +126,7 @@ module ActionView
         attr_writer :full_sanitizer, :link_sanitizer, :white_list_sanitizer
 
         # Vendors the full, link and white list sanitizers.
-        # Provided strictly for compatibility and can be removed in Rails 5.1.
+        # Provided strictly for compatibility and can be removed in Rails 6.
         def sanitizer_vendor
           Rails::Html::Sanitizer
         end


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/24386#issuecomment-403926683