### PR TITLE
Remove/Replace some more calls to Mocha#stubs

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
@@ -45,9 +45,10 @@ class Mysql2DatetimePrecisionQuotingTest < ActiveRecord::Mysql2TestCase
     end
 
     def stub_version(full_version_string)
-      @connection.stubs(:full_version).returns(full_version_string)
-      @connection.remove_instance_variable(:@version) if @connection.instance_variable_defined?(:@version)
-      yield
+      @connection.stub(:full_version, full_version_string) do
+        @connection.remove_instance_variable(:@version) if @connection.instance_variable_defined?(:@version)
+        yield
+      end
     ensure
       @connection.remove_instance_variable(:@version) if @connection.instance_variable_defined?(:@version)
     end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -876,15 +876,16 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
   private
 
     def fire_connection_notification(connection)
-      ActiveRecord::Base.connection_handler.stubs(:retrieve_connection).with("book").returns(connection)
-      message_bus = ActiveSupport::Notifications.instrumenter
-      payload = {
-        spec_name: "book",
-        config: nil,
-        connection_id: connection.object_id
-      }
+      ActiveRecord::Base.connection_handler.stub(:retrieve_connection, connection) do
+        message_bus = ActiveSupport::Notifications.instrumenter
+        payload = {
+          spec_name: "book",
+          config: nil,
+          connection_id: connection.object_id
+        }
 
-      message_bus.instrument("!connection.active_record", payload) {}
+        message_bus.instrument("!connection.active_record", payload) {}
+      end
     end
 end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -163,7 +163,6 @@ module ActiveRecord
 
     def test_ignores_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
-      $stderr.stubs(:puts)
 
       assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
         ActiveRecord::Tasks::DatabaseTasks.create_all

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -141,7 +141,6 @@ module ActiveRecord
     def setup
       @configurations = { "development" => { "database" => "my-db" } }
 
-      ActiveRecord::Base.stubs(:configurations).returns(@configurations)
       # To refrain from connecting to a newly created empty DB in sqlite3_mem tests
       ActiveRecord::Base.connection_handler.stubs(:establish_connection)
 
@@ -156,51 +155,71 @@ module ActiveRecord
     def test_ignores_configurations_without_databases
       @configurations["development"].merge!("database" => nil)
 
-      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
-        ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
       end
     end
 
     def test_ignores_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
 
-      assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
-        ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        assert_not_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
       end
     end
 
     def test_warning_for_remote_databases
       @configurations["development"].merge!("host" => "my.server.tld")
 
-      ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        ActiveRecord::Tasks::DatabaseTasks.create_all
 
-      assert_match "This task only modifies local databases. my-db is on a remote host.",
-        $stderr.string
+        assert_match "This task only modifies local databases. my-db is on a remote host.",
+          $stderr.string
+      end
     end
 
     def test_creates_configurations_with_local_ip
       @configurations["development"].merge!("host" => "127.0.0.1")
 
-      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
-        ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
       end
     end
 
     def test_creates_configurations_with_local_host
       @configurations["development"].merge!("host" => "localhost")
 
-      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
-        ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
       end
     end
 
     def test_creates_configurations_with_blank_hosts
       @configurations["development"].merge!("host" => nil)
 
-      assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
-        ActiveRecord::Tasks::DatabaseTasks.create_all
+      with_stubbed_configurations do
+        assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
       end
     end
+
+    private
+
+      def with_stubbed_configurations
+        ActiveRecord::Base.stub(:configurations, @configurations) do
+          yield
+        end
+      end
   end
 
   class DatabaseTasksCreateCurrentTest < ActiveRecord::TestCase


### PR DESCRIPTION
Removes an unnecessary call to `Mocha#stubs` following up on #33309.

Replaces calls to `Mocha#stubs` with `Minitest#stub` following up on #33337.