### PR TITLE
Enable `sudo` only in the required build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ before_install:
   - "[[ $GEM != 'av:ujs' ]] || nvm install node"
   - "[[ $GEM != 'av:ujs' ]] || node --version"
   - "[[ $GEM != 'av:ujs' ]] || (cd actionview && npm install)"
-  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
-  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo mysql_upgrade"
-  - "[[ $GEM != 'ar:mysql2' ]] || [[ $MYSQL == 'mariadb' ]] || sudo service mysql restart"
 
 before_script:
   # Set Sauce Labs username and access key. Obfuscated, purposefully not encrypted.
@@ -60,7 +57,6 @@ env:
     - "GEM=ap,ac"
     - "GEM=am,amo,as,av,aj,ast"
     - "GEM=as PRESERVE_TIMEZONES=1"
-    - "GEM=ar:mysql2"
     - "GEM=ar:sqlite3"
     - "GEM=ar:postgresql"
     - "GEM=guides"
@@ -93,6 +89,27 @@ matrix:
         - memcached
         - redis-server
         - rabbitmq
+    - rvm: 2.4.4
+      env: "GEM=ar:mysql2"
+      sudo: required
+      before_install:
+        - "sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
+        - "sudo mysql_upgrade"
+        - "sudo service mysql restart"
+    - rvm: 2.5.1
+      env: "GEM=ar:mysql2"
+      sudo: required
+      before_install:
+        - "sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
+        - "sudo mysql_upgrade"
+        - "sudo service mysql restart"
+    - rvm: ruby-head
+      env: "GEM=ar:mysql2"
+      sudo: required
+      before_install:
+        - "sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
+        - "sudo mysql_upgrade"
+        - "sudo service mysql restart"
     - rvm: 2.5.1
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"


### PR DESCRIPTION
Currently, PostgreSQL + Ruby 2.5.1 build has failed.

https://travis-ci.org/rails/rails/jobs/427502723#L2940-L2942
https://travis-ci.org/rails/rails/jobs/427496382#L2921-L2923
https://travis-ci.org/rails/rails/jobs/427470858#L2921-L2923

This is because PostgreSQL server abnormally terminates when ramfs becomes full.
Ref: https://travis-ci.org/rails/rails/jobs/427960998#L7614

This occurs since d54d0c95750e2693da495b75ac5fa0280253972d.
In d54d0c95750e2693da495b75ac5fa0280253972d, `sudo` is used in preprocessing for setting MySQL.

In Travis, even if specified `sudo: false`, when using `sudo` in build, sudo-enabled infrastructure is used.
https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system

As container-based infrastructure was changed to sudo-enabled infrastructure, the disk settings etc were also changed, it seems that this phenomenon occurred.

This can also be handled by extending ramfs(https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213).
However, using sudo-enabled in all builds affects the execution time of build, so I think that it is good to use sudo-enabled only in the necessary builds.

