### PR TITLE
fix typo in testing guides and system tests generator assert_selector -> assert_select

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -711,7 +711,7 @@ class UsersTest < ApplicationSystemTestCase
   # test "visiting the index" do
   #   visit users_url
   #
-  #   assert_selector "h1", text: "Users"
+  #   assert_select "h1", text: "Users"
   # end
 end
 ```
@@ -817,7 +817,7 @@ require "application_system_test_case"
 class ArticlesTest < ApplicationSystemTestCase
   test "viewing the index" do
     visit articles_path
-    assert_selector "h1", text: "Articles"
+    assert_select "h1", text: "Articles"
   end
 end
 ```
@@ -888,7 +888,7 @@ class PostsTest < MobileSystemTestCase
 
   test "visiting the index" do
     visit posts_url
-    assert_selector "h1", text: "Posts"
+    assert_select "h1", text: "Posts"
   end
 end
 ```

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
@@ -8,7 +8,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit <%= plural_table_name %>_url
-    assert_selector "h1", text: "<%= class_name.pluralize.titleize %>"
+    assert_select "h1", text: "<%= class_name.pluralize.titleize %>"
   end
 
   test "creating a <%= human_name %>" do

--- a/railties/lib/rails/generators/test_unit/system/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/system/templates/system_test.rb.tt
@@ -4,6 +4,6 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
   # test "visiting the index" do
   #   visit <%= plural_table_name %>_url
   #
-  #   assert_selector "h1", text: "<%= class_name %>"
+  #   assert_select "h1", text: "<%= class_name %>"
   # end
 end


### PR DESCRIPTION
Hello 👋 

I just found this typo in the guides and the system test generators! Easy peasy!

Cheers,
Julia