### PR TITLE
Deprecate the `LoggerSilence` constant:

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate the use of `LoggerSilence` in favor of `ActiveSupport::LoggerSilence`
+
+    *Edouard Chin*
+
 *   Deprecate using negative limits in `String#first` and `String#last`.
 
     *Gannon McGibbon*, *Eric Turner*

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -7,22 +7,37 @@ module LoggerSilence
   extend ActiveSupport::Concern
 
   included do
-    cattr_accessor :silencer, default: true
+    ActiveSupport::Deprecation.warn(
+      "Including LoggerSilence is deprecated and will be removed in Rails 6.1. " \
+      "Please use `ActiveSupport::LoggerSilence` instead"
+    )
+
+    include ActiveSupport::LoggerSilence
   end
+end
 
-  # Silences the logger for the duration of the block.
-  def silence(temporary_level = Logger::ERROR)
-    if silencer
-      begin
-        old_local_level            = local_level
-        self.local_level           = temporary_level
+module ActiveSupport
+  module LoggerSilence
+    extend ActiveSupport::Concern
 
+    included do
+      cattr_accessor :silencer, default: true
+    end
+
+    # Silences the logger for the duration of the block.
+    def silence(temporary_level = Logger::ERROR)
+      if silencer
+        begin
+          old_local_level            = local_level
+          self.local_level           = temporary_level
+
+          yield self
+        ensure
+          self.local_level = old_local_level
+        end
+      else
         yield self
-      ensure
-        self.local_level = old_local_level
       end
-    else
-      yield self
     end
   end
 end

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -114,6 +114,14 @@ module ActiveSupport
       assert_equal [[::Logger::FATAL, "seen", nil]], log2.adds
     end
 
+    test "Including top constant LoggerSilence is deprecated" do
+      assert_deprecated("Please use `ActiveSupport::LoggerSilence`") do
+        logger = Class.new(CustomLogger) do
+          include ::LoggerSilence
+        end
+      end
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level
@@ -166,7 +174,7 @@ module ActiveSupport
     end
 
     class FakeLogger < CustomLogger
-      include LoggerSilence
+      include ActiveSupport::LoggerSilence
     end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -119,12 +119,12 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 * `config.logger` is the logger that will be used for `Rails.logger` and any related Rails logging such as `ActiveRecord::Base.logger`. It defaults to an instance of `ActiveSupport::TaggedLogging` that wraps an instance of `ActiveSupport::Logger` which outputs a log to the `log/` directory. You can supply a custom logger, to get full compatibility you must follow these guidelines:
   * To support a formatter, you must manually assign a formatter from the `config.log_formatter` value to the logger.
   * To support tagged logs, the log instance must be wrapped with `ActiveSupport::TaggedLogging`.
-  * To support silencing, the logger must include `LoggerSilence` and `ActiveSupport::LoggerThreadSafeLevel` modules. The `ActiveSupport::Logger` class already includes these modules.
+  * To support silencing, the logger must include `ActiveSupport::LoggerSilence` and `ActiveSupport::LoggerThreadSafeLevel` modules. The `ActiveSupport::Logger` class already includes these modules.
 
     ```ruby
     class MyLogger < ::Logger
       include ActiveSupport::LoggerThreadSafeLevel
-      include LoggerSilence
+      include ActiveSupport::LoggerSilence
     end
 
     mylogger           = MyLogger.new(STDOUT)


### PR DESCRIPTION
- I found this weird that the LoggerSilence wasn't using the
  `ActiveSupport` namespace (AFAIK all other classes have it).

  This PR deprecate the use of `LoggerSilence` for
  `ActiveSupport::LoggerSilence` instead.

