### PR TITLE
Use the same option for create database statements

### DIFF
--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -9,10 +9,10 @@ commands = [
   'mysql -e "grant all privileges on activerecord_unittest.* to rails@localhost;"',
   'mysql -e "grant all privileges on activerecord_unittest2.* to rails@localhost;"',
   'mysql -e "grant all privileges on inexistent_activerecord_unittest.* to rails@localhost;"',
-  'mysql -e "create database activerecord_unittest;"',
-  'mysql -e "create database activerecord_unittest2;"',
-  'psql  -c "create database activerecord_unittest;" -U postgres',
-  'psql  -c "create database activerecord_unittest2;" -U postgres'
+  'mysql -e "create database activerecord_unittest default character set utf8mb4;"',
+  'mysql -e "create database activerecord_unittest2 default character set utf8mb4;"',
+  'psql  -c "create database -E UTF8 -T template0 activerecord_unittest;" -U postgres',
+  'psql  -c "create database -E UTF8 -T template0 activerecord_unittest2;" -U postgres'
 ]
 
 commands.each do |command|


### PR DESCRIPTION
### Summary

This pull request changs travis.rb file to use the same option for create database statements between Raketask and travis.rb

* travis.rb for creating database at Travis CI
https://github.com/rails/rails/blob/b658743ac2a69d196d283e780816f5ad4a305753/ci/travis.rb#L12-L15

* Raketask for MySQL databases

https://github.com/rails/rails/blob/b658743ac2a69d196d283e780816f5ad4a305753/activerecord/Rakefile#L97-L98

* Raketask for PostgreSQL databases

https://github.com/rails/rails/blob/b658743ac2a69d196d283e780816f5ad4a305753/activerecord/Rakefile#L116-L117