### PR TITLE
Move the initializers rake task to Rails::Command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `rake initializers` in favor of `rails initializers`.
+
+    *Annie-Claude Côté*
+
 *   Deprecate `rake dev:cache` in favor of `rails dev:cache`.
 
     *Annie-Claude Côté*

--- a/railties/lib/rails/commands/initializers/initializers_command.rb
+++ b/railties/lib/rails/commands/initializers/initializers_command.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Rails
+  module Command
+    class InitializersCommand < Base # :nodoc:
+      desc "Print out all defined initializers in the order they are invoked by Rails."
+      def perform
+        require_application_and_environment!
+
+        Rails.application.initializers.tsort_each do |initializer|
+          puts "#{initializer.context_class}.#{initializer.name}"
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "rails/command"
+require "active_support/deprecation"
+
 desc "Print out all defined initializers in the order they are invoked by Rails."
-task initializers: :environment do
-  Rails.application.initializers.tsort_each do |initializer|
-    puts "#{initializer.context_class}.#{initializer.name}"
-  end
+task :initializers do
+  ActiveSupport::Deprecation.warn("Using `bin/rake initializers` is deprecated and will be removed in Rails 6.1. Use `bin/rails initializers` instead.\n")
+  Rails::Command.invoke "initializers"
 end

--- a/railties/test/application/rake/initializers_test.rb
+++ b/railties/test/application/rake/initializers_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  module RakeTests
+    class RakeInitializersTest < ActiveSupport::TestCase
+      setup :build_app
+      teardown :teardown_app
+
+      test "`rake initializers` prints out defined initializers invoked by Rails" do
+        capture(:stderr) do
+          initial_output = run_rake_initializers
+          initial_output_length = initial_output.split("\n").length
+
+          assert_operator initial_output_length, :>, 0
+          assert_not initial_output.include?("set_added_test_module")
+
+          add_to_config <<-RUBY
+            initializer(:set_added_test_module) { }
+          RUBY
+
+          final_output = run_rake_initializers
+          final_output_length = final_output.split("\n").length
+
+          assert_equal 1, (final_output_length - initial_output_length)
+          assert final_output.include?("set_added_test_module")
+        end
+      end
+
+      test "`rake initializers` outputs a deprecation warning" do
+        stderr = capture(:stderr) { run_rake_initializers }
+        assert_match(/DEPRECATION WARNING: Using `bin\/rake initializers` is deprecated and will be removed in Rails 6.1/, stderr)
+      end
+
+      private
+        def run_rake_initializers
+          Dir.chdir(app_path) { `bin/rake initializers` }
+        end
+    end
+  end
+end

--- a/railties/test/commands/initializers_test.rb
+++ b/railties/test/commands/initializers_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::InitializersTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  test "`rails initializers` prints out defined initializers invoked by Rails" do
+    initial_output = run_initializers_command
+    initial_output_length = initial_output.split("\n").length
+
+    assert_operator initial_output_length, :>, 0
+    assert_not initial_output.include?("set_added_test_module")
+
+    add_to_config <<-RUBY
+      initializer(:set_added_test_module) { }
+    RUBY
+
+    final_output = run_initializers_command
+    final_output_length = final_output.split("\n").length
+
+    assert_equal 1, (final_output_length - initial_output_length)
+    assert final_output.include?("set_added_test_module")
+  end
+
+  private
+    def run_initializers_command
+      rails "initializers"
+    end
+end


### PR DESCRIPTION
What this is doing:

* Moves the `initializers` rake task to use Rails::Command without changing the API
* Adds deprecation when calling it with `bin/rake` instead of `bin/rails`
* Adds tests for the rake task since there wasn't any

cc/ @kaspth 