### PR TITLE
 Add gitignore configuration for mac [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ debug.log
 node_modules/
 package-lock.json
 pkg/
+
+.DS_Store


### PR DESCRIPTION
### Summary

I think we can add `.DS_Store` to the gitignore file for MacOS.

