### PR TITLE
Remove `:javascript` from `Rails::PluginBuilder::PASSTHROUGH_OPTIONS`

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -88,7 +88,7 @@ task default: :test
 
     PASSTHROUGH_OPTIONS = [
       :skip_active_record, :skip_active_storage, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_sprockets, :database,
-      :javascript, :skip_yarn, :api, :quiet, :pretend, :skip
+      :skip_yarn, :api, :quiet, :pretend, :skip
     ]
 
     def generate_test_dummy(force = false)


### PR DESCRIPTION
`--javascript` option was removed by 42198064c35ff3b701496309f90df2abc229efbe
