### PR TITLE
use set_server_option if possible

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -559,14 +559,32 @@ module ActiveRecord
         end
 
         def with_multi_statements
-          previous_flags = @config[:flags]
-          @config[:flags] = Mysql2::Client::MULTI_STATEMENTS
-          reconnect!
+          if supports_set_server_option?
+            @connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+          elsif !supports_multi_statements?
+            previous_flags = @config[:flags]
+            @config[:flags] = Mysql2::Client::MULTI_STATEMENTS
+            reconnect!
+          end
 
           yield
         ensure
-          @config[:flags] = previous_flags
-          reconnect!
+          unless supports_multi_statements?
+            if supports_set_server_option?
+              @connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
+            else
+              @config[:flags] = previous_flags
+              reconnect!
+            end
+          end
+        end
+
+        def supports_multi_statements?
+          (@config[:flags] & Mysql2::Client::MULTI_STATEMENTS) != 0
+        end
+
+        def supports_set_server_option?
+          @connection.respond_to?(:set_server_option)
         end
 
         def initialize_type_map(m = type_map)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -114,6 +114,21 @@ class FixturesTest < ActiveRecord::TestCase
         end
       end
     end
+
+    def test_bulk_insert_with_a_multi_statement_query_in_a_nested_transaction
+      fixtures = {
+        "traffic_lights" => [
+          { "location" => "US", "state" => ["NY"], "long_state" => ["a"] },
+        ]
+      }
+
+      ActiveRecord::Base.transaction do
+        con = ActiveRecord::Base.connection
+        assert_equal 1, con.open_transactions
+        con.insert_fixtures_set(fixtures)
+        assert_equal 1, con.open_transactions
+      end
+    end
   end
 
   if current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
### Summary
original issue https://github.com/rails/rails/pull/31422 (since rails 5.2.0)
```
We loose all open transactions; Inside the original code, when inserting fixtures, a transaction is open. Multple delete statements are executed and finally the fixtures are inserted. The problem with this patch is that we need to open the transaction only after we reconnect to the DB otherwise reconnecting drops the open transaction which doesn't commit all delete statements and inserting fixtures doesn't work since we duplicated them (Primary key duplicate exception)...
```
it breaks https://github.com/DatabaseCleaner/database_cleaner transaction strategy

```
open a transaction
insert fixtures
run a test
rollback
```

the problem is that inserting fixtures reconnects to the db that drops all active transactions, so the next rollback won't work.

### Other Information
I used https://github.com/brianmario/mysql2/pull/943 for this purpose, but it's available only in mysql2 0.5.0+. There's a fallback to the previous (current) behaviour, but it won't fix the bug.
I added an additional workaround, if you set up Mysql2::Client::MULTI_STATEMENTS in a database config manually, it won't require reconnect. This way it will work even with previous versions of mysql2 gem.