### PR TITLE
Make `rake routes` deprecate before deleting

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `rake routes` in favor of `rails routes`.
+
+    *Yuji Yaginuma*
+
 *   Deprecate `rake initializers` in favor of `rails initializers`.
 
     *Annie-Claude Côté*

--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -12,6 +12,7 @@ require "rake"
   middleware
   misc
   restart
+  routes
   tmp
   yarn
 ).tap { |arr|

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails/command"
+require "active_support/deprecation"
+
+task routes: :environment do
+  ActiveSupport::Deprecation.warn("Using `bin/rake routes` is deprecated and will be removed in Rails 6.1. Use `bin/rails routes` instead.\n")
+  Rails::Command.invoke "routes"
+end

--- a/railties/test/application/rake/routes_test.rb
+++ b/railties/test/application/rake/routes_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  module RakeTests
+    class RakeRoutesTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+      setup :build_app
+      teardown :teardown_app
+
+      test "`rake routes` outputs routes" do
+        app_file "config/routes.rb", <<-RUBY
+          Rails.application.routes.draw do
+            get '/cart', to: 'cart#show'
+          end
+        RUBY
+
+        assert_equal <<~MESSAGE, run_rake_routes
+                   Prefix Verb URI Pattern                                                                              Controller#Action
+                     cart GET  /cart(.:format)                                                                          cart#show
+       rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
+rails_blob_representation GET  /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
+       rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
+update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:format)                                      active_storage/disk#update
+     rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                                           active_storage/direct_uploads#create
+        MESSAGE
+      end
+
+      test "`rake routes` outputs a deprecation warning" do
+        remove_from_env_config("development", ".*config\.active_support\.deprecation.*\n")
+        add_to_env_config("development", "config.active_support.deprecation = :stderr")
+
+        stderr = capture(:stderr) { run_rake_routes }
+        assert_match(/DEPRECATION WARNING: Using `bin\/rake routes` is deprecated and will be removed in Rails 6.1/, stderr)
+      end
+
+      private
+        def run_rake_routes
+          Dir.chdir(app_path) { `bin/rake routes` }
+        end
+    end
+  end
+end


### PR DESCRIPTION
`rake routes` was a public task. Therefore, I think that we should deprecate it before deleting it.

Related to #32121.