### PR TITLE
Update documentation to ActionController::ConditionalGet

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -230,6 +230,12 @@ module ActionController
     # This method will overwrite an existing Cache-Control header.
     # See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
     #
+    # HTTP Cache-Control Extensions for Stale Content. See https://tools.ietf.org/html/rfc5861
+    # It helps to cache an asset and serve it while is being revalidated and/or returning with an error.
+    #
+    #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds
+    #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds, stale_if_error: 5.minutes
+    #
     # The method will also ensure an HTTP Date header for client compatibility.
     def expires_in(seconds, options = {})
       response.cache_control.merge!(


### PR DESCRIPTION
### Summary

Follow up: https://github.com/rails/rails/pull/33134 add missing documentation
Details: https://support.cloudflare.com/hc/en-us/articles/115003206852s

Two implemented but undocumented features are to help indicate that cache is fresh for 3 hours, and it may continue to be served stale for up to an additional 60 seconds *to parallel requests for the same resource* or up to 5 minutes while errors are being returned back while the initial synchronous revalidation is attempted.

Caching re-invalidation may cause thundering herd effect under high load, with these [two new HTTP standardized features](https://tools.ietf.org/html/rfc5861) we can leverage CDN or any proxy caching layer to reduce throughput while cache is being populated with a new response.

