### PR TITLE
Focus search input after page load on /rails/info/routes

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -197,4 +197,7 @@
 
   setupMatchPaths();
   setupRouteToggleHelperLinks();
+
+  // Focus the search input after page has loaded
+  document.getElementById('search').focus();
 </script>


### PR DESCRIPTION
### Summary
Causes the search input to be focused after page load when viewing routes via `/rails/info/routes`.

### Rationale
Over the years I have found when using this page my primary used case is to filter routes and as such I believe that having the search input focused on load would be a very small yet helpful enhancement.