### PR TITLE
Fix HashWithIndifferentAccess#without bug

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug where `#without` for `ActiveSupport::HashWithIndifferentAccess` would fail
+    with symbol arguments
+
+    *Abraham Chan*
+
 *   Treat `#delete_prefix`, `#delete_suffix` and `#unicode_normalize` results as non-`html_safe`.
     Ensure safety of arguments for `#insert`, `#[]=` and `#replace` calls on `html_safe` Strings.
 

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -279,6 +279,8 @@ module ActiveSupport
       super(convert_key(key))
     end
 
+    alias_method :without, :except
+
     def stringify_keys!; self end
     def deep_stringify_keys!; self end
     def stringify_keys; dup end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -672,6 +672,17 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal "bender", slice["login"]
   end
 
+  def test_indifferent_without
+    original = { a: "x", b: "y", c: 10 }.with_indifferent_access
+    expected = { c: 10 }.with_indifferent_access
+
+    [["a", "b"], [:a, :b]].each do |keys|
+      # Should return a new hash without the given keys.
+      assert_equal expected, original.without(*keys), keys.inspect
+      assert_not_equal expected, original
+    end
+  end
+
   def test_indifferent_extract
     original = { :a => 1, "b" => 2, :c => 3, "d" => 4 }.with_indifferent_access
     expected = { a: 1, b: 2 }.with_indifferent_access


### PR DESCRIPTION
### Summary

Inconsistent behavior when calling `without` on a HashWithIndifferentAccess e.g.
``` Ruby
{a: 1}.with_indifferent_access.without("a")
# {}
{a: 1}.with_indifferent_access.without(:a)
# {"a"=>1} 
# Expected {}

# But except works
{a: 1}.with_indifferent_access.except("a")
# {}
{a: 1}.with_indifferent_access.except(:a)
# {}
```

### Other Information
I'm not sure if the approach I took was the correct one, but `except` behaves correctly and appears to do the exact same thing, as far as I can tell.
