### PR TITLE
Handle STI use cases in ignored_columns

### DIFF
--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -5,15 +5,16 @@ require "active_model/attribute"
 module ActiveModel
   class AttributeSet # :nodoc:
     class Builder # :nodoc:
-      attr_reader :types, :default_attributes
+      attr_reader :types, :default_attributes, :ignored_columns
 
-      def initialize(types, default_attributes = {})
+      def initialize(types, default_attributes = {}, ignored_columns = [])
         @types = types
         @default_attributes = default_attributes
+        @ignored_columns = ignored_columns
       end
 
       def build_from_database(values = {}, additional_types = {})
-        attributes = LazyAttributeHash.new(types, values, additional_types, default_attributes)
+        attributes = LazyAttributeHash.new(types, values.except(*ignored_columns), additional_types, default_attributes)
         AttributeSet.new(attributes)
       end
     end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     def find_by_sql(sql, binds = [], preparable: nil, &block)
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable)
       column_types = result_set.column_types.dup
-      columns_hash.each_key { |k| column_types.delete k }
+      possible_column_names.each { |k| column_types.delete k }
       message_bus = ActiveSupport::Notifications.instrumenter
 
       payload = {

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1043,8 +1043,8 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        elsif klass.ignored_columns.any?
-          arel.project(*klass.column_names.map { |field| arel_attribute(field) })
+        elsif klass.fully_ignored_columns.any?
+          arel.project(*klass.possible_column_names.map { |field| arel_attribute(field) })
         else
           arel.project(table[Arel.star])
         end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1437,8 +1437,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "ignored columns are respected for STI models" do
-    regular_project = Project.create!(name: 'Something boring')
-    special_project = SpecialProject.create!(name: 'Exciting new stuff', special_project_details: 'Top secret')
+    regular_project = Project.create!(name: "Something boring")
+    special_project = SpecialProject.create!(name: "Exciting new stuff", special_project_details: "Top secret")
 
     assert_respond_to special_project, :special_project_details
     assert_respond_to special_project, :special_project_details=
@@ -1453,7 +1453,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_respond_to regular_project, :special_project_details
     assert_not_respond_to regular_project, :special_project_details=
 
-    assert_equal 'Top secret', special_project.special_project_details
+    assert_equal "Top secret", special_project.special_project_details
   end
 
   test "when #reload called, ignored columns' attribute methods are not defined" do

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1457,7 +1457,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "enums whose columns are ignored by a parent class can be defined in subclasses" do
-    special_project = SpecialProject.create!(special_project_status: 'top_secret')
+    special_project = SpecialProject.create!(special_project_status: "top_secret")
 
     assert_respond_to special_project, :special_project_status
     assert_respond_to special_project, :secret?

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1436,6 +1436,26 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal(%w(first_name last_name), SymbolIgnoredDeveloper.ignored_columns)
   end
 
+  test "ignored columns are respected for STI models" do
+    regular_project = Project.create!(name: 'Something boring')
+    special_project = SpecialProject.create!(name: 'Exciting new stuff', special_project_details: 'Top secret')
+
+    assert_respond_to special_project, :special_project_details
+    assert_respond_to special_project, :special_project_details=
+    assert_not_respond_to regular_project, :special_project_details
+    assert_not_respond_to regular_project, :special_project_details=
+
+    regular_project = Project.find(regular_project.id)
+    special_project = Project.find(special_project.id)
+
+    assert_respond_to special_project, :special_project_details
+    assert_respond_to special_project, :special_project_details=
+    assert_not_respond_to regular_project, :special_project_details
+    assert_not_respond_to regular_project, :special_project_details=
+
+    assert_equal 'Top secret', special_project.special_project_details
+  end
+
   test "when #reload called, ignored columns' attribute methods are not defined" do
     developer = Developer.create!(name: "Developer")
     assert_not_respond_to developer, :first_name

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1456,6 +1456,28 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "Top secret", special_project.special_project_details
   end
 
+  test "enums whose columns are ignored by a parent class can be defined in subclasses" do
+    special_project = SpecialProject.create!(special_project_status: 'top_secret')
+
+    assert_respond_to special_project, :special_project_status
+    assert_respond_to special_project, :secret?
+    assert_respond_to special_project, :top_secret?
+
+    assert_equal "top_secret", special_project.special_project_status
+    assert_equal true, special_project.top_secret?
+    assert_equal false, special_project.secret?
+
+    reloaded_project = Project.find(special_project.id)
+
+    assert_respond_to reloaded_project, :special_project_status
+    assert_respond_to reloaded_project, :secret?
+    assert_respond_to reloaded_project, :top_secret?
+
+    assert_equal "top_secret", reloaded_project.special_project_status
+    assert_equal true, reloaded_project.top_secret?
+    assert_equal false, reloaded_project.secret?
+  end
+
   test "when #reload called, ignored columns' attribute methods are not defined" do
     developer = Developer.create!(name: "Developer")
     assert_not_respond_to developer, :first_name

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Project < ActiveRecord::Base
+  self.ignored_columns = %w(special_project_details)
+
   belongs_to :mentor
   has_and_belongs_to_many :developers, -> { distinct.order "developers.name desc, developers.id desc" }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, class_name: "Developer"
@@ -39,4 +41,5 @@ class Project < ActiveRecord::Base
 end
 
 class SpecialProject < Project
+  self.ignored_columns = []
 end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Project < ActiveRecord::Base
-  self.ignored_columns = %w(special_project_details)
+  self.ignored_columns = %w(special_project_details special_project_status)
 
   belongs_to :mentor
   has_and_belongs_to_many :developers, -> { distinct.order "developers.name desc, developers.id desc" }
@@ -42,4 +42,9 @@ end
 
 class SpecialProject < Project
   self.ignored_columns = []
+
+  enum special_project_status: {
+    secret: 1,
+    top_secret: 2
+  }
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -738,6 +738,7 @@ ActiveRecord::Schema.define do
     t.references :firm, index: false
     t.integer :mentor_id
     t.string :special_project_details
+    t.integer :special_project_status
   end
 
   create_table :randomly_named_table1, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -737,6 +737,7 @@ ActiveRecord::Schema.define do
     t.string :type
     t.references :firm, index: false
     t.integer :mentor_id
+    t.string :special_project_details
   end
 
   create_table :randomly_named_table1, force: true do |t|


### PR DESCRIPTION
### Summary

When using ignored_columns on models using STI, ensure that possibly-needed columns are still loaded from the database, while omitting ignored columns from the attribute set.

Fixes #34344.