### PR TITLE
Remove ensure from with_transaction_returning_status

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -375,10 +375,6 @@ module ActiveRecord
         raise ActiveRecord::Rollback unless status
       end
       status
-    ensure
-      if @transaction_state && @transaction_state.committed?
-        clear_transaction_record_state
-      end
     end
 
     private


### PR DESCRIPTION
The test added in https://github.com/rails/rails/pull/20947 passes even without this code since https://github.com/rails/rails/pull/29378, as the call to `id` in `remember_transaction_record_state` now triggers a `sync_with_transaction_state` which discards the leftover state from the previous transaction.

This issue had already been fixed for `save!`, `destroy` and `touch` in https://github.com/rails/rails/pull/18200, but continued to affect `save` because the call to `rollback_active_record_state!` in that method would increment the transaction level before `add_to_transaction` could clear it, preventing the fix from working correctly.

As `rollback_active_record_state!` was removed entirely in https://github.com/rails/rails/pull/32878, this code is no longer needed.

r? @kamipo 