### PR TITLE
SQLite3 adapter supports expression indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   SQLite3 adapter supports expression indexes
+
+    ```
+    create_table :users do |t|
+      t.string :email
+    end
+
+    add_index :users, 'lower(email)', name: 'index_users_on_email', unique: true
+    ```
+
+    *Gray Kemmey*
+
 *   Allow subclasses to redefine autosave callbacks for associated records.
 
     Fixes #33305.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -21,10 +21,14 @@ module ActiveRecord
               WHERE name = #{quote(row['name'])} AND type = 'index'
             SQL
 
-            /\sWHERE\s+(?<where>.+)$/i =~ index_sql
+            /\sON\s+"(\w+?)"\s+\((?<expressions>.+?)\)(\sWHERE\s+(?<where>.+))?$/i =~ index_sql
 
             columns = exec_query("PRAGMA index_info(#{quote(row['name'])})", "SCHEMA").map do |col|
               col["name"]
+            end
+
+            if columns.any?(&:nil?) # index created with an expression
+              columns = expressions.split(", ").map { |e| e.gsub(/^\"|\"?$/, "") }
             end
 
             # Add info on sort order for columns (only desc order is explicitly specified, asc is

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -125,6 +125,10 @@ module ActiveRecord
         true
       end
 
+      def supports_expression_index?
+        sqlite_version >= "3.9.0"
+      end
+
       def requires_reloading?
         true
       end


### PR DESCRIPTION
@rafaelfranca I busted something in https://github.com/rails/rails/pull/33862 rebasing that closed the PR. Sorry about that. Didn't mean for this to become more trouble than it's worth 😅 

### Summary

Adds expression indexes support to SQLite adapter. Example:

```rb
create_table :users do |t|
  t.references :account
  t.string :email
end

add_index :users, 'account_id, lower(email)', name: 'index_users_on_account_id_and_email',
                                              unique: true
```