### PR TITLE
23% faster Nil#try

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -143,14 +143,14 @@ class NilClass
   #
   # With +try+
   #   @person.try(:children).try(:first).try(:name)
-  def try(*args)
+  def try(method_name = nil, *args)
     nil
   end
 
   # Calling +try!+ on +nil+ always returns +nil+.
   #
   #   nil.try!(:name) # => nil
-  def try!(*args)
+  def try!(method_name = nil, *args)
     nil
   end
 end


### PR DESCRIPTION
~~This PR speeds up Nil#try by avoiding an allocation when only one argument is passed:~~

```ruby
class FooNew
  def try(method_name = nil, *args)
    nil
  end
end

class FooOld
  def try(*args)
    nil
  end
end

require 'benchmark/ips'


foo_new = FooNew.new
foo_old = FooOld.new

Benchmark.ips do |x|
  x.report("new") { foo_new.try(:anything) }
  x.report("old") { foo_old.try(:anything) }
  x.compare!
end
# Warming up --------------------------------------
#                  new   250.633k i/100ms
#                  old   232.322k i/100ms
# Calculating -------------------------------------
#                  new      6.476M (± 4.8%) i/s -     32.332M in   5.005777s
#                  old      5.258M (± 3.2%) i/s -     26.485M in   5.042589s

# Comparison:
#                  new:  6476002.5 i/s
#                  old:  5257912.5 i/s - 1.23x  slower
```

It's worth noting that checking for nil separately as in https://github.com/rails/rails/pull/34067 seems to be MUCH faster. It might be worth it to apply a blanket `&.` to every internal `try` call.
