### PR TITLE
[close #9343] Skip logging backtrace when exception is in `rescue_responses`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Configuration setting to skip logging an uncaught exception backtrace when
+    the exception is present in `rescued_responses`.
+
+    It may be too noisy to get all backtraces logged for applications that
+    manage uncaught exceptions via `rescued_responses` and `exceptions_app`.
+    `config.action_dispatch.log_rescued_responses` (defaults to `true`) can be
+    set to `false` in this case, so that only exceptions not found in
+    `rescued_responses` will be logged.
+
+    *Alexander Azarov*
+
 *   Add `ActionController::Parameters#each_value`.
 
     *Lukáš Zapletal*

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -50,6 +50,8 @@ module ActionDispatch
       end
     end
 
+    cattr_accessor :log_rescued_responses, default: true
+
     cattr_reader :interceptors, instance_accessor: false, default: []
 
     def self.register_interceptor(object = nil, &block)
@@ -175,6 +177,7 @@ module ActionDispatch
         return unless logger
 
         exception = wrapper.exception
+        return if !log_rescued_responses(request) && ActionDispatch::ExceptionWrapper.rescue_responses.key?(exception.class.name)
 
         trace = wrapper.application_trace
         trace = wrapper.framework_trace if trace.empty?
@@ -212,6 +215,11 @@ module ActionDispatch
 
       def api_request?(content_type)
         @response_format == :api && !content_type.html?
+      end
+
+      def log_rescued_responses(request)
+        per_request = request.get_header "action_dispatch.log_rescued_responses"
+        per_request.nil? ? @@log_rescued_responses : per_request
       end
   end
 end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -23,6 +23,7 @@ module ActionDispatch
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.use_cookies_with_metadata = false
     config.action_dispatch.perform_deep_munge = true
+    config.action_dispatch.log_rescued_responses = true
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -49,6 +50,8 @@ module ActionDispatch
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
+
+      ActionDispatch::DebugExceptions.log_rescued_responses = app.config.action_dispatch.log_rescued_responses
 
       ActionDispatch.test_app = app
     end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -448,6 +448,19 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_operator((output.rewind && output.read).lines.count, :>, 10)
   end
 
+  test "skips logging when rescued" do
+    @app = DevelopmentApp
+    output = StringIO.new
+
+    env = { "action_dispatch.show_exceptions" => true,
+           "action_dispatch.log_rescued_responses" => false,
+           "action_dispatch.logger" => Logger.new(output) }
+
+    get "/parameter_missing", headers: env
+    assert_response 400
+    assert_empty (output.rewind && output.read).lines
+  end
+
   test "display backtrace when error type is SyntaxError" do
     @app = DevelopmentApp
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -548,6 +548,9 @@ Defaults to `'signed cookie'`.
 
   Any exceptions that are not configured will be mapped to 500 Internal Server Error.
 
+* `config.action_dispatch.log_rescued_responses` enables logging those unhandled
+  exceptions configured in `rescue_responses`. It defaults to `true`.
+
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.


### PR DESCRIPTION
### Summary

`DebugExceptions` always logs backtrace for uncaught exceptions. This behavior may be undesireable for applications that manage `exceptions_app` and maintain own list of `rescue_responses`. There is proposal #9343 and I also described the scenario in detail [on Stackoverlow](https://stackoverflow.com/questions/52465009).

These code changes –

* make it possible for `DebugExceptions` to skip logging backtraces for "known" uncaught exceptions, i.e. those in `rescue_responses`
* provide a configuration setting to control this behaviour
