### PR TITLE
Mention active_storage/engine as install instruction note

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -16,6 +16,8 @@ A key difference to how Active Storage works compared to other attachment soluti
 
 Run `rails active_storage:install` to copy over active_storage migrations.
 
+NOTE: If the rake task cannot be found, verify that `require "active_storage/engine"` is present in `config/application.rb`.
+
 ## Examples
 
 One attachment:

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -16,7 +16,7 @@ A key difference to how Active Storage works compared to other attachment soluti
 
 Run `rails active_storage:install` to copy over active_storage migrations.
 
-NOTE: If the rake task cannot be found, verify that `require "active_storage/engine"` is present in `config/application.rb`.
+NOTE: If the task cannot be found, verify that `require "active_storage/engine"` is present in `config/application.rb`.
 
 ## Examples
 


### PR DESCRIPTION
### Summary

I was updating a rails api only server from 5.1 to 5.2 and ran into this: 
```
rails aborted!
Don't know how to build task 'active_storage:install' (see --tasks)
```
I'm not sure if api-only matters since it seems active_storage was just added in 5.2? After some googling I got to a stack overflow post [here](https://stackoverflow.com/questions/50781131/rails-active-storageinstall-is-not-working) but it may be worth mentioning in the docs
