### PR TITLE
Fix the obvious typos detected by github.com/client9/misspell

### DIFF
--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -290,7 +290,7 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
-  def test_assert_enqueued_email_with_with_no_block_wiht_parameterized_args
+  def test_assert_enqueued_email_with_with_no_block_with_parameterized_args
     assert_nothing_raised do
       silence_stream($stdout) do
         TestHelperMailer.with(all: "good").test_parameter_args.deliver_later

--- a/activerecord/test/cases/arel/attributes/math_test.rb
+++ b/activerecord/test/cases/arel/attributes/math_test.rb
@@ -6,35 +6,35 @@ module Arel
   module Attributes
     class MathTest < Arel::Spec
       %i[* /].each do |math_operator|
-        it "average should be compatiable with #{math_operator}" do
+        it "average should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].average.public_send(math_operator, 2)).to_sql.must_be_like %{
             AVG("users"."id") #{math_operator} 2
           }
         end
 
-        it "count should be compatiable with #{math_operator}" do
+        it "count should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].count.public_send(math_operator, 2)).to_sql.must_be_like %{
             COUNT("users"."id") #{math_operator} 2
           }
         end
 
-        it "maximum should be compatiable with #{math_operator}" do
+        it "maximum should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].maximum.public_send(math_operator, 2)).to_sql.must_be_like %{
             MAX("users"."id") #{math_operator} 2
           }
         end
 
-        it "minimum should be compatiable with #{math_operator}" do
+        it "minimum should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].minimum.public_send(math_operator, 2)).to_sql.must_be_like %{
             MIN("users"."id") #{math_operator} 2
           }
         end
 
-        it "attribute node should be compatiable with #{math_operator}" do
+        it "attribute node should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].public_send(math_operator, 2)).to_sql.must_be_like %{
             "users"."id" #{math_operator} 2
@@ -43,35 +43,35 @@ module Arel
       end
 
       %i[+ - & | ^ << >>].each do |math_operator|
-        it "average should be compatiable with #{math_operator}" do
+        it "average should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].average.public_send(math_operator, 2)).to_sql.must_be_like %{
             (AVG("users"."id") #{math_operator} 2)
           }
         end
 
-        it "count should be compatiable with #{math_operator}" do
+        it "count should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].count.public_send(math_operator, 2)).to_sql.must_be_like %{
             (COUNT("users"."id") #{math_operator} 2)
           }
         end
 
-        it "maximum should be compatiable with #{math_operator}" do
+        it "maximum should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].maximum.public_send(math_operator, 2)).to_sql.must_be_like %{
             (MAX("users"."id") #{math_operator} 2)
           }
         end
 
-        it "minimum should be compatiable with #{math_operator}" do
+        it "minimum should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].minimum.public_send(math_operator, 2)).to_sql.must_be_like %{
             (MIN("users"."id") #{math_operator} 2)
           }
         end
 
-        it "attribute node should be compatiable with #{math_operator}" do
+        it "attribute node should be compatible with #{math_operator}" do
           table = Arel::Table.new :users
           (table[:id].public_send(math_operator, 2)).to_sql.must_be_like %{
             ("users"."id" #{math_operator} 2)

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -278,7 +278,7 @@ module Arel
         @m2.where(table[:age].lt(99))
       end
 
-      it "should interact two managers" do
+      it "should intersect two managers" do
         # FIXME should this intersect "managers" or "statements" ?
         # FIXME this probably shouldn't return a node
         node = @m1.intersect @m2

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -278,7 +278,7 @@ module Arel
         @m2.where(table[:age].lt(99))
       end
 
-      it "should interect two managers" do
+      it "should interact two managers" do
         # FIXME should this intersect "managers" or "statements" ?
         # FIXME this probably shouldn't return a node
         node = @m1.intersect @m2

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -215,7 +215,7 @@ module Arel
           }
         end
 
-        it "should know how to generate paranthesis when supplied with many Dimensions" do
+        it "should know how to generate parenthesis when supplied with many Dimensions" do
           dim1 = Arel::Nodes::GroupingElement.new(@table[:name])
           dim2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
           node = Arel::Nodes::Cube.new([dim1, dim2])
@@ -241,7 +241,7 @@ module Arel
           }
         end
 
-        it "should know how to generate paranthesis when supplied with many Dimensions" do
+        it "should know how to generate parenthesis when supplied with many Dimensions" do
           group1 = Arel::Nodes::GroupingElement.new(@table[:name])
           group2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
           node = Arel::Nodes::GroupingSet.new([group1, group2])
@@ -267,7 +267,7 @@ module Arel
           }
         end
 
-        it "should know how to generate paranthesis when supplied with many Dimensions" do
+        it "should know how to generate parenthesis when supplied with many Dimensions" do
           group1 = Arel::Nodes::GroupingElement.new(@table[:name])
           group2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
           node = Arel::Nodes::RollUp.new([group1, group2])

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -427,7 +427,7 @@ module Arel
           compile(node).must_equal %(("products"."price" - 7))
         end
 
-        it "should handle Concatination" do
+        it "should handle Concatenation" do
           table = Table.new(:users)
           node = table[:name].concat(table[:name])
           compile(node).must_equal %("users"."name" || "users"."name")

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
   class SelectTest < ActiveRecord::TestCase
     fixtures :posts
 
-    def test_select_with_nil_agrument
+    def test_select_with_nil_argument
       expected = Post.select(:title).to_sql
       assert_equal expected, Post.select(nil).select(:title).to_sql
     end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -148,7 +148,7 @@ module CacheStoreBehavior
     end
   end
 
-  # Use strings that are guarenteed to compress well, so we can easily tell if
+  # Use strings that are guaranteed to compress well, so we can easily tell if
   # the compression kicked in or not.
   SMALL_STRING = "0" * 100
   LARGE_STRING = "0" * 2.kilobytes

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -286,7 +286,7 @@ module Rails
             original_options.concat [ "-u", using ]
           else
             # Use positional internally to get around Thor's immutable options.
-            # TODO: Replace `using` occurences with `options[:using]` after deprecation removal.
+            # TODO: Replace `using` occurrences with `options[:using]` after deprecation removal.
             @using = options[:using]
           end
         end


### PR DESCRIPTION
### Summary

This pull request fixes several minor typos in the source code. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell .
actionmailer/test/test_helper_test.rb:293:52: "wiht" is a misspelling of "with"
activerecord/test/cases/arel/attributes/math_test.rb:9:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:16:28: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:23:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:30:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:37:37: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:46:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:53:28: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:60:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:67:30: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/attributes/math_test.rb:74:37: "compatiable" is a misspelling of "compatible"
activerecord/test/cases/arel/visitors/postgres_test.rb:218:40: "paranthesis" is a misspelling of "parenthesis"
activerecord/test/cases/arel/visitors/postgres_test.rb:244:40: "paranthesis" is a misspelling of "parenthesis"
activerecord/test/cases/arel/visitors/postgres_test.rb:270:40: "paranthesis" is a misspelling of "parenthesis"
activerecord/test/cases/arel/visitors/to_sql_test.rb:430:26: "Concatination" is a misspelling of "Contamination"
activerecord/test/cases/arel/select_manager_test.rb:281:17: "interect" is a misspelling of "interacted"
activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:261:10: "devels" is a misspelling of "delves"
activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb:269:23: "devels" is a misspelling of "delves"
activerecord/test/cases/fixtures_test.rb:109:31: "aircrafts" is a misspelling of "aircraft"
activerecord/test/cases/fixtures_test.rb:110:30: "aircrafts" is a misspelling of "aircraft"
activerecord/test/cases/persistence_test.rb:1118:17: "aircrafts" is a misspelling of "aircraft"
activerecord/test/cases/relation/select_test.rb:10:29: "agrument" is a misspelling of "argument"
activesupport/test/cache/behaviors/cache_store_behavior.rb:151:25: "guarenteed" is a misspelling of "guaranteed"
railties/lib/rails/commands/server/server_command.rb:289:36: "occurences" is a misspelling of "occurrences"
```
### Other Information

None
