### PR TITLE
Add database configuration to configure `in_clause_length`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add database configuration to configure `in_clause_length`.
+
+    ```
+    production:
+      adapter: mysql2
+      in_clause_length: 1000
+    ```
+
+    *Yasuo Honda*
+
 *   Added `index` option for `change_table` migration helpers.
     With this change you can create indexes while adding new
     columns into the existing tables.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       # Returns the maximum number of elements in an IN (x,y,z) clause.
       # +nil+ means no limit.
       def in_clause_length
-        nil
+        @in_clause_length
       end
 
       # Returns the maximum length of an SQL query.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -125,6 +125,10 @@ module ActiveRecord
         @advisory_locks_enabled = self.class.type_cast_config_to_boolean(
           config.fetch(:advisory_locks, true)
         )
+
+        @in_clause_length = self.class.type_cast_config_to_integer(
+          config.fetch(:in_clause_length, nil)
+        )
       end
 
       def replica?

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -9,6 +9,8 @@ require "models/event"
 
 module ActiveRecord
   class AdapterTest < ActiveRecord::TestCase
+    include ConnectionHelper
+
     def setup
       @connection = ActiveRecord::Base.connection
       @connection.materialize_transactions
@@ -328,6 +330,15 @@ module ActiveRecord
 
     def test_joins_per_query_is_deprecated
       assert_deprecated { @connection.joins_per_query }
+    end
+
+    unless in_memory_db?
+      def test_configure_in_clause_length
+        run_without_connection do |orig_connection|
+          ActiveRecord::Base.establish_connection(orig_connection.deep_merge(in_clause_length: 1000))
+          assert_equal 1000,  ActiveRecord::Base.connection.in_clause_length
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

MySQL 5.7 introduces `range_optimizer_max_mem_size` to control memory usage for range access method. It sometimes changes execution plans of SQL statements with a large number of in clause, like 10000 from index range scan to full table scan.

"Limiting Memory Use for Range Optimization"
https://dev.mysql.com/doc/refman/5.7/en/range-optimization.html#range-optimization-memory-use

> If the specified limit is about to be exceeded, the range access method is abandoned
> and other methods, including a full table scan, are considered instead.

Instead of changing `range_optimizer_max_mem_size` value at MySQL server,
setting `in_clause_length` in Rails splits large in clause into smaller in list.

As of right now, `in_clause_length` can be configured as follows.

* Quote from @kamipo blog article https://blog.kamipo.net/entry/2017/12/23/230514 in Japanese

```ruby
ActiveSupport.on_load(:active_record) do
  module ActiveRecord
    module ConnectionAdapters
      module DatabaseLimitsExt
        def in_clause_length
          1000
        end
      end

      class AbstractAdapter
        prepend DatabaseLimitsExt
      end
    end
  end
end
```

This commit enables to configure `in_clause_length` value in the database.yml file.

* database.yml

```
production:
  adapter: mysql2
  in_clause_length: 1000
```

`in_clause_length` has been useful for Oracle enhanced adapter since Oracle database has a limit to allow the number of in list to 1000.
This parameter is not limited to MySQL. I have not found use cases for PostgreSQL and SQLite databases, though.
