### PR TITLE
Adjust bind length of SQLite to default (999)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -396,6 +396,12 @@ module ActiveRecord
       end
 
       private
+        # See https://www.sqlite.org/limits.html,
+        # the default value is 999 when not configured.
+        def bind_params_length
+          999
+        end
+
         def check_version
           if sqlite_version < "3.8.0"
             raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SQLite3Adapter
+      class BindParameterTest < ActiveRecord::SQLite3TestCase
+        def test_too_many_binds
+          topics = Topic.where(id: (1..999).to_a << 2**63)
+          assert_equal Topic.count, topics.count
+
+          topics = Topic.where.not(id: (1..999).to_a << 2**63)
+          assert_equal 0, topics.count
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes `#bind_params_length` in SQLite adapter to return the default maximum amount (999). See https://www.sqlite.org/limits.html.

Fixes https://github.com/rails/rails/issues/34423.

r? @rafaelfranca 
