### PR TITLE
Add to_bool behaviour to String, Integer, Float, Array, Hash, TrueClass, FalseClass and NilClass

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -289,4 +289,10 @@
     *Eileen M. Uchitelle*, *Aaron Patterson*
 
 
+*   Adds `.to_bool` behaviour to String, Integer, Float, Array, Hash, TrueClass, FalseClass and NilClass.
+
+    Parallelize your test suite with forked processes or threads.
+
+    *André Leoni*
+
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -29,6 +29,7 @@ require "active_support/version"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/core_ext/object/to_boolean"
 
 module ActiveSupport
   extend ActiveSupport::Autoload

--- a/activesupport/lib/active_support/core_ext/object/to_boolean.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_boolean.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ToBoolean
+  # Returns a boolean value, according the Object type and value.
+  # Uses the active model role to define the result
+  #
+  def to_bool
+    return false unless self
+    ActiveModel::Type::Boolean.new.cast(self)
+  end
+end
+
+# Add the to_bool behaviour to all the follow classes:
+#
+class String; include ToBoolean; end
+class Integer; include ToBoolean; end
+class Float; include ToBoolean; end
+class Array; include ToBoolean; end
+class Hash; include ToBoolean; end
+class TrueClass; include ToBoolean; end
+class FalseClass; include ToBoolean; end
+class NilClass; include ToBoolean; end

--- a/activesupport/test/core_ext/object/to_boolean_test.rb
+++ b/activesupport/test/core_ext/object/to_boolean_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/object/inclusion"
+
+class ToBoolean < ActiveSupport::TestCase
+  def test_object_to_b
+    assert true.to_bool
+    assert 1.to_bool
+    assert "1".to_bool
+    assert "t".to_bool
+    assert "T".to_bool
+    assert "true".to_bool
+    assert "TRUE".to_bool
+    assert "on".to_bool
+    assert "ON".to_bool
+    assert " ".to_bool
+    assert "\u3000\r\n".to_bool
+    assert "\u0000".to_bool
+    assert "SOMETHING RANDOM".to_bool
+
+    # explicitly check for false vs nil
+    assert_equal false, "".to_bool
+    assert_equal false, nil.to_bool
+    assert_equal false, false.to_bool
+    assert_equal false, 0.to_bool
+    assert_equal false, "0".to_bool
+    assert_equal false, "f".to_bool
+    assert_equal false, "F".to_bool
+    assert_equal false, "false".to_bool
+    assert_equal false, "FALSE".to_bool
+    assert_equal false, "off".to_bool
+    assert_equal false, "OFF".to_bool
+  end
+end


### PR DESCRIPTION
First of all, sorry because of my bad english, and secondly, this is my first Rails commit, sorry if any wrong. Concluding: I'm very happy by contribute!

### Summary

Added `to_bool` behaviour to String, Integer, Float, Array, Hash, TrueClass, FalseClass and NilClass.

The behaviour was used with the `ActiveModel::Type::Boolean` as base class.
