### PR TITLE
Re-add changes_applied doc

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -141,7 +141,9 @@ module ActiveModel
       @mutations_from_database = nil
     end
 
-    def changes_applied # :nodoc:
+    # Clears dirty data and moves +changes+ to +previously_changed+ and
+    # +mutations_from_database+ to +mutations_before_last_save+ respectively.
+    def changes_applied
       unless defined?(@attributes)
         @previously_changed = changes
       end


### PR DESCRIPTION
### Summary

Re-adds `ActiveModel::Dirty#changes_applied` docs. Diffing documentation for this ([edge](https://edgeapi.rubyonrails.org/classes/ActiveModel/Dirty.html), [5.0](https://api.rubyonrails.org/v5.0/classes/ActiveModel/Dirty.html)), I can't see any other method missing. Did I miss one?

r? @rafaelfranca 
cc @matthewd 