### PR TITLE
Ignore warnings such as `Psych.safe_load is deprecated`

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -45,6 +45,8 @@ module ApplicationTests
         output.sub!(/^Resolving dependencies\.\.\.\n/, "")
         # Suppress Bundler platform warnings from output
         output.gsub!(/^The dependency .* will be unused .*\.\n/, "")
+        # Ignore warnings such as `Psych.safe_load is deprecated`
+        output.gsub!(/^warning:\s.*\n/, "")
 
         assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==


### PR DESCRIPTION
### Summary

Ruby 2.6.0 revision [65659](https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=65659&view=revision) merges the latest version of Pysch-3.1.0.pre2 which introduces 

This pull request ignores warnings such as `Psych.safe_load is deprecated`. Addressing warnings are important but it should be out of this test scope.

https://travis-ci.org/rails/rails/jobs/454145524#L4122-L4131

```ruby
.F
Failure:
ApplicationTests::BinSetupTest#test_bin_setup_output [test/application/bin_setup_test.rb:49]:
--- expected
+++ actual
@@ -1,4 +1,5 @@
 "== Installing dependencies ==
+warning: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.
 The Gemfile's dependencies are satisfied

 == Preparing database ==
rails test test/application/bin_setup_test.rb:38
```