### PR TITLE
Ensure external redirects are explicitly allowed

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ensure external redirects are explicitly allowed
+
+    Add `fallback_location` and `allow_other_host` options to `redirect_to`.
+
+    *Gannon McGibbon*
+
 *   Introduce ActionDispatch::HostAuthorization
 
     This is a new middleware that guards against DNS rebinding attacks by

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -44,18 +44,18 @@ module ActionController #:nodoc:
     end
 
     private
-      def redirect_to(options = {}, response_status_and_flash = {}) #:doc:
+      def redirect_to(options = {}, response_options_and_flash = {}) #:doc:
         self.class._flash_types.each do |flash_type|
-          if type = response_status_and_flash.delete(flash_type)
+          if type = response_options_and_flash.delete(flash_type)
             flash[flash_type] = type
           end
         end
 
-        if other_flashes = response_status_and_flash.delete(:flash)
+        if other_flashes = response_options_and_flash.delete(:flash)
           flash.update(other_flashes)
         end
 
-        super(options, response_status_and_flash)
+        super(options, response_options_and_flash)
       end
   end
 end

--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -13,7 +13,7 @@ module ActionController
 
     ACTION_OPTIONS = [:only, :except, :if, :unless]
     URL_OPTIONS = [:protocol, :host, :domain, :subdomain, :port, :path]
-    REDIRECT_OPTIONS = [:status, :flash, :alert, :notice]
+    REDIRECT_OPTIONS = [:status, :flash, :alert, :notice, :allow_other_host]
 
     module ClassMethods # :nodoc:
       def force_ssl(options = {})
@@ -40,7 +40,8 @@ module ActionController
           protocol: "https://",
           host: request.host,
           path: request.fullpath,
-          status: :moved_permanently
+          status: :moved_permanently,
+          allow_other_host: true,
         }
 
         if host_or_options.is_a?(Hash)

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -28,13 +28,13 @@ class ActionPackAssertionsController < ActionController::Base
 
   def redirect_to_path() redirect_to "/some/path" end
 
-  def redirect_invalid_external_route() redirect_to "ht_tp://www.rubyonrails.org" end
+  def redirect_invalid_external_route() redirect_to "ht_tp://www.rubyonrails.org", allow_other_host: true end
 
   def redirect_to_named_route() redirect_to route_one_url end
 
-  def redirect_external() redirect_to "http://www.rubyonrails.org"; end
+  def redirect_external() redirect_to "http://www.rubyonrails.org", allow_other_host: true; end
 
-  def redirect_external_protocol_relative() redirect_to "//www.rubyonrails.org"; end
+  def redirect_external_protocol_relative() redirect_to "//www.rubyonrails.org", allow_other_host: true; end
 
   def response404() head "404 AWOL" end
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -25,11 +25,11 @@ module Another
     end
 
     def redirector
-      redirect_to "http://foo.bar/"
+      redirect_to "http://foo.bar/", allow_other_host: true
     end
 
     def filterable_redirector
-      redirect_to "http://secret.foo.bar/"
+      redirect_to "http://secret.foo.bar/", allow_other_host: true
     end
 
     def data_sender

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -49,11 +49,11 @@ class RedirectController < ActionController::Base
   end
 
   def url_redirect_with_status
-    redirect_to("http://www.example.com", status: :moved_permanently)
+    redirect_to("http://www.example.com", status: :moved_permanently, allow_other_host: true)
   end
 
   def url_redirect_with_status_hash
-    redirect_to("http://www.example.com", status: 301)
+    redirect_to("http://www.example.com", status: 301, allow_other_host: true)
   end
 
   def relative_url_redirect_with_status
@@ -81,19 +81,27 @@ class RedirectController < ActionController::Base
   end
 
   def redirect_to_url
+    redirect_to "http://www.rubyonrails.org/", allow_other_host: true
+  end
+
+  def redirect_to_unsafe_url
     redirect_to "http://www.rubyonrails.org/"
   end
 
+  def redirect_to_relative_unsafe_url
+    redirect_to ".br"
+  end
+
   def redirect_to_url_with_unescaped_query_string
-    redirect_to "http://example.com/query?status=new"
+    redirect_to "http://example.com/query?status=new", allow_other_host: true
   end
 
   def redirect_to_url_with_complex_scheme
-    redirect_to "x-test+scheme.complex:redirect"
+    redirect_to "x-test+scheme.complex:redirect", allow_other_host: true
   end
 
   def redirect_to_url_with_network_path_reference
-    redirect_to "//www.rubyonrails.org/"
+    redirect_to "//www.rubyonrails.org/", allow_other_host: true
   end
 
   def redirect_to_existing_record
@@ -113,12 +121,12 @@ class RedirectController < ActionController::Base
   end
 
   def redirect_to_with_block
-    redirect_to proc { "http://www.rubyonrails.org/" }
+    redirect_to proc { "http://www.rubyonrails.org/" }, allow_other_host: true
   end
 
   def redirect_to_with_block_and_assigns
     @url = "http://www.rubyonrails.org/"
-    redirect_to proc { @url }
+    redirect_to proc { @url }, allow_other_host: true
   end
 
   def redirect_to_with_block_and_options
@@ -243,6 +251,28 @@ class RedirectTest < ActionController::TestCase
     get :redirect_to_url
     assert_response :redirect
     assert_redirected_to "http://www.rubyonrails.org/"
+  end
+
+  def test_redirect_to_unsafe_url
+    error = assert_raises(ArgumentError) do
+      get :redirect_to_unsafe_url
+    end
+    assert_equal <<~MSG.squish, error.message
+      Unsafe redirect \"http://www.rubyonrails.org/\",
+      use :fallback_location to specify a fallback or
+      :allow_other_host to redirect anyway.
+    MSG
+  end
+
+  def test_redirect_to_relative_unsafe_url
+    error = assert_raises(ArgumentError) do
+      get :redirect_to_relative_unsafe_url
+    end
+    assert_equal <<~MSG.squish, error.message
+      Unsafe redirect \"http://test.host.br\",
+      use :fallback_location to specify a fallback or
+      :allow_other_host to redirect anyway.
+    MSG
   end
 
   def test_redirect_to_url_with_unescaped_query_string


### PR DESCRIPTION
### Summary

Fixes: https://github.com/rails/rails/issues/33577.

Adds `allow_other_host` and `fallback_location` functionality to `redirect_to` so external hosts can be permitted for redirect explicitly.

r? @rafaelfranca 
