### PR TITLE
Deprecate passing irrelevant class to `becomes`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate passing an irrelevant class to `becomes` or `becomes!`.
+
+    * Yoshiyuki Kinjo*
+
 *   Fix default value for mysql time types with specified precision.
 
     *Nikolay Kondratyev*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -380,6 +380,11 @@ module ActiveRecord
     # Any change to the attributes on either instance will affect both instances.
     # If you want to change the sti column as well, use #becomes! instead.
     def becomes(klass)
+      unless self.class <= klass || klass < self.class || self.class.table_name == klass.table_name
+        ActiveSupport::Deprecation.warn \
+          "Passing irrelevant class to `becomes' is now deprecated and will result in ArgumentError in Rails 6.1. " \
+          "Please make sure that #{self.class.name} and #{klass.name} are in inheritance relationship or share same table via `table_name'."
+      end
       became = klass.allocate
       became.send(:initialize)
       became.instance_variable_set("@attributes", @attributes)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -324,6 +324,16 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal %w{name}, client.changed
   end
 
+  def test_becomes_irrelevant_class_is_deprecated
+    company = Company.new(name: "37signals")
+    assert_deprecated do
+      company.becomes(Topic)
+    end
+    assert_deprecated do
+      company.becomes!(Topic)
+    end
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])


### PR DESCRIPTION
`becomes` should receive a class which share same table.
If this is not satisfied, it usually does not make sense and often is
a programmer's mistake.

I propose to deprecate this case.