### PR TITLE
Fix `rails initializers --help` and `rails dev:cache --help`

### DIFF
--- a/railties/lib/rails/commands/dev/dev_command.rb
+++ b/railties/lib/rails/commands/dev/dev_command.rb
@@ -5,7 +5,10 @@ require "rails/dev_caching"
 module Rails
   module Command
     class DevCommand < Base # :nodoc:
-      desc "Toggle development mode caching on/off"
+      def help
+        say "rails dev:cache # Toggle development mode caching on/off."
+      end
+
       def cache
         Rails::DevCaching.enable_by_file
       end

--- a/railties/lib/rails/commands/initializers/initializers_command.rb
+++ b/railties/lib/rails/commands/initializers/initializers_command.rb
@@ -3,7 +3,7 @@
 module Rails
   module Command
     class InitializersCommand < Base # :nodoc:
-      desc "Print out all defined initializers in the order they are invoked by Rails."
+      desc "initializers", "Print out all defined initializers in the order they are invoked by Rails."
       def perform
         require_application_and_environment!
 


### PR DESCRIPTION
- `rails initializers --help` should show description set by `desc`
  See railties/lib/rails/command/base.rb:27

- Fix `rails dev:cache --help`

 ```
 Traceback (most recent call last):
         10: from bin/rails:4:in `<main>'
          9: from bin/rails:4:in `require'
          8: from /work/rails/railties/lib/rails/commands.rb:18:in `<top (required)>'
          7: from /work/rails/railties/lib/rails/command.rb:46:in `invoke'
          6: from /work/rails/railties/lib/rails/command/base.rb:65:in `perform'
          5: from /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
          4: from /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
          3: from /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
          2: from /work/rails/railties/lib/rails/command/base.rb:150:in `help'
          1: from /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor.rb:170:in `command_help'
 /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:497:in `handle_no_command_error': Could not find command "dev". (Thor::UndefinedCommandError)
  ```

Context https://github.com/rails/rails/pull/33694#issuecomment-415127304
r? @rafaelfranca 

Would be great to set a description to other commands.