### PR TITLE
ActiveRecord::Associations::Preloader should preload all instances of the same record

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -88,7 +88,6 @@ module ActiveRecord
         if records.empty?
           []
         else
-          records.uniq!
           Array.wrap(associations).flat_map { |association|
             preloaders_on association, records, preload_scope
           }

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -71,6 +71,15 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
                  club1.members.sort_by(&:id)
   end
 
+  def test_preload_multiple_instances_of_the_same_record
+    club = Club.create!(name: "Aaron cool banana club")
+    Membership.create! club: club, member: Member.create!(name: "Aaron")
+    Membership.create! club: club, member: Member.create!(name: "Bob")
+
+    preloaded_clubs = Club.joins(:memberships).preload(:membership).to_a
+    assert_no_queries { preloaded_clubs.each(&:membership) }
+  end
+
   def test_ordered_has_many_through
     person_prime = Class.new(ActiveRecord::Base) do
       def self.name; "Person"; end


### PR DESCRIPTION
Hello. The example from test is not the condition in what I have found the bug. In our project we have an `ActiveModelSerializers` adapter which preloads associations from fields metadata using `ActiveRecord::Associations::Preloader` directly. I would put the exact example in specs, but I am not sure if `Preloader` is a public interface. Is it?
https://github.com/rails/rails/pull/33886 is another part of fixing the issue of using `Preloader` this way.