### PR TITLE
Use strings instead of symbols on calls to decorate_matching_attribute_types

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -73,7 +73,7 @@ module ActiveRecord
             # `skip_time_zone_conversion_for_attributes` would not be picked up.
             subclass.class_eval do
               matcher = ->(name, type) { create_time_zone_conversion_attribute?(name, type) }
-              decorate_matching_attribute_types(matcher, :_time_zone_conversion) do |type|
+              decorate_matching_attribute_types(matcher, "_time_zone_conversion") do |type|
                 TimeZoneConverter.new(type)
               end
             end

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -165,7 +165,7 @@ module ActiveRecord
             def inherited(subclass)
               subclass.class_eval do
                 is_lock_column = ->(name, _) { lock_optimistically && name == locking_column }
-                decorate_matching_attribute_types(is_lock_column, :_optimistic_locking) do |type|
+                decorate_matching_attribute_types(is_lock_column, "_optimistic_locking") do |type|
                   LockingType.new(type)
                 end
               end


### PR DESCRIPTION
### Summary

The first thing this method does is run `to_s` on the argument. This change passes
in a string so we don't allocate a bunch of unnecessary extra strings by
calling to_s on a symbol over and over.
