### PR TITLE
Update request.xhr?

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -264,7 +264,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i
+      !!(get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i)
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
xhr? comment is misleading due to determining that it should return "true" if header "X-Requested-With: XMLHttpRequest" is present, but returns "0" instead due to operator "=~":

https://ruby-doc.org/core-2.1.1/Regexp.html#class-Regexp-label-3D~+operator "... If a match is found, the operator returns index of first match in string, otherwise it returns nil"
