### PR TITLE
Avoid i18n 1.1.0 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "dalli"
 gem "listen", ">= 3.0.5", "< 3.2", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
+gem "i18n", "~> 1.0.1"
 
 # for railties app_generator_test
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,7 @@ DEPENDENCIES
   ffi (<= 1.9.21)
   google-cloud-storage (~> 1.11)
   hiredis
+  i18n (~> 1.0.1)
   image_processing (~> 1.2)
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)


### PR DESCRIPTION
### Summary

This pull request workarounds railties CI failure at https://travis-ci.org/rails/rails/jobs/413582591
It is triggered by using i18n 1.1.0 just released Aug 7 https://rubygems.org/gems/i18n/versions/1.1.0

Will open an issue to i18n soon.

### Steps to reproduce

```ruby
$ cd railties
$ bundle update i18n
$ bundle exec ruby -w -Itest test/application/initializers/i18n_test.rb
```

### Actual result

```ruby
$ cd railties
$ bundle update i18n
$ bundle exec ruby -w -Itest test/application/initializers/i18n_test.rb
Run options: --seed 16202

# Running:

.......F

Failure:
ApplicationTests::I18nTest#test_config.i18n.fallbacks_=_true_initializes_I18n.fallbacks_with_default_settings [test/application/initializers/i18n_test.rb:220]:
expected fallbacks for :de to be [:de, :en], but were [:de].
Expected: [:de, :en]
  Actual: [:de]


rails test test/application/initializers/i18n_test.rb:216

..F

Failure:
ApplicationTests::I18nTest#test_config.i18n.fallbacks.map_=_{_:ca_=>_:'es-ES'_}_initializes_fallbacks_with_a_mapping_ca_=>_es-ES [test/application/initializers/i18n_test.rb:240]:
expected fallbacks for :ca to be [:ca, :"es-ES", :es, :en], but were [:ca, :"es-ES", :es].
Expected: [:ca, :"es-ES", :es, :en]
  Actual: [:ca, :"es-ES", :es]


rails test test/application/initializers/i18n_test.rb:237

F

Failure:
ApplicationTests::I18nTest#test_config.i18n.fallbacks_=_true_initializes_I18n.fallbacks_with_default_settings_even_when_backend_changes [test/application/initializers/i18n_test.rb:228]:
expected fallbacks for :de to be [:de, :en], but were [:de].
Expected: [:de, :en]
  Actual: [:de]


rails test test/application/initializers/i18n_test.rb:223

...F

Failure:
ApplicationTests::I18nTest#test_[shortcut]_config.i18n.fallbacks_=_[{_:ca_=>_:'es-ES'_}]_initializes_fallbacks_with_a_mapping_ca_=>_es-ES [test/application/initializers/i18n_test.rb:252]:
expected fallbacks for :ca to be [:ca, :"es-ES", :es, :en], but were [:ca, :"es-ES", :es].
Expected: [:ca, :"es-ES", :es, :en]
  Actual: [:ca, :"es-ES", :es]


rails test test/application/initializers/i18n_test.rb:249

..

Finished in 6.690818s, 2.6903 runs/s, 5.0816 assertions/s.
18 runs, 34 assertions, 4 failures, 0 errors, 0 skips
$
```