### PR TITLE
webpacker-default: Modify `AssetsGeneratorTest`

### DIFF
--- a/railties/test/generators/assets_generator_test.rb
+++ b/railties/test/generators/assets_generator_test.rb
@@ -9,13 +9,11 @@ class AssetsGeneratorTest < Rails::Generators::TestCase
 
   def test_assets
     run_generator
-    assert_file "app/assets/javascripts/posts.js"
     assert_file "app/assets/stylesheets/posts.css"
   end
 
   def test_skipping_assets
-    run_generator ["posts", "--no-stylesheets", "--no-javascripts"]
-    assert_no_file "app/assets/javascripts/posts.js"
+    run_generator ["posts", "--no-stylesheets"]
     assert_no_file "app/assets/stylesheets/posts.css"
   end
 end


### PR DESCRIPTION
I think webpacker is a good compromise to manage modern JS in Rails.

Before:

```
$ bin/test test/generators/assets_generator_test.rb
Run options: --seed 46201

F

Failure:
AssetsGeneratorTest#test_assets [/Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/assets_generator_test.rb:12]:
Expected file "app/assets/javascripts/posts.js" to exist, but does not

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/assets_generator_test.rb:10

.

Finished in 0.031343s, 63.8101 runs/s, 95.7152 assertions/s.
2 runs, 3 assertions, 1 failures, 0 errors, 0 skips
```

After:

```
$ bin/test test/generators/assets_generator_test.rb
Run options: --seed 43571

..

Finished in 0.030370s, 65.8545 runs/s, 65.8545 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

Related to https://github.com/rails/rails/pull/33079/files#diff-ae2aefc2ab4fb2f0455362777c1111d0 and https://github.com/rails/rails/pull/33079#issuecomment-405560742
