### PR TITLE
Partly revert #31819

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1618,32 +1618,6 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
-  # Associations::Preloader#preloaders_on works with hash-like objects
-  test "preloading works with an object that responds to :to_hash" do
-    CustomHash = Class.new(Hash)
-
-    assert_nothing_raised do
-      Post.preload(CustomHash.new(comments: [{ author: :essays }])).first
-    end
-  end
-
-  # Associations::Preloader#preloaders_on works with string-like objects
-  test "preloading works with an object that responds to :to_str" do
-    CustomString = Class.new(String)
-
-    assert_nothing_raised do
-      Post.preload(CustomString.new("comments")).first
-    end
-  end
-
-  # Associations::Preloader#preloaders_on does not work with ranges
-  test "preloading fails when Range is passed" do
-    exception = assert_raises(ArgumentError) do
-      Post.preload(1..10).first
-    end
-    assert_equal("1..10 was not recognized for preload", exception.message)
-  end
-
   private
     def find_all_ordered(klass, include = nil)
       klass.order("#{klass.table_name}.#{klass.primary_key}").includes(include).to_a


### PR DESCRIPTION
The PR #31819 changed `#preloaders_on` and added some test,
then #33938 reverted changes that were added to the method in #31819.
Since changes in the method were reverted and as mentioned in the
comment https://github.com/rails/rails/pull/31819#discussion_r221847481
that titles of the tests added in #31819 don't reflect implementation I
think we can remove those tests for now.
