### PR TITLE
Add comments to markdown templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,13 +1,12 @@
 ### Steps to reproduce
-
-(Guidelines for creating a bug report are [available
-here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report))
+<!-- (Guidelines for creating a bug report are [available
+here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->
 
 ### Expected behavior
-Tell us what should happen
+<!-- Tell us what should happen -->
 
 ### Actual behavior
-Tell us what happens instead
+<!-- Tell us what happens instead -->
 
 ### System configuration
 **Rails version**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 ### Summary
 
-Provide a general description of the code changes in your pull
+<!-- Provide a general description of the code changes in your pull
 request... were there any bugs you had fixed? If so, mention them. If
 these bugs have open GitHub issues, be sure to tag them here as well,
-to keep the conversation linked together.
+to keep the conversation linked together. -->
 
 ### Other Information
 
-If there's anything else that's important and relevant to your pull
+<!-- If there's anything else that's important and relevant to your pull
 request, mention that information here. This could include
 benchmarks, or other information.
 
@@ -18,4 +18,4 @@ Finally, if your pull request affects documentation or any non-code
 changes, guidelines for those changes are [available
 here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
 
-Thanks for contributing to Rails!
+Thanks for contributing to Rails! -->


### PR DESCRIPTION
### Summary

Added comments to the areas of text that will be deleted from templates anyway.

### Other Information

This is a practice I have seen in a handful of repos, and personally find it convenient.
