### PR TITLE
Fix issue where duration where always rounded up to a second:

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix duration being rounded to a full second.
+    ```
+      time = DateTime.parse("2018-1-1")
+      time += 0.51.seconds
+    ```
+    Will now correctly add 0.51 second and not 1 full second.
+
+    *Edouard Chin*
+
 *   Deprecate `ActiveSupport::Multibyte::Unicode#normalize` and `ActiveSuppport::Multibyte::Chars#normalize`
     in favor of `String#unicode_normalize`
 

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -110,7 +110,7 @@ class DateTime
   # instance time. Do not use this method in combination with x.months, use
   # months_since instead!
   def since(seconds)
-    self + Rational(seconds.round, 86400)
+    self + Rational(seconds, 86400)
   end
   alias :in :since
 

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -152,8 +152,8 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005, 2, 22, 11, 10, 10), DateTime.civil(2005, 2, 22, 10, 10, 10).since(3600)
     assert_equal DateTime.civil(2005, 2, 24, 10, 10, 10), DateTime.civil(2005, 2, 22, 10, 10, 10).since(86400 * 2)
     assert_equal DateTime.civil(2005, 2, 24, 11, 10, 35), DateTime.civil(2005, 2, 22, 10, 10, 10).since(86400 * 2 + 3600 + 25)
-    assert_equal DateTime.civil(2005, 2, 22, 10, 10, 11), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.333)
-    assert_equal DateTime.civil(2005, 2, 22, 10, 10, 12), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.667)
+    assert_not_equal DateTime.civil(2005, 2, 22, 10, 10, 11), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.333)
+    assert_not_equal DateTime.civil(2005, 2, 22, 10, 10, 12), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.667)
   end
 
   def test_change


### PR DESCRIPTION
- Adding a Float as a duration to a datetime would result in the Float
  being rounded. Doing something like would have no effect because the
  0.45 seconds would be rounded to 0 second.

  ```ruby
    time = DateTime.parse("2018-1-1")
    time += 0.45.seconds
  ```

  This behavior was intentionally added a very long time ago, the
  reason was because Ruby 1.8 was using `Integer#gcd` in the
  constructor of Rational which didn't accept a float value.

  That's no longer the case and doing `Rational(0.45, 86400)` would
  now perfectly work fine.

- Fixes #34008

cc/ @pixeltrix 