### PR TITLE
Fix example in thread_mattr_accessor documentation

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -136,7 +136,7 @@ class Module
   # Or pass <tt>instance_accessor: false</tt>, to opt out both instance methods.
   #
   #   class Current
-  #     mattr_accessor :user, instance_accessor: false
+  #     thread_mattr_accessor :user, instance_accessor: false
   #   end
   #
   #   Current.new.user = "DHH"  # => NoMethodError


### PR DESCRIPTION
Hello, just stumbled over this example in the documentation of `thread_mattr_accessor`. 
The example misleadingly demonstrates usage of `mattr_accessor` instead of `thread_mattr_accessor`.


