### PR TITLE
[ci skip] Engine routes are namespaced

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -96,7 +96,7 @@ that provides the following:
   * A `config/routes.rb` file:
 
     ```ruby
-    Rails.application.routes.draw do
+    Blorgh::Engine.routes.draw do
     end
     ```
 


### PR DESCRIPTION
### Summary

Update documentation to reflect current behaviour.