### PR TITLE
Fix bug in Form Helpers section of Rails Guide

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -149,7 +149,7 @@ URL fields, email fields, number fields, and range fields:
 ```erb
 <%= text_area_tag(:message, "Hi, nice site", size: "24x6") %>
 <%= password_field_tag(:password) %>
-<%= hidden_field_tag(:parent_id, "5") %>
+<%= hidden_field_tag(:parent_id, value: "5") %>
 <%= search_field(:user, :name) %>
 <%= telephone_field(:user, :phone) %>
 <%= date_field(:user, :born_on) %>


### PR DESCRIPTION
### Summary

Correct a misleading example of how to create a hidden field.

### Other Information

The issue has long been documented on [StackOverflow](https://stackoverflow.com/questions/6636875/rails-hidden-field-undefined-method-merge-error)