### PR TITLE
Allow `perform_enqueued_jobs` to be called without a block.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow `perform_enqueued_jobs` to be called without a block.
+
+    Performs all of the jobs that have been enqueued up to this point in the test.
+
+    *Kevin Deisz*
+
 *   Move `enqueue`/`enqueue_at` notifications to an around callback.
 
     Improves timing accuracy over the old after callback by including

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -610,7 +610,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
 end
 
 class PerformedJobsTest < ActiveJob::TestCase
-  def test_performed_enqueue_jobs_with_only_option_doesnt_leak_outside_the_block
+  def test_perform_enqueued_jobs_with_only_option_doesnt_leak_outside_the_block
     assert_nil queue_adapter.filter
     perform_enqueued_jobs only: HelloJob do
       assert_equal HelloJob, queue_adapter.filter
@@ -618,12 +618,28 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_nil queue_adapter.filter
   end
 
-  def test_performed_enqueue_jobs_with_except_option_doesnt_leak_outside_the_block
+  def test_perform_enqueued_jobs_with_except_option_doesnt_leak_outside_the_block
     assert_nil queue_adapter.reject
     perform_enqueued_jobs except: HelloJob do
       assert_equal HelloJob, queue_adapter.reject
     end
     assert_nil queue_adapter.reject
+  end
+
+  def test_perform_enqueued_jobs_without_block
+    HelloJob.perform_later("kevin")
+
+    assert_performed_jobs 1, only: HelloJob do
+      perform_enqueued_jobs
+    end
+  end
+
+  def test_perform_enqueued_jobs_without_block_respects_filter
+    HelloJob.perform_later("kevin")
+
+    assert_no_performed_jobs do
+      perform_enqueued_jobs only: LoggingJob
+    end
   end
 
   def test_assert_performed_jobs


### PR DESCRIPTION
Performs all of the jobs that have been enqueued up to this point in the test.

Allows you to test code that is in some intermediate state between the time that the job is enqueued to the time that the job is performed. For example in my case, when uploading an image asynchronously a default image is set until the thumbnails have been processed in the background. This allows me to test that after the job is enqueued the default image is set, then call `perform_enqueued_jobs` to make sure it then gets updated afterward.