### PR TITLE
Add support for hash and url configs to be used in connected_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add support for hash and url configs in database hash of `ActiveRecord::Base.connected_to`.
+
+    ````
+    User.connected_to(database: { writing: "postgres://foo" }) do
+      User.create!(name: "Gannon")
+    end
+
+    config = { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" }
+    User.connected_to(database: { reading: config }) do
+      User.count
+    end
+    ````
+
+    *Gannon McGibbon*
+
 *   Support default expression for MySQL.
 
     MySQL 8.0.13 and higher supports default value to be a function or expression.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -109,12 +109,15 @@ module ActiveRecord
       if database && role
         raise ArgumentError, "connected_to can only accept a database or role argument, but not both arguments."
       elsif database
-        config_hash = resolve_config_for_connection(database)
-        handler = lookup_connection_handler(database.to_sym)
+        database = { database => database } if database.is_a?(Symbol)
+        database.each do |role, database_key|
+          config_hash = resolve_config_for_connection(database_key)
+          handler = lookup_connection_handler(role.to_sym)
 
-        with_handler(database.to_sym) do
-          handler.establish_connection(config_hash)
-          return yield
+          with_handler(role.to_sym) do
+            handler.establish_connection(config_hash)
+            return yield
+          end
         end
       elsif role
         with_handler(role.to_sym, &blk)


### PR DESCRIPTION
### Summary

I noticed when using the new connection switching API, if I use a string database name, it bubbles down to [this connection resolution method](https://github.com/rails/rails/blob/8df7ed3b88fc9f19446d7207a745a331893b81cd/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L216) which thinks strings are database URLs. Do we want to support URLs, or is this acceptable behaviour? If not, we should make `DatabaseConfig#spec_name` return a symbol instead of a string.
