### PR TITLE
ActiveRecord Basics guide: correct explanation of the `updated_at` logic [ci skip]

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -115,7 +115,7 @@ to Active Record instances:
 * `created_at` - Automatically gets set to the current date and time when the
   record is first created.
 * `updated_at` - Automatically gets set to the current date and time whenever
-  the record is updated.
+  the record is created or updated.
 * `lock_version` - Adds [optimistic
   locking](http://api.rubyonrails.org/classes/ActiveRecord/Locking.html) to
   a model.


### PR DESCRIPTION
It's misleanding/incorrect to state that `updated_at` is set on updates, since creation != update (and the column is actually set on creation, too).