### PR TITLE
ActiveSupport::Cache raises infinite loop when using Mongoid >= 6

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -649,9 +649,12 @@ module ActiveSupport
 
         def expanded_version(key)
           case
-          when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
-          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
+          when key.respond_to?(:cache_version)
+            key.cache_version.to_param
+          when key.is_a?(Array)
+            key.map { |element| expanded_version(element) }.compact.to_param
+          when key.respond_to?(:to_a) && key.to_a != [key]
+            expanded_version(key.to_a)
           end
         end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -66,6 +66,36 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read("foo")
   end
 
+  def test_should_not_raise_stack_too_deep
+    obj = Object.new
+    def obj.cache_key
+      :foo
+    end
+    def obj.to_a
+      [self]
+    end
+    assert_nothing_raised do
+      @cache.write(obj, 'foo')
+      @cache.read(obj)
+      @cache.fetch(obj){ 'foo' }
+      @cache.delete(obj)
+    end
+  end
+
+  def test_should_read_store_expected_key_when_obj_respond_to_a
+    obj = Object.new
+    def obj.cache_key
+      :foo
+    end
+    def obj.to_a
+      [self]
+    end
+    assert_nothing_raised do
+      @cache.write(obj, 'foo')
+    end
+    assert_equal @cache.read(obj), 'foo'
+  end
+
   def test_should_read_and_write_hash
     assert @cache.write("foo", a: "b")
     assert_equal({ a: "b" }, @cache.read("foo"))

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -75,9 +75,9 @@ module CacheStoreBehavior
       [self]
     end
     assert_nothing_raised do
-      @cache.write(obj, 'foo')
+      @cache.write(obj, "foo")
       @cache.read(obj)
-      @cache.fetch(obj){ 'foo' }
+      @cache.fetch(obj){ "foo" }
       @cache.delete(obj)
     end
   end
@@ -91,9 +91,9 @@ module CacheStoreBehavior
       [self]
     end
     assert_nothing_raised do
-      @cache.write(obj, 'foo')
+      @cache.write(obj, "foo")
     end
-    assert_equal @cache.read(obj), 'foo'
+    assert_equal @cache.read(obj), "foo"
   end
 
   def test_should_read_and_write_hash


### PR DESCRIPTION
### Summary
Rails Cache SystemStackError: stack level too deep

Dependencies:
- Rails 5.2.1
- Mongoid >= 6

#### Problem:
Mongoid Models return an array when called `to_a`

```ruby
article = Article.create!(name: 'Rails rocks', content: 'Yep!')
# => #<Article _id: 5b89612ad80e4c90e98b9abe, name: "Rails rocks", content: "Yep!">
article.to_a
# => [#<Article _id: 5b89612ad80e4c90e98b9abe, name: "Rails rocks", content: "Yep!">]
```

The infinite loop is here:

https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L663

Proposed solution:

https://github.com/arturictus/rails/blob/fix_cache_infinite_loop/activesupport/lib/active_support/cache.rb#L656

### Other Information

I created a test project with instructions to test

https://github.com/arturictus/Rails_mongoid_cache_fix