### PR TITLE
Added mandatory region and bucket

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -58,6 +58,8 @@ amazon:
   service: S3
   access_key_id: ""
   secret_access_key: ""
+  bucket: ""
+  region: "" # e.g. 'us-east-1'
 ```
 
 Tell Active Storage which service to use by setting


### PR DESCRIPTION
The 'setup' section was misleadingly leaving out :bucket and :region in the sample, but servers don't start without them.