### PR TITLE
Add unused optional path parameters to query

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -44,7 +44,10 @@ module ActionDispatch
             parameterized_parts.delete(key)
           end
 
-          return [route.format(parameterized_parts), params]
+          path = route.format(parameterized_parts)
+          # Add all unused parameters back to params
+          params.merge!(parameterized_parts) unless parameterized_parts.empty?
+          return [path, params]
         end
 
         unmatched_keys = (missing_keys || []) & constraints.keys

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -37,12 +37,17 @@ module ActionDispatch
       def evaluate(hash)
         parts = @parts.dup
 
-        @parameters.each do |index|
+        used_keys = @parameters.each_with_object([]) do |index, keys|
           param = parts[index]
           value = hash[param.name]
           return "".freeze unless value
+
+          keys << param.name
           parts[index] = param.escape value
         end
+
+        # Delete used items from the hash
+        hash.except!(*used_keys)
 
         @children.each { |index| parts[index] = parts[index].evaluate(hash) }
 


### PR DESCRIPTION
### Summary

This PR fixes the problem that is well described here https://github.com/rails/rails/issues/7047

Optional path parameters can be unused when nested. In that case they should be included in the query (as it used to be in Rails 3.1 (Rack::Mount))

For example: 

```
# routes.rb
get "path(/:foo(:bar))", as: :test,  # ...

# current behaviour
test_path(bar: "bar") # => "/path"

# expected behaviour
test_path(bar: "bar") # => "/path?bar=bar"
```

