### PR TITLE
LoggerSilence doesn't require concurrent:

### DIFF
--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -2,7 +2,6 @@
 
 require "active_support/concern"
 require "active_support/core_ext/module/attribute_accessors"
-require "concurrent"
 
 module LoggerSilence
   extend ActiveSupport::Concern

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
+require "concurrent"
 
 module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:


### PR DESCRIPTION
LoggerSilence doesn't require concurrent:

- LoggerThreadSafeLevel does nowaday since 2518bda97cbbcb33dc9a92e70d5b01c09e64d12d

