### PR TITLE
Make it possible to override the implicit order column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Make the implicit order column configurable.
+
+    When calling ordered finder methods such as +first+ or +last+ without an
+    explicit order clause, ActiveRecord sorts records by primary key. This can
+    result in unpredictable and surprising behaviour when the primary key is
+    not an auto-incrementing integer, for example when it's a UUID. This change
+    makes it possible to override the column used for implicit ordering such
+    that +first+ and +last+ will return more predictable results.
+
+    Example:
+
+        class Project < ActiveRecord::Base
+          self.implicit_order_column = "created_at"
+        end
+
+    *Tekin Suleyman*
+
 *   Bump minimum PostgreSQL version to 9.3.
 
     *Yasuo Honda*

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -102,6 +102,21 @@ module ActiveRecord
     # If true, the default table name for a Product class will be "products". If false, it would just be "product".
     # See table_name for the full rules on table/class naming. This is true, by default.
 
+    ##
+    # :singleton-method: implicit_order_column
+    # :call-seq: implicit_order_column
+    #
+    # The name of the column records are ordered by if no explicit order clause
+    # is used during an ordered finder call. If not set the primary key is used.
+
+    ##
+    # :singleton-method: implicit_order_column=
+    # :call-seq: implicit_order_column=(column_name)
+    #
+    # Sets the column to sort records by when no explicit order clause is used
+    # during an ordered finder call. Useful when the primary key is not an
+    # auto-incrementing integer, for example when it's a UUID. Note that using
+    # a non-unique column can result in non-deterministic results.
     included do
       mattr_accessor :primary_key_prefix_type, instance_writer: false
 
@@ -110,6 +125,7 @@ module ActiveRecord
       class_attribute :schema_migrations_table_name, instance_accessor: false, default: "schema_migrations"
       class_attribute :internal_metadata_table_name, instance_accessor: false, default: "ar_internal_metadata"
       class_attribute :pluralize_table_names, instance_writer: false, default: true
+      class_attribute :implicit_order_column, instance_accessor: false
 
       self.protected_environments = ["production"]
       self.inheritance_column = "type"

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -550,8 +550,8 @@ module ActiveRecord
       end
 
       def ordered_relation
-        if order_values.empty? && primary_key
-          order(arel_attribute(primary_key).asc)
+        if order_values.empty? && (implicit_order_column || primary_key)
+          order(arel_attribute(implicit_order_column || primary_key).asc)
         else
           self
         end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -741,6 +741,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, clients.limit(5).first(2)
   end
 
+  def test_implicit_order_column_is_configurable
+    old_implicit_order_column = Topic.implicit_order_column
+    Topic.implicit_order_column = "title"
+
+    assert_equal topics(:fifth), Topic.first
+    assert_equal topics(:third), Topic.last
+  ensure
+    Topic.implicit_order_column = old_implicit_order_column
+  end
+
   def test_take_and_first_and_last_with_integer_should_return_an_array
     assert_kind_of Array, Topic.take(5)
     assert_kind_of Array, Topic.first(5)


### PR DESCRIPTION
When calling ordered finder methods such as `first` or `last` without an explicit order clause, ActiveRecord sorts records by primary key. This can result in unpredictable and surprising behaviour when the primary key is not an an auto-incrementing integer, for example when it's a UUID. This change makes it possible to override the column used for implicit ordering such that `first` and `last` will return more predictable results.

Example:

```ruby
  class Project < ActiveRecord::Base
    self.implicit_order_column = "created_at"
  end
```

This takes a different approach to https://github.com/rails/rails/pull/34236, which automatically switches to using `created_at` if the primary key is a UUID and a `created_at` column exists.