### PR TITLE
Fix rails guides markdown.rb and renderer.rb to use custom header id

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -103,7 +103,7 @@ module RailsGuides
                   hierarchy = hierarchy[0, 3] + [node]
                 end
 
-                node[:id] = dom_id(hierarchy)
+                node[:id] = dom_id(hierarchy) unless node[:id]
                 node.inner_html = "#{node_index(hierarchy)} #{node.inner_html}"
               end
             end

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -29,7 +29,12 @@ HTML
         # Always increase the heading level by 1, so we can use h1, h2 heading in the document
         header_level += 1
 
-        %(<h#{header_level}>#{text}</h#{header_level}>)
+        header_with_id = text.scan(/(.*){#(.*)}/)
+        unless header_with_id.empty?
+          %(<h#{header_level} id=#{header_with_id[0][1].strip}>#{header_with_id[0][0].strip}</h#{header_level}>)
+        else
+          %(<h#{header_level}>#{text}</h#{header_level}>)
+        end
       end
 
       def paragraph(text)


### PR DESCRIPTION
Fix rails guides markdown render to use custom header id.

eg. 
render `# Introduction {#custom_id}`

`<h4 id="custom_id"><a class="anchorlink" href="#custom_id">1.1 Introduction</a></h4>`

It would be useful when translating rails guides without URLencoding(%-strings).

Reference
1. [Extended Syntax](https://www.markdownguide.org/extended-syntax/#heading-ids)
