### PR TITLE
Speed up ActiveRecord#respond_to? for pages with caching

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -275,6 +275,12 @@ module ActiveRecord
         name = "to_partial_path"
       when :to_model
         name = "to_model"
+      when :cache_version
+        name = "cache_version"
+      when :cache_key
+        name = "cache_key"
+      when :updated_at
+        name = "updated_at"
       else
         name = name.to_s
       end


### PR DESCRIPTION
Normally calling `respond_to?` on an active record object allocates a string for any method call that is not defined directly on the object (but is instead an attribute from the database)

These three methods are called every time a cache key is generated `:updated_at`, `:cache_key`, and `:cache_version`. By removing this string allocation, in CodeTriage we save memory:

Before: Total allocated: 751921 bytes (6525 objects)
After: Total allocated: 744009 bytes (6327 objects)
Diff: (751921 - 744009) / 751921.0 # => 1 %

Early testing is showing a perf diff of per request on CodeTriage (though with high variance).