### PR TITLE
Handle only specifically relevant Azure HTTPErrors ActiveStorage::Service::AzureStorageService#upload and #delete

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveStorage::Service::AzureStorageService` only handles specifically
+    relevant types of `Azure::Core::Http::HTTPError`. It previously obscured
+    other types of `HTTPError`, which is the azure-storage gem’s catch-all
+    exception class.
+
+    *Cameron Bothner*
+
 *   `ActiveStorage::DiskController#show` generates a 404 Not Found response when
     the requested file is missing from the disk service. It previously raised
     `Errno::ENOENT`.


### PR DESCRIPTION
The Azure gem uses `Azure::Core::Http::HTTPError` for everything:
checksum mismatch, missing object, network unavailable, and many more.
(https://www.rubydoc.info/github/yaxia/azure-storage-ruby/Azure/Core/Http/HTTPError).
Rescuing that class obscures all sorts of configuration errors. We
should check the type of error in those rescue blocks, and reraise when
needed.

This is a resubmission of #33667, which had a bug sneak through.

r? @georgeclaghorn 