### PR TITLE
Fix `ActionController::Parameters#each_value` and add changelog entry to this method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActionController::Parameters#each_value`.
+
+    *Lukáš Zapletal*
+
 *   Deprecate `ActionDispatch::Http::ParameterFilter` in favor of `ActiveSupport::ParameterFilter`.
 
     *Yoshiyuki Kinjo*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -352,7 +352,7 @@ module ActionController
     # the same way as <tt>Hash#each_value</tt>.
     def each_value(&block)
       @parameters.each_pair do |key, value|
-        yield [convert_hashes_to_parameters(key, value)]
+        yield convert_hashes_to_parameters(key, value)
       end
     end
 

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -77,11 +77,15 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each_value carries permitted status" do
     @params.permit!
-    @params["person"].each_value { |value| assert(value.permitted?) if value == 32 }
+    @params.each_value do |value|
+      assert_predicate(value, :permitted?)
+    end
   end
 
   test "each_value carries unpermitted status" do
-    @params["person"].each_value { |value| assert_not(value.permitted?) if value == 32 }
+    @params.each_value do |value|
+      assert_not_predicate(value, :permitted?)
+    end
   end
 
   test "each_key converts to hash for permitted" do


### PR DESCRIPTION
- Fix `ActionController::Parameters#each_value`
  `each_value` should yield with "value" of the params instead of "value" as an array.

  Example:
  ```ruby
  hash = {a: 1, b: {c: 2}}
  params = ActionController::Parameters.new(hash)
  
  puts "hash values:"
  hash.each_value do |value|
    p value
  end
  # hash values:
  # 1
  # {:c=>2}

  # Before
  puts "params values:"
  params.each_value do |value|
    p value
  end
  # params values:
  # [1]
  # [<ActionController::Parameters {"c"=>2} permitted: false>]

  
  # After
  puts "params values:"
  params.each_value do |value|
    p value
  end
  # params values:
  # 1
  # <ActionController::Parameters {"c"=>2} permitted: false>

  ```

   Related to #33979

- Add changelog entry about `ActionController::Parameters#each_value`.
  Follow up #33979

r? @rafaelfranca 
