### PR TITLE
Fix for eager loading with absent records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -117,8 +117,9 @@ module ActiveRecord
 
             recs = loaders.flat_map(&:preloaded_records).uniq
 
-            if first_record = records.first
-              reflection = first_record.class._reflect_on_association(parent)
+            if recs.any?
+              a_record = records.find(&:itself)
+              reflection = a_record.class._reflect_on_association(parent)
               polymorphic_parent = reflection && reflection.options[:polymorphic]
 
               loaders.concat Array.wrap(child).flat_map { |assoc|

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -117,12 +117,15 @@ module ActiveRecord
 
             recs = loaders.flat_map(&:preloaded_records).uniq
 
-            reflection = records.first.class._reflect_on_association(parent)
-            polymorphic_parent = reflection && reflection.options[:polymorphic]
+            if first_record = records.first
+              reflection = first_record.class._reflect_on_association(parent)
+              polymorphic_parent = reflection && reflection.options[:polymorphic]
 
-            loaders.concat Array.wrap(child).flat_map { |assoc|
-              preloaders_on assoc, recs, scope, polymorphic_parent
-            }
+              loaders.concat Array.wrap(child).flat_map { |assoc|
+                preloaders_on assoc, recs, scope, polymorphic_parent
+              }
+            end
+
             loaders
           }
         end

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -161,6 +161,11 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_eager_association_loading_with_missing_first_record
+    posts = Post.where(id: 3).preload(author: { comments: :post }).to_a
+    assert_equal posts.size, 1
+  end
+
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_many_through
     source = Vertex.all.merge!(includes: { sinks: { sinks: { sinks: :sinks } } }, order: "vertices.id").first
     assert_equal vertices(:vertex_4), assert_no_queries { source.sinks.first.sinks.first.sinks.first }

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -163,7 +163,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_missing_first_record
     posts = Post.where(id: 3).preload(author: { comments: :post }).to_a
-    assert_equal posts.size, 1
+    assert_equal 1, posts.size
   end
 
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_many_through


### PR DESCRIPTION
Fixes the issue discussed below where preloading with a Hash fails if one of the intermediate objects doesn't exist.

If `records` passed to is empty or `[nil]`, skip deciding whether the downstream associations are polymorphic or not.

I'm not sure if it's possible for `records` to have a leading `nil` or not - something like `[nil, <SomeRecord#123>]`. If it is, `find` would be better than `first`.

---
The test added here currently fails with:
```
CascadedEagerLoadingTest#test_eager_association_loading_with_missing_first_record:
NoMethodError: undefined method `_reflect_on_association' for NilClass:Class
    activerecord/lib/active_record/associations/preloader.rb:122:in `block in preloaders_for_hash'
    activerecord/lib/active_record/associations/preloader.rb:115:in `each'
    activerecord/lib/active_record/associations/preloader.rb:115:in `flat_map'
    activerecord/lib/active_record/associations/preloader.rb:115:in `preloaders_for_hash'
    activerecord/lib/active_record/associations/preloader.rb:104:in `preloaders_on'
    activerecord/lib/active_record/associations/preloader.rb:126:in `block (2 levels) in preloaders_for_hash'
    activerecord/lib/active_record/associations/preloader.rb:125:in `each'
    activerecord/lib/active_record/associations/preloader.rb:125:in `flat_map'
    activerecord/lib/active_record/associations/preloader.rb:125:in `block in preloaders_for_hash'
    activerecord/lib/active_record/associations/preloader.rb:115:in `each'
    activerecord/lib/active_record/associations/preloader.rb:115:in `flat_map'
    activerecord/lib/active_record/associations/preloader.rb:115:in `preloaders_for_hash'
    activerecord/lib/active_record/associations/preloader.rb:104:in `preloaders_on'
    activerecord/lib/active_record/associations/preloader.rb:93:in `block in preload'
    activerecord/lib/active_record/associations/preloader.rb:92:in `each'
    activerecord/lib/active_record/associations/preloader.rb:92:in `flat_map'
    activerecord/lib/active_record/associations/preloader.rb:92:in `preload'
    activerecord/lib/active_record/relation.rb:627:in `block in preload_associations'
    activerecord/lib/active_record/relation.rb:625:in `each'
    activerecord/lib/active_record/relation.rb:625:in `preload_associations'
    activerecord/lib/active_record/relation.rb:661:in `block in exec_queries'
    activerecord/lib/active_record/relation.rb:676:in `skip_query_cache_if_necessary'
    activerecord/lib/active_record/relation.rb:645:in `exec_queries'
    activerecord/lib/active_record/relation.rb:508:in `load'
    activerecord/lib/active_record/relation.rb:238:in `records'
    activerecord/lib/active_record/relation.rb:233:in `to_ary'
    activerecord/test/cases/associations/cascaded_eager_loading_test.rb:165:in `test_eager_association_loading_with_missing_first_record'
```

The cause appears to be code added in https://github.com/rails/rails/commit/75ef18c67c29b1b51314b6c8a963cee53394080b which assumes that `preloaders_for_hash` will always be called with `records` having a first value that isn't nil.

The test breaks this assumption, since the `Post` with ID 3 has no author. `records` is passed in as `[nil]`.

I haven't located an example in the existing fixtures, but it's certainly possible to imagine a scenario where `records` could have a *leading* `nil` followed by ActiveRecord objects.

/cc @tenderlove @eileencodes since this is breaking a bunch of our tests :)