### PR TITLE
Drop load_database_yaml and fix test

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -135,7 +135,7 @@ module ActiveRecord
       end
 
       def for_each
-        databases = Rails.application.config.load_database_yaml
+        databases = Rails.application.config.database_configuration
         database_configs = ActiveRecord::DatabaseConfigurations.configs_for(Rails.env, databases)
 
         # if this is a single database application we don't want tasks for each primary database

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -168,18 +168,6 @@ module Rails
         end
       end
 
-      # Loads the database YAML without evaluating ERB.  People seem to
-      # write ERB that makes the database configuration depend on
-      # Rails configuration.  But we want Rails configuration (specifically
-      # `rake` and `rails` tasks) to be generated based on information in
-      # the database yaml, so we need a method that loads the database
-      # yaml *without* the context of the Rails application.
-      def load_database_yaml # :nodoc:
-        path = paths["config/database"].existent.first
-        return {} unless path
-        YAML.load_file(path.to_s)
-      end
-
       # Loads and returns the entire raw configuration of database from
       # values stored in <tt>config/database.yml</tt>.
       def database_configuration

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -52,17 +52,21 @@ module ApplicationTests
       test "db:create and db:drop respect environment setting" do
         app_file "config/database.yml", <<-YAML
           development:
-            database: <%= Rails.application.config.database %>
+            database: db/development.sqlite3
             adapter: sqlite3
         YAML
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.read_encrypted_secrets = true
           end
         RUBY
 
-        db_create_and_drop "db/development.sqlite3", environment_loaded: false
+        app "development"
+
+        assert_equal true, Rails.application.config.read_encrypted_secrets
+
+        db_create_and_drop "db/development.sqlite3"
       end
 
       def with_database_existing


### PR DESCRIPTION
We originally did the whole `load_database_yaml` thing because this test
wasn't cooperating and we needed to finish the namespaced rake tasks for
multiple databases.

However, it turns out that YAML can't eval ERB if you don't tell it it's
ERB so you get Pysch parse errors if you're using multi-line ERB or
ERB with conditionals. It's a hot mess.

After trying a few things and thinking it over we decided that it wasn't
worth bandaiding over, the test needed to be improved. The test was
added in #31135 to test that the env is loaded in these tasks. But it
was blowing up because we were trying to read a database name out of the
configuration - however that's not the purpose of this change. We want
to read environment files in the rake tasks, but not in the config
file.

In this PR we changed the test to test what the PR was actually fixing.
We've also deleted the `load_database_yaml` because it caused more
problems than it was worth. This should fix the issues described in
https://github.com/rails/rails/pull/32274#issuecomment-384161057. We
also had these problems at GitHub.

Co-authored-by: alimi <aibrahim2k2@gmail.com>

cc/ @alimi 
@Edouard-chin this should fix the issue you're seeing at Shopify. Sorry for the delay in getting it fixed.