### PR TITLE
Using write with unless_exist + expires_in should unlock after the gi…

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix bug to make memcached write_entry expire correctly with unless_exist
+
+    *Jye Lee*
+
 *   Add block support to `ActiveSupport::Testing::TimeHelpers#travel_back`.
 
     *Tim Masliuchenko*

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -151,7 +151,7 @@ module ActiveSupport
           method = options && options[:unless_exist] ? :add : :set
           value = options[:raw] ? entry.value.to_s : entry
           expires_in = options[:expires_in].to_i
-          if expires_in > 0 && !options[:raw]
+          if expires_in > 0 && !options[:raw] && !options[:unless_exist]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
             expires_in += 5.minutes
           end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -104,6 +104,20 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_unless_exist_expires_when_configured
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store)
+    called = nil
+    server = Class.new do
+      define_method(:add) { |*args| called = args }
+      def with
+        yield self
+      end
+    end
+    cache.instance_variable_set(:@data, server.new)
+    assert cache.write("foo", "bar", expires_in: 1, unless_exist: true)
+    assert_equal 1, called[2]
+  end
+
   def test_read_should_return_a_different_object_id_each_time_it_is_called
     @cache.write("foo", "bar")
     value = @cache.read("foo")


### PR DESCRIPTION
…ven expires_in and not 5 minutes later

### Summary
Reproduce by using Rails.cache.write('foo', unless_exist: true, expires_in: 1) and then wait 2 seconds
to call it again ... it should not return false

/cc @bdurand @sobrinho @pixeltrix 