### PR TITLE
Generate delegation methods to named scope in the definition time

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -191,6 +191,8 @@ module ActiveRecord
               scope
             end
           end
+
+          generate_relation_method(name)
         end
 
         private

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2391,6 +2391,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_collection_association_with_private_kernel_method
     firm = companies(:first_firm)
     assert_equal [accounts(:signals37)], firm.accounts.open
+    assert_equal [accounts(:signals37)], firm.accounts.available
   end
 
   def test_association_with_or_doesnt_set_inverse_instance_key

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1812,6 +1812,16 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "Thank you for the welcome,Thank you again for the welcome", Post.first.comments.join(",")
   end
 
+  def test_relation_with_private_kernel_method
+    accounts = Account.all
+    assert_equal [accounts(:signals37)], accounts.open
+    assert_equal [accounts(:signals37)], accounts.available
+
+    sub_accounts = SubAccount.all
+    assert_equal [accounts(:signals37)], sub_accounts.open
+    assert_equal [accounts(:signals37)], sub_accounts.available
+  end
+
   test "#skip_query_cache!" do
     Post.cache do
       assert_queries(1) do

--- a/activerecord/test/models/account.rb
+++ b/activerecord/test/models/account.rb
@@ -11,9 +11,8 @@ class Account < ActiveRecord::Base
   end
 
   # Test private kernel method through collection proxy using has_many.
-  def self.open
-    where("firm_name = ?", "37signals")
-  end
+  scope :open, -> { where("firm_name = ?", "37signals") }
+  scope :available, -> { open }
 
   before_destroy do |account|
     if account.firm
@@ -31,4 +30,12 @@ class Account < ActiveRecord::Base
     def private_method
       "Sir, yes sir!"
     end
+end
+
+class SubAccount < Account
+  def self.instantiate_instance_of(klass, attributes, column_types = {}, &block)
+    klass = superclass
+    super
+  end
+  private_class_method :instantiate_instance_of
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -297,8 +297,6 @@ end
 class FakeKlass
   extend ActiveRecord::Delegation::DelegateCache
 
-  inherited self
-
   class << self
     def connection
       Post.connection
@@ -335,5 +333,11 @@ class FakeKlass
     def predicate_builder
       Post.predicate_builder
     end
+
+    def base_class?
+      true
+    end
   end
+
+  inherited self
 end


### PR DESCRIPTION
The delegation methods to named scope are defined when `method_missing`
is invoked on the relation.

Since #29301, the receiver in the named scope is changed to the relation
like others (e.g. `default_scope`, etc) for consistency.

Most named scopes would be delegated from relation by `method_missing`,
since we don't allow scopes to be defined which conflict with instance
methods on `Relation` (#31179). But if a named scope is defined with the
same name as any method on the `superclass` (e.g. `Kernel.open`), the
`method_missing` on the relation is not invoked.

To address the issue, make the delegation methods to named scope is
generated in the definition time.

Fixes #34098.