### PR TITLE
SQLite3 adapter `alter_table` method restores foreign keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   SQLite3 adapter `alter_table` method restores foreign keys.
+
+    *Yasuo Honda*
+
 *   Add environment & load_config dependency to `bin/rake db:seed` to enable
     seed load in environments without Rails and custom DB configuration
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -64,6 +64,19 @@ if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
           assert_equal "astronauts", fk.from_table
           assert_equal "rockets", fk.to_table
         end
+
+        def test_rename_column_of_child_table
+          rocket = Rocket.create!(name: "myrocket")
+          rocket.astronauts << Astronaut.create!
+
+          @connection.rename_column :astronauts, :name, :astronaut_name
+
+          foreign_keys = ActiveRecord::Base.connection.foreign_keys("astronauts")
+          fk = foreign_keys.first
+          assert_equal "myrocket", Rocket.first.name
+          assert_equal "astronauts", fk.from_table
+          assert_equal "rockets", fk.to_table
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

SQLite3 adapter `alter_table` method restores foreign keys. 

Rails 6 supports SQLite database 3.8 or higher which allows executing `alter_table` method for foreign key referenced - "parent" tables. This pull request enables `alter_table` method for foreign keys referencing - "child" tables. 

Related to #33520, this pull request does not support renaming columns for foreign keys.
