### PR TITLE
StringIO or String required for reopen

### DIFF
--- a/activesupport/lib/active_support/testing/stream.rb
+++ b/activesupport/lib/active_support/testing/stream.rb
@@ -28,7 +28,7 @@ module ActiveSupport
           captured_stream = Tempfile.new(stream)
           stream_io = eval("$#{stream}")
           origin_stream = stream_io.dup
-          stream_io.reopen(captured_stream)
+          stream_io.reopen(captured_stream.read)
 
           yield
 


### PR DESCRIPTION
### Summary

I'm getting a TypeError: can't convert Tempfile into StringIO error using ruby 2.4.0. By using the Tempfile's read method it can be avoided.