### PR TITLE
ActionCable.Subscription.perform: Throw error for key name "action" supplied to "data" argument

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/subscription.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscription.coffee
@@ -56,6 +56,8 @@ class ActionCable.Subscription
 
   # Perform a channel action with the optional data passed as an attribute
   perform: (action, data = {}) ->
+    if data.action != undefined
+      throw new Error 'ActionCable.Subscription.perform: The key name "action" may not be supplied to the "data" argument.'
     data.action = action
     @send(data)
 


### PR DESCRIPTION
Throw an error when key name "action" supplied to "data" argument of ActionCable.Subscription.perform. The "action" property of the optional "data" argument gets replaced, but this behavior is not documented.

Should this be a `console.log` instead of an error to prevent breaking existing applications which supply "action" here erroneously?

Thanks!

#33505 