### PR TITLE
Support multiple submit buttons in Active Storage forms

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -855,12 +855,19 @@
     return DirectUploadsController;
   }();
   var processingAttribute = "data-direct-uploads-processing";
+  var submitButtonsByForm = new WeakMap;
   var started = false;
   function start() {
     if (!started) {
       started = true;
+      document.addEventListener("click", didClick, true);
       document.addEventListener("submit", didSubmitForm);
       document.addEventListener("ajax:before", didSubmitRemoteElement);
+    }
+  }
+  function didClick(event) {
+    if (event.target.tagName == "INPUT" && event.target.type == "submit" && event.target.form) {
+      submitButtonsByForm.set(event.target.form, event.target);
     }
   }
   function didSubmitForm(event) {
@@ -894,7 +901,8 @@
     }
   }
   function submitForm(form) {
-    var button = findElement(form, "input[type=submit]");
+    var button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit]");
+
     if (button) {
       var _button = button, disabled = _button.disabled;
       button.disabled = false;
@@ -909,6 +917,7 @@
       button.click();
       form.removeChild(button);
     }
+    submitButtonsByForm.delete(form);
   }
   function disable(input) {
     input.disabled = true;

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -2,13 +2,22 @@ import { DirectUploadsController } from "./direct_uploads_controller"
 import { findElement } from "./helpers"
 
 const processingAttribute = "data-direct-uploads-processing"
+const submitButtonsByForm = new WeakMap
 let started = false
 
 export function start() {
   if (!started) {
     started = true
+    document.addEventListener("click", didClick, true)
     document.addEventListener("submit", didSubmitForm)
     document.addEventListener("ajax:before", didSubmitRemoteElement)
+  }
+}
+
+function didClick(event) {
+  const { target } = event
+  if (target.tagName == "INPUT" && target.type == "submit" && target.form) {
+    submitButtonsByForm.set(target.form, target)
   }
 }
 
@@ -49,7 +58,8 @@ function handleFormSubmissionEvent(event) {
 }
 
 function submitForm(form) {
-  let button = findElement(form, "input[type=submit]")
+  let button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit]")
+
   if (button) {
     const { disabled } = button
     button.disabled = false
@@ -64,6 +74,7 @@ function submitForm(form) {
     button.click()
     form.removeChild(button)
   }
+  submitButtonsByForm.delete(form)
 }
 
 function disable(input) {


### PR DESCRIPTION
Often times forms have more than one submit button enabling different actions, there are [various ways to use this with Rails](https://stackoverflow.com/questions/3027149/how-do-i-create-multiple-submit-buttons-for-the-same-form-in-rails).

![multiple submits](http://i.imgur.com/bSaToGv.png)

Currently `activestorage.js` takes a somewhat naive approach in just using the first `input[type=submit]` inside a form to `click()` and submit the form after direct uploads.

This PR utilizes the name and value from `form._ujsData` to use the input the User has really clicked, when submitting the form after an upload.

I'm not too happy with the code myself, so this is more of a question if Rails should even support multiple submit buttons per form or not. If so, it might be possible for me to find a cleaner approach.

Edit: When this fix is finshed, it might be better if I backport it to 5-2-stable before.
