### PR TITLE
Format respond_to method as code in doc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -105,7 +105,7 @@ module ActionController #:nodoc:
     #
     #   Mime::Type.register "image/jpg", :jpg
     #
-    # Respond to also allows you to specify a common block for different formats by using +any+:
+    # +respond_to+ also allows you to specify a common block for different formats by using +any+:
     #
     #   def index
     #     @people = Person.all


### PR DESCRIPTION
### Summary

This updates the API documentation for the `respond_to` method to be code formatted rather than
plain text (as it refers to the method)