### PR TITLE
Fix autoloading issue with ActiveStorage::Downloader

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -103,6 +103,8 @@ module ActiveSupport #:nodoc:
       # parent.rb then requires namespace/child.rb, the stack will look like
       # [[Object], [Namespace]].
 
+      attr_reader :watching
+
       def initialize
         @watching = []
         @stack = Hash.new { |h, k| h[k] = [] }
@@ -254,7 +256,9 @@ module ActiveSupport #:nodoc:
 
       def load_dependency(file)
         if Dependencies.load? && Dependencies.constant_watch_stack.watching?
-          Dependencies.new_constants_in(Object) { yield }
+          descs = Dependencies.constant_watch_stack.watching.flatten.uniq
+
+          Dependencies.new_constants_in(*descs) { yield }
         else
           yield
         end

--- a/activesupport/test/autoloading_fixtures/module_folder/nested_with_require.rb
+++ b/activesupport/test/autoloading_fixtures/module_folder/nested_with_require.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "dependencies/module_folder/lib_class"
+
+module ModuleFolder
+  class NestedWithRequire
+  end
+end

--- a/activesupport/test/autoloading_fixtures/nested_with_require_parent.rb
+++ b/activesupport/test/autoloading_fixtures/nested_with_require_parent.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class NestedWithRequireParent
+  ModuleFolder::NestedWithRequire
+end

--- a/activesupport/test/dependencies/module_folder/lib_class.rb
+++ b/activesupport/test/dependencies/module_folder/lib_class.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ConstFromLib = 1
+
+module ModuleFolder
+  class LibClass
+  end
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -282,6 +282,32 @@ class DependenciesTest < ActiveSupport::TestCase
     remove_constants(:ModuleFolder)
   end
 
+  def test_module_with_nested_class_requiring_lib_class
+    with_autoloading_fixtures do
+      ModuleFolder::NestedWithRequire
+
+      assert defined?(ModuleFolder::LibClass)
+      assert_not ActiveSupport::Dependencies.autoloaded_constants.include?("ModuleFolder::LibClass")
+      assert_not ActiveSupport::Dependencies.autoloaded_constants.include?("ConstFromLib")
+    end
+  ensure
+    remove_constants(:ModuleFolder)
+    remove_constants(:ConstFromLib)
+  end
+
+  def test_module_with_nested_class_and_parent_requiring_lib_class
+    with_autoloading_fixtures do
+      NestedWithRequireParent
+
+      assert defined?(ModuleFolder::LibClass)
+      assert_not ActiveSupport::Dependencies.autoloaded_constants.include?("ModuleFolder::LibClass")
+      assert_not ActiveSupport::Dependencies.autoloaded_constants.include?("ConstFromLib")
+    end
+  ensure
+    remove_constants(:ModuleFolder)
+    remove_constants(:ConstFromLib)
+  end
+
   def test_directories_may_manifest_as_nested_classes
     with_autoloading_fixtures do
       assert_kind_of Class, ClassFolder


### PR DESCRIPTION
There is currently an issue in local development that cause the following error:

```
  NameError (uninitialized constant ActiveStorage::Downloader):

  bootsnap (1.3.2) lib/bootsnap/load_path_cache/core_ext/active_support.rb:74:in `block in load_missing_constant'
  bootsnap (1.3.2) lib/bootsnap/load_path_cache/core_ext/active_support.rb:8:in `without_bootsnap_cache'
  bootsnap (1.3.2) lib/bootsnap/load_path_cache/core_ext/active_support.rb:74:in `rescue in load_missing_constant'
  bootsnap (1.3.2) lib/bootsnap/load_path_cache/core_ext/active_support.rb:56:in `load_missing_constant'
  rails (134dab46e4e9) activestorage/app/models/active_storage/blob.rb:196:in `open'
```

This seems to happen whenever I change some models in my app that make use of ActiveStorage and try to download a new representation of a file.

Not sure, maybe it is related to this gotcha: https://edgeguides.rubyonrails.org/autoloading_and_reloading_constants.html#when-constants-aren-t-missed

In any case, I looked at where the ActiveStorage::Downloader class is used, and it is only used in "app/models/active_storage/blob.rb". Since the usage is in app/, moving it also into "app/models/" made sense to me. 

This fixed the issue for me, and the Blob model now does not need to manually require "active_storage/downloader" anymore.