### PR TITLE
update mini_magick to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
-    mini_magick (4.8.0)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -568,4 +568,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.16.4
+   1.16.5


### PR DESCRIPTION
v 4.9.2 avoids some warnings that show in our tests.

Although Gemfile.lock currently specifies 4.8.0, the CI already runs 4.9.2
so 4.8.0 warnings do not show in our CI logs.

ref:
https://github.com/minimagick/minimagick/commit/4c36a8747ea8446b236011bf2a67d113d4c6062e