### PR TITLE
Fixtures refactor

### DIFF
--- a/activerecord/lib/active_record/fixture_set/model_metadata.rb
+++ b/activerecord/lib/active_record/fixture_set/model_metadata.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class FixtureSet
+    class ModelMetadata # :nodoc:
+      def initialize(model_class, table_name)
+        @model_class = model_class
+        @table_name  = table_name
+      end
+
+      def primary_key_name
+        @primary_key_name ||= @model_class && @model_class.primary_key
+      end
+
+      def primary_key_type
+        @primary_key_type ||= @model_class && @model_class.type_for_attribute(@model_class.primary_key).type
+      end
+
+      def has_primary_key_column?
+        @has_primary_key_column ||= primary_key_name &&
+          @model_class.columns.any? { |col| col.name == primary_key_name }
+      end
+
+      def timestamp_column_names
+        @timestamp_column_names ||=
+          %w(created_at created_on updated_at updated_on) & column_names
+      end
+
+      def inheritance_column_name
+        @inheritance_column_name ||= @model_class && @model_class.inheritance_column
+      end
+
+      private
+
+        def column_names
+          @column_names ||= @model_class.connection.columns(@table_name).collect(&:name)
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class FixtureSet
+    class TableRow # :nodoc:
+      def initialize(fixture, table_rows:, label:, now:)
+        @table_rows = table_rows
+        @label = label
+        @now = now
+        @row = fixture.to_hash
+        fill_row_model_attributes
+      end
+
+      def to_hash
+        @row
+      end
+
+      private
+
+        def model_metadata
+          @table_rows.model_metadata
+        end
+
+        def model_class
+          @table_rows.model_class
+        end
+
+        def fill_row_model_attributes
+          return unless model_class
+          fill_timestamps
+          interpolate_label
+          generate_primary_key
+          resolve_enums
+          @table_rows.resolve_sti_reflections(@row)
+        end
+
+        def reflection_class
+          @reflection_class ||= if @row.include?(model_metadata.inheritance_column_name)
+            @row[model_metadata.inheritance_column_name].constantize rescue model_class
+          else
+            model_class
+          end
+        end
+
+        def fill_timestamps
+          # fill in timestamp columns if they aren't specified and the model is set to record_timestamps
+          if model_class.record_timestamps
+            model_metadata.timestamp_column_names.each do |c_name|
+              @row[c_name] = @now unless @row.key?(c_name)
+            end
+          end
+        end
+
+        def interpolate_label
+          # interpolate the fixture label
+          @row.each do |key, value|
+            @row[key] = value.gsub("$LABEL", @label.to_s) if value.is_a?(String)
+          end
+        end
+
+        def generate_primary_key
+          # generate a primary key if necessary
+          if model_metadata.has_primary_key_column? && !@row.include?(model_metadata.primary_key_name)
+            @row[model_metadata.primary_key_name] = ActiveRecord::FixtureSet.identify(
+              @label, model_metadata.primary_key_type
+            )
+          end
+        end
+
+        def resolve_enums
+          model_class.defined_enums.each do |name, values|
+            if @row.include?(name)
+              @row[name] = values.fetch(@row[name], @row[name])
+            end
+          end
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/fixture_set/table_rows.rb
+++ b/activerecord/lib/active_record/fixture_set/table_rows.rb
@@ -6,6 +6,38 @@ require "active_record/fixture_set/model_metadata"
 module ActiveRecord
   class FixtureSet
     class TableRows # :nodoc:
+      class ReflectionProxy # :nodoc:
+        def initialize(association)
+          @association = association
+        end
+
+        def join_table
+          @association.join_table
+        end
+
+        def name
+          @association.name
+        end
+
+        def primary_key_type
+          @association.klass.type_for_attribute(@association.klass.primary_key).type
+        end
+      end
+
+      class HasManyThroughProxy < ReflectionProxy # :nodoc:
+        def rhs_key
+          @association.foreign_key
+        end
+
+        def lhs_key
+          @association.through_reflection.foreign_key
+        end
+
+        def join_table
+          @association.through_reflection.table_name
+        end
+      end
+
       def initialize(table_name, model_class:, fixtures:, config:)
         @table_name  = table_name
         @model_class = model_class

--- a/activerecord/lib/active_record/fixture_set/table_rows.rb
+++ b/activerecord/lib/active_record/fixture_set/table_rows.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "active_record/fixture_set/table_row"
+require "active_record/fixture_set/model_metadata"
+
+module ActiveRecord
+  class FixtureSet
+    class TableRows # :nodoc:
+      def initialize(table_name, model_class:, fixtures:, config:)
+        @table_name  = table_name
+        @model_class = model_class
+
+        # track any join tables we need to insert later
+        @tables = Hash.new { |h, table| h[table] = [] }
+
+        build_table_rows_from(fixtures, config)
+      end
+
+      attr_reader :table_name, :model_class
+
+      def to_hash
+        @tables.transform_values { |rows| rows.map(&:to_hash) }
+      end
+
+      def model_metadata
+        @model_metadata ||= ModelMetadata.new(model_class, table_name)
+      end
+
+      def resolve_sti_reflections(row)
+        # If STI is used, find the correct subclass for association reflection
+        reflection_class = reflection_class_for(row)
+
+        reflection_class._reflections.each_value do |association|
+          case association.macro
+          when :belongs_to
+            # Do not replace association name with association foreign key if they are named the same
+            fk_name = (association.options[:foreign_key] || "#{association.name}_id").to_s
+
+            if association.name.to_s != fk_name && value = row.delete(association.name.to_s)
+              if association.polymorphic? && value.sub!(/\s*\(([^\)]*)\)\s*$/, "")
+                # support polymorphic belongs_to as "label (Type)"
+                row[association.foreign_type] = $1
+              end
+
+              fk_type = reflection_class.type_for_attribute(fk_name).type
+              row[fk_name] = ActiveRecord::FixtureSet.identify(value, fk_type)
+            end
+          when :has_many
+            if association.options[:through]
+              add_join_records(row, HasManyThroughProxy.new(association))
+            end
+          end
+        end
+      end
+
+      private
+
+        def build_table_rows_from(fixtures, config)
+          now = config.default_timezone == :utc ? Time.now.utc : Time.now
+
+          @tables[table_name] = fixtures.map do |label, fixture|
+            TableRow.new(
+              fixture,
+              table_rows: self,
+              label: label,
+              now: now,
+            )
+          end
+        end
+
+        def reflection_class_for(row)
+          if row.include?(model_metadata.inheritance_column_name)
+            row[model_metadata.inheritance_column_name].constantize rescue model_class
+          else
+            model_class
+          end
+        end
+
+        def add_join_records(row, association)
+          # This is the case when the join table has no fixtures file
+          if (targets = row.delete(association.name.to_s))
+            table_name  = association.join_table
+            column_type = association.primary_key_type
+            lhs_key     = association.lhs_key
+            rhs_key     = association.rhs_key
+
+            targets = targets.is_a?(Array) ? targets : targets.split(/\s*,\s*/)
+            joins   = targets.map do |target|
+              { lhs_key => row[model_metadata.primary_key_name],
+                rhs_key => ActiveRecord::FixtureSet.identify(target, column_type) }
+            end
+            @tables[table_name].concat(joins)
+          end
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -450,14 +450,16 @@ module ActiveRecord
         @config      = config
 
         # Remove string values that aren't constants or subclasses of AR
-        @class_names.delete_if { |klass_name, klass| !insert_class(@class_names, klass_name, klass) }
+        @class_names.delete_if do |klass_name, klass|
+          !insert_class(@class_names, klass_name, klass)
+        end
       end
 
       def [](fs_name)
-        @class_names.fetch(fs_name) {
+        @class_names.fetch(fs_name) do
           klass = default_fixture_model(fs_name, @config).safe_constantize
           insert_class(@class_names, fs_name, klass)
-        }
+        end
       end
 
       private
@@ -862,12 +864,9 @@ module ActiveRecord
     alias :to_hash :fixture
 
     def find
-      if model_class
-        model_class.unscoped do
-          model_class.find(fixture[model_class.primary_key])
-        end
-      else
-        raise FixtureClassNotFound, "No class attached to find."
+      raise FixtureClassNotFound, "No class attached to find." unless model_class
+      model_class.unscoped do
+        model_class.find(fixture[model_class.primary_key])
       end
     end
   end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -667,38 +667,6 @@ module ActiveRecord
       ).to_hash
     end
 
-    class ReflectionProxy # :nodoc:
-      def initialize(association)
-        @association = association
-      end
-
-      def join_table
-        @association.join_table
-      end
-
-      def name
-        @association.name
-      end
-
-      def primary_key_type
-        @association.klass.type_for_attribute(@association.klass.primary_key).type
-      end
-    end
-
-    class HasManyThroughProxy < ReflectionProxy # :nodoc:
-      def rhs_key
-        @association.foreign_key
-      end
-
-      def lhs_key
-        @association.through_reflection.foreign_key
-      end
-
-      def join_table
-        @association.through_reflection.table_name
-      end
-    end
-
     private
 
       def model_class=(class_name)


### PR DESCRIPTION
### Summary

- `ActiveRecord::FixtureSet` class cleanup.

- Introduce `FixtureSet::ModelMetadata`, `FixtureSet::TableRows`, and
`FixtureSet::TableRow` for generating insertion hashes for fixtures.

- Encapsulate `FixtureSet.create_fixtures` reading and insertion sections
into separate private methods.

Most of this is just trying to break the process of generating and inserting fixture hashes into smaller pieces.

r? @rafaelfranca 
/cc @eileencodes 