### PR TITLE
Improve API document on Object#blank?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -3,8 +3,8 @@
 require "concurrent/map"
 
 class Object
-  # An object is blank if it's false, empty, or a whitespace string.
-  # For example, +false+, '', '   ', +nil+, [], and {} are all blank.
+  # An object is blank if it's falsey, empty, or a whitespace string.
+  # For example, +nil+, +false+, [], {}, '', and '   ' are all blank.
   #
   # This simplifies
   #

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -3,8 +3,8 @@
 require "concurrent/map"
 
 class Object
-  # An object is blank if it's falsey, empty, or a whitespace string.
-  # For example, +nil+, +false+, [], {}, '', and '   ' are all blank.
+  # An object is blank if it's false, empty, or a whitespace string.
+  # For example, +nil+, '', '   ', [], {}, and +false+ are all blank.
   #
   # This simplifies
   #


### PR DESCRIPTION
### Summary

I have improved the API document of `Object#blank?` as follows.

* Introduce `falsey` to represent both `nil` and `false`.
* Keep consistent order between abstract description and examples.

If `falsey` is not suitable in Rails document, I would like to replace `ralsey` with `nil, false`