### PR TITLE
Do not exclude optional path parameters when equal to default and hav…

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -33,13 +33,17 @@ module ActionDispatch
             parameterized_parts.key?(key) || route.defaults.key?(key)
           end
 
-          defaults       = route.defaults
-          required_parts = route.required_parts
+          defaults          = route.defaults
+          required_parts    = route.required_parts
+          nested_parameters = route.nested_parameters
 
           route.parts.reverse_each do |key|
-            break if defaults[key].nil? && parameterized_parts[key].present?
+            next if defaults[key].nil? && parameterized_parts[key].present?
             next if parameterized_parts[key].to_s != defaults[key].to_s
-            break if required_parts.include?(key)
+            next if required_parts.include?(key)
+            # Keep the part if there are nested parameters
+            next if nested_parameters.key?(key) &&
+                      nested_parameters[key].any? { |nested_key| !parameterized_parts[nested_key].nil? }
 
             parameterized_parts.delete(key)
           end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -151,6 +151,18 @@ module ActionDispatch
         end
       end
 
+      # Return hash having parameters names associated with subsequent
+      # optional nested parameters, for example route
+      #
+      #   get "/path(/:one(/:two(/:three/:four)))"
+      #
+      # will have {:one => [:two], :two => [:three, :four]}
+      # as nested_parameters hash.
+      #
+      def nested_parameters
+        @nested_parameters ||= @path_formatter.extract_nested_parameters
+      end
+
       def glob?
         !path.spec.grep(Nodes::Star).empty?
       end

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -48,6 +48,28 @@ module ActionDispatch
 
         parts.join
       end
+
+      def extract_nested_parameters
+        result = {}
+
+        if @parameters.present? && @children.present?
+          nested_keys = @children.inject([]) { |ar, index| ar += @parts[index].parameters_names }
+
+          if nested_keys.present?
+            @parameters.each { |index| result[@parts[index].name] = nested_keys }
+          end
+        end
+
+        @children.each { |index| result.merge! @parts[index].extract_nested_parameters }
+
+        result
+      end
+
+      protected
+
+        def parameters_names
+          @parameters.map { |index| @parts[index].name }
+        end
     end
 
     module Visitors # :nodoc:


### PR DESCRIPTION
### Do not exclude optional path parameters when equal to default and having subsequent optional nested  parameters.

This PR fixes one of the problems called "issues of optional params in the middle".

```
get "/projects(/:year(/:month(/:day)))", to: "projects#index", as: :projects, 
  defaults: { year: "2018", month: "01", day: "01"}

# actual
projects_path(month: "02") => # "/projects"

# expected
projects_path(month: "02") => # "/projects/2018/02"
```
The problem is that when one of optional path parameters is extracted from the path (in this example because it is equal to default value) the subsequent path parameters are extracted too. We should not throw away optional parameters if they have dependent subsequent present parameters.

@pixeltrix Please, take a look. This problem has already been discussed here https://github.com/rails/rails/pull/32382
I took your expanded test case from that PR. Looks like everything is alright now, except for some cases related to wrong mapping of positional arguments to parameters ` by OptimizedUrlHelper#handle_positional_args`. 


