### PR TITLE
Do not wait for a share lock if not required

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Concurrency::ShareLock#yield_shares` no longer waits to
+    reacquire a share lock if it never had one.
+
+    *Tessa Bradbury*
+
 *   Fix bug where `#to_options` for `ActiveSupport::HashWithIndifferentAccess`
     would not act as alias for `#symbolize_keys`.
 


### PR DESCRIPTION
### Summary

After a thread returns from a block passed to `yield_shares` it needs to reacquire any share locks it previously had. But if it did not have any share locks before, it should not wait.

I noticed this while trying to debug a deadlock (#34310). It turns out, in that instance, that this was not the underlying issue. But by the time I realised that, I'd already written the code and the test so I figured I'd offer it up anyway.
