### PR TITLE
Add a way to check for subset of arguments when performing jobs:

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow `assert_enqueued_with`/`assert_performed_with` methods to accept
+    a proc for the `args` argument. This is useful to check if only a subset of arguments
+    matches your expectations.
+
+    *Edouard Chin*
+
 *   `ActionDispatch::IntegrationTest` includes `ActiveJob::TestHelper` module by default.
 
     *Ricardo Díaz*

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -538,6 +538,29 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_with_selective_args
+    args = ->(job_args) do
+      assert_equal 1, job_args.first[:argument1]
+      assert job_args.first[:argument2].key?(:b)
+    end
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+    end
+  end
+
+  def test_assert_enqueued_with_selective_args_fails
+    args = ->(job_args) do
+      false
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+      end
+    end
+  end
+
   def test_assert_enqueued_with_with_no_block_args
     assert_raise ArgumentError do
       NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
@@ -1576,6 +1599,29 @@ class PerformedJobsTest < ActiveJob::TestCase
   def test_assert_performed_with_with_hash_arg
     assert_performed_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
       MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+    end
+  end
+
+  def test_assert_performed_with_selective_args
+    args = ->(job_args) do
+      assert_equal 1, job_args.first[:argument1]
+      assert job_args.first[:argument2].key?(:b)
+    end
+
+    assert_performed_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+    end
+  end
+
+  def test_assert_performed_with_selective_args_fails
+    args = ->(job_args) do
+      false
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+      end
     end
   end
 


### PR DESCRIPTION
- When calling `assert_performed_with`/`assert_enqueued_with`, the
  +args+ needs to match exactly what the job get passed.

  Some jobs can have lot of arguments, or even a simple hash argument
  has many key. This is not convenient to test as most tests doesn't
  need to check if the arguments matches perfectly.

  This PR make it possible to only check if a subset of arguments were
  passed to the job.
