### PR TITLE
Eagerly define attribute methods in production

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -137,6 +137,14 @@ end_error
       end
     end
 
+    initializer "active_record.define_attribute_methods" do |app|
+      config.after_initialize do
+        ActiveSupport.on_load(:active_record) do
+          descendants.each(&:define_attribute_methods) if app.config.eager_load
+        end
+      end
+    end
+
     initializer "active_record.warn_on_records_fetched_greater_than" do
       if config.active_record.warn_on_records_fetched_greater_than
         ActiveSupport.on_load(:active_record) do


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/29559.

The attribute methods for a model are currently defined lazily the first time that model is instantiated, even when `config.eager_load` is true. This means the first request to use each model incurs the cost, which usually involves a database round trip to fetch the schema definition.

By defining the attribute methods for all models while the application is booting, we move that work out of any individual request. When using a forking web server, this also reduces the number of times the schema definition is queried by doing it once in the parent process instead of from each forked process during their first request.