### PR TITLE
Fix deprecation warning of `ActiveRecord::Migrator.migrations_path=`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1169,7 +1169,7 @@ module ActiveRecord
 
       def migrations_path=(path)
         ActiveSupport::Deprecation.warn \
-          "ActiveRecord::Migrator.migrations_paths= is now deprecated and will be removed in Rails 6.0." \
+          "`ActiveRecord::Migrator.migrations_path=` is now deprecated and will be removed in Rails 6.0. " \
           "You can set the `migrations_paths` on the `connection` instead through the `database.yml`."
         self.migrations_paths = [path]
       end


### PR DESCRIPTION
`ActiveRecord::Migrator.migrations_path=` was deprecated in #31727.

This commit fixes:
- `ActiveRecord::Migrator.migrations_path=` is deprecated, but not
`ActiveRecord::Migrator.migrations_paths=`
- Adds missing space

The warning including this commit:
```
DEPRECATION WARNING: `ActiveRecord::Migrator.migrations_path=` is now
deprecated and will be removed in Rails 6.0. You can set the `migrations_paths`
on the `connection` instead through the `database.yml`, or
use `ActiveRecord::Migrator.migrations_paths=`.
```

Since It was deprecated in Rails 5.2 we should backport it to the `5-2-stable` branch.

Related to #31727

r? @eileencodes 
