### PR TITLE
Add an alias for the --webpack option

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -258,8 +258,8 @@ module Rails
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false,
                                  desc: "Don't run bundle install"
 
-      class_option :webpack, type: :string, default: nil,
-                             desc: "Preconfigure Webpack with a particular framework (options: #{WEBPACKS.join('/')})"
+      class_option :webpack, type: :string, aliases: "--webpacker", default: nil,
+                             desc: "Preconfigure Webpack with a particular framework (options: #{WEBPACKS.join(", ")})"
 
       class_option :skip_webpack_install, type: :boolean, default: false,
                                           desc: "Don't run Webpack install"


### PR DESCRIPTION
### Summary

It happens too often to forget if the option to initialise Rails with webpacker is either `--webpack` or `--webpacker`. This PR solves the issue by adding an alias.
I tend to think that Rails should be as nice as possible to the developer, and this addition goes in the direction of making the developer life easier. ❤️ 

### Other Information

I also changed the way we display the possible options, splitting them with a comma as for the other options instead of a backslash.

I don't believe an update to the changelog or the docs is needed since the `--webpack` option is still available.