### PR TITLE
Faster cache by avoiding `try` call.

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -653,7 +653,7 @@ module ActiveSupport
         end
 
         def normalize_version(key, options = nil)
-          (options && options[:version].try(:to_param)) || expanded_version(key)
+          (options && options[:version]&.try(:to_param)) || expanded_version(key)
         end
 
         def expanded_version(key)


### PR DESCRIPTION
Before: Total allocated: 741573 bytes (6638 objects)
After: Total allocated: 737853 bytes (6534 objects)
Diff: (741573 - 737853) / 741573.0 # => 0.5 %

The common case for this try is that there is no version provided, i.e. it is `nil`. When that happens the `try` is very slow and even with optimizations still allocates. Adding in a nil check (via lonely operator) is faster than a raw `try` in the case it is getting a nil, and not noticeably different the case where it is not nil.

```
require 'benchmark/ips'

nil_case = nil

Benchmark.ips do |x|
  x.report("nil &. ") { nil_case&.try(:foo) }
  x.report("nil try") { nil_case.try(:foo) }
  x.compare!
end
# Warming up --------------------------------------
#              nil &.    309.913k i/100ms
#              nil try   192.341k i/100ms
# Calculating -------------------------------------
#              nil &.      11.042M (± 6.4%) i/s -     55.165M in   5.022975s
#              nil try      3.569M (± 7.7%) i/s -     17.888M in   5.043223s

# Comparison:
#              nil &. : 11042472.9 i/s
#              nil try:  3568893.8 i/s - 3.09x  slower

foo_case = Class.new { def foo; "foo" end }.new

Benchmark.ips do |x|
  x.report("non-nil &. ") { foo_case&.try(:foo) }
  x.report("non-nil try") { foo_case.try(:foo) }
  x.compare!
end
# Warming up --------------------------------------
#          non-nil &.
#    147.334k i/100ms
#          non-nil try   138.635k i/100ms
# Calculating -------------------------------------
#          non-nil &.       2.258M (± 4.8%) i/s -     11.345M in   5.036496s
#          non-nil try      2.045M (±12.8%) i/s -     10.120M in   5.043652s

# Comparison:
#          non-nil &. :  2258024.8 i/s
#          non-nil try:  2044922.0 i/s - same-ish: difference falls within error
```

We can make the NilClass version of `try` faster by applying the same technique as before

```
  def try(method_name = nil, *args)
    nil
  end
```

However, it is still much slower than `&.`.