### PR TITLE
Fix test failure

### DIFF
--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -142,7 +142,7 @@ class JsonSerializationTest < ActiveModel::TestCase
       assert_kind_of Hash, json
       assert_kind_of Hash, json["contact"]
       %w(name age created_at awesome preferences).each do |field|
-        assert_equal @contact.send(field), json["contact"][field]
+        assert_equal @contact.send(field).as_json, json["contact"][field]
       end
     ensure
       Contact.include_root_in_json = original_include_root_in_json


### PR DESCRIPTION
```
...
(snip)
............F
Failure:
JsonSerializationTest#test_as_json_should_return_a_hash_if_include_root_
in_json_is_true [/home/travis/build/rails/rails/activemodel/test/cases/serializers/json_serialization_test.rb:145]:
Expected: 2006-08-01 00:00:00 UTC
  Actual: "2006-08-01T00:00:00.000Z"
rails test home/travis/build/rails/rails/activemodel/test/cases/serializers/json_serialization_test.rb:136
(snip)
...
```

Related to #31503

/cc @bogdan, @eileencodes 