### PR TITLE
Add message to exception in datetime type

### DIFF
--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -39,9 +39,9 @@ module ActiveModel
         end
 
         def value_from_multiparameter_assignment(values_hash)
-          missing_parameter = (1..3).detect { |key| !values_hash.key?(key) }
-          if missing_parameter
-            raise ArgumentError, missing_parameter
+          missing_parameters = (1..3).select { |key| !values_hash.key?(key) }
+          if missing_parameters.any?
+            raise ArgumentError, "Provided hash #{values_hash} doesn't contain necessary keys: #{missing_parameters}"
           end
           super
         end

--- a/activemodel/test/cases/type/date_time_test.rb
+++ b/activemodel/test/cases/type/date_time_test.rb
@@ -25,6 +25,17 @@ module ActiveModel
         end
       end
 
+      def test_hash_to_time
+        type = Type::DateTime.new
+        assert_equal ::Time.utc(2018, 10, 15, 0, 0, 0), type.cast(1 => 2018, 2 => 10, 3 => 15)
+      end
+
+      def test_hash_with_wrong_keys
+        type = Type::DateTime.new
+        error = assert_raises(ArgumentError) { type.cast(a: 1) }
+        assert_equal "Provided hash {:a=>1} doesn't contain necessary keys: [1, 2, 3]", error.message
+      end
+
       private
 
         def with_timezone_config(default:)


### PR DESCRIPTION
### Summary

While I was working with DateTime type, I found that this exception description is unclear. If someone made a mistake and passed hash here, for example in the process of mass assignment, it will see the message: `ArgumentError 1`. I've tried to add more clarity by adding information about this exception.