### PR TITLE
Move digest path calculation out of loop

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -40,8 +40,12 @@ module ActionView
       end
 
       def expanded_cache_key(key)
-        key = @view.combined_fragment_cache_key(@view.cache_fragment_name(key, virtual_path: @template.virtual_path))
+        key = @view.combined_fragment_cache_key(@view.cache_fragment_name(key, virtual_path: @template.virtual_path, digest_path: digest_path))
         key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
+      end
+
+      def digest_path
+        @digest_path ||= @view.digest_path_from_virtual(@template.virtual_path)
       end
 
       def fetch_or_cache_partial(cached_partials, order_by:)


### PR DESCRIPTION
On every iteration of generating a cache for a collection a “digest path” is calculated even though it’s exactly the same for every element.

This PR exposes a method `digest_path_from_virtual` that returns back a “digest_path”. This can, in turn, be passed back into `cache_fragment_name`. This not only does less work but it also (you guessed it) uses less memory.

before: Total allocated: 762539 bytes (7035 objects)
after: Total allocated: 743590 bytes (6621 objects) 


(762539 - 743590)/ 762539.0 # => 2.4% faster ⚡️⚡️

