### PR TITLE
Fix obsoleted method URI.unescape in activesupport/test

### DIFF
--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -88,7 +88,7 @@ class ToQueryTest < ActiveSupport::TestCase
     }
     expected = "foo[contents][][name]=gorby&foo[contents][][id]=123&foo[contents][][name]=puff&foo[contents][][d]=true"
 
-    assert_equal expected, URI.decode(params.to_query)
+    assert_equal expected, URI.decode_www_form_component(params.to_query)
   end
 
   private


### PR DESCRIPTION
### Summary

When running `bundle exec rake`, I was getting this warning:
`/Users/someone/rails/activesupport/test/core_ext/object/to_query_test.rb:91:in 'test_hash_not_sorted_lexicographically_for_nested_structure': warning: URI.unescape is obsolete`

I think this test should be using a method that isn't obsolete.