### PR TITLE
Add method hash_pluck

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,
              :having, :create_with, :distinct, :references, :none, :unscope, :merge, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
-    delegate :pluck, :pick, :ids, to: :all
+    delegate :pluck, :hash_pluck, :pick, :ids, to: :all
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array with columns requested encapsulated as attributes of the model you call

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -200,6 +200,10 @@ module ActiveRecord
       end
     end
 
+    def hash_pluck(*column_names)
+      pluck(column_names).map { |result| Hash[column_names.zip([result].flatten)] }
+    end
+
     # Pick the value(s) from the named column(s) in the current relation.
     # This is short-hand for <tt>relation.limit(1).pluck(*column_names).first</tt>, and is primarily useful
     # when you have a relation that's already narrowed down to a single row.

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -829,6 +829,10 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_hash_pluck
+    assert_equal [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}], Topic.order(:id).hash_pluck(:id)
+  end
+
   def test_pick_one
     assert_equal "The First Topic", Topic.order(:id).pick(:heading)
     assert_nil Topic.none.pick(:heading)


### PR DESCRIPTION
### ActiveRecord::Calculations#hash_pluck

It would be great to have a `pluck` like method that returns a hash instead of an array. It should behave exactly like `pluck`, except for the returned value:

```
Book.hash_pluck(:title) # [{title: 'Foo'}, {title: 'Bar'} ...]
Book.hash_pluck(:id, :author) # [{id: 1, author: 'Foo'}, ...]
```
Sometimes I write code to transform `pluck`'s returned values to a hash. This is my main motivation to open this PR.

`hash_pluck` is an awful name. I think it should be a new method instead of passing a new parameter to `pluck`.

I know the code is not efficient or good enough but it can give an ideia about this feature request.