### PR TITLE
Enable withCredentials for authenticated cross-origin requests

### DIFF
--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -14,6 +14,7 @@ export class BlobRecord {
     this.xhr = new XMLHttpRequest
     this.xhr.open("POST", url, true)
     this.xhr.responseType = "json"
+    this.xhr.withCredentials = true
     this.xhr.setRequestHeader("Content-Type", "application/json")
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")


### PR DESCRIPTION
### Summary

We have a VueJS fontend on one domain which includes the ActiveStorage npm package to upload files on another backend domain, with Rails API. To make it work we had to enable `withCredentials` in the `blob_record.js` file, otherwise the cookies are not passed on the backend. 
I've seen some issues (like #32208) around this topic but still not a pull-request to fix this specific simple issue.

### Other Information

Actually to make it work we had to directly edit the compiled `activestorage.js` file inside `node_modules/activestorage/app/assets/javascripts/`, but the source of the issue is in `blob_record.js`.
To make everything work we also had to `skip_forgery_protection` as suggested in [this comment](https://github.com/rails/rails/issues/32208#issuecomment-383243070).

To me seems ok to have `withCredentials` always enabled, what do you think?

Thanks to @marcogregorio for finding and fixing the problem.