### PR TITLE
Make `ActiveRecord::Result#to_a` as alias to `ActiveRecord::Result#to_ary`

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -65,11 +65,6 @@ module ActiveRecord
       end
     end
 
-    # Returns an array of hashes representing each row record.
-    def to_a
-      hash_rows
-    end
-
     def to_hash
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
         `ActiveRecord::Result#to_hash` has been renamed to `to_a`.
@@ -90,6 +85,8 @@ module ActiveRecord
     def to_ary
       hash_rows
     end
+
+    alias :to_a :to_ary
 
     def [](idx)
       hash_rows[idx]


### PR DESCRIPTION
`ActiveRecord::Result#to_a` was introduced in #33912.

I would prefer to make `to_a` as alias to the `to_ary` because:
  - It would be clear for users from https://edgeapi.rubyonrails.org/classes/ActiveRecord/Result.html
    that `to_a` and `to_ary` are the same
  - For us it would take less efforts in case if we needed to change the docs
    or implementation, since the methods are the same

Follow up #33912
