### PR TITLE
Exercise stringify of database configurations

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -170,6 +170,11 @@ module ActiveRecord
         ActiveRecord::Base.configurations = config
         ActiveRecord::Base.configurations.configs_for.each do |db_config|
           assert_instance_of ActiveRecord::DatabaseConfigurations::HashConfig, db_config
+          assert_instance_of String, db_config.env_name
+          assert_instance_of String, db_config.spec_name
+          db_config.config.keys.each do |key|
+            assert_instance_of String, key
+          end
         end
       ensure
         ActiveRecord::Base.configurations = @prev_configs


### PR DESCRIPTION
Since #33968 we stringify keys of database configuration
This commit adds more assertions in order to ensure that and prevent any
regression in the future.
Currently, if remove `to_s` added in #33968 from `env_name.to_s` on the
line
(activerecord/lib/active_record/database_configurations.rb:107), there is
no test that would fail. One of the added assertions should emphasize why we need
this `to_s`.

Follow up #33968