### PR TITLE
Add regression test against has_and_belong_to_many memoized singular_ids

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -25,6 +25,8 @@ require "models/user"
 require "models/member"
 require "models/membership"
 require "models/sponsor"
+require "models/lesson"
+require "models/student"
 require "models/country"
 require "models/treaty"
 require "models/vertex"
@@ -778,6 +780,16 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     developer.reload
     assert_equal 2, developer.projects.length
     assert_equal [projects(:active_record), projects(:action_controller)].map(&:id).sort, developer.project_ids.sort
+  end
+
+  def test_singular_ids_are_reloaded_after_collection_concat
+    student = Student.create(name: "Alberto Almagro")
+    student.lesson_ids
+
+    lesson = Lesson.create(name: "DSI")
+    student.lessons << lesson
+
+    assert_includes student.lesson_ids, lesson.id
   end
 
   def test_scoped_find_on_through_association_doesnt_return_read_only_records


### PR DESCRIPTION
### Summary

Starting in Rails 5.0.0 and still present in Rails 5.2.1, `singular_ids` got memoized and didn't reload after more items were added to the relation.

Although 19c8071 happens to fix the issue for Rails edge, it only adds tests for `has_many` relations while this bug only affected `has_and_belongs_to_many` relations.

This patch adds a regression test to ensure it never happens again with `habtm` relations.

Ensures #34179 never happens again.

Thanks!