### PR TITLE
Test that blank keys raise an error

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -12,6 +12,15 @@ require "active_support/core_ext/string/inflections"
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
   module Cache
+    class InvalidCacheKeyError < StandardError
+      def initialize(key)
+        super("You are attempting to use a key: `#{key.inspect}` which is not\n" \
+          "supported because it is blank. If you are intentionally" \
+          "trying to use the cache with a blank key, please instead pass in\n" \
+          "a string such as: `'intentionally_empty'`")
+      end
+    end
+
     autoload :FileStore,        "active_support/cache/file_store"
     autoload :MemoryStore,      "active_support/cache/memory_store"
     autoload :MemCacheStore,    "active_support/cache/mem_cache_store"
@@ -622,6 +631,8 @@ module ActiveSupport
         #   namespace_key 'foo', namespace: -> { 'cache' }
         #   # => 'cache:foo'
         def namespace_key(key, options = nil)
+          raise InvalidCacheKeyError.new(key) if key.nil? || key.empty?
+
           options = merged_options(options)
           namespace = options[:namespace]
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -498,8 +498,49 @@ module CacheStoreBehavior
     ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
   end
 
-  private
+  def test_empty_keys_are_not_supported
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.write(nil, "baz")
+    end
 
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.read(nil)
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.write([nil], "bizz")
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.read([nil])
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.write("", "bizz")
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.read("")
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.write([""], "bizz")
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.read([""])
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.write({}, "bar")
+    end
+
+    assert_raises(ActiveSupport::Cache::InvalidCacheKeyError) do
+      @cache.read({})
+    end
+  end
+
+  private
     def assert_compressed(value, **options)
       assert_compression(true, value, **options)
     end


### PR DESCRIPTION
Explicitly empty keys such as `nil` and `""` are not valid on all cache stores and are likely to indicate an error. When a user generates a cache key that ends up being completely blank, then raise an error to alert them to this issue.
