### PR TITLE
Load target on collection proxy finders

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow position finder methods invoked from collection proxies to load the association's target early.
+
+    *Gannon McGibbon*
+
 *   Add an `:if_not_exists` option to `create_table`.
 
     Example:

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -140,12 +140,6 @@ module ActiveRecord
         @association.find(*args)
       end
 
-      ##
-      # :method: first
-      #
-      # :call-seq:
-      #   first(limit = nil)
-      #
       # Returns the first record, or the first +n+ records, from the collection.
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.
@@ -172,63 +166,53 @@ module ActiveRecord
       #   another_person_without.pets          # => []
       #   another_person_without.pets.first    # => nil
       #   another_person_without.pets.first(3) # => []
+      def first(limit = nil)
+        load_target
+        super
+      end
 
-      ##
-      # :method: second
-      #
-      # :call-seq:
-      #   second()
-      #
       # Same as #first except returns only the second record.
+      def second
+        load_target
+        super
+      end
 
-      ##
-      # :method: third
-      #
-      # :call-seq:
-      #   third()
-      #
       # Same as #first except returns only the third record.
+      def third
+        load_target
+        super
+      end
 
-      ##
-      # :method: fourth
-      #
-      # :call-seq:
-      #   fourth()
-      #
       # Same as #first except returns only the fourth record.
+      def fourth
+        load_target
+        super
+      end
 
-      ##
-      # :method: fifth
-      #
-      # :call-seq:
-      #   fifth()
-      #
       # Same as #first except returns only the fifth record.
+      def fifth
+        load_target
+        super
+      end
 
-      ##
-      # :method: forty_two
-      #
-      # :call-seq:
-      #   forty_two()
-      #
       # Same as #first except returns only the forty second record.
       # Also known as accessing "the reddit".
+      def fourty_two
+        load_target
+        super
+      end
 
-      ##
-      # :method: third_to_last
-      #
-      # :call-seq:
-      #   third_to_last()
-      #
       # Same as #first except returns only the third-to-last record.
+      def third_to_last
+        load_target
+        super
+      end
 
-      ##
-      # :method: second_to_last
-      #
-      # :call-seq:
-      #   second_to_last()
-      #
       # Same as #first except returns only the second-to-last record.
+      def second_to_last
+        load_target
+        super
+      end
 
       # Returns the last record, or the last +n+ records, from the collection.
       # If the collection is empty, the first form returns +nil+, and the second
@@ -257,7 +241,7 @@ module ActiveRecord
       #   another_person_without.pets.last    # => nil
       #   another_person_without.pets.last(3) # => []
       def last(limit = nil)
-        load_target if find_from_target?
+        load_target
         super
       end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -367,7 +367,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate devel.projects, :loaded?
 
     assert_equal devel.projects.last, proj
-    assert_not_predicate devel.projects, :loaded?
+    assert_predicate devel.projects, :loaded?
 
     assert_predicate proj, :persisted?
     assert_equal Developer.find(1).projects.sort_by(&:id).last, proj  # prove join table is updated

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -801,8 +801,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     original_object = collection.first
     assert_same original_object, collection.first, "Expected second call to #first to cache the same object"
 
-    # It should return a different object, since the association has been reloaded
-    assert_not_same original_object, firm.clients.first, "Expected #first to return a new object"
+    # It should return a the same object, since the association has been loaded on the model
+    assert_same original_object, firm.clients.first, "Expected #first to return same object"
   end
 
   def test_find_first_after_reset
@@ -2038,12 +2038,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal false, firm.clients.include?(client)
   end
 
-  def test_calling_first_nth_or_last_on_association_should_not_load_association
+  def test_calling_first_nth_or_last_on_association_should_load_association
     firm = companies(:first_firm)
     firm.clients.first
     firm.clients.second
     firm.clients.last
-    assert_not_predicate firm.clients, :loaded?
+    assert_predicate firm.clients, :loaded?
   end
 
   def test_calling_first_or_last_on_loaded_association_should_not_fetch_with_query
@@ -2073,18 +2073,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_predicate firm.clients, :loaded?
   end
 
-  def test_calling_first_nth_or_last_on_existing_record_with_create_should_not_load_association
+  def test_calling_first_nth_or_last_on_existing_record_with_create_should_load_association
     firm = companies(:first_firm)
     firm.clients.create(name: "Foo")
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries 3 do
+    assert_queries 1 do
       firm.clients.first
       firm.clients.second
       firm.clients.last
     end
 
-    assert_not_predicate firm.clients, :loaded?
+    assert_predicate firm.clients, :loaded?
   end
 
   def test_calling_first_nth_or_last_on_new_record_should_not_run_queries
@@ -2097,17 +2097,17 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_calling_first_or_last_with_integer_on_association_should_not_load_association
+  def test_calling_first_or_last_with_integer_on_association_should_load_association
     firm = companies(:first_firm)
     firm.clients.create(name: "Foo")
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries 2 do
+    assert_queries 1 do
       firm.clients.first(2)
       firm.clients.last(2)
     end
 
-    assert_not_predicate firm.clients, :loaded?
+    assert_predicate firm.clients, :loaded?
   end
 
   def test_calling_many_should_count_instead_of_loading_association


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/34460.

I find the behaviour of `record.assoc_records.first` misleading. I'm not sure why, but I had always thought that positional finder methods (`first`,  `second`, `third`, etc.) loaded the collection proxy target, but they don't. The linked issue expects the opposite behaviour, and there's a bug in that it is not responding to `#loaded?` properly if you call `#first` and the collection has at least one record in it.

This might be a bad idea, and I might be trampling on performance optimization, but I want to know what others think of this approach.

r? @rafaelfranca 
