### PR TITLE
Reduce memory bloat on new ActiveRecord connections (When DB has large number of tables)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -37,18 +37,18 @@ module ActiveRecord
             known_type_names = @store.keys.map { |n| "'#{n}'" }
             known_type_types = %w('r' 'e' 'd')
             <<-SQL % [known_type_names.join(", "), known_type_types.join(", ")]
-              LEFT join pg_type as composite_children on t.typelem=composite_children.oid
+              LEFT JOIN pg_type AS composite_children ON t.typelem = composite_children.oid
               WHERE
-              t.typname IN (%s)
-              OR t.typtype IN (%s)
-              OR
-              (
+                t.typname IN (%s)
+                OR t.typtype IN (%s)
+                OR
                 (
-                  t.typinput = 'array_in(cstring,oid,integer)'::regprocedure
-                  OR t.typelem != 0
+                  (
+                    t.typinput = 'array_in(cstring,oid,integer)'::regprocedure
+                    OR t.typelem != 0
+                  )
+                  AND composite_children.typtype != 'c'
                 )
-                AND composite_children.typtype != 'c'
-              )
             SQL
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -41,8 +41,7 @@ module ActiveRecord
               WHERE
                 t.typname IN (%s)
                 OR t.typtype IN (%s)
-                OR
-                (
+                OR (
                   (
                     t.typinput = 'array_in(cstring,oid,integer)'::regprocedure
                     OR t.typelem != 0

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -38,19 +38,16 @@ module ActiveRecord
             known_type_types = %w('r' 'e' 'd')
             <<-SQL % [known_type_names.join(", "), known_type_types.join(", ")]
               LEFT join pg_type as composite_children on t.typelem=composite_children.oid
-              WHERE (
+              WHERE
+              t.typname IN (%s)
+              OR t.typtype IN (%s)
+              OR
+              (
                 (
-                  t.typname IN (%s)
-                  OR t.typtype IN (%s)
+                  t.typinput = 'array_in(cstring,oid,integer)'::regprocedure
+                  OR t.typelem != 0
                 )
-                OR
-                (
-                  (
-                    t.typinput = 'array_in(cstring,oid,integer)'::regprocedure
-                    OR t.typelem != 0
-                  )
-                  AND composite_children.typtype != 'c'
-                )
+                AND composite_children.typtype != 'c'
               )
             SQL
           end


### PR DESCRIPTION
### Summary
Continuation of 
#28369 (Merged but reverted)
#28834 (Open but stale) 

#query_conditions_for_initial_load currently loads many more
records than it needs. Including the children of composite types
when the parent composites themselves were not loaded.

In the current query a record is returned for each table in the DB
but is not used, while this is normally pretty minimal overhead;
In databases with a large number of tables (eg. tenanted app with
multiple schemas) the issue is exacerbated and results in memory
bloat each time a connection is established.

This attempts to reduce the bloat by amending the query to not
include the children of composite types (including the records
for each table) as suggested [here in #28834](https://github.com/rails/rails/pull/28834#issuecomment-312422423)

### Other Information

Created 2 dummy databases using the following [script](
https://gist.github.com/jonathan-wheeler/db266d98c4d61ecd942e3cd466baefdc)
one single tenant with 100 tables and one large multitenant with
1000 schemas each with 100 tables. They contain no data but it
should still illustrate the issue.

10.times { ActiveRecord::Base.establish_connection(....).connection }
[Full benchmark scripts](https://gist.github.com/jonathan-wheeler/c4c8726773311f9785f22d4d1ca24eeb)
#### Memory
##### Single tenant
```
Calculating -------------------------------------
master_single_tenant_test
                        20.982M memsize (    18.984M retained)
                        23.535k objects (     1.109k retained)
                        50.000  strings (    50.000  retained)

patch_single_tenant_test
                        11.938M memsize (    10.559M retained)
                        16.082k objects (   811.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
patch_single_tenant_test:   11938187 allocated
master_single_tenant_test:   20982362 allocated - 1.76x more
```
##### Multitenant
```
Calculating -------------------------------------
master_large_multi_tenant_tenant_test
                       493.410M memsize (    18.983M retained)
                         5.069M objects (     1.099k retained)
                        50.000  strings (    50.000  retained)
patch_large_multi_tenant_tenant_test
                        12.843M memsize (    11.337M retained)
                        23.825k objects (     7.024k retained)
                        50.000  strings (    50.000  retained)

Comparison:
patch_large_multi_tenant_tenant_test:   12843438 allocated
master_large_multi_tenant_tenant_test:  493410349 allocated - 38.42x more
```

Not in the same league of improvement seen in #28834 as this patch is
less aggressive so still includes some clutter but still a
sizeable reduction in allocations to be made. Not a huge difference
in retained memory but initial bloat maybe more of an issue as the
number of tables scale (example 10,000 schemas is not huge).

#### Speed
##### Single tenant
```
Rehearsal -------------------------------------------------------------
master_single_tenant_test   0.043770   0.019775   0.063545 (  0.227460)
patch_single_tenant_test    0.039852   0.009767   0.049619 (  0.191569)
---------------------------------------------------- total: 0.113164sec

                                user     system      total        real
master_single_tenant_test   0.034316   0.006944   0.041260 (  0.195248)
patch_single_tenant_test    0.027595   0.006390   0.033985 (  0.179472)
```

##### Multitenant
```
Rehearsal -------------------------------------------------------------------------
master_large_multi_tenant_tenant_test   4.232676   0.268989   4.501665 ( 12.966424)
patch_large_multi_tenant_tenant_test    0.027335   0.006216   0.033551 ( 13.238648)
---------------------------------------------------------------- total: 4.535216sec

                                            user     system      total        real
master_large_multi_tenant_tenant_test   0.026196   0.005952   0.032148 ( 12.977751)
patch_large_multi_tenant_tenant_test    0.027290   0.006186   0.033476 ( 13.293085)
```

No substantial differences.

