### PR TITLE
Maintain html_safe? on sliced HTML safe strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Maintain `html_safe?` on html_safe strings when sliced
+
+        string = "<div>test</div>".html_safe
+        string[-1..1].html_safe? # => true
+
+    *Elom Gomez, Yumin Wong*
+
 *   Add `Array#extract!`.
 
     The method removes and returns the elements for which the block returns a true value.

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -149,9 +149,7 @@ module ActiveSupport #:nodoc:
     end
 
     def [](*args)
-      if args.size < 2
-        super
-      elsif html_safe?
+      if html_safe?
         new_safe_buffer = super
 
         if new_safe_buffer

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -150,6 +150,18 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_not y.html_safe?, "should not be safe"
   end
 
+  test "Should continue safe on slice" do
+    x = "<div>foo</div>".html_safe
+
+    assert x.html_safe?, "should be safe"
+
+    # getting a slice of it
+    y = x[0..-1]
+
+    # should still be safe
+    assert y.html_safe?, "should be safe"
+  end
+
   test "Should work with interpolation (array argument)" do
     x = "foo %s bar".html_safe % ["qux"]
     assert_equal "foo qux bar", x

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -153,13 +153,13 @@ class SafeBufferTest < ActiveSupport::TestCase
   test "Should continue safe on slice" do
     x = "<div>foo</div>".html_safe
 
-    assert x.html_safe?, "should be safe"
+    assert_predicate x, :html_safe?
 
     # getting a slice of it
     y = x[0..-1]
 
     # should still be safe
-    assert y.html_safe?, "should be safe"
+    assert_predicate y, :html_safe?
   end
 
   test "Should work with interpolation (array argument)" do


### PR DESCRIPTION
### Summary

This change allows for an HTML safe string to remain HTML safe even when accessed via a range. 

**Before**

```ruby
string = "<div>test</div>".html_safe
substring = string[-1..1]
substring.html_safe? # => false
```

**After**

```ruby
string = "<div>test</div>".html_safe
substring = string[-1..1]
substring.html_safe? # => true
```

cc @tenderlove @no-itsbackpack