### PR TITLE
remove redundant establish_connection call in test_databases.rb

### DIFF
--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -19,7 +19,6 @@ module ActiveRecord
 
       connection_spec["database"] += "-#{i}"
       ActiveRecord::Tasks::DatabaseTasks.create(connection_spec)
-      ActiveRecord::Base.establish_connection(connection_spec)
       ActiveRecord::Tasks::DatabaseTasks.load_schema(connection_spec)
     ensure
       ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env])


### PR DESCRIPTION
Now that we're using `load_schema` instead of `migrate` for parallel tests we don't need to establish the connection in `create_and_load_schema` since it already gets established in `load_schema`

I ran the tests in a sample app against this to make sure it establishes the correct connection and it checks out.

/cc @eileencodes  
