### PR TITLE
add `any?` to DatabaseConfigurations

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -10,6 +10,7 @@ module ActiveRecord
   # application's database configuration hash or url string.
   class DatabaseConfigurations
     attr_reader :configurations
+    delegate :any?, to: :configurations
 
     def initialize(configurations = {})
       @configurations = build_configs(configurations)


### PR DESCRIPTION
### Summary

To make the new DatabaseConfigurations backward compatible and act hash-like, we need an `any?` method. At least spring depends on this: https://github.com/rails/spring/blob/master/lib/spring/application.rb#L366 but other gems might also depend on it.