### PR TITLE
Change contributing guide to suggest using safer force push

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -576,13 +576,13 @@ $ git rebase -i rails/master
 < Choose 'squash' for all of your commits except the first one. >
 < Edit the commit message to make sense, and describe all your changes. >
 
-$ git push fork my_new_branch -f
+$ git push fork my_new_branch --force-with-lease
 ```
 
 You should be able to refresh the pull request on GitHub and see that it has
 been updated.
 
-#### Updating pull request
+#### Updating a pull request
 
 Sometimes you will be asked to make some changes to the code you have
 already committed. This can include amending existing commits. In this
@@ -592,12 +592,13 @@ you can force push to your branch on GitHub as described earlier in
 squashing commits section:
 
 ```bash
-$ git push fork my_new_branch -f
+$ git push fork my_new_branch --force-with-lease
 ```
 
-This will update the branch and pull request on GitHub with your new code. Do
-note that using force push may result in commits being lost on the remote branch; use it with care.
-
+This will update the branch and pull request on GitHub with your new code.
+By force pushing with `--force-with-lease`, git will more safely update
+the remote than with a typical `-f`, which can delete work from the remote
+that you don't already have.
 
 ### Older Versions of Ruby on Rails
 


### PR DESCRIPTION
This PR changes the contributing guide in rails to suggest using git
with [force-with-lease](https://git-scm.com/docs/git-push#git-push---force-with-leaseltrefnamegt) over typical force pushing. In practice, most
rails contributors won't ever encounter a situation where updating their
local fork could result in lost changes as a result of a force push.

That being said, git is a complex tool and arcane flags like
force-with-lease are indeed safer, and by promoting it in rails, there's
a chance more people will discover it and use it in other contexts
outside of rails. In just the same way that herd immunity works by most
people being vaccinated, proliferating knowledge of force-with-lease
should help nudge people towards using safer git practices in general.