### PR TITLE
Update guide for the counter variable when rendering with the `as:` option

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1266,7 +1266,7 @@ You can also pass in arbitrary local variables to any partial you are rendering 
 
 In this case, the partial will have access to a local variable `title` with the value "Products Page".
 
-TIP: Rails also makes a counter variable available within a partial called by the collection, named after the title of the partial followed by `_counter`. For example, when rendering a collection `@products` the partial `_product.html.erb` can access the variable `product_counter` which indexes the number of times it has been rendered within the enclosing view.
+TIP: Rails also makes a counter variable available within a partial called by the collection, named after the title of the partial followed by `_counter`. For example, when rendering a collection `@products` the partial `_product.html.erb` can access the variable `product_counter` which indexes the number of times it has been rendered within the enclosing view. Note that it also applies for when the partial name was changed by using the `as:` option. For example, the counter variable for the code above would be `item_counter`.
 
 You can also specify a second partial to be rendered between instances of the main partial by using the `:spacer_template` option:
 


### PR DESCRIPTION
### Summary

This PR adds a note to the guide to make sure people understand that when rendering a collection using partials like `<%= render partial: "product", collection: @products, as: :item %>`, the counter variable name will not be `product_counter`, but `item_counter` because of the `as:` option.

It should close https://github.com/rails/rails/issues/34199

This is my first PR to rails, I'm just trying to contribute, thanks.