### PR TITLE
clarify role of unique_id in ActiveSupport::Notifications [ci skip]

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -34,7 +34,7 @@ module ActiveSupport
   #     name    # => String, name of the event (such as 'render' from above)
   #     start   # => Time, when the instrumented block started execution
   #     finish  # => Time, when the instrumented block ended execution
-  #     id      # => String, unique ID for this notification
+  #     id      # => String, unique ID for the instrumenter that fired the event
   #     payload # => Hash, the payload
   #   end
   #
@@ -59,7 +59,7 @@ module ActiveSupport
   #   event.payload   # => { extra: :information }
   #
   # The block in the <tt>subscribe</tt> call gets the name of the event, start
-  # timestamp, end timestamp, a string with a unique identifier for that event
+  # timestamp, end timestamp, a string with a unique identifier for that event's instrumenter
   # (something like "535801666f04d0298cd6"), and a hash with the payload, in
   # that order.
   #

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -623,7 +623,7 @@ The block receives the following arguments:
 * The name of the event
 * Time when it started
 * Time when it finished
-* A unique ID for this event
+* A unique ID for the instrumenter that fired the event
 * The payload (described in previous sections)
 
 ```ruby
@@ -672,7 +672,8 @@ Creating custom events
 Adding your own events is easy as well. `ActiveSupport::Notifications` will take care of
 all the heavy lifting for you. Simply call `instrument` with a `name`, `payload` and a block.
 The notification will be sent after the block returns. `ActiveSupport` will generate the start and end times
-as well as the unique ID. All data passed into the `instrument` call will make it into the payload.
+and add the instrumenter's unique ID. All data passed into the `instrument` call will make 
+it into the payload.
 
 Here's an example:
 


### PR DESCRIPTION
### Summary

The documentation for ActiveSupport::Notifications is misleading about the role of `unique_id` — it's not unique per event, but rather unique per instrumenter. 