### PR TITLE
Fix example for database-specific locking clause

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -14,9 +14,9 @@ module ActiveRecord
     # of your own such as 'LOCK IN SHARE MODE' or 'FOR UPDATE NOWAIT'. Example:
     #
     #   Account.transaction do
-    #     # select * from accounts where name = 'shugo' limit 1 for update
-    #     shugo = Account.where("name = 'shugo'").lock(true).first
-    #     yuko = Account.where("name = 'yuko'").lock(true).first
+    #     # select * from accounts where name = 'shugo' limit 1 for update nowait
+    #     shugo = Account.lock("FOR UPDATE NOWAIT").find_by(name: "shugo")
+    #     yuko = Account.lock("FOR UPDATE NOWAIT").find_by(name: "yuko")
     #     shugo.balance -= 100
     #     shugo.save!
     #     yuko.balance += 100


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/33894.

Makes DB specific locking clause example actually use a database-specific locking clause.

r? @rafaelfranca 
