### PR TITLE
Add event object subscriptions to AS::Notifications

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Add "event object" support to the notification system.
+    Before this change, end users were forced to create hand made arsenal
+    event objects on their own, like this:
+
+        ActiveSupport::Notifications.subscribe('wait') do |*args|
+          @event = ActiveSupport::Notifications::Event.new(*args)
+        end
+        
+        ActiveSupport::Notifications.instrument('wait') do
+          sleep 1
+        end
+        
+        @event.duration # => 1000.138
+
+    After this change, if the block passed to `subscribe` only takes one
+    parameter, the framework will yield an event object to the block.  Now
+    end users are no longer required to make their own:
+
+        ActiveSupport::Notifications.subscribe('wait') do |event|
+          @event = event
+        end
+        
+        ActiveSupport::Notifications.instrument('wait') do
+          sleep 1
+        end
+        
+        p @event.allocations # => 7
+        p @event.cpu_time    # => 0.256
+        p @event.idle_time   # => 1003.2399
+
+    Now you can enjoy event objects without making them yourself.  Neat!
+
+    *Aaron "t.lo" Patterson*
+
 *   Add cpu_time, idle_time, and allocations to Event
 
     *Eileen M. Uchitelle*, *Aaron Patterson*

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -70,13 +70,18 @@ module ActiveSupport
 
       module Subscribers # :nodoc:
         def self.new(pattern, listener)
+          subscriber_class = Timed
+
           if listener.respond_to?(:start) && listener.respond_to?(:finish)
             subscriber_class = Evented
           else
-            if listener.respond_to?(:arity) && listener.arity == 1
-              subscriber_class = EventObject
-            else
-              subscriber_class = Timed
+            # Doing all this to detect a block like `proc { |x| }` vs
+            # `proc { |*x| }` or `proc { |**x| }`
+            if listener.respond_to?(:parameters)
+              params = listener.parameters
+              if params.length == 1 && params.first.first == :opt
+                subscriber_class = EventObject
+              end
             end
           end
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -76,8 +76,8 @@ module ActiveSupport
       end
 
       def finish!
-        @end = now
         @cpu_time_finish = now_cpu
+        @end = now
         @allocation_count_finish = now_allocations
       end
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -81,14 +81,20 @@ module ActiveSupport
         @allocation_count_finish = now_allocations
       end
 
+      # Returns the CPU time (in milliseconds) passed since the call to
+      # +start!+ and the call to +finish!+
       def cpu_time
-        @cpu_time_finish - @cpu_time_start
+        (@cpu_time_finish - @cpu_time_start) * 1000
       end
 
+      # Returns the idle time time (in milliseconds) passed since the call to
+      # +start!+ and the call to +finish!+
       def idle_time
         duration - cpu_time
       end
 
+      # Returns the number of allocations made since the call to +start!+ and
+      # the call to +finish!+
       def allocations
         @allocation_count_finish - @allocation_count_start
       end

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -69,12 +69,14 @@ module ActiveSupport
         @allocation_count_finish = 0
       end
 
+      # Record information at the time this event starts
       def start!
         @time = now
         @cpu_time_start = now_cpu
         @allocation_count_start = now_allocations
       end
 
+      # Record information at the time this event finishes
       def finish!
         @cpu_time_finish = now_cpu
         @end = now

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -41,6 +41,18 @@ module Notifications
       assert_operator event.idle_time, :>, 0
       assert_operator event.duration, :>, 0
     end
+
+    def test_subscribe_via_subscribe_method
+      events = []
+      @notifier.subscribe do |event|
+        events << event
+      end
+
+      ActiveSupport::Notifications.instrument("foo")
+      event = events.first
+      assert event, "should have an event"
+      assert_operator event.allocations, :>, 0
+    end
   end
 
   class SubscribedTest < TestCase

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -26,6 +26,23 @@ module Notifications
     end
   end
 
+  class SubscribeEventObjects < TestCase
+    def test_subscribe_events
+      events = []
+      @notifier.subscribe_event do |event|
+        events << event
+      end
+
+      ActiveSupport::Notifications.instrument("foo")
+      event = events.first
+      assert event, "should have an event"
+      assert_operator event.allocations, :>, 0
+      assert_operator event.cpu_time, :>, 0
+      assert_operator event.idle_time, :>, 0
+      assert_operator event.duration, :>, 0
+    end
+  end
+
   class SubscribedTest < TestCase
     def test_subscribed
       name     = "foo"


### PR DESCRIPTION
This PR builds on #33449 to allow users to subscribe to event objects from the top level `AS::Notifications` API.  Here is a demonstration of the difference:

## Before
```
ActiveSupport::Notifications.subscribe('wait') do |*args|
  @event = ActiveSupport::Notifications::Event.new(*args)
end

ActiveSupport::Notifications.instrument('wait') do
  sleep 1
end

p @event.duration # => 1000.138
```

## After
```
ActiveSupport::Notifications.subscribe('wait') do |event|
  @event = event
end

ActiveSupport::Notifications.instrument('wait') do
  sleep 1
end

p @event.duration    # => 1000.138
p @event.allocations # => 7
p @event.cpu_time    # => 0.256
p @event.idle_time   # => 1003.2399
```

Notice that we don't have to manually construct `Event` objects anymore.  I've found it's incredibly common (in GitHub's codebase anyway) to allocate `Event` objects in the pattern above, and I think it would be generally helpful if the framework does it for us.  In addition, this will give us easy access to performance statistics for every notification event.

/cc @jeremy @eileencodes 
