### PR TITLE
Avoid extra scoping in delegating to klass methods in the `scope` block

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -309,10 +309,10 @@ module ActiveRecord
     # Please check unscoped if you want to remove all previous scopes (including
     # the default_scope) during the execution of a block.
     def scoping
-      previous, klass.current_scope = klass.current_scope(true), self
+      previous, klass.current_scope = klass.current_scope(true), self unless @delegate_to_klass
       yield
     ensure
-      klass.current_scope = previous
+      klass.current_scope = previous unless @delegate_to_klass
     end
 
     def _exec_scope(*args, &block) # :nodoc:

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -254,6 +254,11 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_scoping_works_in_the_scope_block
+    expected = SpecialPostWithDefaultScope.unscoped.to_a
+    assert_equal expected, SpecialPostWithDefaultScope.unscoped_all
+  end
+
   def test_circular_joins_with_scoping_does_not_crash
     posts = Post.joins(comments: :post).scoping do
       Post.first(10)

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -253,6 +253,7 @@ class SpecialPostWithDefaultScope < ActiveRecord::Base
   self.inheritance_column = :disabled
   self.table_name = "posts"
   default_scope { where(id: [1, 5, 6]) }
+  scope :unscoped_all, -> { unscoped { all } }
 end
 
 class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base


### PR DESCRIPTION
Since #29301, delegating to klass methods in the `scope` block would
cause extra scoping by the receiver itself. The extra scoping would
always override intermediate scoping like `unscoped` and caused the
regression #33387. To keep the original scoping behavior, should avoid
the extra scoping in the `scope` block.

Fixes #33387.