### PR TITLE
sub, sub!, gsub, and gsub! should set back references

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -287,14 +287,7 @@ module ActiveSupport #:nodoc:
       end
 
       def set_block_back_references(block, match_data)
-        Thread.current[:__active_support_safe_buffer_backref] = match_data
-        begin
-          block.binding.eval(<<-EOC)
-            $~ = Thread.current[:__active_support_safe_buffer_backref]
-          EOC
-        ensure
-          Thread.current[:__active_support_safe_buffer_backref] = nil
-        end
+        block.binding.eval("proc { |m| $~ = m }").call(match_data)
       end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -254,28 +254,28 @@ module ActiveSupport #:nodoc:
     UNSAFE_STRING_METHODS_WITH_BACKREF.each do |unsafe_method|
       if unsafe_method.respond_to?(unsafe_method)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)
-            if block
-              to_str.#{unsafe_method}(*args) { |*params|
-                set_block_back_references(block, $~)
-                block.call(*params)
-              }
-            else
-              to_str.#{unsafe_method}(*args)
-            end
-          end
+          def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
+            if block                                      #   if block
+              to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|  
+                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
+                block.call(*params)                       #       block.call(*params)
+              }                                           #     }
+            else                                          #   else
+              to_str.#{unsafe_method}(*args)              #     to_str.gsub(*args)
+            end                                           #   end
+          end                                             # end
 
-          def #{unsafe_method}!(*args, &block)
-            @html_safe = false
-            if block
-              super(*args) { |*params|
-                set_block_back_references(block, $~)
-                block.call(*params)
-              }
-            else
-              super
-            end
-          end
+          def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
+            @html_safe = false                            #   @html_safe = false
+            if block                                      #   if block
+              super(*args) { |*params|                    #     super(*args) { |*params|
+                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
+                block.call(*params)                       #       block.call(*params)
+              }                                           #     }
+            else                                          #   else
+              super                                       #     super
+            end                                           #   end
+          end                                             # end
         EOT
       end
     end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -256,7 +256,7 @@ module ActiveSupport #:nodoc:
         class_eval <<-EOT, __FILE__, __LINE__ + 1
           def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
             if block                                      #   if block
-              to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|  
+              to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|
                 set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
                 block.call(*params)                       #       block.call(*params)
               }                                           #     }

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -216,4 +216,22 @@ class SafeBufferTest < ActiveSupport::TestCase
     x = "Hello".html_safe
     assert_nil x[/a/, 1]
   end
+
+  test "Should set back references" do
+    a = "foo123".html_safe
+    a2 = a.sub(/([a-z]+)([0-9]+)/) { $2 + $1 }
+    assert_equal "123foo", a2
+    assert_not_predicate a2, :html_safe?
+    a.sub!(/([a-z]+)([0-9]+)/) { $2 + $1 }
+    assert_equal "123foo", a
+    assert_not_predicate a, :html_safe?
+
+    b = "foo123 bar456".html_safe
+    b2 = b.gsub(/([a-z]+)([0-9]+)/) { $2 + $1 }
+    assert_equal "123foo 456bar", b2
+    assert_not_predicate b2, :html_safe?
+    b.gsub!(/([a-z]+)([0-9]+)/) { $2 + $1 }
+    assert_equal "123foo 456bar", b
+    assert_not_predicate b, :html_safe?
+  end
 end


### PR DESCRIPTION
### Summary

ActiveSupport::SafeBuffer has a trap that back references are unavailable:

```ruby
"foo123".html_safe.sub(/([a-z]+)([0-9]+)/) {
  $2 + $1 #=> undefined method `+' for nil:NilClass (NoMethodError)
}
```

This PR sets back references using Proc#binding.
