### PR TITLE
Update image_processing version everywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :storage do
   gem "google-cloud-storage", "~> 1.11", require: false
   gem "azure-storage", require: false
 
-  gem "image_processing", "~> 1.2"
+  gem "image_processing", "~> 1.6"
   gem "ffi", "<= 1.9.21"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.11)
   hiredis
   i18n (~> 1.0.1)
-  image_processing (~> 1.2)
+  image_processing (~> 1.6)
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)
   libxml-ruby

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -66,7 +66,7 @@ class ActiveStorage::Variation
         rescue LoadError
           ActiveSupport::Deprecation.warn <<~WARNING
             Generating image variants will require the image_processing gem in Rails 6.1.
-            Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
+            Please add `gem 'image_processing', '~> 1.6'` to your Gemfile.
           WARNING
 
           ActiveStorage::Transformers::MiniMagickTransformer.new(transformations)

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -416,7 +416,7 @@ can also use [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image).
 To enable variants, add the `image_processing` gem to your `Gemfile`:
 
 ```ruby
-gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.6'
 ```
 
 When the browser hits the variant URL, Active Storage will lazily transform the

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -23,7 +23,7 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 <% unless skip_active_storage? -%>
 
 # Use ActiveStorage variant
-# gem 'image_processing', '~> 1.2'
+# gem 'image_processing', '~> 1.6'
 <% end -%>
 
 # Use Capistrano for deployment


### PR DESCRIPTION
Follow-up on c5fbfb8c1205baeb2f093f4c94528d4a04f63644.

#33633 updated Gemfile.lock, but left some use of version 1.2 lingering behind. This patch fixes those.
