### PR TITLE
Stop trying to reconnect on unauthorized cable connections

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The JavaScript WebSocket client will no longer try to reconnect
+    when you call `reject_unauthorized_connection` on the connection.
+
+    *Mick Staugaard*
+
 *   `ActionCable.Connection#getState` now references the configurable
     `ActionCable.adapters.WebSocket` property rather than the `WebSocket` global
     variable, matching the behavior of `ActionCable.Connection#open`.

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -136,9 +136,15 @@
   var INTERNAL = {
     message_types: {
       welcome: "welcome",
+      disconnect: "disconnect",
       ping: "ping",
       confirmation: "confirm_subscription",
       rejection: "reject_subscription"
+    },
+    disconnect_reasons: {
+      unauthorized: "unauthorized",
+      invalid_request: "invalid_request",
+      server_restart: "server_restart"
     },
     default_mount_path: "/cable",
     protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
@@ -251,11 +257,17 @@
       if (!this.isProtocolSupported()) {
         return;
       }
-      var _JSON$parse = JSON.parse(event.data), identifier = _JSON$parse.identifier, message = _JSON$parse.message, type = _JSON$parse.type;
+      var _JSON$parse = JSON.parse(event.data), identifier = _JSON$parse.identifier, message = _JSON$parse.message, reason = _JSON$parse.reason, reconnect = _JSON$parse.reconnect, type = _JSON$parse.type;
       switch (type) {
        case message_types.welcome:
         this.monitor.recordConnect();
         return this.subscriptions.reload();
+
+       case message_types.disconnect:
+        logger.log("Disconnecting. Reason: " + reason);
+        return this.close({
+          allowReconnect: reconnect
+        });
 
        case message_types.ping:
         return this.monitor.recordPing();

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -117,11 +117,14 @@ Connection.reopenDelay = 500
 Connection.prototype.events = {
   message(event) {
     if (!this.isProtocolSupported()) { return }
-    const {identifier, message, type} = JSON.parse(event.data)
+    const {identifier, message, reason, reconnect, type} = JSON.parse(event.data)
     switch (type) {
       case message_types.welcome:
         this.monitor.recordConnect()
         return this.subscriptions.reload()
+      case message_types.disconnect:
+        logger.log(`Disconnecting. Reason: ${reason}`)
+        return this.close({allowReconnect: reconnect})
       case message_types.ping:
         return this.monitor.recordPing()
       case message_types.confirmation:

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -33,9 +33,15 @@ module ActionCable
   INTERNAL = {
     message_types: {
       welcome: "welcome",
+      disconnect: "disconnect",
       ping: "ping",
       confirmation: "confirm_subscription",
       rejection: "reject_subscription"
+    },
+    disconnect_reasons: {
+      unauthorized: "unauthorized",
+      invalid_request: "invalid_request",
+      server_restart: "server_restart"
     },
     default_mount_path: "/cable",
     protocols: ["actioncable-v1-json", "actioncable-unsupported"].freeze

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -36,7 +36,9 @@ module ActionCable
       end
 
       def restart
-        connections.each(&:close)
+        connections.each do |connection|
+          connection.close(reason: ActionCable::INTERNAL[:disconnect_reasons][:server_restart])
+        end
 
         @mutex.synchronize do
           # Shutdown the worker pool

--- a/actioncable/test/connection/authorization_test.rb
+++ b/actioncable/test/connection/authorization_test.rb
@@ -25,8 +25,11 @@ class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
         "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
 
       connection = Connection.new(server, env)
-      assert_called(connection.websocket, :close) do
-        connection.process
+
+      assert_called_with(connection.websocket, :transmit, [{ type: "disconnect", reason: "unauthorized", reconnect: false }.to_json]) do
+        assert_called(connection.websocket, :close) do
+          connection.process
+        end
       end
     end
   end

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -108,7 +108,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
       connection.process
 
       assert_called(connection.websocket, :close) do
-        connection.close
+        connection.close(reason: "testing")
       end
     end
   end

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -58,7 +58,7 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
       client.instance_variable_get("@stream")
         .instance_variable_get("@rack_hijack_io")
         .define_singleton_method(:close) { event.set }
-      connection.close
+      connection.close(reason: "testing")
       event.wait
     end
   end


### PR DESCRIPTION
### Summary

When calling `reject_unauthorized_connection` from an `ActionCable::Connection`, the client would keep retrying to establish a connection. These would keep failing as the client is still unauthorized.

This stops that. If you call `reject_unauthorized_connection`, the connection is now closed and is not retried.

