### PR TITLE
Instrument middleware processing

### DIFF
--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -3,13 +3,24 @@
 require "abstract_unit"
 
 class MiddlewareStackTest < ActiveSupport::TestCase
-  class FooMiddleware; end
-  class BarMiddleware; end
-  class BazMiddleware; end
-  class HiyaMiddleware; end
-  class BlockMiddleware
+  class Base
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    end
+  end
+
+  class FooMiddleware < Base; end
+  class BarMiddleware < Base; end
+  class BazMiddleware < Base; end
+  class HiyaMiddleware < Base; end
+  class BlockMiddleware < Base
     attr_reader :block
-    def initialize(&block)
+    def initialize(app, &block)
+      super(app)
       @block = block
     end
   end
@@ -107,6 +118,24 @@ class MiddlewareStackTest < ActiveSupport::TestCase
 
   test "can check if Middleware are equal - Middleware" do
     assert_equal @stack.last, @stack.last
+  end
+
+  test "instruments the execution of middlewares" do
+    app = @stack.build(proc { |env| [200, {}, []] })
+    env = {}
+
+    events = []
+
+    subscriber = proc do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "process_middleware.action_dispatch") do
+      app.call(env)
+    end
+
+    assert_equal 2, events.count
+    assert_equal ["MiddlewareStackTest::BarMiddleware", "MiddlewareStackTest::FooMiddleware"], events.map { |e| e.payload[:middleware] }
   end
 
   test "includes a middleware" do


### PR DESCRIPTION
Adds ActiveSupport::Notifications instrumentation of the processing of each middleware in the stack.

@jeremy here's the first PR!