### PR TITLE
Avoid bundler 1.16.6 in railties build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       before_install:
         - "rm ${BUNDLE_GEMFILE}.lock"
         - "travis_retry gem update --system"
-        - "travis_retry gem install bundler"
+        - "travis_retry gem install bundler -v 1.16.5"
         - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
         - "sudo service postgresql restart 10"
     - rvm: 2.5.1
@@ -86,7 +86,7 @@ matrix:
       before_install:
         - "rm ${BUNDLE_GEMFILE}.lock"
         - "travis_retry gem update --system"
-        - "travis_retry gem install bundler"
+        - "travis_retry gem install bundler -v 1.16.5"
         - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
         - "sudo service postgresql restart 10"
     - rvm: ruby-head
@@ -95,7 +95,7 @@ matrix:
       before_install:
         - "rm ${BUNDLE_GEMFILE}.lock"
         - "travis_retry gem update --system"
-        - "travis_retry gem install bundler"
+        - "travis_retry gem install bundler -v 1.16.5"
         - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
         - "sudo service postgresql restart 10"
     - rvm: 2.5.1


### PR DESCRIPTION
Because warning about platform not used is output to the execution result of `bundler check` and `bin_setup_test.rb` fails.
https://travis-ci.org/rails/rails/jobs/437501226#L2047-L2058

Related to: https://github.com/bundler/bundler/issues/6724

