### PR TITLE
Fix filtering out ActionView::Template method names from backtrace.

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -5,7 +5,7 @@ require "active_support/backtrace_cleaner"
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner
     APP_DIRS_PATTERN = /^\/?(app|config|lib|test|\(\w*\))/
-    RENDER_TEMPLATE_PATTERN = /:in `_render_template_\w*'/
+    RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
     EMPTY_STRING = "".freeze
     SLASH        = "/".freeze
     DOT_SLASH    = "./".freeze

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -32,4 +32,11 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal "(irb):1", result[0]
     assert_equal 1, result.length
   end
+
+  test "should omit ActionView template methods names" do
+    method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, {}).send :method_name
+    backtrace = [ "app/views/application/index.html.erb:4:in `block in #{method_name}'"]
+    result = @cleaner.clean(backtrace, :all)
+    assert_equal "app/views/application/index.html.erb:4", result[0]
+  end
 end


### PR DESCRIPTION
The `Rails::BacktraceCleaner` has a filter to strip out the automatically generated method names for active record templates. 

However, the format of the method names has changed and so they no longer match the filter and don't get removed anymore.

In addition, the pattern to match the filters would only match the backtrace if there as no decoration on the label (i.e. `block in `).

This updates the pattern to match the ActionView method names, and adds a test to ensure that they stay in sync.