### PR TITLE
Ensure references creates id before type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -163,7 +163,15 @@ module ActiveRecord
         end
 
         def polymorphic_options
-          as_options(polymorphic).merge(options.slice(:null, :first, :after))
+          as_options(polymorphic).merge(options.slice(:null)).merge(polymorphic_position)
+        end
+
+        def polymorphic_position
+          if options.has_key?(:first) || options.has_key?(:after)
+            { after: column_name }
+          else
+            {}
+          end
         end
 
         def index_options
@@ -177,7 +185,7 @@ module ActiveRecord
         def columns
           result = [[column_name, type, options]]
           if polymorphic
-            result.unshift(["#{name}_type", :string, polymorphic_options])
+            result << ["#{name}_type", :string, polymorphic_options]
           end
           result
         end
@@ -187,7 +195,7 @@ module ActiveRecord
         end
 
         def column_names
-          columns.map(&:first)
+          columns.map(&:first).reverse
         end
 
         def foreign_table_name

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -871,7 +871,7 @@ module ActiveRecord
       #   add_reference(:products, :supplier, foreign_key: {to_table: :firms})
       #
       def add_reference(table_name, ref_name, **options)
-        ReferenceDefinition.new(ref_name, options).add_to(update_table_definition(table_name, self))
+        ReferenceDefinition.create(ref_name, options).add_to(update_table_definition(table_name, self))
       end
       alias :add_belongs_to :add_reference
 

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -32,6 +32,14 @@ module ActiveRecord
         assert column_exists?(table_name, :taggable_type, :string)
       end
 
+      def test_creates_reference_id_before_type
+        add_reference table_name, :taggable, polymorphic: true
+        column_names = connection.columns(@table_name).map(&:name)
+        id_index = column_names.index("taggable_id")
+        type_index = column_names.index("taggable_type")
+        assert_operator id_index, :<, type_index, "id should be before type"
+      end
+
       def test_does_not_create_reference_id_index_if_index_is_false
         add_reference table_name, :user, index: false
         assert_not index_exists?(table_name, :user_id)


### PR DESCRIPTION
Prior to https://github.com/rails/rails/commit/d26704a15f88d384dd282425daa832affdb5f8c1, using `references` with `polymorphic: true` in a migration created an id column before creating the  corresponding type column.

After that commit, the order is reversed.

This PR restores the previous order and adds a test to prevent regressions.

I'm not aware of any production impact for the column ordering change, but it broke the schema linting on github/github.

/cc @tenderlove @eileencodes 