### PR TITLE
Wrap "db:seed" task in transaction

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -219,7 +219,9 @@ db_namespace = namespace :db do
   desc "Loads the seed data from db/seeds.rb"
   task seed: :load_config do
     db_namespace["abort_if_pending_migrations"].invoke
-    ActiveRecord::Tasks::DatabaseTasks.load_seed
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Tasks::DatabaseTasks.load_seed
+    end
   end
 
   namespace :fixtures do

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -219,9 +219,7 @@ db_namespace = namespace :db do
   desc "Loads the seed data from db/seeds.rb"
   task seed: :load_config do
     db_namespace["abort_if_pending_migrations"].invoke
-    ActiveRecord::Base.transaction do
-      ActiveRecord::Tasks::DatabaseTasks.load_seed
-    end
+    ActiveRecord::Tasks::DatabaseTasks.load_seed
   end
 
   namespace :fixtures do

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -548,7 +548,18 @@ module Rails
     # Blog::Engine.load_seed
     def load_seed
       seed_file = paths["db/seeds.rb"].existent.first
-      load(seed_file) if seed_file
+      return unless seed_file
+      ActiveRecord::Base.transaction do
+        begin
+          load(seed_file)
+        rescue Exception
+          $stderr.puts <<~EOS
+            An exception was raised while loading #{seed_file}
+            All database changes have been rolled back. You can safely rerun your seeds when you have fixed the error.
+          EOS
+          raise
+        end
+      end
     end
 
     # Add configured load paths to Ruby's load path, and remove duplicate entries.

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -903,20 +903,11 @@ YAML
 
       boot_rails
 
-      begin
-        Rails.application.load_seed
-      rescue Exception => err
-        assert_equal "Rails.application seed error", err.message
-      end
-      assert Rails.application.config.app_seeds_loaded
-      assert_raise(NoMethodError) { Bukkits::Engine.config.bukkits_seeds_loaded }
+      rails_app_error = assert_raise(RuntimeError) { Rails.application.load_seed }
+      assert_equal "Rails.application seed error", rails_app_error.message
 
-      begin
-        Bukkits::Engine.load_seed
-      rescue Exception => err
-        assert_equal "Bukkits seed error", err.message
-      end
-      assert Bukkits::Engine.config.bukkits_seeds_loaded
+      bukkits_error = assert_raise(RuntimeError) { Bukkits::Engine.load_seed }
+      assert_equal "Bukkits seed error", bukkits_error.message
 
       buffer.rewind
       output = buffer.read

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -921,10 +921,10 @@ YAML
       buffer.rewind
       output = buffer.read
 
-      assert output.include?("An exception was raised while loading")
-      assert output.include?("app/db/seeds.rb")
-      assert output.include?("bukkits/db/seeds.rb")
-      assert output.include?("All database changes have been rolled back. You can safely rerun your seeds when you have fixed the error.")
+      assert_includes output, "An exception was raised while loading"
+      assert_includes output, "app/db/seeds.rb"
+      assert_includes output, "bukkits/db/seeds.rb"
+      assert_includes output, "All database changes have been rolled back. You can safely rerun your seeds when you have fixed the error."
 
       $stderr = original_stderr
     end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -912,7 +912,7 @@ YAML
       assert_raise(NoMethodError) { Bukkits::Engine.config.bukkits_seeds_loaded }
 
       begin
-        Bukkits::Engine.load_seed rescue Exception
+        Bukkits::Engine.load_seed
       rescue Exception => err
         assert_equal "Bukkits seed error", err.message
       end


### PR DESCRIPTION
Fixes #33302

If running your seeds file failed halfway through for some reason you could be
left with a database in an inconsistent state. That is fixed by wrapping it in
a transaction.

I guess it might be nice to tell the user that the changes were rolled back.
Let me know if I should add that 😄 
