### PR TITLE
[CaptureHelperTest] Fix a content_for test description

### DIFF
--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -40,7 +40,7 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "&lt;em&gt;bar&lt;/em&gt;", string
   end
 
-  def test_capture_used_for_read
+  def test_content_for_used_for_read
     content_for :foo, "foo"
     assert_equal "foo", content_for(:foo)
 


### PR DESCRIPTION
### Summary

This PR updates one of `content_for` test description. Spotted while browsing.

### Other Information

Originally introduced from https://github.com/rails/rails/commit/86a0f7f73594e5ba56b78b74c16cd6efa7e6cfa9.