### PR TITLE
Rails.application.credentials.env fetches Rails.env specific configs.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   ActiveSupport::EncryptedConfiguration.new now accepts an optional rail_env
+    parameter. When set, rails_env specific settings are exposed at #env.
+
+        development:
+          foo: development foo
+        production:
+          foo: production foo
+
+    For example, in development mode.
+
+        Rails.application.credentials.env.foo == "development foo"
+
+    *John Gorman*
+
 *   Changed `ActiveSupport::TaggedLogging.new` to return a new logger instance instead
     of mutating the one received as parameter.
 

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -12,7 +12,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
 
     @credentials = ActiveSupport::EncryptedConfiguration.new(
       config_path: @credentials_config_path, key_path: @credentials_key_path,
-      env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true
+      env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true, rails_env: "test"
     )
   end
 
@@ -63,5 +63,28 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
 
   test "raises key error when accessing config via bang method" do
     assert_raise(KeyError) { @credentials.something! }
+  end
+
+  test "rails_env configuration lookups" do
+    @credentials.write({ foo: "global foo", test: { foo: "test foo" } }.to_yaml)
+
+    assert_equal "global foo", @credentials.foo
+    assert_equal "test foo", @credentials.env.foo
+    assert_equal "test foo", @credentials.env[:foo]
+    assert_equal "test foo", @credentials.env.dig(:foo)
+    assert_equal "test foo", @credentials.env.fetch(:foo)
+    assert_equal ({ foo: "test foo" }), @credentials.env.config
+
+    assert_nil @credentials.env.missing
+    assert_raises ::KeyError do @credentials.env.missing! end
+    assert_nil @credentials.env[:missing]
+    assert_nil @credentials.env.dig(:missing)
+    assert_equal "missing key", @credentials.env.fetch(:missing, "missing key")
+
+    # Check that credentials and credentials.env get the new configuration.
+    @credentials.write({ foo: "global bar", test: { foo: "test bar" } }.to_yaml)
+    assert_equal "global bar", @credentials.foo
+    assert_equal "global bar", @credentials[:foo]
+    assert_equal "test bar", @credentials.env.foo
   end
 end

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1225,8 +1225,15 @@ For example, with the following decrypted `config/credentials.yml.enc`:
 
     secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
     some_api_key: SOMEKEY
+    development:
+      timer_key: DEVTIMERKEY
+    production:
+      timer_key: PRODUCTIONTIMERKEY
 
 `Rails.application.credentials.some_api_key` returns `SOMEKEY` in any environment.
+
+`Rails.application.credentials.env.timer_key` returns `DEVTIMERKEY`
+in development and `PRODUCTIONTIMERKEY` in production.
 
 If you want an exception to be raised when some key is blank, use the bang
 version:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   `Rails.application.credentials.env` now exposes the current `Rails.env`
+    slice of the credentials. This is true of all files opened with
+    `Rails.application.encrypted()`.
+
+    The `#env` interface makes it easy to migrate from deprecated encrypted
+    secrets to credentials. Secrets supported environmentally responsive
+    configurations and `#env` brings that convenience to credentials.
+
+        development:
+          foo: development foo
+        production:
+          foo: production foo
+
+    For example, in development mode.
+
+        Rails.application.credentials.env.foo == "development foo"
+
+    *John Gorman*
+
 *   Make `ActiveSupport::Cache::NullStore` the default cache store in the test environment.
 
     *Michael C. Nelson*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -474,7 +474,8 @@ module Rails
         config_path: Rails.root.join(path),
         key_path: Rails.root.join(key_path),
         env_key: env_key,
-        raise_if_missing_key: config.require_master_key
+        raise_if_missing_key: config.require_master_key,
+        rails_env: Rails.env
       )
     end
 

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -38,3 +38,28 @@ the encrypted credentials.
 When the temporary file is next saved the contents are encrypted and written to
 `config/credentials.yml.enc` while the file itself is destroyed to prevent credentials
 from leaking.
+
+=== Fetching Credentials
+
+The credentials added to this file are accessible via
+`Rails.application.credentials`.
+
+For example, with the following decrypted `config/credentials.yml.enc`:
+
+    secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
+    some_api_key: SOMEKEY
+    development:
+      timer_key: DEVTIMERKEY
+    production:
+      timer_key: PRODUCTIONTIMERKEY
+
+`Rails.application.credentials.some_api_key` returns `SOMEKEY`
+in any environment.
+
+`Rails.application.credentials.env.timer_key` returns `DEVTIMERKEY`
+in development and `PRODUCTIONTIMERKEY` in production.
+
+If you want an exception to be raised when some key is blank, use the bang
+version:
+
+    Rails.application.credentials.some_api_key!

--- a/railties/lib/rails/commands/secrets/USAGE
+++ b/railties/lib/rails/commands/secrets/USAGE
@@ -58,3 +58,12 @@ That command opens a temporary file in `$EDITOR` with the decrypted contents of
 When the temporary file is next saved the contents are encrypted and written to
 `config/secrets.yml.enc` while the file itself is destroyed to prevent secrets
 from leaking.
+
+=== Migrating from Secrets to Credentials
+
+Encrypted secrets are deprecated in favor of credentials.
+Run `rails credentials:help` for more information.
+
+To migrate, move the contents of secrets to credentials and replace calls to
+`Rails.application.secrets` with `Rails.application.credentials.env`
+to retrieve RAILS_ENV specific credentials.


### PR DESCRIPTION
The new #env interface is available for all files opened with Rails.application.encrypted().

The #env interface makes it easy to migrate from deprecated encrypted
secrets to credentials. Secrets supported environmentally responsive
configurations and #env brings that convenience to credentials.

    development:
      foo: development foo
    production:
      foo: production foo

For example, in development mode.

    Rails.application.credentials.env.foo == "development foo"

### Summary

I added #env to ActiveSupport::EncryptedConfiguration and added test cases.
This fixes a tiny bug where rewriting an encrypted file is not reflected in the
in-memory config hash.

I updated Rails.application.encrypted() to pass Rails.env into EncryptedConfiguration.new()
so that Rails.application.credentials.env returns the correct values for the current environment.

I updated the CHANGELOGS in railties and activesupport.

I updated the Security Guide to explain the new credentials.env interface.

I updated the rails credentials:help usage file to explain how to fetch from #env.

I updated the rails secrets:help usage file to explain that encrypted secrets are deprecated
and how to migrate to credentials using credentials.env to match how Rails.application.secrets works.

### Other Information

The #env interface has been extracted into the credentials_for_rails_env gem to assist with
the migration from secrets to credentials before Rails 6.0 lands.

https://github.com/jgorman/credentials_for_rails_env