### PR TITLE
Remove Rubocop's comments from Rails code base

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
     - 'railties/test/fixtures/tmp/**/*'
 
+Performance:
+  Exclude:
+    - '**/test/**/*'
+
 Rails:
   Enabled: true
 

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -105,20 +105,16 @@ class HeaderTest < ActiveSupport::TestCase
   end
 
   test "#merge! headers with mutation" do
-    # rubocop:disable Performance/RedundantMerge
     @headers.merge!("Host" => "http://example.test",
                     "Content-Type" => "text/html")
-    # rubocop:enable Performance/RedundantMerge
     assert_equal({ "HTTP_HOST" => "http://example.test",
                   "CONTENT_TYPE" => "text/html",
                   "HTTP_REFERER" => "/some/page" }, @headers.env)
   end
 
   test "#merge! env with mutation" do
-    # rubocop:disable Performance/RedundantMerge
     @headers.merge!("HTTP_HOST" => "http://first.com",
                     "CONTENT_TYPE" => "text/html")
-    # rubocop:enable Performance/RedundantMerge
     assert_equal({ "HTTP_HOST" => "http://first.com",
                   "CONTENT_TYPE" => "text/html",
                   "HTTP_REFERER" => "/some/page" }, @headers.env)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -187,7 +187,7 @@ module ActiveRecord
       end
 
       relation = Relation.new(klass)
-      relation.merge!(where: ["foo = ?", "bar"]) # rubocop:disable Performance/RedundantMerge
+      relation.merge!(where: ["foo = ?", "bar"])
       assert_equal Relation::WhereClause.new(["foo = bar"]), relation.where_clause
     end
 

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -88,7 +88,7 @@ module ActiveSupport
     end
 
     def finish(name, id, payload)
-      event     = event_stack.pop
+      event = event_stack.pop
       event.finish!
       event.payload.merge!(payload)
 


### PR DESCRIPTION
PR#32381 added Rubocop's comments to some tests files in order to
exclude `Performance/RedundantMerge`.

Turn off `Performance` cops for tests files via `Exclude`
in `.rubocop.yml`.

<hr/>
Fix Rubocop offense

```
Offenses:

activesupport/lib/active_support/subscriber.rb:91:17:
C: Layout/SpaceAroundOperators: Operator = should be surrounded by a single space.
      event     = event_stack.pop
```