### PR TITLE
Updating sample code on ActiveRecord#before_destroy callback [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -95,7 +95,7 @@ module ActiveRecord
   #
   #     private
   #       def delete_parents
-  #         self.class.delete_all "parent_id = #{id}"
+  #         self.class.where(parent_id: id).delete_all
   #       end
   #   end
   #


### PR DESCRIPTION
### Summary

It was executing a delete_all method with wrong parameter

