### PR TITLE
[Realties] config_for as ActiveSupport::OrderedOptions

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -232,10 +232,12 @@ module Rails
 
       if yaml.exist?
         require "erb"
-        require "active_support/ordered_options"
+        config = YAML.load(ERB.new(yaml.read).result) || {}
+        config = (config["shared"] || {}).merge(config[env] || {})
 
-        config = (YAML.load(ERB.new(yaml.read).result) || {})[env] || {}
-        ActiveSupport::InheritableOptions.new(config.deep_symbolize_keys)
+        ActiveSupport::OrderedOptions.new.tap do |config_as_ordered_options|
+          config_as_ordered_options.update(config.deep_symbolize_keys)
+        end
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1728,21 +1728,6 @@ module ApplicationTests
       assert_equal true, Rails.application.config.action_mailer.show_previews
     end
 
-    test "config_for loads custom configuration from yaml files" do
-      app_file "config/custom.yml", <<-RUBY
-      development:
-        foo: 'bar'
-      RUBY
-
-      add_to_config <<-RUBY
-        config.my_custom_config = config_for('custom')
-      RUBY
-
-      app "development"
-
-      assert_equal "bar", Rails.application.config.my_custom_config["foo"]
-    end
-
     test "config_for loads custom configuration from yaml accessible as symbol" do
       app_file "config/custom.yml", <<-RUBY
       development:
@@ -1756,21 +1741,6 @@ module ApplicationTests
       app "development"
 
       assert_equal "bar", Rails.application.config.my_custom_config[:foo]
-    end
-
-    test "config_for loads custom configuration from yaml accessible as method" do
-      app_file "config/custom.yml", <<-RUBY
-      development:
-        foo: 'bar'
-      RUBY
-
-      add_to_config <<-RUBY
-        config.my_custom_config = config_for('custom')
-      RUBY
-
-      app "development"
-
-      assert_equal "bar", Rails.application.config.my_custom_config.foo
     end
 
     test "config_for loads nested custom configuration from yaml as symbol keys" do
@@ -1787,7 +1757,31 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal 1, Rails.application.config.my_custom_config.foo[:bar][:baz]
+      assert_equal 1, Rails.application.config.my_custom_config[:foo][:bar][:baz]
+    end
+
+    test "config_for makes all hash methods available" do
+      app_file "config/custom.yml", <<-RUBY
+      development:
+        foo: 0
+        bar:
+          baz: 1
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      actual = Rails.application.config.my_custom_config
+
+      assert_equal actual, foo: 0, bar: { baz: 1 }
+      assert_equal actual.keys, [ :foo, :bar ]
+      assert_equal actual.values, [ 0, baz: 1]
+      assert_equal actual.to_h, foo: 0, bar: { baz: 1 }
+      assert_equal actual[:foo], 0
+      assert_equal actual[:bar], baz: 1
     end
 
     test "config_for uses the Pathname object if it is provided" do
@@ -1802,7 +1796,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal "custom key", Rails.application.config.my_custom_config["key"]
+      assert_equal "custom key", Rails.application.config.my_custom_config[:key]
     end
 
     test "config_for raises an exception if the file does not exist" do
@@ -1830,6 +1824,40 @@ module ApplicationTests
       app "development"
 
       assert_equal({}, Rails.application.config.my_custom_config)
+    end
+
+    test "config_for implements shared configuration as secrets case found" do
+      app_file "config/custom.yml", <<-RUBY
+      shared:
+        foo: :bar
+      test:
+        foo: :baz
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "test"
+
+      assert_equal(:baz, Rails.application.config.my_custom_config[:foo])
+    end
+
+    test "config_for implements shared configuration as secrets case not found" do
+      app_file "config/custom.yml", <<-RUBY
+      shared:
+        foo: :bar
+      test:
+        foo: :baz
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal(:bar, Rails.application.config.my_custom_config[:foo])
     end
 
     test "config_for with empty file returns an empty hash" do
@@ -1901,7 +1929,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal "custom key", Rails.application.config.my_custom_config["key"]
+      assert_equal "custom key", Rails.application.config.my_custom_config[:key]
     end
 
     test "config_for with syntax error show a more descriptive exception" do
@@ -1934,7 +1962,7 @@ module ApplicationTests
       RUBY
       require "#{app_path}/config/environment"
 
-      assert_equal "unicorn", Rails.application.config.my_custom_config["key"]
+      assert_equal "unicorn", Rails.application.config.my_custom_config[:key]
     end
 
     test "api_only is false by default" do


### PR DESCRIPTION
### Summary

After the change introduced in #33815 , @morgoth noticed that the behaviour of `ActiveSupport::OrderedOptions` and its subclasses is quite different from hashes on initialisation: https://github.com/rails/rails/pull/33815#issuecomment-421349795

This appears to be a quite common issue when subclassing Hash: e.g. [SO-13109183](https://stackoverflow.com/questions/13109183/subclassing-ruby-hash-object-has-no-methods-of-hash)

Thanks to this change you will be able to call all the classic hash methods such as `.keys`, `.values`, `.to_h` etc.