### PR TITLE
Fix current_page? behavior with trailing slash and parameters

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `current_page?` sometimes incorrectly returning `false`.
+
+    When called with an URL which had a path ending on `/` and having query
+    parameters, the `current_page?` function would return `false`.
+
+    Fixes #33956.
+
+    *Rien Maertens*
+
 *   ActionView::Helpers::SanitizeHelper: support rails-html-sanitizer 1.1.0.
 
     *Juanito Fatas*

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -559,10 +559,8 @@ module ActionView
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
-        if url_string.start_with?("/") && url_string != "/"
-          url_string.chomp!("/")
-          request_uri.chomp!("/")
-        end
+        url_string = remove_trailing_slash(url_string)
+        request_uri = remove_trailing_slash(request_uri)
 
         if %r{^\w+://}.match?(url_string)
           url_string == "#{request.protocol}#{request.host_with_port}#{request_uri}"
@@ -765,6 +763,30 @@ module ActionView
           end
 
           params.sort_by { |pair| pair[:name] }
+        end
+
+        # Returns the given url string with the trailing slash removed,
+        # unless the given url is the root ('/').
+        #
+        #  remove_trailing_slash('/posts/')
+        #  # => '/posts'
+        #
+        #  remove_trailing_slash('/posts/?order=desc')
+        #  # => '/posts?order=desc'
+        #
+        #  remove_trailing_slash('/?locale=en')
+        #  # => '/?locale=en'
+        #
+        #  remove_trailing_slash('https://example.com/?locale=en')
+        #  # => 'https://example.com/?locale=en'
+        #
+        def remove_trailing_slash(url_string)
+          pre, slash, post = url_string.rpartition("/")
+          if pre.empty? || pre == "#{request.protocol}#{request.host_with_port}"
+            url_string
+          else
+            pre + post
+          end
         end
     end
   end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -585,6 +585,12 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert current_page?("/posts/")
   end
 
+  def test_current_page_with_trailing_slash_and_params
+    @request = request_for_url("/posts?order=desc")
+
+    assert current_page?("/posts/?order=desc")
+  end
+
   def test_current_page_with_not_get_verb
     @request = request_for_url("/events", method: :post)
 


### PR DESCRIPTION
### Summary
This PR fixes issue #33956. When you're on the page '/posts/?order=desc' and you called `current_page?('/posts/')` the previous implementation would return `false`. This should now be fixed.

### Other Information

I have fixed the issue by adding a `remove_trailing_slash` function, which removes the trailing slash of an URL, unless it is the root path.

Example:
`https://example.com/posts/` becomes `https://example.com/posts`, but `https://example.com/` stays `https://example.com/`. (This also works with relative URL's).

I have updated the CHANGELOG, but I can remove this if this bugfix isn't significant enough.
