### PR TITLE
Emit warning for unknown inflection rule when generating model.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Emit warning for unknown inflection rule when generating model.
+
+    *Yoshiyuki Kinjo*
+
 *   Add `--migrations_paths` option to migration generator.
 
     If you're using multiple databases and have a folder for each database

--- a/railties/lib/rails/generators/model_helpers.rb
+++ b/railties/lib/rails/generators/model_helpers.rb
@@ -7,6 +7,10 @@ module Rails
     module ModelHelpers # :nodoc:
       PLURAL_MODEL_NAME_WARN_MESSAGE = "[WARNING] The model name '%s' was recognized as a plural, using the singular '%s' instead. " \
                                        "Override with --force-plural or setup custom inflection rules for this noun before running the generator."
+      IRREGULAR_MODEL_NAME_WARN_MESSAGE = <<~WARNING
+      [WARNING] Rails cannot recover singular form from its plural form '%s'.
+      Please setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.
+      WARNING
       mattr_accessor :skip_warn
 
       def self.included(base) #:nodoc:
@@ -19,11 +23,14 @@ module Rails
           singular = name.singularize
           unless ModelHelpers.skip_warn
             say PLURAL_MODEL_NAME_WARN_MESSAGE % [name, singular]
-            ModelHelpers.skip_warn = true
           end
           name.replace singular
           assign_names!(name)
         end
+        if name.singularize != name.pluralize.singularize && ! ModelHelpers.skip_warn
+          say IRREGULAR_MODEL_NAME_WARN_MESSAGE % [name.pluralize]
+        end
+        ModelHelpers.skip_warn = true
       end
     end
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -7,6 +7,11 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   arguments %w(Account name:string age:integer)
 
+  def setup
+    super
+    Rails::Generators::ModelHelpers.skip_warn = false
+  end
+
   def test_help_shows_invoked_generators_options
     content = run_generator ["--help"]
     assert_match(/ActiveRecord options:/, content)
@@ -37,10 +42,22 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_plural_names_are_singularized
-    content = run_generator ["accounts".freeze]
+    content = run_generator ["accounts"]
     assert_file "app/models/account.rb", /class Account < ApplicationRecord/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/\[WARNING\] The model name 'accounts' was recognized as a plural, using the singular 'account' instead\. Override with --force-plural or setup custom inflection rules for this noun before running the generator\./, content)
+  end
+
+  def test_unknown_inflection_rule_are_warned
+    content = run_generator ["porsche"]
+    assert_match("[WARNING] Rails cannot recover singular form from its plural form 'porsches'.\nPlease setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.", content)
+    assert_file "app/models/porsche.rb", /class Porsche < ApplicationRecord/
+
+    uncountable_content = run_generator ["sheep"]
+    assert_no_match("[WARNING] Rails cannot recover singular form from its plural form", uncountable_content)
+
+    regular_content = run_generator ["account"]
+    assert_no_match("[WARNING] Rails cannot recover singular form from its plural form", regular_content)
   end
 
   def test_model_with_underscored_parent_option

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -7,7 +7,11 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   arguments %w(account)
 
-  setup :copy_routes
+  def setup
+    super
+    copy_routes
+    Rails::Generators::ModelHelpers.skip_warn = false
+  end
 
   def test_help_with_inherited_options
     content = run_generator ["--help"]


### PR DESCRIPTION
### Summary
For words like "abuse", Rails cannot derive its singular form from
plural form "abuses" without defining custom inflection rule.
`rails generate model` and its families now emit warning for this case.

### Other Information

refs #33688.
