### PR TITLE
Permit of ActionController::Parameters for ActiveJob Serializable Argument

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -72,10 +72,10 @@ module ActiveJob
           convert_to_global_id_hash(argument)
         when Array
           argument.map { |arg| serialize_argument(arg) }
-        when ActionController::Parameters
-          serialize_indifferent_hash(argument.to_h)
         when ActiveSupport::HashWithIndifferentAccess
           serialize_indifferent_hash(argument)
+        when defined?(ActionController) && ActionController::Parameters
+          serialize_indifferent_hash(argument.to_h)
         when Hash
           symbol_keys = argument.each_key.grep(Symbol).map(&:to_s)
           result = serialize_hash(argument)

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -72,10 +72,10 @@ module ActiveJob
           convert_to_global_id_hash(argument)
         when Array
           argument.map { |arg| serialize_argument(arg) }
+        when ActionController::Parameters
+          serialize_indifferent_hash(argument.to_h)
         when ActiveSupport::HashWithIndifferentAccess
-          result = serialize_hash(argument)
-          result[WITH_INDIFFERENT_ACCESS_KEY] = serialize_argument(true)
-          result
+          serialize_indifferent_hash(argument)
         when Hash
           symbol_keys = argument.each_key.grep(Symbol).map(&:to_s)
           result = serialize_hash(argument)
@@ -144,6 +144,12 @@ module ActiveJob
         else
           raise SerializationError.new("Only string and symbol hash keys may be serialized as job arguments, but #{key.inspect} is a #{key.class}")
         end
+      end
+
+      def serialize_indifferent_hash(indifferent_hash)
+        result = serialize_hash(indifferent_hash)
+        result[WITH_INDIFFERENT_ACCESS_KEY] = serialize_argument(true)
+        result
       end
 
       def transform_symbol_keys(hash, symbol_keys)

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -74,7 +74,7 @@ module ActiveJob
           argument.map { |arg| serialize_argument(arg) }
         when ActiveSupport::HashWithIndifferentAccess
           serialize_indifferent_hash(argument)
-        when defined?(ActionController) && ActionController::Parameters
+        when -> (arg) { arg.respond_to?(:permitted) }
           serialize_indifferent_hash(argument.to_h)
         when Hash
           symbol_keys = argument.each_key.grep(Symbol).map(&:to_s)

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -5,6 +5,7 @@ require "active_job/arguments"
 require "models/person"
 require "active_support/core_ext/hash/indifferent_access"
 require "jobs/kwargs_job"
+require "action_controller/metal/strong_parameters"
 
 class ArgumentSerializationTest < ActiveSupport::TestCase
   setup do
@@ -53,6 +54,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     symbol_key = { a: 1 }
     string_key = { "a" => 1 }
     indifferent_access = { a: 1 }.with_indifferent_access
+    parameters = ActionController::Parameters.new(a: 1).permit(:a)
 
     assert_equal(
       { "a" => 1, "_aj_symbol_keys" => ["a"] },
@@ -65,6 +67,10 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_equal(
       { "a" => 1, "_aj_hash_with_indifferent_access" => true },
       ActiveJob::Arguments.serialize([indifferent_access]).first
+    )
+    assert_equal(
+      { "a" => 1, "_aj_hash_with_indifferent_access" => true },
+      ActiveJob::Arguments.serialize([parameters]).first
     )
   end
 

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -5,7 +5,7 @@ require "active_job/arguments"
 require "models/person"
 require "active_support/core_ext/hash/indifferent_access"
 require "jobs/kwargs_job"
-require "action_controller/metal/strong_parameters"
+require "support/stubs/strong_parameters"
 
 class ArgumentSerializationTest < ActiveSupport::TestCase
   setup do
@@ -50,11 +50,19 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_arguments_roundtrip([a: 1, "b" => 2])
   end
 
+  test "serialize a ActionController::Parameters" do
+    parameters = Parameters.new(a: 1).permit(:a)
+
+    assert_equal(
+      { "a" => 1, "_aj_hash_with_indifferent_access" => true },
+      ActiveJob::Arguments.serialize([parameters]).first
+    )
+  end
+
   test "serialize a hash" do
     symbol_key = { a: 1 }
     string_key = { "a" => 1 }
     indifferent_access = { a: 1 }.with_indifferent_access
-    parameters = ActionController::Parameters.new(a: 1).permit(:a)
 
     assert_equal(
       { "a" => 1, "_aj_symbol_keys" => ["a"] },
@@ -67,10 +75,6 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_equal(
       { "a" => 1, "_aj_hash_with_indifferent_access" => true },
       ActiveJob::Arguments.serialize([indifferent_access]).first
-    )
-    assert_equal(
-      { "a" => 1, "_aj_hash_with_indifferent_access" => true },
-      ActiveJob::Arguments.serialize([parameters]).first
     )
   end
 

--- a/activejob/test/support/stubs/strong_parameters.rb
+++ b/activejob/test/support/stubs/strong_parameters.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Parameters
+  delegate :to_h, to: :@parameters
+
+  def initialize(parameters = {})
+    @parameters = parameters.with_indifferent_access
+  end
+
+  def permitted
+    true
+  end
+
+  def permit(*filters)
+    @parameters
+  end
+end


### PR DESCRIPTION
### Summary

Since `ActionController::Parameters` has a method to safely transform its type to `ActiveSupport::HashWithIndifferentAccess` [to_h](https://github.com/rails/rails/blob/140ec68c0dc157d1b3cd481f48dd403b58c74923/actionpack/lib/action_controller/metal/strong_parameters.rb#L258), so I think it can also be allowed to permit in the ActiveJob serializable argument, right ? 🤔🤔

And before Rails 5, `ActionController::Parameters` still inherits from `ActiveSupport::HashWithIndifferentAccess`, so this behaviour can still be acceptable in this situation I suppose.

This might resolve the issue here : )
https://github.com/rails/rails/issues/33643