### PR TITLE
Deprecate most methods which were never used in `DatabaseLimits`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `column_name_length`, `table_name_length`, `columns_per_table`,
+    `indexes_per_table`, `columns_per_multicolumn_index`, `sql_query_length`,
+    and `joins_per_query` methods in `DatabaseLimits`.
+
+    *Ryuta Kamizono*
+
 *   ActiveRecord::Base.configurations now returns an object.
 
     ActiveRecord::Base.configurations used to return a hash, but this

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module DatabaseLimits
@@ -12,11 +14,13 @@ module ActiveRecord
       def column_name_length
         64
       end
+      deprecate :column_name_length
 
       # Returns the maximum length of a table name.
       def table_name_length
         64
       end
+      deprecate :table_name_length
 
       # Returns the maximum allowed length for an index name. This
       # limit is enforced by \Rails and is less than or equal to
@@ -36,16 +40,19 @@ module ActiveRecord
       def columns_per_table
         1024
       end
+      deprecate :columns_per_table
 
       # Returns the maximum number of indexes per table.
       def indexes_per_table
         16
       end
+      deprecate :indexes_per_table
 
       # Returns the maximum number of columns in a multicolumn index.
       def columns_per_multicolumn_index
         16
       end
+      deprecate :columns_per_multicolumn_index
 
       # Returns the maximum number of elements in an IN (x,y,z) clause.
       # +nil+ means no limit.
@@ -57,11 +64,13 @@ module ActiveRecord
       def sql_query_length
         1048575
       end
+      deprecate :sql_query_length
 
       # Returns maximum number of joins in a single query.
       def joins_per_query
         256
       end
+      deprecate :joins_per_query
     end
   end
 end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -300,6 +300,34 @@ module ActiveRecord
     def test_supports_multi_insert_is_deprecated
       assert_deprecated { @connection.supports_multi_insert? }
     end
+
+    def test_column_name_length_is_deprecated
+      assert_deprecated { @connection.column_name_length }
+    end
+
+    def test_table_name_length_is_deprecated
+      assert_deprecated { @connection.table_name_length }
+    end
+
+    def test_columns_per_table_is_deprecated
+      assert_deprecated { @connection.columns_per_table }
+    end
+
+    def test_indexes_per_table_is_deprecated
+      assert_deprecated { @connection.indexes_per_table }
+    end
+
+    def test_columns_per_multicolumn_index_is_deprecated
+      assert_deprecated { @connection.columns_per_multicolumn_index }
+    end
+
+    def test_sql_query_length_is_deprecated
+      assert_deprecated { @connection.sql_query_length }
+    end
+
+    def test_joins_per_query_is_deprecated
+      assert_deprecated { @connection.joins_per_query }
+    end
   end
 
   class AdapterForeignKeyTest < ActiveRecord::TestCase


### PR DESCRIPTION
`DatabaseLimits` and those methods were introduced at 3809c80, but most
methods were never used and never tested from the beginning (except
`table_alias_length`, `index_name_length`, and `in_clause_length` (since
66c09372)).

There is no reason to maintain unused those methods for about 8 years.