### PR TITLE
Remove newline from encrypted strings, and provide detail error message when decrypt failed

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -182,7 +182,12 @@ module ActiveSupport
 
       def _decrypt(encrypted_message, purpose)
         cipher = new_cipher
-        encrypted_data, iv, auth_tag = encrypted_message.split("--").map { |v| ::Base64.strict_decode64(v) }
+        begin
+          encrypted_data, iv, auth_tag = encrypted_message.gsub("\n", '').split("--".freeze).map { |v| ::Base64.strict_decode64(v) }
+        rescue
+          raise InvalidMessage, "Given encrypted message cannot be parsed by Base64. " \
+            "Please check your credentials is correct: \n\n#{encrypted_message}"
+        end
 
         # Currently the OpenSSL bindings do not raise an error if auth_tag is
         # truncated, which would allow an attacker to easily forge it. See


### PR DESCRIPTION
Hi, thank you for the great work.
This is my first time to create PR to Rails, so I am sorry if I have something missing.

# Summary

When I run `bin/rails credentials:edit` I got `ActiveSupport::MessageEncryptor::InvalidMessage`.
This is because `config/credentials.yml.enc` has trailing new line.

I spent few hours figuring this out, because I thought the `config/master.key` was wrong at first, wheares `config/credentials.yml.enc` was wrong.

As a solution, I wrote the following features:

- Remove new line from encrypted_message before decryption
- Provide detail error messages

Some text editor and Git hook add newline at the end of file, so this problem can be found commonly.

Best Regards,