### PR TITLE
Make ActiveSupport HashWithIndifferentAccess#to_options and alias for HashWithIndifferentAccess#symbolize_keys

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix bug where `#to_options` for `ActiveSupport::HashWithIndifferentAccess`
+    would not act as alias for `#symbolize_keys`.
+
+    *Nick Weiland*
+
 *   Improve the logic that detects non-autoloaded constants.
 
     *Jan Habermann*, *Xavier Noria*

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -289,6 +289,7 @@ module ActiveSupport
     undef :symbolize_keys!
     undef :deep_symbolize_keys!
     def symbolize_keys; to_hash.symbolize_keys! end
+    alias_method :to_options, :symbolize_keys
     def deep_symbolize_keys; to_hash.deep_symbolize_keys! end
     def to_options!; self end
 

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -57,6 +57,13 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal @symbols, @mixed.with_indifferent_access.symbolize_keys
   end
 
+  def test_to_options_for_hash_with_indifferent_access
+    assert_instance_of Hash, @symbols.with_indifferent_access.to_options
+    assert_equal @symbols, @symbols.with_indifferent_access.to_options
+    assert_equal @symbols, @strings.with_indifferent_access.to_options
+    assert_equal @symbols, @mixed.with_indifferent_access.to_options
+  end
+
   def test_deep_symbolize_keys_for_hash_with_indifferent_access
     assert_instance_of Hash, @nested_symbols.with_indifferent_access.deep_symbolize_keys
     assert_equal @nested_symbols, @nested_symbols.with_indifferent_access.deep_symbolize_keys


### PR DESCRIPTION
Fixes #34359

### Summary

Prior to 5.2.0 (de9e323, 2cad8d7), `HashWithIndifferentAccess#to_options` acted as
an alias to `HashWithIndifferentAccess#symbolize_keys`. Now, `#to_options`
returns an instance of `HashWithIndifferentAccess` while `#symbolize_keys`
returns and instance of `Hash`.

This pr makes it so `HashWithIndifferentAccess#to_options` acts as an
alias for `HashWithIndifferentAccess#symbolize_keys` once again.

### Other Information

See #34359 

Thanks!
