### PR TITLE
Windows support for parallelization and instrumenter

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -55,6 +55,11 @@ module ActiveSupport
       attr_reader :name, :time, :transaction_id, :payload, :children
       attr_accessor :end
 
+      def self.clock_gettime_supported? # :nodoc:
+        defined?(Process::CLOCK_PROCESS_CPUTIME_ID) &&
+        !Gem.win_platform?
+      end
+
       def initialize(name, start, ending, transaction_id, payload)
         @name           = name
         @payload        = payload.dup
@@ -130,7 +135,7 @@ module ActiveSupport
           Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
-        if defined?(Process::CLOCK_PROCESS_CPUTIME_ID)
+        if clock_gettime_supported?
           def now_cpu
             Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID)
           end

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "drb"
-require "drb/unix"
+require "drb/unix" unless Gem.win_platform?
 require "active_support/core_ext/module/attribute_accessors"
 
 module ActiveSupport

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -4,7 +4,7 @@ require 'rails/test_help'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-<% if defined?(JRUBY_VERSION) -%>
+<% if defined?(JRUBY_VERSION) || Gem.win_platform? -%>
   parallelize(workers: 2, with: :threads)
 <%- else -%>
   parallelize(workers: 2)


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34374.

Adds Windows support for `ActiveSupport::Testing::Parallelization` and `ActiveSupport::Notifications::Instrumenter`.

Unsure of how I can adequately test this aside from adding a Windows build to CI.

r? @eileencodes since you added test parallelization and event CPU time to Rails 😄 
