### PR TITLE
Skip node_modules dir in the rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - '**/vendor/**/*'
     - 'actionpack/lib/action_dispatch/journey/parser.rb'
     - 'railties/test/fixtures/tmp/**/*'
+    - 'node_modules/**/*'
 
 Performance:
   Exclude:


### PR DESCRIPTION
- Otherwise it is running the check against all files in node_modules