### PR TITLE
Make null_store the default cache store in test environment config

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -21,6 +21,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
### Summary

It's surprising to me that by default, [low-level caching](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching) is functional in the test environment. This simply adds `config.cache_store = :null_store` in `config/environments/test.rb`.

The existing defaults in `test.rb` as well as the Rails Guides kinda have you believe the `null_store` is the default.

Really was on the fence about opening this as it may not be a substantial enough change to warrant dev resources. But since Rails has such a great reputation of providing sane defaults, I felt like this would be worth it.

### Other Information

I perused the tests and wasn't sure where best to add anything. `railties/test/application/generators_test.rb`?

Appropriate to update CHANGELOG?