### PR TITLE
Removed invalid -X flag for pg_dump, fixes #33996

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -61,7 +61,7 @@ module ActiveRecord
             ActiveRecord::Base.dump_schemas
           end
 
-        args = ["-s", "-X", "-x", "-O", "-f", filename]
+        args = ["-s", "-x", "-O", "-f", filename]
         args.concat(Array(extra_flags)) if extra_flags
         unless search_path.blank?
           args += search_path.split(",").map do |part|

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -366,7 +366,7 @@ if current_adapter?(:PostgreSQLAdapter)
         assert_called_with(
           Kernel,
           :system,
-          ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename, "my-app-db"],
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "my-app-db"],
           returns: true
         ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
@@ -383,7 +383,7 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       def test_structure_dump_with_extra_flags
-        expected_command = ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename, "--noop", "my-app-db"]
+        expected_command = ["pg_dump", "-s", "-x", "-O", "-f", @filename, "--noop", "my-app-db"]
 
         assert_called_with(Kernel, :system, expected_command, returns: true) do
           with_structure_dump_flags(["--noop"]) do
@@ -401,7 +401,7 @@ if current_adapter?(:PostgreSQLAdapter)
           assert_called_with(
             Kernel,
             :system,
-            ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db"],
+            ["pg_dump", "-s", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db"],
             returns: true
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
@@ -415,7 +415,7 @@ if current_adapter?(:PostgreSQLAdapter)
         assert_called_with(
           Kernel,
           :system,
-          ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
           returns: true
         ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
@@ -428,7 +428,7 @@ if current_adapter?(:PostgreSQLAdapter)
         assert_called_with(
           Kernel,
           :system,
-          ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename,  "my-app-db"],
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename,  "my-app-db"],
           returns: true
         ) do
           with_dump_schemas(:all) do
@@ -441,7 +441,7 @@ if current_adapter?(:PostgreSQLAdapter)
         assert_called_with(
           Kernel,
           :system,
-          ["pg_dump", "-s", "-X", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
+          ["pg_dump", "-s", "-x", "-O", "-f", @filename, "--schema=foo", "--schema=bar", "my-app-db"],
           returns: true
         ) do
           with_dump_schemas("foo,bar") do
@@ -455,7 +455,7 @@ if current_adapter?(:PostgreSQLAdapter)
         assert_called_with(
           Kernel,
           :system,
-          ["pg_dump", "-s", "-X", "-x", "-O", "-f", filename, "my-app-db"],
+          ["pg_dump", "-s", "-x", "-O", "-f", filename, "my-app-db"],
           returns: nil
         ) do
           e = assert_raise(RuntimeError) do


### PR DESCRIPTION
### Summary

This fixes #33996: Currently, the db:structure:dump task for PostgreSQL uses a flag, "-X" (note capital case), that is invalid, and has (as far as I can find), never existed.