### PR TITLE
Testing Guide: unnecessary comment

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -105,7 +105,7 @@ class ArticleTest < ActiveSupport::TestCase
 The `ArticleTest` class defines a _test case_ because it inherits from `ActiveSupport::TestCase`. `ArticleTest` thus has all the methods available from `ActiveSupport::TestCase`. Later in this guide, we'll see some of the methods it gives us.
 
 Any method defined within a class inherited from `Minitest::Test`
-(which is the superclass of `ActiveSupport::TestCase`) that begins with `test_` (case sensitive) is simply called a test. So, methods defined as `test_password` and `test_valid_password` are legal test names and are run automatically when the test case is run.
+(which is the superclass of `ActiveSupport::TestCase`) that begins with `test_` is simply called a test. So, methods defined as `test_password` and `test_valid_password` are legal test names and are run automatically when the test case is run.
 
 Rails also adds a `test` method that takes a test name and a block. It generates a normal `Minitest::Unit` test with method names prefixed with `test_`. So you don't have to worry about naming the methods, and you can write something like:
 


### PR DESCRIPTION
This has been around as far back as I can [see](https://github.com/rails/rails/blob/5137d03cc5b2a5f0820bdcf11b0fffe5bf461470/guides/source/testing.md).

No need to specify the obvious.

[ci skip]