### PR TITLE
Handle null object on presence validation

### DIFF
--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -5,7 +5,9 @@ module ActiveRecord
     class PresenceValidator < ActiveModel::Validations::PresenceValidator # :nodoc:
       def validate_each(record, attribute, association_or_value)
         if record.class._reflect_on_association(attribute)
-          association_or_value = Array.wrap(association_or_value).reject(&:marked_for_destruction?)
+          association_or_value = Array.wrap(association_or_value)
+                                      .reject(&:blank?)
+                                      .reject(&:marked_for_destruction?)
         end
         super
       end

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -8,7 +8,21 @@ require "models/speedometer"
 require "models/dashboard"
 
 class PresenceValidationTest < ActiveRecord::TestCase
-  class Boy < Man; end
+  class NullFace
+    def blank?
+      true
+    end
+
+    def mark_for_destruction?
+      false
+    end
+  end
+
+  class Boy < Man
+    def face
+      super || NullFace.new
+    end
+  end
 
   repair_validations(Boy)
 
@@ -100,6 +114,14 @@ class PresenceValidationTest < ActiveRecord::TestCase
       interest = Interest.new
       interest.save!
       assert_not interest.valid?(:required_name)
+    end
+  end
+
+  def test_validates_presence_of_null_object
+    repair_validations(Boy) do
+      Boy.validates_presence_of(:face)
+      boy = Boy.new
+      assert_not_predicate boy, :valid?
     end
   end
 end


### PR DESCRIPTION
What?
Fixes #33445 - Check whether value is `blank?` or not when applying
presence validation.