### PR TITLE
Reset Capybara sessions if failed system test screenshot raising an exception

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Reset Capybara sessions if failed system test screenshot raising an exception.
+
+    Reset Capybara sessions if `take_failed_screenshot` raise exception
+    in system test `after_teardown`.
+
+    *Maxim Perepelitsa*
+
 *   Use request object for context if there's no controller
 
     There is no controller instance when using a redirect route or a

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -17,8 +17,11 @@ module ActionDispatch
         end
 
         def after_teardown
-          take_failed_screenshot
-          Capybara.reset_sessions!
+          begin
+            take_failed_screenshot
+          ensure
+            Capybara.reset_sessions!
+          end
         ensure
           super
         end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -703,6 +703,31 @@ module ApplicationTests
       end
     end
 
+    def test_reset_sessions_on_failed_system_test_screenshot
+      app_file "test/system/reset_sessions_on_failed_system_test_screenshot_test.rb", <<~RUBY
+        require "application_system_test_case"
+
+        class ResetSessionsOnFailedSystemTestScreenshotTest < ApplicationSystemTestCase
+          ActionDispatch::SystemTestCase.class_eval do
+            def take_failed_screenshot
+              raise Capybara::CapybaraError
+            end
+          end
+
+          Capybara.instance_eval do
+            def reset_sessions!
+              puts "Capybara.reset_sessions! called"
+            end
+          end
+
+          test "dummy" do
+          end
+        end
+      RUBY
+      output = run_test_command("test/system/reset_sessions_on_failed_system_test_screenshot_test.rb")
+      assert_match "Capybara.reset_sessions! called", output
+    end
+
     def test_system_tests_are_not_run_with_the_default_test_command
       app_file "test/system/dummy_test.rb", <<-RUBY
         require "application_system_test_case"


### PR DESCRIPTION
If Capybara or driver like Selenium raising exception while system test trying to take failed screenshot in teardown, for example:

```ruby
Error:
PagesTest#test_creating_and_viewing_a_page:
Selenium::WebDriver::Error::UnhandledAlertError: unexpected alert open: {Alert text : Delete "About EN"?}
  (Session info: headless chrome=70.0.3538.77)
  (Driver info: chromedriver=2.41,platform=Linux 4.15.0-38-generic x86_64)
```

We don't reset Capybara sessions.