### PR TITLE
Faster permitted_scalar_filter

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Expose ActionController::Parameters#each_key which allows iterating over
+    keys without allocating an array.
+
+    *Richard Schneeman*
+
 *   Purpose metadata for signed/encrypted cookies.
 
     Rails can now thwart attacks that attempt to copy signed/encrypted value


### PR DESCRIPTION
When running with code triage and derailed benchmarks and focusing on this file:

Before

     16199  /Users/rschneeman/Documents/projects/rails/actionpack/lib/action_controller/metal/strong_parameters.r

After

      2280  /Users/rschneeman/Documents/projects/rails/actionpack/lib/action_controller/metal/strong_parameters.rb

In an ["hello world" app](https://github.com/rails/rails/pull/33758#issuecomment-417689955) i'm seeing a roughly 20% speed increase.
