### PR TITLE
Follow up #32937 [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -10,8 +10,6 @@
     Enable `action_dispatch.use_cookies_with_metadata` to use this feature, which
     writes cookies with the new purpose and expiry metadata embedded.
 
-    Pull Request: #32937
-
     *Assain Jaleel*
 
 *   Raises `ActionController::RespondToMismatchError` with confliciting `respond_to` invocations.
@@ -39,7 +37,7 @@
 
     *Aaron Kromer*
 
-*   Pass along arguments to underlying `get` method in `follow_redirect!`
+*   Pass along arguments to underlying `get` method in `follow_redirect!`.
 
     Now all arguments passed to `follow_redirect!` are passed to the underlying
     `get` method. This for example allows to set custom headers for the
@@ -56,7 +54,7 @@
 
     *Vinicius Stock*
 
-*   Introduce ActionDispatch::DebugExceptions.register_interceptor
+*   Introduce `ActionDispatch::DebugExceptions.register_interceptor`.
 
     Exception aware plugin authors can use the newly introduced
     `.register_interceptor` method to get the processed exception, instead of

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -516,6 +516,9 @@ Defaults to `'signed cookie'`.
   signed and encrypted cookies use the AES-256-GCM cipher or
   the older AES-256-CBC cipher. It defaults to `true`.
 
+* `config.action_dispatch.use_cookies_with_metadata` enables writing
+  cookies with the purpose and expiry metadata embedded. It defaults to `true`.
+
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)
   for more information. It defaults to `true`.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -85,6 +85,17 @@ Rails 6.1. You are encouraged to enable `config.force_ssl` to enforce HTTPS
 connections throughout your application. If you need to exempt certain endpoints
 from redirection, you can use `config.ssl_options` to configure that behavior.
 
+### Purpose in signed or encrypted cookie is now embedded in the cookies values
+
+To improve security, Rails now embeds the purpose information in encrypted or signed cookies value.
+Rails can now thwart attacks that attempt to copy signed/encrypted value
+of a cookie and use it as the value of another cookie.
+
+This new embed information make those cookies incompatible with versions of Rails older than 6.0.
+
+If you require your cookies to be read by 5.2 and older, or you are still validating your 6.0 deploy and want
+to allow you to rollback set
+`Rails.application.config.action_dispatch.use_cookies_with_metadata` to `false`.
 
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------


### PR DESCRIPTION
- Fix `actionpack/CHANGELOG.md` [ci skip]

    Remove the reference to the PR.
    Usually, we write reference to solved issues in the changelog files.
    Related to #33605.

    Add missing dots.

    Improve formatting.

<hr/>

- Add info about `config.action_dispatch.use_cookies_with_metadata` to "Configuring Rails Applications" guide [ci skip]

    Related to #32937, #33605.

<hr/>

- Add info about purpose in cookies to "Upgrading Ruby on Rails" guide [ci skip]

    Context https://github.com/rails/rails/pull/33605#discussion_r210354278

    Related to #32937, #33605

<hr/>

/cc @assain, @kaspth
