### PR TITLE
add mysql and sqlite3 default test

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -853,8 +853,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal company, Company.find(company.id)
   end
 
-  # TODO: extend defaults tests to other databases!
-  if current_adapter?(:PostgreSQLAdapter)
+  if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter, :SQLite3Adapter)
     def test_default
       with_timezone_config default: :local do
         default = Default.new
@@ -866,7 +865,10 @@ class BasicsTest < ActiveRecord::TestCase
         # char types
         assert_equal "Y", default.char1
         assert_equal "a varchar field", default.char2
-        assert_equal "a text field", default.char3
+        # Mysql text type can't have default value
+        unless current_adapter?(:Mysql2Adapter)
+          assert_equal "a text field", default.char3
+        end
       end
     end
   end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -14,6 +14,13 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :defaults, force: true do |t|
+    t.date :fixed_date, default: "2004-01-01"
+    t.datetime :fixed_time, default: "2004-01-01 00:00:00"
+    t.column :char1, "char(1)", default: "Y"
+    t.string :char2, limit: 50, default: "a varchar field"
+  end
+
   create_table :binary_fields, force: true do |t|
     t.binary :var_binary, limit: 255
     t.binary :var_binary_large, limit: 4095

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+ActiveRecord::Schema.define do
+  create_table :defaults, force: true do |t|
+    t.date :fixed_date, default: "2004-01-01"
+    t.datetime :fixed_time, default: "2004-01-01 00:00:00"
+    t.column :char1, "char(1)", default: "Y"
+    t.string :char2, limit: 50, default: "a varchar field"
+    t.text :char3, limit: 50, default: "a text field"
+  end
+end


### PR DESCRIPTION
### Summary

Squashed and rebased version of https://github.com/rails/rails/pull/25097. Adds test coverage for defaults when using mysql and sqlite3 adapters.

Closes https://github.com/rails/rails/pull/25097.
