### PR TITLE
use BacktraceCleaner for ActiveRecord verbose logging

### DIFF
--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -20,6 +20,7 @@ module ActionDispatch
 
     setup do
       @cleaner = ActiveSupport::BacktraceCleaner.new
+      @cleaner.remove_filters!
       @cleaner.add_silencer { |line| line !~ /^lib/ }
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -77,6 +77,10 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
+    initializer "active_record.backtrace_cleaner" do
+      ActiveSupport.on_load(:active_record) { LogSubscriber.backtrace_cleaner = ::Rails.backtrace_cleaner }
+    end
+
     initializer "active_record.migration_error" do
       if config.active_record.delete(:migration_error) == :page_load
         config.app_middleware.insert_after ::ActionDispatch::Callbacks,

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -31,6 +31,9 @@ module ActiveSupport
   class BacktraceCleaner
     def initialize
       @filters, @silencers = [], []
+      add_gem_filter
+      add_gem_silencer
+      add_stdlib_silencer
     end
 
     # Returns the backtrace after all filters and silencers have been run
@@ -82,6 +85,26 @@ module ActiveSupport
     end
 
     private
+
+      FORMATTED_GEMS_PATTERN = /\A[^\/]+ \([\w.]+\) /
+
+      def add_gem_filter
+        gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
+        return if gems_paths.empty?
+
+        gems_regexp = %r{(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
+        gems_result = '\3 (\4) \5'.freeze
+        add_filter { |line| line.sub(gems_regexp, gems_result) }
+      end
+
+      def add_gem_silencer
+        add_silencer { |line| FORMATTED_GEMS_PATTERN.match?(line) }
+      end
+
+      def add_stdlib_silencer
+        add_silencer { |line| line.start_with?(RbConfig::CONFIG["rubylibdir"]) }
+      end
+
       def filter_backtrace(backtrace)
         @filters.each do |f|
           backtrace = backtrace.map { |line| f.call(line) }

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -16,19 +16,7 @@ module Rails
       add_filter { |line| line.sub(@root, EMPTY_STRING) }
       add_filter { |line| line.sub(RENDER_TEMPLATE_PATTERN, EMPTY_STRING) }
       add_filter { |line| line.sub(DOT_SLASH, SLASH) } # for tests
-
-      add_gem_filters
       add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end
-
-    private
-      def add_gem_filters
-        gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
-        return if gems_paths.empty?
-
-        gems_regexp = %r{(#{gems_paths.join('|')})/gems/([^/]+)-([\w.]+)/(.*)}
-        gems_result = '\2 (\3) \4'.freeze
-        add_filter { |line| line.sub(gems_regexp, gems_result) }
-      end
   end
 end

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -8,22 +8,6 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     @cleaner = Rails::BacktraceCleaner.new
   end
 
-  test "should format installed gems correctly" do
-    backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-    result = @cleaner.clean(backtrace, :all)
-    assert_equal "nosuchgem (1.2.3) lib/foo.rb", result[0]
-  end
-
-  test "should format installed gems not in Gem.default_dir correctly" do
-    target_dir = Gem.path.detect { |p| p != Gem.default_dir }
-    # skip this test if default_dir is the only directory on Gem.path
-    if target_dir
-      backtrace = [ "#{target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-      result = @cleaner.clean(backtrace, :all)
-      assert_equal "nosuchgem (1.2.3) lib/foo.rb", result[0]
-    end
-  end
-
   test "should consider traces from irb lines as User code" do
     backtrace = [ "(irb):1",
                   "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",


### PR DESCRIPTION
In #33455, the ActiveRecord caller logging was altered to prevent logging the log_subscriber as the caller source.

However, this caused the tests to fail if the bundle was installed within the rails repo (i.e. under `vendor/bundle`.

This PR alters the rules for excluding callers from the verbose query logger to exclude the lib directories of `ActiveRecord` and `ActiveSupport` as they contain the instrumentation code that is not related to the source of the caller and the gems installed in the gem path.

This causes the tests to return `test/cases/log_subscriber_test.rb:38` as the caller and doesn't rely on `minitest` sitting outside of the Rails gem root for the tests to pass.

As a result of this change, it is possible that the caller to be reported as one of the other Rails frameworks such as `ActiveStorage` or `ActiveJob` if the app is running using against a local checkout of Rails. @kaspth suggested that `ActiveStorage` should be excluded from being reported as a caller as well, but as it only occurs when running with a local checkout of rails I believe that it should be ok to have there gems be reported as caller, and I am not sure how to exclude them given that ActiveRecord does not know about there existance. I would be interested in other peoples thoughts around this.

For reference, some examples of caller reports in rails when using a local checkout are:

```
(0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
↳ /Users/xxxxx/libs/rails/actionpack/lib/action_dispatch/middleware/callbacks.rb:28

ActiveStorage::Blob Load (0.2ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = ? LIMIT ?  [["id", 6], ["LIMIT", 1]]
↳ /Users/xxxxx/libs/rails/activestorage/app/models/active_storage/blob.rb:45

[ActiveJob] [ActiveStorage::AnalyzeJob] [71b7dc46-fc25-4eba-be9a-4e93871de0f7]   ActiveStorage::Blob Update (0.4ms)  UPDATE "active_storage_blobs" SET "metadata" = ? WHERE "active_storage_blobs"."id" = ?  [["metadata", "{\"identified\":true,\"width\":255,\"height\":197,\"analyzed\":true}"], ["id", 6]]
[ActiveJob] [ActiveStorage::AnalyzeJob] [71b7dc46-fc25-4eba-be9a-4e93871de0f7]   ↳ /Users/xxxxx/libs/rails/activestorage/app/models/active_storage/blob/analyzable.rb:29

ActiveStorage::Blob Load (0.3ms)  SELECT  "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = ? LIMIT ?  [["id", 6], ["LIMIT", 1]]
↳ /Users/xxxxx/libs/rails/activejob/lib/active_job/arguments.rb:113
```