### PR TITLE
[WIP] Multi db fixtures

### DIFF
--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -2,6 +2,8 @@
 
 require "abstract_unit"
 
+ENV["RAILS_ENV"] = "sqlite3_ar_integration"
+
 # Define the essentials
 class ActiveRecordTestConnector
   cattr_accessor :able_to_connect

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -165,6 +165,10 @@ module ActiveRecord
         @config[:migrations_paths] || Migrator.migrations_paths
       end
 
+      def fixtures_path # :nodoc:
+        @config[:fixtures_path] || FixtureSet.fixtures_path
+      end
+
       def migration_context # :nodoc:
         MigrationContext.new(migrations_paths)
       end

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def fixtures_path
+        raise NotImplementedError
+      end
+
       def url_config?
         false
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -45,6 +45,10 @@ module ActiveRecord
       def migrations_paths
         config["migrations_paths"]
       end
+
+      def fixtures_path
+        config["fixtures_path"]
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -55,6 +55,10 @@ module ActiveRecord
         config["migrations_paths"]
       end
 
+      def fixtures_path
+        config["fixtures_path"]
+      end
+
       private
 
         def build_url_hash(url)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -439,6 +439,12 @@ module ActiveRecord
     # possibly in a folder with the same name.
     #++
 
+    class << self
+      attr_accessor :fixtures_path
+    end
+
+    self.fixtures_path = "test/fixtures"
+
     MAX_ID = 2**30 - 1
 
     @@all_cached_fixtures = Hash.new { |h, k| h[k] = {} }
@@ -531,12 +537,12 @@ module ActiveRecord
         end
       end
 
-      def create_fixtures(fixtures_directory, fixture_set_names, class_names = {}, config = ActiveRecord::Base)
+      def create_fixtures(fixtures_directory, fixture_set_names, class_names = {}, connection = nil, config = ActiveRecord::Base)
         fixture_set_names = Array(fixture_set_names).map(&:to_s)
         class_names = ClassCache.new class_names, config
 
         # FIXME: Apparently JK uses this.
-        connection = block_given? ? yield : ActiveRecord::Base.connection
+        connection ||= block_given? ? yield : ActiveRecord::Base.connection
 
         fixture_files_to_read = fixture_set_names.reject do |fs_name|
           fixture_is_cached?(connection, fs_name)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -266,7 +266,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     # DB2 is not case-sensitive.
     return true if current_adapter?(:DB2Adapter)
 
-    assert_equal @loaded_fixtures["computers"]["workstation"].to_hash, Computer.first.attributes
+    assert_equal @loaded_fixtures["primary"]["computers"]["workstation"].to_hash, Computer.first.attributes
   end
 
   test "attributes without primary key" do

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -21,8 +21,8 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
   def test_configs_for_getter_with_env_name
     configs = ActiveRecord::Base.configurations.configs_for(env_name: "arunit")
 
-    assert_equal 1, configs.size
-    assert_equal ["arunit"], configs.map(&:env_name)
+    assert_equal 2, configs.size
+    assert_equal ["arunit", "arunit"], configs.map(&:env_name)
   end
 
   def test_configs_for_getter_with_env_and_spec_name
@@ -66,7 +66,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
         ActiveRecord::Base.configurations["readonly"] = config
       end
 
-      assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements", "readonly"], ActiveRecord::Base.configurations.configs_for.map(&:env_name).sort
+      assert_equal ["arunit", "arunit", "arunit2", "arunit_without_prepared_statements", "readonly"], ActiveRecord::Base.configurations.configs_for.map(&:env_name).sort
     ensure
       ActiveRecord::Base.configurations = old_config
       ActiveRecord::Base.establish_connection :arunit
@@ -81,7 +81,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   def test_each_is_deprecated
     assert_deprecated do
       ActiveRecord::Base.configurations.each do |db_config|
-        assert_equal "primary", db_config.spec_name
+        assert_includes %w(primary shard), db_config.spec_name
       end
     end
   end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -154,13 +154,15 @@ def load_schema
   original_stdout = $stdout
   $stdout = StringIO.new
 
-  adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
-  adapter_specific_schema_file = SCHEMA_ROOT + "/#{adapter_name}_specific_schema.rb"
+  ActiveRecord::Base.configurations.configs_for(env_name: "arunit").each do |db_config|
+    adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
+    adapter_specific_schema_file = SCHEMA_ROOT + "/#{adapter_name}_specific_schema.rb"
 
-  load SCHEMA_ROOT + "/schema.rb"
+    load SCHEMA_ROOT + "/schema.rb"
 
-  if File.exist?(adapter_specific_schema_file)
-    load adapter_specific_schema_file
+    if File.exist?(adapter_specific_schema_file)
+      load adapter_specific_schema_file
+    end
   end
 
   ActiveRecord::FixtureSet.reset_cache

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -8,6 +8,8 @@ require "active_record/fixtures"
 
 require "cases/validations_repair_helper"
 
+ENV["RAILS_ENV"] = "arunit"
+
 module ActiveRecord
   # = Active Record Test Case
   #

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -90,16 +90,26 @@ connections:
 
   sqlite3:
     arunit:
-      database: <%= FIXTURES_ROOT %>/fixture_database.sqlite3
-      timeout:  5000
+      primary:
+        database: <%= FIXTURES_ROOT %>/fixture_database.sqlite3
+        timeout:  5000
+      shard:
+        database: <%= FIXTURES_ROOT %>/fixture_database_shard.sqlite3
+        fixtures_path: <%= FIXTURES_ROOT %>/../shard_fixtures
+        timeout:  5000
     arunit2:
       database: <%= FIXTURES_ROOT %>/fixture_database_2.sqlite3
       timeout:  5000
 
   sqlite3_mem:
     arunit:
-      adapter: sqlite3
-      database: ':memory:'
+      primary:
+        adapter: sqlite3
+        database: ':memory:'
+      shard:
+        adapter: sqlite3
+        fixtures_path: <%= FIXTURES_ROOT %>/../shard_fixtures
+        database: ':memory:'
     arunit2:
       adapter: sqlite3
       database: ':memory:'

--- a/activerecord/test/shard_fixtures/books.yml
+++ b/activerecord/test/shard_fixtures/books.yml
@@ -1,0 +1,7 @@
+ruby_under_a_microscope:
+  author_id: 1
+  id: 1
+  name: "Ruby Under a Microscope"
+  format: "ebook"
+  status: "proposed"
+  read_status: "reading"

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -27,16 +27,23 @@ module ARTest
       end
 
       def expand_config(config)
-        config["connections"].each do |adapter, connection|
-          dbs = [["arunit", "activerecord_unittest"], ["arunit2", "activerecord_unittest2"],
-                 ["arunit_without_prepared_statements", "activerecord_unittest"]]
-          dbs.each do |name, dbname|
-            unless connection[name].is_a?(Hash)
-              connection[name] = { "database" => connection[name] }
-            end
+        config["connections"].each do |adapter, connections|
+          dbs = {
+            "arunit" => "activerecord_unittest",
+            "arunit2" => "activerecord_unittest2",
+            "arunit_without_prepared_statements" => "activerecord_unittest",
+          }
 
-            connection[name]["database"] ||= dbname
-            connection[name]["adapter"]  ||= adapter
+          dbs.each do |env_name, dbname|
+            unless connections[env_name].is_a?(Hash)
+              connections[env_name] = { "database" => connections[env_name] }
+            end
+            configs = connections[env_name].keys.include?("primary") ?
+              connections[env_name].values : [connections[env_name]]
+            configs.each do |config|
+              config["database"] ||= dbname
+              config["adapter"]  ||= adapter
+            end
           end
         end
 

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -24,7 +24,7 @@ if defined?(ActiveRecord::Base)
     include ActiveRecord::TestDatabases
     include ActiveRecord::TestFixtures
 
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
+    self.fixture_path = ActiveRecord::FixtureSet.fixtures_path
     self.file_fixture_path = fixture_path + "files"
   end
 


### PR DESCRIPTION
### Summary

Adds multiple database support to `ActiveRecord::Fixtures`.

Similar to the new `migrations_paths` config option for databases, `fixtures_path` can now 
 be added as a configuration option on your `database.yml`.  Here's what it would look like:

```yml
test:
  primary:
    <<: *default
    database: db/primary_test.sqlite3
  secondary:
    <<: *default
    database: db/secondary_test.sqlite3
    migrations_paths: db/secondary_migrate
    fixtures_path: test/secondary_fixtures
```

You can also specify which database you want to load fixtures into via the `.fixtures` method. Here's what that looks like:

```ruby
fixtures :blogs, :posts, database: :secondary # defaults to :all
``` 

This will define a database name prefixed accessor for your fixtures eg. `secondary_blogs(:a_fixture)`. Primary database fixtures will not receive a prefix on their accessor (for legacy support and convenience).

I'm still fairly new to the rails codebase so I might've made some mistakes in my implementation. Any comments or suggestions would be greatly appreciated!

/cc @eileencodes 

r? @rafaelfranca 