### PR TITLE
Remove `javascripts` and `javascript_engine` options for generators

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -200,8 +200,6 @@ The full set of methods that can be used in this block are as follows:
 * `helper` defines whether or not to generate helpers. Defaults to `true`.
 * `integration_tool` defines which integration tool to use to generate integration tests. Defaults to `:test_unit`.
 * `system_tests` defines which integration tool to use to generate system tests. Defaults to `:test_unit`.
-* `javascripts` turns on the hook for JavaScript files in generators. Used in Rails for when the `scaffold` generator is run. Defaults to `true`.
-* `javascript_engine` configures the engine to be used (for eg. coffee) when generating assets. Defaults to `:js`.
 * `orm` defines which orm to use. Defaults to `false` and will use Active Record by default.
 * `resource_controller` defines which generator to use for generating a controller when using `rails generate resource`. Defaults to `:controller`.
 * `resource_route` defines whether a resource route definition should be generated

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -54,8 +54,6 @@ module Rails
         force_plural: false,
         helper: true,
         integration_tool: nil,
-        javascripts: true,
-        javascript_engine: :js,
         orm: false,
         resource_controller: :controller,
         resource_route: true,


### PR DESCRIPTION
It is unused since #33079
