### PR TITLE
Add pluralization for 'canvas'

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -31,6 +31,7 @@ module ActiveSupport
     inflect.plural(/^(ox)$/i, '\1en')
     inflect.plural(/^(oxen)$/i, '\1')
     inflect.plural(/(quiz)$/i, '\1zes')
+    inflect.plural(/(canva)s$/i, '\1ses')
 
     inflect.singular(/s$/i, "")
     inflect.singular(/(ss)$/i, '\1')
@@ -59,6 +60,7 @@ module ActiveSupport
     inflect.singular(/(matr)ices$/i, '\1ix')
     inflect.singular(/(quiz)zes$/i, '\1')
     inflect.singular(/(database)s$/i, '\1')
+    inflect.singular(/(canvas)(es)?$/i, '\1')
 
     inflect.irregular("person", "people")
     inflect.irregular("man", "men")

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -79,7 +79,7 @@ module InflectorTestCases
     "information" => "information",
     "equipment"   => "equipment",
     "bus"         => "buses",
-    "canvas"         => "canvases",
+    "canvas"      => "canvases",
     "status"      => "statuses",
     "status_code" => "status_codes",
     "mouse"       => "mice",

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -79,6 +79,7 @@ module InflectorTestCases
     "information" => "information",
     "equipment"   => "equipment",
     "bus"         => "buses",
+    "canvas"         => "canvases",
     "status"      => "statuses",
     "status_code" => "status_codes",
     "mouse"       => "mice",


### PR DESCRIPTION
### Summary

This is a proposed fix for the pluralization of the word "canvas." Related issue: #34035 

This is only my second time contributing to open source (and my first time contributing to an active project), so please let me know if I'm doing anything wrong.

Cheers,

Ian