### PR TITLE
Add missing dot in comment in .gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -22,7 +22,7 @@
 <% end -%>
 
 <% unless skip_active_storage? -%>
-# Ignore uploaded files in development
+# Ignore uploaded files in development.
 /storage/*
 <% if keeps? -%>
 !/storage/.keep


### PR DESCRIPTION
My submission for the tiniest commit and PR contest.
(I just noticed this missing; consistency is king :-)

### Summary

Add missing dot and end on comment line of generator template for .gitignore.