### PR TITLE
Allow usage of the `generate` action in generators when testing

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -213,9 +213,9 @@ module Rails
       #   generate(:authenticated, "user session")
       def generate(what, *args)
         log :generate, what
-        argument = args.flat_map(&:to_s).join(" ")
+        argument = args.flat_map(&:to_s)
 
-        in_root { run_ruby_script("bin/rails generate #{what} #{argument}", verbose: false) }
+        Generators.invoke(what, argument, behavior: :invoke, destination_root: destination_root)
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -2,6 +2,7 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/app/app_generator"
+require "rails/generators/rails/model/model_generator"
 require "env_helpers"
 
 class ActionsTest < Rails::Generators::TestCase
@@ -265,9 +266,8 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options
-    assert_called_with(generator, :run_ruby_script, ["bin/rails generate model MyModel", verbose: false]) do
-      action :generate, "model", "MyModel"
-    end
+    action :generate, "model", "MyModel"
+    assert_file("app/models/my_model.rb")
   end
 
   def test_rails_should_run_rake_command_with_default_env


### PR DESCRIPTION
### Summary

It was previously not possible to test whether a generator could
invoke another generator using the `generate` command, because this
shells out and can potentially be mocked or its errors can be hidden
from the user. The command always runs, but its effects cannot be
observed. For example, if a file is supposed to be generated using
`generate :model`, the file will not exist in the `destination_root` of
the test when executed. To remedy this, instead of shelling out with
`#run_ruby_script`, use `Generator.invoke` directly and pass in all of
the arguments given to the command.

### Other Information

(none)