### PR TITLE
Array with single item correctly uses cache_key

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -647,7 +647,7 @@ module ActiveSupport
             if key.size > 1
               key = key.collect { |element| expanded_key(element) }
             else
-              key = key.first
+              key = expanded_key(key.first)
             end
           when Hash
             key = key.sort_by { |k, _| k.to_s }.collect { |k, v| "#{k}=#{v}" }

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -290,6 +290,55 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read("fu/foo")
   end
 
+  InstanceTest = Struct.new(:name, :id) do
+    def cache_key
+      "#{name}/#{id}"
+    end
+
+    def to_param
+      "hello"
+    end
+  end
+
+  def test_array_with_single_instance_as_cache_key_uses_cache_key_method
+    test_instance_one = InstanceTest.new("test", 1)
+    test_instance_two = InstanceTest.new("test", 2)
+
+    @cache.write([test_instance_one], "one")
+    @cache.write([test_instance_two], "two")
+
+    assert_equal "one", @cache.read([test_instance_one])
+    assert_equal "two", @cache.read([test_instance_two])
+  end
+
+  def test_array_with_multiple_instances_as_cache_key_uses_cache_key_method
+    test_instance_one = InstanceTest.new("test", 1)
+    test_instance_two = InstanceTest.new("test", 2)
+    test_instance_three = InstanceTest.new("test", 3)
+
+    @cache.write([test_instance_one, test_instance_three], "one")
+    @cache.write([test_instance_two, test_instance_three], "two")
+
+    assert_equal "one", @cache.read([test_instance_one, test_instance_three])
+    assert_equal "two", @cache.read([test_instance_two, test_instance_three])
+  end
+
+  def test_format_of_expanded_key_for_single_instance
+    test_instance_one = InstanceTest.new("test", 1)
+
+    expanded_key = @cache.send(:expanded_key, test_instance_one)
+
+    assert_equal expanded_key, test_instance_one.cache_key
+  end
+
+  def test_format_of_expanded_key_for_single_instance_in_array
+    test_instance_one = InstanceTest.new("test", 1)
+
+    expanded_key = @cache.send(:expanded_key, [test_instance_one])
+
+    assert_equal expanded_key, test_instance_one.cache_key
+  end
+
   def test_hash_as_cache_key
     @cache.write({ foo: 1, fu: 2 }, "bar")
     assert_equal "bar", @cache.read("foo=1/fu=2")


### PR DESCRIPTION
Fixes `expanded_key` to correctly work with arrays that contain a single element that responds to `cache_key`

addresses https://github.com/rails/rails/issues/34000

@schneems mentioned that he had a WIP branch that would address this as well, does it make sense to submit this as a stopgap for the bug?

I couldn't find a proper place to put new test models for `active_suppourt` so I created a struct inline, let me know if there would be a better way to handle it.