### PR TITLE
2nd argument should be a hash

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -39,7 +39,7 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        config.present? ? YAML.load(config, content_path) : {}
+        config.present? ? YAML.load(config, filename: content_path) : {}
       end
   end
 end


### PR DESCRIPTION
### Summary

YAML.load 2nd argument is not correct and does not work with *safe_yaml* gem. It should be a hash.
*filename* option is the one used by *psych* cf. https://github.com/ruby/psych/blob/master/lib/psych.rb#L266
