### PR TITLE
Backport prevent deadlocks when waiting for connection from pool to 5-1-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -191,7 +191,9 @@ module ActiveRecord
             t0 = Time.now
             elapsed = 0
             loop do
-              @cond.wait(timeout - elapsed)
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                @cond.wait(timeout - elapsed)
+              end
 
               return remove if any?
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -107,6 +107,44 @@ module ActiveRecord
         assert_equal connection, t.join.value
       end
 
+      def test_full_pool_blocking_shares_load_interlock
+        @pool.instance_variable_set(:@size, 1)
+
+        load_interlock_latch = Concurrent::CountDownLatch.new
+        connection_latch = Concurrent::CountDownLatch.new
+
+        able_to_get_connection = false
+        able_to_load = false
+
+        thread_with_load_interlock = Thread.new do
+          ActiveSupport::Dependencies.interlock.running do
+            load_interlock_latch.count_down
+            connection_latch.wait
+
+            @pool.with_connection do
+              able_to_get_connection = true
+            end
+          end
+        end
+
+        thread_with_last_connection = Thread.new do
+          @pool.with_connection do
+            connection_latch.count_down
+            load_interlock_latch.wait
+
+            ActiveSupport::Dependencies.interlock.loading do
+              able_to_load = true
+            end
+          end
+        end
+
+        thread_with_load_interlock.join
+        thread_with_last_connection.join
+
+        assert able_to_get_connection
+        assert able_to_load
+      end
+
       def test_removing_releases_latch
         cs = @pool.size.times.map { @pool.checkout }
         t = Thread.new { @pool.checkout }


### PR DESCRIPTION
### Summary

Back-port of #31696 for the rails 5.1

When a thread has the load interlock and is waiting to check a connection out of the connection pool because there are no free connections and the threads with connections are waiting for the load interlock, an `ActiveRecord::ConnectionTimeoutError` exception will be thrown by the thread waiting for the connection.

When waiting for the connection to check out we should allow autoloading to proceed to avoid this deadlock.