### PR TITLE
Fix regression in use of string attribute in the added? method

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -328,7 +328,7 @@ module ActiveModel
     #  person.errors.added? :name, "is too long"                            # => false
     def added?(attribute, message = :invalid, options = {})
       if message.is_a? Symbol
-        self.details[attribute].map { |e| e[:error] }.include? message
+        self.details[attribute.to_sym].map { |e| e[:error] }.include? message
       else
         message = message.call if message.respond_to?(:call)
         message = normalize_message(attribute, message, options)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -185,6 +185,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert person.errors.added?(:name, :blank)
   end
 
+  test "added? returns true when string attribute is used with a symbol message" do
+    person = Person.new
+    person.errors.add(:name, :blank)
+    assert person.errors.added?("name", :blank)
+  end
+
   test "added? handles proc messages" do
     person = Person.new
     message = Proc.new { "cannot be blank" }


### PR DESCRIPTION
### Summary

A bug [was introduced](https://github.com/rails/rails/pull/31117/commits/15cb4efadb61a8813967d3c25f4adfc9a918a0c0) in ActiveModel 5.2 that caused the `added?` method to fail if a string parameter for the attribute was used with a symbol for the message.

```ruby
model.added?("name", :blank)
```

Issue #33357 includes a test case to demonstrate the behavior and my initial write up of it can be found on [the PR that created the bug](https://github.com/rails/rails/pull/31117#issuecomment-404972922).

This is a fairly simple fix. The details has [normalizes to symbol keys in the add method](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L309) so we're just forcing the string to a symbol when doing the check in the added method.

I questioned whether it was worth a test of it's own, but decided it was better to be explicit.

Is this worth a CHANGELOG entry?