### PR TITLE
5-2-stable: Backport #33361

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -323,7 +323,7 @@ module ActiveModel
     #  person.errors.added? :name, "is too long"                            # => false
     def added?(attribute, message = :invalid, options = {})
       if message.is_a? Symbol
-        self.details[attribute].map { |e| e[:error] }.include? message
+        self.details[attribute.to_sym].map { |e| e[:error] }.include? message
       else
         message = message.call if message.respond_to?(:call)
         message = normalize_message(attribute, message, options)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -186,6 +186,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert person.errors.added?(:name, :blank)
   end
 
+  test "added? returns true when string attribute is used with a symbol message" do
+    person = Person.new
+    person.errors.add(:name, :blank)
+    assert person.errors.added?("name", :blank)
+  end
+
   test "added? handles proc messages" do
     person = Person.new
     message = Proc.new { "cannot be blank" }


### PR DESCRIPTION
Backport to `5-2-stable` since the bug was introduced in Rails 5.2,
see 15cb4efadb61a8813967d3c25f4adfc9a918a0c0.

cherry-pick 05bef140519fe3410fd8d352f5ea84fd1a278063.