### PR TITLE
DRY in Active Record Query Interface [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1277,22 +1277,6 @@ class Article < ApplicationRecord
 end
 ```
 
-This is almost the same as defining a class method, except for that scopes always return an `ActiveRecord::Relation` object. 
-
-```ruby
-class Article < ApplicationRecord
-  scope :by_user, ->(user) { where(user: user) if user }
-  def self.published_since(date)
-    where('published_at > ?', date) if date
-  end
-end
-
-Article.by_user(nil)
-# => #<ActiveRecord::Relation []>
-Article.published_since(nil)
-# => nil
-```
-
 Scopes are also chainable within scopes:
 
 ```ruby


### PR DESCRIPTION
The sentence "This is exactly the same as defining a class method ..."
is not true, so #33653 fixed it, but added changes repeat what is explained
a few lines below. We can remove this part since a user is able to get info
about the difference between scopes and class methods below.

Context https://github.com/rails/rails/pull/33653#discussion_r211105969.

Reverts #33653, 97feb4996b1c88f770101dfce6d4d3a6baf6bb33.
r? @kamipo 