### PR TITLE
Make sure `assert_enqueued_with()` & `assert_performed_with()` work reliably with hash arguments

### DIFF
--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -8,6 +8,7 @@ require "jobs/logging_job"
 require "jobs/nested_job"
 require "jobs/rescue_job"
 require "jobs/inherited_job"
+require "jobs/multiple_kwargs_job"
 require "models/person"
 
 class EnqueuedJobsTest < ActiveJob::TestCase
@@ -553,6 +554,12 @@ class EnqueuedJobsTest < ActiveJob::TestCase
   def test_assert_enqueued_with_with_no_block_with_at_option
     HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
     assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
+  end
+
+  def test_assert_enqueued_with_with_hash_arg
+    assert_enqueued_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
+      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+    end
   end
 
   def test_assert_enqueued_with_with_global_id_args
@@ -1563,6 +1570,12 @@ class PerformedJobsTest < ActiveJob::TestCase
 
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_performed_with(job: HelloJob, at: Date.today.noon)
+    end
+  end
+
+  def test_assert_performed_with_with_hash_arg
+    assert_performed_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
+      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
     end
   end
 

--- a/activejob/test/jobs/multiple_kwargs_job.rb
+++ b/activejob/test/jobs/multiple_kwargs_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../support/job_buffer"
+
+class MultipleKwargsJob < ActiveJob::Base
+  def perform(argument1:, argument2:)
+    JobBuffer.add("Job with argument1: #{argument1}, argument2: #{argument2}")
+  end
+end


### PR DESCRIPTION
The test helpers now treat `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` as equals

Fixes #33847