### PR TITLE
Add `skip-webpack-install` option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -399,6 +399,10 @@ module Rails
         !options[:skip_spring] && !options.dev? && Process.respond_to?(:fork) && !RUBY_PLATFORM.include?("cygwin")
       end
 
+      def webpack_install?
+        !(options[:skip_javascript] || options[:skip_webpack_install])
+      end
+
       def depends_on_system_test?
         !(options[:skip_system_test] || options[:skip_test] || options[:api])
       end
@@ -420,7 +424,7 @@ module Rails
       end
 
       def run_webpack
-        unless options[:skip_javascript]
+        if webpack_install?
           rails_command "webpacker:install"
           rails_command "webpacker:install:#{options[:webpack]}" if options[:webpack] && options[:webpack] != "webpack"
         end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -261,6 +261,9 @@ module Rails
       class_option :webpack, type: :string, default: nil,
                              desc: "Preconfigure Webpack with a particular framework (options: #{WEBPACKS.join('/')})"
 
+      class_option :skip_webpack_install, type: :boolean, default: false,
+                                          desc: "Don't run Webpack install"
+
       def initialize(*args)
         super
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -98,6 +98,7 @@ task default: :test
       opts[:skip_listen] = true
       opts[:skip_git] = true
       opts[:skip_turbolinks] = true
+      opts[:skip_webpack_install] = true
       opts[:dummy_app] = true
 
       invoke Rails::Generators::AppGenerator,

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -68,7 +68,7 @@ module Rails
           capture(:stdout) do
             args += ["--skip-bundle"] unless args.include? "--dev"
             args |= ["--skip-bootsnap"] unless args.include? "--no-skip-bootsnap"
-            args |= ["--skip-javascript"] unless args.include? "--no-skip-javascript"
+            args |= ["--skip-webpack-install"] unless args.include? "--no-skip-webpack-install"
 
             generator_class.start(args, config.reverse_merge(destination_root: destination_root))
           end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -113,7 +113,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_assets
-    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator
 
     assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track': 'reload'/)
     assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+'application', 'data-turbolinks-track': 'reload'/)
@@ -840,7 +840,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_if_skip_turbolinks_is_given
-    run_generator [destination_root, "--skip-turbolinks", "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator [destination_root, "--skip-turbolinks"]
 
     assert_no_gem "turbolinks"
     assert_file "app/views/layouts/application.html.erb" do |content|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -113,7 +113,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_assets
-    run_generator [destination_root, "--no-skip-javascript"]
+    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
 
     assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track': 'reload'/)
     assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+'application', 'data-turbolinks-track': 'reload'/)
@@ -840,7 +840,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_if_skip_turbolinks_is_given
-    run_generator [destination_root, "--skip-turbolinks", "--no-skip-javascript"]
+    run_generator [destination_root, "--skip-turbolinks", "--no-skip-javascript", "--skip-webpack-install"]
 
     assert_no_gem "turbolinks"
     assert_file "app/views/layouts/application.html.erb" do |content|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -825,6 +825,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "webpacker"
   end
 
+  def test_skip_webpack_install
+    command_check = -> command do
+      if command == "webpacker:install"
+        assert false, "webpacker:install expected not to be called."
+      end
+    end
+
+    generator([destination_root], skip_webpack_install: true).stub(:rails_command, command_check) do
+      quietly { generator.invoke_all }
+    end
+
+    assert_gem "webpacker"
+  end
+
   def test_generator_if_skip_turbolinks_is_given
     run_generator [destination_root, "--skip-turbolinks", "--no-skip-javascript"]
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -27,7 +27,7 @@ module SharedGeneratorTests
   end
 
   def test_skeleton_is_created
-    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator
 
     default_files.each { |path| assert_file path }
   end
@@ -196,7 +196,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_for_active_storage
-    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator
 
     unless generator_class.name == "Rails::Generators::PluginGenerator"
       assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
@@ -226,7 +226,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_if_skip_active_storage_is_given
-    run_generator [destination_root, "--skip-active-storage", "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator [destination_root, "--skip-active-storage"]
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
@@ -256,7 +256,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_does_not_generate_active_storage_contents_if_skip_active_record_is_given
-    run_generator [destination_root, "--skip-active-record", "--no-skip-javascript", "--skip-webpack-install"]
+    run_generator [destination_root, "--skip-active-record"]
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -27,7 +27,7 @@ module SharedGeneratorTests
   end
 
   def test_skeleton_is_created
-    run_generator [destination_root, "--no-skip-javascript"]
+    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
 
     default_files.each { |path| assert_file path }
   end
@@ -196,7 +196,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_for_active_storage
-    run_generator [destination_root, "--no-skip-javascript"]
+    run_generator [destination_root, "--no-skip-javascript", "--skip-webpack-install"]
 
     unless generator_class.name == "Rails::Generators::PluginGenerator"
       assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
@@ -226,7 +226,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_if_skip_active_storage_is_given
-    run_generator [destination_root, "--skip-active-storage", "--no-skip-javascript"]
+    run_generator [destination_root, "--skip-active-storage", "--no-skip-javascript", "--skip-webpack-install"]
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
@@ -256,7 +256,7 @@ module SharedGeneratorTests
   end
 
   def test_generator_does_not_generate_active_storage_contents_if_skip_active_record_is_given
-    run_generator [destination_root, "--skip-active-record", "--no-skip-javascript"]
+    run_generator [destination_root, "--skip-active-record", "--no-skip-javascript", "--skip-webpack-install"]
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 


### PR DESCRIPTION
This option is useful when want to check only the files generated by `rails new`, or if want to do something before `webpacker:install`. 

It is also useful to avoid running unnecessary `webpacker:install` in the generator test.
