### PR TITLE
Clarify new_framework_defaults instructions.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -1,12 +1,8 @@
 # Be sure to restart your server when you modify this file.
 #
 # This file contains explicit, new configuration defaults to ease your Rails 6.0
-# upgrade.
-#
-# After upgrading Rails, uncomment each of these new defaults one at a time and
-# test your application. Once you have uncommented all of the new configuration
-# defaults, you can set `config.load_defaults` to `6.0` in
-# `config/application.rb` and delete this file.
+# upgrade. After upgrading Rails, uncomment each of these new defaults one at a
+# time and test your application.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -1,8 +1,12 @@
 # Be sure to restart your server when you modify this file.
 #
-# This file contains migration options to ease your Rails 6.0 upgrade.
+# This file contains explicit, new configuration defaults to ease your Rails 6.0
+# upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
+# After upgrading Rails, uncomment each of these new defaults one at a time and
+# test your application. If you accept all of the new configuration defaults,
+# you may update the argument to `config.load_defaults` in config/application.rb
+# and delete this file.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -4,9 +4,9 @@
 # upgrade.
 #
 # After upgrading Rails, uncomment each of these new defaults one at a time and
-# test your application. If you accept all of the new configuration defaults,
-# you may update the argument to `config.load_defaults` in config/application.rb
-# and delete this file.
+# test your application. Once you have uncommented all of the new configuration
+# defaults, you can set `config.load_defaults` to `6.0` in
+# `config/application.rb` and delete this file.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 


### PR DESCRIPTION
The instructions for using new_framework_defaults is confusing, primarily
due to the word 'flip', which implies changing a boolean value. This isn't
how the new_framework_defaults is to be used. Instead, users are expected
to _uncomment_ each new default and try each out, one at a time.

Clarify the instructions to match the intended use of new_framework_defaults.
