### PR TITLE
Use ActiveSupport::InheritableOptions and deep_symbolize_keys in config_for

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -232,7 +232,10 @@ module Rails
 
       if yaml.exist?
         require "erb"
-        (YAML.load(ERB.new(yaml.read).result) || {})[env] || {}
+        require "active_support/ordered_options"
+
+        config = (YAML.load(ERB.new(yaml.read).result) || {})[env] || {}
+        ActiveSupport::InheritableOptions.new(config.deep_symbolize_keys)
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1671,7 +1671,7 @@ module ApplicationTests
     test "config_for loads custom configuration from yaml files" do
       app_file "config/custom.yml", <<-RUBY
       development:
-        key: 'custom key'
+        foo: 'bar'
       RUBY
 
       add_to_config <<-RUBY
@@ -1680,7 +1680,54 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal "custom key", Rails.application.config.my_custom_config["key"]
+      assert_equal "bar", Rails.application.config.my_custom_config["foo"]
+    end
+
+    test "config_for loads custom configuration from yaml accessible as symbol" do
+      app_file "config/custom.yml", <<-RUBY
+      development:
+        foo: 'bar'
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal "bar", Rails.application.config.my_custom_config[:foo]
+    end
+
+    test "config_for loads custom configuration from yaml accessible as method" do
+      app_file "config/custom.yml", <<-RUBY
+      development:
+        foo: 'bar'
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal "bar", Rails.application.config.my_custom_config.foo
+    end
+
+    test "config_for loads nested custom configuration from yaml as symbol keys" do
+      app_file "config/custom.yml", <<-RUBY
+      development:
+        foo:
+          bar:
+            baz: 1
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal 1, Rails.application.config.my_custom_config.foo[:bar][:baz]
     end
 
     test "config_for uses the Pathname object if it is provided" do


### PR DESCRIPTION
### Summary

`config_for` method is currently parsing a YAML file with the same name in the `config` directory and including it as an hash in the configuration with string keys.

After Rails 5.1, the style for secrets has changed from string keys to symbols. I guess it would be important to reflect this change also in this method to be consistent when accessing configuration across the application.

https://apidock.com/rails/Rails/Application/config_for

