### PR TITLE
webpacker-default: Modify `ChannelGeneratorTest`

### DIFF
--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -26,8 +26,8 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
       assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
     end
 
-    assert_file "app/assets/javascripts/channels/chat.js" do |channel|
-      assert_match(/App\.chat = App\.cable\.subscriptions\.create\("ChatChannel/, channel)
+    assert_file "app/javascript/channels/chat_channel.js" do |channel|
+      assert_match(/import consumer from "\.\/consumer"\s+consumer\.subscriptions\.create\("ChatChannel/, channel)
     end
   end
 
@@ -40,8 +40,8 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
       assert_match(/def mute/, channel)
     end
 
-    assert_file "app/assets/javascripts/channels/chat.js" do |channel|
-      assert_match(/App\.chat = App\.cable\.subscriptions\.create\("ChatChannel/, channel)
+    assert_file "app/javascript/channels/chat_channel.js" do |channel|
+      assert_match(/import consumer from "\.\/consumer"\s+consumer\.subscriptions\.create\("ChatChannel/, channel)
       assert_match(/,\n\n  speak/, channel)
       assert_match(/,\n\n  mute: function\(\) \{\n    return this\.perform\('mute'\);\n  \}\n\}\);/, channel)
     end
@@ -54,15 +54,17 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
       assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
     end
 
-    assert_no_file "app/assets/javascripts/channels/chat.js"
+    assert_no_file "app/javascript/channels/chat_channel.js"
   end
 
   def test_cable_js_is_created_if_not_present_already
     run_generator ["chat"]
-    FileUtils.rm("#{destination_root}/app/assets/javascripts/cable.js")
+    FileUtils.rm("#{destination_root}/app/javascript/channels/index.js")
+    FileUtils.rm("#{destination_root}/app/javascript/channels/consumer.js")
     run_generator ["camp"]
 
-    assert_file "app/assets/javascripts/cable.js"
+    assert_file "app/javascript/channels/index.js"
+    assert_file "app/javascript/channels/consumer.js"
   end
 
   def test_channel_on_revoke
@@ -74,7 +76,8 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/channels/application_cable/channel.rb"
     assert_file "app/channels/application_cable/connection.rb"
-    assert_file "app/assets/javascripts/cable.js"
+    assert_file "app/javascript/channels/index.js"
+    assert_file "app/javascript/channels/consumer.js"
   end
 
   def test_channel_suffix_is_not_duplicated
@@ -84,6 +87,6 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/channels/chat_channel.rb"
 
     assert_no_file "app/assets/javascripts/channels/chat_channel.js"
-    assert_file "app/assets/javascripts/channels/chat.js"
+    assert_file "app/javascript/channels/chat_channel.js"
   end
 end


### PR DESCRIPTION
Before:

```
$ bin/test test/generators/channel_generator_test.rb
Run options: --seed 8986

.F

Failure:
ChannelGeneratorTest#test_channel_with_multiple_actions_is_created [/Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:43]:
Expected file "app/assets/javascripts/channels/chat.js" to exist, but does not

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:34

.F

Failure:
ChannelGeneratorTest#test_channel_is_created [/Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:29]:
Expected file "app/assets/javascripts/channels/chat.js" to exist, but does not

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:22

E

Error:
ChannelGeneratorTest#test_cable_js_is_created_if_not_present_already:
Errno::ENOENT: No such file or directory @ apply2files - /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/fixtures/tmp/app/assets/javascripts/cable.js

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:60

F

Failure:
ChannelGeneratorTest#test_channel_suffix_is_not_duplicated [/Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:87]:
Expected file "app/assets/javascripts/channels/chat.js" to exist, but does not

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:80

F

Failure:
ChannelGeneratorTest#test_channel_on_revoke [/Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:77]:
Expected file "app/assets/javascripts/cable.js" to exist, but does not

bin/test /Users/ttanimichi/ghq/github.com/ttanimichi/rails/railties/test/generators/channel_generator_test.rb:68

Finished in 0.064384s, 108.7227 runs/s, 481.4861 assertions/s.
7 runs, 31 assertions, 4 failures, 1 errors, 0 skips
```

After:

```
$ bin/test test/generators/channel_generator_test.rb
Run options: --seed 44857

.......

Finished in 0.060243s, 116.1961 runs/s, 697.1764 assertions/s.
7 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```

Related to https://github.com/rails/rails/pull/33079/files#diff-d4d06ba548169082c37200f114d72daf and https://github.com/rails/rails/pull/33079#issuecomment-405560742