### PR TITLE
Follow up #34064

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -378,8 +378,6 @@ module ActionDispatch
         @disable_clear_and_finalize = false
         @finalized                  = false
         @env_key                    = "ROUTES_#{object_id}_SCRIPT_NAME"
-        @url_helpers                = nil
-        @deferred_classes           = []
 
         @set    = Journey::Routes.new
         @router = Journey::Router.new @set
@@ -434,25 +432,6 @@ module ActionDispatch
         end
       end
       private :eval_block
-
-      def include_helpers(klass, include_path_helpers)
-        if @finalized
-          include_helpers_now klass, include_path_helpers
-        else
-          @deferred_classes << [klass, include_path_helpers]
-        end
-      end
-
-      def include_helpers_now(klass, include_path_helpers)
-        namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_include_helpers) }
-
-        if namespace && namespace.railtie_namespace.routes != self
-          namespace.railtie_include_helpers(klass, include_path_helpers)
-        else
-          klass.include(url_helpers(include_path_helpers))
-        end
-      end
-      private :include_helpers_now
 
       def finalize!
         return if @finalized


### PR DESCRIPTION
The removed code was added in 7f870a5ba2aa9177aa4a0e03a9d027928ba60e49,
then 7f870a5ba2aa9177aa4a0e03a9d027928ba60e49 was reverted by #34064.
But I found that that commit wasn't completely reverted, I guess it was
caused by resolving some conflicts during reverting.
@schneems could you please confirm that those changes weren't reverted
unintentionally, or reject this commit otherwise?

r? @schneems 