### PR TITLE
Fix Rubocop lambda syntax offenses

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -971,10 +971,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     template = %{ after_bundle { run 'echo ran after_bundle' } }.dup
     template.instance_eval "def read; self; end" # Make the string respond to read
 
-    check_open = -> *args do
+    check_open = -> *args {
       assert_equal [ path, "Accept" => "application/x-thor-template" ], args
       template
-    end
+    }
 
     sequence = ["git init", "install", "exec spring binstub --all", "echo ran after_bundle"]
     @sequence_step ||= 0

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -740,10 +740,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     template = %{ after_bundle { run "echo ran after_bundle" } }.dup
     template.instance_eval "def read; self; end" # Make the string respond to read
 
-    check_open = -> *args do
+    check_open = -> *args {
       assert_equal [ path, "Accept" => "application/x-thor-template" ], args
       template
-    end
+    }
 
     sequence = ["echo ran after_bundle"]
     @sequence_step ||= 0

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -86,10 +86,10 @@ module SharedGeneratorTests
     template = %{ say "It works!" }.dup
     template.instance_eval "def read; self; end" # Make the string respond to read
 
-    check_open = -> *args do
+    check_open = -> *args {
       assert_equal [ path, "Accept" => "application/x-thor-template" ], args
       template
-    end
+    }
 
     generator([destination_root], template: path).stub(:open, check_open, template) do
       generator.stub :bundle_command, nil do


### PR DESCRIPTION
### Summary
Using do-end syntax instead of brackets in lambda caused Rubocop to report this offense in 3 different test files, together with other false positives induced by it. By fixing this, the main offense and the related false positives are gone.

**Before:**
```
$ rubocop
Inspecting 2567 files
Offenses:

railties/test/generators/app_generator_test.rb:974:27: E: Lint/Syntax: unexpected token kDO
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    check_open = -> *args do
                          ^^
railties/test/generators/app_generator_test.rb:986:85: E: Lint/Syntax: unexpected token kDO_LAMBDA
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    generator([destination_root], template: path).stub(:open, check_open, template) do
                                                                                    ^^
railties/test/generators/app_generator_test.rb:997:3: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
  end
  ^^^
railties/test/generators/app_generator_test.rb:1085:1: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
railties/test/generators/plugin_generator_test.rb:743:27: E: Lint/Syntax: unexpected token kDO
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    check_open = -> *args do
                          ^^
railties/test/generators/plugin_generator_test.rb:756:85: E: Lint/Syntax: unexpected token kDO_LAMBDA
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    generator([destination_root], template: path).stub(:open, check_open, template) do
                                                                                    ^^
railties/test/generators/plugin_generator_test.rb:768:3: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
  end
  ^^^
railties/test/generators/plugin_generator_test.rb:804:1: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
railties/test/generators/shared_generator_tests.rb:89:27: E: Lint/Syntax: unexpected token kDO
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    check_open = -> *args do
                          ^^
railties/test/generators/shared_generator_tests.rb:94:85: E: Lint/Syntax: unexpected token kDO_LAMBDA
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
    generator([destination_root], template: path).stub(:open, check_open, template) do
                                                                                    ^^
railties/test/generators/shared_generator_tests.rb:99:3: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
  end
  ^^^
railties/test/generators/shared_generator_tests.rb:364:1: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
```

**After:**
```
$ rubocop
Inspecting 2567 files
2567 files inspected, no offenses detected
```