### PR TITLE
Add progressive JPG MIME-type to default variable content types

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add progressive JPG to default list of variable content types
+
+    *Maurice Kühlborn*
+
 *   Add `ActiveStorage.routes_prefix` for configuring generated routes.
 
     *Chris Bisnett*

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -26,6 +26,7 @@ module ActiveStorage
       image/gif
       image/jpg
       image/jpeg
+      image/pjpeg
       image/vnd.adobe.photoshop
       image/vnd.microsoft.icon
     )

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -813,7 +813,7 @@ normal Rails server.
    config.active_storage.paths[:ffprobe] = '/usr/local/bin/ffprobe'
    ```
 
-* `config.active_storage.variable_content_types` accepts an array of strings indicating the content types that Active Storage can transform through ImageMagick. The default is `%w(image/png image/gif image/jpg image/jpeg image/vnd.adobe.photoshop image/vnd.microsoft.icon)`.
+* `config.active_storage.variable_content_types` accepts an array of strings indicating the content types that Active Storage can transform through ImageMagick. The default is `%w(image/png image/gif image/jpg image/jpeg image/pjpeg image/vnd.adobe.photoshop image/vnd.microsoft.icon)`.
 
 * `config.active_storage.content_types_to_serve_as_binary` accepts an array of strings indicating the content types that Active Storage will always serve as an attachment, rather than inline. The default is `%w(text/html
 text/javascript image/svg+xml application/postscript application/x-shockwave-flash text/xml application/xml application/xhtml+xml)`.


### PR DESCRIPTION
### Summary

I want to suggest including the MIME-type for progressive JPGs (`image/pjpeg`) in the list of variable content types. It is not an uncommon MIME-type and including it in the default list might save a bunch of people some debugging time, when something like this does not work out of the box:

```
<% if asset.attachment.image? %>
  <%= image_tag(asset.attachment.variant(resize: '100x100') %>
<% end %>
```

I know, you can configure this on a per-app basis, but I think it would also be reasonable to have this in the default list.