### PR TITLE
Add clarification note for flash hashes

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -516,6 +516,8 @@ You can pass anything that the session can store; you're not limited to notices 
 <% end %>
 ```
 
+NOTE: When storing Hash objects in the flash, bear in mind how your session storage settings may affect. For example, storing `Hash` objects with symbol keys using Rails' default session storage settings (`CookieStore` and `:json` serialization) may cause keys to be stringified when flash is retrieved on next action.
+
 If you want a flash value to be carried over to another request, use the `keep` method:
 
 ```ruby


### PR DESCRIPTION
### Summary

When saving hash values in the flash, depending on session storage settings the result after serialization and deserialization can be different as expected. To avoid the confusion that this may cause I have added a note to the documentation.

See issue #33447