### PR TITLE
Prevent `RequestEncoder#encode_params` to parse falsey params

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -50,5 +50,12 @@
 
     *Jeremy Daer*
 
+*   Prevent `RequestEncoder#encode_params` to parse falsey params
+    
+    Now `RequestEncoder#encode_params` doesn't convert
+    falsey params into query string.
+
+    *Alireza Bashiri*
+
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -34,7 +34,7 @@ module ActionDispatch
     end
 
     def encode_params(params)
-      @param_encoder.call(params)
+      @param_encoder.call(params) if params
     end
 
     def self.parser(content_type)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1079,6 +1079,20 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_get_request_with_json_excludes_null_query_string
+    with_routing do |routes|
+      routes.draw do
+        ActiveSupport::Deprecation.silence do
+          get ":action" => FooController
+        end
+      end
+
+      get "/foos_json", as: :json
+
+      assert_equal "http://www.example.com/foos_json", request.url
+    end
+  end
+
   private
     def post_to_foos(as:)
       with_routing do |routes|


### PR DESCRIPTION
Fixes #33388 - When a `get` method called with `as: :json` and `params: nil`
(explicitly or implicitly) `RequestEncoder#encode_params` converts it
into a `null` value which includes a unexpected `null=` query string
into request URL. From now on `RequestEncoder#encode_params` checks
whether `params` is nil or not otherwise returns.