### PR TITLE
Make active job name prefix static since Rails.env will always be the same

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "<%= app_name %>_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "<%= app_name %>_production"
 
   <%- unless options.skip_action_mailer? -%>
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
This PR addresses #33583.

Makes active job queue name prefix static since Rails.env will always return production.