### PR TITLE
Reduce string allocations in read/write_attribute

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -29,10 +29,9 @@ module ActiveRecord
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
       def read_attribute(attr_name, &block)
-        name = if self.class.attribute_alias?(attr_name)
-          self.class.attribute_alias(attr_name).to_s
-        else
-          attr_name.to_s
+        name = attr_name.to_s
+        if self.class.attribute_alias?(name)
+          name = self.class.attribute_alias(name)
         end
 
         primary_key = self.class.primary_key

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -33,10 +33,9 @@ module ActiveRecord
       # specified +value+. Empty strings for Integer and Float columns are
       # turned into +nil+.
       def write_attribute(attr_name, value)
-        name = if self.class.attribute_alias?(attr_name)
-          self.class.attribute_alias(attr_name).to_s
-        else
-          attr_name.to_s
+        name = attr_name.to_s
+        if self.class.attribute_alias?(name)
+          name = self.class.attribute_alias(name)
         end
 
         primary_key = self.class.primary_key


### PR DESCRIPTION
When `attr_name` is passed as a symbol, it's currently converted to a string by [`attribute_alias?`](https://github.com/rails/rails/blob/26a202a91b5a4754be5e3e137c390786ec977e56/activemodel/lib/active_model/attribute_methods.rb#L219), and potentially also [`attribute_alias`](https://github.com/rails/rails/blob/26a202a91b5a4754be5e3e137c390786ec977e56/activemodel/lib/active_model/attribute_methods.rb#L224), as well as by the `read_attribute`/`write_attribute` method itself.

By converting `attr_name` to a string up front, the extra allocations related to attribute aliases can be avoided.