### PR TITLE
Prefer assert_not instead of refute [ci skip]

### DIFF
--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -18,6 +18,6 @@ require "minitest/autorun"
 class BugTest < Minitest::Test
   def test_stuff
     assert "zomg".present?
-    refute "".present?
+    assert_not "".present?
   end
 end

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -17,6 +17,6 @@ require "minitest/autorun"
 class BugTest < Minitest::Test
   def test_stuff
     assert "zomg".present?
-    refute "".present?
+    assert_not "".present?
   end
 end


### PR DESCRIPTION
### Summary

As mentioned in the contributing to Ruby on Rails guides, we should prefer `assert_not` instead of `refute`, and the best place to start giving example are our bug report templates 😉 

See: https://github.com/rails/rails/blame/master/guides/source/contributing_to_ruby_on_rails.md#L256

Thanks!