### PR TITLE
Enum raises on invalid definition values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Enum raises on invalid definition values
+
+    When defining a Hash enum it can be easy to use [] instead of {}. This
+    commit checks that only valid definition values are provided, those can
+    be a Hash, an array of Symbols or an array of Strings. Otherwise it
+    raises an ArgumentError.
+
+    Fixes #33961
+
+    *Alberto Almagro*
+
 *   Reloading associations now clears the Query Cache like `Persistence#reload` does.
 
     ```

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -150,6 +150,7 @@ module ActiveRecord
       enum_prefix = definitions.delete(:_prefix)
       enum_suffix = definitions.delete(:_suffix)
       definitions.each do |name, values|
+        assert_valid_enum_definition_values(values)
         # statuses = { }
         enum_values = ActiveSupport::HashWithIndifferentAccess.new
         name = name.to_s
@@ -207,6 +208,15 @@ module ActiveRecord
           mod = Module.new
           include mod
           mod
+        end
+      end
+
+      def assert_valid_enum_definition_values(values)
+        unless values.is_a?(Hash) || values.all? { |v| v.is_a?(Symbol) } || values.all? { |v| v.is_a?(String) }
+          error_message = <<~MSG
+            Enum values #{values} must be either a hash, an array of symbols, or an array of strings.
+          MSG
+          raise ArgumentError, error_message
         end
       end
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -224,6 +224,7 @@ module ActiveRecord
         "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
         "this will generate a %{type} method \"%{method}\", which is already defined " \
         "by %{source}."
+      private_constant :ENUM_CONFLICT_MESSAGE
 
       def detect_enum_conflict!(enum_name, method_name, klass_method = false)
         if klass_method && dangerous_class_method?(method_name)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -265,6 +265,17 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "published", @book.status
   end
 
+  test "invalid definition values raise an ArgumentError" do
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [proposed: 1, written: 2, published: 3]
+      end
+    end
+
+    assert_match(/must be either a hash, an array of symbols, or an array of strings./, e.message)
+  end
+
   test "reserved enum names" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"


### PR DESCRIPTION
### Summary

Fixes #33961

When defining a Hash enum it can be easy to use [] instead of {}. This patch checks that only valid definition values are provided, those can be a Hash or an array of Symbols or Strings. Otherwise it raises an ArgumentError.
