### PR TITLE
ActiveStorage guide: Add instruction for test environment

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -82,6 +82,14 @@ To use the Amazon S3 service in production, you add the following to
 config.active_storage.service = :amazon
 ```
 
+To use the test service when testing, you add the following to
+`config/environments/test.rb`:
+
+```ruby
+# Store uploaded files on the local file system in a temporary directory.
+config.active_storage.service = :test
+```
+
 Continue reading for more information on the built-in service adapters (e.g.
 `Disk` and `S3`) and the configuration they require.
 


### PR DESCRIPTION
### Summary
When going through the ActiveStorage guide, I thought it was odd that there were configurations for `development` and `production` but not `test`. I mentally noted that I never set it up and figured it might be ok. Later, when trying to test adding an attachment, I ran into this issue.


### Other Information
At least two other people have had this same issue too: https://stackoverflow.com/a/47584366