### PR TITLE
Use MethodCallAssertions instead of Mocha part 2

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -157,14 +157,19 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_indexes_in_create
-    ActiveRecord::Base.connection.stubs(:data_source_exists?).with(:temp).returns(false)
+    assert_called_with(
+      ActiveRecord::Base.connection,
+      :data_source_exists?,
+      [:temp],
+      returns: false
+    ) do
+      expected = "CREATE TEMPORARY TABLE `temp` ( INDEX `index_temp_on_zip`  (`zip`)) AS SELECT id, name, zip FROM a_really_complicated_query"
+      actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+        t.index :zip
+      end
 
-    expected = "CREATE TEMPORARY TABLE `temp` ( INDEX `index_temp_on_zip`  (`zip`)) AS SELECT id, name, zip FROM a_really_complicated_query"
-    actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
-      t.index :zip
+      assert_equal expected, actual
     end
-
-    assert_equal expected, actual
   end
 
   private

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -21,11 +21,17 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_establishes_connection_without_database
-        ActiveRecord::Base.stubs(:establish_connection)
         ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.expects(:establish_connection).
-            with("adapter" => "mysql2", "database" => nil)
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              [ "adapter" => "mysql2", "database" => nil ],
+              [ "adapter" => "mysql2", "database" => "my-app-db" ],
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 
@@ -58,12 +64,17 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       def test_establishes_connection_to_database
-        ActiveRecord::Base.stubs(:establish_connection)
-
         ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.expects(:establish_connection).with(@configuration)
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              ["adapter" => "mysql2", "database" => nil],
+              [@configuration]
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -21,14 +21,24 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_establishes_connection_to_postgresql_database
-        ActiveRecord::Base.stubs(:establish_connection)
         ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.expects(:establish_connection).with(
-            "adapter"            => "postgresql",
-            "database"           => "postgres",
-            "schema_search_path" => "public"
-          )
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              [
+                "adapter"            => "postgresql",
+                "database"           => "postgres",
+                "schema_search_path" => "public"
+              ],
+              [
+                "adapter"            => "postgresql",
+                "database"           => "my-app-db"
+              ]
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 
@@ -78,11 +88,23 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_establishes_connection_to_new_database
-        ActiveRecord::Base.stubs(:establish_connection)
         ActiveRecord::Base.stub(:connection, @connection) do
-          ActiveRecord::Base.expects(:establish_connection).with(@configuration)
-
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              [
+                "adapter"            => "postgresql",
+                "database"           => "postgres",
+                "schema_search_path" => "public"
+              ],
+              [
+                @configuration
+              ]
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration
+          end
         end
       end
 
@@ -207,15 +229,24 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_establishes_connection_to_postgresql_database
-        ActiveRecord::Base.stubs(:establish_connection)
         with_stubbed_connection do
-          ActiveRecord::Base.expects(:establish_connection).with(
-            "adapter"            => "postgresql",
-            "database"           => "postgres",
-            "schema_search_path" => "public"
-          )
-
-          ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              [
+                "adapter"            => "postgresql",
+                "database"           => "postgres",
+                "schema_search_path" => "public"
+              ],
+              [
+                "adapter"            => "postgresql",
+                "database"           => "my-app-db"
+              ]
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          end
         end
       end
 
@@ -244,11 +275,23 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_establishes_connection
-        ActiveRecord::Base.stubs(:establish_connection)
         with_stubbed_connection do
-          ActiveRecord::Base.expects(:establish_connection).with(@configuration)
-
-          ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          assert_called_with(
+            ActiveRecord::Base,
+            :establish_connection,
+            [
+              [
+                "adapter"            => "postgresql",
+                "database"           => "postgres",
+                "schema_search_path" => "public"
+              ],
+              [
+                @configuration
+              ]
+            ]
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+          end
         end
       end
 


### PR DESCRIPTION
This patch replaces calls to `Mocha#expects` with `MethodCallAssertions` where expectations need to be more detailed in order to meet Minitest's stricter mocking. A detailed explanation is in the commit message.

Step 6 in #33162.

While preparing this I've noticed two additional cases of `Mocha#stubs` that can be replaced with MethodCallAssetions. One has slipped out of #33337. The other could have made an atypical change in either #33337 or #33391. They are included as separate commits.