### PR TITLE
Change `etc` to `etc.` as the latter is used in most of the code

### DIFF
--- a/actioncable/test/javascript/vendor/mock-socket.js
+++ b/actioncable/test/javascript/vendor/mock-socket.js
@@ -229,7 +229,7 @@
     // ----
     // publicsuffix.org is more current and actually used by a couple of browsers internally.
     // downside is it also contains domains like "dyndns.org" - which is fine for the security
-    // issues browser have to deal with (SOP for cookies, etc) - but is way overboard for URI.js
+    // issues browser have to deal with (SOP for cookies, etc.) - but is way overboard for URI.js
     // ----
     list: {
       'ac':' com gov mil net org ',

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -34,7 +34,7 @@ Controller Naming Convention
 
 The naming convention of controllers in Rails favors pluralization of the last word in the controller's name, although it is not strictly required (e.g. `ApplicationController`). For example, `ClientsController` is preferable to `ClientController`, `SiteAdminsController` is preferable to `SiteAdminController` or `SitesAdminsController`, and so on.
 
-Following this convention will allow you to use the default route generators (e.g. `resources`, etc) without needing to qualify each `:path` or `:controller`, and will keep URL and path helpers' usage consistent throughout your application. See [Layouts & Rendering Guide](layouts_and_rendering.html) for more details.
+Following this convention will allow you to use the default route generators (e.g. `resources`, etc.) without needing to qualify each `:path` or `:controller`, and will keep URL and path helpers' usage consistent throughout your application. See [Layouts & Rendering Guide](layouts_and_rendering.html) for more details.
 
 NOTE: The controller naming convention differs from the naming convention of models, which are expected to be named in singular form.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1130,7 +1130,7 @@ Many modern web servers can be used as a proxy server to balance third-party ele
 
 One such application server you can use is [Unicorn](https://bogomips.org/unicorn/) to run behind a reverse proxy.
 
-In this case, you would need to configure the proxy server (NGINX, Apache, etc) to accept connections from your application server (Unicorn). By default Unicorn will listen for TCP connections on port 8080, but you can change the port or configure it to use sockets instead.
+In this case, you would need to configure the proxy server (NGINX, Apache, etc.) to accept connections from your application server (Unicorn). By default Unicorn will listen for TCP connections on port 8080, but you can change the port or configure it to use sockets instead.
 
 You can find more information in the [Unicorn readme](https://bogomips.org/unicorn/README.html) and understand the [philosophy](https://bogomips.org/unicorn/PHILOSOPHY.html) behind it.
 

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -24,7 +24,7 @@ STATS_DIRECTORIES = [
   [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
 end.select { |name, dir| File.directory?(dir) }
 
-desc "Report code statistics (KLOCs, etc) from the application or engine"
+desc "Report code statistics (KLOCs, etc.) from the application or engine"
 task :stats do
   require "rails/code_statistics"
   CodeStatistics.new(*STATS_DIRECTORIES).to_s

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -87,7 +87,7 @@ module ApplicationTests
         %w(Rails::Rack::Logger Rack::MethodOverride ActionDispatch::RequestId ActionDispatch::RemoteIp),
 
         # Serving public/ doesn't invoke user code, so it should skip
-        # locks etc
+        # locks etc.
         %w(ActionDispatch::Executor ActionDispatch::Static),
 
         # Errors during reload must be reported


### PR DESCRIPTION
[ci skip]

### Summary

Change `etc` to `etc.` as the latter is used in most of the code

Note that there are some more places which use `etc` (without the leading period) but I haven't changed them because there's a comma right after those. I don't think it'd be apt to add a period to those.