### PR TITLE
update I18n fallbacks configuration to be compatible with i18n 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem "dalli"
 gem "listen", ">= 3.0.5", "< 3.2", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
-gem "i18n", "~> 1.0.1"
 
 # for railties app_generator_test
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
     hiredis (0.6.1-java)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.6.0)
       mini_magick (~> 4.0)
@@ -531,7 +531,6 @@ DEPENDENCIES
   ffi (<= 1.9.21)
   google-cloud-storage (~> 1.11)
   hiredis
-  i18n (~> 1.0.1)
   image_processing (~> 1.2)
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -87,8 +87,20 @@ module I18n
         when Hash, Array
           Array.wrap(fallbacks)
         else # TrueClass
-          []
+          [I18n.default_locale]
         end
+
+      if args.empty? || args.first.is_a?(Hash)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Using I18n fallbacks with an empty `defaults` sets the defaults to
+          include the `default_locale`. This behavior will change in Rails 6.1.
+          If you desire the default local to be included in the defaults, please
+          explicitly configure it with `config.i18n.fallbacks.defaults =
+          [I18n.default_locale]` or `config.i18n.fallbacks = [I18n.default_locale,
+          {...}]`
+        MSG
+        args.unshift I18n.default_locale
+      end
 
       I18n.fallbacks = I18n::Locale::Fallbacks.new(*args)
     end


### PR DESCRIPTION
In I18n 1.1.0, there was a change to no longer include the default locale as a default fallback.

As a result, this broke the tests for Rails, and in #33566 we avoided using it in order to get the tests to pass again.

This PR attempt to provide a permanent solution for compatibility with I18n 1.1.0.

When `config.i18n.fallbacks = true` Rails would set the fallback defaults to `[]` relying on I18n to add the default locale into the fallbacks. As I18n no longer does this, Rails will now explicitly set the fallback defaults to the current locale.

Where `config.i18n.fallbacks` is a Hash or `config.i18n.fallbacks.map` is set, I18n would also be setting the default to the current locale, but that was not documented as part of Rails, and may have been unexpected behaviour. I have maintained this behaviour by explicitly adding in the current locale to the defaults, and added a depreciation message so that it can be removed in the future.

In the case were no fallbacks were configured Rails would not include the Fallbacks module in the backend, so it appears to behave correctly across both versions of i18n.

 

