### PR TITLE
Add `inspection_masks` to make values of sensitive database columns w…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Configuration item `config.filter_parameters` could also filter out sensitive value of database column when call `#inspect`.
+
+    ```
+    Rails.application.config.filter_parameters += [:credit_card_number]
+    Account.last.insepct # => #<Account id: 123, credit_card_number: [FILTERED] ...>
+    ```
+
+    *Zhang Kang*
+
 *   Deprecate `column_name_length`, `table_name_length`, `columns_per_table`,
     `indexes_per_table`, `columns_per_multicolumn_index`, `sql_query_length`,
     and `joins_per_query` methods in `DatabaseLimits`.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -235,5 +235,11 @@ MSG
         end
       end
     end
+
+    initializer "active_record.set_filter_attributes" do
+      ActiveSupport.on_load(:active_record) do
+        self.filter_attributes += Rails.application.config.filter_parameters
+      end
+    end
   end
 end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/admin"
+require "models/admin/user"
+require "models/admin/account"
+require "pp"
+
+class FilterAttributesTest < ActiveRecord::TestCase
+  fixtures :"admin/users", :"admin/accounts"
+
+  setup do
+    ActiveRecord::Base.filter_attributes = [:name]
+  end
+
+  teardown do
+    ActiveRecord::Base.filter_attributes = []
+  end
+
+  test "filter_attributes" do
+    Admin::User.all.each do |user|
+      assert_includes user.inspect, "name: [FILTERED]"
+      assert_equal 1, user.inspect.scan("[FILTERED]").length
+    end
+
+    Admin::Account.all.each do |account|
+      assert_includes account.inspect, "name: [FILTERED]"
+      assert_equal 1, account.inspect.scan("[FILTERED]").length
+    end
+  end
+
+  test "filter_attributes could be overwritten by models" do
+    Admin::Account.all.each do |account|
+      assert_includes account.inspect, "name: [FILTERED]"
+      assert_equal 1, account.inspect.scan("[FILTERED]").length
+    end
+
+    Admin::Account.filter_attributes = []
+
+    # Above changes should not impact other models
+    Admin::User.all.each do |user|
+      assert_includes user.inspect, "name: [FILTERED]"
+      assert_equal 1, user.inspect.scan("[FILTERED]").length
+    end
+
+    Admin::Account.all.each do |account|
+      assert_not_includes account.inspect, "name: [FILTERED]"
+      assert_equal 0, account.inspect.scan("[FILTERED]").length
+    end
+
+    Admin::Account.filter_attributes = [:name]
+  end
+
+  test "filter_attributes should not filter nil value" do
+    account = Admin::Account.new
+
+    assert_includes account.inspect, "name: nil"
+    assert_not_includes account.inspect, "name: [FILTERED]"
+    assert_equal 0, account.inspect.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes on pretty_print" do
+    user = admin_users(:david)
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
+
+    assert_includes actual, "name: [FILTERED]"
+    assert_equal 1, actual.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes on pretty_print should not filter nil value" do
+    user = Admin::User.new
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
+
+    assert_includes actual, "name: nil"
+    assert_not_includes actual, "name: [FILTERED]"
+    assert_equal 0, actual.scan("[FILTERED]").length
+  end
+end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1996,6 +1996,15 @@ module ApplicationTests
       assert_equal false, ActionView::Template.finalize_compiled_template_methods
     end
 
+    test "ActiveRecord::Base.filter_attributes should equal to filter_parameters" do
+      app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
+        Rails.application.config.filter_parameters += [ :password, :credit_card_number ]
+      RUBY
+      app "development"
+      assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
+      assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.


### PR DESCRIPTION
…on't be exposed while call `#inspect`.

* Why:
Some sensitive data will be exposed in log accidentally, e.g.

```ruby
account = Account.find params[:id]
payload = { account: @account }
logger.info "payload will be #{ payload }"
```

All the information of `account` will be exposed in log.

* Solution:
Add a class attribute `inspection_masks` to specify which values of columns shouldn't be exposed.
```
class Account < ActiveRecord::Base
  self.inspection_masks = [:credit_card_number]
end

Account.last.insepct # => #<Account id: 123, credit_card_number: [FILTERED] ...>
```

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
