### PR TITLE
Sort before_commit callbacks to avoid deadlocks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -116,7 +116,12 @@ module ActiveRecord
       end
 
       def before_commit_records
-        records.uniq.each(&:before_committed!) if records && @run_commit_callbacks
+        return unless records && @run_commit_callbacks
+
+        deterministic_order = records.uniq.sort_by do |r|
+          r.class.name + r.id.to_s
+        end
+        deterministic_order.each(&:before_committed!)
       end
 
       def commit_records

--- a/activerecord/test/cases/touch_later_test.rb
+++ b/activerecord/test/cases/touch_later_test.rb
@@ -125,6 +125,10 @@ class TouchLaterTest < ActiveRecord::TestCase
   class FullCommitTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
+    def self.run(*args)
+      super unless current_adapter?(:SQLite3Adapter)
+    end
+
     def test_before_commit_update_deadlocks
       assert_nothing_raised do
         topic1 = Topic.create!


### PR DESCRIPTION
### Summary

When callbacks are applied before commit, it may happen that concurrent
transactions are updating the same records in reverse order and cause a
deadlock.

This different ordering often happens from multiple child records all needing
to touch their parent/grandparent records through different association paths.

### Other Information

Tested with postgresql adapter, where the current implementation fails with:

```
ActiveRecord::Deadlocked: PG::TRDeadlockDetected: ERROR:  deadlock detected
DETAIL:  Process 53367 waits for ShareLock on transaction 1820787; blocked by process 53368.
Process 53368 waits for ShareLock on transaction 1820786; blocked by process 53367.
HINT:  See server log for query details.
: UPDATE "topics" SET "updated_at" = $1 WHERE "topics"."id" = $2
```