### PR TITLE
Document missing supported types [ci skip]

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -14,11 +14,14 @@ module ActiveJob
   end
 
   # Raised when an unsupported argument type is set as a job argument. We
-  # currently support NilClass, Integer, Float, String, TrueClass, FalseClass,
-  # BigDecimal, and objects that can be represented as GlobalIDs (ex: Active Record).
+  # currently support String, Integer, Float, NilClass, TrueClass, FalseClass,
+  # BigDecimal, Symbol, Date, Time, DateTime, ActiveSupport::TimeWithZone,
+  # ActiveSupport::Duration, Hash, ActiveSupport::HashWithIndifferentAccess,
+  # Array or GlobalID::Identification instances, although this can be extended
+  # by adding custom serializers.
   # Raised if you set the key for a Hash something else than a string or
   # a symbol. Also raised when trying to serialize an object which can't be
-  # identified with a Global ID - such as an unpersisted Active Record model.
+  # identified with a GlobalID - such as an unpersisted Active Record model.
   class SerializationError < ArgumentError; end
 
   module Arguments

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -9,10 +9,12 @@ module ActiveJob
 
     # Includes the +perform_later+ method for job initialization.
     module ClassMethods
-      # Push a job onto the queue. The arguments must be legal JSON types
-      # (+string+, +int+, +float+, +nil+, +true+, +false+, +hash+ or +array+) or
-      # GlobalID::Identification instances. Arbitrary Ruby objects
-      # are not supported.
+      # Push a job onto the queue. By default the arguments must be either String,
+      # Integer, Float, NilClass, TrueClass, FalseClass, BigDecimal, Symbol, Date,
+      # Time, DateTime, ActiveSupport::TimeWithZone, ActiveSupport::Duration,
+      # Hash, ActiveSupport::HashWithIndifferentAccess, Array or
+      # GlobalID::Identification instances, although this can be extended by adding
+      # custom serializers.
       #
       # Returns an instance of the job class queued with arguments available in
       # Job#arguments.


### PR DESCRIPTION
### Summary

While reading ActiveJob's code I realized `BigDecimal` was missing at `perform_later`'s documentation.

This patch adds BigDecimal to the supported types list at `perform_later`. To double check supported types see [`ActiveJob::Arguments::PERMITTED_TYPES`](https://github.com/rails/rails/blob/master/activejob/lib/active_job/arguments.rb#L27).

Edit: After @kamipo's CR this patch also documents types added with #30941