### PR TITLE
 [ci skip]  Add situation for belongs to association.

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -96,7 +96,7 @@ end
 
 ![belongs_to Association Diagram](images/association_basics/belongs_to.png)
 
-NOTE: `belongs_to` associations _must_ use the singular term. If you used the pluralized form in the above example for the `author` association in the `Book` model, you would be told that there was an "uninitialized constant Book::Authors". This is because Rails automatically infers the class name from the association name. If the association name is wrongly pluralized, then the inferred class will be wrongly pluralized too.
+NOTE: `belongs_to` associations _must_ use the singular term. If you used the pluralized form in the above example for the `author` association in the `Book` model and tried to create the instance by `Book.create(authors: @author)`, you would be told that there was an "uninitialized constant Book::Authors". This is because Rails automatically infers the class name from the association name. If the association name is wrongly pluralized, then the inferred class will be wrongly pluralized too.
 
 The corresponding migration might look like this:
 


### PR DESCRIPTION
### Summary

I think it will be clearer to give the situation for reader which they will get "uninitialized constant Book::Authors" errors when they use pluralized form of `author`.