### PR TITLE
Raise an error when loading all fixtures from nil fixture_path

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise an error instead of scanning the filesystem root when `fixture_path` is blank.
+
+    *Gannon McGibbon*, *Max Albrecht*
+
 *   Allow `ActiveRecord::Base.configurations=` to be set with a symbolized hash.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -892,6 +892,7 @@ module ActiveRecord
 
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
+          raise StandardError, "No fixture path found. Please set `#{self}.fixture_path`." if fixture_path.blank?
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"].uniq
           fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
         else

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1344,3 +1344,19 @@ class SameNameDifferentDatabaseFixturesTest < ActiveRecord::TestCase
     assert_kind_of OtherDog, other_dogs(:lassie)
   end
 end
+
+class NilFixturePathTest < ActiveRecord::TestCase
+  test "raises an error when all fixtures loaded" do
+    error = assert_raises(StandardError) do
+      TestCase = Class.new(ActiveRecord::TestCase)
+      TestCase.class_eval do
+        self.fixture_path = nil
+        fixtures :all
+      end
+    end
+    assert_equal <<~MSG.squish, error.message
+      No fixture path found.
+      Please set `NilFixturePathTest::TestCase.fixture_path`.
+    MSG
+  end
+end


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/pull/19414. Raises an error `fixture_path` is nil instead of scanning your filesystem root.

r? @rafaelfranca 
