### PR TITLE
add missing indifferent_access require for #normalize_encode_params

### DIFF
--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/hash/indifferent_access"
+
 module ActionDispatch
   class Request
     class Utils # :nodoc:


### PR DESCRIPTION
### Summary

Adds a missing require to `ActionDispatch::Request::Utils` class. Fixes #33634.

### Other Information

Note that `core_ext/hash/indifferent_access` is already `require`d as part of `actionpack`'s core `abstract_unit.rb` test helper (the chain is `abstract_unit` => `action_controller` => `action_controller/metal/strong_parameters` => `active_support/core_ext/hash/indifferent_access`), so it's not easy to add an automated test covering the failure-case this PR fixes.