### PR TITLE
Add docs for ActiveRecord::ConnectionAdapters::AbstractAdapter#check_…

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -504,6 +504,9 @@ module ActiveRecord
       end
 
       private
+        # Check the version of the connected database. This method is called
+        # at the end of +initialize+; the adapter can use this to fail early if
+        # the connected database is not the correct version.
         def check_version
         end
 


### PR DESCRIPTION
### Summary

Adding docs to [ActiveRecord::ConnectionAdapters::AbstractAdapter#check_version](https://github.com/rails/rails/blob/ff008c00f6cabe78d3b90bc3b9c14346aae01cb0/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb/#L507)

### Other Information

I found this method through [Codetriage](https://www.codetriage.com/doc_methods/1916859)
