### PR TITLE
Fewer allocations in caching/fragments.rb

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -88,7 +88,11 @@ module AbstractController
       def combined_fragment_cache_key(key)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
-        [ :views, (ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]), *head, *tail ].compact
+
+        cache_key = [:views, ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"], head, tail]
+        cache_key.flatten!(1)
+        cache_key.compact!
+        cache_key
       end
 
       # Writes +content+ to the location signified by


### PR DESCRIPTION
Instead of using a splat on the head and tail we can mutate the array by flattening 1 level. We get further savings by not allocating another via `compact` but instead by using `compact!`

### before

```
Total allocated: 973198 bytes (8367 objects)
Total retained:  1608 bytes (13 objects)
```

### after

```
Total allocated: 962841 bytes (8292 objects)
```


Total savings of about 1% fewer bytes per page render

