### PR TITLE
Redact SQL in errors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Move `ActiveRecord::StatementInvalid` SQL to error property and include binds as separate error property.
+
+    `ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class` now requires `binds` to be passed as the last argument.
+
+    `ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception` now requires `message`, `sql`, and `binds` to be passed as keyword arguments.
+
+    Subclasses of `ActiveRecord::StatementInvalid` must now provide `sql:` and `binds:` arguments to `super`.
+
+    Example:
+
+    ```
+    class MySubclassedError < ActiveRecord::StatementInvalid
+      def initialize(message, sql:, binds:)
+        super(message, sql: sql, binds: binds)
+      end
+    end
+    ```
+
+    *Gannon McGibbon*
+
 *   Add an `:if_not_exists` option to `create_table`.
 
     Example:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -529,18 +529,18 @@ module ActiveRecord
           @sqlite_version ||= SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)"))
         end
 
-        def translate_exception(exception, message)
+        def translate_exception(exception, message:, sql:, binds:)
           case exception.message
           # SQLite 3.8.2 returns a newly formatted error message:
           #   UNIQUE constraint failed: *table_name*.*column_name*
           # Older versions of SQLite return:
           #   column *column_name* is not unique
           when /column(s)? .* (is|are) not unique/, /UNIQUE constraint failed: .*/
-            RecordNotUnique.new(message)
+            RecordNotUnique.new(message, sql: sql, binds: binds)
           when /.* may not be NULL/, /NOT NULL constraint failed: .*/
-            NotNullViolation.new(message)
+            NotNullViolation.new(message, sql: sql, binds: binds)
           when /FOREIGN KEY constraint failed/i
-            InvalidForeignKey.new(message)
+            InvalidForeignKey.new(message, sql: sql, binds: binds)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -97,9 +97,13 @@ module ActiveRecord
   #
   # Wraps the underlying database error as +cause+.
   class StatementInvalid < ActiveRecordError
-    def initialize(message = nil)
+    def initialize(message = nil, sql: nil, binds: nil)
       super(message || $!.try(:message))
+      @sql = sql
+      @binds = binds
     end
+
+    attr_reader :sql, :binds
   end
 
   # Defunct wrapper class kept for compatibility.
@@ -118,7 +122,7 @@ module ActiveRecord
 
   # Raised when a foreign key constraint cannot be added because the column type does not match the referenced column type.
   class MismatchedForeignKey < StatementInvalid
-    def initialize(adapter = nil, message: nil, table: nil, foreign_key: nil, target_table: nil, primary_key: nil)
+    def initialize(adapter = nil, message: nil, sql: nil, binds: nil, table: nil, foreign_key: nil, target_table: nil, primary_key: nil)
       @adapter = adapter
       if table
         msg = +<<~EOM
@@ -135,7 +139,7 @@ module ActiveRecord
       if message
         msg << "\nOriginal message: #{message}"
       end
-      super(msg)
+      super(msg, sql: sql, binds: binds)
     end
 
     private

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -286,18 +286,6 @@ module ActiveRecord
       assert_equal "special_db_type", @connection.type_to_sql(:special_db_type)
     end
 
-    unless current_adapter?(:PostgreSQLAdapter)
-      def test_log_invalid_encoding
-        error = assert_raises RuntimeError do
-          @connection.send :log, "SELECT 'ы' FROM DUAL" do
-            raise (+"ы").force_encoding(Encoding::ASCII_8BIT)
-          end
-        end
-
-        assert_equal "ы", error.message
-      end
-    end
-
     def test_supports_multi_insert_is_deprecated
       assert_deprecated { @connection.supports_multi_insert? }
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -218,8 +218,8 @@ class CalculationsTest < ActiveRecord::TestCase
       Account.select("credit_limit, firm_name").count
     }
 
-    assert_match %r{accounts}i, e.message
-    assert_match "credit_limit, firm_name", e.message
+    assert_match %r{accounts}i, e.sql
+    assert_match "credit_limit, firm_name", e.sql
   end
 
   def test_apply_distinct_in_count

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/book"
+
+module ActiveRecord
+  class StatementInvalidTest < ActiveRecord::TestCase
+    fixtures :books
+
+    class MockDatabaseError < StandardError
+      def result
+        0
+      end
+
+      def error_number
+        0
+      end
+    end
+
+    test "message contains no sql" do
+      sql = Book.where(author_id: 96, cover: "hard").to_sql
+      error = assert_raises(ActiveRecord::StatementInvalid) do
+        Book.connection.send(:log, sql, Book.name) do
+          raise MockDatabaseError
+        end
+      end
+      assert_not error.message.include?("SELECT")
+    end
+
+    test "statement and binds are set on select" do
+      sql = Book.where(author_id: 96, cover: "hard").to_sql
+      binds = [Minitest::Mock.new, Minitest::Mock.new]
+      error = assert_raises(ActiveRecord::StatementInvalid) do
+        Book.connection.send(:log, sql, Book.name, binds) do
+          raise MockDatabaseError
+        end
+      end
+      assert_equal error.sql, sql
+      assert_equal error.binds, binds
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34316.

Allows redaction of SQL in translated SQL errors with `config.active_record.redacted_sql_errors = true`. I'm not a regex pro, so I think there's room for improvement on both expressions. Also, now that we don't use mocha, what's the best way to mock initializer that raises an error?

r? @rafaelfranca 
