### PR TITLE
Always add records to parent of nested transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -137,7 +137,7 @@ module ActiveRecord
             record.committed!
           else
             # if not running callbacks, only adds the record to the parent transaction
-            record.add_to_transaction
+            connection.add_transaction_record(record)
           end
         end
       ensure

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -591,6 +591,17 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
     assert_equal [:before_commit, :after_commit], @topic.history
   end
 
+  def test_commit_run_transactions_callbacks_with_nested_transactions
+    @topic.transaction do
+      @topic.transaction(requires_new: true) do
+        @topic.content = "foo"
+        @topic.save!
+        @topic.class.connection.add_transaction_record(@topic)
+      end
+    end
+    assert_equal [:before_commit, :after_commit], @topic.history
+  end
+
   def test_rollback_does_not_run_transactions_callbacks_without_enrollment
     @topic.transaction do
       @topic.content = "foo"


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/34390.

When a record with transactional callbacks is saved, it's attached to the current transaction so that the callbacks can be run when the transaction is committed. Records can also be added manually with `add_transaction_record`, even if they have no transactional callbacks.

When a nested transaction is committed, its records are transferred to the parent transaction, as transactional callbacks should only be run when the outermost transaction is committed (the "real" transaction). However, this currently only happens when the record has transactional callbacks, and not when added manually with `add_transaction_record`.

If a record is added to a nested transaction, we should always attach it to the parent transaction when the nested transaction is committed, regardless of whether it has any transactional callbacks.