### PR TITLE
Deprecate Unicode's #pack_graphemes and #unpack_graphemes methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `ActiveSupport::Multibyte::Unicode#pack_graphemes(array)` and `ActiveSuppport::Multibyte::Unicode#unpack_graphemes(string)`
+    in favor of `array.flatten.pack("U*")` and `string.scan(/\X/).map(&:codepoints)`, respectively.
+
+    *Francesco Rodríguez*
+
 *   Deprecate `ActiveSupport::Multibyte::Chars.consumes?` in favor of `String#is_utf8?`.
 
     *Francesco Rodríguez*

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -34,6 +34,11 @@ module ActiveSupport
       #   Unicode.unpack_graphemes('क्षि') # => [[2325, 2381], [2359], [2367]]
       #   Unicode.unpack_graphemes('Café') # => [[67], [97], [102], [233]]
       def unpack_graphemes(string)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveSupport::Multibyte::Unicode#unpack_graphemes is deprecated and will be
+          removed from Rails 6.1. Use string.scan(/\X/).map(&:codepoints) instead.
+        MSG
+
         string.scan(/\X/).map(&:codepoints)
       end
 
@@ -41,6 +46,11 @@ module ActiveSupport
       #
       #   Unicode.pack_graphemes(Unicode.unpack_graphemes('क्षि')) # => 'क्षि'
       def pack_graphemes(unpacked)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveSupport::Multibyte::Unicode#pack_graphemes is deprecated and will be
+          removed from Rails 6.1. Use array.flatten.pack("U*") instead.
+        MSG
+
         unpacked.flatten.pack("U*")
       end
 

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -17,10 +17,12 @@ class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
   end
 
   def test_breaks
-    each_line_of_break_tests do |*cols|
-      *clusters, comment = *cols
-      packed = ActiveSupport::Multibyte::Unicode.pack_graphemes(clusters)
-      assert_equal clusters, ActiveSupport::Multibyte::Unicode.unpack_graphemes(packed), comment
+    ActiveSupport::Deprecation.silence do
+      each_line_of_break_tests do |*cols|
+        *clusters, comment = *cols
+        packed = ActiveSupport::Multibyte::Unicode.pack_graphemes(clusters)
+        assert_equal clusters, ActiveSupport::Multibyte::Unicode.unpack_graphemes(packed), comment
+      end
     end
   end
 


### PR DESCRIPTION
in favor of `array.flatten.pack("U*")` and `string.scan(/\X/).map(&:codepoints)`, respectively.

r? @jeremy 