### PR TITLE
Document `deep_interpolation` parameter for bulk lookups

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -664,6 +664,26 @@ I18n.t 'activerecord.errors.messages'
 # => {:inclusion=>"is not included in the list", :exclusion=> ... }
 ```
 
+If you want to perform interpolation on a bulk hash of translations, you need to pass `deep_interpolation: true` as a parameter. When you have the following dictionary:
+
+```yaml
+en:
+  welcome:
+    title: "Welcome!"
+    content: "Welcome to the %{app_name}"
+```
+
+then the nested interpolation will be ignored without the setting:
+
+```ruby
+I18n.t 'welcome', app_name: 'book store'
+# => {:title=>"Welcome!", :content=>"Welcome to the %{app_name}"}
+
+I18n.t 'welcome', deep_interpolation: true, app_name: 'book store'
+# => {:title=>"Welcome!", :content=>"Welcome to the book store"}
+```
+
+
 #### "Lazy" Lookup
 
 Rails implements a convenient way to look up the locale inside _views_. When you have the following dictionary:


### PR DESCRIPTION
Bulk lookups are sort of an edge case, I have not heard of them until a colleague of mine decided to dynamically iterate over a growing set of translations and receiving them in bulk as a hash with `I18n.t 'welcome'` as in the added example of the guide.

When passing an interpolation to these bulk lookups, they will only be performed when also passing `deep_interpolation: true`.

**Without passing `deep_interpolation` flag:**

```ruby
I18n.t 'welcome', app_name: 'book store'
# => {:title=>"Welcome!", :content=>"Welcome to the %{app_name}"}
```

**With passing `deep_interpolation`:**

```ruby
I18n.t 'welcome', deep_interpolation: true, app_name: 'book store'
# => {:title=>"Welcome!", :content=>"Welcome to the book store"}
```

I found this digging in the I18n lookup backend, the flag is listed on [I18n's Rubydoc](https://www.rubydoc.info/github/svenfuchs/i18n/master/I18n) but not otherwise listed. Since bulk lookups are mentioned here, I suggest to add a note with this flag along with it.

[ci skip]