### PR TITLE
Add support for multi environment credentials.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support environment specific credentials file.
+
+    For `production` environment look first for `config/credentials/production.yml.enc` file that can be decrypted by
+    `ENV["RAILS_MASTER_KEY"]` or `config/credentials/production.key` master key.
+    Edit given environment credentials file by command `rails credentials:edit --environment production`.
+    Default paths can be overwritten by setting `config.credentials.content_path` and `config.credentials.key_path`.
+
+    *Wojciech Wnętrzak*
+
 *   Make `ActiveSupport::Cache::NullStore` the default cache store in the test environment.
 
     *Michael C. Nelson*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -438,8 +438,12 @@ module Rails
     # Decrypts the credentials hash as kept in +config/credentials.yml.enc+. This file is encrypted with
     # the Rails master key, which is either taken from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading
     # +config/master.key+.
+    # If specific credentials file exists for current environment, it takes precedence, thus for +production+
+    # environment look first for +config/credentials/production.yml.enc+ with master key taken
+    # from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading +config/credentials/production.key+.
+    # Default behavior can be overwritten by setting +config.credentials.content_path+ and +config.credentials.key_path+.
     def credentials
-      @credentials ||= encrypted("config/credentials.yml.enc")
+      @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)
     end
 
     # Shorthand to decrypt any encrypted configurations or files.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -17,7 +17,7 @@ module Rails
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
-                    :content_security_policy_nonce_generator, :require_master_key
+                    :content_security_policy_nonce_generator, :require_master_key, :credentials
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -60,6 +60,9 @@ module Rails
         @content_security_policy_nonce_generator = nil
         @require_master_key                      = false
         @loaded_config_version                   = nil
+        @credentials                             = ActiveSupport::OrderedOptions.new
+        @credentials.content_path                = default_credentials_content_path
+        @credentials.key_path                    = default_credentials_key_path
       end
 
       def load_defaults(target_version)
@@ -273,6 +276,27 @@ module Rails
           true
         end
       end
+
+      private
+        def credentials_available_for_current_env?
+          File.exist?("#{root}/config/credentials/#{Rails.env}.yml.enc")
+        end
+
+        def default_credentials_content_path
+          if credentials_available_for_current_env?
+            File.join(root, "config", "credentials", "#{Rails.env}.yml.enc")
+          else
+            File.join(root, "config", "credentials.yml.enc")
+          end
+        end
+
+        def default_credentials_key_path
+          if credentials_available_for_current_env?
+            File.join(root, "config", "credentials", "#{Rails.env}.key")
+          else
+            File.join(root, "config", "master.key")
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -38,3 +38,12 @@ the encrypted credentials.
 When the temporary file is next saved the contents are encrypted and written to
 `config/credentials.yml.enc` while the file itself is destroyed to prevent credentials
 from leaking.
+
+=== Environment Specific Credentials
+
+It is possible to have credentials for each environment. If the file for current environment exists it will take
+precedence over `config/credentials.yml.enc`, thus for `production` environment first look for
+`config/credentials/production.yml.enc` that can be decrypted using master key taken from `ENV["RAILS_MASTER_KEY"]`
+or stored in `config/credentials/production.key`.
+To edit given file use command `rails credentials:edit --environment production`
+Default paths can be overwritten by setting `config.credentials.content_path` and `config.credentials.key_path`.

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -55,6 +55,14 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "edit command modifies file specified by environment option" do
+    assert_match(/access_key_id: 123/, run_edit_command(environment: "production"))
+    Dir.chdir(app_path) do
+      assert File.exist?("config/credentials/production.key")
+      assert File.exist?("config/credentials/production.yml.enc")
+    end
+  end
+
   test "show credentials" do
     assert_match(/access_key_id: 123/, run_show_command)
   end
@@ -70,17 +78,25 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     remove_file "config/master.key"
     add_to_config "config.require_master_key = false"
 
-    assert_match(/Missing master key to decrypt credentials/, run_show_command)
+    assert_match(/Missing 'config\/master\.key' to decrypt credentials/, run_show_command)
+  end
+
+  test "show command displays content specified by environment option" do
+    run_edit_command(environment: "production")
+
+    assert_match(/access_key_id: 123/, run_show_command(environment: "production"))
   end
 
   private
-    def run_edit_command(editor: "cat")
+    def run_edit_command(editor: "cat", environment: nil, **options)
       switch_env("EDITOR", editor) do
-        rails "credentials:edit"
+        args = environment ? ["--environment", environment] : []
+        rails "credentials:edit", args, **options
       end
     end
 
-    def run_show_command(**options)
-      rails "credentials:show", **options
+    def run_show_command(environment: nil, **options)
+      args = environment ? ["--environment", environment] : []
+      rails "credentials:show", args, **options
     end
 end

--- a/railties/test/credentials_test.rb
+++ b/railties/test/credentials_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+class Rails::CredentialsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  test "reads credentials from environment specific path" do
+    with_credentials do |content, key|
+      Dir.chdir(app_path) do
+        Dir.mkdir("config/credentials")
+        File.write("config/credentials/production.yml.enc", content)
+        File.write("config/credentials/production.key", key)
+      end
+
+      app("production")
+
+      assert_equal "revealed", Rails.application.credentials.mystery
+    end
+  end
+
+  test "reads credentials from customized path and key" do
+    with_credentials do |content, key|
+      Dir.chdir(app_path) do
+        Dir.mkdir("config/credentials")
+        File.write("config/credentials/staging.yml.enc", content)
+        File.write("config/credentials/staging.key", key)
+      end
+
+      add_to_env_config("production", "config.credentials.content_path = config.root.join('config/credentials/staging.yml.enc')")
+      add_to_env_config("production", "config.credentials.key_path = config.root.join('config/credentials/staging.key')")
+      app("production")
+
+      assert_equal "revealed", Rails.application.credentials.mystery
+    end
+  end
+
+  private
+    def with_credentials
+      key = "2117e775dc2024d4f49ddf3aeb585919"
+      # secret_key_base: secret
+      # mystery: revealed
+      content = "vgvKu4MBepIgZ5VHQMMPwnQNsLlWD9LKmJHu3UA/8yj6x+3fNhz3DwL9brX7UA==--qLdxHP6e34xeTAiI--nrcAsleXuo9NqiEuhntAhw=="
+      yield(content, key)
+    end
+end


### PR DESCRIPTION
Usage:

If one wants to use staging encrypted credentials:
```
rails credentials:edit --environment staging
```
This will create files `config/credentials/staging.yml.enc` and `config/credentials/staging.key`
When calling `Rails.application.credentials` in staging environment, it takes precedence over default
`config/credentials.yml.enc`
Default paths can be overwritten by setting `config.credentials.content_path` and `config.credentials.key_path`

It is backward compatible.

Another try for https://github.com/rails/rails/pull/30067#issuecomment-410026127