### PR TITLE
Call block to #redirect_to in controller context

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -105,7 +105,7 @@ module ActionController
       when String
         request.protocol + request.host_with_port + options
       when Proc
-        _compute_redirect_to_location request, options.call
+        _compute_redirect_to_location request, instance_eval(&options)
       else
         url_for(options)
       end.delete("\0\r\n")

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -5,6 +5,12 @@ require "abstract_unit"
 class Workshop
   extend ActiveModel::Naming
   include ActiveModel::Conversion
+
+  OUT_OF_SCOPE_BLOCK = proc do
+    raise "Not executed in controller's context" unless RedirectController === self
+    request.original_url
+  end
+
   attr_accessor :id
 
   def initialize(id)
@@ -120,12 +126,7 @@ class RedirectController < ActionController::Base
   end
 
   def redirect_to_out_of_scope_block
-    redirect_to self.class.class_eval(<<~END)
-      Proc.new do
-        raise "Not executed in controller's context" unless RedirectController === self
-        request.original_url
-      end
-    END
+    redirect_to Workshop::OUT_OF_SCOPE_BLOCK
   end
 
   def redirect_with_header_break


### PR DESCRIPTION
The documentation for ActionController::Redirecting states that a Proc
argument "will be executed in the controller's context."  However,
unless #instance_eval is used (removed in 6b3ad0ca), that statement is
false for procs defined outside of the controller instance.

This commit restores the documented behavior.

Fixes 33731.