### PR TITLE
Remove bundler warnings from bin/setup output

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -43,18 +43,20 @@ module ApplicationTests
 
         # Ignore line that's only output by Bundler < 1.14
         output.sub!(/^Resolving dependencies\.\.\.\n/, "")
+        # Suppress Bundler platform warnings from output
+        output.gsub!(/^The dependency .* will be unused .*\.\n/, "")
 
-        assert_equal(<<-OUTPUT, output)
-== Installing dependencies ==
-The Gemfile's dependencies are satisfied
+        assert_equal(<<~OUTPUT, output)
+          == Installing dependencies ==
+          The Gemfile's dependencies are satisfied
 
-== Preparing database ==
-Created database 'db/development.sqlite3'
-Created database 'db/test.sqlite3'
+          == Preparing database ==
+          Created database 'db/development.sqlite3'
+          Created database 'db/test.sqlite3'
 
-== Removing old logs and tempfiles ==
+          == Removing old logs and tempfiles ==
 
-== Restarting application server ==
+          == Restarting application server ==
         OUTPUT
       end
     end


### PR DESCRIPTION
### Summary

Fixes failing `bin/setup` railties test on `bundler-1.16.6`.

r? @rafaelfranca 