### PR TITLE
Correct some tests related to changes in #33079

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -794,7 +794,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       @called ||= 0
       if command == "webpacker:install"
         @called += 1
-        assert_equal 0, @called, "webpacker:install expected not to be called once, but was called #{@called} times."
+        assert_equal 0, @called, "webpacker:install expected not to be called, but was called #{@called} times."
       end
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -610,7 +610,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/views/layouts/application.html.erb" do |contents|
       assert_match(/stylesheet_link_tag\s+'application', media: 'all' %>/, contents)
-      assert_no_match(/javascript_include_tag\s+'application' \%>/, contents)
+      assert_no_match(/javascript_pack_tag\s+'application'/, contents)
     end
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -15,6 +15,8 @@ DEFAULT_APP_FILES = %w(
   app/assets/images
   app/javascript
   app/javascript/channels
+  app/javascript/channels/consumer.js
+  app/javascript/channels/index.js
   app/javascript/packs/application.js
   app/assets/stylesheets
   app/assets/stylesheets/application.css

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -231,7 +231,7 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
     assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
-      assert_no_match(/^\/\/= require activestorage/, content)
+      assert_no_match(/activestorage/, content)
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|
@@ -261,7 +261,7 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
     assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
-      assert_no_match(/^import * as ActiveStorage from "activestorage"\nActiveStorage.start()/, content)
+      assert_no_match(/^import * as ActiveStorage from "activestorage"\nActiveStorage.start\(\)/, content)
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|


### PR DESCRIPTION
- Fix assertions of auto-generated ActiveStorage JS
- Correct message on the `assert_equal` failure
- Test ActionCable's js files
  This commit adds `app/javascript/channels/consumer.js`, and
  `app/javascript/channels/index.js` to `DEFAULT_APP_FILES` in order
  to assert their existance in `test_skeleton_is_created`.
- Assert no match `javascript_pack_tag` in `application.html.erb`
  Since #33079 `rails new` generates `application.html.erb` file
  with `javascript_pack_tag` instead of `javascript_include_tag`.

  Note that there some tests that asserting no matching
  `javascript_include_tag` in the `application.html.erb` file
  for newly generated rails plugins.
  It is related to #34009 and shouldn't be changed right now.

Related to #33079  