### PR TITLE
Disable content security policy for mailer previews

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -10,6 +10,8 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
   helper_method :part_query, :locale_query
 
+  content_security_policy(false)
+
   def index
     @previews = ActionMailer::Preview.all
     @page_title = "Mailer Previews"


### PR DESCRIPTION
Rails 5.2 introduced a default `content_security_policy` block to `Rails::ApplicationController`. `Rails::ApplicationController` is required by the MailersController, but any app-defined application_controller is not loaded. This means that regardless of CSP configuration in an app-defined application_controller or content_security_policy.rb initializer, the default CSP values will be included in the response headers for mailer previews.

These default CSP header values break certain middleware (e.g., guard-livereload, profilers). To my knowledge there is no benefit to supporting CSP in mailer previews, so maybe we can just disable them there?