### PR TITLE
Move query cache question to the handler instead of pool

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Move question of whether query cache is on from the pool to the connection
+    handler. This fixes cases where a database is connected after the application
+    is booted. This would occur in development or test in applications that use
+    multiple databases.
+
+    *Eileen M. Uchitelle*, *Aaron Patterson*
+
 *   Add basic API for connection switching to support multiple databases.
 
     1) Adds a `connects_to` method for models to connect to multiple databases. Example:
@@ -73,7 +80,6 @@
         end
 
     *Mehmet Emin İNAÇ*
-
 *   Fix `transaction` reverting for migrations.
 
     Before: Commands inside a `transaction` in a reverted migration ran uninverted.


### PR DESCRIPTION
If a connection is connected to the database after boot (for example in
development, models are not eagerly loaded) the query cache won't be
applied to queries to that model until the second request. On one-hand
this is _just_ development and test, but query cache is kind of
mysterious and it's a pain to test it on production. I think it's
important for it to behave the same in dev/test so that testing is
easier.

This is especially important for multiple databases. In a standard
application this isn't a problem - there's only one connection and it's
connected on boot. However, in a multiple database application, the
additional models are connected after boot, on the first request to that
database (lazily). So the first request with multiple queries to that
second database won't be cached at all.

To fix this scenario we've moved the question of whether the cache
should be turned on up to the handler. Since the handler will always be
connected, connections that are added to that handler after boot will
get the cache also.

The test here was deleted because it broke. But the broken test wasn't
something that was possible in the Real World anyway. The test was
establishing a connection in one thread and another thread was asking if
the query cache was on. In an application this would and should break in
unexpected ways.

[Eileen M. Uchitelle + Aaron Patterson]

cc/ @matthewd @rafaelfranca @tenderlove 