### PR TITLE
Fix ActionMailer assertion not working for mail defining delivery_job:

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix ActionMailer assertions not working when a Mail defines
+    a custom delivery job class
+
+    *Edouard Chin*
+
 *   Mails with multipart `format` blocks with implicit render now also check for
     a template name in options hash instead of only using the action name.
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow all assertion helpers that have a `only` and `except` keyword to accept
+    Procs.
+
+    *Edouard Chin*
+
 *   Restore HashWithIndifferentAccess support to ActiveJob::Arguments.deserialize.
 
     *Gannon McGibbon*

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -65,10 +65,16 @@ module ActiveJob
 
         def filtered_job_class?(job)
           if filter
-            !Array(filter).include?(job.class)
+            !filter_as_proc(filter).call(job)
           elsif reject
-            Array(reject).include?(job.class)
+            filter_as_proc(reject).call(job)
           end
+        end
+
+        def filter_as_proc(filter)
+          return filter if filter.is_a?(Proc)
+
+          ->(job) { Array(filter).include?(job.class) }
         end
     end
   end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -114,9 +114,29 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_jobs_with_only_option_as_proc
+    assert_nothing_raised do
+      assert_enqueued_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" }) do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+        LoggingJob.perform_later
+      end
+    end
+  end
+
   def test_assert_enqueued_jobs_with_except_option
     assert_nothing_raised do
       assert_enqueued_jobs 1, except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_enqueued_jobs_with_except_option_as_proc
+    assert_nothing_raised do
+      assert_enqueued_jobs(1, except: ->(job) { job.fetch(:job).name == "LoggingJob" }) do
         HelloJob.perform_later("jeremy")
         LoggingJob.perform_later
         LoggingJob.perform_later
@@ -911,6 +931,15 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_performed_jobs_with_only_option_as_proc
+    assert_nothing_raised do
+      assert_performed_jobs(1, only: ->(job) { job.is_a?(HelloJob) }) do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("bogdan")
+      end
+    end
+  end
+
   def test_assert_performed_jobs_without_block_with_only_option
     HelloJob.perform_later("jeremy")
     LoggingJob.perform_later("bogdan")
@@ -918,6 +947,15 @@ class PerformedJobsTest < ActiveJob::TestCase
     perform_enqueued_jobs
 
     assert_performed_jobs 1, only: HelloJob
+  end
+
+  def test_assert_performed_jobs_without_block_with_only_option_as_proc
+    HelloJob.perform_later("jeremy")
+    LoggingJob.perform_later("bogdan")
+
+    perform_enqueued_jobs
+
+    assert_performed_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" })
   end
 
   def test_assert_performed_jobs_without_block_with_only_option_failure
@@ -942,6 +980,15 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_performed_jobs_with_except_option_as_proc
+    assert_nothing_raised do
+      assert_performed_jobs(1, except: ->(job) { job.is_a?(HelloJob) }) do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("bogdan")
+      end
+    end
+  end
+
   def test_assert_performed_jobs_without_block_with_except_option
     HelloJob.perform_later("jeremy")
     LoggingJob.perform_later("bogdan")
@@ -949,6 +996,15 @@ class PerformedJobsTest < ActiveJob::TestCase
     perform_enqueued_jobs
 
     assert_performed_jobs 1, except: HelloJob
+  end
+
+  def test_assert_performed_jobs_without_block_with_except_option_as_proc
+    HelloJob.perform_later("jeremy")
+    LoggingJob.perform_later("bogdan")
+
+    perform_enqueued_jobs
+
+    assert_performed_jobs(1, except: ->(job) { job.fetch(:job).name == "HelloJob" })
   end
 
   def test_assert_performed_jobs_without_block_with_except_option_failure


### PR DESCRIPTION
Fix ActionMailer assertion not working for mail defining delivery_job:

- If a Mail defines a custom delivery_job, all ActionMailer assertion
      helper (assert_emails, assert_enqueued_emails ...) wouldn't work.

 ```ruby
MyMailer < ApplicationMailer
  self.delivery_job = MyJob
end

# This assertion will fail
assert_emails(1) do
  MyMailer.my_mail.deliver_later
end
```

This PR leverage the new ActiveJob feature that accepts Procs for the
      `only` keyword and check if the delivery job is one of ActionMailer
       registered ones.