### PR TITLE
perform_or_enqueue instead of enqueue_or_perform

### DIFF
--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -29,14 +29,14 @@ module ActiveJob
         return if filtered?(job)
 
         job_data = job_to_hash(job)
-        enqueue_or_perform(perform_enqueued_jobs, job, job_data)
+        perform_or_enqueue(perform_enqueued_jobs, job, job_data)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
         return if filtered?(job)
 
         job_data = job_to_hash(job, at: timestamp)
-        enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
+        perform_or_enqueue(perform_enqueued_at_jobs, job, job_data)
       end
 
       private
@@ -44,7 +44,7 @@ module ActiveJob
           { job: job.class, args: job.serialize.fetch("arguments"), queue: job.queue_name }.merge!(extras)
         end
 
-        def enqueue_or_perform(perform, job, job_data)
+        def perform_or_enqueue(perform, job, job_data)
           if perform
             performed_jobs << job_data
             Base.execute job.serialize


### PR DESCRIPTION
### Summary

The first operation that `enqueue_or_perform` method looks to carry out is performing the job; and when perform is false, it enqueues it. 

https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/activejob/lib/active_job/queue_adapters/test_adapter.rb#L47-L54

Hence the method should be called `perform_or_enqueue` instead of `enqueue_or_perform`.
