### PR TITLE
Remove asset paths from autoload_paths

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove `app/assets` and `app/javascript` from `eager_load_paths` and `autoload_paths`.
+
+    *Gannon McGibbon*
+
 *   Add JSON support to rails properties route (`/rails/info/properties`).
 
     Now, `Rails::Info` properties may be accessed in JSON format at `/rails/info/properties.json`.

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -38,7 +38,9 @@ module Rails
         @paths ||= begin
           paths = Rails::Paths::Root.new(@root)
 
-          paths.add "app",                 eager_load: true, glob: "{*,*/concerns}"
+          paths.add "app",                 eager_load: true,
+                                           glob: "{*,*/concerns}",
+                                           exclude: %w(assets javascript)
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -113,10 +113,11 @@ module Rails
       attr_accessor :glob
 
       def initialize(root, current, paths, options = {})
-        @paths    = paths
-        @current  = current
-        @root     = root
-        @glob     = options[:glob]
+        @paths   = paths
+        @current = current
+        @root    = root
+        @glob    = options[:glob]
+        @exclude = options[:exclude]
 
         options[:autoload_once] ? autoload_once! : skip_autoload_once!
         options[:eager_load]    ? eager_load!    : skip_eager_load!
@@ -189,13 +190,11 @@ module Rails
         raise "You need to set a path root" unless @root.path
         result = []
 
-        each do |p|
-          path = File.expand_path(p, @root.path)
+        each do |path|
+          path = File.expand_path(path, @root.path)
 
           if @glob && File.directory?(path)
-            Dir.chdir(path) do
-              result.concat(Dir.glob(@glob).map { |file| File.join path, file }.sort)
-            end
+            result.concat files_in(path)
           else
             result << path
           end
@@ -222,6 +221,17 @@ module Rails
       end
 
       alias to_a expanded
+
+      private
+
+        def files_in(path)
+          Dir.chdir(path) do
+            files = Dir.glob(@glob)
+            files -= @exclude if @exclude
+            files.map! { |file| File.join(path, file) }
+            files.sort
+          end
+        end
     end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1663,6 +1663,14 @@ module ApplicationTests
       assert_kind_of Hash, Rails.application.config.database_configuration
     end
 
+    test "autoload paths do not include asset paths" do
+      app "development"
+      ActiveSupport::Dependencies.autoload_paths.each do |path|
+        assert_not_operator path, :ends_with?, "app/assets"
+        assert_not_operator path, :ends_with?, "app/javascript"
+      end
+    end
+
     test "raises with proper error message if no database configuration found" do
       FileUtils.rm("#{app_path}/config/database.yml")
       err = assert_raises RuntimeError do


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34397.

Removes `app/assets` and `app/javascript` from `autoload_paths`.
