### PR TITLE
Only use CLOCK_PROCESS_CPUTIME_ID if it's defined

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -130,8 +130,14 @@ module ActiveSupport
           Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
-        def now_cpu
-          Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID)
+        if defined?(Process::CLOCK_PROCESS_CPUTIME_ID)
+          def now_cpu
+            Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID)
+          end
+        else
+          def now_cpu
+            0
+          end
         end
 
         if defined?(JRUBY_VERSION)


### PR DESCRIPTION
This addresses the feedback of broken Rails 6 builds on JRuby: https://github.com/rails/rails/pull/33449#issuecomment-408272093 and https://github.com/rsim/oracle-enhanced/issues/1735. Once it's defined/supported it should start working without changes to Rails.

/cc @eileencodes @yahonda 