### PR TITLE
Allow users to supply a non-global binary for dumps/loads

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -75,7 +75,7 @@ module ActiveRecord
         end
 
         args << configuration["database"]
-        run_cmd("pg_dump", args, "dumping")
+        run_cmd(ENV.fetch("PG_DUMP_COMMAND", "pg_dump"), args, "dumping")
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
@@ -85,7 +85,7 @@ module ActiveRecord
         args = ["-v", ON_ERROR_STOP_1, "-q", "-X", "-f", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << configuration["database"]
-        run_cmd("psql", args, "loading")
+        run_cmd(ENV.fetch("PSQL_COMMAND", "psql"), args, "loading")
       end
 
       private


### PR DESCRIPTION
### Summary

Subshells can have a very difficult time with localized binaries, see: asdf or similar. `run_cmd()` eventually calls `Kernel.system()` which uses `/bin/sh`, which has it's own path.  This can cause a lot of frustration as it uses the wrong/nonexistant global-to-sh `pg_dump` or `psql`. Instead, the user should be allowed to specify the location of the command.

Here's what's left for this PR:

  - Do this for all other db tasks
  - (possibly) Store this as part of database.yml instead of env variable?
  - (possibly) Make this metamagicy AKA `run_cmd("psql", ...)` automatically looks up `PSQL_PATH` or something?
  