### PR TITLE
Conditionally use `helper_method` in Flash concern

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -33,10 +33,12 @@ module ActionController #:nodoc:
         types.each do |type|
           next if _flash_types.include?(type)
 
-          define_method(type) do
-            request.flash[type]
+          if respond_to? :helper_method
+            define_method(type) do
+              request.flash[type]
+            end
+            helper_method type
           end
-          helper_method type
 
           self._flash_types += [type]
         end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -342,6 +342,14 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_flash_usable_in_metal_without_helper
+    assert_nothing_raised do
+      Class.new ActionController::Metal do
+        include ActionController::Flash
+      end
+    end
+  end
+
   private
 
     # Overwrite get to send SessionSecret in env hash


### PR DESCRIPTION
I was attempting to use the `flash` functionality in a `Metal` controller. When including the `flash` concern I received the following error:

    NoMethodError: undefined method `helper_method'....

Either:

- `AbstractController::Helpers` should be a dependency of `ActionController::Flash`
- `ActionController::Flash` should not require the existence of `AbstractController::Helpers`.

Since my use case (set a flash and redirect) has no need for the helper method and that is a common use case, making the dependency conditional seemed the better option.

NOTE: This is similar to issue #21067 only the error is within Rails itself while that issue had the error within Devise.