### PR TITLE
Two fewer array allocations on action_methods

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -78,7 +78,10 @@ module AbstractController
             # Except for public instance methods of Base and its ancestors
             internal_methods +
             # Be sure to include shadowed public instance methods of this class
-            public_instance_methods(false)).uniq.map(&:to_s)
+            public_instance_methods(false))
+
+          methods.uniq!
+          methods.map!(&:to_s)
 
           methods.to_set
         end


### PR DESCRIPTION
Instead of creating new arrays for `uniq` and `map` we can instead modify the array in place.

PR open for CI tests.
