### PR TITLE
Enable `Layout/EmptyLinesAroundBlockBody` to reduce review cost in the future

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Layout/EndAlignment:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
 # In a regular class definition, no empty lines around the body.
 Layout/EmptyLinesAroundClassBody:
   Enabled: true

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -41,7 +41,6 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
       # Internal hax = :(
       client = connection.websocket.send(:websocket)
       client.instance_variable_get("@stream").stub(:write, proc { raise "foo" }) do
-
         assert_not_called(client, :client_gone) do
           client.write("boo")
         end

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -41,7 +41,6 @@ module ActionDispatch
         rescue SystemCallError
           false
         end
-
       }
         return ::Rack::Utils.escape_path(match).b
       end

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -66,7 +66,6 @@ class ResourcesTest < ActionController::TestCase
         member_methods.each_key do |action|
           assert_named_route "/messages/1/#{path_names[action] || action}", "#{action}_message_path", action: action, id: "1"
         end
-
       end
     end
   end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -937,7 +937,6 @@ class RouteSetTest < ActiveSupport::TestCase
     @default_route_set ||= begin
       set = ActionDispatch::Routing::RouteSet.new
       set.draw do
-
         ActiveSupport::Deprecation.silence do
           get "/:controller(/:action(/:id))"
         end
@@ -1342,11 +1341,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_namespace
     set.draw do
-
       namespace "api" do
         get "inventory" => "products#inventory"
       end
-
     end
 
     params = request_path_params("/api/inventory", method: :get)

--- a/activerecord/test/cases/arel/insert_manager_test.rb
+++ b/activerecord/test/cases/arel/insert_manager_test.rb
@@ -220,7 +220,6 @@ module Arel
     end
 
     describe "select" do
-
       it "accepts a select query in place of a VALUES clause" do
         table   = Table.new :users
 
@@ -238,7 +237,6 @@ module Arel
           INSERT INTO "users" ("id", "name") (SELECT 1, "aaron")
         }
       end
-
     end
   end
 end

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -244,8 +244,6 @@ module Arel
         @m2 = Arel::SelectManager.new table
         @m2.project Arel.star
         @m2.where(table[:age].gt(99))
-
-
       end
 
       it "should union two managers" do
@@ -266,7 +264,6 @@ module Arel
           ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION ALL SELECT * FROM "users"  WHERE "users"."age" > 99 )
         }
       end
-
     end
 
     describe "intersect" do
@@ -279,8 +276,6 @@ module Arel
         @m2 = Arel::SelectManager.new table
         @m2.project Arel.star
         @m2.where(table[:age].lt(99))
-
-
       end
 
       it "should interect two managers" do
@@ -293,7 +288,6 @@ module Arel
           ( SELECT * FROM "users"  WHERE "users"."age" > 18 INTERSECT SELECT * FROM "users"  WHERE "users"."age" < 99 )
         }
       end
-
     end
 
     describe "except" do
@@ -318,7 +312,6 @@ module Arel
           ( SELECT * FROM "users"  WHERE "users"."age" BETWEEN 18 AND 60 EXCEPT SELECT * FROM "users"  WHERE "users"."age" BETWEEN 40 AND 99 )
         }
       end
-
     end
 
     describe "with" do
@@ -647,7 +640,6 @@ module Arel
     end
 
     describe "joins" do
-
       it "returns inner join sql" do
         table   = Table.new :users
         aliaz   = table.alias
@@ -1002,7 +994,6 @@ module Arel
     end
 
     describe "update" do
-
       it "creates an update statement" do
         table   = Table.new :users
         manager = Arel::SelectManager.new
@@ -1075,7 +1066,6 @@ module Arel
           UPDATE "users" SET "id" = 1 WHERE "users"."id" IN (SELECT "users"."id" FROM "users" WHERE "users"."foo" = 10 LIMIT 42)
         }
       end
-
     end
 
     describe "project" do
@@ -1097,7 +1087,6 @@ module Arel
         manager.project "*"
         manager.to_sql.must_be_like %{ SELECT * }
       end
-
     end
 
     describe "projections" do

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -91,7 +91,6 @@ class InheritanceTest < ActiveRecord::TestCase
     end
 
     ActiveSupport::Dependencies.stub(:safe_constantize, proc { raise e }) do
-
       exception = assert_raises NameError do
         Company.send :compute_type, "InvalidModel"
       end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -669,7 +669,6 @@ module NestedAttributesOnACollectionAssociationTests
   def test_should_take_a_hash_with_composite_id_keys_and_assign_the_attributes_to_the_associated_models
     @child_1.stub(:id, "ABC1X") do
       @child_2.stub(:id, "ABC2X") do
-
         @pirate.attributes = {
           association_getter => [
             { id: @child_1.id, name: "Grace OMalley" },

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -482,7 +482,6 @@ class QueryCacheTest < ActiveRecord::TestCase
           assert_not ActiveRecord::Base.connection.query_cache_enabled
         }.join
       }.call({})
-
     end
   end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -573,7 +573,6 @@ class TransactionTest < ActiveRecord::TestCase
     assert_called(Topic.connection, :begin_db_transaction) do
       Topic.connection.stub(:commit_db_transaction, -> { raise("OH NOES") }) do
         assert_called(Topic.connection, :rollback_db_transaction) do
-
           e = assert_raise RuntimeError do
             Topic.transaction do
               # do nothing

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-
   if subsecond_precision_supported?
     create_table :datetime_defaults, force: true do |t|
       t.datetime :modified_datetime, default: -> { "CURRENT_TIMESTAMP" }

--- a/activerecord/test/schema/oracle_specific_schema.rb
+++ b/activerecord/test/schema/oracle_specific_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-
   execute "drop table test_oracle_defaults" rescue nil
   execute "drop sequence test_oracle_defaults_seq" rescue nil
   execute "drop sequence companies_nonstd_seq" rescue nil
@@ -38,5 +37,4 @@ create sequence test_oracle_defaults_seq minvalue 10000
   )
   SQL
   execute "create sequence defaults_seq minvalue 10000"
-
 end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-
   enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
   enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
 

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -258,7 +258,6 @@ module Rails
 
         namespaces = Hash[subclasses.map { |klass| [klass.namespace, klass] }]
         lookups.each do |namespace|
-
           klass = namespaces[namespace]
           return klass if klass
         end

--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 namespace :log do
-
   ##
   # Truncates all/specified log files
   # ENV['LOGS']

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -570,7 +570,6 @@ YAML
 
       get("/arunagw")
       assert_equal "arunagw", last_response.body
-
     end
 
     test "it provides routes as default endpoint" do


### PR DESCRIPTION
We sometimes ask "✂️ extra blank lines" to a contributor in reviews like
https://github.com/rails/rails/pull/33337#discussion_r201509738.

It is preferable to deal automatically without depending on manpower.