### PR TITLE
Only select known attributes on a model

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -326,7 +326,7 @@ module ActiveRecord
     #   person.attributes
     #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
     def attributes
-      @attributes.to_hash
+      @attributes.to_hash.slice(*self.class.column_names)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1046,10 +1046,8 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        elsif klass.ignored_columns.any?
-          arel.project(*klass.column_names.map { |field| arel_attribute(field) })
         else
-          arel.project(table[Arel.star])
+          arel.project(*klass.column_names.map { |field| arel_attribute(field) })
         end
       end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1046,8 +1046,10 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        else
+        elsif klass.ignored_columns.any?
           arel.project(*klass.column_names.map { |field| arel_attribute(field) })
+        else
+          arel.project(table[Arel.star])
         end
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1455,6 +1455,17 @@ class BasicsTest < ActiveRecord::TestCase
     assert query.include?("name")
   end
 
+  def test_only_known_attributes_selected
+    Computer.connection.add_column :computers, :new_field, :string
+
+    attributes = Computer.first.attributes
+
+    assert_not attributes.key?("new_field")
+  ensure
+    Computer.connection.remove_column :new_field, :new_field rescue nil
+    Computer.reset_column_information
+  end
+
   test "column names are quoted when using #from clause and model has ignored columns" do
     assert_not_empty Developer.ignored_columns
     query = Developer.from("developers").to_sql


### PR DESCRIPTION
### Summary

This fixes an issue where `add_column` becomes non-zero-downtime safe. If you have a deploy process that runs migrations before reloading the rails processes you’ll temporarily be in a state where the database table has extra columns that the model doesn’t know about yet. During this window in time doing something like `Computer.new(Computer.last.attributes.except(:id))` will fail with an `ActiveModel::UnknownAttributeError` because `#attributes` would include the new column, but the model’s column cache doesn’t know about it.

Fixes #33793