### PR TITLE
Clarify transactional behavior of after_commit and after_rollback callbacks

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -435,7 +435,9 @@ class PictureFile < ApplicationRecord
 end
 ```
 
-WARNING. The `after_commit` and `after_rollback` callbacks are called for all models created, updated, or destroyed within a transaction block. However, if an exception is raised within one of these callbacks, the exception will bubble up and any remaining `after_commit` or `after_rollback` methods will _not_ be executed. As such, if your callback code could raise an exception, you'll need to rescue it and handle it within the callback in order to allow other callbacks to run.
+WARNING. When a transaction completes, the `after_commit` or `after_rollback` callbacks are called for all models created, updated, or destroyed within that transaction. However, if an exception is raised within one of these callbacks, the exception will bubble up and any remaining `after_commit` or `after_rollback` methods will _not_ be executed. As such, if your callback code could raise an exception, you'll need to rescue it and handle it within the callback in order to allow other callbacks to run.
+
+WARNING. The code executed within `after_commit` or `after_rollback` callbacks is itself not enclosed within a transaction.
 
 WARNING. Using both `after_create_commit` and `after_update_commit` in the same model will only allow the last callback defined to take effect, and will override all others.
 


### PR DESCRIPTION
### Summary

This sentence in the Active Record Callbacks guide tripped me up: "The after_commit and after_rollback callbacks are called for all models created, updated, or destroyed within a transaction block". I read it as "The after_commit and after_rollback callbacks are called ... within a transaction block", that is, as if all these callbacks together would be wrapped within a transaction.

However, this turns out to be the incorrect reading. In fact, these callbacks do not run in any database transaction at all! (This also tripped me up after some experimenting, thinking that perhaps each individual callback would be wrapped in a transaction.) I think it is worthwhile to be more explicit about this, hence this pull request.