### PR TITLE
Make actionview templates marshalable

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -235,6 +235,15 @@ module ActionView
       end
     end
 
+    def marshal_dump
+      [ @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @formats, @variants ]
+    end
+
+    def marshal_load(array)
+      @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @formats, @variants = *array
+      @compile_mutex = Mutex.new
+    end
+
     private
 
       # Compile a template. This method ensures a template is compiled

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -196,6 +196,13 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_match(Regexp.new("\xFC"), e.message)
   end
 
+  def test_template_is_marshalable
+    template = new_template
+    serialized = Marshal.load(Marshal.dump(template))
+    assert_equal template.identifier, serialized.identifier
+    assert_equal template.source, serialized.source
+  end
+
   def with_external_encoding(encoding)
     old = Encoding.default_external
     Encoding::Converter.new old, encoding if old != encoding


### PR DESCRIPTION
When running parallel tests, any errors raised in an ActionView::Template are reported as `DRb::DRbServerNotFound (DRb::DRbConnError)`.

This is because this errors contain references to the template, which contain reference a `Mutex` which can't be marshalled.

This PR makes the `Marshal.dump`ing of a template exclude the `Mutex` so that it can be transmitted over `DRb`.