### PR TITLE
Stringify database configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `ActiveRecord::Base.configurations=` to be set with a symbolized hash.
+
+    *Gannon McGibbon*
+
 *   Don't update counter cache unless the record is actually saved.
 
     Fixes #31493, #33113, #33117.

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -104,7 +104,7 @@ module ActiveRecord
         return configs.configurations if configs.is_a?(DatabaseConfigurations)
 
         build_db_config = configs.each_pair.flat_map do |env_name, config|
-          walk_configs(env_name, "primary", config)
+          walk_configs(env_name.to_s, "primary", config)
         end.compact
 
         if url = ENV["DATABASE_URL"]
@@ -119,7 +119,7 @@ module ActiveRecord
         when String
           build_db_config_from_string(env_name, spec_name, config)
         when Hash
-          build_db_config_from_hash(env_name, spec_name, config)
+          build_db_config_from_hash(env_name, spec_name, config.stringify_keys)
         end
       end
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -151,6 +151,30 @@ module ActiveRecord
         ActiveRecord::Base.configurations = @prev_configs
       end
 
+      def test_symbolized_configurations_assignment
+        @prev_configs = ActiveRecord::Base.configurations
+        config = {
+          development: {
+            primary: {
+              adapter: "sqlite3",
+              database: "db/development.sqlite3",
+            },
+          },
+          test: {
+            primary: {
+              adapter: "sqlite3",
+              database: "db/test.sqlite3",
+            },
+          },
+        }
+        ActiveRecord::Base.configurations = config
+        ActiveRecord::Base.configurations.configs_for.each do |config|
+          assert_instance_of ActiveRecord::DatabaseConfigurations::HashConfig, config
+        end
+      ensure
+        ActiveRecord::Base.configurations = @prev_configs
+      end
+
       def test_retrieve_connection
         assert @handler.retrieve_connection(@spec_name)
       end


### PR DESCRIPTION
Allows configurations to be assigned as symbolized hashes as in https://github.com/rails/rails/blob/06274428e534f8e12fc7d6904a89678b23c5b404/actionview/test/active_record_unit.rb#L48-L52

Without this, sometimes `ActiveRecord::DatabaseConfigurations` can think that a configuration is a URL config when its really a hash config.

r? @eileencodes 
/cc @rafaelfranca 