### PR TITLE
Fix `rails routes -c` for controller name consists of multiple word.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -83,7 +83,7 @@ module ActionDispatch
       private
         def normalize_filter(filter)
           if filter[:controller]
-            { controller: /#{filter[:controller].downcase.sub(/_?controller\z/, '').sub('::', '/')}/ }
+            { controller: /#{filter[:controller].underscore.sub(/_?controller\z/, "")}/ }
           elsif filter[:grep]
             { controller: /#{filter[:grep]}/, action: /#{filter[:grep]}/,
               verb: /#{filter[:grep]}/, name: /#{filter[:grep]}/, path: /#{filter[:grep]}/ }

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -13,20 +13,33 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
         resource :post
+        resource :user_permission
       end
     RUBY
 
-    expected_output = ["   Prefix Verb   URI Pattern          Controller#Action",
-                       " new_post GET    /post/new(.:format)  posts#new",
-                       "edit_post GET    /post/edit(.:format) posts#edit",
-                       "     post GET    /post(.:format)      posts#show",
-                       "          PATCH  /post(.:format)      posts#update",
-                       "          PUT    /post(.:format)      posts#update",
-                       "          DELETE /post(.:format)      posts#destroy",
-                       "          POST   /post(.:format)      posts#create\n"].join("\n")
+    expected_post_output = ["   Prefix Verb   URI Pattern          Controller#Action",
+                            " new_post GET    /post/new(.:format)  posts#new",
+                            "edit_post GET    /post/edit(.:format) posts#edit",
+                            "     post GET    /post(.:format)      posts#show",
+                            "          PATCH  /post(.:format)      posts#update",
+                            "          PUT    /post(.:format)      posts#update",
+                            "          DELETE /post(.:format)      posts#destroy",
+                            "          POST   /post(.:format)      posts#create\n"].join("\n")
 
     output = run_routes_command(["-c", "PostController"])
-    assert_equal expected_output, output
+    assert_equal expected_post_output, output
+
+    expected_perm_output = ["              Prefix Verb   URI Pattern                     Controller#Action",
+                            " new_user_permission GET    /user_permission/new(.:format)  user_permissions#new",
+                            "edit_user_permission GET    /user_permission/edit(.:format) user_permissions#edit",
+                            "     user_permission GET    /user_permission(.:format)      user_permissions#show",
+                            "                     PATCH  /user_permission(.:format)      user_permissions#update",
+                            "                     PUT    /user_permission(.:format)      user_permissions#update",
+                            "                     DELETE /user_permission(.:format)      user_permissions#destroy",
+                            "                     POST   /user_permission(.:format)      user_permissions#create\n"].join("\n")
+
+    output = run_routes_command(["-c", "UserPermissionController"])
+    assert_equal expected_perm_output, output
   end
 
   test "rails routes with global search key" do
@@ -64,17 +77,30 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       Rails.application.routes.draw do
         get '/cart', to: 'cart#show'
         get '/basketball', to: 'basketball#index'
+        get '/user_permission', to: 'user_permission#index'
       end
     RUBY
 
+    expected_cart_output = "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n"
     output = run_routes_command(["-c", "cart"])
-    assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    assert_equal expected_cart_output, output
 
     output = run_routes_command(["-c", "Cart"])
-    assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    assert_equal expected_cart_output, output
 
     output = run_routes_command(["-c", "CartController"])
-    assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    assert_equal expected_cart_output, output
+
+    expected_perm_output = ["         Prefix Verb URI Pattern                Controller#Action",
+                            "user_permission GET  /user_permission(.:format) user_permission#index\n"].join("\n")
+    output = run_routes_command(["-c", "user_permission"])
+    assert_equal expected_perm_output, output
+
+    output = run_routes_command(["-c", "UserPermission"])
+    assert_equal expected_perm_output, output
+
+    output = run_routes_command(["-c", "UserPermissionController"])
+    assert_equal expected_perm_output, output
   end
 
   test "rails routes with namespaced controller search key" do
@@ -82,24 +108,40 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       Rails.application.routes.draw do
         namespace :admin do
           resource :post
+          resource :user_permission
         end
       end
     RUBY
 
-    expected_output = ["         Prefix Verb   URI Pattern                Controller#Action",
-                       " new_admin_post GET    /admin/post/new(.:format)  admin/posts#new",
-                       "edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit",
-                       "     admin_post GET    /admin/post(.:format)      admin/posts#show",
-                       "                PATCH  /admin/post(.:format)      admin/posts#update",
-                       "                PUT    /admin/post(.:format)      admin/posts#update",
-                       "                DELETE /admin/post(.:format)      admin/posts#destroy",
-                       "                POST   /admin/post(.:format)      admin/posts#create\n"].join("\n")
+    expected_post_output = ["         Prefix Verb   URI Pattern                Controller#Action",
+                            " new_admin_post GET    /admin/post/new(.:format)  admin/posts#new",
+                            "edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit",
+                            "     admin_post GET    /admin/post(.:format)      admin/posts#show",
+                            "                PATCH  /admin/post(.:format)      admin/posts#update",
+                            "                PUT    /admin/post(.:format)      admin/posts#update",
+                            "                DELETE /admin/post(.:format)      admin/posts#destroy",
+                            "                POST   /admin/post(.:format)      admin/posts#create\n"].join("\n")
 
     output = run_routes_command(["-c", "Admin::PostController"])
-    assert_equal expected_output, output
+    assert_equal expected_post_output, output
 
     output = run_routes_command(["-c", "PostController"])
-    assert_equal expected_output, output
+    assert_equal expected_post_output, output
+
+    expected_perm_output = ["                    Prefix Verb   URI Pattern                           Controller#Action",
+                            " new_admin_user_permission GET    /admin/user_permission/new(.:format)  admin/user_permissions#new",
+                            "edit_admin_user_permission GET    /admin/user_permission/edit(.:format) admin/user_permissions#edit",
+                            "     admin_user_permission GET    /admin/user_permission(.:format)      admin/user_permissions#show",
+                            "                           PATCH  /admin/user_permission(.:format)      admin/user_permissions#update",
+                            "                           PUT    /admin/user_permission(.:format)      admin/user_permissions#update",
+                            "                           DELETE /admin/user_permission(.:format)      admin/user_permissions#destroy",
+                            "                           POST   /admin/user_permission(.:format)      admin/user_permissions#create\n"].join("\n")
+
+    output = run_routes_command(["-c", "Admin::UserPermissionController"])
+    assert_equal expected_perm_output, output
+
+    output = run_routes_command(["-c", "UserPermissionController"])
+    assert_equal expected_perm_output, output
   end
 
   test "rails routes displays message when no routes are defined" do


### PR DESCRIPTION
### Summary

`rails routes -c UserPermissionsController` did not output routes for corresponding controller because its name  consists of multiple word.
