### PR TITLE
Added `_scope_prefix` and `_scope_suffix` options for `enum`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Added `_scope_prefix` and `_scope_suffix` options for `enum`.
+    Use for avoid the `scope` name conflicts with Ruby syntax, when using the
+    dangerous keywords like `private / public / protected` as the enum value.
+
+    Example:
+
+        class Conversation < ActiveRecord::Base
+          enum privacy: [:private, :public], _scope_prefix: :in
+        end
+
+        conversation = Conversation.last
+        conversation.private!
+        conversation.public?
+        Conversation.in_public.first
+        Conversation.in_private.any?
+
+    *Jason Lee*
+
 *   Added `index` option for `change_table` migration helpers.
     With this change you can create indexes while adding new
     columns into the existing tables.

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -22,6 +22,9 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate @book, :illustrator_visibility_visible?
     assert_predicate @book, :with_medium_font_size?
     assert_predicate @book, :medium_to_read?
+    assert_predicate @book, :private?
+    assert_predicate @book, :black?
+    assert_predicate @book, :light?
   end
 
   test "query state with strings" do
@@ -31,6 +34,9 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.author_visibility
     assert_equal "visible", @book.illustrator_visibility
     assert_equal "medium", @book.difficulty
+    assert_equal "private", @book.privacy
+    assert_equal "black", @book.color
+    assert_equal "light", @book.font_weight
   end
 
   test "find via scope" do
@@ -42,6 +48,9 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal @book, Book.medium_to_read.first
     assert_equal books(:ddd), Book.forgotten.first
     assert_equal books(:rfr), authors(:david).unpublished_books.first
+    assert_equal @book, Book.in_private.first
+    assert_equal @book, Book.black_color.first
+    assert_equal @book, Book.font_weight_light.first
   end
 
   test "find via where with values" do
@@ -96,6 +105,8 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate @book, :in_english?
     @book.author_visibility_visible!
     assert_predicate @book, :author_visibility_visible?
+    @book.public!
+    assert_predicate @book, :public?
   end
 
   test "update by setter" do

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -10,6 +10,9 @@ awdr:
   illustrator_visibility: :visible
   font_size: :medium
   difficulty: :medium
+  privacy: :private
+  color: :black
+  font_weight: :light
 
 rfr:
   author_id: 1

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -18,6 +18,9 @@ class Book < ActiveRecord::Base
   enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
   enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
+  enum privacy: [:private, :public], _scope_prefix: :in
+  enum font_weight: [:light, :bold], _scope_prefix: true
+  enum color: [:black, :blue], _scope_suffix: true
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -105,6 +105,9 @@ ActiveRecord::Schema.define do
     t.column :illustrator_visibility, :integer, default: 0
     t.column :font_size, :integer, default: 0
     t.column :difficulty, :integer, default: 0
+    t.column :privacy, :integer, default: 0
+    t.column :color, :integer, default: 0
+    t.column :font_weight, :integer, default: 0
     t.column :cover, :string, default: "hard"
   end
 


### PR DESCRIPTION
Use for avoid the `scope` name conflicts with Ruby syntax, when using the dangerous keywords like `private / public / protected` as the enum value.

For fix issue #34129 