### PR TITLE
Use RuboCop 0.60.0 and remove exclude files for `Style/RedundantFreeze`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-58
+    channel: rubocop-0-60
 
 ratings:
   paths:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,9 +133,6 @@ Style/FrozenStringLiteralComment:
 
 Style/RedundantFreeze:
   Enabled: true
-  Exclude:
-    - 'actionpack/lib/action_dispatch/journey/router/utils.rb'
-    - 'activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb'
 
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:


### PR DESCRIPTION
### Summary

Use RuboCop 0.60.0 and remove exclude files for `Style/RedundantFreeze` since https://github.com/rubocop-hq/rubocop/pull/6333 has been included into RuboCop 0.60.0.

and RuboCop 0.60 is available at Code Climate https://github.com/codeclimate/codeclimate-rubocop/tree/channel/rubocop-0-60

Follow up #32031