### PR TITLE
fix broken link in Action Cable guides and readme [ci skip]

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -442,7 +442,7 @@ Beware that currently, the cable server will _not_ auto-reload any changes in th
 
 We'll get all this abstracted properly when the framework is integrated into Rails.
 
-The WebSocket server doesn't have access to the session, but it has access to the cookies. This can be used when you need to handle authentication. You can see one way of doing that with Devise in this [article](http://www.rubytutorial.io/actioncable-devise-authentication).
+The WebSocket server doesn't have access to the session, but it has access to the cookies. This can be used when you need to handle authentication. You can see one way of doing that with Devise in this [article](https://greg.molnar.io/blog/actioncable-devise-authentication/).
 
 ## Dependencies
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -665,7 +665,7 @@ The above will start a cable server on port 28080.
 
 The WebSocket server doesn't have access to the session, but it has
 access to the cookies. This can be used when you need to handle
-authentication. You can see one way of doing that with Devise in this [article](http://www.rubytutorial.io/actioncable-devise-authentication).
+authentication. You can see one way of doing that with Devise in this [article](https://greg.molnar.io/blog/actioncable-devise-authentication/).
 
 ## Dependencies
 


### PR DESCRIPTION
I retired the tutorial site a while ago and moved the posts to a different domain, which leads to broken links in the guide and readme.