### PR TITLE
Faster multiple_of? method

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/multiple.rb
+++ b/activesupport/lib/active_support/core_ext/integer/multiple.rb
@@ -7,6 +7,6 @@ class Integer
   #   6.multiple_of?(5)  # => false
   #   10.multiple_of?(2) # => true
   def multiple_of?(number)
-    number != 0 ? self % number == 0 : zero?
+    number == 0 ? self == 0 : self % number == 0
   end
 end


### PR DESCRIPTION
### Summary

activesupport core extension `Integer#multiple_of?`

- use faster `== 0` instead of `zero?`
- use faster `==` instead of `!=`

### Benchmark

#### `0.multiple_of?(0)`

```
Warming up --------------------------------------
    new_multiple_of?    19.633M i/s -     19.747M times in 1.005812s (50.93ns/i)
        multiple_of?    15.569M i/s -     15.741M times in 1.011058s (64.23ns/i)
Calculating -------------------------------------
    new_multiple_of?    29.591M i/s -     58.899M times in 1.990465s (33.79ns/i)
        multiple_of?    22.291M i/s -     46.706M times in 2.095339s (44.86ns/i)

Comparison:
    new_multiple_of?:  29590706.2 i/s
        multiple_of?:  22290597.8 i/s - 1.33x  slower
```

#### `4611686018427387903.multiple_of?(42)`
```
Warming up --------------------------------------
    new_multiple_of?    13.721M i/s -     13.824M times in 1.007495s (72.88ns/i)
        multiple_of?    14.243M i/s -     14.374M times in 1.009176s (70.21ns/i)
Calculating -------------------------------------
    new_multiple_of?    20.231M i/s -     41.164M times in 2.034712s (49.43ns/i)
        multiple_of?    18.813M i/s -     42.729M times in 2.271264s (53.16ns/i)

Comparison:
    new_multiple_of?:  20230631.7 i/s
        multiple_of?:  18812736.4 i/s - 1.08x  slower
```
