### PR TITLE
add test for cache_version precision

### DIFF
--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -157,16 +157,38 @@ class IntegrationTest < ActiveRecord::TestCase
     skip("Subsecond precision is not supported") unless subsecond_precision_supported?
     dev = Developer.first
     key = dev.cache_key
-    dev.touch
+    travel_to dev.updated_at + 0.000001 do
+      dev.touch
+    end
     assert_not_equal key, dev.cache_key
   end
 
   def test_cache_key_format_is_not_too_precise
-    skip("Subsecond precision is not supported") unless subsecond_precision_supported?
     dev = Developer.first
     dev.touch
     key = dev.cache_key
     assert_equal key, dev.reload.cache_key
+  end
+
+  def test_cache_version_format_is_precise_enough
+    skip("Subsecond precision is not supported") unless subsecond_precision_supported?
+    with_cache_versioning do
+      dev = Developer.first
+      version = dev.cache_version.to_param
+      travel_to Developer.first.updated_at + 0.000001 do
+        dev.touch
+      end
+      assert_not_equal version, dev.cache_version.to_param
+    end
+  end
+
+  def test_cache_version_format_is_not_too_precise
+    with_cache_versioning do
+      dev = Developer.first
+      dev.touch
+      key = dev.cache_version.to_param
+      assert_equal key, dev.reload.cache_version.to_param
+    end
   end
 
   def test_named_timestamps_for_cache_key
@@ -185,50 +207,52 @@ class IntegrationTest < ActiveRecord::TestCase
   end
 
   def test_cache_key_is_stable_with_versioning_on
-    Developer.cache_versioning = true
+    with_cache_versioning do
+      developer = Developer.first
+      first_key = developer.cache_key
 
-    developer = Developer.first
-    first_key = developer.cache_key
+      developer.touch
+      second_key = developer.cache_key
 
-    developer.touch
-    second_key = developer.cache_key
-
-    assert_equal first_key, second_key
-  ensure
-    Developer.cache_versioning = false
+      assert_equal first_key, second_key
+    end
   end
 
   def test_cache_version_changes_with_versioning_on
-    Developer.cache_versioning = true
+    with_cache_versioning do
+      developer     = Developer.first
+      first_version = developer.cache_version
 
-    developer     = Developer.first
-    first_version = developer.cache_version
+      travel 10.seconds do
+        developer.touch
+      end
 
-    travel 10.seconds do
-      developer.touch
+      second_version = developer.cache_version
+
+      assert_not_equal first_version, second_version
     end
-
-    second_version = developer.cache_version
-
-    assert_not_equal first_version, second_version
-  ensure
-    Developer.cache_versioning = false
   end
 
   def test_cache_key_retains_version_when_custom_timestamp_is_used
-    Developer.cache_versioning = true
+    with_cache_versioning do
+      developer = Developer.first
+      first_key = developer.cache_key_with_version
 
-    developer = Developer.first
-    first_key = developer.cache_key_with_version
+      travel 10.seconds do
+        developer.touch
+      end
 
-    travel 10.seconds do
-      developer.touch
+      second_key = developer.cache_key_with_version
+
+      assert_not_equal first_key, second_key
     end
+  end
 
-    second_key = developer.cache_key_with_version
-
-    assert_not_equal first_key, second_key
+  def with_cache_versioning(value = true)
+    @old_cache_versioning = ActiveRecord::Base.cache_versioning
+    ActiveRecord::Base.cache_versioning = value
+    yield
   ensure
-    Developer.cache_versioning = false
+    ActiveRecord::Base.cache_versioning = @old_cache_versioning
   end
 end


### PR DESCRIPTION
Adds test to ensure that the `cache_version` supports subseconds on databases that support it. This should help preventing losing precision when optimising the cache keys in #33835.

Note that the additional `touch` in `test_cache_key_format_is_precise_enough` was added as the test was intermittently passing depending if the test was running after first second of test suite. And the skip for `test_cache_key_format_is_not_too_precise` was dropped because the test is still valid for when there is no sub-second support.

/cc @schneems 