### PR TITLE
Backport `update_columns` bug fix to 5-2-stable

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -207,6 +207,7 @@ module ActiveModel
           raise ActiveModel::MissingAttributeError, "can't write unknown attribute `#{name}`"
         end
         alias_method :with_value_from_user, :with_value_from_database
+        alias_method :with_cast_value, :with_value_from_database
       end
 
       class Uninitialized < Attribute # :nodoc:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `update_columns` now correctly raises `ActiveModel::MissingAttributeError`
+    if the attribute does not exist.
+     *Sean Griffin*
+
 *   Fix collection cache key with limit and custom select to avoid ambiguous timestamp column error.
 
     Fixes #33056.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -471,6 +471,7 @@ module ActiveRecord
         verify_readonly_attribute(key.to_s)
       end
 
+      id_in_database = self.id_in_database
       attributes.each do |k, v|
         write_attribute_without_type_cast(k, v)
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -471,14 +471,14 @@ module ActiveRecord
         verify_readonly_attribute(key.to_s)
       end
 
+      attributes.each do |k, v|
+        write_attribute_without_type_cast(k, v)
+      end
+
       affected_rows = self.class._update_record(
         attributes,
         self.class.primary_key => id_in_database
       )
-
-      attributes.each do |k, v|
-        write_attribute_without_type_cast(k, v)
-      end
 
       affected_rows == 1
     end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -323,6 +323,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "New topic", topic.title
   end
 
+  test "write_attribute raises ActiveModel::MissingAttributeError when the attribute does not exist" do
+    topic = Topic.first
+    assert_raises(ActiveModel::MissingAttributeError) { topic.update_columns(no_column_exists: "Hello!") }
+    assert_raises(ActiveModel::UnknownAttributeError) { topic.update(no_column_exists: "Hello!") }
+  end
+
   test "read_attribute" do
     topic = Topic.new
     topic.title = "Don't change the topic"


### PR DESCRIPTION
These changes are on master and I think they also also be on 5-2-stable.

```
Subject: [PATCH] `update_columns` raises if the column is unknown

Previosly, `update_columns` would just take whatever keys you gave it
and tried to run the update query. Most likely this would result in an
error from the database. However, if the column actually did exist, but
was in `ignored_columns`, this would result in the method returning
successfully when it should have raised, and an attribute that should
not exist written to `@attributes`.
```