### PR TITLE
Add support for WITH on index statements, primarily for Postgres fillfactor

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1145,7 +1145,7 @@ module ActiveRecord
       def add_index_options(table_name, column_name, comment: nil, **options) # :nodoc:
         column_names = index_column_names(column_name)
 
-        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :opclass)
+        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :opclass, :with)
 
         index_type = options[:type].to_s if options.key?(:type)
         index_type ||= options[:unique] ? "UNIQUE" : ""
@@ -1160,6 +1160,12 @@ module ActiveRecord
 
         using = "USING #{options[:using]}" if options[:using].present?
 
+        with = nil
+        if options[:with].present?
+          with_items = options[:with].map {|name, value| "#{name} = #{value}"}
+          with = "WITH #{with_items.join(',')}" 
+        end
+
         if supports_partial_index?
           index_options = options[:where] ? " WHERE #{options[:where]}" : ""
         end
@@ -1171,7 +1177,7 @@ module ActiveRecord
         end
         index_columns = quoted_columns_for_index(column_names, options).join(", ")
 
-        [index_name, index_type, index_columns, index_options, algorithm, using, comment]
+        [index_name, index_type, index_columns, index_options, algorithm, using, with, comment]
       end
 
       def options_include_default?(options)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -462,8 +462,8 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, options = {}) #:nodoc:
-          index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using, comment = add_index_options(table_name, column_name, options)
-          execute("CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}").tap do
+          index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using, index_with, comment = add_index_options(table_name, column_name, options)
+          execute("CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} #{index_with} (#{index_columns_and_opclasses})#{index_options}").tap do
             execute "COMMENT ON INDEX #{quote_column_name(index_name)} IS #{quote(comment)}" if comment
           end
         end


### PR DESCRIPTION
### Summary

Indexes often become fragmented in high-write-load tables. One solution to this is to rotate indexes frequently using something like `CREATE INDEX CONCURRENTLY new_index_name` followed by `DELETE INDEX old_index_name`, but this becomes a routine maintenance headache.

Building indexes with an initial fillfactor less than the default value (on Postgresql, 90%), means that there is room in the index pages to store additional values. This is something to be cautious about, because higher fillfactor indexes pack better into memory, but it might be something useful to tweak on occasion.

### Other Information

This pullrequest does not currently include documentation changes, I wanted to gather feedback about whether this change would be more broadly useful before investing too heavily into it.