### PR TITLE
Revert the breaking existing default sort order contract

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,9 +1,3 @@
-*   Don't impose primary key order if limit() has already been supplied.
-
-    Fixes #23607
-
-    *Brian Christian*
-
 *   Add environment & load_config dependency to `bin/rake db:seed` to enable
     seed load in environments without Rails and custom DB configuration
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -550,7 +550,7 @@ module ActiveRecord
       end
 
       def ordered_relation
-        if order_values.empty? && primary_key && limit_value.blank?
+        if order_values.empty? && primary_key
           order(arel_attribute(primary_key).asc)
         else
           self

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1278,21 +1278,6 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def test_first_and_last_with_limit_for_order_without_primary_key
-    # While Topic.first should impose an ordering by primary key,
-    # Topic.limit(n).first should not
-
-    Topic.first.touch # PostgreSQL changes the default order if no order clause is used
-
-    assert_equal Topic.limit(1).to_a.first, Topic.limit(1).first
-    assert_equal Topic.limit(2).to_a.first, Topic.limit(2).first
-    assert_equal Topic.limit(2).to_a.first(2), Topic.limit(2).first(2)
-
-    assert_equal Topic.limit(1).to_a.last, Topic.limit(1).last
-    assert_equal Topic.limit(2).to_a.last, Topic.limit(2).last
-    assert_equal Topic.limit(2).to_a.last(2), Topic.limit(2).last(2)
-  end
-
   def test_finder_with_offset_string
     assert_nothing_raised { Topic.offset("3").to_a }
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -463,6 +463,7 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:first)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.first
+    assert_equal expected, Topic.limit(5).first
   end
 
   def test_model_class_responds_to_first_bang
@@ -485,6 +486,7 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:second)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.second
+    assert_equal expected, Topic.limit(5).second
   end
 
   def test_model_class_responds_to_second_bang
@@ -507,6 +509,7 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:third)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.third
+    assert_equal expected, Topic.limit(5).third
   end
 
   def test_model_class_responds_to_third_bang
@@ -529,6 +532,7 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:fourth)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.fourth
+    assert_equal expected, Topic.limit(5).fourth
   end
 
   def test_model_class_responds_to_fourth_bang
@@ -551,6 +555,7 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:fifth)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.fifth
+    assert_equal expected, Topic.limit(5).fifth
   end
 
   def test_model_class_responds_to_fifth_bang
@@ -711,6 +716,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal comments.limit(2).to_a.first, comments.limit(2).first
     assert_equal comments.limit(2).to_a.first(2), comments.limit(2).first(2)
     assert_equal comments.limit(2).to_a.first(3), comments.limit(2).first(3)
+  end
+
+  def test_first_have_determined_order_by_default
+    expected = [companies(:second_client), companies(:another_client)]
+    clients = Client.where(name: expected.map(&:name))
+
+    assert_equal expected, clients.first(2)
+    assert_equal expected, clients.limit(5).first(2)
   end
 
   def test_take_and_first_and_last_with_integer_should_return_an_array


### PR DESCRIPTION
This reverts commit d162188, reversing
changes made to 3576782.

Reason: #24131 conflicts the #5153's default order contract, it means
that existing apps would be broken by that change.

Since #5153, introduced `take` as a replacement to the old behavior of `first`.
At least there is no inconsistency between `limit(1).last` and `limit(1).take`.
(given ORDER on `last` without `limit` is a limitation for current implementation
of `last` to depend on `reverse_order`)

We don't want to break existing apps without a deprecation cycle.