### PR TITLE
cpu_time and allocations are 0 when JRuby is used

### DIFF
--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -80,10 +80,15 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     instrument "some_event.my_log_subscriber"
     wait
     event = @log_subscriber.event
+    if defined?(JRUBY_VERSION)
+      assert_equal 0, event.cpu_time
+      assert_equal 0, event.allocations
+    else
+      assert_operator event.cpu_time, :>, 0
+      assert_operator event.allocations, :>, 0
+    end
     assert_operator event.duration, :>, 0
-    assert_operator event.cpu_time, :>, 0
     assert_operator event.idle_time, :>, 0
-    assert_operator event.allocations, :>, 0
   end
 
   def test_does_not_send_the_event_if_it_doesnt_match_the_class


### PR DESCRIPTION
### Summary

According to #33449 and #33468, cpu_time and allocations are 0 when JRuby is used.

This pull request addresses the following failure with JRuby.

```ruby
$ ruby -v
jruby 9.2.1.0-SNAPSHOT (2.5.0) 2018-07-27 13b2df5 Java HotSpot(TM) 64-Bit Server VM 25.181-b13 on 1.8.0_181-b13 [linux-x86_64]
$ bundle exec ruby -w -Itest test/log_subscriber_test.rb -n test_event_attributes
Run options: -n test_event_attributes --seed 6231

F

Failure:
SyncLogSubscriberTest#test_event_attributes [test/log_subscriber_test.rb:84]:
Expected 0 to be > 0.

rails test test/log_subscriber_test.rb:78

Finished in 0.018983s, 52.6791 runs/s, 105.3582 assertions/s.
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

