### PR TITLE
Add `connect_src` example to content security policy initializer

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -11,6 +11,10 @@
 #   policy.object_src  :none
 #   policy.script_src  :self, :https
 #   policy.style_src   :self, :https
+<%- unless options[:skip_javascript] -%>
+#   # If you are using webpack-dev-server then specify webpack-dev-server host
+#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+<%- end -%>
 
 #   # Specify URI for violation reports
 #   # policy.report_uri "/csp-violation-report-endpoint"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -230,6 +230,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_equal "false\n", output
   end
 
+  def test_csp_initializer_include_connect_src_example
+    run_generator
+
+    assert_file "config/initializers/content_security_policy.rb" do |content|
+      assert_match(/#   policy\.connect_src/, content)
+    end
+  end
+
   def test_app_update_keep_the_cookie_serializer_if_it_is_already_configured
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root]
@@ -807,6 +815,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_no_gem "webpacker"
+    assert_file "config/initializers/content_security_policy.rb" do |content|
+      assert_no_match(/policy\.connect_src/, content)
+    end
   end
 
   def test_webpack_option_with_js_framework


### PR DESCRIPTION
If want to use `webpack-dev-server` with CSP enabled, need to specify `connect-src`.
Related to: https://github.com/rails/webpacker/commit/cd7ecf4d48496341aecd81c0c2f69fe4e50a7cd4

This is a matter of `webpacker`. But since `webpacker` is now used by default, to prevent user confusion, I think that better to include an example of `connect-src.`

