### PR TITLE
Fix generated Gemfile missing gems on jruby

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
+<% end -%>
 group :development do
 <%- unless options.api? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
@@ -75,7 +76,6 @@ group :test do
   gem 'chromedriver-helper'
 end
 <%- end -%>
-<% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
### Summary

I noticed that when generating a Rails application on `jruby`, development and test gems are never included. On Linux in particular, that causes the generated application to fail in development because the `file_watcher` is configured to depend on `listen`, but the `listen` gem is not included.

This PR should fix that. 
