### PR TITLE
ActiveJob Backburner adapter: fix priority

### DIFF
--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -16,12 +16,12 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :backburner
     class BackburnerAdapter
       def enqueue(job) #:nodoc:
-        Backburner::Worker.enqueue JobWrapper, [ job.serialize ], queue: job.queue_name
+        Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
         delay = timestamp - Time.current.to_f
-        Backburner::Worker.enqueue JobWrapper, [ job.serialize ], queue: job.queue_name, delay: delay
+        Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority, delay: delay)
       end
 
       class JobWrapper #:nodoc:

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -137,4 +137,16 @@ class QueuingTest < ActiveSupport::TestCase
     assert job_executed "#{@id}.2"
     assert job_executed_at("#{@id}.2") < job_executed_at("#{@id}.1")
   end
+
+  test "should run job with higher priority first in Backburner" do
+    skip unless adapter_is?(:backburner)
+
+    jobs_manager.tube.pause(3)
+    TestJob.set(priority: 20).perform_later "#{@id}.1"
+    TestJob.set(priority: 10).perform_later "#{@id}.2"
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert job_executed "#{@id}.1"
+    assert job_executed "#{@id}.2"
+    assert job_executed_at("#{@id}.2") < job_executed_at("#{@id}.1")
+  end
 end


### PR DESCRIPTION
### Summary

The priority wasn't being passed from `ActiveJob` to `Backburner`, despite
priority being supported. This also brings it inline with the docs,
which mark `Backburner` as supporting priorities in the "Backend Features"
table: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html

### Other Information

A small note on the test. I did not add the adapter to the existing priority test and created a new one because the existing one relies on `wait_until`, which is handled differently by `Backburner`.