### PR TITLE
Follow up #33751

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -94,7 +94,7 @@ module ActiveJob
           wait = event.payload[:wait]
 
           error do
-            "Retrying #{job.class} in #{wait} seconds, due to a #{ex.class}. The original exception was #{ex.cause.inspect}."
+            "Retrying #{job.class} in #{wait.inspect} seconds, due to a #{ex&.class.inspect}. The original exception was #{ex&.cause.inspect}."
           end
         end
 

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -173,6 +173,11 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_enqueue_retry_logging_on_retry_job
+    perform_enqueued_jobs { RescueJob.perform_later "david" }
+    assert_match(/Retrying RescueJob in nil seconds, due to a nil\. The original exception was nil\./, @logger.messages)
+  end
+
   def test_retry_stopped_logging
     perform_enqueued_jobs do
       RetryJob.perform_later "CustomCatchError", 6

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -467,6 +467,7 @@ Active Job
 | `:job`       | Job object                             |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:error`     | The error that caused the retry        |
+| `:wait`      | The delay of the retry                 |
 
 ### perform_start.active_job
 


### PR DESCRIPTION
 - Payload of `enqueue_retry.active_job` includes `:wait`

    Add mention about it to the "Active Support Instrumentation" guide

    Related to https://github.com/rails/rails/pull/33751#discussion_r214745153
    Follow up #33751

- `retry_job` should publish `enqueue_retry.active_job` notification

    Also this commit removes `:wait` from payload of
    `retry_stopped.active_job`.

    Related to https://github.com/rails/rails/pull/33751#discussion_r214140008
    Follow up #33751

    /cc @kaspth, @rafaelfranca
