### PR TITLE
Update ParameterFilter to yield original parameters

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1078,10 +1078,13 @@ class RequestParameterFilter < BaseRequestTest
       filter_words << lambda { |key, value|
         value.reverse! if key =~ /bargain/
       }
+      filter_words << lambda { |key, value, original_params|
+        value.replace("world!") if original_params["barg"]["blah"] == "bar" && key == "hello"
+      }
 
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)
-      before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo" } } }
-      after_filter["barg"]  = { :bargain => "niag", "blah" => "[FILTERED]", "bar" => { "bargain" => { "blah" => "[FILTERED]" } } }
+      before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world" } } }
+      after_filter["barg"]  = { :bargain => "niag", "blah" => "[FILTERED]", "bar" => { "bargain" => { "blah" => "[FILTERED]", "hello" => "world!" } } }
 
       assert_equal after_filter, parameter_filter.filter(before_filter)
     end


### PR DESCRIPTION
### Summary

When yielding a block as a parameter filter, it's often useful to have the original parameters in the block. This gives context to the structure of the parameters when writing filters (e.g. in a case where you want to do "filter x if y"). This does not break any legacy code as it checks whether the block takes in 2 or 3 parameters.

### Other Information

N/A