### PR TITLE
Remove circular dependency warnings in ActionCable javascript and include source code in published package

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -467,20 +467,21 @@
     }
     return new Consumer(createWebSocketURL(url));
   }
-  var ActionCable = {};
-  ActionCable.createConsumer = createConsumer;
-  ActionCable.createWebSocketURL = createWebSocketURL;
-  ActionCable.Connection = Connection;
-  ActionCable.ConnectionMonitor = ConnectionMonitor;
-  ActionCable.Consumer = Consumer;
-  ActionCable.getConfig = getConfig;
-  ActionCable.INTERNAL = INTERNAL;
-  ActionCable.log = log;
-  ActionCable.startDebugging = startDebugging;
-  ActionCable.stopDebugging = stopDebugging;
-  ActionCable.Subscription = Subscription;
-  ActionCable.Subscriptions = Subscriptions;
-  Object.defineProperties(ActionCable, {
+  var ActionCable = Object.freeze({
+    getConfig: getConfig,
+    createWebSocketURL: createWebSocketURL,
+    createConsumer: createConsumer,
+    Connection: Connection,
+    ConnectionMonitor: ConnectionMonitor,
+    Consumer: Consumer,
+    INTERNAL: INTERNAL,
+    log: log,
+    startDebugging: startDebugging,
+    stopDebugging: stopDebugging,
+    Subscription: Subscription,
+    Subscriptions: Subscriptions
+  });
+  var index = Object.defineProperties(Object.create(ActionCable), {
     logger: {
       get: function get() {
         return adapters.logger;
@@ -498,5 +499,5 @@
       }
     }
   });
-  return ActionCable;
+  return index;
 });

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -424,30 +424,30 @@
     };
     return Consumer;
   }();
+  function getConfig(name) {
+    var element = document.head.querySelector("meta[name='action-cable-" + name + "']");
+    return element ? element.getAttribute("content") : undefined;
+  }
+  function createWebSocketURL(url) {
+    if (url && !/^wss?:/i.test(url)) {
+      var a = document.createElement("a");
+      a.href = url;
+      a.href = a.href;
+      a.protocol = a.protocol.replace("http", "ws");
+      return a.href;
+    } else {
+      return url;
+    }
+  }
   var ActionCable = {
     WebSocket: window.WebSocket,
     logger: window.console,
     createConsumer: function createConsumer(url) {
       if (url == null) {
-        var urlConfig = this.getConfig("url");
+        var urlConfig = getConfig("url");
         url = urlConfig ? urlConfig : INTERNAL.default_mount_path;
       }
-      return new Consumer(this.createWebSocketURL(url));
-    },
-    getConfig: function getConfig(name) {
-      var element = document.head.querySelector("meta[name='action-cable-" + name + "']");
-      return element ? element.getAttribute("content") : undefined;
-    },
-    createWebSocketURL: function createWebSocketURL(url) {
-      if (url && !/^wss?:/i.test(url)) {
-        var a = document.createElement("a");
-        a.href = url;
-        a.href = a.href;
-        a.protocol = a.protocol.replace("http", "ws");
-        return a.href;
-      } else {
-        return url;
-      }
+      return new Consumer(createWebSocketURL(url));
     },
     startDebugging: function startDebugging() {
       this.debugging = true;
@@ -466,9 +466,11 @@
       }
     }
   };
+  ActionCable.createWebSocketURL = createWebSocketURL;
   ActionCable.Connection = Connection;
   ActionCable.ConnectionMonitor = ConnectionMonitor;
   ActionCable.Consumer = Consumer;
+  ActionCable.getConfig = getConfig;
   ActionCable.INTERNAL = INTERNAL;
   ActionCable.Subscription = Subscription;
   ActionCable.Subscriptions = Subscriptions;

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -425,12 +425,6 @@
     return Consumer;
   }();
   var ActionCable = {
-    Connection: Connection,
-    ConnectionMonitor: ConnectionMonitor,
-    Consumer: Consumer,
-    INTERNAL: INTERNAL,
-    Subscription: Subscription,
-    Subscriptions: Subscriptions,
     WebSocket: window.WebSocket,
     logger: window.console,
     createConsumer: function createConsumer(url) {
@@ -472,5 +466,11 @@
       }
     }
   };
+  ActionCable.Connection = Connection;
+  ActionCable.ConnectionMonitor = ConnectionMonitor;
+  ActionCable.Consumer = Consumer;
+  ActionCable.INTERNAL = INTERNAL;
+  ActionCable.Subscription = Subscription;
+  ActionCable.Subscriptions = Subscriptions;
   return ActionCable;
 });

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -2,6 +2,10 @@
   typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : global.ActionCable = factory();
 })(this, function() {
   "use strict";
+  var adapters = {
+    logger: window.console,
+    WebSocket: window.WebSocket
+  };
   var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function(obj) {
     return typeof obj;
   } : function(obj) {
@@ -156,7 +160,7 @@
         if (this.webSocket) {
           this.uninstallEventHandlers();
         }
-        this.webSocket = new ActionCable.WebSocket(this.consumer.url, protocols);
+        this.webSocket = new adapters.WebSocket(this.consumer.url, protocols);
         this.installEventHandlers();
         this.monitor.start();
         return true;
@@ -447,8 +451,6 @@
     return new Consumer(createWebSocketURL(url));
   }
   var ActionCable = {
-    WebSocket: window.WebSocket,
-    logger: window.console,
     startDebugging: function startDebugging() {
       this.debugging = true;
     },
@@ -475,5 +477,23 @@
   ActionCable.INTERNAL = INTERNAL;
   ActionCable.Subscription = Subscription;
   ActionCable.Subscriptions = Subscriptions;
+  Object.defineProperties(ActionCable, {
+    logger: {
+      get: function get() {
+        return adapters.logger;
+      },
+      set: function set(value) {
+        adapters.logger = value;
+      }
+    },
+    WebSocket: {
+      get: function get() {
+        return adapters.WebSocket;
+      },
+      set: function set(value) {
+        adapters.WebSocket = value;
+      }
+    }
+  });
   return ActionCable;
 });

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -430,7 +430,7 @@
     createConsumer: function createConsumer(url) {
       if (url == null) {
         var urlConfig = this.getConfig("url");
-        url = urlConfig ? urlConfig : this.INTERNAL.default_mount_path;
+        url = urlConfig ? urlConfig : INTERNAL.default_mount_path;
       }
       return new Consumer(this.createWebSocketURL(url));
     },

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -439,16 +439,16 @@
       return url;
     }
   }
+  function createConsumer(url) {
+    if (url == null) {
+      var urlConfig = getConfig("url");
+      url = urlConfig ? urlConfig : INTERNAL.default_mount_path;
+    }
+    return new Consumer(createWebSocketURL(url));
+  }
   var ActionCable = {
     WebSocket: window.WebSocket,
     logger: window.console,
-    createConsumer: function createConsumer(url) {
-      if (url == null) {
-        var urlConfig = getConfig("url");
-        url = urlConfig ? urlConfig : INTERNAL.default_mount_path;
-      }
-      return new Consumer(createWebSocketURL(url));
-    },
     startDebugging: function startDebugging() {
       this.debugging = true;
     },
@@ -466,6 +466,7 @@
       }
     }
   };
+  ActionCable.createConsumer = createConsumer;
   ActionCable.createWebSocketURL = createWebSocketURL;
   ActionCable.Connection = Connection;
   ActionCable.ConnectionMonitor = ConnectionMonitor;

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -1,34 +1,34 @@
 import Consumer from "./consumer"
 import INTERNAL from "./internal"
 
+export function getConfig(name) {
+  const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
+  return (element ? element.getAttribute("content") : undefined)
+}
+
+export function createWebSocketURL(url) {
+  if (url && !/^wss?:/i.test(url)) {
+    const a = document.createElement("a")
+    a.href = url
+    // Fix populating Location properties in IE. Otherwise, protocol will be blank.
+    a.href = a.href
+    a.protocol = a.protocol.replace("http", "ws")
+    return a.href
+  } else {
+    return url
+  }
+}
+
 const ActionCable = {
   WebSocket: window.WebSocket,
   logger: window.console,
 
   createConsumer(url) {
     if (url == null) {
-      const urlConfig = this.getConfig("url")
+      const urlConfig = getConfig("url")
       url = (urlConfig ? urlConfig : INTERNAL.default_mount_path)
     }
-    return new Consumer(this.createWebSocketURL(url))
-  },
-
-  getConfig(name) {
-    const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
-    return (element ? element.getAttribute("content") : undefined)
-  },
-
-  createWebSocketURL(url) {
-    if (url && !/^wss?:/i.test(url)) {
-      const a = document.createElement("a")
-      a.href = url
-      // Fix populating Location properties in IE. Otherwise, protocol will be blank.
-      a.href = a.href
-      a.protocol = a.protocol.replace("http", "ws")
-      return a.href
-    } else {
-      return url
-    }
+    return new Consumer(createWebSocketURL(url))
   },
 
   startDebugging() {

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -1,4 +1,5 @@
 import Consumer from "./consumer"
+import INTERNAL from "./internal"
 
 const ActionCable = {
   WebSocket: window.WebSocket,
@@ -7,7 +8,7 @@ const ActionCable = {
   createConsumer(url) {
     if (url == null) {
       const urlConfig = this.getConfig("url")
-      url = (urlConfig ? urlConfig : this.INTERNAL.default_mount_path)
+      url = (urlConfig ? urlConfig : INTERNAL.default_mount_path)
     }
     return new Consumer(this.createWebSocketURL(url))
   },

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -1,0 +1,49 @@
+import Consumer from "./consumer"
+
+const ActionCable = {
+  WebSocket: window.WebSocket,
+  logger: window.console,
+
+  createConsumer(url) {
+    if (url == null) {
+      const urlConfig = this.getConfig("url")
+      url = (urlConfig ? urlConfig : this.INTERNAL.default_mount_path)
+    }
+    return new Consumer(this.createWebSocketURL(url))
+  },
+
+  getConfig(name) {
+    const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
+    return (element ? element.getAttribute("content") : undefined)
+  },
+
+  createWebSocketURL(url) {
+    if (url && !/^wss?:/i.test(url)) {
+      const a = document.createElement("a")
+      a.href = url
+      // Fix populating Location properties in IE. Otherwise, protocol will be blank.
+      a.href = a.href
+      a.protocol = a.protocol.replace("http", "ws")
+      return a.href
+    } else {
+      return url
+    }
+  },
+
+  startDebugging() {
+    this.debugging = true
+  },
+
+  stopDebugging() {
+    this.debugging = null
+  },
+
+  log(...messages) {
+    if (this.debugging) {
+      messages.push(Date.now())
+      this.logger.log("[ActionCable]", ...messages)
+    }
+  }
+}
+
+export { ActionCable }

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -19,17 +19,17 @@ export function createWebSocketURL(url) {
   }
 }
 
+export function createConsumer(url) {
+  if (url == null) {
+    const urlConfig = getConfig("url")
+    url = (urlConfig ? urlConfig : INTERNAL.default_mount_path)
+  }
+  return new Consumer(createWebSocketURL(url))
+}
+
 const ActionCable = {
   WebSocket: window.WebSocket,
   logger: window.console,
-
-  createConsumer(url) {
-    if (url == null) {
-      const urlConfig = getConfig("url")
-      url = (urlConfig ? urlConfig : INTERNAL.default_mount_path)
-    }
-    return new Consumer(createWebSocketURL(url))
-  },
 
   startDebugging() {
     this.debugging = true

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -1,5 +1,10 @@
+import Connection from "./connection"
+import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
 import INTERNAL from "./internal"
+import { log, startDebugging, stopDebugging } from "./logger"
+import Subscription from "./subscription"
+import Subscriptions from "./subscriptions"
 
 export function getConfig(name) {
   const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
@@ -27,7 +32,14 @@ export function createConsumer(url) {
   return new Consumer(createWebSocketURL(url))
 }
 
-const ActionCable = {
+export {
+  Connection,
+  ConnectionMonitor,
+  Consumer,
+  INTERNAL,
+  log,
+  startDebugging,
+  stopDebugging,
+  Subscription,
+  Subscriptions
 }
-
-export { ActionCable }

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -28,20 +28,6 @@ export function createConsumer(url) {
 }
 
 const ActionCable = {
-  startDebugging() {
-    this.debugging = true
-  },
-
-  stopDebugging() {
-    this.debugging = null
-  },
-
-  log(...messages) {
-    if (this.debugging) {
-      messages.push(Date.now())
-      this.logger.log("[ActionCable]", ...messages)
-    }
-  }
 }
 
 export { ActionCable }

--- a/actioncable/app/javascript/action_cable/action_cable.js
+++ b/actioncable/app/javascript/action_cable/action_cable.js
@@ -28,9 +28,6 @@ export function createConsumer(url) {
 }
 
 const ActionCable = {
-  WebSocket: window.WebSocket,
-  logger: window.console,
-
   startDebugging() {
     this.debugging = true
   },

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,0 +1,4 @@
+export default {
+  logger: window.console,
+  WebSocket: window.WebSocket
+}

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -1,4 +1,4 @@
-import ActionCable from "./index"
+import { ActionCable } from "./action_cable"
 import ConnectionMonitor from "./connection_monitor"
 import INTERNAL from "./internal"
 

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -1,4 +1,5 @@
 import ActionCable from "./index"
+import ConnectionMonitor from "./connection_monitor"
 import INTERNAL from "./internal"
 
 // Encapsulate the cable connection held by the consumer. This is an internal class not intended for direct user manipulation.
@@ -13,7 +14,7 @@ class Connection {
     this.open = this.open.bind(this)
     this.consumer = consumer
     this.subscriptions = this.consumer.subscriptions
-    this.monitor = new ActionCable.ConnectionMonitor(this)
+    this.monitor = new ConnectionMonitor(this)
     this.disconnected = true
   }
 

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -1,7 +1,7 @@
-import { ActionCable } from "./action_cable"
 import adapters from "./adapters"
 import ConnectionMonitor from "./connection_monitor"
 import INTERNAL from "./internal"
+import { log } from "./logger"
 
 // Encapsulate the cable connection held by the consumer. This is an internal class not intended for direct user manipulation.
 
@@ -30,10 +30,10 @@ class Connection {
 
   open() {
     if (this.isActive()) {
-      ActionCable.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`)
+      log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`)
       return false
     } else {
-      ActionCable.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`)
+      log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`)
       if (this.webSocket) { this.uninstallEventHandlers() }
       this.webSocket = new adapters.WebSocket(this.consumer.url, protocols)
       this.installEventHandlers()
@@ -48,15 +48,15 @@ class Connection {
   }
 
   reopen() {
-    ActionCable.log(`Reopening WebSocket, current state is ${this.getState()}`)
+    log(`Reopening WebSocket, current state is ${this.getState()}`)
     if (this.isActive()) {
       try {
         return this.close()
       } catch (error) {
-        ActionCable.log("Failed to reopen WebSocket", error)
+        log("Failed to reopen WebSocket", error)
       }
       finally {
-        ActionCable.log(`Reopening WebSocket in ${this.constructor.reopenDelay}ms`)
+        log(`Reopening WebSocket in ${this.constructor.reopenDelay}ms`)
         setTimeout(this.open, this.constructor.reopenDelay)
       }
     } else {
@@ -134,16 +134,16 @@ Connection.prototype.events = {
   },
 
   open() {
-    ActionCable.log(`WebSocket onopen event, using '${this.getProtocol()}' subprotocol`)
+    log(`WebSocket onopen event, using '${this.getProtocol()}' subprotocol`)
     this.disconnected = false
     if (!this.isProtocolSupported()) {
-      ActionCable.log("Protocol is unsupported. Stopping monitor and disconnecting.")
+      log("Protocol is unsupported. Stopping monitor and disconnecting.")
       return this.close({allowReconnect: false})
     }
   },
 
   close(event) {
-    ActionCable.log("WebSocket onclose event")
+    log("WebSocket onclose event")
     if (this.disconnected) { return }
     this.disconnected = true
     this.monitor.recordDisconnect()
@@ -151,7 +151,7 @@ Connection.prototype.events = {
   },
 
   error() {
-    ActionCable.log("WebSocket onerror event")
+    log("WebSocket onerror event")
   }
 }
 

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -1,4 +1,5 @@
 import { ActionCable } from "./action_cable"
+import adapters from "./adapters"
 import ConnectionMonitor from "./connection_monitor"
 import INTERNAL from "./internal"
 
@@ -34,7 +35,7 @@ class Connection {
     } else {
       ActionCable.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`)
       if (this.webSocket) { this.uninstallEventHandlers() }
-      this.webSocket = new ActionCable.WebSocket(this.consumer.url, protocols)
+      this.webSocket = new adapters.WebSocket(this.consumer.url, protocols)
       this.installEventHandlers()
       this.monitor.start()
       return true

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -1,4 +1,4 @@
-import ActionCable from "./index"
+import { ActionCable } from "./action_cable"
 
 // Responsible for ensuring the cable connection is in good health by validating the heartbeat pings sent from the server, and attempting
 // revival reconnections if things go astray. Internal class, not intended for direct user manipulation.

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -1,4 +1,4 @@
-import { ActionCable } from "./action_cable"
+import { log } from "./logger"
 
 // Responsible for ensuring the cable connection is in good health by validating the heartbeat pings sent from the server, and attempting
 // revival reconnections if things go astray. Internal class, not intended for direct user manipulation.
@@ -22,7 +22,7 @@ class ConnectionMonitor {
       delete this.stoppedAt
       this.startPolling()
       document.addEventListener("visibilitychange", this.visibilityDidChange)
-      ActionCable.log(`ConnectionMonitor started. pollInterval = ${this.getPollInterval()} ms`)
+      log(`ConnectionMonitor started. pollInterval = ${this.getPollInterval()} ms`)
     }
   }
 
@@ -31,7 +31,7 @@ class ConnectionMonitor {
       this.stoppedAt = now()
       this.stopPolling()
       document.removeEventListener("visibilitychange", this.visibilityDidChange)
-      ActionCable.log("ConnectionMonitor stopped")
+      log("ConnectionMonitor stopped")
     }
   }
 
@@ -47,12 +47,12 @@ class ConnectionMonitor {
     this.reconnectAttempts = 0
     this.recordPing()
     delete this.disconnectedAt
-    ActionCable.log("ConnectionMonitor recorded connect")
+    log("ConnectionMonitor recorded connect")
   }
 
   recordDisconnect() {
     this.disconnectedAt = now()
-    ActionCable.log("ConnectionMonitor recorded disconnect")
+    log("ConnectionMonitor recorded disconnect")
   }
 
   // Private
@@ -82,12 +82,12 @@ class ConnectionMonitor {
 
   reconnectIfStale() {
     if (this.connectionIsStale()) {
-      ActionCable.log(`ConnectionMonitor detected stale connection. reconnectAttempts = ${this.reconnectAttempts}, pollInterval = ${this.getPollInterval()} ms, time disconnected = ${secondsSince(this.disconnectedAt)} s, stale threshold = ${this.constructor.staleThreshold} s`)
+      log(`ConnectionMonitor detected stale connection. reconnectAttempts = ${this.reconnectAttempts}, pollInterval = ${this.getPollInterval()} ms, time disconnected = ${secondsSince(this.disconnectedAt)} s, stale threshold = ${this.constructor.staleThreshold} s`)
       this.reconnectAttempts++
       if (this.disconnectedRecently()) {
-        ActionCable.log("ConnectionMonitor skipping reopening recent disconnect")
+        log("ConnectionMonitor skipping reopening recent disconnect")
       } else {
-        ActionCable.log("ConnectionMonitor reopening")
+        log("ConnectionMonitor reopening")
         this.connection.reopen()
       }
     }
@@ -105,7 +105,7 @@ class ConnectionMonitor {
     if (document.visibilityState === "visible") {
       setTimeout(() => {
         if (this.connectionIsStale() || !this.connection.isOpen()) {
-          ActionCable.log(`ConnectionMonitor reopening stale connection on visibilitychange. visbilityState = ${document.visibilityState}`)
+          log(`ConnectionMonitor reopening stale connection on visibilitychange. visbilityState = ${document.visibilityState}`)
           this.connection.reopen()
         }
       }

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -1,4 +1,5 @@
-import ActionCable from "./index"
+import Connection from "./connection"
+import Subscriptions from "./subscriptions"
 
 // The ActionCable.Consumer establishes the connection to a server-side Ruby Connection object. Once established,
 // the ActionCable.ConnectionMonitor will ensure that its properly maintained through heartbeats and checking for stale updates.
@@ -29,8 +30,8 @@ import ActionCable from "./index"
 export default class Consumer {
   constructor(url) {
     this.url = url
-    this.subscriptions = new ActionCable.Subscriptions(this)
-    this.connection = new ActionCable.Connection(this)
+    this.subscriptions = new Subscriptions(this)
+    this.connection = new Connection(this)
   }
 
   send(data) {

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -1,4 +1,4 @@
-import { ActionCable } from "./action_cable"
+import { ActionCable, createWebSocketURL, getConfig } from "./action_cable"
 import Connection from "./connection"
 import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
@@ -6,9 +6,11 @@ import INTERNAL from "./internal"
 import Subscription from "./subscription"
 import Subscriptions from "./subscriptions"
 
+ActionCable.createWebSocketURL = createWebSocketURL
 ActionCable.Connection = Connection
 ActionCable.ConnectionMonitor = ConnectionMonitor
 ActionCable.Consumer = Consumer
+ActionCable.getConfig = getConfig
 ActionCable.INTERNAL = INTERNAL
 ActionCable.Subscription = Subscription
 ActionCable.Subscriptions = Subscriptions

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -1,4 +1,4 @@
-import { ActionCable, createWebSocketURL, getConfig } from "./action_cable"
+import { ActionCable, createConsumer, createWebSocketURL, getConfig } from "./action_cable"
 import Connection from "./connection"
 import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
@@ -6,6 +6,7 @@ import INTERNAL from "./internal"
 import Subscription from "./subscription"
 import Subscriptions from "./subscriptions"
 
+ActionCable.createConsumer = createConsumer
 ActionCable.createWebSocketURL = createWebSocketURL
 ActionCable.Connection = Connection
 ActionCable.ConnectionMonitor = ConnectionMonitor

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -1,3 +1,4 @@
+import { ActionCable } from "./action_cable"
 import Connection from "./connection"
 import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
@@ -5,54 +6,11 @@ import INTERNAL from "./internal"
 import Subscription from "./subscription"
 import Subscriptions from "./subscriptions"
 
-export default {
-  Connection,
-  ConnectionMonitor,
-  Consumer,
-  INTERNAL,
-  Subscription,
-  Subscriptions,
-  WebSocket: window.WebSocket,
-  logger: window.console,
+ActionCable.Connection = Connection
+ActionCable.ConnectionMonitor = ConnectionMonitor
+ActionCable.Consumer = Consumer
+ActionCable.INTERNAL = INTERNAL
+ActionCable.Subscription = Subscription
+ActionCable.Subscriptions = Subscriptions
 
-  createConsumer(url) {
-    if (url == null) {
-      const urlConfig = this.getConfig("url")
-      url = (urlConfig ? urlConfig : this.INTERNAL.default_mount_path)
-    }
-    return new Consumer(this.createWebSocketURL(url))
-  },
-
-  getConfig(name) {
-    const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
-    return (element ? element.getAttribute("content") : undefined)
-  },
-
-  createWebSocketURL(url) {
-    if (url && !/^wss?:/i.test(url)) {
-      const a = document.createElement("a")
-      a.href = url
-      // Fix populating Location properties in IE. Otherwise, protocol will be blank.
-      a.href = a.href
-      a.protocol = a.protocol.replace("http", "ws")
-      return a.href
-    } else {
-      return url
-    }
-  },
-
-  startDebugging() {
-    this.debugging = true
-  },
-
-  stopDebugging() {
-    this.debugging = null
-  },
-
-  log(...messages) {
-    if (this.debugging) {
-      messages.push(Date.now())
-      this.logger.log("[ActionCable]", ...messages)
-    }
-  }
-}
+export default ActionCable

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -1,4 +1,5 @@
 import { ActionCable, createConsumer, createWebSocketURL, getConfig } from "./action_cable"
+import adapters from "./adapters"
 import Connection from "./connection"
 import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
@@ -15,5 +16,16 @@ ActionCable.getConfig = getConfig
 ActionCable.INTERNAL = INTERNAL
 ActionCable.Subscription = Subscription
 ActionCable.Subscriptions = Subscriptions
+
+Object.defineProperties(ActionCable, {
+  logger: {
+    get() { return adapters.logger },
+    set(value) { adapters.logger = value }
+  },
+  WebSocket: {
+    get() { return adapters.WebSocket },
+    set(value) { adapters.WebSocket = value }
+  }
+})
 
 export default ActionCable

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -1,27 +1,7 @@
-import { ActionCable, createConsumer, createWebSocketURL, getConfig } from "./action_cable"
+import * as ActionCable from "./action_cable"
 import adapters from "./adapters"
-import Connection from "./connection"
-import ConnectionMonitor from "./connection_monitor"
-import Consumer from "./consumer"
-import INTERNAL from "./internal"
-import { log, startDebugging, stopDebugging } from "./logger"
-import Subscription from "./subscription"
-import Subscriptions from "./subscriptions"
 
-ActionCable.createConsumer = createConsumer
-ActionCable.createWebSocketURL = createWebSocketURL
-ActionCable.Connection = Connection
-ActionCable.ConnectionMonitor = ConnectionMonitor
-ActionCable.Consumer = Consumer
-ActionCable.getConfig = getConfig
-ActionCable.INTERNAL = INTERNAL
-ActionCable.log = log
-ActionCable.startDebugging = startDebugging
-ActionCable.stopDebugging = stopDebugging
-ActionCable.Subscription = Subscription
-ActionCable.Subscriptions = Subscriptions
-
-Object.defineProperties(ActionCable, {
+export default Object.defineProperties(Object.create(ActionCable), {
   logger: {
     get() { return adapters.logger },
     set(value) { adapters.logger = value }
@@ -31,5 +11,3 @@ Object.defineProperties(ActionCable, {
     set(value) { adapters.WebSocket = value }
   }
 })
-
-export default ActionCable

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -4,6 +4,7 @@ import Connection from "./connection"
 import ConnectionMonitor from "./connection_monitor"
 import Consumer from "./consumer"
 import INTERNAL from "./internal"
+import { log, startDebugging, stopDebugging } from "./logger"
 import Subscription from "./subscription"
 import Subscriptions from "./subscriptions"
 
@@ -14,6 +15,9 @@ ActionCable.ConnectionMonitor = ConnectionMonitor
 ActionCable.Consumer = Consumer
 ActionCable.getConfig = getConfig
 ActionCable.INTERNAL = INTERNAL
+ActionCable.log = log
+ActionCable.startDebugging = startDebugging
+ActionCable.stopDebugging = stopDebugging
 ActionCable.Subscription = Subscription
 ActionCable.Subscriptions = Subscriptions
 

--- a/actioncable/app/javascript/action_cable/logger.js
+++ b/actioncable/app/javascript/action_cable/logger.js
@@ -1,0 +1,18 @@
+import adapters from "./adapters"
+
+let enabled
+
+export function log(...messages) {
+  if (enabled) {
+    messages.push(Date.now())
+    adapters.logger.log("[ActionCable]", ...messages)
+  }
+}
+
+export function startDebugging() {
+  enabled = true
+}
+
+export function stopDebugging() {
+  enabled = false
+}

--- a/actioncable/app/javascript/action_cable/subscriptions.js
+++ b/actioncable/app/javascript/action_cable/subscriptions.js
@@ -1,4 +1,4 @@
-import ActionCable from "./index"
+import Subscription from "./subscription"
 
 // Collection class for creating (and internally managing) channel subscriptions. The only method intended to be triggered by the user
 // us ActionCable.Subscriptions#create, and it should be called through the consumer like so:
@@ -18,7 +18,7 @@ export default class Subscriptions {
   create(channelName, mixin) {
     const channel = channelName
     const params = typeof channel === "object" ? channel : {channel}
-    const subscription = new ActionCable.Subscription(this.consumer, params, mixin)
+    const subscription = new Subscription(this.consumer, params, mixin)
     return this.add(subscription)
   }
 

--- a/actioncable/package.json
+++ b/actioncable/package.json
@@ -4,7 +4,8 @@
   "description": "WebSocket framework for Ruby on Rails.",
   "main": "app/assets/javascripts/action_cable.js",
   "files": [
-    "app/assets/javascripts/*.js"
+    "app/assets/javascripts/*.js",
+    "src/*.js"
   ],
   "repository": {
     "type": "git",
@@ -36,6 +37,7 @@
   "scripts": {
     "prebuild": "yarn lint && bundle exec rake assets:codegen",
     "build": "rollup --config rollup.config.js",
-    "lint": "eslint app/javascript"
+    "lint": "eslint app/javascript",
+    "prepublishOnly": "rm -rf src && cp -R app/javascript/action_cable src"
   }
 }

--- a/actioncable/rollup.config.js
+++ b/actioncable/rollup.config.js
@@ -1,5 +1,4 @@
 import resolve from "rollup-plugin-node-resolve"
-import commonjs from "rollup-plugin-commonjs"
 import babel from "rollup-plugin-babel"
 import uglify from "rollup-plugin-uglify"
 
@@ -21,7 +20,6 @@ export default {
   },
   plugins: [
     resolve(),
-    commonjs(),
     babel(),
     uglify(uglifyOptions)
   ]


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/pull/34177, we've converted the ActionCable javascript to ES2015 (in that PR we avoided refactoring the existing structure, which has some circular dependency warnings). This PR builds on top of that work. In this PR we:

1. Reorganize the module imports to remove the circular dependency warnings
2. Update the ActionCable npm package to ship untranspiled ES2015 source code in addition to the heavier compiled bundle
   - This enables ActionCable users to ship smaller javascript bundles to their visitors with modern browsers. We added this enhancement to ActiveStorage in https://github.com/rails/rails/pull/31880.

In an [example repository](https://github.com/rmacklin/actioncable-es2015-build-example/tree/pr-34258), the bundle shrinks by 2.5K (23.6%) when you simply change the actioncable import to point to the untranspiled src, e.g. by [setting up an alias](https://github.com/rmacklin/actioncable-es2015-build-example/commit/172204aa043877158da131c92934b97ed5876dbb):

```
resolve: {
  alias: {
    actioncable: 'actioncable/src'
  }
}
```

If you go a step further, by [importing the tree-shaking-friendly source](https://github.com/rmacklin/actioncable-es2015-build-example/commit/f02de269be4c7ac98913a99689b126326e1f4e07), e.g.:
```diff
diff --git a/app/scripts/main.js b/app/scripts/main.js
index 17bc031..1a2b2e0 100644
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,6 +1,6 @@
-import ActionCable from 'actioncable';
+import * as ActionCable from 'actioncable/action_cable';

 let cable = ActionCable.createConsumer('wss://cable.example.com');

 cable.subscriptions.create('AppearanceChannel', {
```

then the bundle shrinks by 3.2K (30%).