### PR TITLE
Update with_options.rb [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -68,7 +68,7 @@ class Object
   # You can access these methods using the class name instead:
   #
   #   class Phone < ActiveRecord::Base
-  #     enum phone_number_type: [home: 0, office: 1, mobile: 2]
+  #     enum phone_number_type: { home: 0, office: 1, mobile: 2 }
   #
   #     with_options presence: true do
   #       validates :phone_number_type, inclusion: { in: Phone.phone_number_types.keys }


### PR DESCRIPTION
### Summary

explicit mapping for enum accepts a Hash not an Array, plus the example is using `.keys` which also exists on hash