### PR TITLE
Move db:migrate:status to DatabaseTasks method

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -149,18 +149,7 @@ db_namespace = namespace :db do
 
     desc "Display status of migrations"
     task status: :load_config do
-      unless ActiveRecord::SchemaMigration.table_exists?
-        abort "Schema migrations table does not exist yet."
-      end
-
-      # output
-      puts "\ndatabase: #{ActiveRecord::Base.connection_config[:database]}\n\n"
-      puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
-      puts "-" * 50
-      ActiveRecord::Base.connection.migration_context.migrations_status.each do |status, version, name|
-        puts "#{status.center(8)}  #{version.ljust(14)}  #{name}"
-      end
-      puts
+      ActiveRecord::Tasks::DatabaseTasks.migrate_status
     end
   end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -197,6 +197,21 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
+      def migrate_status
+        unless ActiveRecord::SchemaMigration.table_exists?
+          Kernel.abort "Schema migrations table does not exist yet."
+        end
+
+        # output
+        puts "\ndatabase: #{ActiveRecord::Base.connection_config[:database]}\n\n"
+        puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
+        puts "-" * 50
+        ActiveRecord::Base.connection.migration_context.migrations_status.each do |status, version, name|
+          puts "#{status.center(8)}  #{version.ljust(14)}  #{name}"
+        end
+        puts
+      end
+
       def check_target_version
         if target_version && !(Migration::MigrationFilenameRegexp.match?(ENV["VERSION"]) || /\A\d+\z/.match?(ENV["VERSION"]))
           raise "Invalid format of target version: `VERSION=#{ENV['VERSION']}`"


### PR DESCRIPTION
### Summary

Move `db:migrate:status` code to `ActiveRecord::Tasks::DatabaseTasks` method. I've also changed the `abort` call to an actual exception. This made multi-db statuses easier to implement so I'm PR-ing this first. We gain some test coverage for migration status too!

r? @eileencodes  
/cc @rafaelfranca 
