### PR TITLE
Allow hashes with defaults to be used as STI attributes

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -257,7 +257,9 @@ module ActiveRecord
         def subclass_from_attributes(attrs)
           attrs = attrs.to_h if attrs.respond_to?(:permitted?)
           if attrs.is_a?(Hash)
-            subclass_name = attrs[inheritance_column] || attrs[inheritance_column.to_sym]
+            subclass_name = attrs.fetch(inheritance_column) do
+              attrs.fetch(inheritance_column.to_sym, nil)
+            end
 
             if subclass_name.present?
               find_sti_class(subclass_name)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -206,6 +206,17 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::SubclassNotFound) { Company.find(100) }
   end
 
+  def test_default_proc_attributes_doesnt_raise_sti_model
+    attributes = Hash.new { "DefaultStringThatIsNotAType" }
+    assert_kind_of Cabbage, Cabbage.new(attributes)
+  end
+
+  def test_default_attributes_doesnt_raise_sti_model
+    attributes = Hash.new
+    attributes.default = "DefaultStringThatIsNotAType"
+    assert_kind_of Cabbage, Cabbage.new(attributes)
+  end
+
   def test_inheritance_find
     assert_kind_of Firm, Company.find(1), "37signals should be a firm"
     assert_kind_of Firm, Firm.find(1), "37signals should be a firm"


### PR DESCRIPTION
### Summary

Allow hashes with defaults to be used as STI attributes.

Closes https://github.com/rails/rails/issues/34217.

I used `#fetch` instead of subscripting on https://github.com/rails/rails/blob/d7f48c9c39befaf23ccd63e0248a3bd5bf295ee5/activerecord/lib/active_record/inheritance.rb#L260 to make this work, but I'm unsure if this is actually a bug. If we always know the name of the inheritance column, is it safe to assume the default value of an attributes hash will never be the `inheritance_column` value we want to use?
