### PR TITLE
Allow using queue prefix with a default queue name

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -34,7 +34,7 @@ module ActiveJob
     end
 
     included do
-      class_attribute :queue_name, instance_accessor: false, default: default_queue_name
+      class_attribute :queue_name, instance_accessor: false, default: -> { self.class.default_queue_name }
       class_attribute :queue_name_delimiter, instance_accessor: false, default: "_"
     end
 

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -7,7 +7,7 @@ require "jobs/nested_job"
 
 class QueueNamingTest < ActiveSupport::TestCase
   test "name derived from base" do
-    assert_equal "default", HelloJob.queue_name
+    assert_equal "default", HelloJob.new.queue_name
   end
 
   test "uses given queue name job" do
@@ -94,6 +94,33 @@ class QueueNamingTest < ActiveSupport::TestCase
       ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
       ActiveJob::Base.queue_name_delimiter = original_queue_name_delimiter
       HelloJob.queue_name = original_queue_name
+    end
+  end
+
+  test "using a custom default_queue_name" do
+    original_default_queue_name = ActiveJob::Base.default_queue_name
+
+    begin
+      ActiveJob::Base.default_queue_name = "default_queue_name"
+
+      assert_equal "default_queue_name", HelloJob.new.queue_name
+    ensure
+      ActiveJob::Base.default_queue_name = original_default_queue_name
+    end
+  end
+
+  test "queue_name_prefix prepended to the default_queue_name" do
+    original_queue_name_prefix = ActiveJob::Base.queue_name_prefix
+    original_default_queue_name = ActiveJob::Base.default_queue_name
+
+    begin
+      ActiveJob::Base.queue_name_prefix = "prefix"
+      ActiveJob::Base.default_queue_name = "default_queue_name"
+
+      assert_equal "prefix_default_queue_name", HelloJob.new.queue_name
+    ensure
+      ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
+      ActiveJob::Base.default_queue_name = original_default_queue_name
     end
   end
 


### PR DESCRIPTION
Fixes #34366

Currently setting queue_name_prefix will not combine a prefix with the
default_queue_name; it will only affect queue names set with `queue_as`.
With this PR the prefix will affect the default_queue_name as well.

Closes #19831

Currently setting default_queue_name doesn't actually affect the
queue_name default (although default_queue_name does get used if you
pass a falsey `part_name` to `queue_as`). This PR would get
default_queue_name working [as expected](https://edgeguides.rubyonrails.org/configuring.html#configuring-active-job) as well.

Because the queue_name default is now a lambda wrapping the
default_queue_name, rather than the default_queue_name itself, I had to
update one test to use the instance method `#queue_name` (which
[`instance_exec`s the value](https://github.com/rails/rails/blob/688d16e25cf02acb88e2f23daf0a7279b16d0b39/activejob/lib/active_job/queue_name.rb#L44)) instead of the class method. I think this
change is OK, since only the instance method is documented.

There was a question about whether we want a `default_queue_name`
configuration. If we want to get rid of it, I would also be happy to
open a PR for that instead. It has been around for a while now, but it
also hasn't really worked for a while now.

r? @matthewd
since you had an opinion about this before
