### PR TITLE
Guard Enums against definitions with blank label names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,8 @@
-Adds support for multiple databases to `rails db:schema:cache:dump` and `rails db:schema:cache:clear`.
+*   Defining an Enum as a Hash with blank key, or as an Array with a blank value, now raises an `ArgumentError`.
+
+    *Christophe Maximin*
+
+*   Adds support for multiple databases to `rails db:schema:cache:dump` and `rails db:schema:cache:clear`.
 
     *Gannon McGibbon*
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -218,6 +218,10 @@ module ActiveRecord
           MSG
           raise ArgumentError, error_message
         end
+
+        if values.is_a?(Hash) && values.keys.any?(&:blank?) || values.is_a?(Array) && values.any?(&:blank?)
+          raise ArgumentError, "Enum label name must not be blank."
+        end
       end
 
       ENUM_CONFLICT_MESSAGE = \

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -274,6 +274,24 @@ class EnumTest < ActiveRecord::TestCase
     end
 
     assert_match(/must be either a hash, an array of symbols, or an array of strings./, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: { "" => 1, "active" => 2 }
+      end
+    end
+
+    assert_match(/Enum label name must not be blank/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: ["active", ""]
+      end
+    end
+
+    assert_match(/Enum label name must not be blank/, e.message)
   end
 
   test "reserved enum names" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/34365

TL;DR: Defining an enum as a Hash with an empty key internally triggered these @ [enum.rb](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/enum.rb#L191):
```ruby
# (value_method_name would be an empty string)
define_method("#{value_method_name}?") { self[attr] == label }
# ...
define_method("#{value_method_name}!") { update!(attr => value) }
```
... which silently broke the model's behavior, as described [by the issue](https://github.com/rails/rails/issues/34365).

There is no reason to allow this in the first place, therefore this PR checks for it and raises an `ArgumentError` if found.