### PR TITLE
Update bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -41,9 +36,6 @@ class TestController < ActionController::Base
 end
 
 require "minitest/autorun"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 class BugTest < Minitest::Test
   include Rack::Test::Methods

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -18,9 +13,6 @@ end
 
 require "minitest/autorun"
 require "active_job"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 class BuggyJob < ActiveJob::Base
   def perform

--- a/guides/bug_report_templates/active_job_master.rb
+++ b/guides/bug_report_templates/active_job_master.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -17,9 +12,6 @@ end
 
 require "active_job"
 require "minitest/autorun"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 class BuggyJob < ActiveJob::Base
   def perform

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -20,9 +15,6 @@ end
 require "active_record"
 require "minitest/autorun"
 require "logger"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -20,9 +15,6 @@ end
 require "active_record"
 require "minitest/autorun"
 require "logger"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -19,9 +14,6 @@ end
 require "active_record"
 require "minitest/autorun"
 require "logger"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 # This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"
@@ -19,9 +14,6 @@ end
 require "active_support"
 require "active_support/core_ext/object/blank"
 require "minitest/autorun"
-
-# Ensure backward compatibility with minitest 4.
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 class BugTest < Minitest::Test
   def test_stuff

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "bundler/inline"
-rescue LoadError => e
-  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
-  raise e
-end
+require "bundler/inline"
 
 gemfile(true) do
   source "https://rubygems.org"


### PR DESCRIPTION
Hello,

This pull request updates a bit the bug report templates, removing unneeded stuff.

Given that Bundler 1.10 was released [back in 2015](https://rubygems.org/gems/bundler/versions/1.10.0), we can assume that people are at least on this version or a higher one so there is no need to ask people to upgrade.

Also, given that Rails 5.0 supports Ruby 2.2+ and given that this version come with [Minitest 5.4.3](https://stdgems.org/2.2.10/#bundled-gems) bundled, we don't need to ensure backward compatibility with Minitest 4.

Have a nice day !