### PR TITLE
Make parallel testing db faster

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -248,6 +248,7 @@ module ActiveRecord
       def load_schema(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = env, spec_name = "primary") # :nodoc:
         file ||= dump_filename(spec_name, format)
 
+        verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]
         check_schema_file(file)
         ActiveRecord::Base.establish_connection(configuration)
 
@@ -261,6 +262,8 @@ module ActiveRecord
         end
         ActiveRecord::InternalMetadata.create_table
         ActiveRecord::InternalMetadata[:environment] = environment
+      ensure
+        Migration.verbose = verbose_was
       end
 
       def schema_file(format = ActiveRecord::Base.schema_format)

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -5,14 +5,14 @@ require "active_support/testing/parallelization"
 module ActiveRecord
   module TestDatabases # :nodoc:
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
-      create_and_migrate(i, spec_name: Rails.env)
+      create_and_load_schema(i, spec_name: Rails.env)
     end
 
-    ActiveSupport::Testing::Parallelization.run_cleanup_hook do |i|
-      drop(i, spec_name: Rails.env)
+    ActiveSupport::Testing::Parallelization.run_cleanup_hook do |_|
+      drop(spec_name: Rails.env)
     end
 
-    def self.create_and_migrate(i, spec_name:)
+    def self.create_and_load_schema(i, spec_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       connection_spec = ActiveRecord::Base.configurations[spec_name]
@@ -20,13 +20,13 @@ module ActiveRecord
       connection_spec["database"] += "-#{i}"
       ActiveRecord::Tasks::DatabaseTasks.create(connection_spec)
       ActiveRecord::Base.establish_connection(connection_spec)
-      ActiveRecord::Tasks::DatabaseTasks.migrate
+      ActiveRecord::Tasks::DatabaseTasks.load_schema(connection_spec)
     ensure
       ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])
       ENV["VERBOSE"] = old
     end
 
-    def self.drop(i, spec_name:)
+    def self.drop(spec_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
       connection_spec = ActiveRecord::Base.configurations[spec_name]
 


### PR DESCRIPTION
### Summary

Currently TestDatabases.create_and_migrate for parallel tests uses migrate. For a large number of workers this makes the tests run pretty slowly. The PR changes this to load_schema which shows an increase of speed.

Benchmarks below are for a sample app with 6 tables, 10 workers, and generated tests.

Before: <img width="754" alt="screen shot 2018-07-27 at 2 19 14 pm" src="https://user-images.githubusercontent.com/3744370/43432751-647733bc-9442-11e8-8d60-194353520f77.png">
After: <img width="745" alt="screen shot 2018-07-27 at 2 19 09 pm" src="https://user-images.githubusercontent.com/3744370/43432741-5afd209e-9442-11e8-8ebf-f83727bff8b4.png">


/cc @eileencodes 
