### PR TITLE
Restore HWIA support to AJ::Arguments.deserialize

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Restore HashWithIndifferentAccess support to ActiveJob::Arguments.deserialize.
+
+    *Gannon McGibbon*
+
 *   Include deserialized arguments in job instances returned from
     `assert_enqueued_with` and `assert_performed_with`
 

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -147,7 +147,10 @@ module ActiveJob
       end
 
       def transform_symbol_keys(hash, symbol_keys)
-        hash.transform_keys do |key|
+        # NOTE: HashWithIndifferentAccess#transform_keys always
+        # returns stringified keys with indifferent access
+        # so we call #to_h here to ensure keys are symbolized.
+        hash.to_h.transform_keys do |key|
           if symbol_keys.include?(key)
             key.to_sym
           else

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -73,6 +73,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     string_key = { "a" => 1, "_aj_symbol_keys" => [] }
     another_string_key = { "a" => 1 }
     indifferent_access = { "a" => 1, "_aj_hash_with_indifferent_access" => true }
+    indifferent_access_symbol_key = symbol_key.with_indifferent_access
 
     assert_equal(
       { a: 1 },
@@ -89,6 +90,10 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_equal(
       { "a" => 1 },
       ActiveJob::Arguments.deserialize([indifferent_access]).first
+    )
+    assert_equal(
+      { a: 1 },
+      ActiveJob::Arguments.deserialize([indifferent_access_symbol_key]).first
     )
   end
 


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/34262.

Restores `HashWithIndifferentAccess` support to `ActiveJob::Arguments.deserialize`.