### PR TITLE
Follow up #33530

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow `:to_table` option to `invert_remove_foreign_key`.
+
+    Example:
+
+       remove_foreign_key :accounts, to_table: :owners
+
+    *Nikolay Epifanov*, *Rich Chen*
+
 *   Add environment & load_config dependency to `bin/rake db:seed` to enable
     seed load in environments without Rails and custom DB configuration
 
@@ -72,10 +80,6 @@
 *   Add `Relation#pick` as short-hand for single-value plucks.
 
     *DHH*
-
-*   Allow `to_table` in `invert_remove_foreign_key`.
-
-    *Nikolay Epifanov*, *Rich Chen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -980,9 +980,9 @@ module ActiveRecord
       #
       #   remove_foreign_key :accounts, column: :owner_id
       #
-      # Removes the foreign key on +accounts.owner_id+. in a reversible manner
+      # Removes the foreign key on +accounts.owner_id+.
       #
-      #   remove_foreign_key :accounts, column: :owner_id, to_table: :owners
+      #   remove_foreign_key :accounts, to_table: :owners
       #
       # Removes the foreign key named +special_fk_name+ on the +accounts+ table.
       #
@@ -991,7 +991,7 @@ module ActiveRecord
       # The +options+ hash accepts the same keys as SchemaStatements#add_foreign_key
       # with an addition of
       # [<tt>:to_table</tt>]
-      #   The table contains the referenced primary key.
+      #   The name of the table that contains the referenced primary key.
       def remove_foreign_key(from_table, options_or_to_table = {})
         return unless supports_foreign_keys?
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -329,6 +329,11 @@ module ActiveRecord
         assert_equal [:add_foreign_key, [:dogs, :people, primary_key: "person_id"]], enable
       end
 
+      def test_invert_remove_foreign_key_with_primary_key_and_to_table_in_options
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, to_table: :people, primary_key: "uuid"]
+        assert_equal [:add_foreign_key, [:dogs, :people, primary_key: "uuid"]], enable
+      end
+
       def test_invert_remove_foreign_key_with_on_delete_on_update
         enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, on_delete: :nullify, on_update: :cascade]
         assert_equal [:add_foreign_key, [:dogs, :people, on_delete: :nullify, on_update: :cascade]], enable


### PR DESCRIPTION
- Move changelog entry of #33530 up in order to preserve the chronology
  since we always add new entries on the top of a changelog file.
- Clarify the changelog entry
- Clarify the docs of remove_foreign_key
- Ensure reversible of `remove_foreign_key` with `:primary_key` and `:to_table`
  options.
