### PR TITLE
ActionController::API *does* support cookies, sessions

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -12,7 +12,7 @@ module ActionController
   #
   # An API Controller is different from a normal controller in the sense that
   # by default it doesn't include a number of features that are usually required
-  # by browser access only: layouts and templates rendering, cookies, sessions,
+  # by browser access only: layouts and templates rendering,
   # flash, assets, and so on. This makes the entire controller stack thinner,
   # suitable for API applications. It doesn't mean you won't have such
   # features if you need them: they're all available for you to include in


### PR DESCRIPTION
### Summary

Correct documentation. ActionController::API *does* support cookies, sessions

### Details

ActionController::Metal provides session support by delegating `session`  to the request (`"@_request"`)
https://github.com/rails/rails/blob/a3dcba42e2422eb9c2e77011a39ce72dc934b420/actionpack/lib/action_controller/metal.rb#L149

Though the ActionController::Cookies modules isn't included, it's really a convenience for providing a first class `cookies` object.
https://github.com/rails/rails/blob/a3dcba42e2422eb9c2e77011a39ce72dc934b420/actionpack/lib/action_controller/metal/cookies.rb#L13

*all* ActionController::Metal subclasses support setting cookies via the `session` object.
https://github.com/rails/rails/blob/a3dcba42e2422eb9c2e77011a39ce72dc934b420/actionpack/lib/action_dispatch/http/request.rb#L349
https://github.com/rails/rails/blob/a3dcba42e2422eb9c2e77011a39ce72dc934b420/actionpack/lib/action_dispatch/request/session.rb#L31
