### PR TITLE
Action cable testing

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -51,4 +51,6 @@ module ActionCable
   autoload :Channel
   autoload :RemoteConnections
   autoload :SubscriptionAdapter
+  autoload :TestHelper
+  autoload :TestCase
 end

--- a/actioncable/lib/action_cable/subscription_adapter.rb
+++ b/actioncable/lib/action_cable/subscription_adapter.rb
@@ -5,6 +5,7 @@ module ActionCable
     extend ActiveSupport::Autoload
 
     autoload :Base
+    autoload :Test
     autoload :SubscriberMap
     autoload :ChannelPrefix
   end

--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "async"
+
+module ActionCable
+  module SubscriptionAdapter
+    # == Test adapter for Action Cable
+    #
+    # The test adapter should be used only in testing. Along with
+    # <tt>ActionCable::TestHelper</tt> it makes a great tool to test your Rails application.
+    #
+    # To use the test adapter set adapter value to +test+ in your +cable.yml+.
+    #
+    # NOTE: Test adapter extends the <tt>ActionCable::SubscriptionsAdapter::Async</tt> adapter,
+    # so it could be used in system tests too.
+    class Test < Async
+      def broadcast(channel, payload)
+        broadcasts(channel) << payload
+        super
+      end
+
+      def broadcasts(channel)
+        channels_data[channel] ||= []
+      end
+
+      def clear_messages(channel)
+        channels_data[channel] = []
+      end
+
+      def clear
+        @channels_data = nil
+      end
+
+      private
+        def channels_data
+          @channels_data ||= {}
+        end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/test_case.rb
+++ b/actioncable/lib/action_cable/test_case.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "active_support/test_case"
+
+module ActionCable
+  class TestCase < ActiveSupport::TestCase
+    include ActionCable::TestHelper
+
+    ActiveSupport.run_load_hooks(:action_cable_test_case, self)
+  end
+end

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module ActionCable
+  # Provides helper methods for testing Action Cable broadcasting
+  module TestHelper
+    def before_setup # :nodoc:
+      server = ActionCable.server
+      test_adapter = ActionCable::SubscriptionAdapter::Test.new(server)
+
+      @old_pubsub_adapter = server.pubsub
+
+      server.instance_variable_set(:@pubsub, test_adapter)
+      super
+    end
+
+    def after_teardown # :nodoc:
+      super
+      ActionCable.server.instance_variable_set(:@pubsub, @old_pubsub_adapter)
+    end
+
+    # Asserts that the number of broadcasted messages to the stream matches the given number.
+    #
+    #   def test_broadcasts
+    #     assert_broadcasts 'messages', 0
+    #     ActionCable.server.broadcast 'messages', { text: 'hello' }
+    #     assert_broadcasts 'messages', 1
+    #     ActionCable.server.broadcast 'messages', { text: 'world' }
+    #     assert_broadcasts 'messages', 2
+    #   end
+    #
+    # If a block is passed, that block should cause the specified number of
+    # messages to be broadcasted.
+    #
+    #   def test_broadcasts_again
+    #     assert_broadcasts('messages', 1) do
+    #       ActionCable.server.broadcast 'messages', { text: 'hello' }
+    #     end
+    #
+    #     assert_broadcasts('messages', 2) do
+    #       ActionCable.server.broadcast 'messages', { text: 'hi' }
+    #       ActionCable.server.broadcast 'messages', { text: 'how are you?' }
+    #     end
+    #   end
+    #
+    def assert_broadcasts(stream, number)
+      if block_given?
+        original_count = broadcasts_size(stream)
+        yield
+        new_count = broadcasts_size(stream)
+        assert_equal number, new_count - original_count, "#{number} broadcasts to #{stream} expected, but #{new_count - original_count} were sent"
+      else
+        actual_count = broadcasts_size(stream)
+        assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
+      end
+    end
+
+    # Asserts that no messages have been sent to the stream.
+    #
+    #   def test_no_broadcasts
+    #     assert_no_broadcasts 'messages'
+    #     ActionCable.server.broadcast 'messages', { text: 'hi' }
+    #     assert_broadcasts 'messages', 1
+    #   end
+    #
+    # If a block is passed, that block should not cause any message to be sent.
+    #
+    #   def test_broadcasts_again
+    #     assert_no_broadcasts 'messages' do
+    #       # No job messages should be sent from this block
+    #     end
+    #   end
+    #
+    # Note: This assertion is simply a shortcut for:
+    #
+    #   assert_broadcasts 'messages', 0, &block
+    #
+    def assert_no_broadcasts(stream, &block)
+      assert_broadcasts stream, 0, &block
+    end
+
+    # Asserts that the specified message has been sent to the stream.
+    #
+    #   def test_assert_transmited_message
+    #     ActionCable.server.broadcast 'messages', text: 'hello'
+    #     assert_broadcast_on('messages', text: 'hello')
+    #   end
+    #
+    # If a block is passed, that block should cause a message with the specified data to be sent.
+    #
+    #   def test_assert_broadcast_on_again
+    #     assert_broadcast_on('messages', text: 'hello') do
+    #       ActionCable.server.broadcast 'messages', text: 'hello'
+    #     end
+    #   end
+    #
+    def assert_broadcast_on(stream, data)
+      # Encode to JSON and back–we want to use this value to compare
+      # with decoded JSON.
+      # Comparing JSON strings doesn't work due to the order if the keys.
+      serialized_msg =
+        ActiveSupport::JSON.decode(ActiveSupport::JSON.encode(data))
+
+      new_messages = broadcasts(stream)
+      if block_given?
+        old_messages = new_messages
+        clear_messages(stream)
+
+        yield
+        new_messages = broadcasts(stream)
+        clear_messages(stream)
+
+        # Restore all sent messages
+        (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(stream, m) }
+      end
+
+      message = new_messages.find { |msg| ActiveSupport::JSON.decode(msg) == serialized_msg }
+
+      assert message, "No messages sent with #{data} to #{stream}"
+    end
+
+    def pubsub_adapter # :nodoc:
+      ActionCable.server.pubsub
+    end
+
+    delegate :broadcasts, :clear_messages, to: :pubsub_adapter
+
+    private
+      def broadcasts_size(channel) # :nodoc:
+        broadcasts(channel).size
+      end
+  end
+end

--- a/actioncable/test/subscription_adapter/test_adapter_test.rb
+++ b/actioncable/test/subscription_adapter/test_adapter_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "common"
+
+class ActionCable::SubscriptionAdapter::TestTest < ActionCable::TestCase
+  include CommonSubscriptionAdapterTest
+
+  def setup
+    super
+
+    @tx_adapter.shutdown
+    @tx_adapter = @rx_adapter
+  end
+
+  def cable_config
+    { adapter: "test" }
+  end
+
+  test "#broadcast stores messages for streams" do
+    @tx_adapter.broadcast("channel", "payload")
+    @tx_adapter.broadcast("channel2", "payload2")
+
+    assert_equal ["payload"], @tx_adapter.broadcasts("channel")
+    assert_equal ["payload2"], @tx_adapter.broadcasts("channel2")
+  end
+
+  test "#clear_messages deletes recorded broadcasts for the channel" do
+    @tx_adapter.broadcast("channel", "payload")
+    @tx_adapter.broadcast("channel2", "payload2")
+
+    @tx_adapter.clear_messages("channel")
+
+    assert_equal [], @tx_adapter.broadcasts("channel")
+    assert_equal ["payload2"], @tx_adapter.broadcasts("channel2")
+  end
+
+  test "#clear deletes all recorded broadcasts" do
+    @tx_adapter.broadcast("channel", "payload")
+    @tx_adapter.broadcast("channel2", "payload2")
+
+    @tx_adapter.clear
+
+    assert_equal [], @tx_adapter.broadcasts("channel")
+    assert_equal [], @tx_adapter.broadcasts("channel2")
+  end
+end

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -15,6 +15,10 @@ end
 # Require all the stubs and models
 Dir[File.expand_path("stubs/*.rb", __dir__)].each { |file| require file }
 
+# Set test adapter and logger
+ActionCable.server.config.cable = { "adapter" => "test" }
+ActionCable.server.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
+
 class ActionCable::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BroadcastChannel < ActionCable::Channel::Base
+end
+
+class TransmissionsTest < ActionCable::TestCase
+  def test_assert_broadcasts
+    assert_nothing_raised do
+      assert_broadcasts("test", 1) do
+        ActionCable.server.broadcast "test", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcasts_with_no_block
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "message"
+      assert_broadcasts "test", 1
+    end
+
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "message 2"
+      ActionCable.server.broadcast "test", "message 3"
+      assert_broadcasts "test", 3
+    end
+  end
+
+  def test_assert_no_broadcasts_with_no_block
+    assert_nothing_raised do
+      assert_no_broadcasts "test"
+    end
+  end
+
+  def test_assert_no_broadcasts
+    assert_nothing_raised do
+      assert_no_broadcasts("test") do
+        ActionCable.server.broadcast "test2", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcasts_message_too_few_sent
+    ActionCable.server.broadcast "test", "hello"
+    error = assert_raises Minitest::Assertion do
+      assert_broadcasts("test", 2) do
+        ActionCable.server.broadcast "test", "world"
+      end
+    end
+
+    assert_match(/2 .* but 1/, error.message)
+  end
+
+  def test_assert_broadcasts_message_too_many_sent
+    error = assert_raises Minitest::Assertion do
+      assert_broadcasts("test", 1) do
+        ActionCable.server.broadcast "test", "hello"
+        ActionCable.server.broadcast "test", "world"
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+end
+
+class TransmitedDataTest < ActionCable::TestCase
+  include ActionCable::TestHelper
+
+  def test_assert_broadcast_on
+    assert_nothing_raised do
+      assert_broadcast_on("test", "message") do
+        ActionCable.server.broadcast "test", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcast_on_with_hash
+    assert_nothing_raised do
+      assert_broadcast_on("test", text: "hello") do
+        ActionCable.server.broadcast "test", text: "hello"
+      end
+    end
+  end
+
+  def test_assert_broadcast_on_with_no_block
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "hello"
+      assert_broadcast_on "test", "hello"
+    end
+
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "world"
+      assert_broadcast_on "test", "world"
+    end
+  end
+
+  def test_assert_broadcast_on_message
+    ActionCable.server.broadcast "test", "hello"
+    error = assert_raises Minitest::Assertion do
+      assert_broadcast_on("test", "world")
+    end
+
+    assert_match(/No messages sent/, error.message)
+  end
+end


### PR DESCRIPTION
This PR is a remake of the older PRs (https://github.com/rails/rails/pull/23211 and https://github.com/rails/rails/pull/27191).

After [discussing it again](https://github.com/rails/rails/pull/23211#issuecomment-413219187) we decided to get it done for Rails 6.

This PR is the first one in the series (and the base). The idea is to merge [`action-cable-testing`](https://github.com/palkan/action-cable-testing) gem into Rails, step by step:

- [x] Add Test adapter
- [x] Add Test helper (for broadcasting tests)
- [x] Add channels unit-testing support (https://github.com/rails/rails/pull/33969)
- [x] Add connections unit-testing support (https://github.com/rails/rails/pull/34845)
- [x] Generators (https://github.com/rails/rails/pull/34933)
- [x] Guides (https://github.com/rails/rails/pull/34933)

/cc @dhh @matthewd @kaspth