### PR TITLE
require webpacker in test app

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -454,7 +454,7 @@ Module.new do
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.
   contents = File.read("#{app_template_path}/config/application.rb")
-  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks).each { |r| require r }")
+  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
   File.write("#{app_template_path}/config/application.rb", contents)
 
   require "rails"


### PR DESCRIPTION
The test application generated in `railties/test/isolation/abstract_unit.rb` has webpacker config added to the environment files by `rails webpacker:install`.

As a result, when you try to load up this app you get the error message `NoMethodError: undefined method `webpacker' for #<Rails::Application::Configuration:0x00007fce6b5525d0>` (this only occurs after you get past issues with the tests hanging as a result of a conflict in `app/javascipt/packs/application.js`).

This PR adds a require of `webpacker` in the test app so that the environment config files can be loaded.