### PR TITLE
Find inverse associations with plural names

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -20,6 +20,7 @@ require "models/company"
 require "models/project"
 require "models/author"
 require "models/post"
+require "models/department"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -723,6 +724,16 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_nothing_raised { Face.first.polymorphic_man = Man.first }
     # fails because Interest does have the correct inverse_of
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.polymorphic_man = Interest.first }
+  end
+
+  def test_favors_has_one_associations_for_inverse_of
+    inverse_name = Post.reflect_on_association(:author).inverse_of.name
+    assert_equal :post, inverse_name
+  end
+
+  def test_finds_inverse_of_for_plural_associations
+    inverse_name = Department.reflect_on_association(:hotel).inverse_of.name
+    assert_equal :departments, inverse_name
   end
 end
 


### PR DESCRIPTION
Previously ActiveRecord couldn't find inverse associations if they were plural, which is a pretty standard use case. This commit changes the behavior to first attempt to find the singular version, then attempt to find the plural version. That makes it work and find plural associations as in the example below:

```ruby
class Post
  has_many :comments
end

class Comment
  belongs_to :post
end
```

Previously the `:post` association reflection would only attempt to find a `comment` inverse, as opposed to both a `comment` and `comments` inverse. This drastically cuts down on the number of associations that don't have inverses, and can end up fixing a lot of strange behavior where the parent doesn't save the child records.