### PR TITLE
Deprecate ActiveSupport::Multibyte::Chars.consumes?

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveSupport::Multibyte::Chars.consumes?` in favor of `String#is_utf8?`.
+
+    *Francesco Rodríguez*
+
 *   Fix duration being rounded to a full second.
     ```
       time = DateTime.parse("2018-1-1")

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -76,6 +76,11 @@ module ActiveSupport #:nodoc:
       # Returns +true+ when the proxy class can handle the string. Returns
       # +false+ otherwise.
       def self.consumes?(string)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveSupport::Multibyte::Chars.consumes? is deprecated and will be
+          removed from Rails 6.1. Use string.is_utf8? instead.
+        MSG
+
         string.encoding == Encoding::UTF_8
       end
 

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -73,9 +73,15 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   end
 
   def test_consumes_utf8_strings
-    assert @proxy_class.consumes?(UNICODE_STRING)
-    assert @proxy_class.consumes?(ASCII_STRING)
-    assert_not @proxy_class.consumes?(BYTE_STRING)
+    ActiveSupport::Deprecation.silence do
+      assert @proxy_class.consumes?(UNICODE_STRING)
+      assert @proxy_class.consumes?(ASCII_STRING)
+      assert_not @proxy_class.consumes?(BYTE_STRING)
+    end
+  end
+
+  def test_consumes_is_deprecated
+    assert_deprecated { @proxy_class.consumes?(UNICODE_STRING) }
   end
 
   def test_concatenation_should_return_a_proxy_class_instance


### PR DESCRIPTION
In favor of String#is_utf8? method.

I think this method was made for internal use only, and its usage was removed here: https://github.com/rails/rails/pull/8261/files#diff-ce956ebe93786930e40f18db1da5fd46L39.

r? @jeremy