### PR TITLE
Fix eager_logding with additional attribute via select

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -102,6 +102,13 @@ module ActiveRecord
         parents = model_cache[join_root]
         column_aliases = aliases.column_aliases join_root
 
+        # add custom select columns
+        alias_keys = aliases.columns.map(&:right)
+        result_set.columns[0...result_set.columns.length - alias_keys.length].each do |col|
+          raise(ConfigurationError, "Can't use select alias '#{col}. Please use other alias name.") if alias_keys.include?(col)
+          column_aliases << Aliases::Column.new(col, col)
+        end
+
         message_bus = ActiveSupport::Notifications.instrumenter
 
         payload = {

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1233,6 +1233,17 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal author_addresses(:david_address), authors[0].author_address
   end
 
+  def test_eager_loading_with_custom_select
+    posts = Post.eager_load(:author).select("1 as test_val")
+    assert_equal posts.first.test_val, 1
+  end
+
+  def test_eager_loading_with_custom_select_reserved_alias_name_raise_error
+    assert_raise(ActiveRecord::ConfigurationError) do
+      Post.eager_load(:author).select("1 as t0_r0").to_a
+    end
+  end
+
   def test_preload_belongs_to_uses_exclusive_scope
     people = Person.males.merge(includes: :primary_contact).to_a
     assert_not_equal people.length, 0


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/21197

Rails current behavior of `eager_loading` with `select` is not kind for developer.

```
post = Post.eager_load(:author).select('1 as test_val').first # => no error
post.test_val # => NoMethodError: undefined method `test_val' for Post
```

This behavior make developer confused.
Because he may think that select statement( '1 as test_val' ) is wrong.

So, I think correct behavior is either of these.
1. Raise error when `eager_load` with `select` additional attribute. Message should be like "eager_load is not accept additional attribute with select, use joins or preload instead."
2. Make accessible additional attributes.

This PR is 2nd approach.

For eager_load, it's not sure that 'additional attribute' belongs to which table.
But I think rails developer often think select attribute should belong to the base class (Post in above example).

Please advise me that what kind of approach it should be.
