### PR TITLE
Use string lengths instead of regexp to extract path

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -100,8 +100,7 @@ module ActionController
       #   # => ["application", "chart", "rubygems"]
       def all_helpers_from_path(path)
         helpers = Array(path).flat_map do |_path|
-          extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/
-          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1'.freeze) }
+          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file[_path.to_s.size + 1..-"_helper.rb".size - 1] }
           names.sort!
         end
         helpers.uniq!


### PR DESCRIPTION
The regexp was introduced in 186ac4cdaa911a9af659a29f2179a19b99dea13b, and looks cosmetic. While they should be functionally identical in theory, in practice, case insensitive (but preserving) filesystems can give results that are differently-cased from the pattern we supplied.

I don't know how to force the filesystem to do the surprising thing, even when running in an environment that _could_, so no new test.

Fixes #18660.

I'd held off on making this change for a Very Long Time, because I mistakenly thought the use of the regexp was important for safety (and introduced more recently). It turns out that was wrong, and I just needed to dig into history to better understand how we got here. 🕰🕵🏻‍♂️