### PR TITLE
Use utf8mb4 character set by default for MySQL database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,14 @@ addons:
     sources:
       - sourceline: "ppa:mc3man/trusty-media"
       - sourceline: "ppa:ubuntuhandbook1/apps"
+      - mysql-5.7-trusty
     packages:
       - ffmpeg
       - mupdf
       - mupdf-tools
       - poppler-utils
+      - mysql-server
+      - mysql-client
 
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
@@ -37,6 +40,9 @@ before_install:
   - "[[ $GEM != 'av:ujs' ]] || nvm install node"
   - "[[ $GEM != 'av:ujs' ]] || node --version"
   - "[[ $GEM != 'av:ujs' ]] || (cd actionview && npm install)"
+  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
+  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo mysql_upgrade"
+  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo service mysql restart"
 
 before_script:
   # Set Sauce Labs username and access key. Obfuscated, purposefully not encrypted.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -5,10 +5,6 @@
 
     *Yasuo Honda*
 
-*   Bump minimum MySQL version to 5.7.9.
-
-    *Yasuo Honda*
-
 *   Fix duplicated record creation when using nested attributes with `create_with`.
 
     *Darwin Wu*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use MySQL utf8mb4 character set by default.
+
+    `utf8mb4` character set with 4-Byte encoding supports supplementary characters including emoji.
+    The previous default 3-Byte encoding character set `utf8` is not enough to support them.
+
+    *Yasuo Honda*
+
 *   Bump minimum MySQL version to 5.7.9.
 
     *Yasuo Honda*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump minimum MySQL version to 5.7.9.
+
+    *Yasuo Honda*
+
 *   Fix duplicated record creation when using nested attributes with `create_with`.
 
     *Darwin Wu*

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -94,8 +94,8 @@ namespace :db do
     desc "Build the MySQL test databases"
     task :build do
       config = ARTest.config["connections"]["mysql2"]
-      %x( mysql --user=#{config["arunit"]["username"]} --password=#{config["arunit"]["password"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
-      %x( mysql --user=#{config["arunit2"]["username"]} --password=#{config["arunit2"]["password"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
+      %x( mysql --user=#{config["arunit"]["username"]} --password=#{config["arunit"]["password"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql --user=#{config["arunit2"]["username"]} --password=#{config["arunit2"]["password"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
     end
 
     desc "Drop the MySQL test databases"

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -53,8 +53,10 @@ module ActiveRecord
 
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
-        if version < "5.1.10"
-          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.1.10."
+        if version < "5.7.9"
+          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.7.9."
+        elsif mariadb? && version < "10.2.2"
+          raise "Your version of MariaDB (#{version_string}) is too old. Active Record supports MariaDB >= 10.2.2"
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -243,7 +243,7 @@ module ActiveRecord
       end
 
       # Create a new MySQL database with optional <tt>:charset</tt> and <tt>:collation</tt>.
-      # Charset defaults to utf8.
+      # Charset defaults to utf8mb4.
       #
       # Example:
       #   create_database 'charset_test', charset: 'latin1', collation: 'latin1_bin'
@@ -253,7 +253,7 @@ module ActiveRecord
         if options[:collation]
           execute "CREATE DATABASE #{quote_table_name(name)} DEFAULT COLLATE #{quote_table_name(options[:collation])}"
         else
-          execute "CREATE DATABASE #{quote_table_name(name)} DEFAULT CHARACTER SET #{quote_table_name(options[:charset] || 'utf8')}"
+          execute "CREATE DATABASE #{quote_table_name(name)} DEFAULT CHARACTER SET #{quote_table_name(options[:charset] || 'utf8mb4')}"
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -53,10 +53,8 @@ module ActiveRecord
 
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
-        if version < "5.7.9"
-          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.7.9."
-        elsif mariadb? && version < "10.2.2"
-          raise "Your version of MariaDB (#{version_string}) is too old. Active Record supports MariaDB >= 10.2.2"
+        if version < "5.1.10"
+          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.1.10."
         end
       end
 

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -106,7 +106,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_create_mysql_database_with_encoding
-    assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8`", create_database(:matt)
+    assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8mb4`", create_database(:matt)
     assert_equal "CREATE DATABASE `aimonetti` DEFAULT CHARACTER SET `latin1`", create_database(:aimonetti, charset: "latin1")
     assert_equal "CREATE DATABASE `matt_aimonetti` DEFAULT COLLATE `utf8mb4_bin`", create_database(:matt_aimonetti, collation: "utf8mb4_bin")
   end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -104,8 +104,8 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_mysql_connection_collation_is_configured
-    assert_equal "utf8_unicode_ci", @connection.show_variable("collation_connection")
-    assert_equal "utf8_general_ci", ARUnit2Model.connection.show_variable("collation_connection")
+    assert_equal "utf8mb4_unicode_ci", @connection.show_variable("collation_connection")
+    assert_equal "utf8mb4_general_ci", ARUnit2Model.connection.show_variable("collation_connection")
   end
 
   def test_mysql_default_in_strict_mode

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -54,11 +54,11 @@ connections:
   mysql2:
     arunit:
       username: rails
-      encoding: utf8
-      collation: utf8_unicode_ci
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
     arunit2:
       username: rails
-      encoding: utf8
+      encoding: utf8mb4
 
   oracle:
      arunit:

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define do
     t.index :var_binary
   end
 
-  create_table :key_tests, force: true, options: "ENGINE=MyISAM" do |t|
+  create_table :key_tests, force: true do |t|
     t.string :awesome
     t.string :pizza
     t.string :snacks

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.1.10 and up are supported.
+# MySQL. Versions 5.7.9 and up are supported.
 #
 # Install the MySQL driver:
 #   gem install activerecord-jdbcmysql-adapter

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.7.9 and up are supported.
+# MySQL. Versions 5.1.10 and up are supported.
 #
 # Install the MySQL driver:
 #   gem install activerecord-jdbcmysql-adapter

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -11,7 +11,7 @@
 #
 default: &default
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.1.10 and up are supported.
+# MySQL. Versions 5.7.9 and up are supported.
 #
 # Install the MySQL driver
 #   gem install mysql2

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.7.9 and up are supported.
+# MySQL. Versions 5.1.10 and up are supported.
 #
 # Install the MySQL driver
 #   gem install mysql2


### PR DESCRIPTION
### Summary

This pull request implements #33596. It includes these changes:

* Replace `utf8` character set with `utf8mb4` to support supplementary characters including emoji
* Removed `utf8_unicode_ci` collation from Active Record unit test databases to let MySQL server use the default collation for the character set
* Bump the minimum version of MySQL to 5.7.9 and MariaDB to 10.2.2 to support `utf8mb4` character set and 3072 bytes key length with InnoDB
*  Addressed `Specified key was too long; max key length is 1000 bytes` for MyISAM table in the test by using InnoDB storage engine
* CI against MySQL 5.7