### PR TITLE
Fix typo in i18n_railtie.rb [ci skip]

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -94,7 +94,7 @@ module I18n
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           Using I18n fallbacks with an empty `defaults` sets the defaults to
           include the `default_locale`. This behavior will change in Rails 6.1.
-          If you desire the default local to be included in the defaults, please
+          If you desire the default locale to be included in the defaults, please
           explicitly configure it with `config.i18n.fallbacks.defaults =
           [I18n.default_locale]` or `config.i18n.fallbacks = [I18n.default_locale,
           {...}]`


### PR DESCRIPTION
### Summary

Fix typo introduced in #33574

Keeping @rafaelfranca in the loop since you recently merged the above mentioned PR.