### PR TITLE
Fix typo: the manifest BELOW

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -605,7 +605,7 @@ config.assets.debug = false
 ```
 
 When debug mode is off, Sprockets concatenates and runs the necessary
-preprocessors on all files. With debug mode turned off the manifest above would
+preprocessors on all files. With debug mode turned on the manifest above would
 generate instead:
 
 ```html

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -605,7 +605,7 @@ config.assets.debug = false
 ```
 
 When debug mode is off, Sprockets concatenates and runs the necessary
-preprocessors on all files. With debug mode turned on the manifest above would
+preprocessors on all files. With debug mode turned off the manifest below would
 generate instead:
 
 ```html


### PR DESCRIPTION
There appears to be a typo in this sentence. Correction given between [[]]. See below

When debug mode is off, Sprockets concatenates and runs the necessary
preprocessors on all files. With debug mode turned [[on]] the manifest above would
generate instead:

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
