### PR TITLE
Ignore empty condition on #construct_relation_for_exists

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -363,7 +363,7 @@ module ActiveRecord
 
         case conditions
         when Array, Hash
-          relation.where!(conditions)
+          relation.where!(conditions) unless conditions.empty?
         else
           relation.where!(primary_key => conditions) unless conditions == :none
         end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -246,6 +246,10 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.first.replies.exists?
   end
 
+  def test_exists_with_empty_hash_arg
+    assert_equal true, Topic.exists?({})
+  end
+
   # Ensure +exists?+ runs without an error by excluding distinct value.
   # See https://github.com/rails/rails/pull/26981.
   def test_exists_with_order_and_distinct


### PR DESCRIPTION
## Summary

At https://github.com/rails/rails/commit/fc0e3354af7e7878bdd905a95ce4c1491113af9a,

```rb
relation = relation.where(conditions)
```

was rewritten to:

```rb
relation.where!(condition)
```

This change accidentally changed the result of `Topic.exists?({})` from true to false.

To fix this regression, I moved the blank check logic (`opts.blank?`) from `#where` to `#where!`.

I think `#where!` should be identical to `#where`, except that instead of returning a new relation, it adds the condition to the existing relation.

## Details

### Steps to reproduce

```ruby
begin
  require "bundler/inline"
rescue LoadError
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise
end

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :topics, force: true
end

ActiveRecord::Base.logger = Logger.new(STDOUT)

class Topic < ActiveRecord::Base
end

class ExistsTest < Minitest::Test
  def setup
    Topic.create!
  end

  def test_exists_with_empty_hash_argument
    assert_equal true, Topic.exists?({})
  end
end
```

### Expected behavior

```
-- create_table(:topics, {:force=>true})
   -> 0.0024s
Run options: --seed 39899

# Running:

D, [2018-10-27T14:57:50.240167 #60154] DEBUG -- :    (0.0ms)  begin transaction
D, [2018-10-27T14:57:50.240357 #60154] DEBUG -- :   Topic Create (0.1ms)  INSERT INTO "topics" DEFAULT VALUES
D, [2018-10-27T14:57:50.240578 #60154] DEBUG -- :    (0.0ms)  commit transaction
D, [2018-10-27T14:57:50.241155 #60154] DEBUG -- :   Topic Exists (0.1ms)  SELECT 1 AS one FROM "topics" LIMIT ?  [["LIMIT", 1]]
.

Finished in 0.003765s, 265.6042 runs/s, 265.6042 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

### Actual behavior

```
-- create_table(:topics, {:force=>true})
   -> 0.0024s
Run options: --seed 53123

# Running:

D, [2018-10-27T14:58:16.323575 #60237] DEBUG -- :    (0.0ms)  begin transaction
D, [2018-10-27T14:58:16.323774 #60237] DEBUG -- :   Topic Create (0.1ms)  INSERT INTO "topics" DEFAULT VALUES
D, [2018-10-27T14:58:16.323973 #60237] DEBUG -- :    (0.0ms)  commit transaction
D, [2018-10-27T14:58:16.324506 #60237] DEBUG -- :   Topic Exists (0.1ms)  SELECT 1 AS one FROM "topics" WHERE (1=0) LIMIT ?  [["LIMIT", 1]]
F

Failure:
ExistsTest#test_exists_with_empty_hash_argument [/Users/r7kamura/Desktop/test.rb:37]:
Expected: true
  Actual: false


rails test Users/r7kamura/Desktop/test.rb:36



Finished in 0.003548s, 281.8489 runs/s, 281.8489 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```
