### PR TITLE
Failing test case for current_page?

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -505,6 +505,12 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert current_page?("http://www.example.com/")
   end
 
+  def test_current_page_with_only_action
+    @request = request_for_url("/")
+    assert current_page?(url_hash.slice(:action))
+    assert current_page?("http://www.example.com/")
+  end
+
   def test_current_page_ignoring_params
     @request = request_for_url("/?order=desc&page=1")
 


### PR DESCRIPTION
The method `current_page?` should accept only `:action` parameter. This
commit adds failing test showing that `current_page?` fails when only
`:action` parameter is passed.

related: #33461