### PR TITLE
Remove unnecessary `coffee-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "rake", ">= 11.1"
 gem "capybara", ">= 2.15"
 
 gem "rack-cache", "~> 1.2"
-gem "coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
 gem "webpacker", github: "rails/webpacker", require: ENV["SKIP_REQUIRE_WEBPACKER"] != "true"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,9 +193,6 @@ GEM
     chromedriver-helper (2.0.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -529,7 +526,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
-  coffee-rails
   connection_pool
   dalli
   delayed_job


### PR DESCRIPTION
Since we no longer use coffeescript in the generated files by 4838c1716a0340137d858fab49bf460e23be5a4b, this is no longer necessary.
