### PR TITLE
Raise ArgumentError for enum attribute, when argument has a duplicate value

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -169,11 +169,11 @@ module ActiveRecord
 
         _enum_methods_module.module_eval do
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-          value_checked = {}
+          valid_checked = {}
           pairs.each do |label, value|
             # check a value exist in both key
-            raise ArgumentError, "value #{value} exist in both of #{value_checked[value]}, #{label}" if value_checked[value]
-            value_checked[value] = label
+            raise ArgumentError, "Values must be unique. The value '#{value}' was used on #{valid_checked[value]} and #{label}." if valid_checked[value]
+            valid_checked[value] = label
 
             if enum_prefix == true
               prefix = "#{name}_"

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -169,7 +169,12 @@ module ActiveRecord
 
         _enum_methods_module.module_eval do
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+          value_checked = {}
           pairs.each do |label, value|
+            # check a value exist in both key
+            raise ArgumentError, "value #{value} exist in both of #{value_checked[value]}, #{label}" if value_checked[value]
+            value_checked[value] = label
+
             if enum_prefix == true
               prefix = "#{name}_"
             elsif enum_prefix


### PR DESCRIPTION
### Summary

With enum attribute in ActiveRecord, I want to check duplicate value
# For example:

#### Start with code:
```
class Google < ApplicationRecord
 enum status: { publish: 0, draft: 0 }
end

class Youtube < ApplicationRecord
 enum status: { publish: 0, draft: 1 }
end
```

#### Before fix
```
with `rails console` or `rails server`  => done with no error

Google.publish.new
=> <Google id: nil, status: "publish", created_at: nil, updated_at: nil>
Google.draft.new
=> <Google id: nil, status: "publish", created_at: nil, updated_at: nil>

Youtube.publish.new
=> <Youtube id: nil, status: "publish", created_at: nil, updated_at: nil>
Youtube.draft.new
=> <Youtube id: nil, status: "draft", created_at: nil, updated_at: nil>
```
#### After fix
```
with `rails console` or `rails server` 
rails will raise an ArgumentError

	 3: from /home/max/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/enum.rb:176:in `block (2 levels) in enum'
	 2: from /home/max/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/enum.rb:176:in `each'
	 1: from /home/max/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/enum.rb:176:in `each_pair'
/home/max/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/enum.rb:178:in `block (3 levels) in enum': value 0 exist in both of publish, draft (ArgumentError)
```

So I create this pull, let avoid duplicate value in an enum attribute.