### PR TITLE
Add .dockerignore when it executes rails new

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -66,6 +66,10 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def dockerignore
+      template "dockerignore", ".dockerignore"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run "git init", capture: options[:quiet]
@@ -288,6 +292,7 @@ module Rails
         build(:gemfile)     unless options[:skip_gemfile]
         build(:version_control)
         build(:package_json) unless options[:skip_yarn]
+        build(:dockerignore)
       end
 
       def create_app_files

--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -1,0 +1,35 @@
+<% unless options.git? -%>
+.git*
+
+<% end -%>
+.bundle
+.byebug_history
+.dockerignore
+.env
+.ruby-version
+config/master.key
+
+# Ignore all logfiles and tempfiles.
+log/*
+tmp/*
+
+<% if sqlite3? -%>
+# Ignore the default SQLite database.
+db/*.sqlite3
+db/*.sqlite3-journal
+
+<% end -%>
+<% unless skip_active_storage? -%>
+# Ignore uploaded files in development
+storage/*
+
+<% end -%>
+<% unless options.skip_yarn? -%>
+node_modules
+yarn-error.log
+
+<% end -%>
+<% unless options.api? -%>
+public/assets
+public/packs*
+<% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -6,6 +6,7 @@ require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
   .gitignore
+  .dockerignore
   .ruby-version
   README.md
   Gemfile
@@ -1000,6 +1001,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file ".gitignore" do |content|
+      assert_match(/config\/master\.key/, content)
+    end
+  end
+
+  def test_dockerignore
+    run_generator
+
+    assert_file ".dockerignore" do |content|
       assert_match(/config\/master\.key/, content)
     end
   end


### PR DESCRIPTION
### Summary

When we build a docker image, we often forget to add `config/master.key` to `.dockerignore`.
If we push this image to Dockerhub, `config/master.key` is unintentionally exposed to the world.

Therefore, whether we use Docker or not, I thought it's better to add `.dockerignore` to Rails app.