### PR TITLE
Change Ruby version to 2.3.0 which move at Rails 5.0 [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -36,7 +36,7 @@ You can find a list of all released Rails versions [here](https://rubygems.org/g
 Rails generally stays close to the latest released Ruby version when it's released:
 
 * Rails 6 requires Ruby 2.4.1 or newer.
-* Rails 5 requires Ruby 2.2.2 or newer.
+* Rails 5 requires Ruby 2.3.0 or newer.
 * Rails 4 prefers Ruby 2.0 and requires 1.9.3 or newer.
 * Rails 3.2.x is the last branch to support Ruby 1.8.7.
 * Rails 3 and above require Ruby 1.8.7 or higher. Support for all of the previous Ruby versions has been dropped officially. You should upgrade as early as possible.


### PR DESCRIPTION
### Summary
https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions
Ruby 2.2.2 Rails 5.0 written as working in the guide did not work. After changing to supported Ruby 2.3, I want to change the document because it worked.Ruby 2.2 was EOL.

### Other informations
#### Enviroment
MacOS(10.12.6)
Ruby 2.2.4p230

#### Error reproduction procedure

Execute the following command according to Readme
```
$ rails new myapp
An error occurred while installing ruby_dep (1.5.0), and Bundler cannot continue.
Make sure that `gem install ruby_dep -v '1.5.0'` succeeds before bundling.
         run  bundle exec spring binstub --all
Could not find gem 'coffee-rails (~> 4.2)' in any of the gem sources listed in your Gemfile or available on this machine.
```
An error occurred
Executed according to the error

```
$ gem install ruby_dep -v '1.5.0'
ERROR:  Error installing ruby_dep:
	ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
tomonomasanobu-no-MacBook-Air:rails$ ruby -v
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin14]
```
An error appeared unless ruby version matched.
It solved by installing ruby 2.3.0.