### PR TITLE
fix reloader

### DIFF
--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -56,7 +56,6 @@ module ActiveSupport
           end
         end
       end
-      prepare!
     end
 
     def self.run! # :nodoc:

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -58,7 +58,7 @@ class ReloaderTest < ActiveSupport::TestCase
 
     called = []
     reloader.reload!
-    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete, :prepare], called
+    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete], called
 
     reloader.check = lambda { false }
 
@@ -68,7 +68,7 @@ class ReloaderTest < ActiveSupport::TestCase
 
     called = []
     reloader.reload!
-    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete, :prepare], called
+    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete], called
   end
 
   def test_class_unload_block

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -51,18 +51,19 @@ class ConsoleTest < ActiveSupport::TestCase
 
   def test_reload_should_fire_preparation_and_cleanup_callbacks
     load_environment
-    a = b = c = nil
+    a = b = c = d = nil
 
     # TODO: These should be defined on the initializer
     ActiveSupport::Reloader.to_complete { a = b = c = 1 }
     ActiveSupport::Reloader.to_complete { b = c = 2 }
-    ActiveSupport::Reloader.to_prepare { c = 3 }
+    ActiveSupport::Reloader.to_prepare { c = d = 3 }
 
     irb_context.reload!(false)
 
     assert_equal 1, a
     assert_equal 2, b
-    assert_equal 3, c
+    assert_equal 2, c
+    assert_equal 3, d
   end
 
   def test_reload_should_reload_constants


### PR DESCRIPTION
after upgrading to rails 5.2.0 (5.2.1.rc1), reloader stopped working. Rails 4.2.8 was fine.

```
ActiveSupport::Reloader.to_prepare(*args, &block)
 ....
end
```
is called twice, so it fails on an exception (duplicated constants, callbacks etc.). This issue could be related to https://github.com/rails/rails/issues/32892

the test case is very simple
```
Application.reload!
```

Maybe it's my fault. I'll look into this more closely and keep you informed.


