### PR TITLE
Multi db fixtures config fixtures path

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -15,9 +15,9 @@ module ActionDispatch
       #
       #   post :change_avatar, params: { avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary) }
       def fixture_file_upload(path, mime_type = nil, binary = false)
-        if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
+        if self.class.respond_to?(:fixtures_paths) && self.class.fixtures_paths &&
             !File.exist?(path)
-          path = File.join(self.class.fixture_path, path)
+          path = File.join(self.class.fixtures_paths.first, path)
         end
         Rack::Test::UploadedFile.new(path, mime_type, binary)
       end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1128,8 +1128,8 @@ class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
     self.class
   end
 
-  def self.fixture_path
-    File.expand_path("../fixtures/multipart", __dir__)
+  def self.fixtures_paths
+    [File.expand_path("../fixtures/multipart", __dir__)]
   end
 
   routes.draw do

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -6,7 +6,7 @@ require "active_support/json/decoding"
 require "rails/engine"
 
 class TestCaseTest < ActionController::TestCase
-  def self.fixture_path; end
+  def self.fixtures_paths; end
 
   class TestController < ActionController::Base
     def no_op
@@ -857,7 +857,7 @@ XML
   end
 
   def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case
-    TestCaseTest.stub :fixture_path, FILES_DIR do
+    TestCaseTest.stub :fixtures_paths, [FILES_DIR] do
       uploaded_file = fixture_file_upload("/ruby_on_rails.jpg", "image/png")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end
@@ -901,14 +901,14 @@ XML
   end
 
   def test_fixture_file_upload_relative_to_fixture_path
-    TestCaseTest.stub :fixture_path, FILES_DIR do
+    TestCaseTest.stub :fixtures_paths, [FILES_DIR] do
       uploaded_file = fixture_file_upload("ruby_on_rails.jpg", "image/jpg")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end
   end
 
   def test_fixture_file_upload_ignores_fixture_path_given_full_path
-    TestCaseTest.stub :fixture_path, __dir__ do
+    TestCaseTest.stub :fixtures_paths, [__dir__] do
       uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpg")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -88,7 +88,7 @@ class ActiveRecordTestCase < ActionController::TestCase
 
   # Set our fixture path
   if ActiveRecordTestConnector.able_to_connect
-    self.fixture_path = [FIXTURE_LOAD_PATH]
+    self.fixtures_paths = [FIXTURE_LOAD_PATH]
     self.use_transactional_tests = false
   end
 

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -2,6 +2,8 @@
 
 require "abstract_unit"
 
+ENV["RAILS_ENV"] = "sqlite3_ar_integration"
+
 # Define the essentials
 class ActiveRecordTestConnector
   cattr_accessor :able_to_connect

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveRecord::TestFixtures.fixture_table_names` in favor of `ActiveRecord::TestFixtures.fixture_files`.
+
+    *Gannon McGibbon*
+
 *   Deprecate `ActiveRecord::TestFixtures.fixture_path` in favor of `ActiveRecord::TestFixtures.fixtures_paths`.
 
     *Gannon McGibbon*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Adds `fixtures_paths` option to database configurations.
+
+    ```
+    test:
+      adapter: sqlite3
+      database: db/test.sqlite3
+      fixtures_paths: test/my_fixtures
+    ```
+
+    *Gannon McGibbon*
+
 *   Fix join table column quoting with SQLite.
 
     *Gannon McGibbon*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveRecord::TestFixtures.fixture_path` in favor of `ActiveRecord::TestFixtures.fixtures_paths`.
+
+    *Gannon McGibbon*
+
 *   Adds `fixtures_paths` option to database configurations.
 
     ```

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def fixtures_paths
+        raise NotImplementedError
+      end
+
       def url_config?
         false
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -45,6 +45,13 @@ module ActiveRecord
       def migrations_paths
         config["migrations_paths"]
       end
+
+      # The fixtures path for a database configuration. If the
+      # `fixtures_paths` key is present in the config, `fixtures_paths`
+      # will return its value.
+      def fixtures_paths
+        config["fixtures_paths"]
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -55,6 +55,13 @@ module ActiveRecord
         config["migrations_paths"]
       end
 
+      # The fixtures path for a database configuration. If the
+      # `fixtures_paths` key is present in the config, `fixtures_paths`
+      # will return its value.
+      def fixtures_paths
+        config["fixtures_paths"]
+      end
+
       private
         def build_config(original_config, url)
           if /^jdbc:/.match?(url)

--- a/activerecord/lib/active_record/fixture_set/class_cache.rb
+++ b/activerecord/lib/active_record/fixture_set/class_cache.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class FixtureSet
+    class ClassCache
+      def initialize(class_names, config)
+        @class_names = class_names.stringify_keys
+        @config      = config
+
+        # Remove string values that aren't constants or subclasses of AR
+        @class_names.delete_if do |klass_name, klass|
+          !insert_class(@class_names, klass_name, klass)
+        end
+      end
+
+      def [](fs_name)
+        @class_names.fetch(fs_name) do
+          klass = default_fixture_model(fs_name, @config).safe_constantize
+          insert_class(@class_names, fs_name, klass)
+        end
+      end
+
+      private
+
+        def insert_class(class_names, name, klass)
+          # We only want to deal with AR objects.
+          if klass && klass < ActiveRecord::Base
+            class_names[name] = klass
+          else
+            class_names[name] = nil
+          end
+        end
+
+        def default_fixture_model(fs_name, config)
+          ActiveRecord::FixtureSet.default_fixture_model_name(fs_name, config)
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -495,7 +495,7 @@ module ActiveRecord
       end
 
       def instantiate_all_loaded_fixtures(object, load_instances = true)
-        all_loaded_fixtures.each_value do |fixture_set|
+        all_loaded_fixtures["primary"].each_value do |fixture_set|
           instantiate_fixtures(object, fixture_set, load_instances)
         end
       end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/digest/uuid"
 require "active_record/fixture_set/file"
 require "active_record/fixture_set/render_context"
 require "active_record/fixture_set/table_rows"
+require "active_record/fixture_set/class_cache"
 require "active_record/test_fixtures"
 require "active_record/errors"
 
@@ -444,40 +445,6 @@ module ActiveRecord
     @@all_cached_fixtures = Hash.new { |h, k| h[k] = {} }
 
     cattr_accessor :all_loaded_fixtures, default: {}
-
-    class ClassCache
-      def initialize(class_names, config)
-        @class_names = class_names.stringify_keys
-        @config      = config
-
-        # Remove string values that aren't constants or subclasses of AR
-        @class_names.delete_if do |klass_name, klass|
-          !insert_class(@class_names, klass_name, klass)
-        end
-      end
-
-      def [](fs_name)
-        @class_names.fetch(fs_name) do
-          klass = default_fixture_model(fs_name, @config).safe_constantize
-          insert_class(@class_names, fs_name, klass)
-        end
-      end
-
-      private
-
-        def insert_class(class_names, name, klass)
-          # We only want to deal with AR objects.
-          if klass && klass < ActiveRecord::Base
-            class_names[name] = klass
-          else
-            class_names[name] = nil
-          end
-        end
-
-        def default_fixture_model(fs_name, config)
-          ActiveRecord::FixtureSet.default_fixture_model_name(fs_name, config)
-        end
-    end
 
     class << self
       def default_fixture_model_name(fixture_set_name, config = ActiveRecord::Base) # :nodoc:

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -20,7 +20,7 @@ module ActiveRecord
   # \Fixtures are a way of organizing data that you want to test against; in short, sample data.
   #
   # They are stored in YAML files, one file per model, which are placed in the directory
-  # appointed by <tt>ActiveSupport::TestCase.fixture_path=(path)</tt> (this is automatically
+  # appointed by <tt>ActiveSupport::TestCase.fixtures_paths=(paths)</tt> (this is automatically
   # configured for Rails, so you can just put your files in <tt><your-rails-app>/test/fixtures/</tt>).
   # The fixture file ends with the +.yml+ file extension, for example:
   # <tt><your-rails-app>/test/fixtures/web_sites.yml</tt>).

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -266,7 +266,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     # DB2 is not case-sensitive.
     return true if current_adapter?(:DB2Adapter)
 
-    assert_equal @loaded_fixtures["computers"]["workstation"].to_hash, Computer.first.attributes
+    assert_equal @loaded_fixtures["primary"]["computers"]["workstation"].to_hash, Computer.first.attributes
   end
 
   test "attributes without primary key" do

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -754,7 +754,8 @@ class MultipleFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    sets = %w(accounts developers topics)
+    assert_equal sets, fixture_files[FIXTURES_ROOT].sort
   end
 end
 
@@ -786,7 +787,8 @@ class OverlappingFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    sets = %w(accounts developers topics)
+    assert_equal sets, fixture_files[FIXTURES_ROOT].sort
   end
 end
 
@@ -1050,7 +1052,8 @@ class LoadAllFixturesTest < ActiveRecord::TestCase
     self.class.fixtures :all
 
     if File.symlink? FIXTURES_ROOT + "/all/admin"
-      assert_equal %w(admin/accounts admin/users developers namespaced/accounts people tasks), fixture_table_names.sort
+      sets = %w(admin/accounts admin/users developers namespaced/accounts people tasks)
+      assert_equal sets, fixture_files[FIXTURES_ROOT + "/all"].sort
     end
   ensure
     ActiveRecord::FixtureSet.reset_cache
@@ -1063,7 +1066,8 @@ class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
     self.class.fixtures :all
 
     if File.symlink? FIXTURES_ROOT + "/all/admin"
-      assert_equal %w(admin/accounts admin/users developers namespaced/accounts people tasks), fixture_table_names.sort
+      sets = %w(admin/accounts admin/users developers namespaced/accounts people tasks)
+      assert_equal sets, fixture_files[FIXTURES_ROOT + "/all"].sort
     end
   ensure
     ActiveRecord::FixtureSet.reset_cache
@@ -1388,5 +1392,19 @@ class DeprecatedFixturesPathsTest < ActiveRecord::TestCase
 
   test "TestCase.fixture_path deprecated" do
     assert_deprecated { @test_case.fixture_path }
+  end
+end
+
+class DeprecatedFixtureTableNamesTest < ActiveRecord::TestCase
+  setup do
+    @test_case = Class.new(ActiveRecord::TestCase)
+  end
+
+  test "TestCase.fixture_table_names= deprecated" do
+    assert_deprecated { @test_case.fixture_table_names = %w(accounts) }
+  end
+
+  test "TestCase.fixture_table_names deprecated" do
+    assert_deprecated { @test_case.fixture_table_names }
   end
 end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -8,6 +8,8 @@ require "active_record/fixtures"
 
 require "cases/validations_repair_helper"
 
+ENV["RAILS_ENV"] = "arunit"
+
 module ActiveRecord
   # = Active Record Test Case
   #

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -18,12 +18,17 @@ module ActiveRecord
     include ActiveRecord::TestFixtures
     include ActiveRecord::ValidationsRepairHelper
 
-    self.fixture_path = FIXTURES_ROOT
+    self.fixtures_paths = [FIXTURES_ROOT]
     self.use_instantiated_fixtures = false
     self.use_transactional_tests = true
 
     def create_fixtures(*fixture_set_names, &block)
-      ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)
+      ActiveRecord::FixtureSet.create_fixtures(
+        ActiveRecord::TestCase.fixtures_paths.first,
+        fixture_set_names,
+        fixture_class_names,
+        &block
+      )
     end
 
     def teardown

--- a/activerecord/test/fixtures/secondary/books.yml
+++ b/activerecord/test/fixtures/secondary/books.yml
@@ -1,0 +1,7 @@
+ruby_under_a_microscope:
+  author_id: 1
+  id: 1
+  name: "Ruby Under a Microscope"
+  format: "ebook"
+  status: "proposed"
+  read_status: "reading"

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -24,12 +24,12 @@ if defined?(ActiveRecord::Base)
     include ActiveRecord::TestDatabases
     include ActiveRecord::TestFixtures
 
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
-    self.file_fixture_path = fixture_path + "files"
+    self.fixtures_paths = ["#{Rails.root}/test/fixtures/"]
+    self.file_fixture_path = fixtures_paths.first + "files"
   end
 
   ActiveSupport.on_load(:action_dispatch_integration_test) do
-    self.fixture_path = ActiveSupport::TestCase.fixture_path
+    self.fixtures_paths = ActiveSupport::TestCase.fixtures_paths
   end
 end
 


### PR DESCRIPTION
### Summary

Prepares fixtures for multi-db support by:

- Moving `FixtureSet::ClassCache` to separate file (refactor)
- Adding `fixtures_paths` to database configuration classes
- Deprecating `fixture_path` in favor of `fixtures_paths` so naming is equivalent across configs and multiple paths can be specified (it loads in the default `TestCase.fixtures_paths` in with the primary config).
- Read from all fixtures_paths (including the ones from primary DB configurations, if specified)

### TODO

- [x] Add changelogs for relevant commits.
- [x] Fully deprecate `TestCase.fixture_path` usage across docs and other components.
- [ ] Add support for multiple file fixture paths (this will be done in a followup PR).

r? @eileencodes 
cc @rafaelfranca 
