### PR TITLE
 Modify the expression's issue for `errors.add` document.

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1133,24 +1133,6 @@ person.errors.full_messages
  # => ["Name cannot contain the characters !@#%*()_-+="]
 ```
 
-An equivalent to `errors#add` is to use `<<` to append a message to the `errors.messages` array for an attribute:
-
-```ruby
-  class Person < ApplicationRecord
-    def a_method_used_for_validation_purposes
-      errors.messages[:name] << "cannot contain the characters !@#%*()_-+="
-    end
-  end
-
-  person = Person.create(name: "!@#")
-
-  person.errors[:name]
-   # => ["cannot contain the characters !@#%*()_-+="]
-
-  person.errors.to_a
-   # => ["Name cannot contain the characters !@#%*()_-+="]
-```
-
 ### `errors.details`
 
 You can specify a validator type to the returned error details hash using the


### PR DESCRIPTION
```
 a = Area.first

> a.errors.messages[:name] << "Just for messages"
 => ["Just for messages"]
> a.errors.details 
 => {}
> a.errors.messages
 => {:name=>["Just for messages"]}

> a.errors.add(:age, "Both messages and details")
 => ["Both messages and details"]
> a.errors.details
 => {:age=>[{:error=>"Both messages and details"}]}
> a.errors.messages
 => {:name=>["Just for messages"], :age=>["Both messages and details"]}
```

As the above example, I think use `<<` to append a message to the `errors.messages` array is not equivalent to `errors#add` . So I think the origin document not very clear clear, I want to correct it.