### PR TITLE
Streaming compressor for cached values

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Streaming compressor for cached values.
+
+    *Max Melentiev*
+
 *   Changed `ActiveSupport::TaggedLogging.new` to return a new logger instance instead
     of mutating the one received as parameter.
 

--- a/activesupport/lib/active_support/cache/streaming_compressor.rb
+++ b/activesupport/lib/active_support/cache/streaming_compressor.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "zlib"
+require "concurrent/executor/cached_thread_pool"
+require "active_support/core_ext/numeric/bytes"
+
+module ActiveSupport
+  module Cache
+    # Serializes object and compresses serialized representation in streaming way.
+    # This avoids storing whole copy of serialized intermediate representation,
+    # like this happens in `Zlib.deflate(Marshal.dump(value))`.
+    module StreamingCompressor
+      DEFLATE_BUFFER_SIZE = 16.kilobytes.to_i
+      INFLATE_CHUNK_SIZE = 4.kilobyte.to_i
+
+      extend self
+
+      # Dumps value into string. Returns nil if `:compress_threshold` option
+      # is set and serialized value is less than given value.
+      def dump(value, **options)
+        io = StringIO.new
+        raw_bytes = dump_to_io(value, io, **options)
+        return unless raw_bytes
+        io.rewind
+        result = io.read
+        result if result.bytesize < raw_bytes
+      end
+
+      # Same as dump but streams compressed data. Returns nil and don't stream
+      # anything if `:compress_threshold` option is set
+      # and serialized value is less than given value.
+      def dump_to_io(value, to_io, compress_threshold: nil)
+        rio, wio = binary_pipe
+        within_safe_thread do
+          begin
+            Marshal.dump(value, wio)
+          ensure
+            wio.close
+          end
+        end
+        if compress_threshold
+          chunk = rio.read([DEFLATE_BUFFER_SIZE, compress_threshold].max)
+          return if chunk.bytesize < compress_threshold
+        end
+        deflate(rio, to_io, initial_chunk: chunk)
+      end
+
+      def load(value)
+        rio, wio = binary_pipe
+        within_safe_thread do
+          begin
+            inflate(value, wio)
+          ensure
+            wio.close
+          end
+        end
+        Marshal.load(rio)
+      end
+
+      # Compresses data from IO stream to another one.
+      # Returns number of processed bytes.
+      def deflate(from_io, to_io, initial_chunk: nil)
+        processed_bytes = initial_chunk&.bytesize || 0
+        zlib = Zlib::Deflate.new
+        to_io << zlib.deflate(initial_chunk) if initial_chunk
+        until from_io.eof?
+          chunk = from_io.read(DEFLATE_BUFFER_SIZE)
+          to_io << zlib.deflate(chunk)
+          processed_bytes += chunk.bytesize
+        end
+        to_io << zlib.finish
+        processed_bytes
+      ensure
+        zlib.close
+      end
+
+      def inflate(value, to_io)
+        zlib = Zlib::Inflate.new
+        from_io = StringIO.new(value)
+        to_io << zlib.inflate(from_io.read(INFLATE_CHUNK_SIZE)) until from_io.eof?
+      ensure
+        zlib.close
+      end
+
+      private
+
+        def binary_pipe
+          rio, wio = IO.pipe(binmode: true)
+          wio.set_encoding(Encoding::BINARY)
+          [rio, wio]
+        end
+
+        def thread_pool
+          @thread_pool ||= Concurrent::CachedThreadPool.new
+        end
+
+        # Runs task within thread and forwards all exceptions to parent thread.
+        def within_safe_thread
+          parent_thread = Thread.current
+          thread_pool.post do
+            begin
+              yield
+            rescue Exception => e
+              parent_thread.raise(e)
+            end
+          end
+        end
+    end
+  end
+end

--- a/activesupport/test/cache/streaming_compressor_test.rb
+++ b/activesupport/test/cache/streaming_compressor_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/cache"
+require "active_support/cache/streaming_compressor"
+
+class CacheStreamingCompressorTest < ActiveSupport::TestCase
+  def described_class
+    ActiveSupport::Cache::StreamingCompressor
+  end
+
+  def assert_load(value)
+    dumped = Zlib.deflate(Marshal.dump(value))
+    assert_equal(value, described_class.load(dumped))
+  end
+
+  def assert_dump(value, **options)
+    dumped = described_class.dump(value, **options)
+    assert_equal(value, Marshal.load(Zlib.inflate(dumped)))
+  end
+
+  def test_load
+    assert_load SecureRandom.hex(1_000_000)
+    assert_load "a" * 100_000_00
+    assert_load "a" * 1_000_000
+    assert_load [{ test: "value" }]
+  end
+
+  def test_dump
+    assert_dump SecureRandom.hex(1_000_000)
+    assert_dump "a" * 100
+    assert_dump "a" * 1_000_000
+    assert_dump [{ test: "a" * 50 }]
+  end
+
+  def test_dump_with_compress_threshold
+    buffer_size = described_class::DEFLATE_BUFFER_SIZE
+
+    threshold = 700
+    assert_nil described_class.dump("a" * 600, compress_threshold: threshold)
+    assert_dump "a" * 800, compress_threshold: threshold
+    assert_dump "a" * buffer_size * 3, compress_threshold: threshold
+
+    threshold = buffer_size + 200
+    assert_nil described_class.dump("a" * buffer_size, compress_threshold: threshold)
+    assert_dump "a" * threshold, compress_threshold: threshold
+    assert_dump "a" * buffer_size * 3, compress_threshold: threshold
+  end
+
+  def test_concurrent_environment
+    Array.new(5) { |i| i.to_s * 1_000_000 }.map do |value|
+      Thread.new do
+        assert_equal(value, described_class.load(described_class.dump(value)))
+      end
+    end.each(&:join)
+  end
+end


### PR DESCRIPTION
Fixes #33910 , cc @jeremy 

For now when cache entry is serialized, it creates temporary marshaled string which is compressed later: https://github.com/rails/rails/blob/e925cb4d856088a815bf4a0cf27518d01bb4029d/activesupport/lib/active_support/cache.rb#L798-L799

We have faced that supervisor was killing job workers due to high memory usage while they were about writing to cache large objects (up to 1gb raw but with high compression ratio). This results in `Zlib::DataError: data error`.

I see that Marshal provides streaming api and can write serialized data to IO object. However Zlib doesn't support streams and stream-compression should be implemented manually. This both should decrease overall memory usage by avoiding storing large intermediate representation.
