### PR TITLE
Improve Active Job test helpers

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `assert_performed_with` to be called without a block.
+
+    *bogdanvlviv*
+
 *   Execution of `assert_performed_jobs`, and `assert_no_performed_jobs`
     without a block should respect passed `:except`, `:only`, and `:queue` options.
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Execution of `assert_performed_jobs`, and `assert_no_performed_jobs`
+    without a block should respect passed `:except`, `:only`, and `:queue` options.
+
+    *bogdanvlviv*
+
 *   Allow `:queue` option to job assertions and helpers.
 
     *bogdanvlviv*

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `:queue` option to job assertions and helpers.
+
+    *bogdanvlviv*
+
 *   Allow `perform_enqueued_jobs` to be called without a block.
 
     Performs all of the jobs that have been enqueued up to this point in the test.
@@ -10,19 +14,6 @@
     time spent writing to the adapter's IO implementation.
 
     *Zach Kemp*
-
-*   Allow `queue` option to `assert_no_enqueued_jobs`.
-
-    Example:
-    ```
-    def test_no_logging
-      assert_no_enqueued_jobs queue: 'default' do
-        LoggingJob.set(queue: :some_queue).perform_later
-      end
-    end
-    ```
-
-    *bogdanvlviv*
 
 *   Allow call `assert_enqueued_with` with no block.
 

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
@@ -54,12 +54,20 @@ module ActiveJob
         end
 
         def filtered?(job)
+          filtered_queue?(job) || filtered_job_class?(job)
+        end
+
+        def filtered_queue?(job)
+          if queue
+            job.queue_name != queue.to_s
+          end
+        end
+
+        def filtered_job_class?(job)
           if filter
             !Array(filter).include?(job.class)
           elsif reject
             Array(reject).include?(job.class)
-          else
-            false
           end
         end
     end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -297,11 +297,20 @@ module ActiveJob
     #     end
     #   end
     #
+    # If the +:queue+ option is specified,
+    # then only the job(s) enqueued to a specific queue will not be performed.
+    #
+    #   def test_assert_no_performed_jobs_with_queue_option
+    #     assert_no_performed_jobs queue: :some_queue do
+    #       HelloJob.set(queue: :other_queue).perform_later("jeremy")
+    #     end
+    #   end
+    #
     # Note: This assertion is simply a shortcut for:
     #
     #   assert_performed_jobs 0, &block
-    def assert_no_performed_jobs(only: nil, except: nil, &block)
-      assert_performed_jobs 0, only: only, except: except, &block
+    def assert_no_performed_jobs(only: nil, except: nil, queue: nil, &block)
+      assert_performed_jobs 0, only: only, except: except, queue: queue, &block
     end
 
     # Asserts that the job has been enqueued with the given arguments.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -415,7 +415,10 @@ module ActiveJob
     #   end
     #
     def perform_enqueued_jobs(only: nil, except: nil, queue: nil)
+      return flush_enqueued_jobs(only: only, except: except, queue: queue) unless block_given?
+
       validate_option(only: only, except: except)
+
       old_perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
       old_perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
       old_filter = queue_adapter.filter
@@ -429,7 +432,7 @@ module ActiveJob
         queue_adapter.reject = except
         queue_adapter.queue = queue
 
-        block_given? ? yield : flush_enqueued_jobs(only: only, except: except, queue: queue)
+        yield
       ensure
         queue_adapter.perform_enqueued_jobs = old_perform_enqueued_jobs
         queue_adapter.perform_enqueued_at_jobs = old_perform_enqueued_at_jobs

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -118,13 +118,17 @@ module ActiveJob
     def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
       if block_given?
         original_count = enqueued_jobs_with(only: only, except: except, queue: queue)
+
         yield
+
         new_count = enqueued_jobs_with(only: only, except: except, queue: queue)
-        assert_equal number, new_count - original_count, "#{number} jobs expected, but #{new_count - original_count} were enqueued"
+
+        actual_count = new_count - original_count
       else
         actual_count = enqueued_jobs_with(only: only, except: except, queue: queue)
-        assert_equal number, actual_count, "#{number} jobs expected, but #{actual_count} were enqueued"
       end
+
+      assert_equal number, actual_count, "#{number} jobs expected, but #{actual_count} were enqueued"
     end
 
     # Asserts that no jobs have been enqueued.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -52,7 +52,7 @@ module ActiveJob
       queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
     end
 
-    # Specifies the queue adapter to use with all active job test helpers.
+    # Specifies the queue adapter to use with all Active Job test helpers.
     #
     # Returns an instance of the queue adapter and defaults to
     # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
@@ -217,7 +217,7 @@ module ActiveJob
     #       end
     #     end
     #
-    # Also if the :except option is specified,
+    # Also if the +:except+ option is specified,
     # then the job(s) except specific class will be performed.
     #
     #     def test_hello_job
@@ -283,7 +283,7 @@ module ActiveJob
     #     end
     #   end
     #
-    # The block form supports filtering. If the :only option is specified,
+    # The block form supports filtering. If the +:only+ option is specified,
     # then only the listed job(s) will not be performed.
     #
     #   def test_no_logging
@@ -292,7 +292,7 @@ module ActiveJob
     #     end
     #   end
     #
-    # Also if the :except option is specified,
+    # Also if the +:except+ option is specified,
     # then the job(s) except specific class will not be performed.
     #
     #   def test_no_logging

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -237,10 +237,20 @@ module ActiveJob
     #         end
     #       end
     #     end
-    def assert_performed_jobs(number, only: nil, except: nil)
+    #
+    # If the +:queue+ option is specified,
+    # then only the job(s) enqueued to a specific queue will be performed.
+    #
+    #     def test_assert_performed_jobs_with_queue_option
+    #       assert_performed_jobs 1, queue: :some_queue do
+    #         HelloJob.set(queue: :some_queue).perform_later("jeremy")
+    #         HelloJob.set(queue: :other_queue).perform_later("bogdan")
+    #       end
+    #     end
+    def assert_performed_jobs(number, only: nil, except: nil, queue: nil)
       if block_given?
         original_count = performed_jobs.size
-        perform_enqueued_jobs(only: only, except: except) { yield }
+        perform_enqueued_jobs(only: only, except: except, queue: queue) { yield }
         new_count = performed_jobs.size
         assert_equal number, new_count - original_count,
           "#{number} jobs expected, but #{new_count - original_count} were performed"


### PR DESCRIPTION
- ec2e8f645eded183224420e209420376c63b99bb

    Allow `:queue` option to `perform_enqueued_jobs`.

    If the `:queue` option is specified, then only the job(s) enqueued to
    a specific queue will be performed.

    Example:
    ```
    def test_perform_enqueued_jobs_with_queue
      perform_enqueued_jobs queue: :some_queue do
        MyJob.set(queue: :some_queue).perform_later(1, 2, 3) # will be performed
        HelloJob.set(queue: :other_queue).perform_later(1, 2, 3) # will not be performed
      end
      assert_performed_jobs 1
    end
    ```

    Follow up #33265

    [bogdanvlviv & Jeremy Daer]

<hr/>

- e0cf042fa2c499c2e0b8fe95ec02ed79f9178feb

    Fix `perform_enqueued_jobs`

    Set
    ````ruby
    queue_adapter.perform_enqueued_jobs = true
    queue_adapter.perform_enqueued_at_jobs = true
    queue_adapter.filter = only
    queue_adapter.reject = except
    queue_adapter.queue = queue
    ```
    if block given.
    Execution of `flush_enqueued_jobs` doesn't require that.

<hr/>

- d50fb21e4d7a526de3b0edb9bb5032d4be6175ae

    Allow `:queue` option to `assert_performed_jobs`.

    If the `:queue` option is specified, then only the job(s) enqueued to a specific
    queue will be performed.

    Example:
    ```ruby
    def test_assert_performed_jobs_with_queue_option
      assert_performed_jobs 1, queue: :some_queue do
        HelloJob.set(queue: :some_queue).perform_later("jeremy")
        HelloJob.set(queue: :other_queue).perform_later("bogdan")
      end
    end
    ```

<hr/>

- de4420da44ecce68a6b7607b828c69959a5f738e

    Allow `:queue` option to `assert_no_performed_jobs`.

    If the `:queue` option is specified, then only the job(s) enqueued to a specific
    queue will not be performed.

    Example:
    ```ruby
    def test_assert_no_performed_jobs_with_queue_option
      assert_no_performed_jobs queue: :some_queue do
        HelloJob.set(queue: :other_queue).perform_later("jeremy")
      end
    end
    ```

<hr/>

- 2bf8b4eb0eceb37fc278c71371a659979844dfb2

    Add changelog entry about adding `:queue` option to job assertions and helpers

    Note that it removes changelog entry of #33265 since the entry in this commits
    includes that too.

<hr/>

- 11634e8ef85870535bad61b999e0f9ec36f6f963

    Fix `assert_performed_jobs` and `assert_no_performed_jobs`

    Execution of `assert_performed_jobs`, and `assert_no_performed_jobs`
    without a block should respect passed `:except`, `:only`, and `:queue` options.

<hr/>

- 2ec60fb8186ad3b227341b7d1874e3f13bd34279

    Allow `assert_performed_with` to be called without a block.

    Example:
    ```ruby
    def test_assert_performed_with
      MyJob.perform_later(1,2,3)

      perform_enqueued_jobs

      assert_performed_with(job: MyJob, args: [1,2,3], queue: 'high')
    end
    ```

    Follow up #33626.

<hr/>

- b7beb5d4e5a5f642d172002723ef269d0c6a0bfd

    Fix formatting of `ActiveJob::TestHelper` api docs

<hr/>

- b8576425eeee2eaa82c5acb08227f5bb2dcd07b7

    DRY in `assert_enqueued_jobs`

<hr/>

Note that these changes keep backward compatibility, so It shouldn't break users' tests during an upgrade to 6.0.