### PR TITLE
Add missing test case for `redirect_to` when request includes a port.

### DIFF
--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -214,6 +214,13 @@ class RedirectTest < ActionController::TestCase
     assert_equal "http://test.host/things/stuff", redirect_to_url
   end
 
+  def test_relative_url_redirect_host_with_port
+    request.host = "test.host:1234"
+    get :relative_url_redirect_with_status
+    assert_response 302
+    assert_equal "http://test.host:1234/things/stuff", redirect_to_url
+  end
+
   def test_simple_redirect_using_options
     get :host_redirect
     assert_response :redirect


### PR DESCRIPTION
If you change `request.host_with_port` to `request.host`, the tests will still pass. https://github.com/rails/rails/blob/a44b7f180d0f03613479fb227d09ce2d7f74a187/actionpack/lib/action_controller/metal/redirecting.rb#L106