### PR TITLE
Fix ActionDispatch::Request#xhr? return value (Boolean)

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -264,7 +264,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i
+      /XMLHttpRequest/i.match?(get_header("HTTP_X_REQUESTED_WITH"))
     end
     alias :xhr? :xml_http_request?
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -643,16 +643,16 @@ class RequestProtocol < BaseRequestTest
   test "xml http request" do
     request = stub_request
 
-    assert_not_predicate request, :xml_http_request?
-    assert_not_predicate request, :xhr?
+    assert_equal request.xml_http_request?, false
+    assert_equal request.xhr?, false
 
     request = stub_request "HTTP_X_REQUESTED_WITH" => "DefinitelyNotAjax1.0"
-    assert_not_predicate request, :xml_http_request?
-    assert_not_predicate request, :xhr?
+    assert_equal request.xml_http_request?, false
+    assert_equal request.xhr?, false
 
     request = stub_request "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"
-    assert_predicate request, :xml_http_request?
-    assert_predicate request, :xhr?
+    assert_equal request.xml_http_request?, true
+    assert_equal request.xhr?, true
   end
 
   test "reports ssl" do


### PR DESCRIPTION
### Summary

Fix `xhr?` by making it return Boolean.

Fixes https://github.com/rails/rails/issues/33939.