### PR TITLE
Fix typo of duplicated `the`

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -29,7 +29,7 @@ module ActiveRecord
     # configs for all environments.
     # <tt>spec_name:</tt> The specification name (ie primary, animals, etc.). Defaults
     # to +nil+.
-    # <tt>include_replicas:</tt> Determines whether to include replicas in the
+    # <tt>include_replicas:</tt> Determines whether to include replicas in
     # the returned list. Most of the time we're only iterating over the write
     # connection (i.e. migrations don't need to run for the write and read connection).
     # Defaults to +false+.

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1105,7 +1105,7 @@ For several reasons the Simple backend shipped with Active Support only does the
 
 That does not mean you're stuck with these limitations, though. The Ruby I18n gem makes it very easy to exchange the Simple backend implementation with something else that fits better for your needs, by passing a backend instance to the `I18n.backend=` setter.
 
-For example, you can replace the Simple backend with the the Chain backend to chain multiple backends together. This is useful when you want to use standard translations with a Simple backend but store custom application translations in a database or other backends.
+For example, you can replace the Simple backend with the Chain backend to chain multiple backends together. This is useful when you want to use standard translations with a Simple backend but store custom application translations in a database or other backends.
 
 With the Chain backend, you could use the Active Record backend and fall back to the (default) Simple backend:
 


### PR DESCRIPTION
### Summary

I assume the title is enough descriptive. I found the typo while reading the guide, and then fixed it.

### Other Information

Nothing.