### PR TITLE
Include deserialized arguments in jobs returned by AJ test helpers

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Include deserialized arguments in job instances returned from
+    `assert_enqueued_with` and `assert_performed_with`
+
+    *Alan Wu*
+
 *   Allow `assert_enqueued_with`/`assert_performed_with` methods to accept
     a proc for the `args` argument. This is useful to check if only a subset of arguments
     matches your expectations.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -594,8 +594,7 @@ module ActiveJob
 
       def flush_enqueued_jobs(only: nil, except: nil, queue: nil)
         enqueued_jobs_with(only: only, except: except, queue: queue) do |payload|
-          args = ActiveJob::Arguments.deserialize(payload[:args])
-          instantiate_job(payload.merge(args: args)).perform_now
+          instantiate_job(payload).perform_now
           queue_adapter.performed_jobs << payload
         end
       end
@@ -613,7 +612,8 @@ module ActiveJob
       end
 
       def instantiate_job(payload)
-        job = payload[:job].new(*payload[:args])
+        args = ActiveJob::Arguments.deserialize(payload[:args])
+        job = payload[:job].new(*args)
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
         job.queue_name = payload[:queue]
         job

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -476,23 +476,23 @@ class EnqueuedJobsTest < ActiveJob::TestCase
 
   def test_assert_enqueued_with_returns
     job = assert_enqueued_with(job: LoggingJob) do
-      LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3)
+      LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
     end
 
     assert_instance_of LoggingJob, job
     assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
     assert_equal "default", job.queue_name
-    assert_equal [1, 2, 3], job.arguments
+    assert_equal [1, 2, 3, { keyword: true }], job.arguments
   end
 
   def test_assert_enqueued_with_with_no_block_returns
-    LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3)
+    LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
     job = assert_enqueued_with(job: LoggingJob)
 
     assert_instance_of LoggingJob, job
     assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
     assert_equal "default", job.queue_name
-    assert_equal [1, 2, 3], job.arguments
+    assert_equal [1, 2, 3, { keyword: true }], job.arguments
   end
 
   def test_assert_enqueued_with_failure
@@ -1515,26 +1515,26 @@ class PerformedJobsTest < ActiveJob::TestCase
   end
 
   def test_assert_performed_with_returns
-    job = assert_performed_with(job: NestedJob, queue: "default") do
-      NestedJob.perform_later
+    job = assert_performed_with(job: LoggingJob, queue: "default") do
+      LoggingJob.perform_later(keyword: :sym)
     end
 
-    assert_instance_of NestedJob, job
+    assert_instance_of LoggingJob, job
     assert_nil job.scheduled_at
-    assert_equal [], job.arguments
+    assert_equal [{ keyword: :sym }], job.arguments
     assert_equal "default", job.queue_name
   end
 
   def test_assert_performed_with_without_block_returns
-    NestedJob.perform_later
+    LoggingJob.perform_later(keyword: :sym)
 
     perform_enqueued_jobs
 
-    job = assert_performed_with(job: NestedJob, queue: "default")
+    job = assert_performed_with(job: LoggingJob, queue: "default")
 
-    assert_instance_of NestedJob, job
+    assert_instance_of LoggingJob, job
     assert_nil job.scheduled_at
-    assert_equal [], job.arguments
+    assert_equal [{ keyword: :sym }], job.arguments
     assert_equal "default", job.queue_name
   end
 


### PR DESCRIPTION
### Summary

`assert_enqueued_with` and `assert_performed_with` return a instantiated
instance of the matching job for further assertion (#21010).

Before this commit the `argument` method on the returned instance
returns a serialized version of the argument.