### PR TITLE
Add support to ActiveJob for locking jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for locking jobs to ActiveJob.
+
+    *steves*
+
 *   Allow `assert_performed_with` to be called without a block.
 
     *bogdanvlviv*

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -11,6 +11,7 @@ require "active_job/exceptions"
 require "active_job/logging"
 require "active_job/timezones"
 require "active_job/translation"
+require "active_job/locking"
 
 module ActiveJob #:nodoc:
   # = Active Job
@@ -70,6 +71,7 @@ module ActiveJob #:nodoc:
     include Logging
     include Timezones
     include Translation
+    include Locking
 
     ActiveSupport.run_load_hooks(:active_job, self)
   end

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_job/locking"
-
 module ActiveJob
   # Provides general behavior that will be included into every Active Job
   # object that inherits from ActiveJob::Base.
@@ -37,29 +35,13 @@ module ActiveJob
       # Timezone to be used during the job.
       attr_accessor :timezone
 
-      # Timeout used if job is locking
-      attr_accessor :lock_timeout
-
-      # The key used within the set if the job is locking
-      attr_accessor :lock_key
+      # The key to use if this job is locking
+      attr_writer :lock_key
     end
 
     # These methods will be included into any Active Job object, adding
     # helpers for de/serialization and creation of job instances.
     module ClassMethods
-      attr_accessor :lock_key
-      attr_accessor :lock_timeout
-
-      def lock_key=(lock_key)
-        include Locking unless self <= Locking
-        @lock_key = lock_key
-      end
-
-      def lock_timeout=(lock_timeout)
-        include Locking unless self <= Locking
-        @lock_timeout = lock_timeout
-      end
-
       # Creates a new job instance from a hash created with +serialize+
       def deserialize(job_data)
         job = job_data["job_class"].constantize.new
@@ -112,7 +94,8 @@ module ActiveJob
         "arguments"  => serialize_arguments_if_needed(arguments),
         "executions" => executions,
         "locale"     => I18n.locale.to_s,
-        "timezone"   => Time.zone.try(:name)
+        "timezone"   => Time.zone.try(:name),
+        "lock_key"   => lock_key,
       }
     end
 
@@ -151,10 +134,7 @@ module ActiveJob
       self.executions           = job_data["executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone.try(:name)
-    end
-
-    def locking?
-      false
+      self.lock_key             = job_data["lock_key"]
     end
 
     private

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -46,13 +46,16 @@ module ActiveJob
       self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
       self.priority     = options[:priority].to_i if options[:priority]
-      unless locking? && self.class.queue_adapter.locked?(self)
-        run_callbacks :enqueue do
-          if scheduled_at
-            self.class.queue_adapter.enqueue_at self, scheduled_at
-          else
-            self.class.queue_adapter.enqueue self
-          end
+
+      if locking? && self.class.queue_adapter.locked?(self)
+        return false
+      end
+
+      run_callbacks :enqueue do
+        if scheduled_at
+          self.class.queue_adapter.enqueue_at self, scheduled_at
+        else
+          self.class.queue_adapter.enqueue self
         end
       end
       self

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -40,6 +40,10 @@ module ActiveJob
       end
     rescue => exception
       rescue_with_handler(exception) || raise
+    ensure
+      if locking?
+        clear_lock
+      end
     end
 
     def perform(*)

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -38,12 +38,12 @@ module ActiveJob
       run_callbacks :perform do
         perform(*arguments)
       end
+
+      clear_lock
     rescue => exception
+      # ensure runs after rescue, which may re-enqueue the job, so we need to clear the lock first
+      clear_lock
       rescue_with_handler(exception) || raise
-    ensure
-      if locking?
-        clear_lock
-      end
     end
 
     def perform(*)

--- a/activejob/lib/active_job/locking.rb
+++ b/activejob/lib/active_job/locking.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  # Provides behavior for controlling how many of a job can be enqueued.
+  module Locking
+    def initialize(*arguments)
+      super
+
+      @lock_timeout = self.class.lock_timeout.to_i
+      if @lock_timeout > 0 && !self.class.lock_key.nil?
+        @lock_key = self.class.lock_key.call(self)
+      end
+    end
+
+    # We determine if a job is locking based on whether or not a timeout
+    # and key are present. Both are required for a lock.
+    def locking?
+      !lock_key.nil? && lock_timeout > 0
+    end
+
+    def clear_lock
+      self.class.queue_adapter.clear_lock(self)
+    end
+  end
+end

--- a/activejob/lib/active_job/locking.rb
+++ b/activejob/lib/active_job/locking.rb
@@ -19,14 +19,9 @@ module ActiveJob
         self._lock_timeout
       end
 
-      # Provide a Proc that returns the lock key this job should use
-      def lock_key=(lock_key)
-        self._lock_key = lock_key
-      end
-
-      # Provide the timeout that this jobs lock key should use
-      def lock_timeout=(lock_timeout)
-        self._lock_timeout = lock_timeout
+      def locked_by(key:, timeout:)
+        self._lock_key = key
+        self._lock_timeout = timeout
       end
     end
 

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -50,7 +50,7 @@ module ActiveJob
           self._queue_adapter = queue_adapter
         end
 
-        QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at].freeze
+        QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at, :locked?, :clear_lock].freeze
 
         def queue_adapter?(object)
           QUEUE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -44,6 +44,13 @@ module ActiveJob
         @scheduler.enqueue_at JobWrapper.new(job), timestamp, queue_name: job.queue_name
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       # Gracefully stop processing jobs. Finishes in-progress work and handles
       # any new jobs following the executor's fallback policy (`caller_runs`).
       # Waits for termination by default. Pass `wait: false` to continue.

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -24,6 +24,13 @@ module ActiveJob
         Backburner::Worker.enqueue JobWrapper, [ job.serialize ], queue: job.queue_name, delay: delay
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         class << self
           def perform(job_data)

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -27,6 +27,13 @@ module ActiveJob
         delayed_job
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         attr_accessor :job_data
 

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -18,6 +18,13 @@ module ActiveJob
       def enqueue_at(*) #:nodoc:
         raise NotImplementedError, "Use a queueing backend to enqueue jobs in the future. Read more at https://guides.rubyonrails.org/active_job_basics.html"
       end
+
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
     end
   end
 end

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -29,6 +29,13 @@ module ActiveJob
         que_job
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper < Que::Job #:nodoc:
         def run(job_data)
           Base.execute job_data

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -37,6 +37,13 @@ module ActiveJob
         qc_job
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       # Builds a <tt>QC::Queue</tt> object to schedule jobs on.
       #
       # If you have a custom <tt>QC::Queue</tt> subclass you'll need to subclass

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -41,6 +41,13 @@ module ActiveJob
         Resque.enqueue_at_with_queue job.queue_name, timestamp, JobWrapper, job.serialize
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         class << self
           def perform(job_data)

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -35,6 +35,13 @@ module ActiveJob
           "at"      => timestamp
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         include Sidekiq::Worker
 

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -33,6 +33,13 @@ module ActiveJob
         raise NotImplementedError, "This queueing backend does not support scheduling jobs. To see what features are supported go to http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html"
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         include Sneakers::Worker
         from_queue "default"

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -37,6 +37,13 @@ module ActiveJob
         end
       end
 
+      def locked?(job) #:nodoc:
+        false
+      end
+
+      def clear_lock(job) #:nodoc:
+      end
+
       class JobWrapper #:nodoc:
         include SuckerPunch::Job
 

--- a/activejob/test/cases/locking_test.rb
+++ b/activejob/test/cases/locking_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "helper"
+require "jobs/locking_job"
+require "models/person"
+
+class LockingTest < ActiveJob::TestCase
+  setup do
+    JobBuffer.clear
+  end
+
+  test "only enqueues a single job for a given key" do
+    LockingJob.perform_later
+    LockingJob.perform_later
+    LockingJob.perform_later
+    assert_equal ["Job enqueued"], JobBuffer.values
+  end
+
+  test "the lock key is cleared after a succssful run" do
+    perform_enqueued_jobs do
+      LockingJob.perform_later
+      assert_equal ["Job enqueued"], JobBuffer.values
+
+      LockingJob.perform_later
+      assert_equal ["Job enqueued", "Job enqueued"], JobBuffer.values
+
+      LockingJob.perform_later
+      assert_equal ["Job enqueued", "Job enqueued", "Job enqueued"], JobBuffer.values
+    end
+  end
+
+  test "locks expire after the configured amount of time" do
+    travel_to Time.now
+    LockingJob.perform_later
+
+    travel_to Time.now + 1.hour + 2
+    LockingJob.perform_later
+
+    travel_to Time.now + 1.hour + 2
+    LockingJob.perform_later
+
+    assert_equal ["Job enqueued", "Job enqueued", "Job enqueued"], JobBuffer.values
+  end
+end

--- a/activejob/test/jobs/locking_job.rb
+++ b/activejob/test/jobs/locking_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../support/job_buffer"
+
+class LockingJob < ActiveJob::Base
+  self.lock_timeout = 1.hour
+  self.lock_key = Proc.new { |job| job.queue_name }
+
+  after_enqueue do |job|
+    JobBuffer.add("Job enqueued")
+  end
+
+  def perform
+    # Nothing
+  end
+end

--- a/activejob/test/jobs/locking_job.rb
+++ b/activejob/test/jobs/locking_job.rb
@@ -5,14 +5,13 @@ require_relative "../support/job_buffer"
 class LockingJobRetryError < StandardError; end
 
 class LockingJob < ActiveJob::Base
-  self.lock_timeout = 1.hour
-  self.lock_key = proc do |job|
+  locked_by timeout: 1.hour, key: -> job {
     if job.arguments.blank?
       "raising_false"
     else
       "raising_#{job.arguments[0][:raising]}"
     end
-  end
+  }
 
   retry_on LockingJobRetryError do |job, error|
     # Nothing

--- a/activejob/test/jobs/locking_job.rb
+++ b/activejob/test/jobs/locking_job.rb
@@ -2,15 +2,29 @@
 
 require_relative "../support/job_buffer"
 
+class LockingJobRetryError < StandardError; end
+
 class LockingJob < ActiveJob::Base
   self.lock_timeout = 1.hour
-  self.lock_key = Proc.new { |job| job.queue_name }
-
-  after_enqueue do |job|
-    JobBuffer.add("Job enqueued")
+  self.lock_key = proc do |job|
+    if job.arguments.blank?
+      "raising_false"
+    else
+      "raising_#{job.arguments[0][:raising]}"
+    end
   end
 
-  def perform
+  retry_on LockingJobRetryError do |job, error|
     # Nothing
+  end
+
+  after_enqueue do |job|
+    JobBuffer.add("Job enqueued with key: #{lock_key}")
+  end
+
+  def perform(raising: false)
+    if raising
+      raise LockingJobRetryError
+    end
   end
 end

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -456,6 +456,23 @@ end
 
 To get more details see the API Documentation for [ActiveJob::Exceptions](http://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html).
 
+### Locking jobs
+
+It's also possible to lock jobs as a way of throttling how many can be enqueued.
+For example:
+
+```ruby
+class GenerateSummaryJob < ApplicationJob
+  locked_by timeout: 30.minutes, key: -> job {
+    job.arguments.join(":")
+  }
+
+  def perform(*args)
+    # Only one job with these args will be queued at a time, with a 30 minute timeout
+  end
+end
+```
+
 ### Deserialization
 
 GlobalID allows serializing full Active Record objects passed to `#perform`.


### PR DESCRIPTION
#### Summary

This adds an API to ActiveJob so queue adapters can support locking jobs. A locking job is one that controls its ability to be enqueued via two things. A key, and a timeout for that key. This PR currently doesn't include the CHANGELOG updates and could use a bit more documentation in the code but I wanted to get us settled on the API first.

If your queue adapter supports lockable jobs all you need to do is:

```ruby
MyJob < ApplicationJob
    self.lock_timeout = 30.minutes
    self.lock_key = Proc.new{ |job| job.arguments.join(":") }
end
```

#### Notes

`lock_key=` and `lock_timeout=` are in `core.rb` so we can conditionally include `Locking` only on a job that actually uses it.

I put `clear_lock` in the module so that jobs have the ability to clear their own locks. I thought about doing the same with `locked?` just for consistency but wasn't sure if there was any real benefit to doing so.

I thought about passing `*arguments` to the proc for the key so that it's signature matched that of `perform`. I suspect that using the arguments to generate the lock key is the most common use case but doing that makes it the only supported use case. Passing the whole job instead is the more flexible approach.

I also thought about adding a base queue adapter the others could extend so that `locked?` and `clear_lock` aren't repeated like they are now but that seemed like a tangential change that we can do separately if anyone likes the idea.