### PR TITLE
Fail more gracefully from ActiveStorage missing file exceptions

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveStorage::DiskController#show` generates a 404 Not Found response when
+    the requested file is missing from the disk service. It previously raised
+    `Errno::ENOENT`.
+
+    *Cameron Bothner*
+
 *   `ActiveStorage::Blob#download` and `ActiveStorage::Blob#open` raise
     `ActiveStorage::FileNotFoundError` when the corresponding file is missing
     from the storage service. Services translate service-specific missing object

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveStorage::Blob#download` and `ActiveStorage::Blob#open` raise
+    `ActiveStorage::FileNotFoundError` when the corresponding file is missing
+    from the storage service. Services translate service-specific missing object
+    exceptions (e.g. `Google::Cloud::NotFoundError` for the GCS service and
+    `Errno::ENOENT` for the disk service) into
+    `ActiveStorage::FileNotFoundError`.
+
+    *Cameron Bothner*
+
 *   Added the `ActiveStorage::SetCurrent` concern for custom Active Storage
     controllers that can't inherit from `ActiveStorage::BaseController`.
 

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -13,6 +13,8 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     else
       head :not_found
     end
+  rescue Errno::ENOENT
+    head :not_found
   end
 
   def update

--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -19,4 +19,8 @@ module ActiveStorage
   # Raised when uploaded or downloaded data does not match a precomputed checksum.
   # Indicates that a network error or a software bug caused data corruption.
   class IntegrityError < Error; end
+
+  # Raised when ActiveStorage::Blob#download is called on a blob where the
+  # backing file is no longer present in its service.
+  class FileNotFoundError < Error; end
 end

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -31,6 +31,14 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     assert_equal " worl", response.body
   end
 
+  test "showing blob that does not exist" do
+    blob = create_blob
+    blob.delete
+
+    get blob.service_url
+    assert_response :not_found
+  end
+
 
   test "directly uploading blob with integrity" do
     data = "Something else entirely!"

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -50,6 +50,13 @@ module ActiveStorage::Service::SharedServiceTests
       assert_equal FIXTURE_DATA, @service.download(@key)
     end
 
+    test "downloading a nonexistent file" do
+      assert_raises(ActiveStorage::FileNotFoundError) do
+        @service.download(SecureRandom.base58(24))
+      end
+    end
+
+
     test "downloading in chunks" do
       key = SecureRandom.base58(24)
       expected_chunks = [ "a" * 5.megabytes, "b" ]
@@ -68,10 +75,24 @@ module ActiveStorage::Service::SharedServiceTests
       end
     end
 
+    test "downloading a nonexistent file in chunks" do
+      assert_raises(ActiveStorage::FileNotFoundError) do
+        @service.download(SecureRandom.base58(24)) {}
+      end
+    end
+
+
     test "downloading partially" do
       assert_equal "\x10\x00\x00", @service.download_chunk(@key, 19..21)
       assert_equal "\x10\x00\x00", @service.download_chunk(@key, 19...22)
     end
+
+    test "partially downloading a nonexistent file" do
+      assert_raises(ActiveStorage::FileNotFoundError) do
+        @service.download_chunk(SecureRandom.base58(24), 19..21)
+      end
+    end
+
 
     test "existing" do
       assert @service.exist?(@key)


### PR DESCRIPTION
This PR translates service-specific missing object exceptions into one generic `ActiveStorage::FileNotFoundError` so that the application can fail more gracefully when a missing file is accessed. Specifically, this PR lets `DiskController` rescue this error and respond with 404 instead of 500. This improves the development experience especially when working, in `development`, with a database of Blob records that point to files in the `production` service.

### Outstanding question
`RepresentationsController` does not presently handle `ActiveStorage::FileNotFoundError`, since @georgeclaghorn argued it truly is exceptional for the service not to have a file that corresponds to a specific blob in the database. I don’t disagree with this, but hope we can nevertheless find a way to reduce the flood of stack traces that fill our `development` logs when loading an index view that tries to display many thumbnails of images stored in our `production` service.

### Related issue

Resolves #33647