### PR TITLE
Eagerly build the routing helper module after routes are committed

### DIFF
--- a/actionpack/lib/abstract_controller/railties/routes_helpers.rb
+++ b/actionpack/lib/abstract_controller/railties/routes_helpers.rb
@@ -7,11 +7,8 @@ module AbstractController
         Module.new do
           define_method(:inherited) do |klass|
             super(klass)
-            if namespace = klass.parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
-              klass.include(namespace.railtie_routes_url_helpers(include_path_helpers))
-            else
-              klass.include(routes.url_helpers(include_path_helpers))
-            end
+
+            routes.include_helpers klass, include_path_helpers
           end
         end
       end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -664,7 +664,6 @@ module ActionDispatch
           def define_generate_prefix(app, name)
             _route = @set.named_routes.get name
             _routes = @set
-            _url_helpers = @set.url_helpers
 
             script_namer = ->(options) do
               prefix_options = options.slice(*_route.segment_keys)
@@ -676,7 +675,7 @@ module ActionDispatch
 
               # We must actually delete prefix segment keys to avoid passing them to next url_for.
               _route.segment_keys.each { |k| options.delete(k) }
-              _url_helpers.send("#{name}_path", prefix_options)
+              @set.url_helpers.send("#{name}_path", prefix_options)
             end
 
             app.routes.define_mounted_helper(name, script_namer)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -444,8 +444,10 @@ module ActionDispatch
       end
 
       def include_helpers_now(klass, include_path_helpers)
-        if namespace = klass.parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
-          klass.include(namespace.railtie_routes_url_helpers(include_path_helpers))
+        namespace = klass.parents.detect { |m| m.respond_to?(:railtie_include_helpers) }
+
+        if namespace && namespace.railtie_namespace.routes != self
+          namespace.railtie_include_helpers(klass, include_path_helpers)
         else
           klass.include(url_helpers(include_path_helpers))
         end

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -138,6 +138,20 @@ module ActionDispatch
         assert_generates(path.is_a?(Hash) ? path[:path] : path, generate_options, defaults, extras, message)
       end
 
+      # Provides a hook on `finalize!` so we can mutate a controller after the
+      # route set has been drawn.
+      class WithRouting < ActionDispatch::Routing::RouteSet # :nodoc:
+        def initialize(&block)
+          super()
+          @block = block
+        end
+
+        def finalize!
+          super
+          @block.call self
+        end
+      end
+
       # A helper to make it easier to test different route configurations.
       # This method temporarily replaces @routes with a new RouteSet instance.
       #
@@ -152,16 +166,19 @@ module ActionDispatch
       #   end
       #
       def with_routing
-        old_routes, @routes = @routes, ActionDispatch::Routing::RouteSet.new
-        if defined?(@controller) && @controller
-          old_controller, @controller = @controller, @controller.clone
-          _routes = @routes
+        old_routes = @routes
+        old_controller = nil
+        @routes = WithRouting.new do |_routes|
+          if defined?(@controller) && @controller
+            old_controller, @controller = @controller, @controller.clone
+            _routes = @routes
 
-          @controller.singleton_class.include(_routes.url_helpers)
+            @controller.singleton_class.include(_routes.url_helpers)
 
-          if @controller.respond_to? :view_context_class
-            @controller.view_context_class = Class.new(@controller.view_context_class) do
-              include _routes.url_helpers
+            if @controller.respond_to? :view_context_class
+              @controller.view_context_class = Class.new(@controller.view_context_class) do
+                include _routes.url_helpers
+              end
             end
           end
         end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -100,7 +100,10 @@ end
 
 class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   def self.build_app(routes = nil)
-    RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
+    routes ||= ActionDispatch::Routing::RouteSet.new.tap { |rs|
+      rs.draw { }
+    }
+    RoutedRackApp.new(routes) do |middleware|
       middleware.use ActionDispatch::ShowExceptions, ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")
       middleware.use ActionDispatch::DebugExceptions
       middleware.use ActionDispatch::Callbacks

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -542,9 +542,6 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         controller = ::IntegrationProcessTest::IntegrationController.clone
-        controller.class_eval do
-          include set.url_helpers
-        end
 
         set.draw do
           get "moved" => redirect("/method")
@@ -553,6 +550,10 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
             match ":action", to: controller, via: [:get, :post], as: :action
             get "get/:action", to: controller, as: :get_action
           end
+        end
+
+        controller.class_eval do
+          include set.url_helpers
         end
 
         singleton_class.include(set.url_helpers)

--- a/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
@@ -4,6 +4,11 @@ require "abstract_unit"
 
 class IPv6IntegrationTest < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    get "/",    to: "bad_route_request#index", as: :index
+    get "/foo", to: "bad_route_request#foo", as: :foo
+  end
+
   include Routes.url_helpers
 
   class ::BadRouteRequestController < ActionController::Base
@@ -15,11 +20,6 @@ class IPv6IntegrationTest < ActionDispatch::IntegrationTest
     def foo
       redirect_to action: :index
     end
-  end
-
-  Routes.draw do
-    get "/",    to: "bad_route_request#index", as: :index
-    get "/foo", to: "bad_route_request#foo", as: :foo
   end
 
   def _routes

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -4,22 +4,23 @@ require "abstract_unit"
 
 module TestUrlGeneration
   class WithMountPoint < ActionDispatch::IntegrationTest
-    Routes = ActionDispatch::Routing::RouteSet.new
-    include Routes.url_helpers
-
     class ::MyRouteGeneratingController < ActionController::Base
-      include Routes.url_helpers
       def index
         render plain: foo_path
       end
     end
 
+    Routes = ActionDispatch::Routing::RouteSet.new
     Routes.draw do
       get "/foo", to: "my_route_generating#index", as: :foo
 
       resources :bars
 
       mount MyRouteGeneratingController.action(:index), at: "/bar"
+    end
+
+    class ::MyRouteGeneratingController
+      include Routes.url_helpers
     end
 
     APP = build_app Routes

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -403,6 +403,12 @@ module Rails
               define_method(:railtie_helpers_paths) { railtie.helpers_paths }
             end
 
+            unless mod.respond_to?(:railtie_include_helpers)
+              define_method(:railtie_include_helpers) { |klass, include_path_helpers|
+                railtie.routes.include_helpers(klass, include_path_helpers)
+              }
+            end
+
             unless mod.respond_to?(:railtie_routes_url_helpers)
               define_method(:railtie_routes_url_helpers) { |include_path_helpers = true| railtie.routes.url_helpers(include_path_helpers) }
             end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -473,9 +473,13 @@ module Rails
     # files inside eager_load paths.
     def eager_load!
       config.eager_load_paths.each do |load_path|
-        matcher = /\A#{Regexp.escape(load_path.to_s)}\/(.*)\.rb\Z/
-        Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
-          require_dependency file.sub(matcher, '\1')
+        if File.file?(load_path)
+          require_dependency load_path
+        else
+          matcher = /\A#{Regexp.escape(load_path.to_s)}\/(.*)\.rb\Z/
+          Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
+            require_dependency file.sub(matcher, '\1')
+          end
         end
       end
     end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -38,6 +38,7 @@ module Rails
         @paths ||= begin
           paths = Rails::Paths::Root.new(@root)
 
+          paths.add "config/routes.rb",    eager_load: true
           paths.add "app",                 eager_load: true, glob: "{*,*/concerns}"
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
@@ -55,7 +56,6 @@ module Rails
           paths.add "config/environments", glob: "#{Rails.env}.rb"
           paths.add "config/initializers", glob: "**/*.rb"
           paths.add "config/locales",      glob: "*.{rb,yml}"
-          paths.add "config/routes.rb"
 
           paths.add "db"
           paths.add "db/migrate"


### PR DESCRIPTION
This commit eagerly builds the route helper module after the routes have
been drawn and finalized.  This allows us to cache the helper module but
not have to worry about people accessing the module while route
definition is "in-flight", and automatically deals with cache
invalidation as the module is regenerated anytime someone redraws the
routes.

The restriction this commit introduces is that the url helper module can
only be accessed *after* the routes are done being drawn.

Refs #24554 and #32892

It turns out that any time a controller class gets loaded, we include the url helpers module [via a railtie (in the `with` method)](https://github.com/rails/rails/blob/21e8c60cb920c3330a7c3c2ee99f22173a195457/actionpack/lib/action_controller/railtie.rb#L53-L66), and this can happen quite frequently in development.  If we're willing to put the constraint that "the module can be accessed only after the routes are done being drawn", then we can safely eagerly build the module and cache it.