### PR TITLE
Active Storage: JS example: HTML encode file name

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -518,10 +518,11 @@ To show the uploaded files in a form:
 addEventListener("direct-upload:initialize", event => {
   const { target, detail } = event
   const { id, file } = detail
+  var fileName = $('<span />').text(file.name).html();
   target.insertAdjacentHTML("beforebegin", `
     <div id="direct-upload-${id}" class="direct-upload direct-upload--pending">
       <div id="direct-upload-progress-${id}" class="direct-upload__progress" style="width: 0%"></div>
-      <span class="direct-upload__filename">${file.name}</span>
+      <span class="direct-upload__filename">${fileName}</span>
     </div>
   `)
 })


### PR DESCRIPTION
Need to HTML encode file name otherwise it allows injecting HTML/CSS and obviously breaks displayed file name.

For example file with name `<b>bold.txt` will be in bold.
Another good example to try is file named `<style>*{visibility:hidden;background-color:red}.txt`

This PRs downside is that it needs jQuery but implementing it without jQuery doesn't seem trivial.
