### PR TITLE
Parameterized mailers can configure delivery job

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow ActionMailer classes to configure the parameterized delivery job
+    Example:
+    ```
+    class MyMailer < ApplicationMailer
+      self.parameterized_delivery_job = MyCustomDeliveryJob
+      ...
+    end
+    ```
+
+    *Luke Pearce*
+
 *   `ActionDispatch::IntegrationTest` includes `ActionMailer::TestHelper` module by default.
 
     *Ricardo Díaz*

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -462,6 +462,7 @@ module ActionMailer
     helper ActionMailer::MailHelper
 
     class_attribute :delivery_job, default: ::ActionMailer::DeliveryJob
+    class_attribute :parameterized_delivery_job, default: ::ActionMailer::Parameterized::DeliveryJob
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -140,7 +140,8 @@ module ActionMailer
             super
           else
             args = @mailer_class.name, @action.to_s, delivery_method.to_s, @params, *@args
-            ActionMailer::Parameterized::DeliveryJob.set(options).perform_later(*args)
+            job = @mailer_class.parameterized_delivery_job
+            job.set(options).perform_later(*args)
           end
         end
     end

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -53,4 +53,17 @@ class ParameterizedTest < ActiveSupport::TestCase
       invitation = mailer.method(:anything)
     end
   end
+
+  test "should enqueue a parameterized request with the correct delivery job" do
+    old_delivery_job = ParamsMailer.parameterized_delivery_job
+    ParamsMailer.parameterized_delivery_job = ParameterizedDummyJob
+
+    assert_performed_with(job: ParameterizedDummyJob, args: ["ParamsMailer", "invitation", "deliver_now", { inviter: "david@basecamp.com", invitee: "jason@basecamp.com" } ]) do
+      @mail.deliver_later
+    end
+
+    ParamsMailer.parameterized_delivery_job = old_delivery_job
+  end
+
+  class ParameterizedDummyJob < ActionMailer::Parameterized::DeliveryJob; end
 end


### PR DESCRIPTION
Setting parameterized_delivery_job on a mailer class will cause Parameterized::MessageDelivery to use the specified job instead of ActionMailer::Parameterized::DeliveryJob:

    class MyMailer < ApplicationMailer
      self.parameterized_delivery_job = MyCustomDeliveryJob
      ...
    end

### Summary

I noticed that if you set self.delivery_job it doesn't use the custom job specified when using the new parameterized mailers.

As they are slightly different implementations I've added a different method ```parameterized_delivery_job``` so you can configure different jobs for parameterized and non-parameterized mailers.
