### PR TITLE
Add docs to ActiveRecord::Persistence#belongs_to_touch_method

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -593,6 +593,8 @@ module ActiveRecord
       @_association_destroy_exception = nil
     end
 
+    # The name of the method used to touch a +belongs_to+ association when the
+    # +:touch+ option is used.
     def belongs_to_touch_method
       :touch
     end


### PR DESCRIPTION
### Summary

Adding docs to ActiveRecord::Persistence#belongs_to_touch_method

### Other Information

I found the method through [Codetriage](https://www.codetriage.com/doc_methods/14511).
