### PR TITLE
Clarify `railties/test/application/rake/notes_test.rb`

### DIFF
--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -30,19 +30,22 @@ module ApplicationTests
         app_file "config/locales/en.yaml", "# TODO: note in yaml"
         app_file "app/views/home/index.ruby", "# TODO: note in ruby"
 
-        run_rake_notes do |output, lines|
-          assert_match(/note in erb/, output)
-          assert_match(/note in js/, output)
-          assert_match(/note in css/, output)
-          assert_match(/note in rake/, output)
-          assert_match(/note in builder/, output)
-          assert_match(/note in yml/, output)
-          assert_match(/note in yaml/, output)
-          assert_match(/note in ruby/, output)
+        stderr = capture(:stderr) do
+          run_rake_notes do |output, lines|
+            assert_match(/note in erb/, output)
+            assert_match(/note in js/, output)
+            assert_match(/note in css/, output)
+            assert_match(/note in rake/, output)
+            assert_match(/note in builder/, output)
+            assert_match(/note in yml/, output)
+            assert_match(/note in yaml/, output)
+            assert_match(/note in ruby/, output)
 
-          assert_equal 9, lines.size
-          assert_equal [4], lines.map(&:size).uniq
+            assert_equal 9, lines.size
+            assert_equal [4], lines.map(&:size).uniq
+          end
         end
+        assert_match(/DEPRECATION WARNING: This rake task is deprecated and will be removed in Rails 6.1/, stderr)
       end
 
       test "notes finds notes in default directories" do
@@ -54,17 +57,20 @@ module ApplicationTests
 
         app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
-        run_rake_notes do |output, lines|
-          assert_match(/note in app directory/, output)
-          assert_match(/note in config directory/, output)
-          assert_match(/note in db directory/, output)
-          assert_match(/note in lib directory/, output)
-          assert_match(/note in test directory/, output)
-          assert_no_match(/note in some_other directory/, output)
+        stderr = capture(:stderr) do
+          run_rake_notes do |output, lines|
+            assert_match(/note in app directory/, output)
+            assert_match(/note in config directory/, output)
+            assert_match(/note in db directory/, output)
+            assert_match(/note in lib directory/, output)
+            assert_match(/note in test directory/, output)
+            assert_no_match(/note in some_other directory/, output)
 
-          assert_equal 5, lines.size
-          assert_equal [4], lines.map(&:size).uniq
+            assert_equal 5, lines.size
+            assert_equal [4], lines.map(&:size).uniq
+          end
         end
+        assert_match(/DEPRECATION WARNING: This rake task is deprecated and will be removed in Rails 6.1/, stderr)
       end
 
       test "notes finds notes in custom directories" do
@@ -76,21 +82,22 @@ module ApplicationTests
 
         app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
-        run_rake_notes "SOURCE_ANNOTATION_DIRECTORIES='some_other_dir' bin/rails notes" do |output, lines|
-          assert_match(/note in app directory/, output)
-          assert_match(/note in config directory/, output)
-          assert_match(/note in db directory/, output)
-          assert_match(/note in lib directory/, output)
-          assert_match(/note in test directory/, output)
+        stderr = capture(:stderr) do
+          run_rake_notes "SOURCE_ANNOTATION_DIRECTORIES='some_other_dir' bin/rake notes" do |output, lines|
+            assert_match(/note in app directory/, output)
+            assert_match(/note in config directory/, output)
+            assert_match(/note in db directory/, output)
+            assert_match(/note in lib directory/, output)
+            assert_match(/note in test directory/, output)
 
-          assert_match(/note in some_other directory/, output)
+            assert_match(/note in some_other directory/, output)
 
-          assert_equal 6, lines.size
-          assert_equal [4], lines.map(&:size).uniq
-
-          log = File.read(Rails.application.config.paths["log"].first)
-          assert_match(/`SOURCE_ANNOTATION_DIRECTORIES` is deprecated/, log)
+            assert_equal 6, lines.size
+            assert_equal [4], lines.map(&:size).uniq
+          end
         end
+        assert_match(/DEPRECATION WARNING: This rake task is deprecated and will be removed in Rails 6.1/, stderr)
+        assert_match(/DEPRECATION WARNING: `SOURCE_ANNOTATION_DIRECTORIES` is deprecated and will be removed in Rails 6.1/, stderr)
       end
 
       test "custom rake task finds specific notes in specific directories" do
@@ -125,11 +132,14 @@ module ApplicationTests
         app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
         app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"
 
-        run_rake_notes do |output, lines|
-          assert_match(/note in scss/, output)
-          assert_match(/note in sass/, output)
-          assert_equal 2, lines.size
+        stderr = capture(:stderr) do
+          run_rake_notes do |output, lines|
+            assert_match(/note in scss/, output)
+            assert_match(/note in sass/, output)
+            assert_equal 2, lines.size
+          end
         end
+        assert_match(/DEPRECATION WARNING: This rake task is deprecated and will be removed in Rails 6.1/, stderr)
       end
 
       test "register additional directories" do
@@ -137,37 +147,26 @@ module ApplicationTests
         app_file "spec/models/user_spec.rb", "# TODO: note in model spec"
         add_to_config ' config.annotations.register_directories("spec") '
 
-        run_rake_notes do |output, lines|
-          assert_match(/note in spec/, output)
-          assert_match(/note in model spec/, output)
-          assert_equal 2, lines.size
+        stderr = capture(:stderr) do
+          run_rake_notes do |output, lines|
+            assert_match(/note in spec/, output)
+            assert_match(/note in model spec/, output)
+            assert_equal 2, lines.size
+          end
         end
+        assert_match(/DEPRECATION WARNING: This rake task is deprecated and will be removed in Rails 6.1/, stderr)
       end
 
       private
 
-        def run_rake_notes(command = "bin/rails notes")
-          boot_rails
-          load_tasks
-
+        def run_rake_notes(command = "bin/rake notes")
           Dir.chdir(app_path) do
             output = `#{command}`
-            lines  = output.scan(/\[([0-9\s]+)\]\s/).flatten
+
+            lines = output.scan(/\[([0-9\s]+)\]\s/).flatten
 
             yield output, lines
           end
-        end
-
-        def load_tasks
-          require "rake"
-          require "rdoc/task"
-          require "rake/testtask"
-
-          Rails.application.load_tasks
-        end
-
-        def boot_rails
-          require "#{app_path}/config/environment"
         end
     end
   end


### PR DESCRIPTION
After 1996fbe2a3e46ff5698bfa3812afb7f42cdfa899 `rails notes`
isn't the same as `rake notes`.
Since that, we should test `rake routes` instead of `rails notes` in
`railties/test/application/rake/notes_test.rb` file.
So I changed all occurrences of `rails routes` to `rake routes` in that file,
and added assertions about deprecation warning of using `rake notes`.
It will help to figure out that we should remove
`railties/test/application/rake/notes_test.rb` entirely in favour of
`railties/test/commands/notes_test.rb` that was added
in 1996fbe2a3e46ff5698bfa3812afb7f42cdfa899.
