### PR TITLE
Keep attribute change in `increment!` when record is not persisted

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -516,7 +516,7 @@ module ActiveRecord
       increment(attribute, by)
       change = public_send(attribute) - (attribute_in_database(attribute.to_s) || 0)
       self.class.update_counters(id, attribute => change, touch: touch)
-      clear_attribute_change(attribute) # eww
+      clear_attribute_change(attribute) if persisted?
       self
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -23,6 +23,8 @@ require "models/ship"
 require "models/toy"
 require "models/admin"
 require "models/admin/user"
+require "models/window"
+require "models/pane"
 require "rexml/document"
 
 class PersistenceTest < ActiveRecord::TestCase
@@ -228,6 +230,12 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal 2, topic.reload.replies_count
     assert_operator previously_updated_at, :<, topic.updated_at
     assert_operator previously_written_on, :<, topic.written_on
+  end
+
+  test "increment! keeps attribute change when record is not persisted" do
+    pane = Pane.create(name: "window 1", window_attributes: { name: "pane 1" })
+    pane.update(window_attributes: { name: "pane 2" })
+    assert_equal 1, Window.last.panes_count
   end
 
   def test_destroy_all

--- a/activerecord/test/models/pane.rb
+++ b/activerecord/test/models/pane.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Pane < ActiveRecord::Base
+  belongs_to :window, counter_cache: true
+  accepts_nested_attributes_for :window
+end

--- a/activerecord/test/models/window.rb
+++ b/activerecord/test/models/window.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Window < ActiveRecord::Base
+  has_many :panes
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1076,6 +1076,16 @@ ActiveRecord::Schema.define do
   create_table :non_primary_keys, force: true, id: false do |t|
     t.integer :id
   end
+
+  create_table :panes, force: true do |t|
+    t.string :name
+    t.integer :window_id
+  end
+
+  create_table :windows, force: true do |t|
+    t.string :name
+    t.integer :panes_count, default: 0, null: false
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
What?
Fixes #33113  - When `counter_cache` and `accepts_nested_attributes_for` defined and updating
parent object through belonging object, the actual counter cache database
column doesn't get persisted.

How?
Added a guard to prevent `clear_attribute_change` occur when record persisted
in `increment!`.