### PR TITLE
 Add note for custom mailer view paths in action mailer guide. [ci skip]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -422,6 +422,22 @@ use the rendered text for the text part. The render command is the same one used
 inside of Action Controller, so you can use all the same options, such as
 `:text`, `:inline` etc.
 
+If you would like to render a template located outside of the default `app/views/mailer_name/` directory, you can apply the `prepend_view_path`, like so:
+
+```ruby
+class UserMailer < ApplicationMailer
+  prepend_view_path "custom/path/to/mailer/view"
+  
+  # This will try to load "custom/path/to/mailer/view/welcome_email" template
+  def welcome_email
+    # ...
+  end
+end
+
+```
+
+You can also consider using the [append_view_path](https://guides.rubyonrails.org/action_view_overview.html#view-paths) method.
+
 #### Caching mailer view
 
 You can perform fragment caching in mailer views like in application views using the `cache` method.


### PR DESCRIPTION
### Summary

Recently I was working on a Rails application which included an unorthodox file structure and had mailer views located outside of the `app/views/mailer_name` directory (I.E. I had something in `Rails.root.to_s + "/custom_folder/app/views"`. The ActionView documentation mentioned the `prepend_view_path` method to help find custom view paths from the controller layer- but I didn't feel that it was emphasized that this method can be applied in the action mailers. This adds a small example to the action mailer documentation to point anyone who might face a similar problem in the right direction.

