### PR TITLE
Prefix Module#parent, Module#parents, and Module#parent_name with module

### DIFF
--- a/actionpack/lib/action_controller/railties/helpers.rb
+++ b/actionpack/lib/action_controller/railties/helpers.rb
@@ -7,7 +7,7 @@ module ActionController
         super
         return unless klass.respond_to?(:helpers_path=)
 
-        if namespace = klass.parents.detect { |m| m.respond_to?(:railtie_helpers_paths) }
+        if namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_helpers_paths) }
           paths = namespace.railtie_helpers_paths
         else
           paths = ActionController::Helpers.helpers_path

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -444,7 +444,7 @@ module ActionDispatch
       end
 
       def include_helpers_now(klass, include_path_helpers)
-        namespace = klass.parents.detect { |m| m.respond_to?(:railtie_include_helpers) }
+        namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_include_helpers) }
 
         if namespace && namespace.railtie_namespace.routes != self
           namespace.railtie_include_helpers(klass, include_path_helpers)

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -252,7 +252,7 @@ module ActiveModel
     #   Person.model_name.plural   # => "people"
     def model_name
       @_model_name ||= begin
-        namespace = parents.detect do |n|
+        namespace = module_parents.detect do |n|
           n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
         end
         ActiveModel::Name.new(self, namespace)

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -24,7 +24,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       if block_given?
         extension_module_name = "#{model.name.demodulize}#{name.to_s.camelize}AssociationExtension"
         extension = Module.new(&Proc.new)
-        model.parent.const_set(extension_module_name, extension)
+        model.module_parent.const_set(extension_module_name, extension)
       end
     end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -218,11 +218,11 @@ module ActiveRecord
       end
 
       def full_table_name_prefix #:nodoc:
-        (parents.detect { |p| p.respond_to?(:table_name_prefix) } || self).table_name_prefix
+        (module_parents.detect { |p| p.respond_to?(:table_name_prefix) } || self).table_name_prefix
       end
 
       def full_table_name_suffix #:nodoc:
-        (parents.detect { |p| p.respond_to?(:table_name_suffix) } || self).table_name_suffix
+        (module_parents.detect { |p| p.respond_to?(:table_name_suffix) } || self).table_name_suffix
       end
 
       # The array of names of environments where destructive actions should be prohibited. By default,
@@ -503,9 +503,9 @@ module ActiveRecord
         def compute_table_name
           if base_class?
             # Nested classes are prefixed with singular parent table name.
-            if parent < Base && !parent.abstract_class?
-              contained = parent.table_name
-              contained = contained.singularize if parent.pluralize_table_names
+            if module_parent < Base && !module_parent.abstract_class?
+              contained = module_parent.table_name
+              contained = contained.singularize if module_parent.pluralize_table_names
               contained += "_"
             end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Rename `Module#parent`, `Module#parents`, and `Module#parent_name` to
+    `module_parent`, `module_parents`, and `module_parent_name`.
+
+    *Gannon McGibbon*
+
 *   Deprecate using negative limits in `String#first` and `String#last`.
 
     *Gannon McGibbon*, *Eric Turner*

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -5,8 +5,8 @@ require "active_support/inflector"
 class Module
   # Returns the name of the module containing this one.
   #
-  #   M::N.parent_name # => "M"
-  def parent_name
+  #   M::N.module_parent_name # => "M"
+  def module_parent_name
     if defined?(@parent_name)
       @parent_name
     else
@@ -14,6 +14,14 @@ class Module
       @parent_name = parent_name unless frozen?
       parent_name
     end
+  end
+
+  def parent_name
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      `Module#parent_name` has been renamed to `module_parent_name`.
+      `parent_name` is deprecated and will be removed in Rails 6.1.
+    MSG
+    module_parent_name
   end
 
   # Returns the module which contains this one according to its name.
@@ -24,15 +32,23 @@ class Module
   #   end
   #   X = M::N
   #
-  #   M::N.parent # => M
-  #   X.parent    # => M
+  #   M::N.module_parent # => M
+  #   X.module_parent    # => M
   #
   # The parent of top-level and anonymous modules is Object.
   #
-  #   M.parent          # => Object
-  #   Module.new.parent # => Object
+  #   M.module_parent          # => Object
+  #   Module.new.module_parent # => Object
+  def module_parent
+    module_parent_name ? ActiveSupport::Inflector.constantize(module_parent_name) : Object
+  end
+
   def parent
-    parent_name ? ActiveSupport::Inflector.constantize(parent_name) : Object
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      `Module#parent` has been renamed to `module_parent`.
+      `parent` is deprecated and will be removed in Rails 6.1.
+    MSG
+    module_parent
   end
 
   # Returns all the parents of this module according to its name, ordered from
@@ -44,13 +60,13 @@ class Module
   #   end
   #   X = M::N
   #
-  #   M.parents    # => [Object]
-  #   M::N.parents # => [M, Object]
-  #   X.parents    # => [M, Object]
-  def parents
+  #   M.module_parents    # => [Object]
+  #   M::N.module_parents # => [M, Object]
+  #   X.module_parents    # => [M, Object]
+  def module_parents
     parents = []
-    if parent_name
-      parts = parent_name.split("::")
+    if module_parent_name
+      parts = module_parent_name.split("::")
       until parts.empty?
         parents << ActiveSupport::Inflector.constantize(parts * "::")
         parts.pop
@@ -58,5 +74,13 @@ class Module
     end
     parents << Object unless parents.include? Object
     parents
+  end
+
+  def parents
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      `Module#parents` has been renamed to `module_parents`.
+      `parents` is deprecated and will be removed in Rails 6.1.
+    MSG
+    module_parents
   end
 end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -521,8 +521,8 @@ module ActiveSupport #:nodoc:
         end
       elsif mod = autoload_module!(from_mod, const_name, qualified_name, path_suffix)
         return mod
-      elsif (parent = from_mod.parent) && parent != from_mod &&
-            ! from_mod.parents.any? { |p| p.const_defined?(const_name, false) }
+      elsif (parent = from_mod.module_parent) && parent != from_mod &&
+            ! from_mod.module_parents.any? { |p| p.const_defined?(const_name, false) }
         # If our parents do not have a constant named +const_name+ then we are free
         # to attempt to load upwards. If they do have such a constant, then this
         # const_missing must be due to from_mod::const_name, which should not

--- a/activesupport/test/core_ext/module/introspection_test.rb
+++ b/activesupport/test/core_ext/module/introspection_test.rb
@@ -15,25 +15,43 @@ module ParentA
 end
 
 class IntrospectionTest < ActiveSupport::TestCase
-  def test_parent_name
-    assert_equal "ParentA", ParentA::B.parent_name
-    assert_equal "ParentA::B", ParentA::B::C.parent_name
-    assert_nil ParentA.parent_name
+  def test_module_parent_name
+    assert_equal "ParentA", ParentA::B.module_parent_name
+    assert_equal "ParentA::B", ParentA::B::C.module_parent_name
+    assert_nil ParentA.module_parent_name
   end
 
-  def test_parent_name_when_frozen
-    assert_equal "ParentA", ParentA::FrozenB.parent_name
-    assert_equal "ParentA::B", ParentA::B::FrozenC.parent_name
+  def test_module_parent_name_when_frozen
+    assert_equal "ParentA", ParentA::FrozenB.module_parent_name
+    assert_equal "ParentA::B", ParentA::B::FrozenC.module_parent_name
+  end
+
+  def test_parent_name
+    assert_deprecated do
+      assert_equal "ParentA", ParentA::B.parent_name
+    end
+  end
+
+  def test_module_parent
+    assert_equal ParentA::B, ParentA::B::C.module_parent
+    assert_equal ParentA, ParentA::B.module_parent
+    assert_equal Object, ParentA.module_parent
   end
 
   def test_parent
-    assert_equal ParentA::B, ParentA::B::C.parent
-    assert_equal ParentA, ParentA::B.parent
-    assert_equal Object, ParentA.parent
+    assert_deprecated do
+      assert_equal ParentA, ParentA::B.parent
+    end
+  end
+
+  def test_module_parents
+    assert_equal [ParentA::B, ParentA, Object], ParentA::B::C.module_parents
+    assert_equal [ParentA, Object], ParentA::B.module_parents
   end
 
   def test_parents
-    assert_equal [ParentA::B, ParentA, Object], ParentA::B::C.parents
-    assert_equal [ParentA, Object], ParentA::B.parents
+    assert_deprecated do
+      assert_equal [ParentA, Object], ParentA::B.parents
+    end
   end
 end

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -224,7 +224,7 @@ module Rails
     end
 
     def railtie_namespace #:nodoc:
-      @railtie_namespace ||= self.class.parents.detect { |n| n.respond_to?(:railtie_namespace) }
+      @railtie_namespace ||= self.class.module_parents.detect { |n| n.respond_to?(:railtie_namespace) }
     end
 
     protected


### PR DESCRIPTION
### Summary

Adds `module_` prefix to `Module#parent`, `Module#parents`, and `Module#parent_name`.

As discussed in https://github.com/rails/rails/pull/20901, `parents` isn't a blacklisted class attribute for model scopes. Using a `parents` scope will result in a `SystemStackError `.

An alternate approach would be to disallow `parents` as a valid scope name, or find a better prefix than `module_` because it can include classes which are technically modules but could be better represented.

I'll look into fixing call sites once we decide what the best course of action is.

r? @rafaelfranca 

/cc @dhh, @sgrif 