### PR TITLE
Use double quotes in *.erb.tt and *.rb.tt templates

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb.tt
+++ b/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb.tt
@@ -1,6 +1,6 @@
 <% module_namespacing do -%>
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end
 <% end %>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
-<%- if migration_action == 'add' -%>
+<%- if migration_action == "add" -%>
   def change
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>
@@ -15,14 +15,14 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
   <%- end -%>
 <%- end -%>
   end
-<%- elsif migration_action == 'join' -%>
+<%- elsif migration_action == "join" -%>
   def change
     create_join_table :<%= join_tables.first %>, :<%= join_tables.second %> do |t|
     <%- attributes.each do |attribute| -%>
       <%- if attribute.reference? -%>
       t.references :<%= attribute.name %><%= attribute.inject_options %>
       <%- else -%>
-      <%= '# ' unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>
+      <%= "# " unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>
       <%- end -%>
     <%- end -%>
     end

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
@@ -1,7 +1,7 @@
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:reference?).each do |attribute| -%>
-  belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', required: true' if attribute.required? %>
+  belongs_to :<%= attribute.name %><%= ", polymorphic: true" if attribute.polymorphic? %><%= ", required: true" if attribute.required? %>
 <% end -%>
 <% attributes.select(&:token?).each do |attribute| -%>
   has_secure_token<% if attribute.name != "token" %> :<%= attribute.name %><% end %>

--- a/activerecord/lib/rails/generators/active_record/model/templates/module.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/module.rb.tt
@@ -1,7 +1,7 @@
 <% module_namespacing do -%>
-module <%= class_path.map(&:camelize).join('::') %>
+module <%= class_path.map(&:camelize).join("::") %>
   def self.table_name_prefix
-    '<%= namespaced? ? namespaced_class_path.join('_') : class_path.join('_') %>_'
+    "<%= namespaced? ? namespaced_class_path.join("_") : class_path.join("_") %>_"
   end
 end
 <% end -%>

--- a/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/edit.html.erb.tt
@@ -1,6 +1,6 @@
 <h1>Editing <%= singular_table_name.titleize %></h1>
 
-<%%= render 'form', <%= singular_table_name %>: @<%= singular_table_name %> %>
+<%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
 
-<%%= link_to 'Show', @<%= singular_table_name %> %> |
-<%%= link_to 'Back', <%= index_helper %>_path %>
+<%%= link_to "Show", @<%= singular_table_name %> %> |
+<%%= link_to "Back", <%= index_helper %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
@@ -18,9 +18,9 @@
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
         <td><%%= <%= singular_table_name %>.<%= attribute.name %> %></td>
 <% end -%>
-        <td><%%= link_to 'Show', <%= model_resource_name %> %></td>
-        <td><%%= link_to 'Edit', edit_<%= singular_route_name %>_path(<%= singular_table_name %>) %></td>
-        <td><%%= link_to 'Destroy', <%= model_resource_name %>, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%%= link_to "Show", <%= model_resource_name %> %></td>
+        <td><%%= link_to "Edit", edit_<%= singular_route_name %>_path(<%= singular_table_name %>) %></td>
+        <td><%%= link_to "Destroy", <%= model_resource_name %>, method: :delete, data: { confirm: "Are you sure?" } %></td>
       </tr>
     <%% end %>
   </tbody>
@@ -28,4 +28,4 @@
 
 <br>
 
-<%%= link_to 'New <%= singular_table_name.titleize %>', new_<%= singular_route_name %>_path %>
+<%%= link_to "New <%= singular_table_name.titleize %>", new_<%= singular_route_name %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/new.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/new.html.erb.tt
@@ -1,5 +1,5 @@
 <h1>New <%= singular_table_name.titleize %></h1>
 
-<%%= render 'form', <%= singular_table_name %>: @<%= singular_table_name %> %>
+<%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
 
-<%%= link_to 'Back', <%= index_helper %>_path %>
+<%%= link_to "Back", <%= index_helper %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
@@ -7,5 +7,5 @@
 </p>
 
 <% end -%>
-<%%= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>) %> |
-<%%= link_to 'Back', <%= index_helper %>_path %>
+<%%= link_to "Edit", edit_<%= singular_table_name %>_path(@<%= singular_table_name %>) %> |
+<%%= link_to "Back", <%= index_helper %>_path %>

--- a/railties/lib/rails/generators/rails/app/templates/app/mailers/application_mailer.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/mailers/application_mailer.rb.tt
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -6,14 +6,14 @@
     <%%= csp_meta_tag %>
 
     <%- if options[:skip_javascript] -%>
-    <%%= stylesheet_link_tag    'application', media: 'all' %>
+    <%%= stylesheet_link_tag    "application", media: "all" %>
     <%- else -%>
       <%- unless options[:skip_turbolinks] -%>
-    <%%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload" %>
+    <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload" %>
       <%- else -%>
-    <%%= stylesheet_link_tag 'application', media: 'all' %>
-    <%%= javascript_pack_tag 'application' %>
+    <%%= stylesheet_link_tag "application", media: "all" %>
+    <%%= javascript_pack_tag "application" %>
       <%- end -%>
     <%- end -%>
   </head>

--- a/railties/lib/rails/generators/rails/app/templates/config.ru.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru.tt
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -1,7 +1,7 @@
-require_relative 'boot'
+require_relative "boot"
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,6 +1,6 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb.tt
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -14,12 +14,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -65,5 +65,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  <%= "# " unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   <%- unless options.skip_sprockets? -%>
   # Compress CSS using a preprocessor.
@@ -31,11 +31,11 @@ Rails.application.configure do
 
   <%- end -%>
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.action_controller.asset_host = "http://assets.example.com"
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   <%- unless skip_active_storage? -%>
   # Store uploaded files on the local file system (see config/storage.yml for options).
@@ -45,8 +45,8 @@ Rails.application.configure do
   <%- unless options[:skip_action_cable] -%>
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  # config.action_cable.url = "wss://example.com/cable"
+  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   <%- end -%>
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
@@ -85,8 +85,8 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  # require "syslog/logger"
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb.tt
@@ -2,7 +2,7 @@
 
 # ActiveSupport::Reloader.to_prepare do
 #   ApplicationController.renderer.defaults.merge!(
-#     http_host: 'example.org',
+#     http_host: "example.org",
 #     https: false
 #   )
 # end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -1,13 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 <%- unless options[:skip_yarn] -%>
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 <%- end -%>
 
 # Precompile additional assets.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb.tt
@@ -7,9 +7,9 @@
 
 # Rails.application.config.middleware.insert_before 0, Rack::Cors do
 #   allow do
-#     origins 'example.com'
+#     origins "example.com"
 #
-#     resource '*',
+#     resource "*",
 #       headers: :any,
 #       methods: [:get, :post, :put, :patch, :delete, :options, :head]
 #   end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb.tt
@@ -4,13 +4,13 @@
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
+#   inflect.plural /^(ox)$/i, "\1en"
+#   inflect.singular /^(ox)en/i, "\1"
+#   inflect.irregular "person", "people"
 #   inflect.uncountable %w( fish sheep )
 # end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
+#   inflect.acronym "RESTful"
 # end

--- a/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
@@ -3,5 +3,5 @@
 #
 # Examples:
 #
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
+#   Character.create(name: "Luke", movie: movies.first)

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers

--- a/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
+++ b/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
@@ -1,3 +1,3 @@
 class <%= class_name %>Generator < Rails::Generators::NamedBase
-  source_root File.expand_path('templates', __dir__)
+  source_root File.expand_path("templates", __dir__)
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
@@ -1,6 +1,6 @@
 <%= wrap_in_modules <<~rb
   class ApplicationController < ActionController::#{api? ? "API" : "Base"}
-    #{ api? ? '# ' : '' }protect_from_forgery with: :exception
+    #{ api? ? "# " : "" }protect_from_forgery with: :exception
   end
 rb
 %>

--- a/railties/lib/rails/generators/rails/plugin/templates/app/mailers/%namespaced_name%/application_mailer.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/app/mailers/%namespaced_name%/application_mailer.rb.tt
@@ -1,7 +1,7 @@
 <%= wrap_in_modules <<~rb
   class ApplicationMailer < ActionMailer::Base
-    default from: 'from@example.com'
-    layout 'mailer'
+    default from: "from@example.com"
+    layout "mailer"
   end
 rb
 %>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
@@ -1,7 +1,7 @@
 <%= wrap_in_modules <<~rb
   class Engine < ::Rails::Engine
-  #{mountable? ? '  isolate_namespace ' + camelized_modules : ' '}
-  #{api? ? "  config.generators.api_only = true" : ' '}
+  #{mountable? ? "  isolate_namespace " + camelized_modules : " "}
+  #{api? ? "  config.generators.api_only = true" : " "}
   end
 rb
 %>

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
@@ -1,7 +1,7 @@
-require_relative 'boot'
+require_relative "boot"
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class <%= camelized_modules %>::Test < ActiveSupport::TestCase
   test "truth" do

--- a/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class NavigationTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
@@ -1,11 +1,11 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require_relative "<%= File.join('..', options[:dummy_path], 'config/environment') -%>"
+require_relative "<%= File.join("..", options[:dummy_path], "config/environment") -%>"
 <% unless options[:skip_active_record] -%>
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]
 <% if options[:mountable] -%>
-ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
+ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 <% end -%>
 <% end -%>
 require "rails/test_help"
@@ -15,7 +15,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 <% unless engine? -%>
 require "rails/test_unit/reporter"
-Rails::TestUnitReporter.executable = 'bin/test'
+Rails::TestUnitReporter.executable = "bin/test"
 <% end -%>
 
 <% unless options[:skip_active_record] -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -54,7 +54,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
-      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(", ") %>)
       <%- end -%>
     end
 end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -61,7 +61,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
-      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(", ") %>)
       <%- end -%>
     end
 end

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb.tt
@@ -1,10 +1,10 @@
-require 'test_helper'
-require '<%= generator_path %>'
+require "test_helper"
+require "<%= generator_path %>"
 
 <% module_namespacing do -%>
 class <%= class_name %>GeneratorTest < Rails::Generators::TestCase
   tests <%= class_name %>Generator
-  destination Rails.root.join('tmp/generators')
+  destination Rails.root.join("tmp/generators")
   setup :prepare_destination
 
   # test "generator runs without errors" do

--- a/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>Test < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/job/templates/unit_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/job/templates/unit_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>JobTest < ActiveJob::TestCase

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>MailerTest < ActionMailer::TestCase

--- a/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>Test < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class <%= class_name %>Test < ActiveSupport::TestCase
   # test "the truth" do

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -115,8 +115,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_assets
     run_generator
 
-    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track': 'reload'/)
-    assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+'application', 'data-turbolinks-track': 'reload'/)
+    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+"application", media: "all", "data-turbolinks-track": "reload"/)
+    assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+"application", "data-turbolinks-track": "reload"/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/javascript/packs/application.js")
   end
@@ -607,8 +607,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/javascript"
 
     assert_file "app/views/layouts/application.html.erb" do |contents|
-      assert_match(/stylesheet_link_tag\s+'application', media: 'all' %>/, contents)
-      assert_no_match(/javascript_include_tag\s+'application' \%>/, contents)
+      assert_match(/stylesheet_link_tag\s+"application", media: "all" %>/, contents)
+      assert_no_match(/javascript_include_tag\s+"application" \%>/, contents)
     end
   end
 
@@ -858,12 +858,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     unless defined?(JRUBY_VERSION)
       assert_gem "bootsnap"
       assert_file "config/boot.rb" do |content|
-        assert_match(/require 'bootsnap\/setup'/, content)
+        assert_match(/require "bootsnap\/setup"/, content)
       end
     else
       assert_no_gem "bootsnap"
       assert_file "config/boot.rb" do |content|
-        assert_no_match(/require 'bootsnap\/setup'/, content)
+        assert_no_match(/require "bootsnap\/setup"/, content)
       end
     end
   end
@@ -873,7 +873,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "bootsnap"
     assert_file "config/boot.rb" do |content|
-      assert_no_match(/require 'bootsnap\/setup'/, content)
+      assert_no_match(/require "bootsnap\/setup"/, content)
     end
   end
 

--- a/railties/test/generators/generator_generator_test.rb
+++ b/railties/test/generators/generator_generator_test.rb
@@ -20,7 +20,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/awesome_generator_test.rb",
                /class AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/awesome\/awesome_generator'/
+               /require "generators\/awesome\/awesome_generator"/
   end
 
   def test_namespaced_generator_skeleton
@@ -36,7 +36,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/rails/awesome_generator_test.rb",
                /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/rails\/awesome\/awesome_generator'/
+               /require "generators\/rails\/awesome\/awesome_generator"/
   end
 
   def test_generator_skeleton_is_created_without_file_name_namespace
@@ -52,7 +52,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/awesome_generator_test.rb",
                /class AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/awesome_generator'/
+               /require "generators\/awesome_generator"/
   end
 
   def test_namespaced_generator_skeleton_without_file_name_namespace
@@ -68,6 +68,6 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/rails/awesome_generator_test.rb",
                /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/rails\/awesome_generator'/
+               /require "generators\/rails\/awesome_generator"/
   end
 end

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -17,8 +17,8 @@ class MailerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/mailers/application_mailer.rb" do |mailer|
       assert_match(/class ApplicationMailer < ActionMailer::Base/, mailer)
-      assert_match(/default from: 'from@example\.com'/, mailer)
-      assert_match(/layout 'mailer'/, mailer)
+      assert_match(/default from: "from@example\.com"/, mailer)
+      assert_match(/layout "mailer"/, mailer)
     end
   end
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -69,7 +69,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["admin/account"]
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
-    assert_file "app/models/admin.rb", /'admin_'/
+    assert_file "app/models/admin.rb", /"admin_"/
     assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationRecord/
   end
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -101,7 +101,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     run_generator ["admin/account"]
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
-    assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
+    assert_file "app/models/test_app/admin.rb", /"test_app_admin_"/
     assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationRecord/
   end
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -72,7 +72,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/require_relative.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
       assert_match(/Minitest\.backtrace_filter = Minitest::BacktraceFilter\.new/, content)
-      assert_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
+      assert_match(/Rails::TestUnitReporter\.executable = "bin\/test"/, content)
     end
     assert_file "lib/bukkits/railtie.rb", /module Bukkits\n  class Railtie < ::Rails::Railtie\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/railtie"/
@@ -304,7 +304,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/bukkits/application_controller.rb", /module Bukkits\n  class ApplicationController < ActionController::Base/
     assert_file "app/models/bukkits/application_record.rb", /module Bukkits\n  class ApplicationRecord < ActiveRecord::Base/
     assert_file "app/jobs/bukkits/application_job.rb", /module Bukkits\n  class ApplicationJob < ActiveJob::Base/
-    assert_file "app/mailers/bukkits/application_mailer.rb", /module Bukkits\n  class ApplicationMailer < ActionMailer::Base\n    default from: 'from@example\.com'\n    layout 'mailer'\n/
+    assert_file "app/mailers/bukkits/application_mailer.rb", /module Bukkits\n  class ApplicationMailer < ActionMailer::Base\n    default from: "from@example\.com"\n    layout "mailer"\n/
     assert_file "app/helpers/bukkits/application_helper.rb", /module Bukkits\n  module ApplicationHelper/
     assert_file "app/views/layouts/bukkits/application.html.erb" do |contents|
       assert_match "<title>Bukkits</title>", contents
@@ -318,7 +318,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+\.\.\/test\/dummy\/db\/migrate/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+<<.+\.\.\/db\/migrate/, content)
       assert_match(/ActionDispatch::IntegrationTest\.fixture_path = ActiveSupport::TestCase\.fixture_pat/, content)
-      assert_no_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
+      assert_no_match(/Rails::TestUnitReporter\.executable = "bin\/test"/, content)
     end
     assert_no_file "bin/test"
   end
@@ -336,7 +336,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "hyphenated-name/app/controllers/hyphenated/name/application_controller.rb", /module Hyphenated\n  module Name\n    class ApplicationController < ActionController::Base\n      protect_from_forgery with: :exception\n    end\n  end\nend\n/
     assert_file "hyphenated-name/app/models/hyphenated/name/application_record.rb",          /module Hyphenated\n  module Name\n    class ApplicationRecord < ActiveRecord::Base\n      self\.abstract_class = true\n    end\n  end\nend/
     assert_file "hyphenated-name/app/jobs/hyphenated/name/application_job.rb",               /module Hyphenated\n  module Name\n    class ApplicationJob < ActiveJob::Base/
-    assert_file "hyphenated-name/app/mailers/hyphenated/name/application_mailer.rb",         /module Hyphenated\n  module Name\n    class ApplicationMailer < ActionMailer::Base\n      default from: 'from@example\.com'\n      layout 'mailer'\n    end\n  end\nend/
+    assert_file "hyphenated-name/app/mailers/hyphenated/name/application_mailer.rb",         /module Hyphenated\n  module Name\n    class ApplicationMailer < ActionMailer::Base\n      default from: "from@example\.com"\n      layout "mailer"\n    end\n  end\nend/
     assert_file "hyphenated-name/app/helpers/hyphenated/name/application_helper.rb",         /module Hyphenated\n  module Name\n    module ApplicationHelper\n    end\n  end\nend/
     assert_file "hyphenated-name/app/views/layouts/hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>Hyphenated name</title>", contents
@@ -358,7 +358,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "my_hyphenated-name/app/controllers/my_hyphenated/name/application_controller.rb", /module MyHyphenated\n  module Name\n    class ApplicationController < ActionController::Base\n      protect_from_forgery with: :exception\n    end\n  end\nend\n/
     assert_file "my_hyphenated-name/app/models/my_hyphenated/name/application_record.rb",          /module MyHyphenated\n  module Name\n    class ApplicationRecord < ActiveRecord::Base\n      self\.abstract_class = true\n    end\n  end\nend/
     assert_file "my_hyphenated-name/app/jobs/my_hyphenated/name/application_job.rb",               /module MyHyphenated\n  module Name\n    class ApplicationJob < ActiveJob::Base/
-    assert_file "my_hyphenated-name/app/mailers/my_hyphenated/name/application_mailer.rb",         /module MyHyphenated\n  module Name\n    class ApplicationMailer < ActionMailer::Base\n      default from: 'from@example\.com'\n      layout 'mailer'\n    end\n  end\nend/
+    assert_file "my_hyphenated-name/app/mailers/my_hyphenated/name/application_mailer.rb",         /module MyHyphenated\n  module Name\n    class ApplicationMailer < ActionMailer::Base\n      default from: "from@example\.com"\n      layout "mailer"\n    end\n  end\nend/
     assert_file "my_hyphenated-name/app/helpers/my_hyphenated/name/application_helper.rb",         /module MyHyphenated\n  module Name\n    module ApplicationHelper\n    end\n  end\nend/
     assert_file "my_hyphenated-name/app/views/layouts/my_hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>My hyphenated name</title>", contents
@@ -380,7 +380,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "deep-hyphenated-name/app/controllers/deep/hyphenated/name/application_controller.rb", /module Deep\n  module Hyphenated\n    module Name\n      class ApplicationController < ActionController::Base\n        protect_from_forgery with: :exception\n      end\n    end\n  end\nend\n/
     assert_file "deep-hyphenated-name/app/models/deep/hyphenated/name/application_record.rb",          /module Deep\n  module Hyphenated\n    module Name\n      class ApplicationRecord < ActiveRecord::Base\n        self\.abstract_class = true\n      end\n    end\n  end\nend/
     assert_file "deep-hyphenated-name/app/jobs/deep/hyphenated/name/application_job.rb",               /module Deep\n  module Hyphenated\n    module Name\n      class ApplicationJob < ActiveJob::Base/
-    assert_file "deep-hyphenated-name/app/mailers/deep/hyphenated/name/application_mailer.rb",         /module Deep\n  module Hyphenated\n    module Name\n      class ApplicationMailer < ActionMailer::Base\n        default from: 'from@example\.com'\n        layout 'mailer'\n      end\n    end\n  end\nend/
+    assert_file "deep-hyphenated-name/app/mailers/deep/hyphenated/name/application_mailer.rb",         /module Deep\n  module Hyphenated\n    module Name\n      class ApplicationMailer < ActionMailer::Base\n        default from: "from@example\.com"\n        layout "mailer"\n      end\n    end\n  end\nend/
     assert_file "deep-hyphenated-name/app/helpers/deep/hyphenated/name/application_helper.rb",         /module Deep\n  module Hyphenated\n    module Name\n      module ApplicationHelper\n      end\n    end\n  end\nend/
     assert_file "deep-hyphenated-name/app/views/layouts/deep/hyphenated/name/application.html.erb" do |contents|
       assert_match "<title>Deep hyphenated name</title>", contents

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -185,14 +185,14 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/admin/users/index.html.erb" do |content|
-      assert_match("'Show', [:admin, user]", content)
-      assert_match("'Edit', edit_admin_user_path(user)", content)
-      assert_match("'Destroy', [:admin, user]", content)
-      assert_match("'New User', new_admin_user_path", content)
+      assert_match("\"Show\", [:admin, user]", content)
+      assert_match("\"Edit\", edit_admin_user_path(user)", content)
+      assert_match("\"Destroy\", [:admin, user]", content)
+      assert_match("\"New User\", new_admin_user_path", content)
     end
 
     assert_file "app/views/admin/users/new.html.erb" do |content|
-      assert_match("'Back', admin_users_path", content)
+      assert_match("\"Back\", admin_users_path", content)
     end
 
     assert_file "app/views/admin/users/_form.html.erb" do |content|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -80,7 +80,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     %w(edit new).each do |view|
-      assert_file "app/views/product_lines/#{view}.html.erb", /render 'form', product_line: @product_line/
+      assert_file "app/views/product_lines/#{view}.html.erb", /render "form", product_line: @product_line/
     end
 
     assert_file "app/views/product_lines/_form.html.erb" do |test|
@@ -280,10 +280,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Views
     assert_file "app/views/admin/roles/index.html.erb" do |content|
-      assert_match("'Show', admin_role", content)
-      assert_match("'Edit', edit_admin_role_path(admin_role)", content)
-      assert_match("'Destroy', admin_role", content)
-      assert_match("'New Admin Role', new_admin_role_path", content)
+      assert_match("\"Show\", admin_role", content)
+      assert_match("\"Edit\", edit_admin_role_path(admin_role)", content)
+      assert_match("\"Destroy\", admin_role", content)
+      assert_match("\"New Admin Role\", new_admin_role_path", content)
     end
 
     %w(edit new show _form).each do |view|

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -79,7 +79,7 @@ module RailtiesTests
         bundled_rails("g model namespaced/topic")
         assert_file "app/models/foo_bar/namespaced.rb", /module FooBar\n  module Namespaced/ do |content|
           assert_class_method :table_name_prefix, content do |method_content|
-            assert_match(/'foo_bar_namespaced_'/, method_content)
+            assert_match(/"foo_bar_namespaced_"/, method_content)
           end
         end
       end


### PR DESCRIPTION
### Summary

Currently we are mixing the use of single and double quotes in our `*.erb.tt` and `*.rb.tt` templates. As we decided to prefer double quotes over single quotes, this patch homogenizes this for these templates.