### PR TITLE
Configure Active Storage route prefix

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveStorage.routes_prefix` for configuring generated routes.
+
+    *Chris Bisnett*
+
 *   `ActiveStorage::Service::AzureStorageService` only handles specifically
     relevant types of `Azure::Core::Http::HTTPError`. It previously obscured
     other types of `HTTPError`, which is the azure-storage gem’s catch-all

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "/rails/active_storage/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+  scope ActiveStorage.routes_prefix do
+    get "/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
 
-  direct :rails_blob do |blob, options|
-    route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
+    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
+
+    get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
+    put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
+    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
   end
-
-  resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
-  resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
-
-
-  get "/rails/active_storage/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
 
   direct :rails_representation do |representation, options|
     signed_blob_id = representation.blob.signed_id
@@ -25,7 +23,10 @@ Rails.application.routes.draw do
   resolve("ActiveStorage::Preview") { |preview, options| route_for(:rails_representation, preview, options) }
 
 
-  get  "/rails/active_storage/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-  put  "/rails/active_storage/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-  post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+  direct :rails_blob do |blob, options|
+    route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
+  end
+
+  resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
+  resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -50,6 +50,7 @@ module ActiveStorage
   mattr_accessor :variable_content_types, default: []
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :service_urls_expire_in, default: 5.minutes
+  mattr_accessor :routes_prefix, default: "/rails/active_storage"
 
   module Transformers
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -51,6 +51,7 @@ module ActiveStorage
         ActiveStorage.previewers        = app.config.active_storage.previewers || []
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
         ActiveStorage.paths             = app.config.active_storage.paths || {}
+        ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -832,6 +832,14 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
   The default is 5 minutes.
 
+* `config.active_storage.routes_prefix` can be used to set the route prefix for the routes served by Active Storage. Accepts a string that will be prepended to the generated routes.
+
+  ```ruby
+  config.active_storage.routes_prefix = '/files'
+  ```
+
+  The default is `/rails/active_storage`
+
 ### Configuring a Database
 
 Just about every Rails application will interact with a database. You can connect to the database by setting an environment variable `ENV['DATABASE_URL']` or by using a configuration file called `config/database.yml`.


### PR DESCRIPTION
Applications can configure the route prefix prepended to the Active
Storage routes. By default this maintains the previous prefix
`/rails/active_storage` but supports custom prefixes.

Before this change the route for serving blobs is fixed to
`/rails/active_storage/blobs/:signed_id/*filename`. After this change
it's possible to configure the route to something like
`/files/blobs/:signed_id/*filename`.