### PR TITLE
fix test_should_impose_childless_html_tags_in_html failure with JRuby

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -401,7 +401,13 @@ XML
     process :test_xml_output, params: { response_as: "text/html" }
 
     # <area> auto-closes, so the <p> becomes a sibling
-    assert_select "root > area + p"
+    if defined?(JRUBY_VERSION)
+      # https://github.com/sparklemotion/nokogiri/issues/1653
+      # HTML parser "fixes" "broken" markup in slightly different ways
+      assert_select "root > map > area + p"
+    else
+      assert_select "root > area + p"
+    end
   end
 
   def test_should_not_impose_childless_html_tags_in_xml


### PR DESCRIPTION
### Summary
fixes: https://github.com/rails/rails/issues/30542

https://github.com/sparklemotion/nokogiri/issues/1653
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area

it's just an inconsistency how nokogiri parsers work. Not a real bug.