### PR TITLE
Allow rescue from parse errors

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow rescue from parameter parse errors:
+
+    ```
+    rescue_from ActionDispatch::Http::Parameters::ParseError do
+      head :unauthorized
+    end
+    ```
+
+    *Gannon McGibbon*, *Josh Cheek*
+
 *   Reset Capybara sessions if failed system test screenshot raising an exception.
 
     Reset Capybara sessions if `take_failed_screenshot` raise exception

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -253,7 +253,10 @@ module ActionController
         # This will display the wrapped hash in the log file.
         request.filtered_parameters.merge! wrapped_filtered_hash
       end
-      super
+    ensure
+      # NOTE: Rescues all exceptions so they
+      # may be caught in ActionController::Rescue.
+      return super
     end
 
     private

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -41,6 +41,8 @@ module ActionDispatch
       # Returns a hash of parameters with all sensitive data replaced.
       def filtered_parameters
         @filtered_parameters ||= parameter_filter.filter(parameters)
+      rescue ActionDispatch::Http::Parameters::ParseError
+        @filtered_parameters = {}
       end
 
       # Returns a hash of request.env with all sensitive data replaced.

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -7,6 +7,11 @@ module ActionDispatch
     module MimeNegotiation
       extend ActiveSupport::Concern
 
+      RESCUABLE_MIME_FORMAT_ERRORS = [
+        ActionController::BadRequest,
+        ActionDispatch::Http::Parameters::ParseError,
+      ]
+
       included do
         mattr_accessor :ignore_accept_header, default: false
       end
@@ -59,7 +64,7 @@ module ActionDispatch
         fetch_header("action_dispatch.request.formats") do |k|
           params_readable = begin
                               parameters[:format]
-                            rescue ActionController::BadRequest
+                            rescue *RESCUABLE_MIME_FORMAT_ERRORS
                               false
                             end
 

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -111,10 +111,20 @@ module ActionDispatch
           begin
             strategy.call(raw_post)
           rescue # JSON or Ruby code block errors.
-            my_logger = logger || ActiveSupport::Logger.new($stderr)
-            my_logger.debug "Error occurred while parsing request parameters.\nContents:\n\n#{raw_post}"
-
+            log_parse_error_once
             raise ParseError
+          end
+        end
+
+        def log_parse_error_once
+          @parse_error_logged ||= begin
+            parse_logger = logger || ActiveSupport::Logger.new($stderr)
+            parse_logger.debug <<~MSG.chomp
+              Error occurred while parsing request parameters.
+              Contents:
+
+              #{raw_post}
+            MSG
           end
         end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -383,9 +383,6 @@ module ActionDispatch
         end
         self.request_parameters = Request::Utils.normalize_encode_params(pr)
       end
-    rescue Http::Parameters::ParseError # one of the parse strategies blew up
-      self.request_parameters = Request::Utils.normalize_encode_params(super || {})
-      raise
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
       raise ActionController::BadRequest.new("Invalid request parameters: #{e.message}")
     end

--- a/actionpack/test/controller/params_parse_test.rb
+++ b/actionpack/test/controller/params_parse_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class ParamsParseTest < ActionController::TestCase
+  class UsersController < ActionController::Base
+    def create
+      head :ok
+    end
+  end
+
+  tests UsersController
+
+  def test_parse_error_logged_once
+    log_output = capture_log_output do
+      post :create, body: "{", as: :json
+    end
+    assert_equal <<~LOG, log_output
+      Error occurred while parsing request parameters.
+      Contents:
+
+      {
+    LOG
+  end
+
+  private
+
+    def capture_log_output
+      output = StringIO.new
+      request.set_header "action_dispatch.logger", ActiveSupport::Logger.new(output)
+      yield
+      output.string
+    end
+end


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/34287, allows parameter parse errors to be caught by `rescue_from` blocks.

Closes https://github.com/rails/rails/pull/34287.

r? @rafaelfranca 
