### PR TITLE
[WIP] Make AJ integration tests work in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"
   - "travis_retry gem install bundler"
-  - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
-  - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"
   - "[[ $GEM != 'av:ujs' ]] || nvm install node"
   - "[[ $GEM != 'av:ujs' ]] || node --version"
@@ -102,22 +100,43 @@ matrix:
       env: "GEM=av:ujs"
     - rvm: 2.4.4
       env: "GEM=aj:integration"
+      sudo: required
       services:
         - memcached
         - redis-server
         - rabbitmq
+      before_install:
+        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
+        - "sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf"
+        - "sudo service postgresql restart 10"
+        - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
+        - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
     - rvm: 2.5.1
+      sudo: required
       env: "GEM=aj:integration"
       services:
         - memcached
         - redis-server
         - rabbitmq
+      before_install:
+        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
+        - "sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf"
+        - "sudo service postgresql restart 10"
+        - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
+        - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
     - rvm: ruby-head
+      sudo: required
       env: "GEM=aj:integration"
       services:
         - memcached
         - redis-server
         - rabbitmq
+      before_install:
+        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
+        - "sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf"
+        - "sudo service postgresql restart 10"
+        - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
+        - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
     - rvm: 2.4.4
       env: "GEM=ar:mysql2"
       sudo: required

--- a/activejob/test/support/integration/adapters/backburner.rb
+++ b/activejob/test/support/integration/adapters/backburner.rb
@@ -8,7 +8,8 @@ module BackburnerJobsManager
     end
     unless can_run?
       puts "Cannot run integration tests for backburner. To be able to run integration tests for backburner you need to install and start beanstalkd.\n"
-      exit
+      status = ENV["CI"] ? false : true
+      exit status
     end
   end
 

--- a/activejob/test/support/integration/adapters/que.rb
+++ b/activejob/test/support/integration/adapters/que.rb
@@ -32,7 +32,8 @@ module QueJobsManager
 
   rescue Sequel::DatabaseConnectionError
     puts "Cannot run integration tests for que. To be able to run integration tests for que you need to install and start postgresql.\n"
-    exit
+    status = ENV["CI"] ? false : true
+    exit status
   end
 
   def stop_workers

--- a/activejob/test/support/integration/adapters/queue_classic.rb
+++ b/activejob/test/support/integration/adapters/queue_classic.rb
@@ -30,7 +30,8 @@ module QueueClassicJobsManager
 
   rescue PG::ConnectionBad
     puts "Cannot run integration tests for queue_classic. To be able to run integration tests for queue_classic you need to install and start postgresql.\n"
-    exit
+    status = ENV["CI"] ? false : true
+    exit status
   end
 
   def stop_workers

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -1,18 +1,7 @@
 # frozen_string_literal: true
 
 require "sneakers/runner"
-require "sneakers/publisher"
 require "timeout"
-
-module Sneakers
-  class Publisher
-    def safe_ensure_connected
-      @mutex.synchronize do
-        ensure_connection! unless connected?
-      end
-    end
-  end
-end
 
 module SneakersJobsManager
   def setup
@@ -80,7 +69,7 @@ module SneakersJobsManager
     def bunny_publisher
       @bunny_publisher ||= begin
         p = ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper.send(:publisher)
-        p.safe_ensure_connected
+        p.ensure_connection!
         p
       end
     end

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -29,7 +29,8 @@ module SneakersJobsManager
                         log: Rails.root.join("log/sneakers.log").to_s
     unless can_run?
       puts "Cannot run integration tests for sneakers. To be able to run integration tests for sneakers you need to install and start rabbitmq.\n"
-      exit
+      status = ENV["CI"] ? false : true
+      exit status
     end
   end
 


### PR DESCRIPTION
Since # 33112, PostgreSQL 10 is used in CI, but since the specification of port was insufficient, the tests `que` and `queue_classic` are not running in CI.
https://travis-ci.org/rails/rails/jobs/442479471#L1788 
https://travis-ci.org/rails/rails/jobs/442479471#L1818 


