### PR TITLE
Added MySQL sort aborted error handling.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -626,6 +626,7 @@ module ActiveRecord
         end
 
         # See https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+        ER_SORT_ABORTED         = 1028
         ER_DUP_ENTRY            = 1062
         ER_NOT_NULL_VIOLATION   = 1048
         ER_NO_REFERENCED_ROW    = 1216
@@ -644,6 +645,8 @@ module ActiveRecord
 
         def translate_exception(exception, message)
           case error_number(exception)
+          when ER_SORT_ABORTED
+            SortAborted.new(message)
           when ER_DUP_ENTRY
             RecordNotUnique.new(message)
           when ER_NO_REFERENCED_ROW, ER_ROW_IS_REFERENCED, ER_ROW_IS_REFERENCED_2, ER_NO_REFERENCED_ROW_2

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -340,6 +340,10 @@ module ActiveRecord
   class LockWaitTimeout < StatementInvalid
   end
 
+  # SortAborted will be raised when sort statement has been aborted.
+  class SortAborted < StatementInvalid
+  end
+
   # StatementTimeout will be raised when statement timeout exceeded.
   class StatementTimeout < StatementInvalid
   end


### PR DESCRIPTION
### Summary

Allows application developers to catch errors related to the following
kinds of situations:
  - Insufficient memory for `sort_buffer_size` to be allocated.
  - A `KILL` happened in the middle of a filesort.
  - Server shutdown while sorting queries.
  - Processing of a subquery failed while sorting.

More info can be found here:

https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_filsort_abort

### Other Information

I wasn't able to find any associated sort-related errors for PostgreSQL or SQLite. Here are the references in case it helps:

- [PostgreSQL Error Code](https://www.postgresql.org/docs/10/static/errcodes-appendix.html).
- [SQLite](https://www.sqlite.org/rescode.html)

I think this change is safe to isolate to MySQL only.

### Tests

I think it'd be worthwhile to add a [transaction test](https://github.com/rails/rails/blob/master/activerecord/test/cases/adapters/mysql2/transaction_test.rb) for this work but ran into errors trying to get my environment set up using Vagrant/Virtual box and the *hard* way without VM support. Kept hitting these errors:

```
==> default: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "f666b204-cb87-4e94-8e1c-099aa4f6d813", "--type", "headless"]

Stderr: VBoxManage: error: The virtual machine 'rails-dev-box_default_1540571688024_40245' has terminated unexpectedly during startup with exit code 1 (0x1)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component MachineWrap, interface IMachine
```

Any advice or recommendations for providing additional testing is welcome.

### Notes

CC: @eileencodes, @tenderlove 
