### PR TITLE
Fix DRb::DRbServerNotFound  errors in parallel tests

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -78,7 +78,14 @@ module ActiveSupport
                 reporter = job[2]
                 result   = Minitest.run_one_method(klass, method)
 
-                queue.record(reporter, result)
+                begin
+                  queue.record(reporter, result)
+                rescue DRb::DRbConnError
+                  result.failures.each do |failure|
+                    failure.exception = DRb::DRbRemoteError.new(failure.exception)
+                  end
+                  queue.record(reporter, result)
+                end
               end
             ensure
               run_cleanup(worker)


### PR DESCRIPTION
When running parallel tests, if a Exception is unable to be `Marshal.dump`ed a `DRb::DRbServerNotFound (DRb::DRbConnError)` error is raised.

The PR captures these errors and converts the errors to `DRb:: DRbRemoteError`s which can be safely marshalled.

Fixes #32682

To reproduce, create an error class that stores a `Proc` (or anything that can't be marshalled`)

```ruby
class BadError < StandardError
  def initialize(*args)
    super
    @proc = ->{ }
  end
end
```

Then raise it in the tests.

Before this fix: 

```
# Running:

..Traceback (most recent call last):
	25: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
	24: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:133:in `run'
	23: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:66:in `start'
	22: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:66:in `map'
	21: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:66:in `each'
	20: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:66:in `times'
	19: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:67:in `block in start'
	18: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:67:in `fork'
	17: from /Users/lachlansylvester/Repos/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:81:in `block (2 levels) in start'
	16: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1138:in `method_missing'
	15: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1158:in `with_friend'
	14: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1139:in `block in method_missing'
	13: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1227:in `open'
	12: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1140:in `block (2 levels) in method_missing'
	11: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1251:in `send_message'
	10: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:929:in `send_request'
	 9: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:610:in `send_request'
	 8: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:610:in `each'
	 7: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:611:in `block in send_request'
	 6: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:564:in `dump'
	 5: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:567:in `rescue in dump'
	 4: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:650:in `make_proxy'
	 3: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:650:in `new'
	 2: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1101:in `initialize'
	 1: from /Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1807:in `to_id'
/Users/lachlansylvester/.rbenv/versions/2.5.0/lib/ruby/2.5.0/drb/drb.rb:1738:in `current_server': DRb::DRbServerNotFound (DRb::DRbConnError)
....

Finished in 0.621037s, 9.6613 runs/s, 12.8817 assertions/s.
6 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```

And after
```
Run options: --seed 51201

# Running:

......E

Error:
MonkeysControllerTest#test_should_show_monkey:
DRb::DRbRemoteError: BadError (BadError)
    app/controllers/monkeys_controller.rb:13:in `show'
    test/controllers/monkeys_controller_test.rb:27:in `block in <class:MonkeysControllerTest>'


rails test test/controllers/monkeys_controller_test.rb:26



Finished in 0.596738s, 11.7304 runs/s, 13.4062 assertions/s.
7 runs, 8 assertions, 0 failures, 1 errors, 0 skips
```


