### PR TITLE
Reference Active Storage instead of third-party libraries in guide

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -651,7 +651,7 @@ def upload
 end
 ```
 
-Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on disk, Amazon S3, etc) and associating them with models to resizing image files and generating thumbnails. The intricacies of this are beyond the scope of this guide, but there are several libraries designed to assist with these. Two of the better known ones are [CarrierWave](https://github.com/jnicklas/carrierwave) and [Paperclip](https://github.com/thoughtbot/paperclip).
+Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on disk, Amazon S3, etc) and associating them with models to resizing image files and generating thumbnails. [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) is designed to assist with these tasks.
 
 NOTE: If the user has not selected a file the corresponding parameter will be an empty string.
 


### PR DESCRIPTION
Paperclip has officially been deprecated, so we shouldn't mention it anymore.

CarrierWave could still be referenced, as there are use cases where it currently makes more sense, but for simplicity, I thought removing the mention of third party libraries made sense. If we want to talk about them, listing "alternatives" within the Active Storage guide could make more sense.
