### PR TITLE
20% faster `try`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -4,28 +4,27 @@ require "delegate"
 
 module ActiveSupport
   module Tryable #:nodoc:
-    def try(*a, &b)
-      return unless a.empty? || respond_to?(a.first)
-      if a.empty? && block_given?
+    def try(method_name = nil, *args, &b)
+      if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
         else
           yield self
         end
-      else
-        public_send(*a, &b)
+      elsif respond_to?(method_name)
+        public_send(method_name, *args, &b)
       end
     end
 
-    def try!(*a, &b)
-      if a.empty? && block_given?
+    def try!(method_name = nil, *args, &b)
+      if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
         else
           yield self
         end
       else
-        public_send(*a, &b)
+        public_send(method_name, *args, &b)
       end
     end
   end


### PR DESCRIPTION
Following up on #33747, this takes things a step further by pulling out
the method name from the arguments array, letting us skip an allocation
in the case where there are no arguments -- notably, this also no longer
*requires* the splat to be an array, allowing us to benefit from
optimizations in Jruby (and maybe MRI in the future) of skipping the
array allocation entirely.

Benchmark results:

```
Warming up --------------------------------------
                 old   179.987k i/100ms
                 new   199.201k i/100ms
Calculating -------------------------------------
                 old      3.029M (± 1.6%) i/s -     15.299M in   5.052417s
                 new      3.657M (± 1.2%) i/s -     18.326M in   5.012648s

Comparison:
                 new:  3656620.7 i/s
                 old:  3028848.3 i/s - 1.21x  slower
```

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
