### PR TITLE
Correctly handle unknown object in parallel tests

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -15,6 +15,8 @@ module ActiveSupport
         end
 
         def record(reporter, result)
+          raise DRb::DRbConnError if result.is_a?(DRb::DRbUnknown)
+
           reporter.synchronize do
             reporter.record(result)
           end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -586,6 +586,20 @@ module ApplicationTests
       assert_match "1 runs, 0 assertions, 0 failures, 1 errors", output
     end
 
+    def test_run_in_parallel_with_unknown_object
+      create_scaffold
+      app_file "config/environments/test.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_controller.allow_forgery_protection = true
+          config.action_dispatch.show_exceptions = false
+        end
+      RUBY
+
+      output = run_test_command("-n test_should_create_user")
+
+      assert_match "ActionController::InvalidAuthenticityToken", output
+    end
+
     def test_raise_error_when_specified_file_does_not_exist
       error = capture(:stderr) { run_test_command("test/not_exists.rb", stderr: true) }
       assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)


### PR DESCRIPTION
DRb wraps in `DRbUnknown` if the data contains a type that can not be resolved locally. 
This can happen if an error occurs in the test and the error class can not be resolved on the server side.

When this happens, an instance of `DRbUnknown` is passed to the `result` of `Server#record`. This causes another error(undefined method assertions for #<DRb::DRbUnknown:> (NoMethodError)) in `reporter.record`.
This can confirm by the following steps.

```
$ rails new app -B --dev; cd app
$ rails g scaffold user name:string
$ edit `config.action_controller.allow_forgery_protection = true` in environments/test.rb
$ bin/rails t
```

In the case of `DRbUnknown` occurs, can't resolve error exception. So wrap exception with `DRbRemoteError` in the same way as an unmarshalled object.
