### PR TITLE
Privatize and add # :nodoc: to constants

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -182,8 +182,9 @@ module ActiveSupport
       "Samoa"                        => "Pacific/Apia"
     }
 
-    UTC_OFFSET_WITH_COLON = "%s%02d:%02d"
-    UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "")
+    UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:
+    UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "") # :nodoc:
+    private_constant :UTC_OFFSET_WITH_COLON, :UTC_OFFSET_WITHOUT_COLON
 
     @lazy_zones_map = Concurrent::Map.new
     @country_zones  = Concurrent::Map.new


### PR DESCRIPTION
### Summary

Both `UTC_OFFSET_WITH_COLON` and `UTC_OFFSET_WITHOUT_COLON` are only used within `ActiveSupport::TimeZone` and in my opinion they do not provide relevant information that should appear in the docs. Therefore this patch makes them private and adds `# :nodoc:` for them.

Thanks!