### PR TITLE
Fix cache_versioning default note

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       # Indicates whether to use a stable #cache_key method that is accompanied
       # by a changing version in the #cache_version method.
       #
-      # This is +false+, by default until Rails 6.0.
+      # This is +true+, by default on Rails 5.2 and above.
       class_attribute :cache_versioning, instance_writer: false, default: false
     end
 


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/pull/34363, I was made aware that this is currently true for [5.2 onward](https://github.com/rails/rails/blob/5-2-0/railties/lib/rails/application/configuration.rb#L94). I think this note should be adjusted to reflect the actual version it is set to `true` for.

r? @rafaelfranca 