### PR TITLE
Use faster globs for template resolving

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -221,9 +221,7 @@ module ActionView
       end
 
       def query(path, details, formats, outside_app_allowed)
-        query = build_query(path, details)
-
-        template_paths = find_template_paths(query)
+        template_paths = find_template_paths_from_details(path, details)
         template_paths = reject_files_external_to_app(template_paths) unless outside_app_allowed
 
         template_paths.map do |template|
@@ -241,6 +239,11 @@ module ActionView
 
       def reject_files_external_to_app(files)
         files.reject { |filename| !inside_path?(@path, filename) }
+      end
+
+      def find_template_paths_from_details(path, details)
+        query = build_query(path, details)
+        find_template_paths(query)
       end
 
       def find_template_paths(query)
@@ -362,19 +365,54 @@ module ActionView
 
   # An Optimized resolver for Rails' most common case.
   class OptimizedFileSystemResolver < FileSystemResolver #:nodoc:
-    def build_query(path, details)
-      query = escape_entry(File.join(@path, path))
+    private
 
-      exts = EXTENSIONS.map do |ext, prefix|
-        if ext == :variants && details[ext] == :any
-          "{#{prefix}*,}"
-        else
-          "{#{details[ext].compact.uniq.map { |e| "#{prefix}#{e}," }.join}}"
+      def find_template_paths_from_details(path, details)
+        # Instead of checking for every possible path, as our other globs would
+        # do, scan the directory for files with the right prefix.
+        query = "#{escape_entry(File.join(@path, path))}*"
+
+        regex = build_regex(path, details)
+
+        Dir[query].uniq.reject do |filename|
+          # This regex match does double duty of finding only files which match
+          # details (instead of just matching the prefix) and also filtering for
+          # case-insensitive file systems.
+          !filename.match(regex) ||
+            File.directory?(filename)
+        end.sort_by do |filename|
+          # Because we scanned the directory, instead of checking for files
+          # one-by-one, they will be returned in an arbitrary order.
+          # We can use the matches found by the regex and sort by their index in
+          # details.
+          match = filename.match(regex)
+          EXTENSIONS.keys.reverse.map do |ext|
+            if match[ext].nil?
+              # No match should be last
+              details[ext].length
+            else
+              found = match[ext].to_sym
+              details[ext].index(found)
+            end
+          end
         end
-      end.join
+      end
 
-      query + exts
-    end
+      def build_regex(path, details)
+        query = escape_entry(File.join(@path, path))
+        exts = EXTENSIONS.map do |ext, prefix|
+          match =
+            if ext == :variants && details[ext] == :any
+              ".*?"
+            else
+              details[ext].compact.uniq.map { |e| Regexp.escape(e) }.join("|")
+            end
+          prefix = Regexp.escape(prefix)
+          "(#{prefix}(?<#{ext}>#{match}))?"
+        end.join
+
+        %r{\A#{query}#{exts}\z}
+      end
   end
 
   # The same as FileSystemResolver but does not allow templates to store

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -387,7 +387,9 @@ module ActionView
           # details.
           match = filename.match(regex)
           EXTENSIONS.keys.reverse.map do |ext|
-            if match[ext].nil?
+            if ext == :variants && details[ext] == :any
+              match[ext].nil? ? 0 : 1
+            elsif match[ext].nil?
               # No match should be last
               details[ext].length
             else


### PR DESCRIPTION
Fixes #20752

`ActionView::PathResolver` (including the more optimized subclasses) works by evaluating a large glob pattern.

Its search is mostly equivalent to:
```
Dir["app/views/users/show{.en,}{.html,.text,.js,.css,.ics,.csv,.vcf,.vtt,.png,.jpeg,.gif,.bmp,.tiff,.svg,.mpeg,.mp3,.ogg,.m4a,.webm,.mp4,.otf,.ttf,.woff,.woff2,.xml,.rss,.atom,.yaml,.multipart_form,.url_encoded_form,.json,.pdf,.zip,.gzip,}{}{.raw,.erb,.html,.builder,.ruby,}"]
```

This is relatively slow. Ruby will check the existance of each possible file:
First `app/views/users/show.en.html.raw`,
then `app/views/users/show.en.html.erb`,
then `app/views/users/show.en.html.html`, ....etc

For the example above, which is not the worst - variants and fallback locales would add to complexity, that's 2 * 35 * 6 = 420 checks. Not nice.

Each of these checks needs 4 syscalls (it checks each path up the tree), resulting in [**1682 syscalls**](https://gist.github.com/jhawthorn/d9410cdf835d9229507450dc8dd45059). This would be even worse in a real app because it scans an absolute path.

It's much faster, as proposed in #20752 to scan the directory with a wildcard, and then filter the results in Ruby.

```
Dir["app/views/users/show*"]
```

This is only [**14 syscalls**](https://gist.github.com/jhawthorn/bc6f08db5e952267dec9fa2b976dda60). Great!

---

Filtering this would be trivial using the existing glob and `File.fnmatch`, but the problem we then run into is sorting (there is some discussion of this in #20752).

Although Ruby's docs don't guarantee an order returned by `Dir.glob`, it is consistent, and Rails relies on that order (ex. we want to prefer `show.en.html.erb` to `show.html.erb`).

This PR solves this by also building a regex to match paths and then using it to both ensure each file actually matches (vs just shares the prefix) and extract the details values which were matched. We then use the matched values to sort the results into the same order they would have been returned by the original glob pattern.

## Benchmark

```
require './config/environment'

Benchmark.ips do |x|
  x.report "lookup users/show" do
    ApplicationController.new.lookup_context.find_template("users/show", [], false, {}, {})
  end
end
```

**Before**

```
Warming up --------------------------------------
   lookup users/show     6.000  i/100ms
Calculating -------------------------------------
   lookup users/show     61.302  (± 4.9%) i/s -    306.000  in   5.011577s
```

**After**

```
Warming up --------------------------------------
   lookup users/show   353.000  i/100ms
Calculating -------------------------------------
   lookup users/show      3.845k (± 5.3%) i/s -     19.415k in   5.064962s
```

---

Thanks for reading ❤️

cc @eileencodes @brianmario @tenderlove 