### PR TITLE
Add lambdas in conditional validations

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -927,6 +927,13 @@ class Account < ApplicationRecord
 end
 ```
 
+As `Lambdas` are a type of `Proc`, they can also be used to write inline
+conditions in a shorter way.
+
+```ruby
+validates :password, confirmation: true, unless: -> { password.blank? }
+```
+
 ### Grouping Conditional validations
 
 Sometimes it is useful to have multiple validations use one condition. It can


### PR DESCRIPTION
As `Lambdas` are a type of `Proc`, they can also be used in the `if`/`unless` option of a validation to decide when the validation is executed. Add this case to the guide for clarification. :bowtie: 

Closes https://github.com/rails/rails/issues/33212
