### PR TITLE
Remove extra execution of `uniq!` on action_methods

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -80,7 +80,6 @@ module AbstractController
             # Be sure to include shadowed public instance methods of this class
             public_instance_methods(false))
 
-          methods.uniq!
           methods.map!(&:to_s)
 
           methods.to_set


### PR DESCRIPTION
Execution of `to_set` below should remove duplicated elements.

Follow up #33693

r? @schneems 