### PR TITLE
Add :as option for ActiveSupport delegate

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow passing a custom method name to the `delegate` method using the `:as` parameter.
+
+        delegate :address, to: :client, as: :home_address
+
+    *Dmitry Tsepelev*
+
 *   Fix bug where `#without` for `ActiveSupport::HashWithIndifferentAccess` would fail
     with symbol arguments
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -13,6 +13,8 @@ Someone = Struct.new(:name, :place) do
   delegate :upcase, to: "place.city"
   delegate :table_name, to: :class
   delegate :table_name, to: :class, prefix: true
+  delegate :street, to: :place, as: :home_street
+  delegate :city, to: :place, as: :home_city
 
   def self.table_name
     "some_table"
@@ -181,6 +183,29 @@ class ModuleTest < ActiveSupport::TestCase
   def test_delegation_to_class_method
     assert_equal "some_table", @david.table_name
     assert_equal "some_table", @david.class_table_name
+  end
+
+  def test_delegation_to_methods_with_renaming
+    assert_equal "Paulina", @david.home_street
+    assert_equal "Chicago", @david.home_city
+  end
+
+  def test_valid_as_passed
+    assert_raise(ArgumentError) do
+      Name.send :delegate, :upcase, as: "1change", to: :@full_name
+    end
+  end
+
+  def test_multiple_methods_passed_with_as
+    assert_raise(ArgumentError) do
+      Name.send :delegate, :upcase, :downcase, as: :change, to: :@full_name
+    end
+  end
+
+  def test_both_prefix_and_as_specified
+    assert_raise(ArgumentError) do
+      Name.send :delegate, :upcase, prefix: :str, as: :change, to: :@full_name
+    end
   end
 
   def test_missing_delegation_target


### PR DESCRIPTION
### Summary

Allow passing `:as` option allows to set up a custom name for the generated
method:

```ruby
class Parcel < Struct.new(:client)
  delegate :address, to: :client, as: :destination
end

parcel.destination # same as parcel.client.address
```

### Other Information

This option can be useful when the delegated method name is too long or not very meaningful in the context of a current class. Currently in order to do that I have to do something like

```ruby
class Parcel < Struct.new(:client)
  delegate :address, to: :client
  alias_method destination  address
end
```

or

```ruby
class Parcel < Struct.new(:client)
  def destination
    client.address
  end
end
```

Limitations:

- throws an exception when both :as and :prefix options are provided
- only one method can be delegated when :as option is passed