### PR TITLE
Clarify test cases

### DIFF
--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -90,7 +90,7 @@ if current_adapter?(:Mysql2Adapter)
       private
 
         def with_stubbed_connection_establish_connection
-          ActiveRecord::Base.stub(:establish_connection, true) do
+          ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do
               yield
             end
@@ -116,11 +116,9 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_raises_error
-        ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.stub(:establish_connection, -> * { raise @error }) do
-            assert_raises(Mysql2::Error, "Invalid permissions") do
-              ActiveRecord::Tasks::DatabaseTasks.create @configuration
-            end
+        ActiveRecord::Base.stub(:establish_connection, -> * { raise @error }) do
+          assert_raises(Mysql2::Error, "Invalid permissions") do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
           end
         end
       end
@@ -168,7 +166,7 @@ if current_adapter?(:Mysql2Adapter)
       private
 
         def with_stubbed_connection_establish_connection
-          ActiveRecord::Base.stub(:establish_connection, true) do
+          ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do
               yield
             end
@@ -215,7 +213,7 @@ if current_adapter?(:Mysql2Adapter)
       private
 
         def with_stubbed_connection_establish_connection
-          ActiveRecord::Base.stub(:establish_connection, true) do
+          ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do
               yield
             end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -211,7 +211,7 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_creates_database
         with_stubbed_connection do
-          ActiveRecord::Base.stub(:establish_connection, true) do
+          ActiveRecord::Base.stub(:establish_connection, nil) do
             @connection.expects(:create_database).
               with("my-app-db", @configuration.merge("encoding" => "utf8"))
 

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -22,7 +22,7 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_db_checks_database_exists
-        ActiveRecord::Base.stub(:establish_connection, true) do
+        ActiveRecord::Base.stub(:establish_connection, nil) do
           assert_called_with(File, :exist?, [@database], returns: false) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
           end
@@ -30,7 +30,7 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_when_db_created_successfully_outputs_info_to_stdout
-        ActiveRecord::Base.stub(:establish_connection, true) do
+        ActiveRecord::Base.stub(:establish_connection, nil) do
           ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
 
           assert_equal "Created database '#{@database}'\n", $stdout.string
@@ -54,10 +54,8 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_db_create_establishes_a_connection
-        File.stub(:exist?, false) do
-          assert_called_with(ActiveRecord::Base, :establish_connection, [@configuration]) do
-            ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
-          end
+        assert_called_with(ActiveRecord::Base, :establish_connection, [@configuration]) do
+          ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
         end
       end
 


### PR DESCRIPTION
Remove extra stub of `ActiveRecord::Base::connection` in
`activerecord/test/cases/tasks/mysql_rake_test.rb`.

Remove extra stub of `File::exist?` in
`activerecord/test/cases/tasks/sqlite_rake_test.rb`.

`ActiveRecord::Base::establish_connection` shouldn't return `true`
in test cases.

Related to https://github.com/rails/rails/pull/33337.

r? @kamipo 