### PR TITLE
Implement AR#inspect using ParameterFilter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -138,13 +138,13 @@
     specify sensitive attributes to specific model.
 
     ```
-    Rails.application.config.filter_parameters += [:credit_card_number]
-    Account.last.inspect # => #<Account id: 123, name: "DHH", credit_card_number: [FILTERED] ...>
+    Rails.application.config.filter_parameters += [:credit_card_number, /phone/]
+    Account.last.inspect # => #<Account id: 123, name: "DHH", credit_card_number: [FILTERED], telephone_number: [FILTERED] ...>
     SecureAccount.filter_attributes += [:name]
     SecureAccount.last.inspect # => #<SecureAccount id: 42, name: [FILTERED], credit_card_number: [FILTERED] ...>
     ```
 
-    *Zhang Kang*
+    *Zhang Kang*, *Yoshiyuki Kinjo*
 
 *   Deprecate `column_name_length`, `table_name_length`, `columns_per_table`,
     `indexes_per_table`, `columns_per_multicolumn_index`, `sql_query_length`,

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -336,14 +336,7 @@ module ActiveRecord
     #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
     def attribute_for_inspect(attr_name)
       value = read_attribute(attr_name)
-
-      if value.is_a?(String) && value.length > 50
-        "#{value[0, 50]}...".inspect
-      elsif value.is_a?(Date) || value.is_a?(Time)
-        %("#{value.to_s(:db)}")
-      else
-        value.inspect
-      end
+      format_for_inspect(value)
     end
 
     # Returns +true+ if the specified +attribute+ has been set by the user or by a
@@ -460,6 +453,16 @@ module ActiveRecord
         attribute_names &= self.class.column_names
         attribute_names.delete_if do |name|
           pk_attribute?(name) && id.nil?
+        end
+      end
+
+      def format_for_inspect(value)
+        if value.is_a?(String) && value.length > 50
+          "#{value[0, 50]}...".inspect
+        elsif value.is_a?(Date) || value.is_a?(Time)
+          %("#{value.to_s(:db)}")
+        else
+          value.inspect
         end
       end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -2,14 +2,12 @@
 
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/string/filters"
+require "active_support/parameter_filter"
 require "concurrent/map"
-require "set"
 
 module ActiveRecord
   module Core
     extend ActiveSupport::Concern
-
-    FILTERED = "[FILTERED]" # :nodoc:
 
     included do
       ##
@@ -239,9 +237,7 @@ module ActiveRecord
       end
 
       # Specifies columns which shouldn't be exposed while calling +#inspect+.
-      def filter_attributes=(attributes_names)
-        @filter_attributes = attributes_names.map(&:to_s).to_set
-      end
+      attr_writer :filter_attributes
 
       # Returns a string like 'Post(id:integer, title:string, body:text)'
       def inspect # :nodoc:
@@ -514,11 +510,14 @@ module ActiveRecord
       inspection = if defined?(@attributes) && @attributes
         self.class.attribute_names.collect do |name|
           if has_attribute?(name)
-            if filter_attribute?(name)
-              "#{name}: #{ActiveRecord::Core::FILTERED}"
+            attr = read_attribute(name)
+            value = if attr.nil?
+              attr.inspect
             else
-              "#{name}: #{attribute_for_inspect(name)}"
+              attr = format_for_inspect(attr)
+              inspection_filter.filter_param(name, attr)
             end
+            "#{name}: #{value}"
           end
         end.compact.join(", ")
       else
@@ -534,18 +533,16 @@ module ActiveRecord
       return super if custom_inspect_method_defined?
       pp.object_address_group(self) do
         if defined?(@attributes) && @attributes
-          column_names = self.class.column_names.select { |name| has_attribute?(name) || new_record? }
-          pp.seplist(column_names, proc { pp.text "," }) do |column_name|
+          attr_names = self.class.attribute_names.select { |name| has_attribute?(name) }
+          pp.seplist(attr_names, proc { pp.text "," }) do |attr_name|
             pp.breakable " "
             pp.group(1) do
-              pp.text column_name
+              pp.text attr_name
               pp.text ":"
               pp.breakable
-              if filter_attribute?(column_name)
-                pp.text ActiveRecord::Core::FILTERED
-              else
-                pp.pp read_attribute(column_name)
-              end
+              value = read_attribute(attr_name)
+              value = inspection_filter.filter_param(attr_name, value) unless value.nil?
+              pp.pp value
             end
           end
         else
@@ -597,8 +594,14 @@ module ActiveRecord
         self.class.instance_method(:inspect).owner != ActiveRecord::Base.instance_method(:inspect).owner
       end
 
-      def filter_attribute?(attribute_name)
-        self.class.filter_attributes.include?(attribute_name) && !read_attribute(attribute_name).nil?
+      def inspection_filter
+        @inspection_filter ||= begin
+          mask = DelegateClass(::String).new(ActiveSupport::ParameterFilter::FILTERED)
+          def mask.pretty_print(pp)
+            pp.text __getobj__
+          end
+          ActiveSupport::ParameterFilter.new(self.class.filter_attributes, mask: mask)
+        end
       end
   end
 end

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -36,6 +36,51 @@ class ParameterFilterTest < ActiveSupport::TestCase
     end
   end
 
+  test "filter should return mask option when value is filtered" do
+    mask = Object.new.freeze
+    test_hashes = [
+    [{ "foo" => "bar" }, { "foo" => "bar" }, %w'food'],
+    [{ "foo" => "bar" }, { "foo" => mask }, %w'foo'],
+    [{ "foo" => "bar", "bar" => "foo" }, { "foo" => mask, "bar" => "foo" }, %w'foo baz'],
+    [{ "foo" => "bar", "baz" => "foo" }, { "foo" => mask, "baz" => mask }, %w'foo baz'],
+    [{ "bar" => { "foo" => "bar", "bar" => "foo" } }, { "bar" => { "foo" => mask, "bar" => "foo" } }, %w'fo'],
+    [{ "foo" => { "foo" => "bar", "bar" => "foo" } }, { "foo" => mask }, %w'f banana'],
+    [{ "deep" => { "cc" => { "code" => "bar", "bar" => "foo" }, "ss" => { "code" => "bar" } } }, { "deep" => { "cc" => { "code" => mask, "bar" => "foo" }, "ss" => { "code" => "bar" } } }, %w'deep.cc.code'],
+    [{ "baz" => [{ "foo" => "baz" }, "1"] }, { "baz" => [{ "foo" => mask }, "1"] }, [/foo/]]]
+
+    test_hashes.each do |before_filter, after_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterFilter.new(filter_words, mask: mask)
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+
+      filter_words << "blah"
+      filter_words << lambda { |key, value|
+        value.reverse! if key =~ /bargain/
+      }
+      filter_words << lambda { |key, value, original_params|
+        value.replace("world!") if original_params["barg"]["blah"] == "bar" && key == "hello"
+      }
+
+      parameter_filter = ActiveSupport::ParameterFilter.new(filter_words, mask: mask)
+      before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world" } } }
+      after_filter["barg"]  = { :bargain => "niag", "blah" => mask, "bar" => { "bargain" => { "blah" => mask, "hello" => "world!" } } }
+
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+    end
+  end
+
+  test "filter_param" do
+    parameter_filter = ActiveSupport::ParameterFilter.new(["foo", /bar/])
+    assert_equal "[FILTERED]", parameter_filter.filter_param("food", "secret vlaue")
+    assert_equal "[FILTERED]", parameter_filter.filter_param("baz.foo", "secret vlaue")
+    assert_equal "[FILTERED]", parameter_filter.filter_param("barbar", "secret vlaue")
+    assert_equal "non secret value", parameter_filter.filter_param("baz", "non secret value")
+  end
+
+  test "filter_param can work with empty filters" do
+    parameter_filter = ActiveSupport::ParameterFilter.new
+    assert_equal "bar", parameter_filter.filter_param("foo", "bar")
+  end
+
   test "parameter filter should maintain hash with indifferent access" do
     test_hashes = [
       [{ "foo" => "bar" }.with_indifferent_access, ["blah"]],
@@ -47,5 +92,14 @@ class ParameterFilterTest < ActiveSupport::TestCase
       assert_instance_of ActiveSupport::HashWithIndifferentAccess,
                          parameter_filter.filter(before_filter)
     end
+  end
+
+  test "filter_param should return mask option when value is filtered" do
+    mask = Object.new.freeze
+    parameter_filter = ActiveSupport::ParameterFilter.new(["foo", /bar/], mask: mask)
+    assert_equal mask, parameter_filter.filter_param("food", "secret vlaue")
+    assert_equal mask, parameter_filter.filter_param("baz.foo", "secret vlaue")
+    assert_equal mask, parameter_filter.filter_param("barbar", "secret vlaue")
+    assert_equal "non secret value", parameter_filter.filter_param("baz", "non secret value")
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2109,7 +2109,7 @@ module ApplicationTests
       RUBY
       app "development"
       assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
-      assert_equal [ "password", "credit_card_number" ].to_set, ActiveRecord::Base.filter_attributes
+      assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
     end
 
     test "ActiveStorage.routes_prefix can be configured via config.active_storage.routes_prefix" do


### PR DESCRIPTION
### Summary

AR instance support filter_parameters since #33756.
Though Regex or Proc is valid as filter_parameters, they are not supported as AR#inspect.
https://github.com/rails/rails/pull/33756#issuecomment-421939136

This PR tries to fix this issue.
