### PR TITLE
Including button tag of type "submit" in activestorage ujs.js

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -867,7 +867,7 @@
   }
   function didClick(event) {
     var target = event.target;
-    if (target.tagName == "INPUT" && target.type == "submit" && target.form) {
+    if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
       submitButtonsByForm.set(target.form, target);
     }
   }

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -902,7 +902,7 @@
     }
   }
   function submitForm(form) {
-    var button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit]");
+    var button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit], button[type=submit]");
     if (button) {
       var _button = button, disabled = _button.disabled;
       button.disabled = false;

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -16,7 +16,7 @@ export function start() {
 
 function didClick(event) {
   const { target } = event
-  if (target.tagName == "INPUT" && target.type == "submit" && target.form) {
+  if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
     submitButtonsByForm.set(target.form, target)
   }
 }

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -58,7 +58,7 @@ function handleFormSubmissionEvent(event) {
 }
 
 function submitForm(form) {
-  let button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit]")
+  let button = submitButtonsByForm.get(form) || findElement(form, "input[type=submit], button[type=submit]")
 
   if (button) {
     const { disabled } = button


### PR DESCRIPTION
There are cases where button tags are used instead of input tags for submit buttons (for example html markup in the button's value). The check at line 19 was restricting this to "INPUT" only. I added the condition to include tagName "BUTTON".

Maybe it would also work without restricting the tagName at all. The defining rule is the type attribute and not the tag name after all, isn't it?