### PR TITLE
active_record/test - fix deprecation hash warning

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   active_record/test - fix deprecation hash warning.
+
+    *Vitor Oliveira*
+
 *   Deprecate `ActiveRecord::Result#to_hash` in favor of `ActiveRecord::Result#to_a`.
 
     *Gannon McGibbon*, *Kevin Cheng*

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -227,7 +227,7 @@ module ActiveRecord
         post = Post.create!(title: "foo", body: "bar")
         expected = @connection.select_all("SELECT * FROM posts WHERE id = #{post.id}")
         result = @connection.select_all("SELECT * FROM posts WHERE id = #{Arel::Nodes::BindParam.new(nil).to_sql}", nil, [[nil, post.id]])
-        assert_equal expected.to_hash, result.to_hash
+        assert_equal expected.to_a, result.to_a
       end
 
       def test_insert_update_delete_with_legacy_binds


### PR DESCRIPTION
This PR should fix a simple warning in an ActiveRecord test.

```
DEPRECATION WARNING: `ActiveRecord::Result#to_hash` has been renamed to `to_a`. `to_hash` is deprecated and will be removed in Rails 6.1. (called from test_select_all_with_legacy_binds at /Users/vitoroliveira/rails/activerecord/test/cases/adapter_test.rb:230)
```