### PR TITLE
Add validations for t.references/add_reference options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -427,6 +427,13 @@ module ActiveRecord
 
       private
         def create_column_definition(name, type, options)
+          options.assert_valid_keys(
+            :after, :array, :as, :auto_increment, :charset, :collation, :comment,
+            :default, :first, :force, :foreign_key, :id, :index, :limit, :null,
+            :options, :polymorphic, :precision, :primary_key, :scale, :stored,
+            :temporary, :type, :unique, :unsigned
+          )
+
           ColumnDefinition.new(name, type, options)
         end
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -62,6 +62,14 @@ if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
           assert_equal([["testings", "testing_parents", "parent_id"]],
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
         end
+
+        test "invalid options can not be passed" do
+          @connection.create_table :testings do |t|
+            assert_raises(ArgumentError) do
+              t.references :testing_parent, fake_option: true
+            end
+          end
+        end
       end
     end
   end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -82,6 +82,12 @@ module ActiveRecord
         assert column_exists?(table_name, :user_id, :string)
       end
 
+      def test_raises_error_on_invalid_reference_options
+        assert_raises(ArgumentError) do
+          add_reference table_name, :user, foo: true, bar: false
+        end
+      end
+
       def test_deletes_reference_id_column
         remove_reference table_name, :supplier
         assert_not column_exists?(table_name, :supplier_id, :integer)


### PR DESCRIPTION
This adds a validation on which options can be passed when adding a
reference to a table. The valid options are: :type, :index, :polymorphic,
:unique, :foreign_key and :limit. Any other key is invalid.

For example, this would not raise an error before this commit, now it does:

create_table :posts do |t|
  t.references :users, fake_option: true
end

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
