### PR TITLE
Fix stale reference on inverse switch for belongs_to/has_many associa…

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -70,7 +70,10 @@ module ActiveRecord
 
           replace_keys(record)
 
-          self.target = record
+          if target != record
+            remove_owner_from_collection_proxy
+            self.target = record
+          end
         end
 
         def update_counters(by)
@@ -106,6 +109,14 @@ module ActiveRecord
 
         def foreign_key_present?
           owner._read_attribute(reflection.foreign_key)
+        end
+
+        def remove_owner_from_collection_proxy
+          return unless target && owner.new_record?
+          inverse = inverse_reflection_for(owner)
+          return unless inverse && inverse.collection?
+
+          target.association(inverse.name).delete(owner)
         end
 
         # NOTE - for now, we're only supporting inverse setting from belongs_to back onto


### PR DESCRIPTION
…tions

### Summary

HasManyAssociation keeps a list of records that refer back, including
new records. When a new record in the list changes its parent,
that record should be removed from the list.

Failing to remove the child, the owner of the HasManyAssociation
will change the parent of the child back to itself when it is saved.

