### PR TITLE
`rake app:update` should update active_storage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,7 @@ Style/FrozenStringLiteralComment:
     - 'actionpack/test/**/*.builder'
     - 'actionpack/test/**/*.ruby'
     - 'activestorage/db/migrate/**/*.rb'
+    - 'activestorage/db/update_migrate/**/*.rb'
     - 'actionmailbox/db/migrate/**/*.rb'
     - 'actiontext/db/migrate/**/*.rb'
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -407,6 +407,10 @@ namespace :railties do
         if railtie.respond_to?(:paths) && (path = railtie.paths["db/migrate"].first)
           railties[railtie.railtie_name] = path
         end
+
+        unless ENV["MIGRATIONS_PATH"].blank?
+          railties[railtie.railtie_name] = railtie.root + ENV["MIGRATIONS_PATH"]
+        end
       end
 
       on_skip = Proc.new do |name, migration|

--- a/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
+++ b/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
@@ -1,0 +1,7 @@
+class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
+  def up
+    unless foreign_key_exists?(:active_storage_attachments, column: :blob_id)
+      add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -12,4 +12,11 @@ namespace :active_storage do
       Rake::Task["app:active_storage:install:migrations"].invoke
     end
   end
+
+  # desc "Copy over the migrations needed to the application upgrading"
+  task update: :environment do
+    ENV["MIGRATIONS_PATH"] = "db/update_migrate"
+
+    Rake::Task["active_storage:install"].invoke
+  end
 end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -306,6 +306,13 @@ module Rails
       end
       remove_task :update_bin_files
 
+      def update_active_storage
+        unless skip_active_storage?
+          rails_command "active_storage:update"
+        end
+      end
+      remove_task :update_active_storage
+
       def create_config_files
         build(:config)
       end

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -2,7 +2,7 @@
 
 namespace :app do
   desc "Update configs and some other initially generated files (or use just update:configs or update:bin)"
-  task update: [ "update:configs", "update:bin", "update:upgrade_guide_info" ]
+  task update: [ "update:configs", "update:bin", "update:active_storage", "update:upgrade_guide_info" ]
 
   desc "Applies the template supplied by LOCATION=(/path/to/template) or URL"
   task template: :environment do
@@ -49,6 +49,10 @@ namespace :app do
     # desc "Adds new executables to the application bin/ directory"
     task :bin do
       Rails::AppUpdater.invoke_from_app_generator :update_bin_files
+    end
+
+    task :active_storage do
+      Rails::AppUpdater.invoke_from_app_generator :update_active_storage
     end
 
     task :upgrade_guide_info do


### PR DESCRIPTION
Add foreign key to active_storage_attachments for `blob_id` via new migration

We need this in order to be able to add this migration for users that
use ActiveStorage during update their apps from Rails 5.2 to Rails 6.0.

Related to #33405

`rake app:update` should update active_storage

`rake app:update` should execute `rake active_storage:update`
if it is used in the app that is being updated.
It will add new active_storage's migrations to users' apps during update Rails.

Context https://github.com/rails/rails/pull/33405#discussion_r204239399

Also, see a related discussion in the Campfire:
https://3.basecamp.com/3076981/buckets/24956/chats/12416418@1236713081
