### PR TITLE
[ci skip] Tidy up formatting of (consecutive) examples

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -741,22 +741,13 @@ module ActiveRecord
       # ====== Creating an index with a specific operator class
       #
       #   add_index(:developers, :name, using: 'gist', opclass: :gist_trgm_ops)
-      #
-      # generates:
-      #
-      #   CREATE INDEX developers_on_name ON developers USING gist (name gist_trgm_ops) -- PostgreSQL
+      #   # CREATE INDEX developers_on_name ON developers USING gist (name gist_trgm_ops) -- PostgreSQL
       #
       #   add_index(:developers, [:name, :city], using: 'gist', opclass: { city: :gist_trgm_ops })
-      #
-      # generates:
-      #
-      #   CREATE INDEX developers_on_name_and_city ON developers USING gist (name, city gist_trgm_ops) -- PostgreSQL
+      #   # CREATE INDEX developers_on_name_and_city ON developers USING gist (name, city gist_trgm_ops) -- PostgreSQL
       #
       #   add_index(:developers, [:name, :city], using: 'gist', opclass: :gist_trgm_ops)
-      #
-      # generates:
-      #
-      #   CREATE INDEX developers_on_name_and_city ON developers USING gist (name gist_trgm_ops, city gist_trgm_ops) -- PostgreSQL
+      #   # CREATE INDEX developers_on_name_and_city ON developers USING gist (name gist_trgm_ops, city gist_trgm_ops) -- PostgreSQL
       #
       # Note: only supported by PostgreSQL
       #


### PR DESCRIPTION
### Summary

The consecutive verbatim blocks were being merged making the output look weird.

### Other Information

**Before**

<img width="986" alt="screen shot 2018-06-13 at 11 41 44" src="https://user-images.githubusercontent.com/809707/43046053-cfcbc9a0-8dc3-11e8-8ee1-4240999979c1.png">

**After**

<img width="950" alt="screen shot 2018-07-22 at 15 28 16" src="https://user-images.githubusercontent.com/809707/43046060-e9892752-8dc3-11e8-9696-7cca8dae8837.png">
