### PR TITLE
[ci skip] Do not recommend testing stored object in template

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1028,8 +1028,8 @@ You should test for things such as:
 * was the web request successful?
 * was the user redirected to the right page?
 * was the user successfully authenticated?
-* was the correct object stored in the response template?
 * was the appropriate message displayed to the user in the view?
+* was the correct information displayed in the response?
 
 The easiest way to see functional tests in action is to generate a controller using the scaffold generator:
 


### PR DESCRIPTION
### Summary

I don't know if this PR is a valid one.

Since `assigns` is not placed by default with Rails, we removed the suggestion to test if the correct object was stored in the response template.
