### PR TITLE
`atomic_write`: Ensure correct permission when `tmpdir` is the same as `dirname`.

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -29,7 +29,7 @@ class File
       old_stat = if exist?(file_name)
         # Get original file permissions
         stat(file_name)
-      elsif temp_dir != dirname(file_name)
+      else
         # If not possible, probe which are the default permissions in the
         # destination directory.
         probe_stat_in(dirname(file_name))

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -59,6 +59,20 @@ class AtomicWriteTest < ActiveSupport::TestCase
     File.unlink(file_name) rescue nil
   end
 
+  def test_atomic_write_preserves_file_permissions_same_directory
+    Dir.mktmpdir do |temp_dir|
+      File.chmod 0700, temp_dir
+
+      probed_permissions = File.probe_stat_in(temp_dir).mode.to_s(8)
+
+      File.atomic_write(File.join(temp_dir, file_name), &:close)
+
+      actual_permissions = File.stat(File.join(temp_dir, file_name)).mode.to_s(8)
+
+      assert_equal actual_permissions, probed_permissions
+    end
+  end
+
   def test_atomic_write_returns_result_from_yielded_block
     block_return_value = File.atomic_write(file_name, Dir.pwd) do |file|
       "Hello world!"


### PR DESCRIPTION
`Tempfile.open` does not use the same permissions as `FileUtils.touch` uses when the directory does not have default permissions, so always probe the permissions, even if the `tmpdir` is the same as the file's `dirname`.