### PR TITLE
Add migrations_paths option to model generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       class_option :parent, type: :string, desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :migrations_paths, type: :string, desc: "The migration path for your generated migrations. If this is not set it will default to db/migrate"
 
       # creates the migration file for the model.
       def create_migration_file

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Adds an option to the model generator to allow setting the
+    migrations paths for that migration. This is useful for
+    applications that use multiple databases and put migrations
+    per database in their own directories.
+
+    ```
+    bin/rails g model Room capacity:integer --migrations-paths=db/kingston_migrate
+          invoke  active_record
+          create    db/kingston_migrate/20180830151055_create_rooms.rb
+    ```
+
+    Because rails scaffolding uses the model generator, you can
+    also specify migrations paths with the scaffold generator.
+
+    *Gannon McGibbon*
+
 *   Raise an error when "recyclable cache keys" are being used by a cache store
     that does not explicitly support it. Custom cache keys that do support this feature
     can bypass this error by implementing the `supports_cache_versioning?` method on their

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -392,6 +392,15 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_migrations_paths_puts_migrations_in_that_folder
+    run_generator ["account", "--migrations_paths=db/test_migrate"]
+    assert_migration "db/test_migrate/create_accounts.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :accounts/, change)
+      end
+    end
+  end
+
   def test_required_belongs_to_adds_required_association
     run_generator ["account", "supplier:references{required}"]
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -476,6 +476,12 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_scaffold_generator_migrations_paths
+    run_generator ["posts", "--migrations-paths=db/kingston_migrate"]
+
+    assert_migration "db/kingston_migrate/create_posts.rb"
+  end
+
   def test_scaffold_generator_password_digest
     run_generator ["user", "name", "password:digest"]
 


### PR DESCRIPTION
### Summary

Followup on https://github.com/rails/rails/pull/33760. Adds support for custom migrations path on `rails generate model`. Example:
```
bin/rails g model Room capacity:integer --migrations-paths=db/kingston_migrate
      invoke  active_record
      create    db/kingston_migrate/20180830151055_create_rooms.rb
```

r? @eileencodes 
/cc @rafaelfranca 