### PR TITLE
Bugfix: ActiveSupport::EncryptedConfiguration reading of comment-only encrypted files

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -39,7 +39,7 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        YAML.load(config, fallback: YAML.parse('{}'))
+        YAML.load(config, fallback: YAML.parse("{}"))
       end
   end
 end

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -39,7 +39,7 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        config.present? ? YAML.load(config, content_path) : {}
+        YAML.load(config, fallback: YAML.parse('{}'))
       end
   end
 end

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -39,7 +39,13 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        YAML.load(config, fallback: YAML.parse("{}"))
+        return {} if config.blank?
+
+        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.0.1")
+          YAML.load(config, fallback: YAML.parse("{}"))
+        else
+          YAML.load(config, nil, YAML.parse("{}"))
+        end
       end
   end
 end

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -39,13 +39,7 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        return {} if config.blank?
-
-        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.0.1")
-          YAML.load(config, fallback: YAML.parse("{}"))
-        else
-          YAML.load(config, nil, YAML.parse("{}"))
-        end
+        YAML.load(config).presence || {}
       end
   end
 end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -42,6 +42,16 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert @credentials.something[:good]
   end
 
+  test "reading example configuration" do
+    require "rails/generators"
+    require "rails/generators/rails/encrypted_file/encrypted_file_generator"
+
+    encrypted_file_generator = Rails::Generators::EncryptedFileGenerator.new
+    encrypted_file_generator.add_encrypted_file_silently(@credentials_config_path, @credentials_key_path)
+
+    assert_equal @credentials.config, {}
+  end
+
   test "change configuration by key file" do
     @credentials.write({ something: { good: true } }.to_yaml)
     @credentials.change do |config_file|

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -42,7 +42,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert @credentials.something[:good]
   end
 
-  test "reading example configuration" do
+  test "reading comment-only configuration" do
     ActiveSupport::EncryptedFile.new(
       content_path: @credentials_config_path, key_path: @credentials_key_path,
       env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -43,11 +43,10 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   end
 
   test "reading example configuration" do
-    require "rails/generators"
-    require "rails/generators/rails/encrypted_file/encrypted_file_generator"
-
-    encrypted_file_generator = Rails::Generators::EncryptedFileGenerator.new
-    encrypted_file_generator.add_encrypted_file_silently(@credentials_config_path, @credentials_key_path)
+    ActiveSupport::EncryptedFile.new(
+      content_path: @credentials_config_path, key_path: @credentials_key_path,
+      env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true
+    ).write("# comment")
 
     assert_equal @credentials.config, {}
   end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -43,10 +43,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   end
 
   test "reading comment-only configuration" do
-    ActiveSupport::EncryptedFile.new(
-      content_path: @credentials_config_path, key_path: @credentials_key_path,
-      env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true
-    ).write("# comment")
+    @credentials.write("# comment")
 
     assert_equal @credentials.config, {}
   end


### PR DESCRIPTION
When an encrypted file only contains comments then reading such a file will raise an error (see test):

    NoMethodError: undefined method `deep_symbolize_keys' for false:FalseClass
        activesupport/lib/active_support/encrypted_configuration.rb:33:in `config'
        test/encrypted_configuration_test.rb:52:in `block in <class:EncryptedConfigurationTest>'

This happened in the previous implementation because it returned `{}` as a fallback for blank YAML strings - but it did not handle YAML strings that aren't blank but still don't contain any _useful_ YAML - like the file created by `Rails::Generators::EncryptedFileGenerator` - which looks like this:

    # aws:
    #   access_key_id: 123
    #   secret_access_key: 345

This PR fixes the issue by passing the fallback directly to `YAML.load` which should cover all cases of blank YAML string. Please note that the signature of how `YAML.load` has changed between Ruby 2.4 and 2.5.