### PR TITLE
Move `dev:cache` rake task to use Rails::Command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `rake dev:cache` in favor of `rails dev:cache`.
+
+    *Annie-Claude Côté*
+
 *   Deprecate `rails notes` subcommands in favor of passing an `annotations` argument to `rails notes`.
 
     The following subcommands are replaced by passing `--annotations` or `-a` to `rails notes`:

--- a/railties/lib/rails/commands/dev/dev_command.rb
+++ b/railties/lib/rails/commands/dev/dev_command.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails/dev_caching"
+
+module Rails
+  module Command
+    class DevCommand < Base # :nodoc:
+      desc "Toggle development mode caching on/off"
+      def cache
+        Rails::DevCaching.enable_by_file
+      end
+    end
+  end
+end

--- a/railties/lib/rails/tasks/dev.rake
+++ b/railties/lib/rails/tasks/dev.rake
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-require "rails/dev_caching"
+require "rails/command"
+require "active_support/deprecation"
 
 namespace :dev do
   desc "Toggle development mode caching on/off"
   task :cache do
-    Rails::DevCaching.enable_by_file
+    ActiveSupport::Deprecation.warn("Using `bin/rake dev:cache` is deprecated and will be removed in Rails 6.1. Use `bin/rails dev:cache` instead.\n")
+    Rails::Command.invoke "dev:cache"
   end
 end

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -17,33 +17,46 @@ module ApplicationTests
 
       test "dev:cache creates file and outputs message" do
         Dir.chdir(app_path) do
-          output = rails("dev:cache")
-          assert File.exist?("tmp/caching-dev.txt")
-          assert_match(/Development mode is now being cached/, output)
+          stderr = capture(:stderr) do
+            output = run_rake_dev_cache
+            assert File.exist?("tmp/caching-dev.txt")
+            assert_match(/Development mode is now being cached/, output)
+          end
+          assert_match(/DEPRECATION WARNING: Using `bin\/rake dev:cache` is deprecated and will be removed in Rails 6.1/, stderr)
         end
       end
 
       test "dev:cache deletes file and outputs message" do
         Dir.chdir(app_path) do
-          rails "dev:cache" # Create caching file.
-          output = rails("dev:cache") # Delete caching file.
-          assert_not File.exist?("tmp/caching-dev.txt")
-          assert_match(/Development mode is no longer being cached/, output)
+          stderr = capture(:stderr) do
+            run_rake_dev_cache # Create caching file.
+            output = run_rake_dev_cache # Delete caching file.
+            assert_not File.exist?("tmp/caching-dev.txt")
+            assert_match(/Development mode is no longer being cached/, output)
+          end
+          assert_match(/DEPRECATION WARNING: Using `bin\/rake dev:cache` is deprecated and will be removed in Rails 6.1/, stderr)
         end
       end
 
       test "dev:cache touches tmp/restart.txt" do
         Dir.chdir(app_path) do
-          rails "dev:cache"
-          assert File.exist?("tmp/restart.txt")
+          stderr = capture(:stderr) do
+            run_rake_dev_cache
+            assert File.exist?("tmp/restart.txt")
 
-          prev_mtime = File.mtime("tmp/restart.txt")
-          sleep(1)
-          rails "dev:cache"
-          curr_mtime = File.mtime("tmp/restart.txt")
-          assert_not_equal prev_mtime, curr_mtime
+            prev_mtime = File.mtime("tmp/restart.txt")
+            run_rake_dev_cache
+            curr_mtime = File.mtime("tmp/restart.txt")
+            assert_not_equal prev_mtime, curr_mtime
+          end
+          assert_match(/DEPRECATION WARNING: Using `bin\/rake dev:cache` is deprecated and will be removed in Rails 6.1/, stderr)
         end
       end
+
+      private
+        def run_rake_dev_cache
+          `bin/rake dev:cache`
+        end
     end
   end
 end

--- a/railties/test/commands/dev_test.rb
+++ b/railties/test/commands/dev_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::DevTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  test "`rails dev:cache` creates both caching and restart file when restart file doesn't exist and dev caching is currently off" do
+    Dir.chdir(app_path) do
+      assert_not File.exist?("tmp/caching-dev.txt")
+      assert_not File.exist?("tmp/restart.txt")
+
+      assert_equal <<~OUTPUT, run_dev_cache_command
+        Development mode is now being cached.
+      OUTPUT
+
+      assert File.exist?("tmp/caching-dev.txt")
+      assert File.exist?("tmp/restart.txt")
+    end
+  end
+
+  test "`rails dev:cache` creates caching file and touches restart file when dev caching is currently off" do
+    Dir.chdir(app_path) do
+      app_file("tmp/restart.txt", "")
+
+      assert_not File.exist?("tmp/caching-dev.txt")
+      assert File.exist?("tmp/restart.txt")
+      restart_file_time_before = File.mtime("tmp/restart.txt")
+
+      assert_equal <<~OUTPUT, run_dev_cache_command
+        Development mode is now being cached.
+      OUTPUT
+
+      assert File.exist?("tmp/caching-dev.txt")
+      restart_file_time_after = File.mtime("tmp/restart.txt")
+      assert_operator restart_file_time_before, :<, restart_file_time_after
+    end
+  end
+
+  test "`rails dev:cache` removes caching file and touches restart file when dev caching is currently on" do
+    Dir.chdir(app_path) do
+      app_file("tmp/caching-dev.txt", "")
+      app_file("tmp/restart.txt", "")
+
+      assert File.exist?("tmp/caching-dev.txt")
+      assert File.exist?("tmp/restart.txt")
+      restart_file_time_before = File.mtime("tmp/restart.txt")
+
+      assert_equal <<~OUTPUT, run_dev_cache_command
+        Development mode is no longer being cached.
+      OUTPUT
+
+      assert_not File.exist?("tmp/caching-dev.txt")
+      restart_file_time_after = File.mtime("tmp/restart.txt")
+      assert_operator restart_file_time_before, :<, restart_file_time_after
+    end
+  end
+
+  private
+    def run_dev_cache_command
+      rails "dev:cache"
+    end
+end


### PR DESCRIPTION
This PR:
1. Moves the `dev:cache` rake task to be using `Rails::Command` instead without changing the API
2. It adds deprecation around calling that command with `rake` instead of `rails` 