### PR TITLE
Added ActionController::Parameters.each_value methods

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -348,6 +348,14 @@ module ActionController
     end
     alias_method :each, :each_pair
 
+    # Convert all hashes in values into parameters, then yield each value in
+    # the same way as <tt>Hash#each_value</tt>.
+    def each_value(&block)
+      @parameters.each_pair do |key, value|
+        yield [convert_hashes_to_parameters(key, value)]
+      end
+    end
+
     # Attribute that keeps track of converted arrays, if any, to avoid double
     # looping in the common use case permit + mass-assignment. Defined in a
     # method to instantiate it only if needed.

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -75,6 +75,24 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
+  test "each_value carries permitted status" do
+    @params.permit!
+    @params["person"].each_value { |value| assert(value.permitted?) if value == 32 }
+  end
+
+  test "each_value carries unpermitted status" do
+    @params["person"].each_value { |value| assert_not(value.permitted?) if value == 32 }
+  end
+
+  test "each_key converts to hash for permitted" do
+    @params.permit!
+    @params.each_key { |key| assert_kind_of(String, key) if key == "person" }
+  end
+
+  test "each_key converts to hash for unpermitted" do
+    @params.each_key { |key| assert_kind_of(String, key) if key == "person" }
+  end
+
   test "empty? returns true when params contains no key/value pairs" do
     params = ActionController::Parameters.new
     assert_empty params


### PR DESCRIPTION
Although Parameters class is far from implementing Hash and it's obvious that
it's not primarly goal to achieve it, having the two convinient methods for
iterating through parameters makes it more quacking like Hash:

* each_value
* each_key