### PR TITLE
Do no watch parent directory of `dirs`

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -76,6 +76,34 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
     Process.wait(pid)
   end
+
+  test "updated should become true when nonexistent directory is added later" do
+    Dir.mktmpdir do |dir|
+      watched_dir = File.join(dir, "app")
+      unwatched_dir = File.join(dir, "node_modules")
+      not_exist_watched_dir = File.join(dir, "test")
+
+      Dir.mkdir(watched_dir)
+      Dir.mkdir(unwatched_dir)
+
+      checker = new_checker([], watched_dir => ".rb", not_exist_watched_dir => ".rb") { }
+
+      FileUtils.touch(File.join(watched_dir, "a.rb"))
+      wait
+      assert_predicate checker, :updated?
+      assert checker.execute_if_updated
+
+      Dir.mkdir(not_exist_watched_dir)
+      wait
+      assert_predicate checker, :updated?
+      assert checker.execute_if_updated
+
+      FileUtils.touch(File.join(unwatched_dir, "a.rb"))
+      wait
+      assert_not_predicate checker, :updated?
+      assert_not checker.execute_if_updated
+    end
+  end
 end
 
 class EventedFileUpdateCheckerPathHelperTest < ActiveSupport::TestCase


### PR DESCRIPTION
`EventedFileUpdateChecker` will search the parent directory if the specified directory does not exist.

Since `test/mailers/previews` is included in the watch target by default, if there is no test directory (e.g. using `rspec`), the Rails root directory will be included in the watch target.

```
$ rails new app
$ cd app
$ ./bin/rails r "p Rails.application.reloaders.last.send(:directories_to_watch).include?(Rails.root)"
false
$ rm -rf test
$ ./bin/rails r "p Rails.application.reloaders.last.send(:directories_to_watch).include?(Rails.root)"
true
```

This causes `node_modules` to be included in watch target. Adding parent directories to watch target may include unexpected directories. I think it should be avoided.

Related to #32700.