### PR TITLE
Fix `query_attributes` for virtual numeric attributes.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -18,8 +18,8 @@ module ActiveRecord
         else
           column = self.class.columns_hash[attr_name]
           if column.nil?
-            if Numeric === value || value !~ /[^0-9]/
-              !value.to_i.zero?
+            if Numeric === value || value =~ /\A[-+]?\d+/
+              !value.to_f.zero?
             else
               return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
               !value.blank?

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -454,6 +454,17 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     object.int_value = "0"
     assert_not_predicate object, :int_value?
+
+    [0.1, "-0.2", "+1.3"].each do |val|
+      NumericData.create!(temperature: val)
+      float_object = NumericData.find_by_sql(<<-SQL).first
+        SELECT temperature, temperature AS dummy_temp
+          FROM numeric_data
+         WHERE temperature = #{val}
+      SQL
+      assert_predicate float_object, :temperature?
+      assert_predicate float_object, :dummy_temp?
+    end
   end
 
   test "non-attribute read and write" do


### PR DESCRIPTION
If a value of virtual attribute is numeric whose absolute value is
less than one, `to_i` returns incorrect result.

I think removing this behavior is a way to go, but that needs
deprecation cycle (#29059).

Meanwhile, this fixes #22429 with keeping backport possible.
