### PR TITLE
Decrease memory allocations in cache.rb

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -596,9 +596,13 @@ module ActiveSupport
         # Merges the default options with ones specific to a method call.
         def merged_options(call_options)
           if call_options
-            options.merge(call_options)
+            if options.empty?
+              call_options
+            else
+              options.merge(call_options)
+            end
           else
-            options.dup
+            options
           end
         end
 


### PR DESCRIPTION
The `merged_options` method is private and the output is never mutated.
Using this info we can get rid of the `dup` behavior. We can also
eliminate the `merge` call which also allocates a hash and only alocate
a new hash if the options being passed in are different than the options
already stored.

Returned results are frozen as an extra layer of protection against
mutation.

Before

```
Total allocated: 741749 bytes (6642 objects)
```

After

```
Total allocated: 734104 bytes (6652 objects)
```

Diff

```
(741749 - 734104) / 741749.0 => ~ 1.0 %
```

If you don't feel comfortable modifying this method, we could rename it
and only use it internally.
