### PR TITLE
Remove extra call `remove_file` on `rails new` with `--skip_action_cable`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -438,7 +438,6 @@ module Rails
 
       def delete_action_cable_files_skipping_action_cable
         if options[:skip_action_cable]
-          remove_file "app/javascript/channels/consumer.js"
           remove_dir "app/javascript/channels"
           remove_dir "app/channels"
         end


### PR DESCRIPTION
There is no need to remove this file since the line below
removes entire directory in which that file is placed.