### PR TITLE
Fix non_numeric_string?

### DIFF
--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -29,7 +29,7 @@ module ActiveModel
             # 'wibble'.to_i will give zero, we want to make sure
             # that we aren't marking int zero to string zero as
             # changed.
-            value.to_s !~ /\A-?\d+\.?\d*\z/
+            !/\A[-+]?\d+/.match?(value.to_s)
           end
       end
     end

--- a/activemodel/test/cases/type/decimal_test.rb
+++ b/activemodel/test/cases/type/decimal_test.rb
@@ -57,9 +57,12 @@ module ActiveModel
       def test_changed?
         type = Decimal.new
 
-        assert type.changed?(5.0, 5.0, "5.0wibble")
+        assert type.changed?(0.0, 0, "wibble")
+        assert type.changed?(5.0, 0, "wibble")
+        assert_not type.changed?(5.0, 5.0, "5.0wibble")
         assert_not type.changed?(5.0, 5.0, "5.0")
         assert_not type.changed?(-5.0, -5.0, "-5.0")
+        assert_not type.changed?(5.0, 5.0, "0.5e+1")
       end
 
       def test_scale_is_applied_before_precision_to_prevent_rounding_errors

--- a/activemodel/test/cases/type/float_test.rb
+++ b/activemodel/test/cases/type/float_test.rb
@@ -21,9 +21,12 @@ module ActiveModel
       def test_changing_float
         type = Type::Float.new
 
-        assert type.changed?(5.0, 5.0, "5wibble")
+        assert type.changed?(0.0, 0, "wibble")
+        assert type.changed?(5.0, 0, "wibble")
+        assert_not type.changed?(5.0, 5.0, "5wibble")
         assert_not type.changed?(5.0, 5.0, "5")
         assert_not type.changed?(5.0, 5.0, "5.0")
+        assert_not type.changed?(500.0, 500.0, "0.5E+4")
         assert_not type.changed?(nil, nil, nil)
       end
     end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -53,9 +53,13 @@ module ActiveModel
       test "changed?" do
         type = Type::Integer.new
 
-        assert type.changed?(5, 5, "5wibble")
+        assert type.changed?(0, 0, "wibble")
+        assert type.changed?(5, 0, "wibble")
+        assert_not type.changed?(5, 5, "5wibble")
         assert_not type.changed?(5, 5, "5")
         assert_not type.changed?(5, 5, "5.0")
+        assert_not type.changed?(5, 5, "+5")
+        assert_not type.changed?(5, 5, "+5.0")
         assert_not type.changed?(-5, -5, "-5")
         assert_not type.changed?(-5, -5, "-5.0")
         assert_not type.changed?(nil, nil, nil)


### PR DESCRIPTION
For example, dirty checking was not right for the following case:

```
model.int_column = "+5"
model.float_column = "0.5E+1"
model.decimal_column = "0.5e-3"
```

Fixes #33801