### PR TITLE
Fix leaking special form_with attributes into html attributes

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1658,6 +1658,7 @@ module ActionView
         @nested_child_index = {}
         @object_name, @object, @template, @options = object_name, object, template, options
         @default_options = @options ? @options.slice(:index, :namespace, :skip_default_ids, :allow_method_names_outside_object) : {}
+        @default_html_options = @default_options.except(:skip_default_ids, :allow_method_names_outside_object)
 
         convert_to_legacy_options(@options)
 

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -820,7 +820,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def select(method, choices = nil, options = {}, html_options = {}, &block)
-        @template.select(@object_name, method, choices, objectify_options(options), @default_options.merge(html_options), &block)
+        @template.select(@object_name, method, choices, objectify_options(options), @default_html_options.merge(html_options), &block)
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_select for form builders:
@@ -832,7 +832,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
-        @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options))
+        @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#grouped_collection_select for form builders:
@@ -844,7 +844,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
-        @template.grouped_collection_select(@object_name, method, collection, group_method, group_label_method, option_key_method, option_value_method, objectify_options(options), @default_options.merge(html_options))
+        @template.grouped_collection_select(@object_name, method, collection, group_method, group_label_method, option_key_method, option_value_method, objectify_options(options), @default_html_options.merge(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#time_zone_select for form builders:
@@ -856,7 +856,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
-        @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), @default_options.merge(html_options))
+        @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), @default_html_options.merge(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_check_boxes for form builders:
@@ -868,7 +868,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
-        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
+        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options), &block)
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_radio_buttons for form builders:
@@ -880,7 +880,7 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
       def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
-        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options), &block)
+        @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options), &block)
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -8,7 +8,7 @@ module ActionView
           @choices = block_given? ? template_object.capture { yield || "" } : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
 
-          @html_options = html_options.except(:skip_default_ids, :allow_method_names_outside_object)
+          @html_options = html_options
 
           super(object_name, method_name, template_object, options)
         end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -464,6 +464,23 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
   end
 
+  def test_form_with_with_collection_select
+    post = Post.new
+    def post.active; false; end
+    form_with(model: post) do |f|
+      concat f.collection_select(:active, [true, false], :to_s, :to_s)
+    end
+
+    expected = whole_form("/posts") do
+      "<select name='post[active]' id='post_active'>" \
+      "<option value='true'>true</option>\n" \
+      "<option selected='selected' value='false'>false</option>" \
+      "</select>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_with_with_collection_radio_buttons
     post = Post.new
     def post.active; false; end


### PR DESCRIPTION
Special form_with attributes `skip_default_ids` and `allow_method_names_outside_object`
attributes are leaking into html attributes of option select tag helpers.

### Summary

Currently, all form options select helpers (except only general `select`) output unnecessary html attributes `skip_default_ids="true"` and `allow_method_names_outside_object="true"`. Because form builder marge passed html options with default form optrions, but `skip_default_ids` and `allow_method_names_outside_object` options does not processed by any methods with operate with this html options.

### Other Information

This issue was partially fixed in #28844 (only for general `select` helper) and then was refactored in e732f29d33f1e856c4a10af694863420c9b79e67.