### PR TITLE
Remove yarn's files from `.gitignore` template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ node_modules/
 package-lock.json
 pkg/
 /tmp/
+/yarn-error.log
 /yarn.lock

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -28,13 +28,8 @@
 !/storage/.keep
 <% end -%>
 <% end -%>
-
-<% unless options.skip_yarn? -%>
-/node_modules
-/yarn-error.log
-
-<% end -%>
 <% unless options.api? -%>
+
 /public/assets
 <% end -%>
 .byebug_history

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -339,11 +339,6 @@ module SharedGeneratorTests
     run_generator
     assert_file "#{application_path}/package.json", /dependencies/
     assert_file "#{application_path}/config/initializers/assets.rb", /node_modules/
-
-    assert_file ".gitignore" do |content|
-      assert_match(/node_modules/, content)
-      assert_match(/yarn-error\.log/, content)
-    end
   end
 
   def test_generator_for_yarn_skipped
@@ -353,11 +348,6 @@ module SharedGeneratorTests
 
     assert_file "#{application_path}/config/initializers/assets.rb" do |content|
       assert_no_match(/node_modules/, content)
-    end
-
-    assert_file ".gitignore" do |content|
-      assert_no_match(/node_modules/, content)
-      assert_no_match(/yarn-error\.log/, content)
     end
   end
 end


### PR DESCRIPTION
- Remove yarn's files from `.gitignore` template for new rails app 
  Webpacker already does it,
  see https://github.com/rails/webpacker/blob/895d2cfc15eda2edae9e667c642a02523d958f53/lib/install/template.rb#L25-L33

  I also opened PR rails/webpacker#1765 in order
  to make it add `/yarn-error.log` file too.
- Add `/yarn-error.log` to `.gitignore`