### PR TITLE
Fix av-ujs build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
+    chromedriver-helper (2.0.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     coffee-rails (4.2.2)

--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "qunit/selenium/test_runner"
-require "chromedriver/helper"
+require "chromedriver-helper"
 
 driver_options = Selenium::WebDriver::Chrome::Options.new
 driver_options.add_argument("--headless")


### PR DESCRIPTION
The bin shim provides by `chromedriver-helper` gem has renamed to `chromedriver-helper` since 2.0.
https://github.com/flavorjones/chromedriver-helper/pull/58

Since bin of new name is set to driver path in `lib/chromedriver-helper.rb`, need to load it.