### PR TITLE
Add block support to `#concat` text helper

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -51,12 +51,14 @@ module ActionView
       #       end
       #       # will either display "Logged in!" or a login link
       #   %>
-      def concat(string)
-        output_buffer << string
+      def concat(string = nil, &block)
+        raise ArgumentError unless string || block
+
+        output_buffer << (block ? block.call : string)
       end
 
-      def safe_concat(string)
-        output_buffer.respond_to?(:safe_concat) ? output_buffer.safe_concat(string) : concat(string)
+      def safe_concat(string, &block)
+        output_buffer.respond_to?(:safe_concat) ? output_buffer.safe_concat(string) : concat(string, &block)
       end
 
       # Truncates a given +text+ after a given <tt>:length</tt> if +text+ is longer than <tt>:length</tt>

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -18,6 +18,16 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "foobar", output_buffer
   end
 
+  def test_concat_with_block
+    self.output_buffer = "foo".dup
+    assert_equal "foobar", concat { "bar" }
+    assert_equal "foobar", output_buffer
+  end
+
+  def test_concat_without_params_and_block
+    assert_raises(ArgumentError) { concat }
+  end
+
   def test_simple_format_should_be_html_safe
     assert_predicate simple_format("<b> test with html tags </b>"), :html_safe?
   end


### PR DESCRIPTION
Using `#concat` with a method with a multiline block is not very handy. 
You have to do something like that
```ruby
concat (link_to my_path, class: 'some_class' do
  some_other_helper do
    # ....
    # ....
    # ....
  end
end)
```
to define a proper order of operations.

This PR adds block support to `#concat` method that will allow us to refactor the above with
```ruby
concat do
  link_to my_path, class: 'some_class' do
    some_other_helper do
      # ....
      # ....
      # ....
  end
end
```
