### PR TITLE
Filter backtrace in test to ensure irb counts as user code

### DIFF
--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -25,10 +25,11 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
   end
 
   test "should consider traces from irb lines as User code" do
-    backtrace = [ "from (irb):1",
-                  "from /Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
-                  "from bin/rails:4:in `<main>'" ]
-    result = @cleaner.clean(backtrace, :all)
-    assert_equal "from (irb):1", result[0]
+    backtrace = [ "(irb):1",
+                  "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+                  "bin/rails:4:in `<main>'" ]
+    result = @cleaner.clean(backtrace)
+    assert_equal "(irb):1", result[0]
+    assert_equal 1, result.length
   end
 end


### PR DESCRIPTION
The test for considering traces from irb as User code was not silencing the the backtrace (:all option for kind of filter) so it wasn't actually testing that the filtering was working.

The test backtrace was incorrect - it was what irb prints out as the formatted backtrace instead of the backtrace as seen by the cleaner.

This PR updates the backtrace and the call to clean so that this functionality is correctly tested.