### PR TITLE
Add retry_on/discard suggestions for common cases to ApplicationJob for new apps.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb.tt
@@ -1,2 +1,7 @@
 class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
 end


### PR DESCRIPTION
This adds the same suggestions included here:
https://github.com/rails/rails/blob/01a69e27a4e55504af8fe776826d659550e6f89e/activejob/lib/rails/generators/job/templates/application_job.rb

These appear when `app/jobs/application_job.rb` doesn't exist, but not for new applications.