### PR TITLE
Changes RecordNotDestroyed message when record has errors

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -364,7 +364,10 @@ module ActiveRecord
     # and #destroy! raises ActiveRecord::RecordNotDestroyed.
     # See ActiveRecord::Callbacks for further details.
     def destroy!
-      destroy || _raise_record_not_destroyed
+      result = destroy
+      return result if result
+      raise RecordNotDestroyed.new(self.errors.first.second, self) if self.errors.present?
+      _raise_record_not_destroyed
     end
 
     # Returns an instance of the specified +klass+ with the attributes of the


### PR DESCRIPTION
### Summary

Include the record errors (resulting from a `restrict_with_error` for example) in the `RecordNotDestroyed` exception raised by `destroy!`, if any.

Currently, if a `restrict_with_error` throws an abort, the exception raised (`RecordNotDestroyed.new("Failed to destroy the record", self)` [here](https://github.com/rails/rails/blob/316513177cf9033d842cc176f8401d4e7c7e7c2a/activerecord/lib/active_record/persistence.rb#L761)) ignores not include the I18n-translated error message resulting from `restrict_with_error`. This is not convenient to provide a comprehensive error to the user. Also, it is not coherent with `save!`, which does include the record errors in the `ActiveRecord::RecordInvalid`.

### Other Information

The code changed is a monkey patch that we've been using for some time. We've been wondering if this could make its way into rails (or if we've missed something entirely). If so, I'm happy to work to make the code cleaner.
