### PR TITLE
ActionCable: add id option to redis adapter config

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `id` option to redis adapter so now you can distinguish
+    ActionCable's redis connections among others. Also, you can set
+    custom id in options.
+
+    Before:
+    ```
+    $ redis-cli client list
+    id=669 addr=127.0.0.1:46442 fd=8 name= age=18 ...
+    ```
+
+    After:
+    ```
+    $ redis-cli client list
+    id=673 addr=127.0.0.1:46516 fd=8 name=ActionCable-PID-19413 age=2 ...
+    ```
+
+    *Ilia Kasianenko*
+
 *   Rails 6 requires Ruby 2.4.1 or newer.
 
     *Jeremy Daer*

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -13,7 +13,8 @@ module ActionCable
       # Overwrite this factory method for Redis connections if you want to use a different Redis library than the redis gem.
       # This is needed, for example, when using Makara proxies for distributed Redis.
       cattr_accessor :redis_connector, default: ->(config) do
-        ::Redis.new(config.slice(:url, :host, :port, :db, :password))
+        config[:id] ||= "ActionCable-PID-#{$$}"
+        ::Redis.new(config.slice(:url, :host, :port, :db, :password, :id))
       end
 
       def initialize(*)

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -30,11 +30,19 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
 end
 
 class RedisAdapterTest::Connector < ActionCable::TestCase
-  test "slices url, host, port, db, and password from config" do
-    config = { url: 1, host: 2, port: 3, db: 4, password: 5 }
+  test "slices url, host, port, db, password and id from config" do
+    config = { url: 1, host: 2, port: 3, db: 4, password: 5, id: "Some custom ID" }
 
     assert_called_with ::Redis, :new, [ config ] do
       connect config.merge(other: "unrelated", stuff: "here")
+    end
+  end
+
+  test "adds default id if it is not specified" do
+    config = { url: 1, host: 2, port: 3, db: 4, password: 5, id: "ActionCable1-PID-#{$$}" }
+
+    assert_called_with ::Redis, :new, [ config ] do
+      connect config
     end
   end
 


### PR DESCRIPTION
### Summary

Add `id` option to Redis adapter so now you can distinguish ActionCable's Redis connections among others. Also, you can set custom id in options.
Can be useful for debugging when a single Redis instance is used by multiple gems or applications.

Before:
```
$ redis-cli client list
id=669 addr=127.0.0.1:46442 fd=8 name= age=18 ...
```

After:
```
$ redis-cli client list
id=673 addr=127.0.0.1:46516 fd=8 name=ActionCable-PID-19413 age=2 ...
```

