### PR TITLE
Add documentation to run tests with specific seed [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -336,6 +336,26 @@ $ bundle exec ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_lay
 The `-n` option allows you to run a single method instead of the whole
 file.
 
+#### Running tests with a specific seed
+
+Test execution is randomized with a randomization seed. If you are experiencing random
+test failures you can more accurately reproduce a failing test scenario by specifically
+setting the randomization seed.
+
+Running all tests for a component:
+
+```bash
+$ cd actionmailer
+$ SEED=15002 bundle exec rake test
+```
+
+Running a single test file:
+
+```bash
+$ cd actionmailer
+$ SEED=15002 bundle exec ruby -w -Itest test/mail_layout_test.rb
+```
+
 #### Testing Active Record
 
 First, create the databases you'll need. You can find a list of the required


### PR DESCRIPTION
### Summary
I'm seen that we are experiencing some test failures that don't happen on every CI build, like for example https://travis-ci.org/rails/rails/jobs/437690919

To help me reproduce this issue I had to provide an specific randomization seed, otherwise it wasn't reproducible.
 
This PR documents how to run our tests with a specific randomization seed to help future contributors so that they don't need to search how to do it.