### PR TITLE
Avoid logging LogSubscriber as the query source when the source is ignored

### DIFF
--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -177,8 +177,21 @@ class LogSubscriberTest < ActiveRecord::TestCase
 
     logger = TestDebugLogSubscriber.new
     logger.sql(Event.new(0, sql: "hi mom!"))
+    assert_equal 2, @logger.logged(:debug).size
     assert_match(/↳/, @logger.logged(:debug).last)
   ensure
+    ActiveRecord::Base.verbose_query_logs = false
+  end
+
+  def test_verbose_query_with_ignored_callstack
+    ActiveRecord::Base.verbose_query_logs = true
+    ActiveRecord::LogSubscriber.ignored_callstack_paths.push("/")
+    logger = TestDebugLogSubscriber.new
+    logger.sql(Event.new(0, sql: "hi mom!"))
+    assert_equal 1, @logger.logged(:debug).size
+    assert_no_match(/↳/, @logger.logged(:debug).last)
+  ensure
+    ActiveRecord::LogSubscriber.ignored_callstack_paths.delete("/")
     ActiveRecord::Base.verbose_query_logs = false
   end
 


### PR DESCRIPTION
When logging `ActiveRecord` queries with `verbose_query_logs` enabled, any query that is generated by an gem installed along side `ActiveRecord` (such as `ActiveStorage`) gets logged as having the caller being `active_record/log_subscriber`

```
  ActiveStorage::Blob Load (7.0ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
  ↳ /Users/xxxxx/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activerecord-5.2.0/lib/active_record/log_subscriber.rb:98
```

This is because the previous code would fall back to the first entry in the caller_locations if there aren't any that aren't being ignored.

This PR omits the caller line from the logs if it unable to find a valid caller location. It also makes the the ignored paths configurable, which was required to implement the test.