### PR TITLE
Abort early if generator command fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ PATH
       activesupport (= 6.0.0.alpha)
       method_source
       rake (>= 0.8.7)
-      thor (>= 0.19.0, < 2.0)
+      thor (>= 0.20.3, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -304,7 +304,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     memoist (0.16.0)
-    method_source (0.9.1)
+    method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -195,6 +195,12 @@ You can also run commands as a super-user:
 rails_command "log:clear", sudo: true
 ```
 
+You can also run commands that should abort application generation if they fail:
+
+```ruby
+rails_command "db:migrate", abort_on_failure: true
+```
+
 ### route(routing_code)
 
 Adds a routing entry to the `config/routes.rb` file. In the steps above, we generated a person scaffold and also removed `README.rdoc`. Now, to make `PeopleController#index` the default page for the application:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add an `abort_on_failure` boolean option to the generator method that shell
+    out (`generate`, `rake`, `rails_command`) to abort the generator if the
+    command fails.
+
+    *David Rodríguez*
+
 *   Remove `app/assets` and `app/javascript` from `eager_load_paths` and `autoload_paths`.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -220,10 +220,10 @@ module Rails
       #
       #   generate(:authenticated, "user session")
       def generate(what, *args)
-        log :generate, what
+        options = args.extract_options!
         argument = args.flat_map(&:to_s).join(" ")
 
-        in_root { run("bin/rails generate #{what} #{argument}", verbose: false) }
+        rails_command("generate #{what} #{argument}", options)
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -307,6 +307,7 @@ module Rails
           config = { verbose: false }
 
           config[:capture] = options[:capture] if options[:capture]
+          config[:abort_on_failure] = options[:abort_on_failure] if options[:abort_on_failure]
 
           in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", config) }
         end

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -220,10 +220,12 @@ module Rails
       #
       #   generate(:authenticated, "user session")
       def generate(what, *args)
+        log :generate, what
+
         options = args.extract_options!
         argument = args.flat_map(&:to_s).join(" ")
 
-        rails_command("generate #{what} #{argument}", options)
+        execute_command :rails, "generate #{what} #{argument}", options
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -223,7 +223,7 @@ module Rails
         log :generate, what
         argument = args.flat_map(&:to_s).join(" ")
 
-        in_root { run_ruby_script("bin/rails generate #{what} #{argument}", verbose: false) }
+        in_root { run("bin/rails generate #{what} #{argument}", verbose: false) }
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack",    version
 
   s.add_dependency "rake", ">= 0.8.7"
-  s.add_dependency "thor", ">= 0.19.0", "< 2.0"
+  s.add_dependency "thor", ">= 0.20.3", "< 2.0"
   s.add_dependency "method_source"
 
   s.add_development_dependency "actionview", version

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -303,11 +303,21 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options
-    assert_called_with(generator, :run, ["rails generate model MyModel RAILS_ENV=development", verbose: false]) do
-      with_rails_env nil do
+    run_generator
+    action :generate, "model", "MyModel"
+    assert_file "app/models/my_model.rb", /MyModel/
+  end
+
+  def test_generate_aborts_when_subprocess_fails_if_requested
+    run_generator
+    content = capture(:stderr) do
+      assert_raises SystemExit do
+        action :generate, "model", "MyModel:ADsad", abort_on_failure: true
         action :generate, "model", "MyModel"
       end
     end
+    assert_match(/wrong constant name MyModel:aDsad/, content)
+    assert_no_file "app/models/my_model.rb"
   end
 
   def test_rake_should_run_rake_command_with_default_env

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -303,7 +303,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options
-    assert_called_with(generator, :run_ruby_script, ["bin/rails generate model MyModel", verbose: false]) do
+    assert_called_with(generator, :run, ["bin/rails generate model MyModel", verbose: false]) do
       action :generate, "model", "MyModel"
     end
   end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -303,8 +303,10 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options
-    assert_called_with(generator, :run, ["bin/rails generate model MyModel", verbose: false]) do
-      action :generate, "model", "MyModel"
+    assert_called_with(generator, :run, ["rails generate model MyModel RAILS_ENV=development", verbose: false]) do
+      with_rails_env nil do
+        action :generate, "model", "MyModel"
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

This PR happens to overlap with #34418, but I think it tries to fix a slightly different problem. My issue is that sometimes rails generator commands that I run in CI fail, and I don't notice because the generator does not abort. So I added [a feature](https://github.com/erikhuda/thor/pull/628) in `thor` to force aborting the process if this happens, which I'm using in this PR. I think this could maybe become the default, but for now I introduced it as an opt-in because there's situations where you don't want it (for example, if you do `rails db:drop` inside a generator, you probably want to ignore the case where the db does not exist).

In my case, I run into this problem when using the `generate` action, so I refactored it to reuse the `rails_command` action, so I only need to add the new `abort_on_failure` option in a single place. 

This probably needs a change log entry and some docs but I wanted to gathers some opinions first!
