### PR TITLE
Use release dates for versions in Rails Guides index

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -207,46 +207,46 @@
       url: 6_0_release_notes.html
       description: Release notes for Rails 6.0.
     -
-      name: 5.2 Release Notes
+      name: Version 5.2 - April 2018
       url: 5_2_release_notes.html
       description: Release notes for Rails 5.2.
     -
-      name: 5.1 Release Notes
+      name: Version 5.1 - April 2017
       url: 5_1_release_notes.html
       description: Release notes for Rails 5.1.
     -
-      name: 5.0 Release Notes
+      name: Version 5.0 - June 2016
       url: 5_0_release_notes.html
       description: Release notes for Rails 5.0.
     -
-      name: 4.2 Release Notes
+      name: Version 4.2 - December 2014
       url: 4_2_release_notes.html
       description: Release notes for Rails 4.2.
     -
-      name: 4.1 Release Notes
+      name: Version 4.1 - April 2014
       url: 4_1_release_notes.html
       description: Release notes for Rails 4.1.
     -
-      name: 4.0 Release Notes
+      name: Version 4.0 - June 2013
       url: 4_0_release_notes.html
       description: Release notes for Rails 4.0.
     -
-      name: 3.2 Release Notes
+      name: Version 3.2 - January 2012
       url: 3_2_release_notes.html
       description: Release notes for Rails 3.2.
     -
-      name: 3.1 Release Notes
+      name: Version 3.1 - August 2011
       url: 3_1_release_notes.html
       description: Release notes for Rails 3.1.
     -
-      name: 3.0 Release Notes
+      name: Version 3.0 - August 2010
       url: 3_0_release_notes.html
       description: Release notes for Rails 3.0.
     -
-      name: 2.3 Release Notes
+      name: Version 2.3 - March 2009
       url: 2_3_release_notes.html
       description: Release notes for Rails 2.3.
     -
-      name: 2.2 Release Notes
+      name: Version 2.2 - November 2008
       url: 2_2_release_notes.html
       description: Release notes for Rails 2.2.


### PR DESCRIPTION
We repeat the phrase "Release Notes" even though release note are listed
under a... "Release Notes" category already. With this change, instead
of repeating ourselves, we can give people a sense of the recency of
each release by simply listing the month and year of each release.

I've tried to use the full date instead but that resulted in variable width which made the layout a bit more messy and difficult to read. I think it might even make sense to remove the specific date and simply list the month of release if `2018-04-09` feels hard to read for humans. Technically it's one of the most universally understandable date formats, unlike most English date formats. But `Version 5.2 - April 2018` does look a bit more pleasing on the eye.

#### Before 

![image](https://user-images.githubusercontent.com/65950/47263105-c5178200-d4c8-11e8-9ad8-b396763871ea.png)

#### After

![image](https://user-images.githubusercontent.com/65950/47248685-067d3400-d3da-11e8-9ffd-c3c2d59dc847.png)

This is a follow-up to #34265 as suggested by @jeremy.