### PR TITLE
Fixing an edge case when using objects as constraints

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -49,11 +49,15 @@ module ActionDispatch
         end
 
         def constraint_args(constraint, request)
-          if constraint.respond_to?(:arity) && constraint.arity == 1
-            [request]
+          arity = if constraint.respond_to?(:arity)
+            constraint.arity
           else
-            [request.path_parameters, request]
+            constraint.method(:call).arity
           end
+
+          return [] if arity < 1
+          return [request] if arity == 1
+          [request.path_parameters, request]
         end
         private :constraint_args
       end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -48,10 +48,14 @@ module ActionDispatch
           @strategy.call @app, req
         end
 
-        private
-          def constraint_args(constraint, request)
-            constraint.arity == 1 ? [request] : [request.path_parameters, request]
+        def constraint_args(constraint, request)
+          if constraint.respond_to?(:arity) && constraint.arity == 1
+            [request]
+          else
+            [request.path_parameters, request]
           end
+        end
+        private :constraint_args
       end
 
       class Mapping #:nodoc:

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -115,6 +115,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 301, status
   end
 
+  def test_accepts_a_constraint_object_responding_to_call
+    constraint = Class.new do
+      def call(*); true; end
+      def matches?(*); false; end
+    end
+
+    draw do
+      get "/", to: "home#show", constraints: constraint.new
+    end
+
+    assert_nothing_raised do
+      get "/"
+    end
+  end
+
   def test_namespace_with_controller_segment
     assert_raise(ArgumentError) do
       draw do


### PR DESCRIPTION
Hello 😊 

### Summary

This PR fixes an issue when the following situation occurs.
If you define a class like this:

```ruby
class MyConstraint
  def call(*args)
    # for some reason this is defined
  end

  def matches?(*args)
    # checking the args
  end
end
```

and try to use it as a constraint:

```ruby
get "/", to: "home#show", constraints: MyConstraint.new
```

if its `matches?` method returns `false` there will be an error because the mapper will ask for the constraint arity, thinking it is a proc, lambda or method.

The new code checks for the presence of the `arity` method on the constraint, calling it only if present, preventing the error while keeping the basic behavior.