### PR TITLE
Disable js in plugins by default to get the tests passing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rack-cache", "~> 1.2"
 gem "coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
-gem "webpacker", github: "rails/webpacker"
+gem "webpacker", github: "rails/webpacker", require: ENV["SKIP_REQUIRE_WEBPACKER"] != "true"
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -68,7 +68,7 @@ module Rails
         class_option :skip_listen,         type: :boolean, default: false,
                                            desc: "Don't generate configuration that depends on the listen gem"
 
-        class_option :skip_javascript,     type: :boolean, aliases: "-J", default: false,
+        class_option :skip_javascript,     type: :boolean, aliases: "-J", default: name == "plugin",
                                            desc: "Skip JavaScript files"
 
         class_option :skip_turbolinks,     type: :boolean, default: false,
@@ -329,7 +329,6 @@ module Rails
 
       def webpacker_gemfile_entry
         return [] if options[:skip_javascript]
-
         GemfileEntry.new "webpacker", nil, "Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker"
       end
 

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -24,7 +24,7 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
 
   def test_runner_command_work_inside_engine
     output = capture(:stdout) do
-      Dir.chdir(plugin_path) { system("bin/rails runner 'puts Rails.env'") }
+      Dir.chdir(plugin_path) { system({"SKIP_REQUIRE_WEBPACKER" => "true"}, "bin/rails runner 'puts Rails.env'") }
     end
 
     assert_equal "test", output.strip
@@ -67,6 +67,7 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
 
     def spawn_command(command, fd)
       Process.spawn(
+        {"SKIP_REQUIRE_WEBPACKER" => "true"},
         "#{plugin_path}/bin/rails #{command}",
         in: fd, out: fd, err: fd
       )

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -257,7 +257,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_creating_engine_with_hyphenated_name_in_full_mode
     run_generator [File.join(destination_root, "hyphenated-name"), "--full"]
-    assert_file "hyphenated-name/app/assets/javascripts/hyphenated/name"
+    assert_no_file "hyphenated-name/app/assets/javascripts/hyphenated/name"
     assert_file "hyphenated-name/app/assets/stylesheets/hyphenated/name"
     assert_file "hyphenated-name/app/assets/images/hyphenated/name"
     assert_file "hyphenated-name/app/models"
@@ -274,7 +274,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_creating_engine_with_hyphenated_and_underscored_name_in_full_mode
     run_generator [File.join(destination_root, "my_hyphenated-name"), "--full"]
-    assert_file "my_hyphenated-name/app/assets/javascripts/my_hyphenated/name"
+    assert_no_file "my_hyphenated-name/app/assets/javascripts/my_hyphenated/name"
     assert_file "my_hyphenated-name/app/assets/stylesheets/my_hyphenated/name"
     assert_file "my_hyphenated-name/app/assets/images/my_hyphenated/name"
     assert_file "my_hyphenated-name/app/models"
@@ -295,7 +295,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_create_mountable_application_with_mountable_option
     run_generator [destination_root, "--mountable"]
-    assert_file "app/assets/javascripts/bukkits"
+    assert_no_file "app/assets/javascripts/bukkits"
     assert_file "app/assets/stylesheets/bukkits"
     assert_file "app/assets/images/bukkits"
     assert_file "config/routes.rb", /Bukkits::Engine\.routes\.draw do/
@@ -311,7 +311,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match "<%= csrf_meta_tags %>", contents
       assert_match "<%= csp_meta_tag %>", contents
       assert_match(/stylesheet_link_tag\s+['"]bukkits\/application['"]/, contents)
-      assert_match(/javascript_include_tag\s+['"]bukkits\/application['"]/, contents)
+      assert_no_match(/javascript_include_tag\s+['"]bukkits\/application['"]/, contents)
       assert_match "<%= yield %>", contents
     end
     assert_file "test/test_helper.rb" do |content|
@@ -325,7 +325,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_create_mountable_application_with_mountable_option_and_hypenated_name
     run_generator [File.join(destination_root, "hyphenated-name"), "--mountable"]
-    assert_file "hyphenated-name/app/assets/javascripts/hyphenated/name"
+    assert_no_file "hyphenated-name/app/assets/javascripts/hyphenated/name"
     assert_file "hyphenated-name/app/assets/stylesheets/hyphenated/name"
     assert_file "hyphenated-name/app/assets/images/hyphenated/name"
     assert_file "hyphenated-name/config/routes.rb",                                          /Hyphenated::Name::Engine\.routes\.draw do/
@@ -341,13 +341,13 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "hyphenated-name/app/views/layouts/hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>Hyphenated name</title>", contents
       assert_match(/stylesheet_link_tag\s+['"]hyphenated\/name\/application['"]/, contents)
-      assert_match(/javascript_include_tag\s+['"]hyphenated\/name\/application['"]/, contents)
+      assert_no_match(/javascript_include_tag\s+['"]hyphenated\/name\/application['"]/, contents)
     end
   end
 
   def test_create_mountable_application_with_mountable_option_and_hypenated_and_underscored_name
     run_generator [File.join(destination_root, "my_hyphenated-name"), "--mountable"]
-    assert_file "my_hyphenated-name/app/assets/javascripts/my_hyphenated/name"
+    assert_no_file "my_hyphenated-name/app/assets/javascripts/my_hyphenated/name"
     assert_file "my_hyphenated-name/app/assets/stylesheets/my_hyphenated/name"
     assert_file "my_hyphenated-name/app/assets/images/my_hyphenated/name"
     assert_file "my_hyphenated-name/config/routes.rb",                                             /MyHyphenated::Name::Engine\.routes\.draw do/
@@ -363,13 +363,13 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "my_hyphenated-name/app/views/layouts/my_hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>My hyphenated name</title>", contents
       assert_match(/stylesheet_link_tag\s+['"]my_hyphenated\/name\/application['"]/, contents)
-      assert_match(/javascript_include_tag\s+['"]my_hyphenated\/name\/application['"]/, contents)
+      assert_no_match(/javascript_include_tag\s+['"]my_hyphenated\/name\/application['"]/, contents)
     end
   end
 
   def test_create_mountable_application_with_mountable_option_and_multiple_hypenates_in_name
     run_generator [File.join(destination_root, "deep-hyphenated-name"), "--mountable"]
-    assert_file "deep-hyphenated-name/app/assets/javascripts/deep/hyphenated/name"
+    assert_no_file "deep-hyphenated-name/app/assets/javascripts/deep/hyphenated/name"
     assert_file "deep-hyphenated-name/app/assets/stylesheets/deep/hyphenated/name"
     assert_file "deep-hyphenated-name/app/assets/images/deep/hyphenated/name"
     assert_file "deep-hyphenated-name/config/routes.rb",                                               /Deep::Hyphenated::Name::Engine\.routes\.draw do/
@@ -385,7 +385,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "deep-hyphenated-name/app/views/layouts/deep/hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>Deep hyphenated name</title>", contents
       assert_match(/stylesheet_link_tag\s+['"]deep\/hyphenated\/name\/application['"]/, contents)
-      assert_match(/javascript_include_tag\s+['"]deep\/hyphenated\/name\/application['"]/, contents)
+      assert_no_match(/javascript_include_tag\s+['"]deep\/hyphenated\/name\/application['"]/, contents)
     end
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -198,8 +198,10 @@ module SharedGeneratorTests
   def test_generator_for_active_storage
     run_generator [destination_root, "--no-skip-javascript"]
 
-    assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
-      assert_match(/^import \* as ActiveStorage from "activestorage"\nActiveStorage.start\(\)/, content)
+    unless generator_class.name == "Rails::Generators::PluginGenerator"
+      assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
+        assert_match(/^import \* as ActiveStorage from "activestorage"\nActiveStorage.start\(\)/, content)
+      end
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|


### PR DESCRIPTION
Disables javascript by default in generated plugins as webpacker does not yet support them.

This should get the remaining tests for the  webpacker-default passing.


