### PR TITLE
Respect config setting when output deprecation notice in rake tasks

### DIFF
--- a/railties/lib/rails/tasks/annotations.rake
+++ b/railties/lib/rails/tasks/annotations.rake
@@ -2,20 +2,20 @@
 
 require "rails/source_annotation_extractor"
 
-task :notes do
+task notes: :environment do
   Rails::SourceAnnotationExtractor::Annotation.notes_task_deprecation_warning
   Rails::Command.invoke :notes
 end
 
 namespace :notes do
   ["OPTIMIZE", "FIXME", "TODO"].each do |annotation|
-    task annotation.downcase.intern do
+    task annotation.downcase.intern => :environment do
       Rails::SourceAnnotationExtractor::Annotation.notes_task_deprecation_warning
       Rails::Command.invoke :notes, ["--annotations", annotation]
     end
   end
 
-  task :custom do
+  task custom: :environment do
     Rails::SourceAnnotationExtractor::Annotation.notes_task_deprecation_warning
     Rails::Command.invoke :notes, ["--annotations", ENV["ANNOTATION"]]
   end

--- a/railties/lib/rails/tasks/dev.rake
+++ b/railties/lib/rails/tasks/dev.rake
@@ -4,7 +4,7 @@ require "rails/command"
 require "active_support/deprecation"
 
 namespace :dev do
-  task :cache do
+  task cache: :environment do
     ActiveSupport::Deprecation.warn("Using `bin/rake dev:cache` is deprecated and will be removed in Rails 6.1. Use `bin/rails dev:cache` instead.\n")
     Rails::Command.invoke "dev:cache"
   end

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -3,7 +3,7 @@
 require "rails/command"
 require "active_support/deprecation"
 
-task :initializers do
+task initializers: :environment do
   ActiveSupport::Deprecation.warn("Using `bin/rake initializers` is deprecated and will be removed in Rails 6.1. Use `bin/rails initializers` instead.\n")
   Rails::Command.invoke "initializers"
 end

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -9,6 +9,7 @@ module ApplicationTests
 
       def setup
         build_app
+        add_to_env_config("development", "config.active_support.deprecation = :stderr")
       end
 
       def teardown

--- a/railties/test/application/rake/initializers_test.rb
+++ b/railties/test/application/rake/initializers_test.rb
@@ -29,6 +29,8 @@ module ApplicationTests
       end
 
       test "`rake initializers` outputs a deprecation warning" do
+        add_to_env_config("development", "config.active_support.deprecation = :stderr")
+
         stderr = capture(:stderr) { run_rake_initializers }
         assert_match(/DEPRECATION WARNING: Using `bin\/rake initializers` is deprecated and will be removed in Rails 6.1/, stderr)
       end

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -10,6 +10,7 @@ module ApplicationTests
 
       def setup
         build_app
+        add_to_env_config("development", "config.active_support.deprecation = :stderr")
         require "rails/all"
         super
       end

--- a/railties/test/application/rake/routes_test.rb
+++ b/railties/test/application/rake/routes_test.rb
@@ -28,7 +28,6 @@ update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:forma
       end
 
       test "`rake routes` outputs a deprecation warning" do
-        remove_from_env_config("development", ".*config\.active_support\.deprecation.*\n")
         add_to_env_config("development", "config.active_support.deprecation = :stderr")
 
         stderr = capture(:stderr) { run_rake_routes }


### PR DESCRIPTION
The rake tasks which became deprecate now does not load the environment.
Therefore, even if the application specifies the behavior of deprecating,
the message is output to stderr ignoring the specification.

It seems that this is not the expected behavior.
We should respect the setting even in the rake tasks.
