### PR TITLE
Fix #33914 : Remove dependent: :destroy option from the belong_to example since there is a warning associated with the usage of dependent: :destroy along with belongs_to 

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -868,7 +868,7 @@ While Rails uses intelligent defaults that will work well in most situations, th
 
 ```ruby
 class Book < ApplicationRecord
-  belongs_to :author, dependent: :destroy,
+  belongs_to :author, touch: :books_updated_at,
     counter_cache: true
 end
 ```
@@ -1048,8 +1048,7 @@ There may be times when you wish to customize the query used by `belongs_to`. Su
 
 ```ruby
 class Book < ApplicationRecord
-  belongs_to :author, -> { where active: true },
-                        dependent: :destroy
+  belongs_to :author, -> { where active: true }
 end
 ```
 


### PR DESCRIPTION
[ci skip]This commit removes the dependent: :destroy option from the belong_to example since there is a warning associated with the usage of dependent: :destroy along with belongs_to. Based on the feedback on the issue #33914, I  replaced dependent: :destroy with touch: :books_updated_at which will make the example consistent with the example that already exists on that page.
