### PR TITLE
Unify changelog entries related to `database` option of Rails generators [ci skip]

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -11,34 +11,18 @@
 
     *DHH*, *Lachlan Sylvester*
 
-*   Refactors `migrations_paths` command option in generators
-    to `database` (aliased as `db`). Now, the migrations paths
-    will be read from the specified database configuration in the
-    current environment.
+*   Add `database` (aliased as `db`) option to model generator to allow
+    setting the database. This is useful for applications that use
+    multiple databases and put migrations per database in their own directories.
 
     ```
-    bin/rails g model Chair brand:string --database=kingston
-          invoke  active_record
-          create    db/kingston_migrate/20180830151055_create_chairs.rb
-    ```
-
-    `--database` can be used with the migration, model, and scaffold generators.
-
-    *Gannon McGibbon*
-
-*   Adds an option to the model generator to allow setting the
-    migrations paths for that migration. This is useful for
-    applications that use multiple databases and put migrations
-    per database in their own directories.
-
-    ```
-    bin/rails g model Room capacity:integer --migrations-paths=db/kingston_migrate
+    bin/rails g model Room capacity:integer --database=kingston
           invoke  active_record
           create    db/kingston_migrate/20180830151055_create_rooms.rb
     ```
 
     Because rails scaffolding uses the model generator, you can
-    also specify migrations paths with the scaffold generator.
+    also specify a database with the scaffold generator.
 
     *Gannon McGibbon*
 
@@ -66,15 +50,15 @@
 
     *Yoshiyuki Kinjo*
 
-*   Add `--migrations_paths` option to migration generator.
+*   Add `database` (aliased as `db`) option to migration generator.
 
     If you're using multiple databases and have a folder for each database
     for migrations (ex db/migrate and db/new_db_migrate) you can now pass the
-    `--migrations_paths` option to the generator to make sure the the migration
+    `--database` option to the generator to make sure the the migration
     is inserted into the correct folder.
 
     ```
-    rails g migration CreateHouses --migrations_paths=db/kingston_migrate
+    rails g migration CreateHouses --database=kingston
       invoke  active_record
       create    db/kingston_migrate/20180830151055_create_houses.rb
     ```


### PR DESCRIPTION
`migrations_paths` option was added to migration generator, with
changelog entry, in #33760.
Also `migrations_paths` option was added to model generator, with
changelog entry, in #33994.
Then `migrations_paths` was renamed to `database` and aliased as `db`
in #34021, and was added new changelog entry.
I think we should edit existed changelog entries instead adding new
about changing the name of the option from `migrations_paths` to `database`
since Rails 6.0 hasn't been released yet, and since It might confuse
readers of the changelog file in case if they've read changelog enty about
adding `migrations_paths` option but haven't read the entry about
change the name of that option to `database`.
@eileencodes, @gmcgibbon, @rafaelfranca Does it make sense?