### PR TITLE
Add missing rdoc +code+ tags [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1582,7 +1582,7 @@ module ActiveRecord
         #   association will use "taggable_type" as the default <tt>:foreign_type</tt>.
         # [:primary_key]
         #   Specify the method that returns the primary key of associated object used for the association.
-        #   By default this is id.
+        #   By default this is +id+.
         # [:dependent]
         #   If set to <tt>:destroy</tt>, the associated object is destroyed when this object is. If set to
         #   <tt>:delete</tt>, the associated object is deleted *without* calling its destroy method.


### PR DESCRIPTION
### Summary

Just adding code tags (+) around an attribute name to make it consistent with the other two examples in the same document.

### Other Information

I read the documentation section of [the contribution guide](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation) and added `[ci skip]` to the PR. Should I have added that to the commit as well (or instead)?