### PR TITLE
Bump the minimum version of mysql2 gem to 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
 
   group :db do
     gem "pg", ">= 0.18.0", "< 1.1"
-    gem "mysql2", ">= 0.4.10"
+    gem "mysql2", "~> 0.5.0"
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   minitest-bisect
-  mysql2 (>= 0.4.10)
+  mysql2 (~> 0.5.0)
   nokogiri (>= 1.8.1)
   pg (>= 0.18.0, < 1.1)
   psych (~> 3.0)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -3,7 +3,7 @@
 require "active_record/connection_adapters/abstract_mysql_adapter"
 require "active_record/connection_adapters/mysql/database_statements"
 
-gem "mysql2", ">= 0.4.4", "< 0.6.0"
+gem "mysql2", "~> 0.5.0"
 require "mysql2"
 
 module ActiveRecord

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -299,7 +299,7 @@ module Rails
       def gem_for_database
         # %w( mysql postgresql sqlite3 oracle frontbase ibm_db sqlserver jdbcmysql jdbcsqlite3 jdbcpostgresql )
         case options[:database]
-        when "mysql"          then ["mysql2", [">= 0.4.4", "< 0.6.0"]]
+        when "mysql"          then ["mysql2", ["~> 0.5.0"]]
         when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]


### PR DESCRIPTION
### Summary

Rails 6 drops MySQL 5.1 support and requires MySQL 5.5.8 by #33853
mysql2 gem 0.5.0 also drops MySQL 5.1 support.

https://github.com/brianmario/mysql2/releases/tag/0.5.0
> MySQL 5.5 or higher required. MySQL 5.0 and 5.1 are not supported.

Related to #31636 #32310 #33853

cc @sodabrew 