### PR TITLE
Use MethodCallAssertions instead of Mocha#expects

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -861,9 +861,9 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def lock_thread=(lock_thread); end
     end.new
 
-    connection.expects(:begin_transaction).with(joinable: false)
-
-    fire_connection_notification(connection)
+    assert_called_with(connection, :begin_transaction, [joinable: false]) do
+      fire_connection_notification(connection)
+    end
   end
 
   def test_notification_established_transactions_are_rolled_back
@@ -891,7 +891,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
   private
 
     def fire_connection_notification(connection)
-      ActiveRecord::Base.connection_handler.stub(:retrieve_connection, connection) do
+      assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book"], returns: connection) do
         message_bus = ActiveSupport::Notifications.instrumenter
         payload = {
           spec_name: "book",

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -31,28 +31,29 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_creates_database_with_no_default_options
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", {})
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(@connection, :create_database, ["my-app-db", {}]) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 
       def test_creates_database_with_given_encoding
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", charset: "latin1")
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge("encoding" => "latin1")
+          assert_called_with(@connection, :create_database, ["my-app-db", charset: "latin1"]) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge("encoding" => "latin1")
+          end
         end
       end
 
       def test_creates_database_with_given_collation
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", collation: "latin1_swedish_ci")
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge("collation" => "latin1_swedish_ci")
+          assert_called_with(
+            @connection,
+            :create_database,
+            ["my-app-db", collation: "latin1_swedish_ci"]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge("collation" => "latin1_swedish_ci")
+          end
         end
       end
 
@@ -149,9 +150,9 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_drops_database
         with_stubbed_connection_establish_connection do
-          @connection.expects(:drop_database).with("my-app-db")
-
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          assert_called_with(@connection, :drop_database, ["my-app-db"]) do
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          end
         end
       end
 
@@ -193,20 +194,22 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_recreates_database_with_no_default_options
         with_stubbed_connection_establish_connection do
-          @connection.expects(:recreate_database).
-            with("test-db", {})
-
-          ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          assert_called_with(@connection, :recreate_database, ["test-db", {}]) do
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          end
         end
       end
 
       def test_recreates_database_with_the_given_options
         with_stubbed_connection_establish_connection do
-          @connection.expects(:recreate_database).
-            with("test-db", charset: "latin", collation: "latin1_swedish_ci")
-
-          ActiveRecord::Tasks::DatabaseTasks.purge @configuration.merge(
-            "encoding" => "latin", "collation" => "latin1_swedish_ci")
+          assert_called_with(
+            @connection,
+            :recreate_database,
+            ["test-db", charset: "latin", collation: "latin1_swedish_ci"]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration.merge(
+              "encoding" => "latin", "collation" => "latin1_swedish_ci")
+          end
         end
       end
 
@@ -232,8 +235,9 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_db_retrieves_charset
         ActiveRecord::Base.stub(:connection, @connection) do
-          @connection.expects(:charset)
-          ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+          assert_called(@connection, :charset) do
+            ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+          end
         end
       end
     end
@@ -249,8 +253,9 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_db_retrieves_collation
         ActiveRecord::Base.stub(:connection, @connection) do
-          @connection.expects(:collation)
-          ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+          assert_called_with(@connection, :collation) do
+            ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+          end
         end
       end
     end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -34,30 +34,46 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_creates_database_with_default_encoding
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", @configuration.merge("encoding" => "utf8"))
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(
+            @connection,
+            :create_database,
+            ["my-app-db", @configuration.merge("encoding" => "utf8")]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 
       def test_creates_database_with_given_encoding
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", @configuration.merge("encoding" => "latin"))
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration.
-            merge("encoding" => "latin")
+          assert_called_with(
+            @connection,
+            :create_database,
+            ["my-app-db", @configuration.merge("encoding" => "latin")]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration.
+              merge("encoding" => "latin")
+          end
         end
       end
 
       def test_creates_database_with_given_collation_and_ctype
         with_stubbed_connection_establish_connection do
-          @connection.expects(:create_database).
-            with("my-app-db", @configuration.merge("encoding" => "utf8", "collation" => "ja_JP.UTF8", "ctype" => "ja_JP.UTF8"))
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration.
-            merge("collation" => "ja_JP.UTF8", "ctype" => "ja_JP.UTF8")
+          assert_called_with(
+            @connection,
+            :create_database,
+            [
+              "my-app-db",
+              @configuration.merge(
+                "encoding" => "utf8",
+                "collation" => "ja_JP.UTF8",
+                "ctype" => "ja_JP.UTF8"
+              )
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration.
+              merge("collation" => "ja_JP.UTF8", "ctype" => "ja_JP.UTF8")
+          end
         end
       end
 
@@ -139,9 +155,13 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_drops_database
         with_stubbed_connection_establish_connection do
-          @connection.expects(:drop_database).with("my-app-db")
-
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          assert_called_with(
+            @connection,
+            :drop_database,
+            ["my-app-db"]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+          end
         end
       end
 
@@ -179,9 +199,9 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_clears_active_connections
         with_stubbed_connection do
           ActiveRecord::Base.stub(:establish_connection, nil) do
-            ActiveRecord::Base.expects(:clear_active_connections!)
-
-            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            assert_called(ActiveRecord::Base, :clear_active_connections!) do
+              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            end
           end
         end
       end
@@ -202,9 +222,9 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_drops_database
         with_stubbed_connection do
           ActiveRecord::Base.stub(:establish_connection, nil) do
-            @connection.expects(:drop_database).with("my-app-db")
-
-            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            assert_called_with(@connection, :drop_database, ["my-app-db"]) do
+              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            end
           end
         end
       end
@@ -212,10 +232,13 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_creates_database
         with_stubbed_connection do
           ActiveRecord::Base.stub(:establish_connection, nil) do
-            @connection.expects(:create_database).
-              with("my-app-db", @configuration.merge("encoding" => "utf8"))
-
-            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            assert_called_with(
+              @connection,
+              :create_database,
+              ["my-app-db", @configuration.merge("encoding" => "utf8")]
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            end
           end
         end
       end
@@ -240,7 +263,10 @@ if current_adapter?(:PostgreSQLAdapter)
 
     class PostgreSQLDBCharsetTest < ActiveRecord::TestCase
       def setup
-        @connection    = Class.new { def create_database(*); end }.new
+        @connection = Class.new do
+          def create_database(*); end
+          def encoding; end
+        end.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -249,16 +275,16 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_db_retrieves_charset
         ActiveRecord::Base.stub(:connection, @connection) do
-          @connection.expects(:encoding)
-
-          ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+          assert_called(@connection, :encoding) do
+            ActiveRecord::Tasks::DatabaseTasks.charset @configuration
+          end
         end
       end
     end
 
     class PostgreSQLDBCollationTest < ActiveRecord::TestCase
       def setup
-        @connection    = Class.new { def create_database(*); end }.new
+        @connection    = Class.new { def collation; end }.new
         @configuration = {
           "adapter"  => "postgresql",
           "database" => "my-app-db"
@@ -267,9 +293,9 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_db_retrieves_collation
         ActiveRecord::Base.stub(:connection, @connection) do
-          @connection.expects(:collation)
-
-          ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+          assert_called(@connection, :collation) do
+            ActiveRecord::Tasks::DatabaseTasks.collation @configuration
+          end
         end
       end
     end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -88,9 +88,9 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_creates_path_from_database
-        Pathname.expects(:new).with(@database).returns(@path)
-
-        ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
+        assert_called_with(Pathname, :new, [@database], returns: @path) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
+        end
       end
 
       def test_removes_file_with_absolute_path


### PR DESCRIPTION
Many calls to `Mocha#expects` preceded the introduction of
`ActiveSupport::Testing::MethodCallAssertions` in 53f64c0fb,
and many are simple to replace with `MethodCallAssertions`.

This patch makes all these simple replacements.

Step 5 in #33162