### PR TITLE
Extend doc for ActiveSupport::Cache#fetch_multi

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -411,8 +411,6 @@ module ActiveSupport
       # to the cache. If you do not want to write the cache when the cache is
       # not found, use #read_multi.
       #
-      # Options are passed to the underlying cache implementation.
-      #
       # Returns a hash with the data for each of the names. For example:
       #
       #   cache.write("bim", "bam")
@@ -422,6 +420,17 @@ module ActiveSupport
       #   # => { "bim" => "bam",
       #   #      "unknown_key" => "Fallback value for key: unknown_key" }
       #
+      # Options are passed to the underlying cache implementation. For example:
+      #
+      #   cache.fetch_multi("fizz", expires_in: 5.seconds) do |key|
+      #     "buzz"
+      #   end
+      #   # => {"fizz"=>"buzz"}
+      #   cache.read("fizz")
+      #   # => "buzz"
+      #   sleep(6)
+      #   cache.read("fizz")
+      #   # => nil
       def fetch_multi(*names)
         raise ArgumentError, "Missing block: `Cache#fetch_multi` requires a block." unless block_given?
 


### PR DESCRIPTION
### Summary

Current documentation for `ActiveSupport::Cache#fetch_multi` method reads:

`Options are passed to the underlying cache implementation.`

But does not provides an example.
Also, given that the method argument signature says (*names) is difficult to understand, without looking at the source code, how to pass options to this method.

I have updated the documentation added an example on how to do this.
