### PR TITLE
Normalize the date component to 2000-01-01 automatically

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -130,6 +130,7 @@ module ActiveRecord
       end
 
       def quoted_time(value) # :nodoc:
+        value = value.change(year: 2000, month: 1, day: 1)
         quoted_date(value).sub(/\A\d\d\d\d-\d\d-\d\d /, "")
       end
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -71,8 +71,8 @@ module ActiveRecord
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
 
-          expected = t.getutc.change(year: 2000, month: 1, day: 1)
-          expected = expected.to_s(:db).sub("2000-01-01 ", "")
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getutc.to_s(:db).slice(11..-1)
 
           assert_equal expected, @quoter.quoted_time(t)
         end
@@ -84,6 +84,28 @@ module ActiveRecord
 
           expected = t.change(year: 2000, month: 1, day: 1)
           expected = expected.getlocal.to_s(:db).sub("2000-01-01 ", "")
+
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_dst_utc
+        with_timezone_config default: :utc do
+          t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getutc.to_s(:db).slice(11..-1)
+
+          assert_equal expected, @quoter.quoted_time(t)
+        end
+      end
+
+      def test_quoted_time_dst_local
+        with_timezone_config default: :local do
+          t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
+
+          expected = t.change(year: 2000, month: 1, day: 1)
+          expected = expected.getlocal.to_s(:db).slice(11..-1)
 
           assert_equal expected, @quoter.quoted_time(t)
         end


### PR DESCRIPTION
### Summary

Fixes #32550 - Normalize the date component to 2000-01-01 automatically when searching by that column by using `change`.

### Other Information
N/A