### PR TITLE
Changelog and improved tests for purpose metadata added to cookies

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Purpose metadata for signed/encrypted cookies.
+
+    Rails can now thwart attacks that attempt to copy signed/encrypted value
+    of a cookie and use it as the value of another cookie.
+
+    It does so by stashing the cookie-name in the purpose field which is
+    then signed/encrypted along with the cookie value. Then, on a server-side
+    read, we verify the cookie-names and discard any attacked cookies.
+
+    Enable `action_dispatch.use_cookies_with_metadata` to use this feature, which
+    writes cookies with the new purpose and expiry metadata embedded.
+
+    Pull Request: #32937
+
+    *Assain Jaleel*
+
 *   Raises `ActionController::RespondToMismatchError` with confliciting `respond_to` invocations.
 
     `respond_to` can match multiple types and lead to undefined behavior when

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1405,8 +1405,7 @@ class CookiesTest < ActionController::TestCase
 
     assert_equal "5-2-Stable Chocolate Cookies", cookies.encrypted[:favorite]
 
-    freeze_time do
-      travel 1001.years
+    travel 1001.years do
       assert_nil cookies.encrypted[:favorite]
     end
 
@@ -1422,8 +1421,7 @@ class CookiesTest < ActionController::TestCase
 
     assert_equal "5-2-Stable Choco Chip Cookie", cookies.signed[:favorite]
 
-    freeze_time do
-      travel 1001.years
+    travel 1001.years do
       assert_nil cookies.signed[:favorite]
     end
 
@@ -1439,8 +1437,7 @@ class CookiesTest < ActionController::TestCase
 
     assert_equal "5-2-Stable Chocolate Cookies", cookies.encrypted[:favorite]
 
-    freeze_time do
-      travel 1001.years
+    travel 1001.years do
       assert_nil cookies.encrypted[:favorite]
     end
 
@@ -1456,8 +1453,7 @@ class CookiesTest < ActionController::TestCase
 
     assert_equal "5-2-Stable Choco Chip Cookie", cookies.signed[:favorite]
 
-    freeze_time do
-      travel 1001.years
+    travel 1001.years do
       assert_nil cookies.signed[:favorite]
     end
 


### PR DESCRIPTION
This pull request adds the changelog for the new purpose metadata added to signed/encrypted cookies and also improves some tests.