### PR TITLE
Implement ActiveRecord::Relation#eql? and ActiveRecord::Relation#hash

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -582,6 +582,11 @@ module ActiveRecord
         records == other
       end
     end
+    alias eql? ==
+
+    def hash
+      records.hash
+    end
 
     def pretty_print(q)
       q.pp(records)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -307,6 +307,14 @@ module ActiveRecord
       assert_equal 3, ratings.count
     end
 
+    test 'eql? aliases ==' do
+      assert Author.all.eql?(Author.all)
+    end
+
+    test 'hash values equal with same records' do
+      assert_equal Author.all.hash, Author.where('1=1').hash
+    end
+
     class EnsureRoundTripTypeCasting < ActiveRecord::Type::Value
       def type
         :string


### PR DESCRIPTION
Per the Ruby documentation regarding `eql?`:

    For objects of class Object, eql? is synonymous with ==. Subclasses
    normally continue this tradition by aliasing eql? to their
    overridden == method....

My reading is that unless there is another good reason not to alias
`eql?` to `==` it should be.

In addition, per the Ruby documentation regarding the `hash` method:

    must have the property that a.eql?(b) implies a.hash == b.hash

For this reason I have also implemented hash so that if two relation
objects contain the same records they return the same hash value.

My specific need is that I am doing a `group_by` where the key is a
`ActiveRecord::Relation`. Internally `group_by` is using a `Hash` which
a `Hash` uses `eql?` and `hash` to index.

The only relevant pre-existing issue I found was:

    https://github.com/rails/rails/issues/11947#issuecomment-22967919

In that issue it was offered that `eql?` could alias `==` if that was
needed by rspec, but since it wasn't the issue went stale.