### PR TITLE
Follow up #33659

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -9,7 +9,7 @@ module ActionCable
     # The test adapter should be used only in testing. Along with
     # <tt>ActionCable::TestHelper</tt> it makes a great tool to test your Rails application.
     #
-    # To use the test adapter set adapter value to +test+ in your +cable.yml+.
+    # To use the test adapter set +adapter+ value to +test+ in your +config/cable.yml+ file.
     #
     # NOTE: Test adapter extends the <tt>ActionCable::SubscriptionsAdapter::Async</tt> adapter,
     # so it could be used in system tests too.

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -125,7 +125,7 @@ module ActionCable
     delegate :broadcasts, :clear_messages, to: :pubsub_adapter
 
     private
-      def broadcasts_size(channel) # :nodoc:
+      def broadcasts_size(channel)
         broadcasts(channel).size
       end
   end

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -47,11 +47,12 @@ module ActionCable
         original_count = broadcasts_size(stream)
         yield
         new_count = broadcasts_size(stream)
-        assert_equal number, new_count - original_count, "#{number} broadcasts to #{stream} expected, but #{new_count - original_count} were sent"
+        actual_count = new_count - original_count
       else
         actual_count = broadcasts_size(stream)
-        assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
       end
+
+      assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
     end
 
     # Asserts that no messages have been sent to the stream.

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -17,7 +17,7 @@ Dir[File.expand_path("stubs/*.rb", __dir__)].each { |file| require file }
 
 # Set test adapter and logger
 ActionCable.server.config.cable = { "adapter" => "test" }
-ActionCable.server.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
+ActionCable.server.config.logger = Logger.new(nil)
 
 class ActionCable::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -62,6 +62,16 @@ class TransmissionsTest < ActionCable::TestCase
 
     assert_match(/1 .* but 2/, error.message)
   end
+
+  def test_assert_no_broadcasts_failure
+    error = assert_raises Minitest::Assertion do
+      assert_no_broadcasts "test" do
+        ActionCable.server.broadcast "test", "hello"
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
 end
 
 class TransmitedDataTest < ActionCable::TestCase

--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
@@ -2,7 +2,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis


### PR DESCRIPTION
- 0e42d3db59593b7641ed42efaddc69b315a36f7e
  Clarify api docs of ActionCable::SubscriptionAdapter::Test
  Remove extra `:nodoc:` comment since private methods don't require that.

- 1055d141276a509bf1a9fa720136ee9f0eb24c65
  Set the test adapter for the test environment by default in `config/cable.yml`

- d2ccf0c6f767d6a8170c2ea0160e51cb8cd29a78
  Simplify configuring of `ActionCable.server.config.logger` for actioncable tests
  See `git grep "= Logger.new(nil)"`

- 86e7de7968b91bd4256bb07ffbe689b385180910
  DRY in `assert_broadcasts`
  Test `assert_no_broadcasts` failure

Related to #33659
/cc @palkan