### PR TITLE
Fix mounted engine url helpers path prefix inside renderer

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -90,7 +90,6 @@ module ActionController
       raise "missing controller" unless controller
 
       request = ActionDispatch::Request.new @env
-      request.routes = controller._routes
 
       instance = controller.new
       instance.set_request! request


### PR DESCRIPTION
When rendering via `Controller.render(...)` in a mounted engine url helpers missed engine path (as if engine was mounted at root)

This fixes #34452 
