### PR TITLE
Don't raise a dirty record exception if locking is turned off

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       # the locked record.
       def lock!(lock = true)
         if persisted?
-          if has_changes_to_save?
+          if lock && has_changes_to_save?
             raise(<<-MSG.squish)
               Locking a record with unpersisted changes is not supported. Use
               `save` to persist the changes, or `reload` to discard them

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -660,6 +660,14 @@ unless in_memory_db?
       end
     end
 
+    def test_lock_does_not_raise_if_record_is_dirty_and_lock_false
+      person = Person.find 1
+      person.first_name = "fooman"
+      assert_nothing_raised do
+        person.lock!(false)
+      end
+    end
+
     def test_locking_in_after_save_callback
       assert_nothing_raised do
         frog = ::Frog.create(name: "Old Frog")


### PR DESCRIPTION
### Summary

If you call `lock!(false)` on a dirty record, you'll still get the "unpersisted changes" exception even though the record won't actually get locked and reloaded.

`lock!` now checks if the `lock` argument is truthy before checking for changes and raising an exception.

### Other Information

Recently, I ran into this situation, and was surprised to get the exception even though I had short-circuited the locking mechanism via `lock!(false)`. This seemed like a bug to me, so here's a fix w/ an accompanying test!