### PR TITLE
Do not reset an already correct counter cache

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Avoid an unnecessary UPDATE query in `ActiveRecord::CounterCache.reset_counters`
+
+    In the best case, when all counter rows are already up to date (so there's
+    nothing to reset), and the `touch: false` option is used, we avoid an
+    unnecessary UPDATE query.
+
+    Using the `touch: true` option will still issue the UPDATE query, though
+    only the timestamp will be updated.
+
+    *Steven Harman*
+
 *   Fix `transaction` reverting for migrations.
 
     Before: Commands inside a `transaction` in a reverted migration ran uninverted.


### PR DESCRIPTION
Avoid an unnecessary `UPDATE` query when a counter cache is already up to date.

In the best case, when all counter rows are already up to date (so there's nothing to reset) this will avoid an unnecessary UPDATE query. This drops the number of queries for each record from 3 (find, count, & update) to two (find & count). With a large number of records, this can be a big savings.

### Other Information

NOTE: if using the `touch: true` option, we'll still issue the UPDATE. This is to preserve the current, though not specified, behavior of `::reset_counters(id, association, touch: true)` wherein all records would have their timestamp updated. I don't know if that's the "right" behavior, but it is consistent.