### PR TITLE
Fix frozen string literal error in ActiveRecord::MismatchedForeignKey

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -126,7 +126,7 @@ module ActiveRecord
           To resolve this issue, change the type of the `#{foreign_key}` column on `#{table}` to be :integer. (For example `t.integer #{foreign_key}`).
         EOM
       else
-        msg = <<-EOM
+        msg = <<-EOM.strip_heredoc
           There is a mismatch between the foreign key and primary key column types.
           Verify that the foreign key column type and the primary key of the associated table match types.
         EOM


### PR DESCRIPTION
### Summary

`ActiveRecord::MismatchedForeignKey` can produce `RuntimeError: can't modify frozen String` if a message is passed into the constructor.

### Other Information

This was fixed in master by https://github.com/rails/rails/commit/e9f0861eb9d8d55172c765d5d4bbc6d363e87a09. That commit does not cleanly apply to `5-2-stable` because it relies on changes from https://github.com/rails/rails/commit/89bcca59e91fa9da941de890012872e8288e77b0