### PR TITLE
Add maxlength attribute usage example to Text Field Api documentation

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1130,6 +1130,9 @@ module ActionView
       #   text_field(:post, :title, class: "create_input")
       #   # => <input type="text" id="post_title" name="post[title]" value="#{@post.title}" class="create_input" />
       #
+      #   text_field(:post, :title,  maxlength: 30, class: "title_input")
+      #   # => <input type="text" id="post_title" name="post[title]" maxlength="30" size="30" value="#{@post.title}" class="title_input" />
+      #
       #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }")
       #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }"/>
       #


### PR DESCRIPTION
This PR references #34291, The usage of maxlength in the text_field helper adds a size attribute to the generated text_field input with the same length as the maxlength. This implicit addition of size attribute by the framework gives a false impression that it may be bug. By adding the implementation of the maxlength to the api docs, we explicitly tell the reader referring the api doc that addition of size along with maxlength is the expected behaviour.  [ci skip]


