### PR TITLE
Fixing some failing queries by composed_of

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -90,9 +90,9 @@ module ActiveRecord
             queries.reduce(&:or)
           elsif table.aggregated_with?(key)
             mapping = table.reflect_on_aggregation(key).mapping
-            queries = Array.wrap(value).map do |object|
+            queries = [value].flatten.map do |object|
               mapping.map do |field_attr, aggregate_attr|
-                if mapping.size == 1 && !object.respond_to?(aggregate_attr)
+                if mapping.size == 1 && !object.respond_to?(aggregate_attr) || object.nil?
                   build(table.arel_attribute(field_attr), object)
                 else
                   build(table.arel_attribute(field_attr), object.send(aggregate_attr))

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -98,8 +98,8 @@ module ActiveRecord
                   build(table.arel_attribute(field_attr), object.send(aggregate_attr))
                 end
               end.reduce(&:and)
-            end
-            queries.reduce(&:or)
+            end.compact
+            queries.reduce(&:or) || ["1=0"]
           else
             build(table.arel_attribute(key), value)
           end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -930,6 +930,13 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal customers(:david), found_customer
   end
 
+  def test_hash_condition_find_with_nil_aggregate_having_three_mappings
+    address = customers(:nikita).address
+    assert_nil address
+    found_customer = Customer.where(address: address).first
+    assert_equal customers(:nikita), found_customer
+  end
+
   def test_hash_condition_find_with_one_condition_being_aggregate_and_another_not
     address = customers(:david).address
     assert_kind_of Address, address

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -902,6 +902,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [customers(:david), customers(:zaphod)], found_customers.sort_by(&:id)
   end
 
+  def test_hash_condition_find_with_aggregate_having_empty_mapping_array
+    found_customers = Customer.where(balance: [])
+    assert_equal [], found_customers
+  end
+
   def test_hash_condition_find_with_aggregate_attribute_having_same_name_as_field_and_key_value_being_aggregate
     gps_location = customers(:david).gps_location
     assert_kind_of GpsLocation, gps_location

--- a/activerecord/test/fixtures/customers.yml
+++ b/activerecord/test/fixtures/customers.yml
@@ -33,3 +33,12 @@ mary:
   address_city: Peaceful Town
   address_country: Nation Land
   gps_location: NULL
+
+nikita:
+  id: 5
+  name: Nikita
+  balance: 300
+  address_street: NULL
+  address_city: NULL
+  address_country: NULL
+  gps_location: NULL


### PR DESCRIPTION
`Customer.where(balance: nil).load`
`Customer.where(balance: []).load`

Both were failing with this:

```
Arel::Visitors::UnsupportedVisitError: Unsupported argument type: NilClass. Construct an Arel node instead.
 ```

