### PR TITLE
Clarify i18n load paths gotcha

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -135,6 +135,8 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
+Note that appending directly to `I18n.load_paths` instead of to the application's configured i18n will _not_ override translations from external gems.
+
 ### Managing the Locale across Requests
 
 The default locale is used for all translations unless `I18n.locale` is explicitly set.

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -116,7 +116,7 @@ NOTE: The backend lazy-loads these translations when a translation is looked up 
 You can change the default locale as well as configure the translations load paths in `config/application.rb` as follows:
 
 ```ruby
-  config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+  config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
   config.i18n.default_locale = :de
 ```
 


### PR DESCRIPTION
Closes https://github.com/rails/rails/pull/29365.

Remove unnecessary `#to_s` in directory glob example code and adds a note about overriding translations from external gems.

r? @rafaelfranca 