### PR TITLE
WIP: Add the ability to swap connections in Active Record

### DIFF
--- a/activerecord/lib/active_record/connection_handling/registration.rb
+++ b/activerecord/lib/active_record/connection_handling/registration.rb
@@ -1,0 +1,35 @@
+module ActiveRecord
+  module ConnectionHandling
+    class Registration # :nodoc:
+      def self.call
+        new.register_connection_handlers
+      end
+
+      def register_connection_handlers
+        register_default_connection_handler
+        register_default_readonly_connection_handler
+      end
+
+      private
+        def register_default_connection_handler
+          ActiveRecord::Base.connection_handlers[:default] ||= ActiveRecord::Base.connection_handler
+        end
+
+        def register_default_readonly_connection_handler
+          config = ActiveRecord::Base.configurations.replica_configs_for(env_name: DEFAULT_ENV.call.to_s)
+          return if config.nil?
+
+          ActiveRecord::Base.connection_handlers[:readonly] ||= register_connection_handler(config)
+        end
+
+        def register_connection_handler(config)
+          handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+
+          config_hash = ActiveRecord::Base.resolve_config_for_connection(config.config)
+          handler.establish_connection(config_hash)
+
+          handler
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -124,6 +124,8 @@ module ActiveRecord
 
       mattr_accessor :belongs_to_required_by_default, instance_accessor: false
 
+      mattr_accessor :connection_handlers, instance_accessor: false, default: {}
+
       class_attribute :default_connection_handler, instance_writer: false
 
       self.filter_attributes = []

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -50,6 +50,32 @@ module ActiveRecord
       end
     end
 
+    # Returns a config for a replica database.
+    #
+    # If a +spec_name+ is provided, will return the config that
+    # corresponds with that environment and specification.
+    #
+    # If a spec name is not provided the first replica config for the
+    # provided environment will be returned.
+    #
+    # Options:
+    #
+    # <tt>env_name:</tt> The environment name. Defaults to nil which will collect
+    # configs for all environments.
+    # <tt>spec_name:</tt> The specification name (ie primary, animals, etc.). Defaults
+    # to +nil+.
+    def replica_configs_for(env_name: nil, spec_name: nil)
+      configs = configs_for(env_name: env_name, spec_name: spec_name, include_replicas: true)
+
+      if configs.is_a?(Array)
+        configs.find do |config|
+          config.replica?
+        end
+      else
+        configs if configs.replica?
+      end
+    end
+
     # Returns the config hash that corresponds with the environment
     #
     # If the application has multiple databases `default_hash` will

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -153,6 +153,12 @@ end_warning
       end
     end
 
+    initializer "active_record.register_connection_handlers" do
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::ConnectionHandling::Registration.call
+      end
+    end
+
     # Expose database runtime to controller for logging.
     initializer "active_record.log_runtime" do
       require "active_record/railties/controller_runtime"


### PR DESCRIPTION
This is a work in progress but I want to get feedback from @tenderlove @rafaelfranca @matthewd and @dhh before continuing. In the comments I'll include a second way of doing connection switching that Matthew suggested.

**Background & Inspiration:**

In github we have 10+ primary configurations, 10+ replica configurations, and a few other types of configurations. To organize these configurations into connections we create a connection handlers hash that creates a mapping from connection type to a handler; `:default`, `:readonly`, and `:readonly_slow`. Note this PR only sets up 2 handlers as I'm trying to keep this PR simple. Later I'd like to add the ability for an application to register custom handlers that would generate `use_x_connection` methods from those handlers.

This PR takes that concept and refactors it a bit. It allows for a simple API for establishing connections and swapping connections for rw/ro splitting.

---

This is the first iteration of adding support for multiple databases in
Rails. Please note that if this version is accepted the next step will
be adding support for QueryCache on multiple handlers and allowing the
application to register multiple handlers.

This PR adds the ability for an application to have multiple handlers
and switch between those handlers in order to change connections.

By default Rails will register a `default` handler (for write
connections), and a `readonly` handler (for readonly connections). On
load these handlers are registered.

In an application model we can connect to the database using
`establish_connection` which will determine which handler to connect to
based on options passed in. For example given a configuration like this:

```
development:
  primary:
    database: my_primary_db
    user: root
  primary_replica:
    database: my_primary_db
    user: ro_user
    replica: true
  animals:
    database: my_animals_db
    user: root
  animals_replica
    database: my_animals_db
    user: ro_user
    replica: true
```

A model would connect like this:

```
class AnimalsBase < ApplicationRecord
  establish_connection :animals, :default
  establish_connection :animals, :readonly
end
```

This will ensure when a model under `AnimalsBase` is loaded, for example
`Dog`, `Dog` will have a connection to the write db and the readonly db
through the connection handlers.

To swap between databases applications can call `use_default_connection`
or `use_readonly_connection`. If no handler or connection type is
provided the application will default to the write db (later I'd like to
make this configurable, for example at GitHub we default to the readonly
connections).

Examples:

```
Animals.use_default_connection do
  # dog will be created
  Dog.create!
end

Animals.use_readonly_connection do
  # exception will be thrown due to using a readonly user
  Dog.create!
end
```

---

To do:

- [ ] Add tests
- [ ] Decide if these are the apis we want
- [ ] Update docs/guides