### PR TITLE
Make it easier to find abort documentation

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -23,6 +23,9 @@ module ActiveSupport
   # +ClassMethods.set_callback+), and run the installed callbacks at the
   # appropriate times (via +run_callbacks+).
   #
+  # By default callbacks are halted by throwing +:abort+.
+  # See +ClassMethods.define_callbacks+ for details.
+  #
   # Three kinds of callbacks are supported: before callbacks, run before a
   # certain event; after callbacks, run after the event; and around callbacks,
   # blocks that surround the event, triggering it when they yield. Callback code


### PR DESCRIPTION
### Summary

Make sure how to abort is documented on https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html

It is important enough to be mentioned in the guide. So it should also be important enough to include in the class description.

And I wasted some time looking through the code because I didn't think to look in the guide first...