### PR TITLE
use semver versions for rails to line up with the js package versions

### DIFF
--- a/actioncable/lib/action_cable/gem_version.rb
+++ b/actioncable/lib/action_cable/gem_version.rb
@@ -12,6 +12,6 @@ module ActionCable
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/actionmailer/lib/action_mailer/gem_version.rb
+++ b/actionmailer/lib/action_mailer/gem_version.rb
@@ -12,6 +12,6 @@ module ActionMailer
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/actionview/lib/action_view/gem_version.rb
+++ b/actionview/lib/action_view/gem_version.rb
@@ -12,6 +12,6 @@ module ActionView
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/activejob/lib/active_job/gem_version.rb
+++ b/activejob/lib/active_job/gem_version.rb
@@ -12,6 +12,6 @@ module ActiveJob
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/activemodel/lib/active_model/gem_version.rb
+++ b/activemodel/lib/active_model/gem_version.rb
@@ -12,6 +12,6 @@ module ActiveModel
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/activerecord/lib/active_record/gem_version.rb
+++ b/activerecord/lib/active_record/gem_version.rb
@@ -12,6 +12,6 @@ module ActiveRecord
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/activestorage/lib/active_storage/gem_version.rb
+++ b/activestorage/lib/active_storage/gem_version.rb
@@ -12,6 +12,6 @@ module ActiveStorage
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/activesupport/lib/active_support/gem_version.rb
+++ b/activesupport/lib/active_support/gem_version.rb
@@ -12,6 +12,6 @@ module ActiveSupport
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/railties/lib/rails/gem_version.rb
+++ b/railties/lib/rails/gem_version.rb
@@ -12,6 +12,6 @@ module Rails
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/package.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/package.json.tt
@@ -2,10 +2,10 @@
   "name": "<%= app_name %>",
   "private": true,
   "dependencies": {
-    "rails-ujs": "6.0.0-alpha"<% unless options[:skip_turbolinks] %>,
+    "rails-ujs": "<%= Rails::VERSION::STRING %>"<% unless options[:skip_turbolinks] %>,
     "turbolinks": "5.1.1"<% end -%><% unless skip_active_storage? %>,
-    "activestorage": "6.0.0-alpha"<% end -%><% unless options[:skip_action_cable] %>,
-    "actioncable": "6.0.0-alpha"<% end -%>
+    "activestorage": "<%= Rails::VERSION::STRING %>"<% end -%><% unless options[:skip_action_cable] %>,
+    "actioncable": "<%= Rails::VERSION::STRING %>"<% end -%>
   },
   "version": "0.1.0"
 }

--- a/version.rb
+++ b/version.rb
@@ -12,6 +12,6 @@ module Rails
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [[MAJOR, MINOR, TINY].join("."), PRE].compact.join("-")
   end
 end


### PR DESCRIPTION
As per discussion in #33640 the rails prerelease versions aren't valid semver versions and so can't align with the versions in the javascript packages which need to be hosted on npm.

This PR updates the generation of the Rails version strings to that they are valid semver versions and match the packages. The `package.json` template can then use the `Rails::VERSION::STRING` directly instead of having to hardcode it. 