### PR TITLE
Update coffeelint to 2.1.0

### DIFF
--- a/actionview/package.json
+++ b/actionview/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "http://rubyonrails.org/",
   "devDependencies": {
-    "coffeelint": "^1.15.7",
+    "coffeelint": "^2.1.0",
     "eslint": "^2.13.1"
   }
 }


### PR DESCRIPTION
There was a warning when running `npm install` in Action View:

    coffee-script@1.11.1: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)

We are not requiring `coffee-script` explicitly, but `coffeelint` does. The latest version, 2.1.0, already fix the dependency package name, so we should upgrade to it to suppress the warning.