### PR TITLE
Ignore column statistics for mysqldump

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -44,6 +44,7 @@ module ActiveRecord
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
         args.concat(["--routines"])
+        args.concat(["--column-statistics=0"])
         args.concat(["--skip-comments"])
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables


### PR DESCRIPTION
Ignore `column_statistics` for edge mysqldump.