### PR TITLE
Fix ignored options in the `#added?` method

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -327,11 +327,11 @@ module ActiveModel
     #  person.errors.added? :name, :too_long                                # => false
     #  person.errors.added? :name, "is too long"                            # => false
     def added?(attribute, message = :invalid, options = {})
+      message = message.call if message.respond_to?(:call)
+
       if message.is_a? Symbol
-        self.details[attribute.to_sym].map { |e| e[:error] }.include? message
+        details[attribute.to_sym].include? normalize_detail(message, options)
       else
-        message = message.call if message.respond_to?(:call)
-        message = normalize_message(attribute, message, options)
         self[attribute].include? message
       end
     end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -228,6 +228,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not person.errors.added?(:name)
   end
 
+  test "added? returns false when checking for an error with an incorrect or missing option" do
+    person = Person.new
+    person.errors.add :name, :too_long, count: 25
+
+    assert person.errors.added? :name, :too_long, count: 25
+    assert_not person.errors.added? :name, :too_long, count: 24
+    assert_not person.errors.added? :name, :too_long
+    assert_not person.errors.added? :name, "is too long"
+  end
+
   test "added? returns false when checking for an error by symbol and a different error with same message is present" do
     I18n.backend.store_translations("en", errors: { attributes: { name: { wrong: "is wrong", used: "is wrong" } } })
     person = Person.new


### PR DESCRIPTION
Fixes #34416

### Summary

A bug was introduced in ActiveModel 5.2 (see commit 15cb4ef); because of it, `ActiveRecord::Errors::added?` returns `true` even when the details of the error that is checked differ. However, as documented, it should not:

> If the error message requires an option, then it returns true with the correct option, or false with an incorrect or missing option.
> 
> ```ruby
> person.errors.add :name, :too_long, { count: 25 }
> person.errors.added? :name, :too_long, count: 25                     # => true
> person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
> person.errors.added? :name, :too_long, count: 24                     # => false
> person.errors.added? :name, :too_long                                # => false
> person.errors.added? :name, "is too long"                            # => false
> ```

### Other Information

`#added?` basically works in two different ways depending on the `message` attribute. If it's a string, then it looks for the message itself. If it's a symbol, it looks for the details of the error: the error itself, and its details.

(The method used to generate the message, when given a symbol, so that it could look for it has if it has been given a string. This took care of the need to take into consideration the details, since they are included in the message, but could return false positives if two errors has the same message. This is what 15cb4ef tried to fix.)