### PR TITLE
Support default expression and expression indexes for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support default expression for MySQL.
+
+    MySQL 8.0.13 and higher supports default value to be a function or expression.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-table.html
+
+    *Ryuta Kamizono*
+
 *   Support expression indexes for MySQL.
 
     MySQL 8.0.13 and higher supports functional key parts that index

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support expression indexes for MySQL.
+
+    MySQL 8.0.13 and higher supports functional key parts that index
+    expression values rather than column or column prefix values.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+
+    *Ryuta Kamizono*
+
 *   Fix collection cache key with limit and custom select to avoid ambiguous timestamp column error.
 
     Fixes #33056.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -72,6 +72,10 @@ module ActiveRecord
         !mariadb? && version >= "8.0.1"
       end
 
+      def supports_expression_index?
+        !mariadb? && version >= "8.0.13"
+      end
+
       def supports_transaction_isolation?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -106,10 +106,13 @@ module ActiveRecord
 
           def new_column_from_field(table_name, field)
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
-            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(field[:Default])
-              default, default_function = nil, field[:Default]
-            else
-              default, default_function = field[:Default], nil
+            default, default_function = field[:Default], nil
+
+            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(default)
+              default, default_function = nil, default
+            elsif type_metadata.extra == "DEFAULT_GENERATED"
+              default = +"(#{default})" unless default.start_with?("(")
+              default, default_function = nil, default
             end
 
             MySQL::Column.new(

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -35,13 +35,39 @@ module ActiveRecord
                 ]
               end
 
-              indexes.last[-2] << row[:Column_name]
-              indexes.last[-1][:lengths][row[:Column_name]] = row[:Sub_part].to_i if row[:Sub_part]
-              indexes.last[-1][:orders].merge!(row[:Column_name] => :desc) if row[:Collation] == "D"
+              if row[:Expression]
+                expression = row[:Expression]
+                expression = +"(#{expression})" unless expression.start_with?("(")
+                indexes.last[-2] << expression
+                indexes.last[-1][:expressions] ||= {}
+                indexes.last[-1][:expressions][expression] = expression
+                indexes.last[-1][:orders][expression] = :desc if row[:Collation] == "D"
+              else
+                indexes.last[-2] << row[:Column_name]
+                indexes.last[-1][:lengths][row[:Column_name]] = row[:Sub_part].to_i if row[:Sub_part]
+                indexes.last[-1][:orders][row[:Column_name]] = :desc if row[:Collation] == "D"
+              end
             end
           end
 
-          indexes.map { |index| IndexDefinition.new(*index) }
+          indexes.map do |index|
+            options = index.last
+
+            if expressions = options.delete(:expressions)
+              orders = options.delete(:orders)
+              lengths = options.delete(:lengths)
+
+              columns = index[-2].map { |name|
+                [ name.to_sym, expressions[name] || +quote_column_name(name) ]
+              }.to_h
+
+              index[-2] = add_options_for_index_columns(
+                columns, order: orders, length: lengths
+              ).values.join(", ")
+            end
+
+            IndexDefinition.new(*index)
+          end
         end
 
         def remove_column(table_name, column_name, type = nil, options = {})

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -106,6 +106,13 @@ if current_adapter?(:Mysql2Adapter)
   class MysqlDefaultExpressionTest < ActiveRecord::TestCase
     include SchemaDumpingHelper
 
+    if supports_default_expression?
+      test "schema dump includes default expression" do
+        output = dump_table_schema("defaults")
+        assert_match %r/t\.binary\s+"uuid",\s+limit: 36,\s+default: -> { "\(uuid\(\)\)" }/i, output
+      end
+    end
+
     if subsecond_precision_supported?
       test "schema dump datetime includes default expression" do
         output = dump_table_schema("datetime_defaults")

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -48,6 +48,15 @@ def mysql_enforcing_gtid_consistency?
   current_adapter?(:Mysql2Adapter) && "ON" == ActiveRecord::Base.connection.show_variable("enforce_gtid_consistency")
 end
 
+def supports_default_expression?
+  if current_adapter?(:PostgreSQLAdapter)
+    true
+  elsif current_adapter?(:Mysql2Adapter)
+    conn = ActiveRecord::Base.connection
+    !conn.mariadb? && conn.version >= "8.0.13"
+  end
+end
+
 def supports_savepoints?
   ActiveRecord::Base.connection.supports_savepoints?
 end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -19,6 +19,9 @@ ActiveRecord::Schema.define do
     t.datetime :fixed_time, default: "2004-01-01 00:00:00"
     t.column :char1, "char(1)", default: "Y"
     t.string :char2, limit: 50, default: "a varchar field"
+    if supports_default_expression?
+      t.binary :uuid, limit: 36, default: -> { "(uuid())" }
+    end
   end
 
   create_table :binary_fields, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -216,7 +216,7 @@ ActiveRecord::Schema.define do
     t.index [:firm_id, :type, :rating], name: "company_index", length: { type: 10 }, order: { rating: :desc }
     t.index [:firm_id, :type], name: "company_partial_index", where: "(rating > 10)"
     t.index :name, name: "company_name_index", using: :btree
-    t.index "(CASE WHEN rating > 0 THEN lower(name) END)", name: "company_expression_index" if supports_expression_index?
+    t.index "(CASE WHEN rating > 0 THEN lower(name) END) DESC", name: "company_expression_index" if supports_expression_index?
   end
 
   create_table :content, force: true do |t|


### PR DESCRIPTION
MySQL 8.0.13 is released a few days ago.

https://mysqlserverteam.com/the-mysql-8-0-13-maintenance-release-is-generally-available/

Now we can supports default expression and expression indexes for mysql2 adapter.