### PR TITLE
[WIP] Filter parameters in ActiveJob logs

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/string/filters"
 require "active_support/tagged_logging"
 require "active_support/logger"
+require "active_support/parameter_filter"
 
 module ActiveJob
   module Logging #:nodoc:
@@ -137,7 +138,9 @@ module ActiveJob
           def format(arg)
             case arg
             when Hash
-              arg.transform_values { |value| format(value) }
+              # TODO: Read filters from config.filter_parameters
+              parameter_filter = ActiveSupport::ParameterFilter.new([:sensitive_data])
+              parameter_filter.filter arg.transform_values { |value| format(value) }
             when Array
               arg.map { |value| format(value) }
             when GlobalID::Identification

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -74,6 +74,13 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_filter_parameters
+    perform_enqueued_jobs do
+      LoggingJob.perform_later("sensitive_data" => "secret")
+      assert_match(/Performing LoggingJob \(Job ID: .*?\) from .*? with arguments: {\"sensitive_data\"=>\"\[FILTERED\]\"}/, @logger.messages)
+    end
+  end
+
   def test_logs_correct_queue_name
     original_queue_name = LoggingJob.queue_name
     LoggingJob.queue_as :php_jobs


### PR DESCRIPTION
### Summary

Filter out parameters in ActiveJob logs using `ActiveSupport::ParameterFilter`.

Fixes #34439.

