### PR TITLE
32% Faster Object#try

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -5,7 +5,16 @@ require "delegate"
 module ActiveSupport
   module Tryable #:nodoc:
     def try(*a, &b)
-      try!(*a, &b) if a.empty? || respond_to?(a.first)
+      return unless a.empty? || respond_to?(a.first)
+      if a.empty? && block_given?
+        if b.arity == 0
+          instance_eval(&b)
+        else
+          yield self
+        end
+      else
+        public_send(*a, &b)
+      end
     end
 
     def try!(*a, &b)


### PR DESCRIPTION
Here’s the micro benchmark:

```ruby
module ActiveSupport
  module NewTryable #:nodoc:
    def try(*a, &b)
      return unless a.empty? || respond_to?(a.first)
      return public_send(*a, &b) unless a.empty?

      return nil unless block_given?
      return instance_eval(&b) if b.arity == 0
      yield self
    end

    def try!(*a, &b)
      return public_send(*a, &b) if !a.empty?
      return nil unless block_given?
      return instance_eval(&b) if b.arity == 0
      yield self
    end
  end
end


module ActiveSupport
  module OldTryable #:nodoc:
    def try(*a, &b)
      try!(*a, &b) if a.empty? || respond_to?(a.first)
    end

    def try!(*a, &b)
      if a.empty? && block_given?
        if b.arity == 0
          instance_eval(&b)
        else
          yield self
        end
      else
        public_send(*a, &b)
      end
    end
  end
end

class FooNew
  include ActiveSupport::NewTryable

  def foo
  end
end

class FooOld
  include ActiveSupport::OldTryable

  def foo
  end
end 


foo_new = FooNew.new
foo_old = FooOld.new

require 'benchmark/ips'

Benchmark.ips do |x|
  x.report("old") { foo_old.try(:foo) }
  x.report("new") { foo_new.try(:foo) }
  x.compare!
end

# Warming up --------------------------------------
#                  old   144.178k i/100ms
#                  new   172.371k i/100ms
# Calculating -------------------------------------
#                  old      2.181M (± 8.0%) i/s -     10.813M in   5.001419s
#                  new      2.889M (± 7.7%) i/s -     14.479M in   5.051760s

# Comparison:
#                  new:  2888691.7 i/s
#                  old:  2180740.7 i/s - 1.32x  slower
```

Also reduces memory. On https://www.codetriage.com i’m seeing 1.5% fewer object allocations per request (in object count).

Before:

Total allocated: 1014475 bytes (8525 objects)

After:

Total allocated: 1015499 bytes (8389 objects)


## Why?

Most of the savings come from getting rid of an arg splat `*a`when calling `try!` from within `try`. This cause an extra array to be allocated. A tiny savings comes from removing the extra method call.

## Did you consider?

A logical question might be why not get rid of the splat in `public_send(*a, &b)` for the case where there's only a single symbol and for some reason it's not as big of a savings. No idea why.

BTW if anyone shows up and wants to performance code golf, please use the microbenchmark to test your own ideas, don't post "did you consider ..." because that's kind of a jerk move to make someone else test your hypothesis for you (unless your in Rails core and you get a pass). Plus you'll get valuable benchmarking experience!
