### PR TITLE
Db schema cache dump and clear multi db

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+Adds support for multiple databases to `rails db:schema:cache:dump` and `rails db:schema:cache:clear`.
+
+    *Gannon McGibbon*
+
 *   `update_columns` now correctly raises `ActiveModel::MissingAttributeError`
     if the attribute does not exist.
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -300,15 +300,22 @@ db_namespace = namespace :db do
     namespace :cache do
       desc "Creates a db/schema_cache.yml file."
       task dump: :load_config do
-        conn = ActiveRecord::Base.connection
-        filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(conn, filename)
+        ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+          ActiveRecord::Base.establish_connection(db_config.config)
+          filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
+            ActiveRecord::Base.connection,
+            filename,
+          )
+        end
       end
 
       desc "Clears a db/schema_cache.yml file."
       task clear: :load_config do
-        filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
-        rm_f filename, verbose: false
+        ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+          filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
+          rm_f filename, verbose: false
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -313,6 +313,16 @@ module ActiveRecord
         ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
       end
 
+      def cache_dump_filename(namespace)
+        filename = if namespace == "primary"
+          "schema_cache.yml"
+        else
+          "#{namespace}_schema_cache.yml"
+        end
+
+        ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
+      end
+
       def load_schema_current(format = ActiveRecord::Base.schema_format, file = nil, environment = env)
         each_current_configuration(environment) { |configuration, spec_name, env|
           load_schema(configuration, format, file, env, spec_name)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -65,6 +65,27 @@ module ApplicationTests
         end
       end
 
+      def db_migrate_and_schema_cache_dump
+        Dir.chdir(app_path) do
+          generate_models_for_animals
+          rails "db:migrate"
+          rails "db:schema:cache:dump"
+          assert File.exist?("db/schema_cache.yml")
+          assert File.exist?("db/animals_schema_cache.yml")
+        end
+      end
+
+      def db_migrate_and_schema_cache_dump_and_schema_cache_clear
+        Dir.chdir(app_path) do
+          generate_models_for_animals
+          rails "db:migrate"
+          rails "db:schema:cache:dump"
+          rails "db:schema:cache:clear"
+          assert_not File.exist?("db/schema_cache.yml")
+          assert_not File.exist?("db/animals_schema_cache.yml")
+        end
+      end
+
       def db_migrate_and_schema_dump_and_load(format)
         Dir.chdir(app_path) do
           generate_models_for_animals
@@ -193,6 +214,16 @@ module ApplicationTests
           db_migrate_namespaced db_config.spec_name, db_config.config["database"]
           db_migrate_status_namespaced db_config.spec_name, db_config.config["database"]
         end
+      end
+
+      test "db:schema:cache:dump works on all databases" do
+        require "#{app_path}/config/environment"
+        db_migrate_and_schema_cache_dump
+      end
+
+      test "db:schema:cache:clear works on all databases" do
+        require "#{app_path}/config/environment"
+        db_migrate_and_schema_cache_dump_and_schema_cache_clear
       end
     end
   end


### PR DESCRIPTION
### Summary

Adds multi-db support to `rails db:schema:cache:dump` and `rails db:schema:cache:clear`. I assume we may need to do some followup on this for rails to actually use the other schema cache files, right?

r? @eileencodes 
cc @rafaelfranca 
