### PR TITLE
Only define attribute methods from schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -77,6 +77,11 @@ module ActiveRecord
         }]
       end
 
+      # Checks whether the columns hash is already cached for a table.
+      def columns_hash?(table_name)
+        @columns_hash.key?(table_name)
+      end
+
       # Clears out internal caches
       def clear!
         @columns.clear

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -283,6 +283,10 @@ module ActiveRecord
         TypeCaster::Map.new(self)
       end
 
+      def _internal? # :nodoc:
+        false
+      end
+
       private
 
         def cached_find_by_statement(key, &block)

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -8,6 +8,10 @@ module ActiveRecord
   # as which environment migrations were run in.
   class InternalMetadata < ActiveRecord::Base # :nodoc:
     class << self
+      def _internal?
+        true
+      end
+
       def primary_key
         "key"
       end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -10,6 +10,10 @@ module ActiveRecord
   # to be executed the next time.
   class SchemaMigration < ActiveRecord::Base # :nodoc:
     class << self
+      def _internal?
+        true
+      end
+
       def primary_key
         "version"
       end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -91,6 +91,22 @@ module ActiveRecord
         @cache.clear_data_source_cache!("posts")
       end
 
+      test "#columns_hash? is populated by #columns_hash" do
+        assert_not @cache.columns_hash?("posts")
+
+        @cache.columns_hash("posts")
+
+        assert @cache.columns_hash?("posts")
+      end
+
+      test "#columns_hash? is not populated by #data_source_exists?" do
+        assert_not @cache.columns_hash?("posts")
+
+        @cache.data_source_exists?("posts")
+
+        assert_not @cache.columns_hash?("posts")
+      end
+
       private
 
         def schema_dump_path


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/33959.

To define the attribute methods for a model, Active Record needs to know the schema of the underlying table, which is usually achieved by making a request to the database. This is undesirable behaviour while the app is booting, for two reasons: it makes the boot process dependent on the availability of the database, and it means every new process will make one query for each table, which can cause issues for large applications.

However, if the application is using the schema cache dump feature, then the schema cache already contains the necessary information, and we can define the attribute methods without causing any extra database queries.

r? @rafaelfranca 