### PR TITLE
Fix mapping of content [ci skip]

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -82,9 +82,9 @@ of two or more words, the model class name should follow the Ruby conventions,
 using the CamelCase form, while the table name must contain the words separated
 by underscores. Examples:
 
-* Database Table - Plural with underscores separating words (e.g., `book_clubs`).
 * Model Class - Singular with the first letter of each word capitalized (e.g.,
 `BookClub`).
+* Database Table - Plural with underscores separating words (e.g., `book_clubs`).
 
 | Model / Class    | Table / Schema |
 | ---------------- | -------------- |


### PR DESCRIPTION
Poor mapping between the list and the table. The list reads database > model and then the table reads model > database. Counterintuitive to read.