### PR TITLE
create inner joins to includes when running in the preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -78,6 +78,8 @@ module ActiveRecord
 
               if joins = values[:joins]
                 scope.joins!(source_reflection.name => joins)
+              else
+                scope.joins!(source_reflection.name)
               end
 
               if left_outer_joins = values[:left_outer_joins]

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -64,6 +64,10 @@ module ActiveRecord
               scope.where_clause = reflection_scope.where_clause
               values = reflection_scope.values
 
+              if klass.finder_needs_type_condition?
+                scope.unscope!(where: klass.inheritance_column)
+              end
+
               if includes = values[:includes]
                 scope.includes!(source_reflection.name => includes)
               else

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -70,10 +70,8 @@ module ActiveRecord
                 scope.includes!(source_reflection.name)
               end
 
-              if values[:references] && !values[:references].empty?
-                scope.references!(values[:references])
-              else
-                scope.references!(source_reflection.table_name)
+              if references = values[:references]
+                scope.references!(references)
               end
 
               if joins = values[:joins]

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -540,7 +540,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nested_has_many_through_with_conditions_on_source_associations_preload
-    authors = assert_queries(4) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
+    authors = assert_queries(2) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
     blue = tags(:blue)
 
     assert_no_queries do


### PR DESCRIPTION
### Summary

When preloading through associations that have a where clause it is possible to generate SQL like

```SQL
LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" AND "comments"."type" IN ('VerySpecialComment') WHERE "comments"."type" IN ('VerySpecialComment') 
```

The left outer join is unnecessary as the where clause ensures that joined table must be present.

~~Also, this is triggering a bug in SQLite where the were clause is being ignored.~~ The SQLite bug occurs regardless of the join type. It can be avoided be removing the `type` from the `where` clause as it is already in the join.

This change ensures that `INNER JOINS` are used when using includes when preloading associations.

As a result of this change, the queries in `test/cases/associations/nested_through_associations_test.rb:542` changed from

```SQL
SELECT "authors".* FROM "authors"
SELECT "posts".* FROM "posts" WHERE "posts"."title" IN (?, ?) AND "posts"."author_id" IN (?, ?, ?)
SELECT "taggings".* FROM "taggings" WHERE "taggings"."taggable_type" = ? AND "taggings"."comment" = ? AND "taggings"."taggable_id" IN (?, ?)
SELECT "tags".* FROM "tags" WHERE "tags"."name" = ? AND "tags"."id" = ?.
```

to 

```SQL
SELECT "authors".* FROM "authors"
SELECT "posts"."id" AS t0_r0, "posts"."author_id" AS t0_r1, "posts"."title" AS t0_r2, "posts"."body" AS t0_r3, "posts"."type" AS t0_r4, "posts"."comments_count" AS t0_r5, "posts"."taggings_with_delete_all_count" AS t0_r6, "posts"."taggings_with_destroy_count" AS t0_r7, "posts"."tags_count" AS t0_r8, "posts"."indestructible_tags_count" AS t0_r9, "posts"."tags_with_destroy_count" AS t0_r10, "posts"."tags_with_nullify_count" AS t0_r11, "tags"."id" AS t1_r0, "tags"."name" AS t1_r1, "tags"."taggings_count" AS t1_r2 FROM "posts" INNER JOIN "taggings" ON "taggings"."taggable_id" = "posts"."id" AND "taggings"."taggable_type" = ? INNER JOIN "tags" ON "tags"."id" = "taggings"."tag_id" AND "tags"."name" = ? AND "taggings"."comment" = ? WHERE "posts"."title" IN (?, ?) AND "posts"."author_id" IN (?, ?, ?)
```

~~which I think is an ok change - and is why the test was updated.~~ I need to confirm the expected behaviour here. When preloading a non STI class - it seems to populate the through associations - but when it is an STI class it doesn't . This change may have fixed or broken something - depending on what the expectation is.