### PR TITLE
Add clarification to 'getting_started.md'

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -583,8 +583,8 @@ the current controller, the `ArticlesController`.
 
 With the form and its associated route defined, you will be able to fill in the
 form and then click the submit button to begin the process of creating a new
-article, so go ahead and do that. When you submit the form, you should see a
-familiar error:
+article, so go ahead and do that (make sure to **reload the page** first to
+apply changes). When you submit the form, you should see a familiar error:
 
 ![Unknown action create for ArticlesController]
 (images/getting_started/unknown_action_create_for_articles.png)

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -581,10 +581,11 @@ associated with the `articles` prefix; and the form will (by default) send a
 `POST` request to that route. This is associated with the `create` action of
 the current controller, the `ArticlesController`.
 
-With the form and its associated route defined, you will be able to fill in the
-form and then click the submit button to begin the process of creating a new
-article, so go ahead and do that (make sure to **reload the page** first to
-apply changes). When you submit the form, you should see a familiar error:
+Make sure to reload the page to apply the changes. With the form and its
+associated route defined, you will be able to fill in the form and then
+click the submit button to begin the process of creating a new article, so
+go ahead and do that. When you submit the form, you should see a familiar
+error:
 
 ![Unknown action create for ArticlesController]
 (images/getting_started/unknown_action_create_for_articles.png)


### PR DESCRIPTION
Stress that the page must be reloaded after making changes to a form, otherwise people might forget about it and get confusing errors.
    
Example: https://stackoverflow.com/questions/23864868/no-route-matches-post-articles-new