### PR TITLE
Log the remote IP addr of clients behind a proxy

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -50,7 +50,7 @@ module Rails
           'Started %s "%s" for %s at %s' % [
             request.request_method,
             request.filtered_path,
-            request.ip,
+            request.remote_ip,
             Time.now.to_default_s ]
         end
 

--- a/railties/test/application/rack/logger_test.rb
+++ b/railties/test/application/rack/logger_test.rb
@@ -53,6 +53,12 @@ module ApplicationTests
         wait
         assert_match 'Started HEAD "/"', logs
       end
+
+      test "logger logs correct remote IP address" do
+        get "/", {}, { "REMOTE_ADDR" => "127.0.0.1", "HTTP_X_FORWARDED_FOR" => "1.2.3.4" }
+        wait
+        assert_match 'Started GET "/" for 1.2.3.4', logs
+      end
     end
   end
 end


### PR DESCRIPTION
If Rails is behind a proxy server, the log will show the IP address of the proxy for each request, rather than the remote IP address. I feel that this information is rarely if ever useful.

My change makes the logger use request.remote_ip, which makes a smart guess at the remote IP address by considering CLIENT_IP / X_FORWARDED_FOR and checking against the list of trusted proxies.

Closes #7979 