### PR TITLE
Structure sql version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Track structure dump versions in separate `structure.version` file.
+
+    *Gannon McGibbon*
+
 *   Fix query attribute method on user-defined attribute to be aware of typecasted value.
 
     For example, the following code no longer return false as casted non-empty string:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1040,11 +1040,6 @@ module ActiveRecord
         options
       end
 
-      def dump_schema_information #:nodoc:
-        versions = ActiveRecord::SchemaMigration.all_versions
-        insert_versions_sql(versions) if versions.any?
-      end
-
       def internal_string_options_for_primary_key # :nodoc:
         { primary_key: true }
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -335,12 +335,6 @@ db_namespace = namespace :db do
         ActiveRecord::Base.establish_connection(db_config.config)
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :sql)
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(db_config.config, filename)
-        if ActiveRecord::SchemaMigration.table_exists?
-          File.open(filename, "a") do |f|
-            f.puts ActiveRecord::Base.connection.dump_schema_information
-            f.print "\n"
-          end
-        end
       end
 
       db_namespace["structure:dump"].reenable

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -19,20 +19,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
     dump_all_table_schema []
   end
 
-  def test_dump_schema_information_with_empty_versions
+  def test_dump_schema_information_contains_no_versions
     ActiveRecord::SchemaMigration.delete_all
-    schema_info = ActiveRecord::Base.connection.dump_schema_information
+    schema_info = perform_schema_dump
     assert_no_match(/INSERT INTO/, schema_info)
   end
 
-  def test_dump_schema_information_outputs_lexically_ordered_versions
+  def test_dump_schema_information_contains_no_versions
     versions = %w{ 20100101010101 20100201010101 20100301010101 }
     versions.reverse_each do |v|
       ActiveRecord::SchemaMigration.create!(version: v)
     end
-
-    schema_info = ActiveRecord::Base.connection.dump_schema_information
-    assert_match(/20100201010101.*20100301010101/m, schema_info)
+    schema_info = perform_schema_dump
+    assert_no_match(/20100201010101.*20100301010101/m, schema_info)
   ensure
     ActiveRecord::SchemaMigration.delete_all
   end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -29,9 +29,9 @@ module ActiveRecord
     end
 
     def with_stubbed_new
-      ActiveRecord::Tasks::MySQLDatabaseTasks.stub(:new, @mysql_tasks) do
-        ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stub(:new, @postgresql_tasks) do
-          ActiveRecord::Tasks::SQLiteDatabaseTasks.stub(:new, @sqlite_tasks) do
+      ActiveRecord::Tasks::MySQLDatabaseTasks.stub(:new, mysql_tasks) do
+        ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stub(:new, postgresql_tasks) do
+          ActiveRecord::Tasks::SQLiteDatabaseTasks.stub(:new, sqlite_tasks) do
             yield
           end
         end
@@ -133,11 +133,11 @@ module ActiveRecord
   class DatabaseTasksCreateTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_create") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_create") do
         with_stubbed_new do
-          assert_called(eval("@#{v}"), :create) do
-            ActiveRecord::Tasks::DatabaseTasks.create "adapter" => k
+          assert_called(public_send(adapter_tasks), :create) do
+            ActiveRecord::Tasks::DatabaseTasks.create "adapter" => adapter
           end
         end
       end
@@ -458,11 +458,11 @@ module ActiveRecord
   class DatabaseTasksDropTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_drop") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_drop") do
         with_stubbed_new do
-          assert_called(eval("@#{v}"), :drop) do
-            ActiveRecord::Tasks::DatabaseTasks.drop "adapter" => k
+          assert_called(public_send(adapter_tasks), :drop) do
+            ActiveRecord::Tasks::DatabaseTasks.drop "adapter" => adapter
           end
         end
       end
@@ -891,11 +891,11 @@ module ActiveRecord
   class DatabaseTasksPurgeTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_purge") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_purge") do
         with_stubbed_new do
-          assert_called(eval("@#{v}"), :purge) do
-            ActiveRecord::Tasks::DatabaseTasks.purge "adapter" => k
+          assert_called(public_send(adapter_tasks), :purge) do
+            ActiveRecord::Tasks::DatabaseTasks.purge "adapter" => adapter
           end
         end
       end
@@ -1073,11 +1073,11 @@ module ActiveRecord
   class DatabaseTasksCharsetTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_charset") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_charset") do
         with_stubbed_new do
-          assert_called(eval("@#{v}"), :charset) do
-            ActiveRecord::Tasks::DatabaseTasks.charset "adapter" => k
+          assert_called(public_send(adapter_tasks), :charset) do
+            ActiveRecord::Tasks::DatabaseTasks.charset "adapter" => adapter
           end
         end
       end
@@ -1087,11 +1087,11 @@ module ActiveRecord
   class DatabaseTasksCollationTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_collation") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_collation") do
         with_stubbed_new do
-          assert_called(eval("@#{v}"), :collation) do
-            ActiveRecord::Tasks::DatabaseTasks.collation "adapter" => k
+          assert_called(public_send(adapter_tasks), :collation) do
+            ActiveRecord::Tasks::DatabaseTasks.collation "adapter" => adapter
           end
         end
       end
@@ -1203,14 +1203,17 @@ module ActiveRecord
   class DatabaseTasksStructureDumpTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_structure_dump") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_structure_dump") do
         with_stubbed_new do
           assert_called_with(
-            eval("@#{v}"), :structure_dump,
-            ["awesome-file.sql", nil]
+            public_send(adapter_tasks),
+            :structure_dump,
+            ["awesome-file.sql", nil],
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => k }, "awesome-file.sql")
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+              { "adapter" => adapter }, "awesome-file.sql"
+            )
           end
         end
       end
@@ -1220,15 +1223,17 @@ module ActiveRecord
   class DatabaseTasksStructureLoadTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 
-    ADAPTERS_TASKS.each do |k, v|
-      define_method("test_#{k}_structure_load") do
+    ADAPTERS_TASKS.each do |adapter, adapter_tasks|
+      define_method("test_#{adapter}_structure_load") do
         with_stubbed_new do
           assert_called_with(
-            eval("@#{v}"),
+            public_send(adapter_tasks),
             :structure_load,
-            ["awesome-file.sql", nil]
+            ["awesome-file.sql", nil],
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.structure_load({ "adapter" => k }, "awesome-file.sql")
+            ActiveRecord::Tasks::DatabaseTasks.structure_load(
+              { "adapter" => adapter }, "awesome-file.sql"
+            )
           end
         end
       end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -116,9 +116,19 @@ module ActiveRecord
       instance = klazz.new
 
       klazz.stub(:new, instance) do
-        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil]) do
-          ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :foo }, "awesome-file.sql")
+        assert_called_with(
+          instance,
+          :structure_dump,
+          ["awesome-file.sql", nil],
+        ) do
+          assert_called_with(
+            ActiveRecord::Tasks::DatabaseTasks,
+            :structure_version_dump,
+            ["awesome-file.sql"],
+          ) do
+            ActiveRecord::Tasks::DatabaseTasks.register_task(/foo/, klazz)
+            ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :foo }, "awesome-file.sql")
+          end
         end
       end
     end
@@ -1211,9 +1221,15 @@ module ActiveRecord
             :structure_dump,
             ["awesome-file.sql", nil],
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.structure_dump(
-              { "adapter" => adapter }, "awesome-file.sql"
-            )
+            assert_called_with(
+              ActiveRecord::Tasks::DatabaseTasks,
+              :structure_version_dump,
+              ["awesome-file.sql"]
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+                { "adapter" => adapter }, "awesome-file.sql"
+              )
+            end
           end
         end
       end
@@ -1231,9 +1247,15 @@ module ActiveRecord
             :structure_load,
             ["awesome-file.sql", nil],
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.structure_load(
-              { "adapter" => adapter }, "awesome-file.sql"
-            )
+            assert_called_with(
+              ActiveRecord::Tasks::DatabaseTasks,
+              :structure_version_load,
+              ["awesome-file.sql"],
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.structure_load(
+                { "adapter" => adapter }, "awesome-file.sql"
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/pull/34078, we discussed potential issues with adding timestamps to `schema_migrations`. In particular, schema migration versions are inserted in sequence when using a SQL structure dump (eg. `rails db:structure:dump`). On the other hand, a schema dump (eg. `rails db:schema:dump`) only tracks the latest migration version.

In this PR, I'm changing structure dumps to track a single schema migration version in a separate file (as opposed to the sequential insert approach currently used). This will allow us to add timestamps to our schema migrations without having the structure file change needlessly when running another developer's migration.

r? @rafaelfranca 
cc @eileencodes, @matthewd, @eugeneius 