### PR TITLE
Deprecate Unicode#downcase/upcase/swapcase.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `ActiveSupport::Multibyte::Unicode#downcase/upcase/swapcase` in favor of
+    `String#downcase/upcase/swapcase`.
+
+    *Francesco Rodríguez*
+
 *   Add `ActiveSupport::ParameterFilter`.
 
     *Yoshiyuki Kinjo*

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -120,13 +120,6 @@ module ActiveSupport #:nodoc:
         slice(0...translate_offset(limit))
       end
 
-      # Converts the first character to uppercase and the remainder to lowercase.
-      #
-      #  'über'.mb_chars.capitalize.to_s # => "Über"
-      def capitalize
-        (slice(0) || chars("")).upcase + (slice(1..-1) || chars("")).downcase
-      end
-
       # Capitalizes the first letter of every word, when possible.
       #
       #   "ÉL QUE SE ENTERÓ".mb_chars.titleize.to_s    # => "Él Que Se Enteró"
@@ -184,7 +177,7 @@ module ActiveSupport #:nodoc:
         to_s.as_json(options)
       end
 
-      %w(capitalize reverse tidy_bytes).each do |method|
+      %w(reverse tidy_bytes).each do |method|
         define_method("#{method}!") do |*args|
           @wrapped_string = send(method, *args).to_s
           self

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -120,27 +120,6 @@ module ActiveSupport #:nodoc:
         slice(0...translate_offset(limit))
       end
 
-      # Converts characters in the string to uppercase.
-      #
-      #   'Laurent, où sont les tests ?'.mb_chars.upcase.to_s # => "LAURENT, OÙ SONT LES TESTS ?"
-      def upcase
-        chars Unicode.upcase(@wrapped_string)
-      end
-
-      # Converts characters in the string to lowercase.
-      #
-      #   'VĚDA A VÝZKUM'.mb_chars.downcase.to_s # => "věda a výzkum"
-      def downcase
-        chars Unicode.downcase(@wrapped_string)
-      end
-
-      # Converts characters in the string to the opposite case.
-      #
-      #    'El Cañón'.mb_chars.swapcase.to_s # => "eL cAÑÓN"
-      def swapcase
-        chars Unicode.swapcase(@wrapped_string)
-      end
-
       # Converts the first character to uppercase and the remainder to lowercase.
       #
       #  'über'.mb_chars.capitalize.to_s # => "Über"
@@ -153,7 +132,7 @@ module ActiveSupport #:nodoc:
       #   "ÉL QUE SE ENTERÓ".mb_chars.titleize.to_s    # => "Él Que Se Enteró"
       #   "日本語".mb_chars.titleize.to_s               # => "日本語"
       def titleize
-        chars(downcase.to_s.gsub(/\b('?\S)/u) { Unicode.upcase($1) })
+        chars(downcase.to_s.gsub(/\b('?\S)/u) { $1.upcase })
       end
       alias_method :titlecase, :titleize
 
@@ -205,7 +184,7 @@ module ActiveSupport #:nodoc:
         to_s.as_json(options)
       end
 
-      %w(capitalize downcase reverse tidy_bytes upcase).each do |method|
+      %w(capitalize reverse tidy_bytes).each do |method|
         define_method("#{method}!") do |*args|
           @wrapped_string = send(method, *args).to_s
           self

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -115,16 +115,15 @@ module ActiveSupport
         end
       end
 
-      def downcase(string)
-        string.downcase
-      end
+      %w(downcase upcase swapcase).each do |method|
+        define_method(method) do |string|
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveSupport::Multibyte::Unicode##{method} is deprecated and
+          will be removed from Rails 6.1. Use String methods directly.
+          MSG
 
-      def upcase(string)
-        string.upcase
-      end
-
-      def swapcase(string)
-        string.swapcase
+          string.send(method)
+        end
       end
 
       private

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -477,7 +477,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
 
   def test_method_works_for_proxyed_methods
     assert_equal "ll", "hello".mb_chars.method(:slice).call(2..3) # Defined on Chars
-    chars = "hello".mb_chars
+    chars = +"hello".mb_chars
     assert_equal "Hello", chars.method(:capitalize!).call # Defined on Chars
     assert_equal "Hello", chars
     assert_equal "jello", "hello".mb_chars.method(:gsub).call(/h/, "j") # Defined on String

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -719,6 +719,12 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
     assert_equal BYTE_STRING.dup.mb_chars.class, ActiveSupport::Multibyte::Chars
   end
 
+  def test_unicode_deprecations
+    assert_deprecated { ActiveSupport::Multibyte::Unicode.downcase("") }
+    assert_deprecated { ActiveSupport::Multibyte::Unicode.upcase("") }
+    assert_deprecated { ActiveSupport::Multibyte::Unicode.swapcase("") }
+  end
+
   private
 
     def string_from_classes(classes)


### PR DESCRIPTION
- Deprecates `ActiveSupport::Multibyte::Unicode#downcase/upcase/swapcase` in favor of using String methods directly.
- Removes `ActiveSupport::Multibyte::Chars` wrappers around the following String methods: `#downcase`, `#upcase`, `#swapcase`, and `#capitalize`.