### PR TITLE
Easier to understand collection_caching.rb

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -21,10 +21,7 @@ module ActionView
         @collection = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
         rendered_partials = @collection.empty? ? [] : yield
 
-        index = 0
-        fetch_or_cache_partial(cached_partials, order_by: keyed_collection.each_key) do
-          rendered_partials[index].tap { index += 1 }
-        end
+        fetch_or_cache_partial(cached_partials, rendered_partials: rendered_partials, order_by: keyed_collection.each_key)
       end
 
       def callable_cache_key?
@@ -48,12 +45,11 @@ module ActionView
         @digest_path ||= @view.digest_path_from_virtual(@template.virtual_path)
       end
 
-      def fetch_or_cache_partial(cached_partials, order_by:)
+      def fetch_or_cache_partial(cached_partials, rendered_partials:, order_by:)
         order_by.map do |cache_key|
           cached_partials.fetch(cache_key) do
-            yield.tap do |rendered_partial|
-              collection_cache.write(cache_key, rendered_partial)
-            end
+            rendered_partial = rendered_partials.unshift
+            collection_cache.write(cache_key, rendered_partial)
           end
         end
       end

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -14,11 +14,29 @@ module ActionView
       def cache_collection_render(instrumentation_payload)
         return yield unless @options[:cached]
 
+        # Result is a hash with the key represents the
+        # key used for cache lookup and the value is the item
+        # on which the partial is being rendered
         keyed_collection = collection_by_cache_keys
+
+        # Pull all partials from cache
+        # Result is a hash, key matches the entry in
+        # `keyed_collection` where the cache was retrieved and the
+        # value is the value that was present in the cache
         cached_partials  = collection_cache.read_multi(*keyed_collection.keys)
         instrumentation_payload[:cache_hits] = cached_partials.size
 
+        # Extract the items for the keys that are not found
+        # Set the uncached values to instance variable @collection
+        # which is used by the caller
         @collection = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
+
+        # If all elements are already in cache then
+        # rendered partials will be an empty array
+        #
+        # If the cache is missing elements then
+        # the block will be called against the remaining items
+        # in the @collection.
         rendered_partials = @collection.empty? ? [] : yield
 
         fetch_or_cache_partial(cached_partials, rendered_partials: rendered_partials, order_by: keyed_collection.each_key)
@@ -45,6 +63,20 @@ module ActionView
         @digest_path ||= @view.digest_path_from_virtual(@template.virtual_path)
       end
 
+      # `order_by` is an enumerable object containing keys of the cache,
+      # all keys are  passed in whether found already or not.
+      #
+      # `cached_partials` is a hash. If the value exists
+      # it represents the rendered partial from the cache
+      # otherwise `Hash#fetch` will take the value of its block.
+      #
+      # `rendered_partials` is an array containing all the rendered results
+      # for each element that was not found in the cache. It is ordered
+      # so that the first empty cache elemnt in `cached_partials` corresponds
+      # to the first element in `rendered_partials`.
+      #
+      # If the partial is not already cached it will also be
+      # written back to the underlying cache store.
       def fetch_or_cache_partial(cached_partials, rendered_partials:, order_by:)
         order_by.map do |cache_key|
           cached_partials.fetch(cache_key) do


### PR DESCRIPTION
### Summary

I added docs for the behavior of collection_caching.rb. To do this effectively I needed to refactor one private method which incidentally also made it trivially faster (via microbenchmarks in the commit), and in my opinion much easier to read. WIthout the refactor the logic of the method cannot be sufficiently described without also describing the logic in the calling block which shouldn't be done since it should have no knowledge of how it is being called.

All methods documented are private, docs are intended for internal use.
