### PR TITLE
URI.unescape handles mixed Unicode/escaped input

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+
+*   Fix bug where `URI.unscape` would fail with mixed Unicode/escaped character input:
+
+        URI.unescape("\xe3\x83\x90")  # => "バ"
+        URI.unescape("%E3%83%90")  # => "バ"
+        URI.unescape("\xe3\x83\x90%E3%83%90")  # => Encoding::CompatibilityError
+
+    GH#32183
+
+    *Ashe Connor*, *Aaron Patterson*
+
 ## Rails 5.2.1 (August 07, 2018) ##
 
 *   Redis cache store: `delete_matched` no longer blocks the Redis server.

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -10,7 +10,7 @@ if RUBY_VERSION < "2.6.0"
       # YK: My initial experiments say yes, but let's be sure please
       enc = str.encoding
       enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
-      str.gsub(escaped) { |match| [match[1, 2].hex].pack("C") }.force_encoding(enc)
+      str.dup.force_encoding(Encoding::ASCII_8BIT).gsub(escaped) { |match| [match[1, 2].hex].pack("C") }.force_encoding(enc)
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -9,6 +9,6 @@ class URIExtTest < ActiveSupport::TestCase
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 
     parser = URI.parser
-    assert_equal str, parser.unescape(parser.escape(str))
+    assert_equal str + str, parser.unescape(str + parser.escape(str).encode(Encoding::UTF_8))
   end
 end


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails/pull/32183 to 5-2-stable.

/cc @eileencodes 

Is this the right way to do backports? I cherry-picked the commit we need in Rails 5.2, should I have grabbed the merge commit instead?