### PR TITLE
Improve test case to test enum correctly

### DIFF
--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -661,6 +661,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     self.table_name = "books"
     belongs_to :author, class_name: "SpecialAuthor"
     has_one :subscription, class_name: "SpecialSupscription", foreign_key: "subscriber_id"
+
+    enum status: [:proposed, :written, :published]
   end
 
   class SpecialAuthor < ActiveRecord::Base
@@ -678,6 +680,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     book = SpecialBook.create!(status: "published")
     author.book = book
 
+    assert_equal "published", book.status
     assert_not_equal 0, SpecialAuthor.joins(:book).where(books: { status: "published" }).count
   end
 


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/blob/fd1ec91c73ccfa1df71098a93cee76e9dd12a24b/activerecord/test/cases/associations/has_one_associations_test.rb#L660-L664

Without define the enum in class “SpecialBook”, any `status` (e.g. `published`) will be casted to integer 0. Then the test have no meaning.

https://github.com/rails/rails/blob/fd1ec91c73ccfa1df71098a93cee76e9dd12a24b/activerecord/test/cases/associations/has_one_associations_test.rb#L676-L682

I add one more `assert_equal` to the test
```
assert_equal "published", book.status
```

### Expect

Test case pass

### Actual

```
Failure:
HasOneAssociationsTest#test_association_enum_works_properly [test/cases/associations/has_one_associations_test.rb:681]:
Expected: "published"
  Actual: 0
```