### PR TITLE
Clarify the validation of present associations

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -538,7 +538,8 @@ end
 
 If you want to be sure that an association is present, you'll need to test
 whether the associated object itself is present, and not the foreign key used
-to map the association.
+to map the association. This way, it is not only checked that the foreign key
+is not empty but also that the referenced object exists.
 
 ```ruby
 class LineItem < ApplicationRecord


### PR DESCRIPTION
Based [on some code I review today](https://github.com/openSUSE/open-build-service/pull/6201#discussion_r232245251) and in some [questions/answers in StackOverflow](https://stackoverflow.com/questions/11695262/when-should-i-validate-the-presence-of-an-activerecord-association-object-vs-its), I think that it is not clear what means that _an association is present_. Add that it is checking that the foreign key is not empty and that the referenced object exists to clarify it. :bowtie: