### PR TITLE
Add common sensitive names to generated filter parameters

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :secret]

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -1,4 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :secret]
+Rails.application.config.filter_parameters += [
+  :password, :secret, :token, :_key, :auth, :crypt, :salt, :certificate, :otp, :access, :private, :protected, :ssn
+]


### PR DESCRIPTION
### Summary

Common sensitive parameter names to consider adding to generated filter parameters for new apps.

The initial commit in this PR is conservative, only adding `:secret` to the current default `[:password]`.

Further candidates distilled from the `filter_parameters` config from a number of open source Rails projects to consider adding:

```rb
# These will filter exact *and* partial matches,
# e.g. :token would filter: token, api_token, access_token, token_foo
:token,
:_key,
:auth,
:crypt,
:salt,
:certificate,
:otp,
:access,
:private,
:protected,
:birth,
:ssn
```

### Other Information

Similar pull request from 2015 discussing adding to these defaults: https://github.com/rails/rails/pull/19809

The Rails apps searched to find these: https://github.com/eliotsykes/real-world-rails/tree/master/apps