### PR TITLE
Fix optionally scoped root route unscoped access

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -390,7 +390,7 @@ module ActionDispatch
       # for root cases, where the latter is the correct one.
       def self.normalize_path(path)
         path = Journey::Router::Utils.normalize_path(path)
-        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/\(+[^)]+\)$}
+        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/(\(+[^)]+\)){1,}$}
         path
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1367,6 +1367,22 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "projects#index", @response.body
   end
 
+  def test_optionally_scoped_root_unscoped_access
+    draw do
+      scope "(:locale)" do
+        scope "(:platform)" do
+          scope "(:browser)" do
+            root to: "projects#index"
+          end
+        end
+      end
+    end
+
+    assert_equal "/", root_path
+    get "/"
+    assert_equal "projects#index", @response.body
+  end
+
   def test_scope_with_format_option
     draw do
       get "direct/index", as: :no_format_direct, format: false


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/pull/24838.
Closes https://github.com/rails/rails/issues/12805.

Fixes the current behaviour of having a deeply scoped root route with optional parameters. I'm not a pro at regex, so maybe there's a better way of solving this issue.

In a dummy app, I have a root route:
```ruby
scope "(:locale)" do
  scope "(:platform)" do
    scope "(:browser)" do
      root to: "application#welcome"
    end
  end
end
```
which generates a route: `root GET (/:locale)(/:platform)(/:browser)(.:format) application#welcome`. This patch makes the route `root GET /(/:locale)(/:platform)(/:browser)(.:format) application#welcome` so you can access the unscoped root as expected.
