### PR TITLE
Update the condition to write timestamp attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Write timestamp attributes when creating a record unless they were already changed.
+
+    Fixes #33443
+
+    *Robertas Godelis*
+
 *   Fix `transaction` reverting for migrations.
 
     Before: Commands inside a `transaction` in a reverted migration ran uninverted.

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -92,9 +92,8 @@ module ActiveRecord
         current_time = current_time_from_proper_timezone
 
         all_timestamp_attributes_in_model.each do |column|
-          if !attribute_present?(column)
-            _write_attribute(column, current_time)
-          end
+          next if will_save_change_to_attribute?(column)
+          _write_attribute(column, current_time)
         end
       end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -456,6 +456,17 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal ["created_at", "updated_at"], toy.send(:all_timestamp_attributes_in_model)
   end
+
+  def test_creating_a_record_after_a_failed_transaction
+    toy = Toy.new
+
+    Toy.transaction do
+      toy.save!
+      raise ActiveRecord::Rollback
+    end
+
+    assert_nothing_raised { toy.save! }
+  end
 end
 
 class TimestampsWithoutTransactionTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

Saving a record in a transaction that fails resets the changed attributes.

If the given record has timestamp recording enabled, saving the same instance of the record again results in a connection adapter's `ConstraintException`.

That happens because the partial write doesn't include the timestamp fields, as their state was reset after the failed transaction.

In other words, this fixes https://github.com/rails/rails/issues/33443