### PR TITLE
Restore `encoding: utf8mb4` in database.yml

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1011,6 +1011,7 @@ If you choose to use MySQL or MariaDB instead of the shipped SQLite3 database, y
 ```yaml
 development:
   adapter: mysql2
+  encoding: utf8mb4
   database: blog_development
   pool: 5
   username: root

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -11,6 +11,7 @@
 #
 default: &default
   adapter: mysql2
+  encoding: utf8mb4
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:


### PR DESCRIPTION
### Summary

rails/rails#33853 and rails/rails#33929 removed `encoding: utf8mb4` from database.yml since at that time, MySQL 5.1 is supported with the master branch.

Since MySQL 5.1 has been dropped, we can restore `encoding: utf8mb4` in database.yml

