### PR TITLE
[ci skip] Fix PullRequest link on Rails 5.1 Release Notes

### DIFF
--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -399,7 +399,7 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 *   Change `datetime_field` and `datetime_field_tag` to generate `datetime-local`
     fields.
-    ([Pull Request](https://github.com/rails/rails/pull/28061))
+    ([Pull Request](https://github.com/rails/rails/pull/25469))
 
 *   New Builder-style syntax for HTML tags (`tag.div`, `tag.br`, etc.)
     ([Pull Request](https://github.com/rails/rails/pull/25543))


### PR DESCRIPTION
### Summary

The correct link for datetime_field changes is https://github.com/rails/rails/pull/25469.
But now, the link point to `encode_special_chars`. So I fixed the link.