### PR TITLE
`ActionMailer::Base::parameterized_delivery_job`: Add docs and fix test case

### DIFF
--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -84,6 +84,14 @@ module ActionMailer
   #   end
   #
   #   InvitationsMailer.with(inviter: person_a, invitee: person_b).account_invitation.deliver_later
+  #
+  # By default, the parameterized email will be enqueued using <tt>ActionMailer::Parameterized::DeliveryJob</tt>. Each
+  # <tt>ActionMailer::Base</tt> class can specify the job to use by setting the class variable
+  # +parameterized_delivery_job+.
+  #
+  #   class InvitationsMailer < ApplicationMailer
+  #     self.parameterized_delivery_job = ParameterizedInvitationDeliveryJob
+  #   end
   module Parameterized
     extend ActiveSupport::Concern
 

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -55,14 +55,16 @@ class ParameterizedTest < ActiveSupport::TestCase
   end
 
   test "should enqueue a parameterized request with the correct delivery job" do
-    old_delivery_job = ParamsMailer.parameterized_delivery_job
-    ParamsMailer.parameterized_delivery_job = ParameterizedDummyJob
+    begin
+      old_delivery_job = ParamsMailer.parameterized_delivery_job
+      ParamsMailer.parameterized_delivery_job = ParameterizedDummyJob
 
-    assert_performed_with(job: ParameterizedDummyJob, args: ["ParamsMailer", "invitation", "deliver_now", { inviter: "david@basecamp.com", invitee: "jason@basecamp.com" } ]) do
-      @mail.deliver_later
+      assert_performed_with(job: ParameterizedDummyJob, args: ["ParamsMailer", "invitation", "deliver_now", { inviter: "david@basecamp.com", invitee: "jason@basecamp.com" } ]) do
+        @mail.deliver_later
+      end
+    ensure
+      ParamsMailer.parameterized_delivery_job = old_delivery_job
     end
-
-    ParamsMailer.parameterized_delivery_job = old_delivery_job
   end
 
   class ParameterizedDummyJob < ActionMailer::Parameterized::DeliveryJob; end


### PR DESCRIPTION
- Ensure `ParamsMailer.parameterized_delivery_job` set to previous value in the tests

- Add mention about `ActionMailer::Base::parameterized_delivery_job` in the docs

Related to https://github.com/rails/rails/pull/34097