### PR TITLE
Prevent ActiveStorage blob from purging if it has shared attachments.

### DIFF
--- a/activestorage/app/jobs/active_storage/purge_job.rb
+++ b/activestorage/app/jobs/active_storage/purge_job.rb
@@ -2,7 +2,7 @@
 
 # Provides asynchronous purging of ActiveStorage::Blob records via ActiveStorage::Blob#purge_later.
 class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
-  discard_on ActiveRecord::RecordNotFound, ActiveRecord::InvalidForeignKey
+  discard_on ActiveRecord::RecordNotFound
 
   def perform(blob)
     blob.purge

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -20,7 +20,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   # Synchronously deletes the attachment and {purges the blob}[rdoc-ref:ActiveStorage::Blob#purge].
   def purge
     delete
-    blob.purge if blob.attachments.blank?
+    blob.purge
   end
 
   # Deletes the attachment and {enqueues a background job}[rdoc-ref:ActiveStorage::Blob#purge_later] to purge the blob.

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -20,7 +20,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   # Synchronously deletes the attachment and {purges the blob}[rdoc-ref:ActiveStorage::Blob#purge].
   def purge
     delete
-    blob.purge
+    blob.purge if blob.attachments.blank?
   end
 
   # Deletes the attachment and {enqueues a background job}[rdoc-ref:ActiveStorage::Blob#purge_later] to purge the blob.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -207,6 +207,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   def purge
     destroy
     delete
+  rescue ActiveRecord::InvalidForeignKey
   end
 
   # Enqueues an ActiveStorage::PurgeJob to call #purge. This is the recommended way to purge blobs from a transaction,

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -8,6 +8,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   setup do
     @user = User.create!(name: "Josh")
+    @another_user = User.create(name: "John")
   end
 
   teardown { ActiveStorage::Blob.all.each(&:delete) }
@@ -409,6 +410,20 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       assert_not @user.avatar.attached?
       assert_not ActiveStorage::Blob.exists?(blob.id)
       assert_not ActiveStorage::Blob.service.exist?(blob.key)
+    end
+  end
+
+  test "purging an attachment with a shared blob" do
+    create_blob(filename: "funky.jpg").tap do |blob|
+      @user.avatar.attach blob
+      @another_user.avatar.attach blob
+      assert @user.avatar.attached?
+      assert @another_user.avatar.attached?
+
+      @user.avatar.purge
+      assert_not @user.avatar.attached?
+      assert ActiveStorage::Blob.exists?(blob.id)
+      assert ActiveStorage::Blob.service.exist?(blob.key)
     end
   end
 

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -8,7 +8,6 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   setup do
     @user = User.create!(name: "Josh")
-    @another_user = User.create(name: "John")
   end
 
   teardown { ActiveStorage::Blob.all.each(&:delete) }
@@ -416,9 +415,11 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "purging an attachment with a shared blob" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      @another_user.avatar.attach blob
       assert @user.avatar.attached?
-      assert @another_user.avatar.attached?
+
+      another_user = User.create!(name: "John")
+      another_user.avatar.attach blob
+      assert another_user.avatar.attached?
 
       @user.avatar.purge
       assert_not @user.avatar.attached?
@@ -439,6 +440,25 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       assert_not @user.avatar.attached?
       assert_not ActiveStorage::Blob.exists?(blob.id)
       assert_not ActiveStorage::Blob.service.exist?(blob.key)
+    end
+  end
+
+  test "purging an attachment later with shared blob" do
+    create_blob(filename: "funky.jpg").tap do |blob|
+      @user.avatar.attach blob
+      assert @user.avatar.attached?
+
+      another_user = User.create!(name: "John")
+      another_user.avatar.attach blob
+      assert another_user.avatar.attached?
+
+      perform_enqueued_jobs do
+        @user.avatar.purge_later
+      end
+
+      assert_not @user.avatar.attached?
+      assert ActiveStorage::Blob.exists?(blob.id)
+      assert ActiveStorage::Blob.service.exist?(blob.key)
     end
   end
 

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -174,10 +174,10 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_not ActiveStorage::Blob.service.exist?(variant.key)
   end
 
-  test "purge fails when attachments exist" do
+  test "purge does nothing when attachments exist" do
     create_blob.tap do |blob|
       User.create! name: "DHH", avatar: blob
-      assert_nothing_raised { blob.purge }
+      assert_no_difference(-> { ActiveStorage::Blob.count }) { blob.purge }
       assert ActiveStorage::Blob.service.exist?(blob.key)
     end
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -177,7 +177,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   test "purge fails when attachments exist" do
     create_blob.tap do |blob|
       User.create! name: "DHH", avatar: blob
-      assert_raises(ActiveRecord::InvalidForeignKey) { blob.purge }
+      assert_nothing_raised { blob.purge }
       assert ActiveStorage::Blob.service.exist?(blob.key)
     end
   end


### PR DESCRIPTION
### **Summary**
Issue #33013 states if you purge an attachment, the blob is destroyed
instantaneously without checking if it has existing attachments.
This behaviour makes a person write more comparison code to determine
if it will use `purge` or `detach` which is unnecessary and verbose.

So, to prevent this, I slightly modified the `purge` method on attachment.rb:

    def purge
      delete
      blob.purge if blob.attachments.blank?
    end

Same for the `purge_later` method, but the condition check is happening on
the PurgeJob job.

    def perform(blob)
      blob.purge if blob.attachments.blank?
    end
