### PR TITLE
Refactor migrations_path command option to database

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -17,6 +17,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def migrations_paths
+        raise NotImplementedError
+      end
+
       def url_config?
         false
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -38,6 +38,13 @@ module ActiveRecord
       def replica?
         config["replica"]
       end
+
+      # The migrations paths for a database configuration. If the
+      # `migrations_paths` key is present in the config, `migrations_paths`
+      # will return its value.
+      def migrations_paths
+        config["migrations_paths"]
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -48,6 +48,13 @@ module ActiveRecord
         config["replica"]
       end
 
+      # The migrations paths for a database configuration. If the
+      # `migrations_paths` key is present in the config, `migrations_paths`
+      # will return its value.
+      def migrations_paths
+        config["migrations_paths"]
+      end
+
       private
         def build_config(original_config, url)
           if /^jdbc:/.match?(url)

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -24,13 +24,24 @@ module ActiveRecord
         end
 
         def db_migrate_path
-          if migrations_paths = options[:migrations_paths]
-            migrations_paths
-          elsif defined?(Rails.application) && Rails.application
-            Rails.application.config.paths["db/migrate"].to_ary.first
+          if defined?(Rails.application) && Rails.application
+            configured_migrate_path || default_migrate_path
           else
             "db/migrate"
           end
+        end
+
+        def default_migrate_path
+          Rails.application.config.paths["db/migrate"].to_ary.first
+        end
+
+        def configured_migrate_path
+          return unless database = options[:database]
+          config = ActiveRecord::Base.configurations.configs_for(
+            env_name: Rails.env,
+            spec_name: database,
+          )
+          config&.migrations_paths
         end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
-      class_option :migrations_paths, type: :string, desc: "The migration path for your generated migrations. If this is not set it will default to db/migrate"
+      class_option :database, type: :string, aliases: %i(db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
       def create_migration_file
         set_local_assigns!

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       class_option :parent, type: :string, desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
-      class_option :migrations_paths, type: :string, desc: "The migration path for your generated migrations. If this is not set it will default to db/migrate"
+      class_option :database, type: :string, aliases: %i(db), desc: "The database for your model's migration. By default, the current environment's primary database is used."
 
       # creates the migration file for the model.
       def create_migration_file

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Refactors `migrations_paths` command option in generators
+    to `database` (aliased as `db`). Now, the migrations paths
+    will be read from the specified database configuration in the
+    current environment.
+
+    ```
+    bin/rails g model Chair brand:string --database=kingston
+          invoke  active_record
+          create    db/kingston_migrate/20180830151055_create_chairs.rb
+    ```
+
+    `--database` can be used with the migration, model, and scaffold generators.
+
+    *Gannon McGibbon*
+
 *   Adds an option to the model generator to allow setting the
     migrations paths for that migration. This is useful for
     applications that use multiple databases and put migrations

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -42,6 +42,20 @@ module GeneratorsTestHelper
     end
   end
 
+  def with_secondary_database_configuration
+    ActiveRecord::Base.configurations = {
+      test: {
+        secondary: {
+          database: "db/secondary.sqlite3",
+          migrations_paths: "db/secondary_migrate",
+        },
+      },
+    }
+    yield
+  ensure
+    ActiveRecord::Base.configurations = {}
+  end
+
   def copy_routes
     routes = File.expand_path("../../lib/rails/generators/rails/app/templates/config/routes.rb.tt", __dir__)
     destination = File.join(destination_root, "config")

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -254,11 +254,13 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_migrations_paths_puts_migrations_in_that_folder
-    run_generator ["create_books", "--migrations_paths=db/test_migrate"]
-    assert_migration "db/test_migrate/create_books.rb" do |content|
-      assert_method :change, content do |change|
-        assert_match(/create_table :books/, change)
+  def test_database_puts_migrations_in_configured_folder
+    with_secondary_database_configuration do
+      run_generator ["create_books", "--database=secondary"]
+      assert_migration "db/secondary_migrate/create_books.rb" do |content|
+        assert_method :change, content do |change|
+          assert_match(/create_table :books/, change)
+        end
       end
     end
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -392,11 +392,13 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_migrations_paths_puts_migrations_in_that_folder
-    run_generator ["account", "--migrations_paths=db/test_migrate"]
-    assert_migration "db/test_migrate/create_accounts.rb" do |content|
-      assert_method :change, content do |change|
-        assert_match(/create_table :accounts/, change)
+  def test_database_puts_migrations_in_configured_folder
+    with_secondary_database_configuration do
+      run_generator ["account", "--database=secondary"]
+      assert_migration "db/secondary_migrate/create_accounts.rb" do |content|
+        assert_method :change, content do |change|
+          assert_match(/create_table :accounts/, change)
+        end
       end
     end
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -476,10 +476,12 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_scaffold_generator_migrations_paths
-    run_generator ["posts", "--migrations-paths=db/kingston_migrate"]
+  def test_scaffold_generator_database
+    with_secondary_database_configuration do
+      run_generator ["posts", "--database=secondary"]
 
-    assert_migration "db/kingston_migrate/create_posts.rb"
+      assert_migration "db/secondary_migrate/create_posts.rb"
+    end
   end
 
   def test_scaffold_generator_password_digest


### PR DESCRIPTION
### Summary

As discussed in https://github.com/rails/rails/pull/33994, refactors `migrations_paths` command option in generators to `database` (aliased as `db`). Now, the migrations paths will be read from the specified database configuration in the current environment.
```
bin/rails g model Chair brand:string --database=kingston
     invoke  active_record
     create    db/kingston_migrate/20180830151055_create_chairs.rb
```
`--database` can be used with the migration, model, and scaffold generators.

r? @eileencodes 

/cc @rafaelfranca @kaspth 
