### PR TITLE
Improve ActiveStorage service adapter error handling

### DIFF
--- a/activestorage/lib/active_storage/service/configurator.rb
+++ b/activestorage/lib/active_storage/service/configurator.rb
@@ -26,7 +26,9 @@ module ActiveStorage
 
       def resolve(class_name)
         require "active_storage/service/#{class_name.to_s.underscore}_service"
-        ActiveStorage::Service.const_get(:"#{class_name}Service")
+        ActiveStorage::Service.const_get(:"#{class_name.classify}Service")
+      rescue LoadError
+        raise "Missing service adapter for #{class_name.inspect}"
       end
   end
 end

--- a/activestorage/test/service/configurator_test.rb
+++ b/activestorage/test/service/configurator_test.rb
@@ -9,6 +9,12 @@ class ActiveStorage::Service::ConfiguratorTest < ActiveSupport::TestCase
     assert_equal "path", service.root
   end
 
+  test "builds correct service instance based on lowercase service name" do
+    service = ActiveStorage::Service::Configurator.build(:foo, foo: { service: "disk", root: "path" })
+    assert_instance_of ActiveStorage::Service::DiskService, service
+    assert_equal "path", service.root
+  end
+
   test "raises error when passing non-existent service name" do
     assert_raise RuntimeError do
       ActiveStorage::Service::Configurator.build(:bigfoot, {})


### PR DESCRIPTION
### Summary

Addresses https://github.com/rails/rails/issues/33157

- Allows for service names to be either lowercase or capitalized 
- Raises an error if the service cannot be loaded and provides an explicit message

### Other Information
Not entirely certain if lower and capital cases should be accepted, but figured I'd give it a shot to see if anyone finds it useful.
