### PR TITLE
ActiveRecord Guide - sqlite3 foreign keys note

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -491,6 +491,10 @@ NOTE: Active Record only supports single column foreign keys. `execute` and
 `structure.sql` are required to use composite foreign keys. See
 [Schema Dumping and You](#schema-dumping-and-you).
 
+NOTE: At this time, only the mysql, mysql2 and postgresql adapters support
+foreign keys. Implementation for sqlite3 is partial, keys are created for new
+tables but not for existing tables via `ALTER TABLE` statement.
+
 Removing a foreign key is easy as well:
 
 ```ruby


### PR DESCRIPTION
I was really surprised about the state of sqlite3 foreign keys. From the
release notes of Rails 4.2:

_The migration DSL now supports adding and removing foreign keys. They are
dumped to schema.rb as well. At this time, only the mysql, mysql2 and
postgresql adapters support foreign keys._

Therefore I am adding a warning into the ActiveRecord Guide so others are not confused by this:

NOTE: At this time, only the mysql, mysql2 and postgresql adapters support
foreign keys. Implementation for sqlite3 is partial, keys are created for new
tables but not for existing tables via `ALTER TABLE` statement.


There is additional discussion about this topic currently at:

https://github.com/rails/rails/issues/33520