### PR TITLE
[ci skip] fix unknown_asset_fallback default in guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -169,7 +169,7 @@ pipeline is enabled. It is set to `true` by default.
 
 * `config.assets.precompile` allows you to specify additional assets (other than `application.css` and `application.js`) which are to be precompiled when `rake assets:precompile` is run.
 
-* `config.assets.unknown_asset_fallback` allows you to modify the behavior of the asset pipeline when an asset is not in the pipeline, if you use sprockets-rails 3.2.0 or newer. Defaults to `true`.
+* `config.assets.unknown_asset_fallback` allows you to modify the behavior of the asset pipeline when an asset is not in the pipeline, if you use sprockets-rails 3.2.0 or newer. Defaults to `false`.
 
 * `config.assets.prefix` defines the prefix where assets are served from. Defaults to `/assets`.
 


### PR DESCRIPTION
### Summary

Fix mismatch between doc and code for 5.1.6 release.

In http://guides.rubyonrails.org/v5.1/configuring.html > 3.2 Configuring Assets > config.assets.unknown_asset_fallback default is true (Here : https://github.com/rails/rails/blob/0ae59ea828ed20141af0d4c9ed9130eb47ce55f3/guides/source/configuring.md#L172)

BUT

In configuration.rb it is set to false : 
https://github.com/rails/rails/blob/0ec23effa74e8e9da6ebb14afbd335bea470ab3e/railties/lib/rails/application/configuration.rb#L84 
