### PR TITLE
`ActiveModel.full_message` interaction with `index_errors`

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -413,7 +413,7 @@ module ActiveModel
       defaults << "%{attribute} %{message}"
 
       attr_name = attribute.tr(".", "_").humanize
-      attr_name = @base.class.human_attribute_name(attribute.to_sym, default: attr_name)
+      attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
 
       I18n.t(defaults.shift,
         default:  defaults,

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -379,9 +379,11 @@ module ActiveModel
     # * <tt>errors.format</tt>
     def full_message(attribute, message)
       return message if attribute == :base
+      attribute = attribute.to_s
 
       if self.class.i18n_full_message && @base.class.respond_to?(:i18n_scope)
-        parts = attribute.to_s.split(".")
+        attribute = attribute.remove(/\[\d\]/)
+        parts = attribute.split(".")
         attribute_name = parts.pop
         namespace = parts.join("/") unless parts.empty?
         attributes_scope = "#{@base.class.i18n_scope}.errors.models"
@@ -410,8 +412,9 @@ module ActiveModel
       defaults << :"errors.format"
       defaults << "%{attribute} %{message}"
 
-      attr_name = attribute.to_s.tr(".", "_").humanize
-      attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
+      attr_name = attribute.tr(".", "_").humanize
+      attr_name = @base.class.human_attribute_name(attribute.to_sym, default: attr_name)
+
       I18n.t(defaults.shift,
         default:  defaults,
         attribute: attr_name,

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -101,6 +101,63 @@ class I18nValidationTest < ActiveModel::TestCase
     assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.country', "cannot be blank")
   end
 
+  def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_attributes_format
+    ActiveModel::Errors.i18n_full_message = true
+
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Contacts/addresses country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_model_format
+    ActiveModel::Errors.i18n_full_message = true
+
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { format: "%{message}" } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_i18n_attribute_name
+    ActiveModel::Errors.i18n_full_message = true
+
+    I18n.backend.store_translations("en", activemodel: {
+      attributes: { 'person/contacts/addresses': { country: "Country" } }
+    })
+
+    person = Person.new
+    assert_equal "Contacts/addresses street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_with_indexed_deeply_nested_attributes_without_i18n_config
+    ActiveModel::Errors.i18n_full_message = false
+
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "Contacts[0]/addresses[0] street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Contacts[0]/addresses[0] country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_with_i18n_attribute_name_without_i18n_config
+    ActiveModel::Errors.i18n_full_message = false
+
+    I18n.backend.store_translations("en", activemodel: {
+      attributes: { 'person/contacts[0]/addresses[0]': { country: "Country" } }
+    })
+
+    person = Person.new
+    assert_equal "Contacts[0]/addresses[0] street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+  end
+
   # ActiveModel::Validations
 
   # A set of common cases for ActiveModel::Validations message generation that

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -35,7 +35,7 @@ class I18nValidationTest < ActiveModel::TestCase
 
   def test_errors_full_messages_translates_human_attribute_name_for_model_attributes
     @person.errors.add(:name, "not found")
-    assert_called_with(Person, :human_attribute_name, [:name, default: "Name"], returns: "Person's name") do
+    assert_called_with(Person, :human_attribute_name, ["name", default: "Name"], returns: "Person's name") do
       assert_equal ["Person's name not found"], @person.errors.full_messages
     end
   end


### PR DESCRIPTION
### Summary

`ActiveModel.full_message` does not allow a custom i18n content when `index_errors: true` is used, as `[0]`, `[1]`, ..., `[n]` needs to be included in the i18n key

This affects the model and attribute `format` override as it's looking for a key with the Index as `activemodel.errors.models.person/contacts[0]/addresses[0].attributes.street.format` which would require n entries in the translations. 

The attribute humanization is also affected  as it sends the indexed key to `human_attribute_name` looking for the attribute at:
`activemodel.attributes.person/contacts[0]/addresses[0].street`
Which makes it impacticle to translate these attributes

Before this PR, the full message is generated as:
`Contacts[0]/addresses[0] country cannot be blank`

This PR allows to get:
`Country cannot be blank`

### Other Information

The behaviour is fully behind the `i18n_full_message` setting so by default apps are not affected. An alternative could be to move the `.remove(/\[\d\]/)` so all apps get the behaviour change of `human_attribute_name`. I'm putting under the config in case some apps rely on the `[0]` being in the error message