### PR TITLE
Add migrations_paths option to migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -24,7 +24,9 @@ module ActiveRecord
         end
 
         def db_migrate_path
-          if defined?(Rails.application) && Rails.application
+          if migrations_paths = options[:migrations_paths]
+            migrations_paths
+          elsif defined?(Rails.application) && Rails.application
             Rails.application.config.paths["db/migrate"].to_ary.first
           else
             "db/migrate"

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -8,6 +8,7 @@ module ActiveRecord
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :migrations_paths, type: :string, desc: "The migration path for your generated migrations. If this is not set it will default to db/migrate"
 
       def create_migration_file
         set_local_assigns!

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `--migrations_paths` option to migration generator.
+
+    If you're using multiple databases and have a folder for each database
+    for migrations (ex db/migrate and db/new_db_migrate) you can now pass the
+    `--migrations_paths` option to the generator to make sure the the migration
+    is inserted into the correct folder.
+
+    ```
+    rails g migration CreateHouses --migrations_paths=db/kingston_migrate
+      invoke  active_record
+      create    db/kingston_migrate/20180830151055_create_houses.rb
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Deprecate `rake routes` in favor of `rails routes`.
 
     *Yuji Yaginuma*

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -254,6 +254,15 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_migrations_paths_puts_migrations_in_that_folder
+    run_generator ["create_books", "--migrations_paths=db/test_migrate"]
+    assert_migration "db/test_migrate/create_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :books/, change)
+      end
+    end
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]


### PR DESCRIPTION
### Summary

Adds an option to the migration generator to allow setting the
migrations paths for that migration. This is useful for applications
that use multiple databases and put migrations per database in their own
directories.

```
bin/rails g migration CreateHouses address:string --migrations-paths=db/kingston_migrate
      invoke  active_record
      create    db/kingston_migrate/20180830151055_create_houses.rb
```