### PR TITLE
[Documentation] Mention default HTTP headers in Rails 3.2 to 4.0 upgrade guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1356,6 +1356,17 @@ config.middleware.insert_before(Rack::Lock, ActionDispatch::BestStandardsSupport
 
 Also check your environment settings for `config.action_dispatch.best_standards_support` and remove it if present.
 
+* Rails 4.0 allows configuration of HTTP headers by setting `config.action_dispatch.default_headers`. The defaults are as follows:
+
+```ruby
+  config.action_dispatch.default_headers = {
+    'X-Frame-Options' => 'SAMEORIGIN',
+    'X-XSS-Protection' => '1; mode=block'
+  }
+```
+
+Please note that if your application is dependent on loading certain pages in a `<frame>` or `<iframe>`, then you may need to explicitly set `X-Frame-Options` to `ALLOW-FROM ...` or `ALLOWALL`.
+
 * In Rails 4.0, precompiling assets no longer automatically copies non-JS/CSS assets from `vendor/assets` and `lib/assets`. Rails application and engine developers should put these assets in `app/assets` or configure `config.assets.precompile`.
 
 * In Rails 4.0, `ActionController::UnknownFormat` is raised when the action doesn't handle the request format. By default, the exception is handled by responding with 406 Not Acceptable, but you can override that now. In Rails 3, 406 Not Acceptable was always returned. No overrides.


### PR DESCRIPTION
### Summary

This pull request updates the Rails 3.2 to 4.0 section of the Upgrade Guide to include a mention and a tip for handling the addition of configurable default HTTP headers that were added in [this commit.](https://github.com/rails/rails/commit/2a290f7f7cdf775491eda05b3690be6d96cd9bf6#diff-182aa02288995070b335f57216738b92)

I'm open to any feedback on the phrasing or other changes or issues that should be added.

### Other Information

Some background on my motivations for adding this:  I was recently upgrading a Rails application that was dependent on loading certain pages in `<iframe>` for various reasons.  

As a result of the changes to the default value of the `X-Frame-Options` header we discovered, once the upgrade made it to production, that many of these pages were not loading properly until we changed the value of this header to something more relaxed.

I figured it would be good to mention this change in the documentation since I used this guide heavily to do the rest of the work for this upgrade and this issue was really the only change that wasn't mentioned in some form in the guide.

Thanks!
Jason
