### PR TITLE
Add sentinel support for ActionCable::SubscriptionAdapter::Redis

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -14,7 +14,7 @@ module ActionCable
       # This is needed, for example, when using Makara proxies for distributed Redis.
       cattr_accessor :redis_connector, default: ->(config) do
         config[:id] ||= "ActionCable-PID-#{$$}"
-        ::Redis.new(config.slice(:url, :host, :port, :db, :password, :id))
+        ::Redis.new(config.slice(:url, :host, :port, :db, :password, :id, :sentinels, :failover_reconnect_timeout))
       end
 
       def initialize(*)


### PR DESCRIPTION
Adds support for multiple Redis sentinels to the Redis SubscriptionAdapter
