### PR TITLE
Fix mapping of content [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -103,14 +103,14 @@ The corresponding migration might look like this:
 ```ruby
 class CreateBooks < ActiveRecord::Migration[5.0]
   def change
-    create_table :authors do |t|
-      t.string :name
-      t.timestamps
-    end
-
     create_table :books do |t|
       t.belongs_to :author, index: true
       t.datetime :published_at
+      t.timestamps
+    end
+    
+    create_table :authors do |t|
+      t.string :name
       t.timestamps
     end
   end


### PR DESCRIPTION
Poor mapping between the one to one image above and the methods. The list reads books > authors and then the methods read authors > books. Counterintuitive to read. The rest of the guide complies.