### PR TITLE
getting started page rails version update to 5.2.1

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -126,7 +126,7 @@ run the following:
 $ rails --version
 ```
 
-If it says something like "Rails 5.1.1", you are ready to continue.
+If it says something like "Rails 5.2.1", you are ready to continue.
 
 ### Creating the Blog Application
 


### PR DESCRIPTION
### Summary
The version of the guide getting start page for 5.2 was 5.1.1, so fix it to 5.2.1.
> https://guides.rubyonrails.org/getting_started.html#installing-rails

### Other Information
none 