### PR TITLE
Fix bulk change table ignores comment option on PostgreSQL.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -700,6 +700,11 @@ module ActiveRecord
             sql
           end
 
+          def add_column_for_alter(table_name, column_name, type, options = {})
+            return super unless options.key?(:comment)
+            [super, Proc.new { change_column_comment(table_name, column_name, options[:comment]) }]
+          end
+
           def change_column_for_alter(table_name, column_name, type, options = {})
             sqls = [change_column_sql(table_name, column_name, type, options)]
             sqls << change_column_default_for_alter(table_name, column_name, options[:default]) if options.key?(:default)
@@ -707,7 +712,6 @@ module ActiveRecord
             sqls << Proc.new { change_column_comment(table_name, column_name, options[:comment]) } if options.key?(:comment)
             sqls
           end
-
 
           # Changes the default value of a table column.
           def change_column_default_for_alter(table_name, column_name, default_or_changes) # :nodoc:


### PR DESCRIPTION
```ruby
change_table :posts, bulk: true do |t|
  t.interger :foo, comment: "This comment is ignored in PostgreSQL"
end
```
In above example, comment option was ignored.

Closes #33598.
