### PR TITLE
Lint: redundant spaces before =

### DIFF
--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -88,7 +88,7 @@ module ActiveSupport
     end
 
     def finish(name, id, payload)
-      event     = event_stack.pop
+      event = event_stack.pop
       event.finish!
       event.payload.merge!(payload)
 


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/42fec4b8de8c40d7778f936e200081c0dded1ed0#diff-e96e89d85fdb9861738081367cc402e0L90-L92 there is no longer need to
indent this.