### PR TITLE
Require the except hash extension before trying to alias it

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/reverse_merge"
+require "active_support/core_ext/hash/except"
 
 module ActiveSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered


### PR DESCRIPTION
#34012 added an alias to to `except` for `HashWithIndiferentAccess`, but the `except` method comes from a core extension which may not have been required. 

The PR adds a require for the `except` method so that it is always available for aliasing.

Should fix some build issues with #33079.