### PR TITLE
`bundle binstubs bundler` should be executed after `bundle install`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -298,8 +298,6 @@ module Rails
         build(:bin)
       end
 
-      public_task :generate_bundler_binstub
-
       def update_bin_files
         build(:bin_when_updating)
       end
@@ -471,7 +469,8 @@ module Rails
       end
 
       public_task :apply_rails_template, :run_bundle
-      public_task :run_webpack, :generate_spring_binstubs
+      public_task :generate_bundler_binstub, :generate_spring_binstubs
+      public_task :run_webpack
 
       def run_after_bundle_callbacks
         @after_bundle_callbacks.each(&:call)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -972,7 +972,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       template
     end
 
-    sequence = ["git init", "binstubs bundler", "install", "exec spring binstub --all", "echo ran after_bundle"]
+    sequence = ["git init", "install", "binstubs bundler", "exec spring binstub --all", "echo ran after_bundle"]
     @sequence_step ||= 0
     ensure_bundler_first = -> command, options = nil do
       assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"


### PR DESCRIPTION
Fixes:

`bundle binstubs bundler` doesn't generate `bin/bundle` for newly
generated Rails app.

```
...
(snip)
run  bundle binstubs bundler
The git source https://github.com/rails/web-console.git is not yet checked out.
Please run `bundle install` before trying to start your application
run  bundle install
Fetching https://github.com/rails/web-console.git
(snip)
...
```

Related to #33202

/cc @deivid-rodriguez, @eileencodes 