### PR TITLE
Fix typo and clarify documentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -89,10 +89,11 @@ module ActiveRecord
       # :singleton-method:
       # PostgreSQL allows the creation of "unlogged" tables, which do not record
       # data in the PostgreSQL Write-Ahead Log. This can make the tables faster,
-      # bug significantly increases the risk of data loss if the database
+      # but significantly increases the risk of data loss if the database
       # crashes. As a result, this should not be used in production
-      # environments. If you would like all created tables to be unlogged you
-      # can add the following line to your test.rb file:
+      # environments. If you would like all created tables to be unlogged in
+      # the test environment you can add the following line to your test.rb
+      # file:
       #
       #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = true
       class_attribute :create_unlogged_tables, default: false


### PR DESCRIPTION
### Summary

This commit fixes a small typo in documentation of the "UNLOGGED" table option for PostgreSQL databases (added in #34221), and clarifies the documentation slightly.

### Question

It just occurred to me that this might be something that should be added to a changelog. Let me know if so and I'll update this PR. If not, feel free to merge!