### PR TITLE
Deep dup default route params.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActionController::Parameters` no longer destroys the route defaults.
+
+    Previously, `Journey::Route#defaults[:action]` object was exactly the same
+    as `params[:action]`.
+    This was a problem that the next request did not work as expected
+    if `params[:action]` was substituted in-place (like `params[:action].sub!(/foo/, "bar")`).
+
+    *Kaito Minatoya*
+
 *   Remove undocumented `params` option from `url_for` helper.
 
     *Ilkka Oksanen*

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -43,7 +43,7 @@ module ActionDispatch
             req.path_info = "/" + req.path_info unless req.path_info.start_with? "/"
           end
 
-          parameters = route.defaults.merge parameters.transform_values { |val|
+          parameters = route.defaults.deep_dup.merge parameters.transform_values { |val|
             val.dup.force_encoding(::Encoding::UTF_8)
           }
 


### PR DESCRIPTION
If default route params (like params[:action]) is substituted in-place after Journey::Router#serve, next request that matches to same controller/action won't work as expected.
To prevent it, we should replace values at the timing of the path_parameters generated.
