### PR TITLE
Add test for normalizing non-unicode string

### DIFF
--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -772,6 +772,16 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
     assert_deprecated { ActiveSupport::Multibyte::Unicode.swapcase("") }
   end
 
+  def test_normalize_non_unicode_string
+    # Fullwidth Latin Capital Letter A in Windows 31J
+    str = "\u{ff21}".encode(Encoding::Windows_31J)
+    assert_raise Encoding::CompatibilityError do
+      ActiveSupport::Deprecation.silence do
+        ActiveSupport::Multibyte::Unicode.normalize(str)
+      end
+    end
+  end
+
   private
 
     def string_from_classes(classes)


### PR DESCRIPTION
Closes #34062

### Summary

Context: https://github.com/rails/rails/issues/34062#issuecomment-427594756

Previously, we don't have any spec for `ActiveSupport::Unicode::Multibyte#normalize` with non-unicode string.
To clarify the behavior, I'd like to add a test.

cc @rafaelfranca 