### PR TITLE
Add documentation for `:collation` column option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -521,7 +521,10 @@ module ActiveRecord
       # * <tt>:precision</tt> -
       #   Specifies the precision for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
       # * <tt>:scale</tt> -
-      #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
+      #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns. 
+      # * <tt>:collation</tt> -
+      #   Specifies the collation for a <tt>:string</tt> or <tt>:text</tt> column. If not specified, the
+      #   column will have the same collation as the table.
       # * <tt>:comment</tt> -
       #   Specifies the comment for the column. This option is ignored by some backends.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -521,7 +521,7 @@ module ActiveRecord
       # * <tt>:precision</tt> -
       #   Specifies the precision for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
       # * <tt>:scale</tt> -
-      #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns. 
+      #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
       # * <tt>:collation</tt> -
       #   Specifies the collation for a <tt>:string</tt> or <tt>:text</tt> column. If not specified, the
       #   column will have the same collation as the table.


### PR DESCRIPTION
### Summary

The table definition supports a `:collation` option for string and text columns, but this is not documented anywhere that I could find.

### Other Information

I'm not sure if the "If not specified" part is accurate. From [this PR](https://github.com/rails/rails/commit/1515c4d98da3f730ef971fa5a13cad828bd9bef4), it looks like it passes `nil` and lets the database handle the collation, but I'm happy to change it if I misread the code.

[ci skip]