### PR TITLE
[ci skip] fix typo in Active Record Associations guide

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -600,7 +600,7 @@ NOTE: If you wish to [enforce referential integrity at the database level](/acti
 
 #### Creating Join Tables for `has_and_belongs_to_many` Associations
 
-If you create a `has_and_belongs_to_many` association, you need to explicitly create the joining table. Unless the name of the join table is explicitly specified by using the `:join_table` option, Active Record creates the name by using the lexical book of the class names. So a join between author and book models will give the default join table name of "authors_books" because "a" outranks "b" in lexical ordering.
+If you create a `has_and_belongs_to_many` association, you need to explicitly create the joining table. Unless the name of the join table is explicitly specified by using the `:join_table` option, Active Record creates the name by using the lexical order of the class names. So a join between author and book models will give the default join table name of "authors_books" because "a" outranks "b" in lexical ordering.
 
 WARNING: The precedence between model names is calculated using the `<=>` operator for `String`. This means that if the strings are of different lengths, and the strings are equal when compared up to the shortest length, then the longer string is considered of higher lexical precedence than the shorter one. For example, one would expect the tables "paper_boxes" and "papers" to generate a join table name of "papers_paper_boxes" because of the length of the name "paper_boxes", but it in fact generates a join table name of "paper_boxes_papers" (because the underscore '\_' is lexicographically _less_ than 's' in common encodings).
 


### PR DESCRIPTION
### Summary

Changes the word `book` to `order` in the phrase: `Active Record creates the name by using the lexical book of the class names`. It appears as though this was the original form prior to the last change altering this line, linked [here](https://github.com/rails/rails/commit/71ff088a09d429657877ddfb58985d30df63fc8a#diff-6cb426645499101965568d643d991110L595). That PR deals with changing the examples from `Customer` and `Order` to `Author` and `Book`, so it's not surprising the phrase `lexical order` was swept up in the frenzy as well.
