### PR TITLE
Improve handling of querying and loading data with ignored_columns

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -77,6 +77,7 @@ module ActiveRecord
       #
       # :nodoc:
       def instantiate_instance_of(klass, attributes, column_types = {}, &block)
+        attributes = attributes.reject { |key, _| klass.ignored_columns.include?(key) }
         attributes = klass.attributes_builder.build_from_database(attributes, column_types)
         klass.allocate.init_from_db(attributes, &block)
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1046,14 +1046,16 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        elsif klass.ignored_columns.any?
-          arel.project(*klass.column_names.map { |field| arel_attribute(field) })
         else
           arel.project(table[Arel.star])
         end
       end
 
       def arel_columns(columns)
+        if klass.ignored_columns.any?
+          columns.reject! { |field| klass.ignored_columns.include?(field.to_s) }
+        end
+
         columns.flat_map do |field|
           if (Symbol === field || String === field) && (klass.has_attribute?(field) || klass.attribute_alias?(field)) && !from_clause.value
             arel_attribute(field)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1443,8 +1443,8 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_respond_to developer, :first_name=
   end
 
-  test "ignored columns not included in SELECT" do
-    query = Developer.all.to_sql.downcase
+  test "ignored columns not included in explicit selects" do
+    query = Developer.select(:id, :name, :first_name, :last_name).all.to_sql.downcase
 
     # ignored column
     assert_not query.include?("first_name")
@@ -1455,10 +1455,16 @@ class BasicsTest < ActiveRecord::TestCase
 
   test "column names are quoted when using #from clause and model has ignored columns" do
     assert_not_empty Developer.ignored_columns
-    query = Developer.from("developers").to_sql
-    quoted_id = "#{Developer.quoted_table_name}.#{Developer.quoted_primary_key}"
+    query = Developer.select(:id, :name, :first_name, :last_name).from("developers").to_sql
+    id_key = Developer.connection.quote_column_name(:id)
+    name_key = Developer.connection.quote_column_name(:name)
 
-    assert_match(/SELECT #{Regexp.escape(quoted_id)}.* FROM developers/, query)
+    assert_match(/SELECT #{id_key}, #{name_key} FROM developers/, query)
+  end
+
+  test "star selector is used when no explicit selects provided and ignored columns exist" do
+    query = Developer.where(name: "Johnson").to_sql
+    assert_match(/SELECT #{Developer.quoted_table_name}\.\* FROM #{Developer.quoted_table_name}/, query)
   end
 
   test "using table name qualified column names unless having SELECT list explicitly" do


### PR DESCRIPTION
There are multiple situations that led to investigating how
`ignored_columns` works, how it interacts with querying and how to make
it better in more situations.

The first problem is that the use of `ignored_columns` in a class was
breaking migrations that ran after the removal of a column in that class
(a column that was not added to `ignored_columns`). This turned out to
be because when `ignored_columns` has entries, AR was exploding the full
list of known columns in the query (including the column that was just
removed , instead of letting `Arel.star` just return the database's known
list. While this is solvable by adding `reset_column_information` in the
migration between column removal and the failing code, this research led
to our next concern.

Our second concern is the performance effects of splatting out the full
column list for every query for a model with `ignored_columns` set. We
haven't done explicit performance testing but processing a list of
`arel_columns` is definitely slower than a simple `Arel.star`, and this
could easily add up for high traffic sites.

As such, we wanted to find a way to support `ignored_columns` properly,
including keeping the correct `reload` functionality, without resorting
to a full set of columns for every query.

This commit contains two changes to fix the above concerns.

* When a select set is explicitly given, remove the columns that are in
the `ignored_columns` list.
* When loading a record from the database, ignore the attributes that
are in the `ignored_columns` list.

/cc @eileencodes @tenderlove 