### PR TITLE
Use reloader to wrap ActionCable work

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -53,8 +53,10 @@ module ActionCable
 
     initializer "action_cable.set_work_hooks" do |app|
       ActiveSupport.on_load(:action_cable) do
+        work_executor = app.config.reload_classes_only_on_change ? app.reloader : app.executor
+
         ActionCable::Server::Worker.set_callback :work, :around, prepend: true do |_, inner|
-          app.executor.wrap do
+          work_executor.wrap do
             # If we took a while to get the lock, we may have been halted
             # in the meantime. As we haven't started doing any real work
             # yet, we should pretend that we never made it off the queue.

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Wrap ActionCable incoming messages with the application reloader if it's checking for changes.
+
+    That allows handling code changes between the execution of Action Cable commands without triggering an HTTP request.
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/guides/source/threading_and_code_execution.md
+++ b/guides/source/threading_and_code_execution.md
@@ -184,13 +184,14 @@ application if any code changes have occurred.
 Active Job also wraps its job executions with the Reloader, loading the latest
 code to execute each job as it comes off the queue.
 
-Action Cable uses the Executor instead: because a Cable connection is linked to
-a specific instance of a class, it's not possible to reload for every arriving
-websocket message. Only the message handler is wrapped, though; a long-running
-Cable connection does not prevent a reload that's triggered by a new incoming
-request or job. Instead, Action Cable uses the Reloader's `before_class_unload`
-callback to disconnect all its connections. When the client automatically
-reconnects, it will be speaking to the new version of the code.
+Action Cable wraps every incoming message with either the Reloader (when it's
+checking for changes, see below) or the Executor.
+
+Since every Cable connection is linked to a specific instance of a class, it's
+not possible to reload the code for already initiated connections. Action Cable
+uses the Reloader's `before_class_unload` callback to disconnect all its connections.
+When the client automatically reconnects, it will be speaking to the new version
+of the code.
 
 The above are the entry points to the framework, so they are responsible for
 ensuring their respective threads are protected, and deciding whether a reload


### PR DESCRIPTION
Wrap ActionCable incoming messages with the application reloader if it's checking for changes.

That allows to handle code changes between the execution of ActionCable commands without triggering an HTTP request (to be handle by Reloader middleware).

Closes #33412.