### PR TITLE
Add support for action only root route path strings

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1638,7 +1638,11 @@ module ActionDispatch
         # of most Rails applications, this is beneficial.
         def root(path, options = {})
           if path.is_a?(String)
-            options[:to] = path
+            if /#/.match?(path)
+              options[:to] = path
+            else
+              options[:action] = path
+            end
           elsif path.is_a?(Hash) && options.empty?
             options = path
           else

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1663,11 +1663,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       namespace :account do
         root to: "account#index"
       end
+      namespace :users do
+        root "index"
+      end
     end
 
     assert_equal "/account", account_root_path
     get "/account"
     assert_equal "account/account#index", @response.body
+
+    assert_equal "/users", users_root_path
+    get "/users"
+    assert_equal "users#index", @response.body
   end
 
   def test_optional_scoped_root


### PR DESCRIPTION
Without this patch, passing the root route a string that does not contain a controller and action will raise an `ArgumentError`.

This patch simply checks for a `#` in the path string and if it is not present sets `options[:action]` instead of `options[:to]`. This mimics functionality of the HttpHelpers like [`get`](https://github.com/rails/rails/blob/b0b0cd1fd77af3eec8b2b8760bace2572e04a3a3/actionpack/lib/action_dispatch/routing/mapper.rb#L1603) when used inside
a namespace. 

Now we can specify the root path of a namespace and infer the controller name. For example:

```rb
namespace :space do
  root "index"  # space#index
  get "shuttle" # space#shuttle
end
```