### PR TITLE
Render checkbox input before hidden field to cater for labels in IE11 / MS Edge

### DIFF
--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -32,7 +32,7 @@ module ActionView
 
           if include_hidden
             hidden = hidden_field_for_checkbox(options)
-            hidden + checkbox
+            checkbox + hidden
           else
             checkbox
           end


### PR DESCRIPTION
By default, Rails' checkbox helper generates a hidden field element before
the checkbox input.

On Microsoft Edge / IE11, clicking a label containing inputs will pass the
click to the first element in the input. Hence, clicking the label description
will not cause the checkbox to be checked. 

This becomes a significant problem when the label is used to style a hidden `_destroy` checkbox as it fails silently for some users.

```
<label>
  <input type="hidden" name="model_name[_destroy]">
  <input type="checkbox" name="model_name[_destroy]">
  Label text
</label>
````

This patch moves the hidden field below the checkbox

```
<label>
  <input type="checkbox" name="model_name[_destroy]">
  <input type="hidden" name="model_name[_destroy]">
  Label text
</label>
```

