### PR TITLE
Include record errors if there's any on which `destroy!` called

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -14,7 +14,8 @@ module ActiveRecord
         when :restrict_with_error
           if load_target
             record = owner.class.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)
+            error = owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)
+            raise ActiveRecord::RecordNotDestroyed.new(error[0], owner)
             throw(:abort)
           end
 


### PR DESCRIPTION
### Summary

Fixes #33420 - Check whether the record has errors and include it otherwise
use the default one.