### PR TITLE
add public_send to included instance methods

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -36,7 +36,7 @@ module ActiveRecord
     class CollectionProxy # :nodoc:
       alias :proxy_extend :extend
 
-      instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|object_id|to_a)$|^__|^respond_to|proxy_/ }
+      instance_methods.each { |m| undef_method m unless m.to_s =~ /^(?:nil\?|send|public_send|object_id|to_a)$|^__|^respond_to|proxy_/ }
 
       delegate :group, :order, :limit, :joins, :where, :preload, :eager_load, :includes, :from,
                :lock, :readonly, :having, :pluck, :to => :scoped


### PR DESCRIPTION
### Summary
(For Rails 3.2)

Patch for Issue #34040 

Simply adds public_send to list of instance methods in ActiveRecord::Associations::CollectionProxy
