### PR TITLE
collection cache versioning

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `ActiveRecord::Relation#cache_version` to support recyclable cache keys via
+    the versioned entries in `ActiveSupport::Cache`. This also means that
+    `ActiveRecord::Relation#cache_key` will now return a stable key that does not
+    include the max timestamp or count any more.
+
+    NOTE: This feature is turned off by default, and `cache_key` will still return
+    cache keys with timestamps until you set `ActiveRecord::Base.collection_cache_versioning = true`.
+    That's the setting for all new apps on Rails 6.0+
+
+    *Lachlan Sylvester*
+
 *   Allow applications to automatically switch connections.
 
     Adds a middleware and configuration options that can be used in your

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -6,6 +6,14 @@ module ActiveRecord
       query_signature = ActiveSupport::Digest.hexdigest(collection.to_sql)
       key = "#{collection.model_name.cache_key}/query-#{query_signature}"
 
+      if collection.cache_version(timestamp_column)
+        key
+      else
+        "#{key}-#{collection_cache_version(collection, timestamp_column)}"
+      end
+    end
+
+    def collection_cache_version(collection = all, timestamp_column = :updated_at)
       if collection.loaded? || collection.distinct_value
         size = collection.records.size
         if size > 0
@@ -44,9 +52,9 @@ module ActiveRecord
       end
 
       if timestamp
-        "#{key}-#{size}-#{timestamp.utc.to_s(cache_timestamp_format)}"
+        "#{size}-#{timestamp.utc.to_s(cache_timestamp_format)}"
       else
-        "#{key}-#{size}"
+        "#{size}"
       end
     end
   end

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -22,6 +22,14 @@ module ActiveRecord
       #
       # This is +true+, by default on Rails 5.2 and above.
       class_attribute :cache_versioning, instance_writer: false, default: false
+
+      ##
+      # :singleton-method:
+      # Indicates whether to use a stable #cache_key method that is accompanied
+      # by a changing version in the #cache_version method on collections.
+      #
+      # This is +false+, by default until Rails 6.1.
+      class_attribute :collection_cache_versioning, instance_writer: false, default: false
     end
 
     # Returns a +String+, which Action Pack uses for constructing a URL to this

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -137,6 +137,10 @@ module Rails
             active_storage.queues.analysis = :active_storage_analysis
             active_storage.queues.purge    = :active_storage_purge
           end
+
+          if respond_to?(:active_record)
+            active_record.collection_cache_versioning = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end


### PR DESCRIPTION
Cache versioning enables the same cache key to be reused when the object being cached changes by moving the volatile part of the cache key out of the cache key and into a version that is embedded in the cache entry. 

This is already occurring when the object being cached is an `ActiveRecord::Base`, but when caching an `ActiveRecord::Relation` we are currently still putting the volatile information (max updated at and count) as part of the cache key.

This PR moves the volatile part of the relations cache_key into the cache_version to support recycling cache keys for `ActiveRecord::Relation`s.
