### PR TITLE
Default to created_at ordering when using UUID as PK

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -551,7 +551,7 @@ module ActiveRecord
 
       def ordered_relation
         if order_values.empty? && primary_key
-          order_column = (columns_hash[primary_key]&.type == :uuid && columns_hash.key?('created_at')) ? 'created_at' : primary_key
+          order_column = (columns_hash[primary_key]&.type == :uuid && columns_hash.key?("created_at")) ? "created_at" : primary_key
           order(arel_attribute(order_column).asc)
         else
           self

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -551,7 +551,8 @@ module ActiveRecord
 
       def ordered_relation
         if order_values.empty? && primary_key
-          order(arel_attribute(primary_key).asc)
+          order_column = (columns_hash[primary_key]&.type == :uuid && columns_hash.key?('created_at')) ? 'created_at' : primary_key
+          order(arel_attribute(order_column).asc)
         else
           self
         end


### PR DESCRIPTION
### Summary

Although Rails supports UUID as a primary key, ordering by id, and therefore .first and .last, are no longer meaningful. The closest way to replicate the original order by ID would be to utilize created_at when available.

Since the Rails default is to order by ID, we can check to see whether the primary_key is of type :uuid, and use created_at to order if it's available.

This is not meant to augment the default Rail's behavior, but rather restore it.

### Other Information

The two other methods often suggested are:

1) Create a default_scope on created_at. Default scopes should be avoided in general and will cause issues with many joins/groupings.
2) Override first and last at the model level. This does not replicate the same functionality of the first and last methods (limit, etc)

Outside of explicitly calling order each time you use .first and .last or monkey patching Active Record, there don't seem to be good solutions available.
