### PR TITLE
Rename event variable

### DIFF
--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -79,12 +79,12 @@ module ActiveSupport
     end
 
     def start(name, id, payload)
-      e = ActiveSupport::Notifications::Event.new(name, nil, nil, id, payload)
-      e.start!
+      event = ActiveSupport::Notifications::Event.new(name, nil, nil, id, payload)
+      event.start!
       parent = event_stack.last
-      parent << e if parent
+      parent << event if parent
 
-      event_stack.push e
+      event_stack.push event
     end
 
     def finish(name, id, payload)


### PR DESCRIPTION
### Summary
This patch improves variable naming by renaming from `e` to `event`.

The arguments to rename this are:
* The naming `e` is usually a convention used for exceptions.
* All other methods in this class are using `event`. No other method uses the naming `e`.