### PR TITLE
Follow up #33637 and #33770

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -24,7 +24,7 @@
     a deprecation warning if used, however calling `ActiveRecord::Base.configurations`
     will use the new version internally and externally.
 
-    For example, the following database.yml...
+    For example, the following `database.yml`:
 
     ```
     development:
@@ -49,13 +49,14 @@
 
     Iterating over the database configurations has also changed. Instead of
     calling hash methods on the `configurations` hash directly, a new method `configs_for` has
-    been provided that allows you to select the correct configuration. `env_name` is a required
-    argument, `spec_name` is optional as well as passing a block. These return an array of
-    database config objects for the requested environment and specification name respectively.
+    been provided that allows you to select the correct configuration. `env_name`, and
+    `spec_name` arguments are optional. For example these return an array of
+    database config objects for the requested environment and a single database config object
+    will be returned for the requested environment and specification name respectively.
 
     ```
-    ActiveRecord::Base.configurations.configs_for("development")
-    ActiveRecord::Base.configurations.configs_for("development", "primary")
+    ActiveRecord::Base.configurations.configs_for(env_name: "development")
+    ActiveRecord::Base.configurations.configs_for(env_name: "development", spec_name: "primary")
     ```
 
     *Eileen M. Uchitelle*, *Aaron Patterson*

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -18,8 +18,8 @@ module ActiveRecord
     # Collects the configs for the environment and optionally the specification
     # name passed in. To include replica configurations pass `include_replicas: true`.
     #
-    # If a spec name is provided a single DatabaseConfiguration object will be
-    # returned, otherwise an array of DatabaseConfiguration objects will be
+    # If a spec name is provided a single DatabaseConfig object will be
+    # returned, otherwise an array of DatabaseConfig objects will be
     # returned that corresponds with the environment and type requested.
     #
     # Options:
@@ -53,7 +53,7 @@ module ActiveRecord
     # Returns the config hash that corresponds with the environment
     #
     # If the application has multiple databases `default_hash` will
-    # the first config hash for the environment.
+    # return the first config hash for the environment.
     #
     #   { database: "my_db", adapter: "mysql2" }
     def default_hash(env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s)
@@ -64,7 +64,7 @@ module ActiveRecord
 
     # Returns a single DatabaseConfig object based on the requested environment.
     #
-    # If the application has multiple databases `select_db_config` will return
+    # If the application has multiple databases `find_db_config` will return
     # the first DatabaseConfig for the environment.
     def find_db_config(env)
       configurations.find do |db_config|
@@ -73,7 +73,7 @@ module ActiveRecord
       end
     end
 
-    # Returns the DatabaseConfig object as a Hash.
+    # Returns the DatabaseConfigurations object as a Hash.
     def to_h
       configs = configurations.reverse.inject({}) do |memo, db_config|
         memo.merge(db_config.to_legacy_hash)

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -12,7 +12,7 @@ module ActiveRecord
     # Becomes:
     #
     #   #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10
-    #     @env_name="development", @spec_name="primary", @config={"db_name"}>
+    #     @env_name="development", @spec_name="primary", @config={"database"=>"db_name"}>
     #
     # Options are:
     #

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -954,7 +954,7 @@ The only way to explicitly not use the connection information in `ENV['DATABASE_
 ```
 $ cat config/database.yml
 development:
-  url: sqlite3://NOT_my_database
+  url: sqlite3:NOT_my_database
 
 $ echo $DATABASE_URL
 postgresql://localhost/my_database
@@ -966,8 +966,8 @@ $ rails runner 'puts ActiveRecord::Base.configurations.inspect'
 #<ActiveRecord::DatabaseConfigurations:0x00007fc8eab02880 @configurations=[
   #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x00007fc8eab020b0
     @env_name="development", @spec_name="primary",
-    @config={"adapter"=>"sqlite3", "database"=>"NOT_my_database", "host"=>"localhost"}
-    @url="sqlite3://NOT_my_database">
+    @config={"adapter"=>"sqlite3", "database"=>"NOT_my_database"}
+    @url="sqlite3:NOT_my_database">
   ]
 ```
 


### PR DESCRIPTION
- Fix sqlite3 url  config in "Configuring Rails Applications" guide
  See `ConnectionUrlResolver#database_from_path` in
  `activerecord/lib/active_record/connection_adapters/connection_specification.rb`

- Fix explanation of `ActiveRecord::Base.configurations.configs_for` in the CHANGELOG
  Since #33770 `#configs_for` changed method signature and it isn't
  supposed to work with a passed block.

-  Fix `ActiveRecord::DatabaseConfigurations`'s docs

-  <del/>Allow `ActiveRecord::DatabaseConfigurations#configs_for` receive `:env_name` and `spec_name` as symbol </del>

- <del>Remove extra `reverse` in `ActiveRecord::DatabaseConfigurations#to_h`</del>

r? @eileencodes 
