### PR TITLE
Faster File Store

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -127,15 +127,19 @@ module ActiveSupport
           hash = Zlib.adler32(fname)
           hash, dir_1 = hash.divmod(0x1000)
           dir_2 = hash.modulo(0x1000)
-          fname_paths = []
 
           # Make sure file name doesn't exceed file system limits.
-          begin
-            fname_paths << fname[0, FILENAME_MAX_SIZE]
-            fname = fname[FILENAME_MAX_SIZE..-1]
-          end until fname.blank?
+          if fname.length < FILENAME_MAX_SIZE
+            fname_paths = fname
+          else
+            fname_paths = []
+            begin
+              fname_paths << fname[0, FILENAME_MAX_SIZE]
+              fname = fname[FILENAME_MAX_SIZE..-1]
+            end until fname.blank?
+          end
 
-          File.join(cache_path, DIR_FORMATTER % dir_1, DIR_FORMATTER % dir_2, *fname_paths)
+          File.join(cache_path, DIR_FORMATTER % dir_1, DIR_FORMATTER % dir_2, fname_paths)
         end
 
         # Translate a file path into a key.


### PR DESCRIPTION
Memory before 1826584.8	 memory after: 1797795.6 difference: 1.58% memory (speed) savings.

When the key is not longer than the limit we can avoid allocating two strings and an array.
