### PR TITLE
Exercise `connected_to` and `connects_to` methods

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -107,7 +107,7 @@ module ActiveRecord
     #   end
     def connected_to(database: nil, role: nil, &blk)
       if database && role
-        raise ArgumentError, "connected_to can only accept a database or role argument, but not both arguments."
+        raise ArgumentError, "connected_to can only accept a `database` or a `role` argument, but not both arguments."
       elsif database
         if database.is_a?(Hash)
           role, database = database.first


### PR DESCRIPTION
Since both methods are public API I think it makes sense to add these tests in order to prevent any regression in the behavior of those methods after the 6.0 release.

Exercise `connected_to`
  - Ensure that the method raises with both `database` and `role` arguments
  - Ensure that the method raises without `database` and `role`

Exercise `connects_to`
  - Ensure that the method returns an array of established connections(as mentioned in the docs of the method https://github.com/eileencodes/rails/blob/31021a8c85bb80300deb01db96876858ff417f4a/activerecord/lib/active_record/connection_handling.rb#L67)

Related to #34052