### PR TITLE
no-cache as default Cache-Control for page with form_authenticity_token

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -114,6 +114,7 @@ module ActionController
           last_modified: last_modified, public: public, template: template
       end
 
+      response.cache_control.delete(:no_cache)
       response.last_modified = last_modified if last_modified
       response.cache_control[:public] = true if public
 
@@ -246,6 +247,7 @@ module ActionController
         stale_if_error: options.delete(:stale_if_error),
       )
       options.delete(:private)
+      response.cache_control.delete(:no_cache)
 
       response.cache_control[:extras] = options.map { |k, v| "#{k}=#{v}" }
       response.date = Time.now unless response.date?

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -311,6 +311,7 @@ module ActionController #:nodoc:
 
       # Sets the token value for the current session.
       def form_authenticity_token(form_options: {})
+        response.cache_control[:no_cache] = true if response.cache_control.empty?
         masked_authenticity_token(session, form_options: form_options)
       end
 

--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -24,8 +24,62 @@ class ConditionalGetApiController < ActionController::API
     end
 end
 
+class ConditionalGetController < ActionController::Base
+  before_action :handle_last_modified_and_etags, only: :two
+
+  def one
+    if stale?(last_modified: Time.now.utc.beginning_of_day, etag: [:foo, 123])
+      render plain: "Hi! token is #{form_authenticity_token}"
+    end
+  end
+
+  def two
+    render plain: "Hi! token is #{form_authenticity_token}"
+  end
+
+  private
+
+    def handle_last_modified_and_etags
+      fresh_when(last_modified: Time.now.utc.beginning_of_day, etag: [ :foo, 123 ])
+    end
+end
+
 class ConditionalGetApiTest < ActionController::TestCase
   tests ConditionalGetApiController
+
+  def setup
+    @last_modified = Time.now.utc.beginning_of_day.httpdate
+  end
+
+  def test_request_gets_last_modified
+    get :two
+    assert_equal @last_modified, @response.headers["Last-Modified"]
+    assert_response :success
+  end
+
+  def test_request_obeys_last_modified
+    @request.if_modified_since = @last_modified
+    get :two
+    assert_response :not_modified
+  end
+
+  def test_last_modified_works_with_less_than_too
+    @request.if_modified_since = 5.years.ago.httpdate
+    get :two
+    assert_response :success
+  end
+
+  def test_request_not_modified
+    @request.if_modified_since = @last_modified
+    get :one
+    assert_equal 304, @response.status.to_i
+    assert_predicate @response.body, :blank?
+    assert_equal @last_modified, @response.headers["Last-Modified"]
+  end
+end
+
+class ConditionalGetTest < ActionController::TestCase
+  tests ConditionalGetController
 
   def setup
     @last_modified = Time.now.utc.beginning_of_day.httpdate

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -191,7 +191,7 @@ module RequestForgeryProtectionTests
         get :index
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -201,7 +201,7 @@ module RequestForgeryProtectionTests
         get :show_button
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -220,7 +220,7 @@ module RequestForgeryProtectionTests
         get :form_for_remote
       end
       assert_match(/authenticity_token/, response.body)
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     ensure
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = original
     end
@@ -252,7 +252,7 @@ module RequestForgeryProtectionTests
         get :form_for_remote_with_token
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -262,7 +262,7 @@ module RequestForgeryProtectionTests
         get :form_for_with_token
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -271,7 +271,7 @@ module RequestForgeryProtectionTests
       get :form_with_remote
     end
     assert_match(/authenticity_token/, response.body)
-    assert_no_cache
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_should_render_form_with_without_token_tag_if_remote_and_embedding_token_is_off
@@ -313,7 +313,7 @@ module RequestForgeryProtectionTests
         get :form_with_remote_with_token
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -323,7 +323,7 @@ module RequestForgeryProtectionTests
         get :form_with_local_with_token
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 
@@ -338,7 +338,7 @@ module RequestForgeryProtectionTests
         end
       end
       assert_select "form>input[name=?][value=?]", "custom_authenticity_token", @token
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     ensure
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = original
     end
@@ -346,12 +346,12 @@ module RequestForgeryProtectionTests
 
   def test_should_allow_get
     assert_not_blocked { get :index }
-    assert_no_cache
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_should_allow_head
     assert_not_blocked { head :index }
-    assert_no_cache
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_should_allow_post_without_token_on_unsafe_action
@@ -627,10 +627,6 @@ module RequestForgeryProtectionTests
     end
   end
 
-  def assert_no_cache
-    assert_equal "no-cache", @response.headers["Cache-Control"]
-  end
-
   def assert_cross_origin_not_blocked
     assert_not_blocked { yield }
   end
@@ -658,7 +654,7 @@ class RequestForgeryProtectionControllerUsingResetSessionTest < ActionController
       assert_select "meta[name=?]", "csrf-token"
       regexp = "#{@token}&lt;=\?"
       assert_match(/#{regexp}/, @response.body)
-      assert_no_cache
+      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
   end
 end
@@ -826,7 +822,7 @@ class PerFormTokensControllerTest < ActionController::TestCase
     expected = ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH
     actual = @controller.send(:per_form_csrf_token, session, "/path", "post").size
     assert_equal expected, actual
-    assert_no_cache
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_accepts_token_for_correct_path_and_method
@@ -878,7 +874,7 @@ class PerFormTokensControllerTest < ActionController::TestCase
     form_token = assert_presence_and_fetch_form_csrf_token
 
     assert_matches_session_token_on_server form_token, "delete"
-    assert_no_cache
+    assert_equal "no-cache", @response.headers["Cache-Control"]
 
     # This is required because PATH_INFO isn't reset between requests.
     @request.env["PATH_INFO"] = "/per_form_tokens/post_one"
@@ -1003,10 +999,6 @@ class PerFormTokensControllerTest < ActionController::TestCase
         assert_not_nil form_csrf_token
         return form_csrf_token
       end
-    end
-
-    def assert_no_cache
-      assert_equal "no-cache", @response.headers["Cache-Control"]
     end
 
     def assert_matches_session_token_on_server(form_token, method = "post")


### PR DESCRIPTION
`form_authenticity_token` uses one time pad to generate token, which is different for every request. Rack::ETag middleware computes a etag for every request based on response body's content. This computation is complete wastage for page using `form_authenticity_token` or any dependent method.

This PR proposes to use no-cache as Cache-Control when form_authenticity_token is called to skip Rack::Etag computation. A person can still set cache_control or use conditional get's helper method without any issue.

Benchmark script:

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end


gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "actionpack", path: "actionpack"
  gem "activesupport", path: "activesupport"
  gem "actionview", path: "actionview"
  gem "activemodel", path: "activemodel"
  gem "capybara"
  gem "benchmark-ips"
end


load 'actionpack/test/abstract_unit.rb'

ActionDispatch::IntegrationTest.app = ActionDispatch::IntegrationTest.build_app do |middleware|
  middleware.use Rack::ETag
end

ActionDispatch::IntegrationTest.app.routes.draw do
  ActiveSupport::Deprecation.silence do
    get ":controller(/:action)"
  end
end

# puts ActionDispatch::IntegrationTest.app.instance_variable_get(:@stack)
class SampleController < ActionController::Base
  self.view_paths = [ActionView::FixtureResolver.new(
      "sample/sample_action.html.erb" => %(
<table>
  <% 5000.times do |index| %>
    <tr>
      <td><%= index %></td>
      <td>Hello</td>
      <td>world</td>
    </tr>
  <% end %>
</table
),
      "layouts/sample.html.erb" => %(
<!DOCTYPE html>
<html>
  <head>
    <%= csrf_meta_tags %>
  </head>
  <body>
    <%= yield %>
  </body>
</html
)
    )]

  layout "sample"

  def sample_action; end
end

def rack_digest_body(body)
  parts = []
  digest = nil

  body.each do |part|
    parts << part
    (digest ||= Digest::SHA256.new) << part unless part.empty?
  end

  [digest && digest.hexdigest.byteslice(0, 32), parts]
end

class SampleTest < Rack::TestCase
  test "sample" do
    Benchmark.ips do |bm|
      bm.report{ get "/sample/sample_action" }
    end
    puts @response.headers
    response_body = [body.to_s]
    # Saving for Content-Length #{@response.headers["Content-Length"]}
    puts Benchmark.measure{ rack_digest_body response_body}
  end
end
```

Truncated Result on master:
```
Calculating -------------------------------------
                         90.847  (±15.4%) i/s -    441.000  in   5.040313s
{"Content-Type"=>"text/html; charset=utf-8", "ETag"=>"W/\"f99945d14c8b44187244c176fedde2c5\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001075)


Calculating -------------------------------------
                         93.704  (± 9.6%) i/s -    464.000  in   5.018735s
{"Content-Type"=>"text/html; charset=utf-8", "ETag"=>"W/\"8a0325dc87a7edef558a4dbfca480657\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001236)

Calculating -------------------------------------
                         86.318  (±16.2%) i/s -    420.000  in   5.093038s
{"Content-Type"=>"text/html; charset=utf-8", "ETag"=>"W/\"ac7bb1bb5863179ac0f65d4d12cd57d7\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001122)


Calculating -------------------------------------
                         88.232  (±17.0%) i/s -    427.000  in   5.071416s
{"Content-Type"=>"text/html; charset=utf-8", "ETag"=>"W/\"2258a52c15e7eb1a511e4880c04712eb\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001054)

Calculating -------------------------------------
                         94.222  (±11.7%) i/s -    464.000  in   5.017895s
{"Content-Type"=>"text/html; charset=utf-8", "ETag"=>"W/\"e9a5cb99f4b3f65fed34594ffdde323d\"", "Cache-Control"=>"max-age=0, private, must-revalidate", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001086)
```

Truncated Result after patch"
```
Calculating -------------------------------------
                        104.491  (± 9.6%) i/s -    520.000  in   5.037808s
{"Content-Type"=>"text/html; charset=utf-8", "Cache-Control"=>"no-cache", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001134)

Calculating -------------------------------------
                        100.414  (±14.9%) i/s -    488.000  in   5.057260s
{"Content-Type"=>"text/html; charset=utf-8", "Cache-Control"=>"no-cache", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001154)

Calculating -------------------------------------
                        101.965  (±16.7%) i/s -    490.000  in   5.024749s
{"Content-Type"=>"text/html; charset=utf-8", "Cache-Control"=>"no-cache", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001110)

Calculating -------------------------------------
                        101.203  (±15.8%) i/s -    488.000  in   5.022862s
{"Content-Type"=>"text/html; charset=utf-8", "Cache-Control"=>"no-cache", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001131)

Calculating -------------------------------------
                        101.474  (±16.8%) i/s -    490.000  in   5.061457s
{"Content-Type"=>"text/html; charset=utf-8", "Cache-Control"=>"no-cache", "Content-Length"=>"404167"}
  0.000000   0.000000   0.000000 (  0.001204)

```

Although provided benchmark test does not mimic production enviornment but does give idea about saving. For page with Content-Length of 404167 saving ranges from 1 to 2 ms. I think the above improvement is not huge but is significant enough to make some difference.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
