### PR TITLE
restrict the version of i18n 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ PATH
       marcel (~> 0.3.1)
     activesupport (6.0.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
+      i18n (>= 0.7, < 1.1)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (6.0.0.alpha)
@@ -578,4 +578,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
   }
 
-  s.add_dependency "i18n",       ">= 0.7", "< 2"
+  s.add_dependency "i18n",       ">= 0.7", "< 1.1"
   s.add_dependency "tzinfo",     "~> 1.1"
   s.add_dependency "minitest",   "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"


### PR DESCRIPTION
Some of the tests in `test/application/initializers/i18n_test.rb` have started failing since i18n 1.1.0 was released.

This is because the tests are checking the  `I18n.fallbacks` which no longer include the the default locale since svenfuchs/i18n#415. 

I think that this change is sensible, but we need to ensure a smooth upgrade path for rails applications.

This PR locks the i18n version to to `1.0.X` so that the tests pass again. 

Further investigation is required not how this change affects rails applications and the best approach to move forward with i18n 1.1.0