### PR TITLE
Fix rubocop offenses

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -46,7 +46,7 @@ module ActionController #:nodoc:
   # allowed via {CORS}[https://en.wikipedia.org/wiki/Cross-origin_resource_sharing]
   # will also be able to create XHR requests. Be sure to check your
   # CORS whitelist before disabling forgery protection for XHR.
-  # 
+  #
   # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method.
   # By default <tt>protect_from_forgery</tt> protects your session with
   # <tt>:null_session</tt> method, which provides an empty session

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -105,7 +105,7 @@ namespace :changelog do
       current_contents = File.read(fname)
 
       header = "## Rails #{version} (#{Date.today.strftime('%B %d, %Y')}) ##\n\n"
-      header += "*   No changes.\n\n\n" if current_contents =~ /\A##/
+      header += "*   No changes.\n\n\n" if current_contents.start_with?("##")
       contents = header + current_contents
       File.write(fname, contents)
     end


### PR DESCRIPTION
- Layout/TrailingWhitespace

```
actionpack/lib/action_controller/metal/request_forgery_protection.rb:49:4:
C: Layout/TrailingWhitespace: Trailing whitespace detected.
  #
   ^
```

Related to c3787494eda

- Performance/StartWith

```
tasks/release.rb:108:44: C: Performance/StartWith:
Use String#start_with? instead of a regex match anchored to the beginning of the string.
      header += "*   No changes.\n\n\n" if current_contents =~ /\A##/
```
