### PR TITLE
Make AJ::Base#enqueue return false if the job wasn't enqueued

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -29,6 +29,9 @@ module ActiveJob
     included do
       define_callbacks :perform
       define_callbacks :enqueue
+
+      class_attribute :return_false_on_aborted_enqueue, instance_accessor: false, instance_predicate: false
+      self.return_false_on_aborted_enqueue = false
     end
 
     # These methods will be included into any Active Job object, adding

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -46,14 +46,25 @@ module ActiveJob
       self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
       self.priority     = options[:priority].to_i if options[:priority]
+      successfully_enqueued = false
       run_callbacks :enqueue do
         if scheduled_at
           self.class.queue_adapter.enqueue_at self, scheduled_at
         else
           self.class.queue_adapter.enqueue self
         end
+        successfully_enqueued = true
       end
-      self
+      if successfully_enqueued
+        self
+      else
+        if self.class.return_false_on_aborted_enqueue
+          false
+        else
+          ActiveSupport::Deprecation.warn "this will return false, set config.active_job.return_false_on_aborted_enqueue = true to remove deprecation."
+          self
+        end
+      end
     end
   end
 end

--- a/activejob/test/jobs/abort_before_enqueue_job.rb
+++ b/activejob/test/jobs/abort_before_enqueue_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AbortBeforeEnqueueJob < ActiveJob::Base
+  before_enqueue { throw(:abort) }
+
+  def perform
+    raise "This should never be called"
+  end
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -15,3 +15,6 @@
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+
+# Return false instead of self when #enqueue method was aborted from the callback
+Rails.application.config.active_job.return_false_on_aborted_enqueue = true


### PR DESCRIPTION
Before this patch, there's no way to know if the job was _really_ enqueued if there's a possibility that callback chain was aborted from `before_enqueue`:

```ruby
class AbortBeforeEnqueueJob < ActiveJob::Base
  before_enqueue { throw(:abort) }
end

> AbortBeforeEnqueueJob.new.enqueue
=> #<AbortBeforeEnqueueJob:0xXXXXXX @arguments=[], @job_id="0d5ef7b9-d32b-4c83-b8cf-44ec31e9d6d9" ...
```

After this patch, `enqueue` may return `false` if the job wasn't enqueued:

```ruby
> AbortBeforeEnqueueJob.new.enqueue
=> false
```

This follows `ActiveSupport::Callbacks` design:

> If the callback chain was halted, returns false. Otherwise returns the result of the block, nil if no callbacks have been set, or true if callbacks have been set but no block is given.

I understand it could be considered as a breaking change because it modifies `#enqueue` return result, but I think it's worth it as it will allow us to control things better.

@Edouard-chin @rafaelfranca 