### PR TITLE
 Fix document issue in active record callback about `after_touch` hook.

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -184,9 +184,9 @@ class Company < ApplicationRecord
   after_touch :log_when_employees_or_company_touched
 
   private
-  def log_when_employees_or_company_touched
-    puts 'Employee/Company was touched'
-  end
+    def log_when_employees_or_company_touched
+      puts 'Employee/Company was touched'
+    end
 end
 
 >> @employee = Employee.last
@@ -194,8 +194,8 @@ end
 
 # triggers @employee.company.touch
 >> @employee.touch
-Employee/Company was touched
 An Employee was touched
+Employee/Company was touched
 => true
 ```
 


### PR DESCRIPTION
### Summary

There are some same code with origin document in other information section. When we run the code and touch the `@employee` instance we will print  'An Employee was touched' first, and then print  'Employee/Company was touched' message. So I think we may have some issue in document.

```
> @employee.touch
An Employee was touched
Employee/Company was touched
```

### Other Information

```

class Company < ApplicationRecord
  has_many :employees

  after_touch :log_when_employees_or_company_touched

  private
    def log_when_employees_or_company_touched
      puts 'Employee/Company was touched'
    end
end

class Employee < ApplicationRecord
  belongs_to :company, touch: true

  after_touch do
    puts 'An Employee was touched'
  end
end
```