### PR TITLE
Allow specifying action on unpermitted parameters

### DIFF
--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -30,4 +30,19 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
       params.permit(book: [:pages])
     end
   end
+
+  test "allows setting the action for just a single Parameters instance" do
+    ActionController::Parameters.action_on_unpermitted_parameters = :log
+
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
+      fishing: "Turnips",
+    )
+
+    params.action_on_unpermitted_parameters = :raise
+
+    assert_raises(ActionController::UnpermittedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
 end


### PR DESCRIPTION
There are cases where this setting cannot be set globally, e.g. if some controllers need different behavior than others, or when e.g. some users are excluded from the requirement that only valid parameters be passed. This allows overriding the `action_on_unpermitted_parameters` setting on a per-instance level.

For instance, you might want to only enable `:raise` in controllers pertaining to your REST API:

```ruby
class ApiBaseController < ApplicationController
  before_action do
    params.action_on_unpermitted_parameters = :raise
  end
end
```