### PR TITLE
Remove "include FileUtils" sentence in setup/update bin files

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,5 +1,4 @@
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -8,7 +7,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -1,5 +1,4 @@
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -8,7 +7,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 


### PR DESCRIPTION
According with rubocop style guide "Style/MixinUsage" is good to use only in
class/module not directly in file.