### PR TITLE
versioned cache entries for collections

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -297,6 +297,11 @@ module ActiveRecord
       @cache_keys[timestamp_column] ||= @klass.collection_cache_key(self, timestamp_column)
     end
 
+    def cache_version(timestamp_column = :updated_at)
+      @cache_versions ||= {}
+      @cache_versions[timestamp_column] ||= @klass.collection_cache_version(self, timestamp_column)
+    end
+
     # Scope all queries to the current scope.
     #
     #   Comment.where(post_id: 1).scoping do

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -12,16 +12,6 @@ module ActiveRecord
   class CollectionCacheKeyTest < ActiveRecord::TestCase
     fixtures :developers, :projects, :developers_projects, :topics, :comments, :posts
 
-    # setup do
-    #   Developer.cache_versioning = false
-    #   Comment.cache_versioning = false
-    # end
-
-    # teardown do
-    #   Developer.cache_versioning = false
-    #   Comment.cache_versioning = false
-    # end
-
     test "collection_cache_key on model" do
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, Developer.collection_cache_key)
     end


### PR DESCRIPTION
### Summary

* #29092 introduced versioned (recyclable) cache entries
* Active Record relations however do not yet have support for versioned
  cache entries
* This can lead to performance issues, irrespective of when versioning
  is on or off
  (see https://github.com/rails/rails/pull/29092#issuecomment-437572543)
* besides this, cache utilization can improve if AR relations also
  supported recyclable keys, and it would be more consistent
* This change added cache_version method in addition to
  cache_key to relations, and delegating to collection_cache_version
  similarly to collection_cache_key
* updated tests to cover non-versioned relations as well as versioned


### Other Information

* this is just a first stab, to gauge interest and explore this
  direction