### PR TITLE
Throw if ujs loaded twice

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/start.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/start.coffee
@@ -9,7 +9,8 @@
 } = Rails
 
 # For backward compatibility
-if jQuery? and jQuery.ajax? and not jQuery.rails
+if jQuery? and jQuery.ajax?
+  throw new Error('If you load both jquery_ujs and rails-ujs, use rails-ujs only.') if jQuery.rails
   jQuery.rails = Rails
   jQuery.ajaxPrefilter (options, originalOptions, xhr) ->
     CSRFProtection(xhr) unless options.crossDomain


### PR DESCRIPTION
I saw two posts of problem about ajax requesting twice on qiita.
So I think detecting double loaded earlier make easy to find the problem.


Qiita posts in Japanese:
- <https://qiita.com/hot_study_man/items/56dc87ad734cfda68bb6>
- <https://qiita.com/hisas/items/8399aec3a5377bf75017>