### PR TITLE
Fix preload with limit scope association

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -94,7 +94,11 @@ module ActiveRecord
             # Make several smaller queries if necessary or make one query if the adapter supports it
             slices = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
             @preloaded_records = slices.flat_map do |slice|
-              records_for(slice, &block)
+              if scope.limit_value
+                slice.flat_map { |owner_key| records_for(owner_key, &block) }
+              else
+                records_for(slice, &block)
+              end
             end
             @preloaded_records.group_by do |record|
               convert_key(record[association_key_name])

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1203,6 +1203,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 2, post_with_readers.lazy_readers_skimmers_or_not.to_a.size
   end
 
+  def test_preload_has_many_with_limit_scope
+    Post.preload(:latest_comments).each do |post|
+      assert_equal post.latest_comments.length, [2, post.comments.length].min
+    end
+  end
+
   def test_eager_loading_with_conditions_on_string_joined_table_preloads
     posts = assert_queries(2) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: "INNER JOIN comments on comments.post_id = posts.id", where: "comments.body like 'Thank you%'", order: "posts.id").to_a

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -88,6 +88,7 @@ class Post < ActiveRecord::Base
   has_one :very_special_comment_with_post_with_joins, -> { joins(:post).order("posts.id") }, class_name: "VerySpecialComment"
   has_many :special_comments
   has_many :nonexistent_comments, -> { where "comments.id < 0" }, class_name: "Comment"
+  has_many :latest_comments, -> { order(id: :desc).limit(2) }, class_name: "Comment"
 
   has_many :special_comments_ratings, through: :special_comments, source: :ratings
   has_many :special_comments_ratings_taggings, through: :special_comments_ratings, source: :taggings


### PR DESCRIPTION
### Summary

partially fix #15854

If you have model association with limit scope like below code, 

```.rb
class Blog < ActiveRecord::Base
  has_many :limited_posts, -> {order(:id).limit(2)}, class_name: 'Post'
as tag_count')}, class_name: 'Post'
end

class Post < ActiveRecord::Base
  belongs_to :blog
end
```

some unexpected behavior happened.

``` .rb
Blog.preload(:limited_posted)
=>
SELECT "blogs".* FROM "blogs" ORDER BY "blogs"."id" ASC
SELECT "posts".* FROM "posts" WHERE "posts"."blog_id" IN (?, ?) ORDER BY "posts"."id" ASC LIMIT ?  [["blog_id", 1], ["blog_id", 2], ["LIMIT", 2]]
```

I expect has_many association with limit scope is instance level, expected behavior is below. (Please advise me if I'm wrong.)

``` .rb
Blog.preload(:limited_posted)
=>
SELECT "blogs".* FROM "blogs" ORDER BY "blogs"."id" ASC
SELECT "posts".* FROM "posts" WHERE "posts"."blog_id" = ? ORDER BY "posts"."id" ASC LIMIT ?  [["blog_id", 1], ["LIMIT", 2]]
SELECT "posts".* FROM "posts" WHERE "posts"."blog_id" = ? ORDER BY "posts"."id" ASC LIMIT ?  [["blog_id", 2], ["LIMIT", 2]]
```

I changed preload association behavior to fix this problem.