### PR TITLE
Fixed the QueryMethod unscope issue for nested attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -553,6 +553,12 @@
 
     *Eileen M. Uchitelle*, *Aaron Patterson*
 
+*   Fix `ActiveRecord::QueryMethod#unscope` for nested attributes.
+
+    Fixes #35150.
+
+    *Abhay Nikam*
+
 *   Add database configuration to disable advisory locks.
 
     ```

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -387,7 +387,7 @@ module ActiveRecord
               raise ArgumentError, "Hash arguments in .unscope(*args) must have :where as the key."
             end
 
-            target_values = Array(target_value).map(&:to_s)
+            target_values = Array(target_value).flatten.map(&:to_s)
             self.where_clause = where_clause.except(*target_values)
           end
         else

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -47,6 +47,7 @@ class Author < ActiveRecord::Base
   has_many :ordered_uniq_comments, -> { distinct.order("comments.id") }, through: :posts, source: :comments
   has_many :ordered_uniq_comments_desc, -> { distinct.order("comments.id DESC") }, through: :posts, source: :comments
   has_many :readonly_comments, -> { readonly }, through: :posts, source: :comments
+  has_many :comments_having_post_tag_count_one, -> { posts_having_tag_count_one }, through: :posts, source: :comments
 
   has_many :special_posts
   has_many :special_post_comments, through: :special_posts, source: :comments

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -10,6 +10,7 @@ class Comment < ActiveRecord::Base
   scope :for_first_post, -> { where(post_id: 1) }
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }
+  scope :posts_having_tag_count_one, -> { where(posts: { tags_count: 1 }) }
 
   belongs_to :post, counter_cache: true
   belongs_to :author,   polymorphic: true

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -51,6 +51,8 @@ class Post < ActiveRecord::Base
 
   scope :typographically_interesting, -> { containing_the_letter_a.or(titled_with_an_apostrophe) }
 
+  scope :having_tag_count_one, -> { where(tags_count: 1) }
+
   has_many :comments do
     def find_most_recent
       order("id DESC").first


### PR DESCRIPTION
Related to: #22100 

fixes #35150

```
class Event < ActiveRecord::Base
  has_many :nominations
  has_many :awards, -> { approved_nomination }, through: :nominations
end

class Nomination < ActiveRecord::Base
  belongs_to :event
  belongs_to :award
end

class Award < ActiveRecord::Base
  has_many :nominations
  has_many :events, through: :nominations

  scope :approved_nomination, -> {where(nominations: {approved: true})}
end
```

Fix allows to unscope the nested scope. Example:
```
@event.awards.unscope(where: {nominations: :approved})
```