### PR TITLE
Add changelog entries for #33849 [ci skip]

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionDispatch::IntegrationTest` includes `ActionMailer::TestHelper` module by default.
+
+    *Ricardo Díaz*
+
 *   Add `perform_deliveries` to a payload of `deliver.action_mailer` notification.
 
     *Yoshiyuki Kinjo*

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionDispatch::IntegrationTest` includes `ActiveJob::TestHelper` module by default.
+
+    *Ricardo Díaz*
+
 *   Added `enqueue_retry.active_job`, `retry_stopped.active_job`, and `discard.active_job` hooks.
 
     *steves*


### PR DESCRIPTION
Since these changes related to the public API, I think we should add
changelog entries.

Related to #33838, #33849
