### PR TITLE
Follow up #33756

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,11 +9,16 @@
 
     *Darwin Wu*
 
-*   Configuration item `config.filter_parameters` could also filter out sensitive value of database column when call `#inspect`.
+*   Configuration item `config.filter_parameters` could also filter out
+    sensitive values of database columns when call `#inspect`.
+    We also added `ActiveRecord::Base::filter_attributes`/`=` in order to
+    specify sensitive attributes to specific model.
 
     ```
     Rails.application.config.filter_parameters += [:credit_card_number]
-    Account.last.inspect # => #<Account id: 123, credit_card_number: [FILTERED] ...>
+    Account.last.inspect # => #<Account id: 123, name: "DHH", credit_card_number: [FILTERED] ...>
+    SecureAccount.filter_attributes += [:name]
+    SecureAccount.last.inspect # => #<SecureAccount id: 42, name: [FILTERED], credit_card_number: [FILTERED] ...>
     ```
 
     *Zhang Kang*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -126,7 +126,7 @@ module ActiveRecord
       class_attribute :default_connection_handler, instance_writer: false
 
       ##
-      # Specifies columns which don't want to be exposed while calling #inspect
+      # Specifies columns which shouldn't be exposed while calling #inspect.
       class_attribute :filter_attributes, instance_writer: false, default: []
 
       def self.connection_handler

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -139,7 +139,7 @@ module ActiveRecord
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
     end
 
-    module ClassMethods # :nodoc:
+    module ClassMethods
       def initialize_find_by_cache # :nodoc:
         @find_by_statement_cache = { true => Concurrent::Map.new, false => Concurrent::Map.new }
       end
@@ -216,7 +216,7 @@ module ActiveRecord
         generated_association_methods
       end
 
-      def generated_association_methods
+      def generated_association_methods # :nodoc:
         @generated_association_methods ||= begin
           mod = const_set(:GeneratedAssociationMethods, Module.new)
           private_constant :GeneratedAssociationMethods
@@ -226,7 +226,7 @@ module ActiveRecord
         end
       end
 
-      # Returns columns which shouldn't be exposed while calling #inspect.
+      # Returns columns which shouldn't be exposed while calling +#inspect+.
       def filter_attributes
         if defined?(@filter_attributes)
           @filter_attributes
@@ -235,13 +235,13 @@ module ActiveRecord
         end
       end
 
-      # Specifies columns which shouldn't be exposed while calling #inspect.
+      # Specifies columns which shouldn't be exposed while calling +#inspect+.
       def filter_attributes=(attributes_names)
         @filter_attributes = attributes_names.map(&:to_s).to_set
       end
 
       # Returns a string like 'Post(id:integer, title:string, body:text)'
-      def inspect
+      def inspect # :nodoc:
         if self == Base
           super
         elsif abstract_class?
@@ -257,7 +257,7 @@ module ActiveRecord
       end
 
       # Overwrite the default class equality method to provide support for decorated models.
-      def ===(object)
+      def ===(object) # :nodoc:
         object.is_a?(self)
       end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -104,7 +104,7 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
 
 * `config.filter_parameters` used for filtering out the parameters that
 you don't want shown in the logs, such as passwords or credit card
-numbers. By default, Rails filters out passwords by adding `Rails.application.config.filter_parameters += [:password]` in `config/initializers/filter_parameter_logging.rb`. Parameters filter works by partial matching regular expression.
+numbers. It also filters out sensitive values of database columns when call `#inspect` on an Active Record object. By default, Rails filters out passwords by adding `Rails.application.config.filter_parameters += [:password]` in `config/initializers/filter_parameter_logging.rb`. Parameters filter works by partial matching regular expression.
 
 * `config.force_ssl` forces all requests to be served over HTTPS by using the `ActionDispatch::SSL` middleware, and sets `config.action_mailer.default_url_options` to be `{ protocol: 'https' }`. This can be configured by setting `config.ssl_options` - see the [ActionDispatch::SSL documentation](http://api.rubyonrails.org/classes/ActionDispatch/SSL.html) for details.
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3,6 +3,7 @@
 require "isolation/abstract_unit"
 require "rack/test"
 require "env_helpers"
+require "set"
 
 class ::MyMailInterceptor
   def self.delivering_email(email); email; end
@@ -2049,7 +2050,7 @@ module ApplicationTests
       RUBY
       app "development"
       assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
-      assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
+      assert_equal [ "password", "credit_card_number" ].to_set, ActiveRecord::Base.filter_attributes
     end
 
     private


### PR DESCRIPTION
-    Clarify docs of `config.filter_parameters` and `#filter_attributes`
    Add mention that `config.filter_parameters` also filters out sensitive
    values of database columns when call `#inspect` since #33756.

-  DRY `activerecord/lib/active_record/core.rb` and fix tests
   - Move
      ```
      filter_attributes = self.filter_attributes.map(&:to_s).to_set

      filter_attributes.include?(attribute_name) && !read_attribute(attribute_name).nil?
      ```
      to private method.
   - Fix tests in `activerecord/test/cases/filter_attributes_test.rb`
      - Ensure that `teardown` sets `ActiveRecord::Base.filter_attributes` to
        previous state.

    - Ensure that `Admin::Account.filter_attributes` is set to previous
        state in the "filter_attributes could be overwritten by models" test.


-  Build string set when `filter_attributes` is assigned
    It would allow `filter_attributes` to be reused across multiple
calls to `#inspect` or `#pretty_print`.
   - Add `require "set"` 
   - Remove `filter_attributes` instance reader. I think there is no need
to keep it.

-    Add mention about `ActiveRecord::Base::filter_attributes` to the changelog entry
    Also remove `# :nodoc:` for `ActiveRecord::Core::ClassMethods` in order
    to show non-nodoc methods in that module on the api docs http://edgeapi.rubyonrails.org


Follow up #33756
