### PR TITLE
SET NAMES utf8mb4 if `supports_longer_index_key_prefix?` returns true

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -766,8 +766,8 @@ module ActiveRecord
           # NAMES does not have an equals sign, see
           # https://dev.mysql.com/doc/refman/5.7/en/set-names.html
           # (trailing comma because variable_assignments will always have content)
-          if @config[:encoding]
-            encoding = +"NAMES #{@config[:encoding]}"
+          if @config[:encoding] || supports_longer_index_key_prefix?
+            encoding = +"NAMES #{@config[:encoding] || 'utf8mb4'}"
             encoding << " COLLATE #{@config[:collation]}" if @config[:collation]
             encoding << ", "
           end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -169,6 +169,16 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  if ActiveRecord::Base.connection.supports_longer_index_key_prefix?
+    def test_mysql_use_utf8mb4_encoding_if_available
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.merge("encoding" => nil))
+        result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.character_set_client")
+        assert_equal "utf8mb4", result
+      end
+    end
+  end
+
   def test_logs_name_show_variable
     ActiveRecord::Base.connection.materialize_transactions
     @subscriber.logged.clear


### PR DESCRIPTION
### Summary

SET NAMES utf8mb4 if `supports_longer_index_key_prefix?` returns true and no `encoding:` specified

Since https://github.com/rails/rails/pull/33853 `config/database.yml` does not have `encoding:` entry by default.  If `supports_longer_index_key_prefix?` returns `true`, database character set becomes `utf8mb4` also it should set client encoding to `utf8mb4`
