### PR TITLE
Add CVE note to security guide and gemspecs

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actioncable"

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionmailer"

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionpack"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionview"

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activejob"

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activemodel"

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activerecord"

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activestorage"

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activesupport"

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1235,6 +1235,11 @@ version:
 Rails.application.credentials.some_api_key! # => raises KeyError: :some_api_key is blank
 ```
 
+Dependency Management and CVEs
+------------------------------
+
+Please note that we do not accept patches for CVE version bumps. This is because application owners need to manually update their gems regardless of our efforts. Use `bundle update --conservative gem_name` to safely update vulnerable dependencies.
+
 Additional Resources
 --------------------
 

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -2,6 +2,9 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
+# NOTE: There's no need to update dependencies for CVEs in minor
+# releases when users can simply run `bundle update vulnerable_gem`.
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "railties"


### PR DESCRIPTION
### Summary

We've been getting a lot of CVE gem bump PRs lately (on other repos, namely [`rails-html-sanitizer`](https://github.com/rails/rails-html-sanitizer/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+CVE)). This adds a note to gemspecs and the security guide that should help prevent unnecessary PRs in future.

r? @rafaelfranca 
cc @kaspth 
