### PR TITLE
Refactored abstract MySQL adapter to support lazy version check.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -28,6 +28,7 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = false
       class_attribute :emulate_booleans, default: true
 
+      SUPPORTED_VERSION = "5.1.10"
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigint auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
@@ -54,10 +55,7 @@ module ActiveRecord
         super(connection, logger, config)
 
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
-
-        if version < "5.1.10"
-          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.1.10."
-        end
+        check_version
       end
 
       def version #:nodoc:
@@ -531,6 +529,15 @@ module ActiveRecord
           super { discard_remaining_results }
         end
       end
+
+      protected
+
+        def check_version
+          if version < SUPPORTED_VERSION
+            raise "Your version of MySQL (#{version_string}) is too old. Active Record supports " \
+                  "MySQL >= #{SUPPORTED_VERSION}."
+          end
+        end
 
       private
         def combine_multi_statements(total_sql)


### PR DESCRIPTION
### Summary

Will allow sub classes to override the protected
`#check_version` method hook if desired.

For example, this will be most helpful in sub classes that wish
to support lazy initialization because the version check can
be postponed until the connection is ready to be initialized.

This is a backport of what is being applied in Rails `master`.

### Other Information

@tenderlove This is a follow-up to this [PR](https://github.com/rails/rails/pull/34227) to ensure support is back ported to Rails 5.2 at a minimum.