### PR TITLE
Add multi-db support to rails db:migrate:status

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -149,7 +149,21 @@ db_namespace = namespace :db do
 
     desc "Display status of migrations"
     task status: :load_config do
-      ActiveRecord::Tasks::DatabaseTasks.migrate_status
+      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+        ActiveRecord::Base.establish_connection(db_config.config)
+        ActiveRecord::Tasks::DatabaseTasks.migrate_status
+      end
+    end
+
+    namespace :status do
+      ActiveRecord::Tasks::DatabaseTasks.for_each do |spec_name|
+        desc "Display status of migrations for #{spec_name} database"
+        task spec_name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+          ActiveRecord::Base.establish_connection(db_config.config)
+          ActiveRecord::Tasks::DatabaseTasks.migrate_status
+        end
+      end
     end
   end
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Adds support for multiple databases to `rails db:migrate:status`.
+    Subtasks are also added to get the status of individual databases (eg. `rails db:migrate:status:animals`).
+
+    *Gannon McGibbon*
+
 *   Use Webpacker by default to manage app-level JavaScript through the new app/javascript directory.
     Sprockets is now solely in charge, by default, of compiling CSS and other static assets.
     Action Cable channel generators will create ES6 stubs rather than use CoffeeScript.


### PR DESCRIPTION
### Summary

Adds multi-db support for `rails db:migrate:status`. Also adds subtasks to list each individual schema migrations table for each database spec name via `rails db:migrate:status:namespace`.

r? @eileencodes 
/cc @rafaelfranca 
