### PR TITLE
Fixed to RAILS_MASTER_KEY as a default env key for decrypting.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Support environment specific credentials file.
 
     For `production` environment look first for `config/credentials/production.yml.enc` file that can be decrypted by
-    `ENV["RAILS_PRODUCTION_KEY"]` or `config/credentials/production.key` master key.
+    `ENV["RAILS_MASTER_KEY"]` or `config/credentials/production.key` master key.
     Edit given environment credentials file by command `rails credentials:edit --environment production`.
     Default paths can be overwritten by setting `config.credentials.content_path` and `config.credentials.key_path`.
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -440,7 +440,7 @@ module Rails
     # +config/master.key+.
     # If specific credentials file exists for current environment, it takes precedence, thus for +production+
     # environment look first for +config/credentials/production.yml.enc+ with master key taken
-    # from <tt>ENV["RAILS_PRODUCTION_KEY"]</tt> or from loading +config/credentials/production.key+.
+    # from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading +config/credentials/production.key+.
     # Default behavior can be overwritten by setting +config.credentials.content_path+ and +config.credentials.key_path+.
     def credentials
       @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -43,7 +43,7 @@ from leaking.
 
 It is possible to have credentials for each environment. If the file for current environment exists it will take
 precedence over `config/credentials.yml.enc`, thus for `production` environment first look for
-`config/credentials/production.yml.enc` that can be decrypted using master key taken from `ENV["RAILS_PRODUCTION_KEY"]`
+`config/credentials/production.yml.enc` that can be decrypted using master key taken from `ENV["RAILS_MASTER_KEY"]`
 or stored in `config/credentials/production.key`.
 To edit given file use command `rails credentials:edit --environment production`
 Default paths can be overwritten by setting `config.credentials.content_path` and `config.credentials.key_path`.

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -24,13 +24,13 @@ module Rails
 
         ensure_editor_available(command: "bin/rails credentials:edit") || (return)
 
-        encrypted = Rails.application.encrypted(content_path, key_path: key_path, env_key: env_key)
+        encrypted = Rails.application.encrypted(content_path, key_path: key_path)
 
         ensure_encryption_key_has_been_added(key_path) if encrypted.key.nil?
         ensure_encrypted_file_has_been_added(content_path, key_path)
 
         catch_editing_exceptions do
-          change_encrypted_file_in_system_editor(content_path, key_path, env_key)
+          change_encrypted_file_in_system_editor(content_path, key_path)
         end
 
         say "File encrypted and saved."
@@ -41,7 +41,7 @@ module Rails
       def show
         require_application_and_environment!
 
-        encrypted = Rails.application.encrypted(content_path, key_path: key_path, env_key: env_key)
+        encrypted = Rails.application.encrypted(content_path, key_path: key_path)
 
         say encrypted.read.presence || missing_encrypted_message(key: encrypted.key, key_path: key_path, file_path: content_path)
       end
@@ -55,10 +55,6 @@ module Rails
           options[:environment] ? "config/credentials/#{options[:environment]}.key" : "config/master.key"
         end
 
-        def env_key
-          options[:environment] ? "RAILS_#{options[:environment].upcase}_KEY" : "RAILS_MASTER_KEY"
-        end
-
 
         def ensure_encryption_key_has_been_added(key_path)
           encryption_key_file_generator.add_key_file(key_path)
@@ -69,8 +65,8 @@ module Rails
           encrypted_file_generator.add_encrypted_file_silently(file_path, key_path)
         end
 
-        def change_encrypted_file_in_system_editor(file_path, key_path, env_key)
-          Rails.application.encrypted(file_path, key_path: key_path, env_key: env_key).change do |tmp_path|
+        def change_encrypted_file_in_system_editor(file_path, key_path)
+          Rails.application.encrypted(file_path, key_path: key_path).change do |tmp_path|
             system("#{ENV["EDITOR"]} #{tmp_path}")
           end
         end


### PR DESCRIPTION
Fixes mistake left in https://github.com/rails/rails/pull/33521/files#diff-2a29095afcfe2c683b82a779a94c2208R59
and misunderstanding in https://github.com/rails/rails/commit/d69b04de0ff33237209afea6f6cac3ab27934908

r? @y-yagi 