### PR TITLE
Attempt to fix build for webpacker-default #33079 WIP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "rack-cache", "~> 1.2"
 gem "coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
-
+gem "webpacker", github: 'rails/webpacker'
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,15 @@ GIT
     queue_classic (3.2.0.RC1)
       pg (>= 0.17, < 2.0)
 
+GIT
+  remote: https://github.com/rails/webpacker.git
+  revision: 40386e215a4016a83fd55f691c7e653976581b93
+  specs:
+    webpacker (4.0.0.pre.pre.2)
+      activesupport (>= 4.2)
+      rack-proxy (>= 0.6.1)
+      railties (>= 4.2)
+
 PATH
   remote: .
   specs:
@@ -371,6 +380,8 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.1)
       rack
+    rack-proxy (0.6.4)
+      rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
@@ -576,7 +587,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   w3c_validators
   wdm (>= 0.1.0)
+  webpacker!
   websocket-client-simple!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -27,7 +27,7 @@ namespace :test do
 
     require "bundler/setup" unless defined?(Bundler)
     require "active_support"
-
+    require_relative 'test/isolation/abstract_unit'
     failing_files = []
 
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -232,6 +232,21 @@ module Rails
         options[:skip_active_storage] || options[:skip_active_record]
       end
 
+      def rails_ujs_version
+        #TODO Rails::VERSION::STRING
+        "file:" + File.expand_path(File.join(__dir__, '../../../../actionview'))
+      end
+
+      def actioncable_version
+        #TODO Rails::VERSION::STRING
+        "file:" + File.expand_path(File.join(__dir__, '../../../../actioncable'))
+      end
+
+      def activestorage_version
+        #TODO Rails::VERSION::STRING
+        "file:" + File.expand_path(File.join(__dir__, '../../../../activestorage'))
+      end
+
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
         def initialize(name, version, comment, options = {}, commented_out = false)
           super

--- a/railties/lib/rails/generators/rails/app/templates/package.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/package.json.tt
@@ -2,9 +2,9 @@
   "name": "<%= app_name %>",
   "private": true,
   "dependencies": {
-    "rails-ujs": "<%= Rails::VERSION::STRING %>"<% unless options[:skip_turbolinks] %>,
+    "rails-ujs": "<%= rails_ujs_version %>"<% unless options[:skip_turbolinks] %>,
     "turbolinks": "5.1.1"<% end -%><% unless skip_active_storage? %>,
-    "activestorage": "<%= Rails::VERSION::STRING %>"<% end -%><% unless options[:skip_action_cable] %>,
-    "actioncable": "<%= Rails::VERSION::STRING %>"<% end -%>
+    "activestorage": "<%= activestorage_version %>"<% end -%><% unless options[:skip_action_cable] %>,
+    "actioncable": "<%= actioncable_version %>"<% end -%>
   }
 }

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -8,6 +8,7 @@ module ApplicationTests
 
     def setup
       build_app
+      FileUtils.rm_rf "#{app_path}/config/webpacker.yml" # Prevent Webpacker::DevServerProxy from being added
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -118,7 +118,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 25     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 32     Test LOC: 0     Code to Test Ratio: 1:0.0",
         rails("stats")
     end
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -205,22 +205,25 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     engine_path = File.join(destination_root, "bukkits")
 
+
     Dir.chdir(engine_path) do
       quietly { `bin/rails g controller dashboard foo` }
       quietly { `bin/rails db:migrate RAILS_ENV=test` }
-      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test test/*_test.rb test/*/*/*_test.rb 2>&1`)
     end
   end
 
   def test_controller_tests_pass_by_default_inside_full_engine
     Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
-
     engine_path = File.join(destination_root, "bukkits")
 
     Dir.chdir(engine_path) do
       quietly { `bin/rails g controller dashboard foo` }
       quietly { `bin/rails db:migrate RAILS_ENV=test` }
-      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      Dir.chdir("test/dummy"){ `yarn add https://github.com/rails/webpacker.git` }
+      Dir.chdir("test/dummy"){ `rails assets:precompile` }
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test test/*_test.rb test/*/*_test.rb 2>&1`)
     end
   end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -445,6 +445,8 @@ Module.new do
   # Build a rails app
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
+  File.write("#{app_template_path}/../../.yarnrc", "--modules-folder \"#{app_template_path}/../../node_modules\"")
+
   Dir.chdir "#{RAILS_FRAMEWORK_ROOT}/actionview" do
     `npm run-script build`
   end
@@ -468,6 +470,7 @@ Module.new do
   Dir.chdir app_template_path do
     `yarn add https://github.com/rails/webpacker.git`
   end
+
 
   require "rails"
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -113,6 +113,8 @@ module TestHelpers
         end
       end
 
+      remove_from_env_config("development", "config.webpacker.check_yarn_integrity = true")
+
       if options[:multi_db]
         File.open("#{app_path}/config/database.yml", "w") do |f|
           f.puts <<-YAML

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -448,7 +448,7 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
   File.write("#{app_template_path}/../../.yarnrc", "--modules-folder \"#{app_template_path}/../../node_modules\"")
-
+  FileUtils.rm_rf("#{app_template_path}/../../node_modules")
   Dir.chdir "#{RAILS_FRAMEWORK_ROOT}/actionview" do
     `npm run-script build`
   end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -30,7 +30,7 @@ require "rails/secrets"
 module TestHelpers
   module Paths
     def app_template_path
-      File.join Dir.tmpdir, "app/template"
+      File.join Dir.tmpdir, "templates/app_template"
     end
 
     def tmp_path(*args)

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -454,7 +454,7 @@ Module.new do
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.
   contents = File.read("#{app_template_path}/config/application.rb")
-  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks).each { |r| require r }")
+  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
   File.write("#{app_template_path}/config/application.rb", contents)
 
   require "rails"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -30,7 +30,7 @@ require "rails/secrets"
 module TestHelpers
   module Paths
     def app_template_path
-      File.join Dir.tmpdir, "app_template"
+      File.join Dir.tmpdir, "app/template"
     end
 
     def tmp_path(*args)
@@ -444,7 +444,7 @@ Module.new do
 
   # Build a rails app
   FileUtils.rm_rf(app_template_path)
-  FileUtils.mkdir(app_template_path)
+  FileUtils.mkdir_p(app_template_path)
   Dir.chdir "#{RAILS_FRAMEWORK_ROOT}/actionview" do
     `npm run-script build`
   end


### PR DESCRIPTION
This is an attempt to resolve the build issues in the webpacker default branch.

I am unused how to resolve these issues correctly, but at least this will provide some guidance around what needs to be done.

So far i have identified:
- [ ] Need to include latest webpacker in the gemfile (without this the command `webpacker:install` fails, and with released version the build hangs.
- [x] Need to use local copies of actioncable, rails-ujs and actviestorage packages as versions 6.0.0.alpha are not published
- [x] Need to build `rails-ujs` as a compiled version is not included in the gem.
- [x] Need to move the template app to be at the same level as the copies of the template so that the relative references in the yarn.lock still work.
- [x] Need up exclude web packer from the middleware to update the tests to include it.
- [x] Adjust the lines of code expectations in the stats test
- [ ] Speed up the railties build (timing out 😦)