### PR TITLE
ActiveModel::Naming delegate match? in the same manner as =~ and !=

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -111,6 +111,22 @@ module ActiveModel
     #   BlogPost.model_name.eql?('Blog Post') # => false
 
     ##
+    # :method: match?
+    #
+    # :call-seq:
+    #   match?(regexp)
+    #
+    # Equivalent to <tt>String#match?</tt>. Match the class name against the
+    # given regexp. Returns +true+ if there is a match, otherwise +false+.
+    #
+    #   class BlogPost
+    #     extend ActiveModel::Naming
+    #   end
+    #
+    #   BlogPost.model_name.match?(/Post/) # => true
+    #   BlogPost.model_name.match?(/\d/) # => false
+
+    ##
     # :method: to_s
     #
     # :call-seq:
@@ -131,7 +147,7 @@ module ActiveModel
     #   to_str()
     #
     # Equivalent to +to_s+.
-    delegate :==, :===, :<=>, :=~, :"!~", :eql?, :to_s,
+    delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
              :to_str, :as_json, to: :name
 
     # Returns a new ActiveModel::Name instance. By default, the +namespace+


### PR DESCRIPTION
The purpose of the module seems to quack like a string, so this gives it parity.

The `match?` core extension [was added](https://github.com/rails/rails/commit/575dbeeefcaafeb566afc07cdd8b55603b698d9f) for ActiveSupport 5.1, although only for Regexp and not String. Not sure if this is worth backporting.