### PR TITLE
Deprecate ActiveRecord::Result#to_hash in favor of #to_a

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveRecord::Result#to_hash` in favor of `ActiveRecord::Result#to_a`.
+
+    *Gannon McGibbon*, *Kevin Cheng*
+
 *   SQLite3 adapter supports expression indexes.
 
     ```

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -576,7 +576,7 @@ module ActiveRecord
               column
             end
           else
-            basic_structure.to_hash
+            basic_structure.to_a
           end
         end
 

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -21,7 +21,7 @@ module ActiveRecord
   #        ]
   #
   #   # Get an array of hashes representing the result (column => value):
-  #   result.to_hash
+  #   result.to_a
   #   # => [{"id" => 1, "title" => "title_1", "body" => "body_1"},
   #         {"id" => 2, "title" => "title_2", "body" => "body_2"},
   #         ...
@@ -66,8 +66,16 @@ module ActiveRecord
     end
 
     # Returns an array of hashes representing each row record.
-    def to_hash
+    def to_a
       hash_rows
+    end
+
+    def to_hash
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        `ActiveRecord::Result#to_hash` has been renamed to `to_a`.
+        `to_hash` is deprecated and will be removed in Rails 6.1.
+      MSG
+      to_a
     end
 
     alias :map! :map

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -21,12 +21,22 @@ module ActiveRecord
       assert_equal 3, result.length
     end
 
-    test "to_hash returns row_hashes" do
+    test "to_a returns row_hashes" do
       assert_equal [
         { "col_1" => "row 1 col 1", "col_2" => "row 1 col 2" },
         { "col_1" => "row 2 col 1", "col_2" => "row 2 col 2" },
         { "col_1" => "row 3 col 1", "col_2" => "row 3 col 2" },
-      ], result.to_hash
+      ], result.to_a
+    end
+
+    test "to_hash (deprecated) returns row_hashes" do
+      assert_deprecated do
+        assert_equal [
+          { "col_1" => "row 1 col 1", "col_2" => "row 1 col 2" },
+          { "col_1" => "row 2 col 1", "col_2" => "row 2 col 2" },
+          { "col_1" => "row 3 col 1", "col_2" => "row 3 col 2" },
+        ], result.to_hash
+      end
     end
 
     test "first returns first row as a hash" do


### PR DESCRIPTION
### Summary

Rebased version of https://github.com/rails/rails/pull/23404 with deprecation. Adds deprecation warning for `ActiveRecord::Result#to_hash` in favor of `ActiveRecord::Result#to_a`.

Closes https://github.com/rails/rails/pull/23404.