### PR TITLE
Add retry, retry_stopped, and discard callbacks to ActiveJob jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `retry`, `retry_stopped`, and `discard` callbacks to jobs.
+
+    *steves*
+
 *   Allow `assert_performed_with` to be called without a block.
 
     *bogdanvlviv*

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -14,6 +14,15 @@ module ActiveJob
   # * <tt>before_perform</tt>
   # * <tt>around_perform</tt>
   # * <tt>after_perform</tt>
+  # * <tt>before_retry</tt>
+  # * <tt>around_retry</tt>
+  # * <tt>after_retry</tt>
+  # * <tt>before_retry_stopped</tt>
+  # * <tt>around_retry_stopped</tt>
+  # * <tt>after_retry_stopped</tt>
+  # * <tt>before_discard</tt>
+  # * <tt>around_discard</tt>
+  # * <tt>after_discard</tt>
   #
   # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
   #
@@ -29,6 +38,9 @@ module ActiveJob
     included do
       define_callbacks :perform
       define_callbacks :enqueue
+      define_callbacks :retry
+      define_callbacks :retry_stopped
+      define_callbacks :discard
     end
 
     # These methods will be included into any Active Job object, adding
@@ -149,6 +161,192 @@ module ActiveJob
       #
       def around_enqueue(*filters, &blk)
         set_callback(:enqueue, :around, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right before the job
+      # is retried.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     before_retry do |job|
+      #       $statsd.increment "retry-video-job.try"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def before_retry(*filters, &blk)
+        set_callback(:retry, :before, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right after the job
+      # is retried.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     after_retry do |job|
+      #       $statsd.increment "retry-video-job.success"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def after_retry(*filters, &blk)
+        set_callback(:retry, :after, *filters, &blk)
+      end
+
+      # Defines a callback that will get called around the retrying
+      # of the job.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     around_retry do |job, block|
+      #       $statsd.time "video-job.retry" do
+      #         block.call
+      #       end
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def around_retry(*filters, &blk)
+        set_callback(:retry, :around, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right before the job
+      # stops being retried.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     before_retry_stopped do |job|
+      #       $statsd.increment "retry-video-job-stopped.try"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def before_retry_stopped(*filters, &blk)
+        set_callback(:retry_stopped, :before, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right after the job
+      # stops being retried.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     after_retry_stopped do |job|
+      #       $statsd.increment "retry-video-job-stopped.success"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def after_retry_stopped(*filters, &blk)
+        set_callback(:retry_stopped, :after, *filters, &blk)
+      end
+
+      # Defines a callback that will get called around retrying being
+      # stopped for the job.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     retry_on VideoProcessingError
+      #
+      #     around_retry_stopped do |job, block|
+      #       $statsd.time "video-job.retry-stopped" do
+      #         block.call
+      #       end
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def around_retry_stopped(*filters, &blk)
+        set_callback(:retry_stopped, :around, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right before the job
+      # is discarded.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     discard_on VideoProcessingError
+      #
+      #     before_discard do |job|
+      #       $statsd.increment "discard-video-job.try"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def before_discard(*filters, &blk)
+        set_callback(:discard, :before, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right after the job
+      # is discarded.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     discard_on VideoProcessingError
+      #
+      #     after_discard do |job|
+      #       $statsd.increment "discard-video-job.success"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def after_discard(*filters, &blk)
+        set_callback(:discard, :after, *filters, &blk)
+      end
+
+      # Defines a callback that will get called around the discarding
+      # of the job.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     discard_on VideoProcessingError
+      #
+      #     around_discard do |job, block|
+      #       $statsd.time "video-job.discard" do
+      #         block.call
+      #       end
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #
+      def around_discard(*filters, &blk)
+        set_callback(:discard, :around, *filters, &blk)
       end
     end
   end

--- a/activejob/test/cases/callbacks_test.rb
+++ b/activejob/test/cases/callbacks_test.rb
@@ -6,6 +6,8 @@ require "jobs/callback_job"
 require "active_support/core_ext/object/inclusion"
 
 class CallbacksTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "perform callbacks" do
     performed_callback_job = CallbackJob.new("A-JOB-ID")
     performed_callback_job.perform_now
@@ -21,5 +23,33 @@ class CallbacksTest < ActiveSupport::TestCase
     assert "CallbackJob ran after_enqueue".in? enqueued_callback_job.history
     assert "CallbackJob ran around_enqueue_start".in? enqueued_callback_job.history
     assert "CallbackJob ran around_enqueue_stop".in? enqueued_callback_job.history
+  end
+
+  test "retry callbacks" do
+    retry_callback_job = CallbackJob.new(:retry)
+    retry_callback_job.perform_now
+    assert "CallbackJob ran before_retry".in? retry_callback_job.history
+    assert "CallbackJob ran after_retry".in? retry_callback_job.history
+    assert "CallbackJob ran around_retry_start".in? retry_callback_job.history
+    assert "CallbackJob ran around_retry_stop".in? retry_callback_job.history
+  end
+
+  test "retry_stopped callbacks" do
+    retry_callback_job = CallbackJob.new(:retry_stopped)
+    retry_callback_job.perform_now
+
+    assert "CallbackJob ran before_retry_stopped".in? retry_callback_job.history
+    assert "CallbackJob ran after_retry_stopped".in? retry_callback_job.history
+    assert "CallbackJob ran around_retry_stopped_start".in? retry_callback_job.history
+    assert "CallbackJob ran around_retry_stopped_stop".in? retry_callback_job.history
+  end
+
+  test "discard callbacks" do
+    discard_callback_job = CallbackJob.new(:discard)
+    discard_callback_job.perform_now
+    assert "CallbackJob ran before_discard".in? discard_callback_job.history
+    assert "CallbackJob ran after_discard".in? discard_callback_job.history
+    assert "CallbackJob ran around_discard_start".in? discard_callback_job.history
+    assert "CallbackJob ran around_discard_stop".in? discard_callback_job.history
   end
 end

--- a/activejob/test/jobs/callback_job.rb
+++ b/activejob/test/jobs/callback_job.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
+class CallbackRetryError < StandardError; end
+class CallbackStopRetryError < StandardError; end
+class CallbackDiscardError < StandardError; end
+
 class CallbackJob < ActiveJob::Base
   before_perform ->(job) { job.history << "CallbackJob ran before_perform" }
   after_perform ->(job) { job.history << "CallbackJob ran after_perform" }
 
   before_enqueue ->(job) { job.history << "CallbackJob ran before_enqueue" }
   after_enqueue ->(job) { job.history << "CallbackJob ran after_enqueue" }
+
+  before_retry ->(job) { job.history << "CallbackJob ran before_retry" }
+  after_retry ->(job) { job.history << "CallbackJob ran after_retry" }
+
+  before_retry_stopped ->(job) { job.history << "CallbackJob ran before_retry_stopped" }
+  after_retry_stopped ->(job) { job.history << "CallbackJob ran after_retry_stopped" }
+
+  before_discard ->(job) { job.history << "CallbackJob ran before_discard" }
+  after_discard ->(job) { job.history << "CallbackJob ran after_discard" }
 
   around_perform do |job, block|
     job.history << "CallbackJob ran around_perform_start"
@@ -19,8 +32,45 @@ class CallbackJob < ActiveJob::Base
     job.history << "CallbackJob ran around_enqueue_stop"
   end
 
-  def perform(person = "david")
-    # NOTHING!
+  around_retry do |job, block|
+    job.history << "CallbackJob ran around_retry_start"
+    block.call
+    job.history << "CallbackJob ran around_retry_stop"
+  end
+
+  around_retry_stopped do |job, block|
+    job.history << "CallbackJob ran around_retry_stopped_start"
+    block.call
+    job.history << "CallbackJob ran around_retry_stopped_stop"
+  end
+
+  around_discard do |job, block|
+    job.history << "CallbackJob ran around_discard_start"
+    block.call
+    job.history << "CallbackJob ran around_discard_stop"
+  end
+
+  retry_on CallbackRetryError, attempts: 2 do |job, error|
+    # Nothing
+  end
+
+  retry_on CallbackStopRetryError, attempts: 1 do |job, error|
+    # Nothing
+  end
+
+  discard_on CallbackDiscardError
+
+  def perform(action = :none)
+    case action
+    when :retry
+      raise CallbackRetryError
+    when :retry_stopped
+      raise CallbackStopRetryError
+    when :discard
+      raise CallbackDiscardError
+    else
+      # Nothing
+    end
   end
 
   def history

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -302,6 +302,15 @@ end
 * `before_perform`
 * `around_perform`
 * `after_perform`
+* `before_retry`
+* `around_retry`
+* `after_retry`
+* `before_retry_stopped`
+* `around_retry_stopped`
+* `after_retry_stopped`
+* `before_discard`
+* `around_discard`
+* `after_discard`
 
 
 Action Mailer


### PR DESCRIPTION
### Summary

These callbacks are useful because they allow us to hook into the retry and discard functionality for monitoring purposes. Right now the only two options to do so are to implement some version of your own `retry_on` and `discard_on` or do the monitoring on each individual job. These allow us to do it globally instead.

### Other Information

I'm not in love with the name of `retry_stopped` and worry that that `retry_*` suggests the callbacks apply to the execution of the retry rather then the enqueuing of it. I wanted to get others' opinions though before spending any more time worrying about the exact names as those are easy enough to change before merging.

Because these are all triggered when an exception is raised it'd be great to pass that exception to the callback. I looked and wasn't able to find any way of doing that though.