### PR TITLE
Fix rubocop issue

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -235,7 +235,7 @@ module ActionView
       end
     end
 
-    
+
     # Exceptions are marshalled when using the parallel test runner with DRb, so we need
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.


### PR DESCRIPTION
Fixes: `Layout/TrailingWhitespace: Trailing whitespace detected.

See https://codeclimate.com/github/rails/rails/issues

Not sure whether this line should be removed since we use two empty lines in order to express a group of methods.

Releted to b707a6d0eb7