### PR TITLE
Amend CVE note and security guide section wordings

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actioncable"
@@ -27,6 +24,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actioncable",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "actionpack", version
 

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionmailer"
@@ -28,6 +25,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionmailer",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "actionpack", version
   s.add_dependency "actionview", version

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionpack"
@@ -28,6 +25,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionpack",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
 

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actionview"
@@ -28,6 +25,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionview",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
 

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activejob"
@@ -27,6 +24,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activejob",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
   s.add_dependency "globalid", ">= 0.3.6"

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activemodel"
@@ -27,6 +24,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activemodel",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activerecord"
@@ -30,6 +27,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activerecord",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activestorage"
@@ -27,6 +24,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activestorage",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activestorage/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "actionpack", version
   s.add_dependency "activerecord", version

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "activesupport"
@@ -29,6 +26,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activesupport",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "i18n",       ">= 0.7", "< 2"
   s.add_dependency "tzinfo",     "~> 1.1"

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1238,7 +1238,7 @@ Rails.application.credentials.some_api_key! # => raises KeyError: :some_api_key 
 Dependency Management and CVEs
 ------------------------------
 
-Please note that we do not accept patches for CVE version bumps. This is because application owners need to manually update their gems regardless of our efforts. Use `bundle update --conservative gem_name` to safely update vulnerable dependencies.
+We don’t bump dependencies just to encourage use of new versions, including for security issues. This is because application owners need to manually update their gems regardless of our efforts. Use `bundle update --conservative gem_name` to safely update vulnerable dependencies.
 
 Additional Resources
 --------------------

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -2,9 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# NOTE: There's no need to update dependencies for CVEs in minor
-# releases when users can simply run `bundle update vulnerable_gem`.
-
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "railties"
@@ -32,6 +29,9 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/railties",
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md"
   }
+
+  # NOTE: Please read our dependency guidelines before updating versions:
+  # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version


### PR DESCRIPTION
### Summary

Followup on https://github.com/rails/rails/pull/34388. I changed the first sentence in the security guide section and moved the gemspec notes just above the dependency lines with a link to the edge security guide.

r? @matthewd 
cc @kaspth, @rafaelfranca 
