### PR TITLE
Bugfix ActiveRecord::Relation#merge special case of from clause

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -171,15 +171,18 @@ module ActiveRecord
         end
 
         def merge_clauses
-          if relation.from_clause.empty? && !other.from_clause.empty?
-            relation.from_clause = other.from_clause
-          end
+          relation.from_clause = other.from_clause if replace_from_clause?
 
           where_clause = relation.where_clause.merge(other.where_clause)
           relation.where_clause = where_clause unless where_clause.empty?
 
           having_clause = relation.having_clause.merge(other.having_clause)
           relation.having_clause = having_clause unless having_clause.empty?
+        end
+
+        def replace_from_clause?
+          relation.from_clause.empty? && !other.from_clause.empty? &&
+            relation.klass.base_class == other.klass.base_class
         end
     end
   end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -122,6 +122,10 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_not_empty relation.from_clause
   end
 
+  def test_merging_with_from_clause_on_different_class
+    assert Comment.joins(:post).merge(Post.from("posts")).first
+  end
+
   def test_merging_with_order_with_binds
     relation = Post.all.merge(Post.order([Arel.sql("title LIKE ?"), "%suffix"]))
     assert_equal ["title LIKE '%suffix'"], relation.order_values


### PR DESCRIPTION
When one relation is merged into another that has a different base class
merging `from_clause` causes invalid SQL to be generated

Here is basic example:

``` ruby
Comment.joins(:post).merge(Post.from("posts")).first
  # => select comments.* from posts where ...
```

There is no sense to replace the basic from clause from the merged relation in case merged relation has a different base class (aka source table).
