### PR TITLE
Fix ActiveStorage direct disk upload when using Mime type synonyms

### DIFF
--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -61,7 +61,6 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     end
 
     def acceptable_content?(token)
-      Mime::Type.lookup(request.content_type) == token[:content_type] &&
-        token[:content_length] == request.content_length
+      token[:content_type] == request.content_mime_type && token[:content_length] == request.content_length
     end
 end

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -61,6 +61,7 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     end
 
     def acceptable_content?(token)
-      token[:content_type] == request.content_type && token[:content_length] == request.content_length
+      Mime::Type.lookup(request.content_type) == token[:content_type] &&
+        token[:content_length] == request.content_length
     end
 end

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -67,6 +67,16 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     assert_not blob.service.exist?(blob.key)
   end
 
+  test "directly uploading blob with different but equivalent content type" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload(
+      byte_size: data.size, checksum: Digest::MD5.base64digest(data), content_type: "application/x-gzip")
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/x-gzip" }
+    assert_response :no_content
+    assert_equal data, blob.download
+  end
+
   test "directly uploading blob with mismatched content length" do
     data = "Something else entirely!"
     blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: Digest::MD5.base64digest(data)


### PR DESCRIPTION
Fix an issue in ActiveStorage where a direct upload to disk storage
would fail due to a content type mismatch if the file was uploaded using
a mime-type synonym.

### Summary

When direct uploading a file using the disk storage backend with that uses a Mime-type synonym, e.g "application/x-gzip" the subsequent blob update will fail. This is due to the controller performing this check with a comparison to `request.content_type` which only returns the primary content type. 

### Other Information

Further documentation in #34058
