### PR TITLE
Allow subclasses to redefine autosave callbacks for associated records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow subclasses to redefine autosave callbacks for associated records.
+
+    Fixes #33305.
+
+    *Andrey Subbota*
+
 *   Don't impose primary key order if limit() has already been supplied.
 
     Fixes #23607

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -149,7 +149,7 @@ module ActiveRecord
       private
 
         def define_non_cyclic_method(name, &block)
-          return if method_defined?(name)
+          return if instance_methods(false).include?(name)
           define_method(name) do |*args|
             result = true; @_already_called ||= {}
             # Loop prevention for validation of associations

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -14,6 +14,7 @@ require "models/line_item"
 require "models/order"
 require "models/parrot"
 require "models/pirate"
+require "models/project"
 require "models/ship"
 require "models/ship_part"
 require "models/tag"
@@ -1772,5 +1773,23 @@ class TestAutosaveAssociationOnAHasManyAssociationWithInverse < ActiveRecord::Te
 
     assert_equal 1, post.comments.count
     assert_equal 1, comment.post_comments_count
+  end
+end
+
+class TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAcceptsNestedAttributes < ActiveRecord::TestCase
+  def test_should_update_children_when_asssociation_redefined_in_subclass
+    agency = Agency.create!(name: "Agency")
+    valid_project = Project.create!(firm: agency, name: "Initial")
+    agency.update!(
+      "projects_attributes" => {
+        "0" => {
+          "name" => "Updated",
+          "id" => valid_project.id
+        }
+      }
+    )
+    valid_project.reload
+
+    assert_equal "Updated", valid_project.name
   end
 end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -122,6 +122,12 @@ class RestrictedWithErrorFirm < Company
   has_many :companies, -> { order("id") }, foreign_key: "client_of", dependent: :restrict_with_error
 end
 
+class Agency < Firm
+  has_many :projects, foreign_key: :firm_id
+
+  accepts_nested_attributes_for :projects
+end
+
 class Client < Company
   belongs_to :firm, foreign_key: "client_of"
   belongs_to :firm_with_basic_id, class_name: "Firm", foreign_key: "firm_id"


### PR DESCRIPTION
### Summary

This addresses this issue #33305 

`AutosaveAssociation` skip creation of callback method if it's already defined (even in parent class).