### PR TITLE
Backport prevent deadlocks when waiting for connection from pool to 5-2-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -188,7 +188,9 @@ module ActiveRecord
             t0 = Time.now
             elapsed = 0
             loop do
-              @cond.wait(timeout - elapsed)
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                @cond.wait(timeout - elapsed)
+              end
 
               return remove if any?
 


### PR DESCRIPTION
### Summary

Back-port of #31696 for the rails 5.2

When a thread has the load interlock and is waiting to check a connection out of the connection pool because there are no free connections and the threads with connections are waiting for the load interlock, an ActiveRecord::ConnectionTimeoutError exception will be thrown by the thread waiting for the connection.

When waiting for the connection to check out we should allow autoloading to proceed to avoid this deadlock.