### PR TITLE
Make scaled ActiveRecord decimals cast to zero

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ActiveModel::RangeError` when infinite decimal is being saved to decimal column.
+
+    *Gannon McGibbon*
+
 *   Add an `:if_not_exists` option to `create_table`.
 
     Example:

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -6,6 +6,7 @@ require "active_record/type/internal/timezone"
 
 require "active_record/type/date"
 require "active_record/type/date_time"
+require "active_record/type/decimal"
 require "active_record/type/decimal_without_scale"
 require "active_record/type/json"
 require "active_record/type/time"
@@ -57,7 +58,6 @@ module ActiveRecord
     BigInteger = ActiveModel::Type::BigInteger
     Binary = ActiveModel::Type::Binary
     Boolean = ActiveModel::Type::Boolean
-    Decimal = ActiveModel::Type::Decimal
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
     String = ActiveModel::Type::String

--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Type
+    class Decimal < ActiveModel::Type::Decimal # :nodoc:
+      def serialize(value)
+        raise ActiveModel::RangeError, "cannot be infinite" if value&.to_d&.infinite?
+        super
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/decimal_without_scale.rb
+++ b/activerecord/lib/active_record/type/decimal_without_scale.rb
@@ -10,6 +10,25 @@ module ActiveRecord
       def type_cast_for_schema(value)
         value.to_s.inspect
       end
+
+      def serialize(value)
+        raise ActiveModel::RangeError, "cannot be infinite" if is_infinite?(value)
+        super
+      end
+
+      private
+
+        def cast_value(value)
+          if is_infinite?(value)
+            value
+          else
+            super
+          end
+        end
+
+        def is_infinite?(value)
+          value&.to_d&.infinite?
+        end
     end
   end
 end

--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module Type
+    class DecimalTest < ActiveRecord::TestCase
+      test "infinity raises range error" do
+        klass = Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          attribute :foo, :decimal
+        end
+        model = klass.new
+
+        error = assert_raises(ActiveModel::RangeError) do
+          model.foo = BigDecimal("Infinity")
+          model.save
+        end
+
+        assert_equal "cannot be infinite", error.message
+      end
+
+      test "infinity with scale-less decimal raises range error" do
+        klass = Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          attribute :foo, Type::DecimalWithoutScale.new
+        end
+        model = klass.new
+
+        error = assert_raises(ActiveModel::RangeError) do
+          model.foo = BigDecimal("Infinity")
+          model.save
+        end
+
+        assert_equal "cannot be infinite", error.message
+      end
+
+      test "negative infinity raises range error" do
+        klass = Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          attribute :foo, :decimal
+        end
+        model = klass.new
+
+        error = assert_raises(ActiveModel::RangeError) do
+          model.foo = BigDecimal("-Infinity")
+          model.save
+        end
+
+        assert_equal "cannot be infinite", error.message
+      end
+
+      test "negative infinity with scale-less decimal raises range error" do
+        klass = Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          attribute :foo, Type::DecimalWithoutScale.new
+        end
+        model = klass.new
+
+        error = assert_raises(ActiveModel::RangeError) do
+          model.foo = BigDecimal("-Infinity")
+          model.save
+        end
+
+        assert_equal "cannot be infinite", error.message
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/32888.

Allows decimals on ActiveRecord models that are infinite to be cast to zero when using scaling so queries aren't built with unquoted `Infinity` values. As far as I can tell, `+/-Infinity` are not supported values for decimal columns anyway, so I think this is an acceptable behaviour change.

r? @rafaelfranca 
