### PR TITLE
Enable CollectionSelect's IncludeBlank to receive value and hidden options

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -184,8 +184,7 @@ module ActionView
             when String
               tag_builder.content_tag_string("option", include_blank, value: "")
             when Hash
-              text = include_blank[:text]
-              value = include_blank[:value]
+              text, value = include_blank.first
               tag_builder.content_tag_string("option", text, value: value)
             else
               tag_builder.content_tag_string("option", nil, value: "")

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -186,8 +186,7 @@ module ActionView
             when Hash
               text = options[:include_blank][:text]
               value = options[:include_blank][:value]
-              hidden = options[:include_blank][:hidden]
-              tag_builder.content_tag_string("option", text, value: value, hidden: hidden)
+              tag_builder.content_tag_string("option", text, value: value)
             else
               tag_builder.content_tag_string("option", nil, value: "")
             end

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -167,7 +167,18 @@ module ActionView
 
           def add_options(option_tags, options, value = nil)
             if options[:include_blank]
-              option_tags = tag_builder.content_tag_string("option", options[:include_blank].kind_of?(String) ? options[:include_blank] : nil, value: "") + "\n" + option_tags
+              blank_option = case options[:include_blank]
+                            when String
+                              tag_builder.content_tag_string('option', options[:include_blank], value: '')
+                            when Hash
+                              text = options[:include_blank][:text]
+                              value = options[:include_blank][:value]
+                              hidden = options[:include_blank][:hidden]
+                              tag_builder.content_tag_string('option', text, value: value, hidden: hidden)
+                            else
+                              tag_builder.content_tag_string('option', nil, value: '')
+                            end
+              option_tags = blank_option + "\n" + option_tags
             end
             if value.blank? && options[:prompt]
               tag_options = { value: "" }.tap do |prompt_opts|

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -167,18 +167,7 @@ module ActionView
 
           def add_options(option_tags, options, value = nil)
             if options[:include_blank]
-              blank_option = case options[:include_blank]
-                            when String
-                              tag_builder.content_tag_string('option', options[:include_blank], value: '')
-                            when Hash
-                              text = options[:include_blank][:text]
-                              value = options[:include_blank][:value]
-                              hidden = options[:include_blank][:hidden]
-                              tag_builder.content_tag_string('option', text, value: value, hidden: hidden)
-                            else
-                              tag_builder.content_tag_string('option', nil, value: '')
-                            end
-              option_tags = blank_option + "\n" + option_tags
+              option_tags = include_blank_option(options) + "\n" + option_tags
             end
             if value.blank? && options[:prompt]
               tag_options = { value: "" }.tap do |prompt_opts|
@@ -188,6 +177,20 @@ module ActionView
               option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), tag_options) + "\n" + option_tags
             end
             option_tags
+          end
+
+          def include_blank_option(options)
+            case options[:include_blank]
+            when String
+              tag_builder.content_tag_string("option", options[:include_blank], value: "")
+            when Hash
+              text = options[:include_blank][:text]
+              value = options[:include_blank][:value]
+              hidden = options[:include_blank][:hidden]
+              tag_builder.content_tag_string("option", text, value: value, hidden: hidden)
+            else
+              tag_builder.content_tag_string("option", nil, value: "")
+            end
           end
 
           def name_and_id_index(options)

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -167,7 +167,7 @@ module ActionView
 
           def add_options(option_tags, options, value = nil)
             if options[:include_blank]
-              option_tags = include_blank_option(options) + "\n" + option_tags
+              option_tags = include_blank_option(options[:include_blank]) + "\n" + option_tags
             end
             if value.blank? && options[:prompt]
               tag_options = { value: "" }.tap do |prompt_opts|
@@ -179,13 +179,13 @@ module ActionView
             option_tags
           end
 
-          def include_blank_option(options)
-            case options[:include_blank]
+          def include_blank_option(include_blank)
+            case include_blank
             when String
-              tag_builder.content_tag_string("option", options[:include_blank], value: "")
+              tag_builder.content_tag_string("option", include_blank, value: "")
             when Hash
-              text = options[:include_blank][:text]
-              value = options[:include_blank][:value]
+              text = include_blank[:text]
+              value = include_blank[:value]
               tag_builder.content_tag_string("option", text, value: value)
             else
               tag_builder.content_tag_string("option", nil, value: "")

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1044,8 +1044,12 @@ class FormOptionsHelperTest < ActionView::TestCase
       collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: {})
     )
     assert_dom_equal(
-      "<select id=\"post_author_name\" name=\"post[author_name]\"><option hidden=\"hidden\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection", hidden: true })
+      "<select id=\"post_author_name\" name=\"post[author_name]\"><option>No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection" })
+    )
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"0\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection", value: "0" })
     )
   end
 
@@ -1054,8 +1058,8 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.author_name = "Babe"
 
     assert_dom_equal(
-      "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"0\" hidden=\"hidden\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", value: "0", hidden: true } }, { "style" => "width: 200px" })
+      "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"0\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", value: "0" } }, { "style" => "width: 200px" })
     )
   end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1035,6 +1035,30 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_select_with_blank_as_hash
+    @post = Post.new
+    @post.author_name = "Babe"
+
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\"><option></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: {} })
+    )
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\"><option hidden=\"hidden\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", hidden: true } })
+    )
+  end
+
+  def test_collection_select_with_blank_as_hash_and_style
+    @post = Post.new
+    @post.author_name = "Babe"
+
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"0\" hidden=\"hidden\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", value: "0", hidden: true } }, { "style" => "width: 200px" })
+    )
+  end
+
   def test_collection_select_with_multiple_option_appends_array_brackets_and_hidden_input
     @post = Post.new
     @post.author_name = "Babe"

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1041,11 +1041,11 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: {} })
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: {})
     )
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option hidden=\"hidden\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", hidden: true } })
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection", hidden: true })
     )
   end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1044,12 +1044,8 @@ class FormOptionsHelperTest < ActionView::TestCase
       collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: {})
     )
     assert_dom_equal(
-      "<select id=\"post_author_name\" name=\"post[author_name]\"><option>No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection" })
-    )
-    assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"0\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { text: "No Selection", value: "0" })
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", include_blank: { "No Selection" => "0" })
     )
   end
 
@@ -1059,7 +1055,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"0\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { text: "No Selection", value: "0" } }, { "style" => "width: 200px" })
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: { "No Selection" => "0" } }, { "style" => "width: 200px" })
     )
   end
 


### PR DESCRIPTION
### Summary

I enabled `collection_select`'s `include_blank` to receive `Hash` with  attributes below, and make it possible to set `blank option`'s `value` and `hidden`.

```sh
# hash parameters
text: 'blank option's text'
value: 'blank option's value'
hidden: 'if true, blank option's hidden attribute set TRUE'
```

### What for?
When you'd like to set `hidden` attribute to `blank option`, there is no way currently.
So, I want to set it easily.

And regarding to `value`, it is needed for example when the field is `Integer` and has `NULL constraints` and I have to send form even when it's not selected.
It's troublesome to set `0` backend at that time.

### Usage
```rb
# give Hash to include_blank
collection_select :sex, Sex.all, :id, :name, { include_blank: { text: 'Select me', value: 0 } }
# => <option value="0">Select me</option>

collection_select :sex, Sex.all, :id, :name, { include_blank: { text: 'Select me', hidden: true } }
# => <option hidden="hidden">Select me</option>


# you can also write it as it were
collection_select :sex, Sex.all, :id, :name, { include_blank: 'Select me' }
```