### PR TITLE
Correct how parser splits accept headers

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -136,6 +136,7 @@ module Mime
     class << self
       TRAILING_STAR_REGEXP = /^(text|application)\/\*/
       PARAMETER_SEPARATOR_REGEXP = /;\s*\w+="?\w+"?/
+      HEADER_SEPARATOR_REGEXP = /(?!".*),(?!.*")/
 
       def register_callback(&block)
         @register_callbacks << block
@@ -175,7 +176,7 @@ module Mime
           parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
         else
           list, index = [], 0
-          accept_header.split(",").each do |header|
+          accept_header.split(HEADER_SEPARATOR_REGEXP).each do |header|
             params, q = header.split(PARAMETER_SEPARATOR_REGEXP)
 
             next unless params

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -75,7 +75,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "parse arbitrary media type parameters" do
-    accept = 'multipart/form-data; boundary="simple boundary"'
+    accept = 'multipart/form-data; boundary="simple boundary, text/html"'
     expect = [Mime[:multipart_form]]
     assert_equal expect, Mime::Type.parse(accept)
   end


### PR DESCRIPTION
### Summary

RFC 7231 sections 5.3.2 and 3.1.1.1 specifies that  media type parameters can be passed as quoted strings. In the event that quoted string includes a comma, the `Mime::Type` parser may split the header incorrectly.

Fixes #33980

