### PR TITLE
Add test retries for railties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
       - postgresql-10
       - postgresql-client-10
 
-bundler_args: --without test --jobs 3 --retry 3
+bundler_args: --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
   gem "minitest-bisect"
+  gem "minitest-retry"
 
   platforms :mri do
     gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,8 @@ GEM
     minitest-bisect (1.4.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.0)
+    minitest-retry (0.1.9)
+      minitest (>= 5.0)
     minitest-server (1.0.5)
       minitest (~> 5.0)
     mono_logger (1.1.0)
@@ -538,6 +540,7 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   minitest-bisect
+  minitest-retry
   mysql2 (>= 0.4.10)
   nokogiri (>= 1.8.1)
   pg (>= 0.18.0)
@@ -576,4 +579,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -16,6 +16,9 @@ require "active_support/testing/autorun"
 require "active_support/testing/stream"
 require "active_support/testing/method_call_assertions"
 require "active_support/test_case"
+require "minitest/retry"
+
+Minitest::Retry.use!(verbose: false, retry_count: 1)
 
 RAILS_FRAMEWORK_ROOT = File.expand_path("../../..", __dir__)
 


### PR DESCRIPTION
### Summary

Adds `minitest-retry` for railties because its been really inconsistent lately. Also, adds `travis_retry` to rake commands if they timeout or blow up (this may be a bad idea).

r? @rafaelfranca 
