### PR TITLE
Don’t allocate array on no args

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -18,9 +18,12 @@ module ActionView
       # * <tt>name</tt>   - Template name
       # * <tt>finder</tt>  - An instance of <tt>ActionView::LookupContext</tt>
       # * <tt>dependencies</tt>  - An array of dependent views
-      def digest(name:, finder:, dependencies: [])
-        dependencies ||= []
-        cache_key = [ name, finder.rendered_format, dependencies ].flatten.compact.join(".")
+      def digest(name:, finder:, dependencies: nil)
+        if dependencies.nil? || dependencies.empty?
+          cache_key = "#{name}.#{finder.rendered_format}"
+        else
+          cache_key = [ name, finder.rendered_format, dependencies ].flatten.compact.join(".")
+        end
 
         # this is a correctly done double-checked locking idiom
         # (Concurrent::Map's lookups have volatile semantics)
@@ -30,7 +33,7 @@ module ActionView
             root = tree(name, finder, partial)
             dependencies.each do |injected_dep|
               root.children << Injected.new(injected_dep, nil, nil)
-            end
+            end if dependencies
             finder.digest_cache[cache_key] = root.digest(finder)
           end
         end

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -19,5 +19,5 @@ class RelationCacheTest < ActionView::TestCase
     assert_equal "Hello World", controller.cache_store.read("views/path/projects-#{Project.count}")
   end
 
-  def view_cache_dependencies; end
+  def view_cache_dependencies; []; end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -10,7 +10,7 @@ module RenderTestCases
   def setup_view(paths)
     @assigns = { secret: "in the sauce" }
     @view = Class.new(ActionView::Base) do
-      def view_cache_dependencies; end
+      def view_cache_dependencies; []; end
 
       def combined_fragment_cache_key(key)
         [ :views, key ]


### PR DESCRIPTION
When no dependencies are present to be digested there is no reason to build an array just to turn around and turn it back into a string.

The dependencies array is not mutated in this method so we can use the same empty array across all invocations.

Total allocated: 791402 bytes (7294 objects)
Total allocated: 777442 bytes (7132 objects)

(791402 - 777442) / 791402.0 # => 1.76 % speed improvement
