### PR TITLE
ActiveSupport::Cache::Key object - Faster Cache Keys

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -85,7 +85,7 @@ module AbstractController
       # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
       # followed by any controller-wide key prefix values, ending
       # with the specified +key+ value.
-      def combined_fragment_cache_key(key)
+      def combined_fragment_cache_key(key = nil)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
 

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -130,6 +130,10 @@ module ActionDispatch
         end
       end
 
+      def cache_key
+        to_a
+      end
+
       # Builds a hash containing the flashes to keep for the next request.
       # If there are none to keep, returns +nil+.
       def to_session_value #:nodoc:

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -16,8 +16,8 @@ class MultifetchCacheTest < ActiveRecordTestCase
         []
       end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.new(view_paths, {})
   end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -12,8 +12,8 @@ module RenderTestCases
     @view = Class.new(ActionView::Base) do
       def view_cache_dependencies; []; end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.new(paths, @assigns)
 

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -114,6 +114,7 @@ module ActiveRecord
 
     # Returns a cache key along with the version.
     def cache_key_with_version
+      deprecate("cache_key_with_version is deprecated and will be removed")
       if version = cache_version
         "#{cache_key}-#{version}"
       else

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -42,12 +42,12 @@ module ActiveRecord
       assert_not_predicate CacheMe.create.cache_version, :present?
     end
 
-    test "cache_key_with_version always has both key and version" do
-      r1 = CacheMeWithVersion.create
-      assert_equal "active_record/cache_key_test/cache_me_with_versions/#{r1.id}-#{r1.updated_at.utc.to_s(:usec)}", r1.cache_key_with_version
+    test "explicitly expanded cache key always has both key and version" do
+      r1 = CacheMe.create
+      assert_equal "active_record/cache_key_test/cache_mes/#{r1.id}-#{r1.updated_at.to_s(:usec)}", ActiveSupport::Cache.expand_cache_key(r1)
 
       r2 = CacheMe.create
-      assert_equal "active_record/cache_key_test/cache_mes/#{r2.id}-#{r2.updated_at.utc.to_s(:usec)}", r2.cache_key_with_version
+      assert_equal "active_record/cache_key_test/cache_mes/#{r2.id}-#{r2.updated_at.to_s(:usec)}", ActiveSupport::Cache.expand_cache_key(r2)
     end
 
     test "cache_version is the same when it comes from the DB or from the user" do

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -236,13 +236,13 @@ class IntegrationTest < ActiveRecord::TestCase
   def test_cache_key_retains_version_when_custom_timestamp_is_used
     with_cache_versioning do
       developer = Developer.first
-      first_key = developer.cache_key_with_version
+      first_key = ActiveSupport::Cache.expand_cache_key(developer)
 
       travel 10.seconds do
         developer.touch
       end
 
-      second_key = developer.cache_key_with_version
+      second_key = ActiveSupport::Cache.expand_cache_key(developer)
 
       assert_not_equal first_key, second_key
     end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -8,6 +8,7 @@ require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/string/inflections"
+require "active_support/cache/key"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -313,6 +314,8 @@ module ActiveSupport
       #   cache.fetch('foo') # => "bar"
       def fetch(name, options = nil)
         if block_given?
+          original_name = name
+          name = ActiveSupport::Cache::Key(name)
           options = merged_options(options)
           key = normalize_key(name, options)
 
@@ -328,7 +331,7 @@ module ActiveSupport
           if entry
             get_entry_value(entry, name, options)
           else
-            save_block_result_to_cache(name, options) { |_name| yield _name }
+            save_block_result_to_cache(name, options) { yield original_name }
           end
         elsif options && options[:force]
           raise ArgumentError, "Missing block: Calling `Cache#fetch` with `force: true` requires a block."
@@ -348,6 +351,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def read(name, options = nil)
         options = merged_options(options)
+        name    = ActiveSupport::Cache::Key(name)
         key     = normalize_key(name, options)
         version = normalize_version(name, options)
 
@@ -458,7 +462,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def write(name, value, options = nil)
         options = merged_options(options)
-
+        name = ActiveSupport::Cache::Key(name)
         instrument(:write, name, options) do
           entry = Entry.new(value, options.merge(version: normalize_version(name, options)))
           write_entry(normalize_key(name, options), entry, options)
@@ -645,24 +649,8 @@ module ActiveSupport
           end
         end
 
-        # Expands key to be a consistent string value. Invokes +cache_key+ if
-        # object responds to +cache_key+. Otherwise, +to_param+ method will be
-        # called. If the key is a Hash, then keys will be sorted alphabetically.
         def expanded_key(key)
-          return key.cache_key.to_s if key.respond_to?(:cache_key)
-
-          case key
-          when Array
-            if key.size > 1
-              key = key.collect { |element| expanded_key(element) }
-            else
-              key = expanded_key(key.first)
-            end
-          when Hash
-            key = key.sort_by { |k, _| k.to_s }.collect { |k, v| "#{k}=#{v}" }
-          end
-
-          key.to_param
+          ActiveSupport::Cache::Key(key).cache_key
         end
 
         def normalize_version(key, options = nil)
@@ -670,11 +658,7 @@ module ActiveSupport
         end
 
         def expanded_version(key)
-          case
-          when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
-          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
-          end
+          ActiveSupport::Cache::Key(key).cache_version
         end
 
         def instrument(operation, key, options = nil)
@@ -713,7 +697,7 @@ module ActiveSupport
 
         def save_block_result_to_cache(name, options)
           result = instrument(:generate, name, options) do
-            yield(name)
+            yield
           end
 
           write(name, result, options) unless result.nil? && options[:skip_nil]

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -91,13 +91,7 @@ module ActiveSupport
 
       private
         def retrieve_cache_key(key)
-          case
-          when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
-          when key.respond_to?(:cache_key)              then key.cache_key
-          when key.is_a?(Array)                         then key.map { |element| retrieve_cache_key(element) }.to_param
-          when key.respond_to?(:to_a)                   then retrieve_cache_key(key.to_a)
-          else                                               key.to_param
-          end.to_s
+          ActiveSupport::Cache::Key(key).cache_key_with_version
         end
 
         # Obtains the specified cache store class, given the name of the +store+.

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Cache
+    # Convenience method to prevent re-generating a Key
+    # instance, if the element being passed in is already
+    # instance of the `Key` class.
+    #
+    # Example:
+    #
+    #   ActiveSupport::Cache::Key("foo").cache_key
+    #    # => "foo"
+    #
+    #   k1 = Key.new("foo")
+    #   key = ActiveSupport::Cache::Key(k1)
+    #   k1.object_id == key.object_id # => true
+    def self.Key(key_or_components) # :nodoc:
+      if key_or_components.is_a?(ActiveSupport::Cache::Key)
+        key_or_components
+      else
+        Key.new(key_or_components)
+      end
+    end
+
+    # This class is responsible for coercing input into a valid
+    # key format and cache version for cache stores.
+    #
+    # The goal of this class is to provide a composable way
+    # to build keys. You can put an instance of Key
+    # into another instance of Key and it should produce
+    # the same `cache_key` and `cache_version`.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k2 = Key.new(k1)
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #
+    # In addition to passing a key into the initialize method,
+    # key fragments can be added onto an existing key through the
+    # `<<` method.
+    #
+    # Example:
+    #
+    #   key = Key.new
+    #   key << "foo"
+    #   key << "bar"
+    #   key.cache_key
+    #   # => "foo/bar"
+    #
+    # Multiple key entries generate the same key regardless of how
+    # they are added. I.e. if they're added via multiple arrays
+    # or directly via the `<<` operator.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k1 << "bar"
+    #   k2 = Key.new(["foo", "bar"])
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #   k3 = Key.new(["foo", ["bar"]])
+    #   k2.cache_key == k3.cache_key
+    #   # => true
+    #
+    # It is faster to directly add objects to the
+    # Key object via `<<` than to generate
+    # an intermediate array of objects.
+    #
+    # The class supports strings, arrays, hashes,
+    # objects with a `cache_key` method and anything
+    # that can be implicitly cast to a string:
+    #
+    # Examples:
+    #
+    #   Key.new("foo").cache_key
+    #   # => "foo"
+    #
+    #   Key.new(["foo", "bar"]).cache_key
+    #   # => "foo/bar"
+    #
+    #   Key.new({ bar: 1, foo: 2 }).cache_key
+    #   # => "bar=1/foo=2"
+    #
+    #   klass = Class.new { def cache_key; "foo"; end }
+    #   Key.new(klass.new).cache_key
+    #   # => "foo"
+    #
+    # In addition to generating a `cache_key`,
+    # a `cache_version` is also generated if the object
+    # passed in responds to `cache_version` or if it contains
+    # an element that responds to `cache_version`.
+    #
+    # The purpose of keeping this value seperate from
+    # `cache_key` is to support the use of "cache versioning"
+    # where the same key is recycled but the version of the object
+    # being stored is kept directly in the cache.
+    #
+    # Example:
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new(klass.new).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new([klass.new]).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new({foo: klass.new}).cache_version
+    #   # => "foo"
+    class Key # :nodoc:
+      attr_reader :cache_key, :cache_version
+
+      def initialize(key = nil)
+        @cache_key = +""
+        @cache_version = +""
+        @empty_key = true
+        self << key
+      end
+
+      def cache_key_with_version
+        "#{cache_key}-#{cache_version}"
+      end
+
+      def update(key)
+        if key.respond_to?(:cache_key)
+          update_version(key)
+          update_key(key.cache_key.to_s)
+        else
+          split_key(key)
+        end
+      end
+      alias :<< :update
+
+      private
+        def update_key(key)
+          @cache_key << "/" unless @empty_key
+          @cache_key << key.to_param.to_s
+          @empty_key = false
+        end
+
+        def update_version(key)
+          if key.respond_to?(:cache_version)
+            @cache_version << "/" unless @cache_version.empty?
+            @cache_version << key.cache_version.to_param.to_s
+          else
+            split_version(key)
+          end
+        end
+
+        def split_key(key)
+          case key
+          when Array
+            key.each { |k| update(k) }
+          when Hash
+            key = key.to_a
+            update_version(key)
+            key.sort_by! { |k, _| k.to_s }
+            key.each { |k, v| update_key("#{k}=#{v}") }
+          else
+            update_version(key)
+            update_key(key)
+          end
+        end
+
+        def split_version(key)
+          if key.is_a?(Array)
+            key.each { |k| update_version(k) }
+          elsif key.respond_to?(:to_a)
+            split_version(key.to_a)
+          end
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -121,7 +121,11 @@ module ActiveSupport
       end
 
       def cache_key_with_version
-        "#{cache_key}-#{cache_version}"
+        if cache_version.empty?
+          cache_key
+        else
+          "#{cache_key}-#{cache_version}"
+        end
       end
 
       def update(key)
@@ -160,8 +164,12 @@ module ActiveSupport
             key.sort_by! { |k, _| k.to_s }
             key.each { |k, v| update_key("#{k}=#{v}") }
           else
-            update_version(key)
-            update_key(key)
+            if key.respond_to?(:to_a) && !key.nil?
+              update(key.to_a)
+            else
+              update_version(key)
+              update_key(key)
+            end
           end
         end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -21,8 +21,9 @@ module CacheStoreBehavior
   end
 
   def test_fetch_with_cache_miss
-    assert_called_with(@cache, :write, ["foo", "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch("foo") { "baz" }
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
+      assert_equal "baz", @cache.fetch(key) { "baz" }
     end
   end
 
@@ -39,8 +40,9 @@ module CacheStoreBehavior
   def test_fetch_with_forced_cache_miss
     @cache.write("foo", "bar")
     assert_not_called(@cache, :read) do
-      assert_called_with(@cache, :write, ["foo", "bar", @cache.options.merge(force: true)]) do
-        @cache.fetch("foo", force: true) { "bar" }
+      key = ActiveSupport::Cache::Key.new("foo")
+      assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(force: true)]) do
+        @cache.fetch(key, force: true) { "bar" }
       end
     end
   end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -280,9 +280,6 @@ module CacheStoreBehavior
     def obj.cache_key
       "foo"
     end
-    def obj.cache_key_with_version
-      "foo-v1"
-    end
     @cache.write(obj, "bar")
     assert_equal "bar", @cache.read("foo")
   end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -107,4 +107,9 @@ class KeyTest < ActiveSupport::TestCase
     assert_equal ActiveSupport::Cache::Key, key.class
     assert_equal "foo", key.cache_key
   end
+
+  def test_enum
+    k1 = ActiveSupport::Cache::Key.new([1, 2, 3].to_enum)
+    assert_equal "1/2/3", k1.cache_key
+  end
 end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/cache"
+
+class KeyTest < ActiveSupport::TestCase
+  def test_composability
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_key, k2.cache_key
+  end
+
+  def test_composable_elements
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k1 << "bar"
+    assert_equal "foo/bar", k1.cache_key
+
+    k2 = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal k1.cache_key, k2.cache_key
+
+    k3 = ActiveSupport::Cache::Key.new(["foo", ["bar"]])
+    assert_equal k2.cache_key, k3.cache_key
+  end
+
+  def test_cache_types
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_equal "foo", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal "foo/bar", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(bar: 1, foo: 2)
+    assert_equal "bar=1/foo=2", key.cache_key
+
+    klass = Class.new { def cache_key; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_key
+  end
+
+  def test_cache_version
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new([klass.new])
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(foo: klass.new)
+    assert_equal "foo", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "foo/foo", key.cache_version
+
+    klass = Class.new { def cache_version; nil; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "", key.cache_version
+  end
+
+  def test_cache_key_with_version
+    klass = Struct.new(:cache_key, :cache_version)
+    key = ActiveSupport::Cache::Key.new(klass.new("foo", 1))
+    assert_equal "foo-1", key.cache_key_with_version
+
+    key = ActiveSupport::Cache::Key.new(klass.new("foo", 1))
+    key << klass.new("bar", 2)
+    assert_equal "foo/bar-1/2", key.cache_key_with_version
+  end
+
+  def test_cache_version_composability
+    klass = Class.new { def cache_version; "foo"; end }
+    k1 = ActiveSupport::Cache::Key.new(klass.new)
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_version, k2.cache_version
+  end
+
+  def test_nil_and_empty_keys
+    key = ActiveSupport::Cache::Key.new([ :a, nil, :b, "", :c ])
+    assert_equal "a//b//c", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(hello: nil, world: "today", nil: "rules")
+    assert_equal "hello=/nil=rules/world=today", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["", "", ""])
+    assert_equal "//", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new([ :foo, [], [], :bar ])
+    assert_equal "foo/bar", key.cache_key
+  end
+
+  def test_nested_to_a_cache_versions
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(hello: { world: klass.new })
+    assert_equal "foo", key.cache_version
+  end
+
+  def test_call_returns_original_if_key
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key(k1)
+    assert_equal k1, k2
+
+    key = ActiveSupport::Cache::Key("foo")
+    assert_equal ActiveSupport::Cache::Key, key.class
+    assert_equal "foo", key.cache_key
+  end
+end


### PR DESCRIPTION
This PR moves the existing logic of `expanded_key` and `expanded_version` methods from ActiveSupport::Cache to their own class. This PR is a performance refactor.

Currently, when a cache entry is fetched the method, `normalize_key` (which calls `ecpanded_key`) is called on the key multiple times both for generating the actual key and for use with the cache store and logging. The existing version of this method is quite expensive and allocates memory. The biggest example is that it generates new arrays when the input is an array by calling `compact` and then again by calling `Array#to_param`. By moving the required logic to generate a key to a class, the need to generate intermediate array objects is drastically reduced. The key is generated as elements are added to the object as opposed to when they are needed. This behavior alleviates the need to re-generate the same key value for cache retrieval and logging.

One crucial property of this new cache class is that keys are composable. This composability means that if you pass the same objects into a class instance in the same order, it will produce the same key. This property allows us to optimize cache key generation in `collection_caching.rb` as the root of all elements being cached are the same.

## Performance

### Memory

Before:

```
Total allocated: 741750 bytes (6645 objects)
Total retained:  18917 bytes (166 objects)
```

After:

```
Total allocated: 707548 bytes (6006 objects)
Total retained:  18917 bytes (166 objects)
```

Diff:

```
(741750 - 707548) / 741750 # => ~4.6 %
```

### Performance

Here's the raw results: https://gist.github.com/schneems/7e808e7a866c1bc3a2d50b5e0ae4db88 for 63 runs, each with 1000 hits to the index of CodeTriage.

On average this patch is **7.24%** faster than the commit before it. This number is statistically significant.
