### PR TITLE
Make sure there are no duplicated nested records with create_with

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix duplicated record creation when using nested attributes with `create_with`.
+
+    *Darwin Wu*
+
 *   Configuration item `config.filter_parameters` could also filter out sensitive value of database column when call `#inspect`.
 
     ```

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -62,7 +62,7 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new(attributes = nil, &block)
-      scoping { klass.new(scope_for_create(attributes), &block) }
+      scoping { klass.new(values_for_create(attributes), &block) }
     end
 
     alias build new
@@ -90,7 +90,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create(attr, &block) }
       else
-        scoping { klass.create(scope_for_create(attributes), &block) }
+        scoping { klass.create(values_for_create(attributes), &block) }
       end
     end
 
@@ -104,7 +104,7 @@ module ActiveRecord
       if attributes.is_a?(Array)
         attributes.collect { |attr| create!(attr, &block) }
       else
-        scoping { klass.create!(scope_for_create(attributes), &block) }
+        scoping { klass.create!(values_for_create(attributes), &block) }
       end
     end
 
@@ -554,10 +554,8 @@ module ActiveRecord
       where_clause.to_h(relation_table_name)
     end
 
-    def scope_for_create(attributes = nil)
-      scope = where_values_hash.merge!(create_with_value.stringify_keys)
-      scope.merge!(attributes) if attributes
-      scope
+    def scope_for_create
+      where_values_hash.merge!(create_with_value.stringify_keys)
     end
 
     # Returns true if relation needs eager loading.
@@ -707,6 +705,19 @@ module ActiveRecord
         # always convert table names to downcase as in Oracle quoted table names are in uppercase
         # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
         string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map(&:downcase).uniq - ["raw_sql_"]
+      end
+
+      def values_for_create(attributes = nil)
+        result = attributes ? where_values_hash.merge!(attributes) : where_values_hash
+
+        # NOTE: if there are same keys in both create_with and result, create_with should be used.
+        # This is to make sure nested attributes don't get passed to the klass.new,
+        # while keeping the precedence of the duplicate keys in create_with.
+        create_with_value.stringify_keys.each do |k, v|
+          result[k] = v if result.key?(k)
+        end
+
+        result
       end
   end
 end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -217,6 +217,18 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     mean_pirate.parrot_attributes = { name: "James" }
     assert_equal "James", mean_pirate.parrot.name
   end
+
+  def test_should_not_create_duplicates_with_create_with
+    Man.accepts_nested_attributes_for(:interests)
+
+    assert_difference("Interest.count", 1) do
+      Man.create_with(
+        interests_attributes: [{ topic: "Pirate king" }]
+      ).find_or_create_by!(
+        name: "Monkey D. Luffy"
+      )
+    end
+  end
 end
 
 class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -9,6 +9,7 @@ require "models/comment"
 require "models/author"
 require "models/entrant"
 require "models/developer"
+require "models/project"
 require "models/person"
 require "models/computer"
 require "models/reply"
@@ -1403,6 +1404,16 @@ class RelationTest < ActiveRecord::TestCase
 
     hens = hens.create_with(name: "cock")
     assert_equal "cock", hens.new.name
+  end
+
+  def test_create_with_nested_attributes
+    assert_difference("Project.count", 1) do
+      developers = Developer.where(name: "Aaron")
+      developers = developers.create_with(
+        projects_attributes: [{ name: "p1" }]
+      )
+      developers.create!
+    end
   end
 
   def test_except

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "models/post"
 require "models/comment"
 require "models/developer"
+require "models/project"
 require "models/computer"
 require "models/vehicle"
 require "models/cat"
@@ -364,6 +365,21 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_create_with_reset
     jamis = PoorDeveloperCalledJamis.create_with(name: "Aaron").create_with(nil).new
     assert_equal "Jamis", jamis.name
+  end
+
+  def test_create_with_takes_precedence_over_where
+    developer = Developer.where(name: nil).create_with(name: "Aaron").new
+    assert_equal "Aaron", developer.name
+  end
+
+  def test_create_with_nested_attributes
+    assert_difference("Project.count", 1) do
+      Developer.create_with(
+        projects_attributes: [{ name: "p1" }]
+      ).scoping do
+        Developer.create!(name: "Aaron")
+      end
+    end
   end
 
   # FIXME: I don't know if this is *desired* behavior, but it is *today's*


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/33610

Looks like the issue is happening at `populate_with_current_scope_attributes` where it shouldn't try to assign the `scope_attributes` on the initial evaluation, which results in a duplicate record.

e.g.) In the test example, when creating a `Man` record, the current behaviour with `:create_with` attribute registered in a `Relation` is that it will try to create an `Interest` record before  the owner `Man`, instead of creating `Man` first, then build `Interest` based on `Man`.

making `scope_attributes?` truly returns boolean should fix it instead returning an empty relation that evaluates to true.