### PR TITLE
Include test helpers in ActionDispatch::IntegrationTest

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -49,7 +49,10 @@ module ActionMailer
         options.each { |k, v| send("#{k}=", v) }
       end
 
-      ActiveSupport.on_load(:action_dispatch_integration_test) { include ActionMailer::TestCase::ClearTestDeliveries }
+      ActiveSupport.on_load(:action_dispatch_integration_test) do
+        include ActionMailer::TestHelper
+        include ActionMailer::TestCase::ClearTestDeliveries
+      end
     end
 
     initializer "action_mailer.compile_config_methods" do

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -30,6 +30,10 @@ module ActiveJob
           send(k, v) if respond_to? k
         end
       end
+
+      ActiveSupport.on_load(:action_dispatch_integration_test) do
+        include ActiveJob::TestHelper
+      end
     end
 
     initializer "active_job.set_reloader_hook" do |app|


### PR DESCRIPTION
### Summary

Fixes #33838

As @dhh brings up, the point of `ActionDispatch::IntegrationTest` is to
allow users to test the integration of all the pieces called by a
controller. Asserting about the emails and jobs queued is part of that
task.

In this commit, I use the `action_dispatch_integration_test` hook to include
the `ActionMailer::TestHelper` and `ActiveJob::TestHelper` modules
when the ActionMailer and ActiveJob railties are initialized respectively.