### PR TITLE
Prevent leaking of user's DB credentials on `rails db:create` failure

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -122,7 +122,7 @@ module ActiveRecord
         $stderr.puts "Database '#{configuration['database']}' already exists" if verbose?
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't create database for #{configuration.inspect}"
+        $stderr.puts "Couldn't create '#{configuration['database']}' database. Please check your configuration."
         raise
       end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -112,7 +112,7 @@ if current_adapter?(:PostgreSQLAdapter)
         ActiveRecord::Base.stub(:connection, @connection) do
           ActiveRecord::Base.stub(:establish_connection, -> * { raise Exception }) do
             assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration }
-            assert_match "Couldn't create database for #{@configuration.inspect}", $stderr.string
+            assert_match "Couldn't create '#{@configuration['database']}' database. Please check your configuration.", $stderr.string
           end
         end
       end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -62,7 +62,7 @@ if current_adapter?(:SQLite3Adapter)
       def test_db_create_with_error_prints_message
         ActiveRecord::Base.stub(:establish_connection, proc { raise Exception }) do
           assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root" }
-          assert_match "Couldn't create database for #{@configuration.inspect}", $stderr.string
+          assert_match "Couldn't create '#{@configuration['database']}' database. Please check your configuration.", $stderr.string
         end
       end
     end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -93,7 +93,7 @@ module ApplicationTests
       test "db:create failure because bad permissions" do
         with_bad_permissions do
           output = rails("db:create", allow_failure: true)
-          assert_match(/Couldn't create database/, output)
+          assert_match("Couldn't create '#{database_url_db_name}' database. Please check your configuration.", output)
           assert_equal 1, $?.exitstatus
         end
       end


### PR DESCRIPTION
Issue #27852 reports that when `rails db:create` fails, it causes
leaking of user's DB credentials to $stderr.
We print a DB's configuration hash in order to help users more quickly
to figure out what could be wrong with his configuration.

This commit changes message from
"Couldn't create database for #{configuration.inspect}" to
"Couldn't create '#{configuration['database']}' database. Please check your configuration.".

There are two PRs that fixing it #27878, #27879, but they need a bit more work.
I decided help to finish this and added Author of those PRs credit in this commit.

Since it is a security issue, I think we should backport it to
`5-2-stable`, and `5-1-stable`.
Guided by https://edgeguides.rubyonrails.org/maintenance_policy.html#security-issues

Fixes #27852
Closes #27879
Related to #27878

[Alexander Marrs & bogdanvlviv]