### PR TITLE
allow right to left styling of docs

### DIFF
--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -1,0 +1,762 @@
+/* Guides.rubyonrails.org */
+/* Main.css */
+/* Created January 30, 2009 */
+/* Modified February 8, 2009
+--------------------------------------- */
+
+/* General
+--------------------------------------- */
+
+.right {float: right; margin-left: 1em;}
+.left {float: left; margin-right: 1em;}
+@media screen and (max-width: 480px) {
+  .right, .left { float: none; }
+}
+.small {font-size: smaller;}
+.large {font-size: larger;}
+.hide {display: none;}
+
+ul, ol { margin: 0 1.5em 1.5em 1.5em; }
+
+ul { list-style-type: disc; }
+ol { list-style-type: decimal; }
+
+dl { margin: 0 0 1.5em 0; }
+dl dt { font-weight: bold; }
+dd { margin-right: 1.5em;}
+
+pre, code {
+  font-size: 1em;
+  font-family: "Anonymous Pro", "Inconsolata", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+  line-height: 1.5;
+  margin: 1.5em 0;
+  overflow: auto;
+  color: #222;
+}
+
+p code {
+  background: #eee;
+  border-radius: 2px;
+  padding: 1px 3px;
+}
+
+pre, tt, code {
+ white-space: pre-wrap;       /* css-3 */
+ white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+ white-space: -pre-wrap;      /* Opera 4-6 */
+ white-space: -o-pre-wrap;    /* Opera 7 */
+ word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+
+abbr, acronym { border-bottom: 1px dotted #666; }
+address { margin: 0 0 1.5em; font-style: italic; }
+del { color:#666; }
+
+blockquote { margin: 1.5em; color: #666; font-style: italic; }
+strong { font-weight: bold; }
+em, dfn { font-style: italic; }
+dfn { font-weight: bold; }
+sup, sub { line-height: 0; }
+p {margin: 0 0 1.5em;}
+
+label { font-weight: bold; }
+fieldset { padding:1.4em; margin: 0 0 1.5em 0; border: 1px solid #ccc; }
+legend { font-weight: bold; font-size:1.2em; }
+
+input.text, input.title,
+textarea, select {
+  margin:0.5em 0;
+  border:1px solid #bbb;
+}
+
+table {
+  margin: 0 0 1.5em;
+  border: 2px solid #CCC;
+  background: #FFF;
+  border-collapse: collapse;
+}
+
+table th, table td {
+  padding: 9px 10px;
+  border: 1px solid #CCC;
+  border-collapse: collapse;
+}
+
+table th {
+  border-bottom: 2px solid #CCC;
+  background: #EEE;
+  font-weight: bold;
+}
+
+img {
+  max-width: 100%;
+}
+
+
+/* Structure and Layout
+--------------------------------------- */
+
+body {
+  text-align: center;
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 87.5%;
+  line-height: 1.5em;
+  background: #fff;
+  color: #999;
+  direction: rtl;
+}
+
+.wrapper {
+  text-align: right;
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 0 1em;
+}
+
+.red-button {
+  display: inline-block;
+  border-top: 1px solid rgba(255,255,255,.5);
+  background: #751913;
+  background: -webkit-gradient(linear, right top, right bottom, from(#c52f24), to(#751913));
+  background: -webkit-linear-gradient(top, #c52f24, #751913);
+  background: -moz-linear-gradient(top, #c52f24, #751913);
+  background: -ms-linear-gradient(top, #c52f24, #751913);
+  background: -o-linear-gradient(top, #c52f24, #751913);
+  padding: 9px 18px;
+  -webkit-border-radius: 11px;
+  -moz-border-radius: 11px;
+  border-radius: 11px;
+  -webkit-box-shadow: rgba(0,0,0,1) 0 1px 0;
+  -moz-box-shadow: rgba(0,0,0,1) 0 1px 0;
+  box-shadow: rgba(0,0,0,1) 0 1px 0;
+  text-shadow: rgba(0,0,0,.4) 0 1px 0;
+  color: white;
+  font-size: 15px;
+  font-family: Helvetica, Arial, Sans-Serif;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+}
+.red-button:active {
+  border-top: none;
+  padding-top: 10px;
+  background: -webkit-gradient(linear, right top, right bottom, from(#751913), to(#c52f24));
+  background: -webkit-linear-gradient(top, #751913, #c52f24);
+  background: -moz-linear-gradient(top, #751913, #c52f24);
+  background: -ms-linear-gradient(top, #751913, #c52f24);
+  background: -o-linear-gradient(top, #751913, #c52f24);
+}
+
+#topNav {
+  padding: 1em 0;
+  color: #565656;
+  background: #222;
+}
+
+.s-hidden {
+  display: none;
+}
+
+@media screen and (min-width: 1025px) {
+  .more-info-button {
+    display: none;
+  }
+  .more-info-links {
+    list-style: none;
+    display: inline;
+    margin: 0;
+  }
+
+  .more-info {
+    display: inline-block;
+  }
+  .more-info:after {
+    content: " |";
+  }
+
+  .more-info:last-child:after {
+    content: "";
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  #topNav .wrapper { text-align: center; }
+  .more-info-button {
+    position: relative;
+    z-index: 25;
+  }
+
+  .more-info-label {
+    display: none;
+  }
+
+  .more-info-container {
+    position: absolute;
+    top: .5em;
+    z-index: 20;
+    margin: 0 auto;
+    right: 0;
+    left: 0;
+    width: 20em;
+  }
+
+  .more-info-links {
+    display: block;
+    list-style: none;
+    background-color: #c52f24;
+    border-radius: 5px;
+    padding-top: 5.25em;
+    border: 1px #980905 solid;
+  }
+  .more-info-links.s-hidden {
+    display: none;
+  }
+  .more-info {
+    padding: .75em;
+    border-top: 1px #980905 solid;
+  }
+  .more-info a, .more-info a:link, .more-info a:visited {
+    display: block;
+    color: white;
+    width: 100%;
+    height: 100%;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+}
+
+#header {
+  background: #c52f24 url(../images/header_tile.gif) repeat-x;
+  color: #FFF;
+  padding: 1.5em 0;
+  z-index: 99;
+}
+
+#feature {
+  background: #d5e9f6 url(../images/feature_tile.gif) repeat-x;
+  color: #333;
+  padding: 0.5em 0 1.5em;
+}
+
+#container {
+  color: #333;
+  padding: 0.5em 0 1.5em 0;
+}
+
+#mainCol {
+  max-width: 630px;
+  margin-right: 2em;
+}
+
+#subCol {
+  position: absolute;
+  z-index: 0;
+  top: 21px;
+  left: 0;
+  background: #FFF;
+  padding: 1em 1.5em 1em 1.25em;
+  width: 17em;
+  font-size: 0.9285em;
+  line-height: 1.3846em;
+  margin-left: 1em;
+}
+
+
+@media screen and (max-width: 800px) {
+  #subCol {
+    position: static;
+    width: inherit;
+    margin-right: -1em;
+    margin-left: 0;
+    padding-left: 1.25em;
+  }
+}
+
+#footer {
+  padding: 2em 0;
+  background: #222 url(../images/footer_tile.gif) repeat-x;
+}
+#footer .wrapper {
+  padding-right: 1em;
+  max-width: 960px;
+}
+
+#header .wrapper, #topNav .wrapper, #feature .wrapper {padding-right: 1em; max-width: 960px;}
+#feature .wrapper {max-width: 640px; padding-left: 23em; position: relative; z-index: 0;}
+
+@media screen and (max-width: 960px) {
+  #container .wrapper { padding-left: 23em; }
+}
+
+@media screen and (max-width: 800px) {
+  #feature .wrapper, #container .wrapper { padding-left: 0; }
+}
+
+/* Links
+--------------------------------------- */
+
+a, a:link, a:visited {
+  color: #ee3f3f;
+  text-decoration: underline;
+}
+
+#mainCol a, #subCol a, #feature a {color: #980905;}
+#mainCol a code, #subCol a code, #feature a code {color: #980905;}
+
+#mainCol a.anchorlink, #mainCol a.anchorlink code {color: #333;}
+#mainCol a.anchorlink { text-decoration: none; }
+#mainCol a.anchorlink:hover { text-decoration: underline; }
+
+/* Navigation
+--------------------------------------- */
+
+.nav {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  float: left;
+  margin-top: 1.5em;
+  font-size: 1.2857em;
+}
+
+.nav .nav-item {color: #FFF; text-decoration: none;}
+.nav .nav-item:hover {text-decoration: underline;}
+
+.guides-index-large, .guides-index-small .guides-index-item {
+  padding: 0.5em 1.5em;
+  border-radius: 1em;
+  -webkit-border-radius: 1em;
+  -moz-border-radius: 1em;
+  background: #980905;
+  position: relative;
+  color: white;
+}
+
+.guides-index .guides-index-item {
+  background: #980905 url(../images/nav_arrow.gif) no-repeat left top;
+  padding-left: 1em;
+  position: relative;
+  z-index: 15;
+  padding-bottom: 0.125em;
+}
+
+.guides-index:hover .guides-index-item, .guides-index .guides-index-item:hover {
+  background-position: left -81px;
+  text-decoration: underline !important;
+}
+
+@media screen and (min-width: 481px) {
+  .nav {
+    float: left;
+    margin-top: 1.5em;
+    font-size: 1.2857em;
+  }
+  .nav>li {
+    display: inline;
+    margin-right: 0.5em;
+  }
+  .guides-index.guides-index-small {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .nav {
+    float: none;
+    width: 100%;
+    text-align: center;
+  }
+  .nav .nav-item {
+    display: block;
+    margin: 0;
+    width: 100%;
+    background-color: #980905;
+    border: solid 1px #620c04;
+    border-top: 0;
+    padding: 15px 0;
+    text-align: center;
+  }
+  .nav .nav-item, .nav-item.guides-index-item {
+    text-transform: uppercase;
+  }
+  .nav .nav-item:first-child, .nav-item.guides-index-small {
+    border-top: solid 1px #620c04;
+  }
+  .guides-index.guides-index-small {
+    display: block;
+    margin-top: 1.5em;
+  }
+  .guides-index.guides-index-large {
+    display: none;
+  }
+  .guides-index-small .guides-index-item {
+    font: inherit;
+    padding-right: .75em;
+    font-size: .95em;
+    background-position: 96% 16px;
+    -webkit-appearance: none;
+  }
+  .guides-index-small .guides-index-item:hover{
+    background-position: 96% -65px;
+  }
+}
+
+#guides {
+  width: 37em;
+  display: block;
+  background: #980905;
+  border-radius: 1em;
+  color: #f1938c;
+  padding: 1.5em 2em;
+  position: absolute;
+  z-index: 10;
+  top: -0.25em;
+  left: 0;
+  padding-top: 2em;
+}
+
+#guides.visible {
+  display: block !important;
+}
+
+.guides-section dt, .guides-section dd {
+  font-weight: normal;
+  font-size: 0.722em;
+  margin: 0;
+  padding: 0;
+}
+.guides-section dt {
+  margin: 0.5em 0 0;
+  padding:0;
+}
+#guides a {
+  background: none !important;
+  color: #FFF;
+  text-decoration: none;
+}
+#guides a:hover {
+  text-decoration: underline;
+}
+.guides-section-container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  width: 100%;
+  max-height: 35em;
+}
+
+.guides-section {
+  min-width: 5em;
+  margin: 0 2em 0.5em 0;
+  flex: auto;
+  max-width: 12em;
+}
+
+.guides-section dd {
+  line-height: 1.3;
+  margin-bottom: 0.5em;
+}
+
+#guides hr {
+  display: block;
+  border: none;
+  height: 1px;
+  color: #f1938c;
+  background: #f1938c;
+}
+
+/* Headings
+--------------------------------------- */
+
+h1 {
+  font-size: 2.5em;
+  line-height: 1em;
+  margin: 0.6em 0 .2em;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 2.1428em;
+  line-height: 1em;
+  margin: 0.7em 0 .2333em;
+  font-weight: bold;
+}
+
+@media screen and (max-width: 480px) {
+  h2 {
+    font-size: 1.45em;
+  }
+}
+
+h3 {
+  font-size: 1.7142em;
+  line-height: 1.286em;
+  margin: 0.875em 0 0.2916em;
+  font-weight: bold;
+}
+
+@media screen and (max-width: 480px) {
+  h3 {
+    font-size: 1.45em;
+  }
+}
+
+h4 {
+  font-size: 1.2857em;
+  line-height: 1.2em;
+  margin: 1.6667em 0 .3887em;
+  font-weight: bold;
+}
+
+h5 {
+  font-size: 1em;
+  line-height: 1.5em;
+  margin: 1em 0 .5em;
+  font-weight: bold;
+}
+
+h6 {
+  font-size: 1em;
+  line-height: 1.5em;
+  margin: 1em 0 .5em;
+  font-weight: normal;
+}
+
+.section {
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid #999;
+}
+
+/* Content
+--------------------------------------- */
+
+.pic {
+  margin: 0 2em 2em 0;
+}
+
+#topNav strong {color: #999; margin-left: 0.5em;}
+#topNav strong a {color: #FFF;}
+
+#header h1 {
+  float: right;
+  background: url(../images/rails_guides_logo_1x.png) no-repeat;
+  width: 297px;
+  text-indent: -9999em;
+  margin: 0;
+  padding: 0;
+}
+
+@media
+only screen and (-webkit-min-device-pixel-ratio: 2),
+only screen and (   min--moz-device-pixel-ratio: 2),
+only screen and (     -o-min-device-pixel-ratio: 2/1),
+only screen and (        min-device-pixel-ratio: 2),
+only screen and (                min-resolution: 192dpi),
+only screen and (                min-resolution: 2dppx) {
+  #header h1 {
+    background: url(../images/rails_guides_logo_2x.png) no-repeat;
+    background-size: 160%;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  #header h1 {
+    float: none;
+  }
+}
+
+#header h1 a {
+  text-decoration: none;
+  display: block;
+  height: 77px;
+}
+
+#feature p {
+  font-size: 1.2857em;
+  margin-bottom: 0.75em;
+}
+
+@media screen and (max-width: 480px) {
+  #feature p {
+    font-size: 1em;
+  }
+}
+
+#feature ul {margin-right: 0;}
+#feature ul li {
+  list-style: none;
+  background: url(../images/check_bullet.gif) no-repeat right 0.5em;
+  padding: 0.5em 1.75em 0.5em 1.75em;
+  font-size: 1.1428em;
+  font-weight: bold;
+}
+
+#mainCol dd, #subCol dd {
+  padding: 0.25em 0 1em;
+  border-bottom: 1px solid #CCC;
+  margin-bottom: 1em;
+  margin-right: 0;
+  /*padding-right: 28px;*/
+  padding-right: 0;
+}
+
+#mainCol dt, #subCol dt {
+  font-size: 1.2857em;
+  padding: 0.125em 0 0.25em 0;
+  margin-bottom: 0;
+}
+
+@media screen and (max-width: 480px) {
+  #mainCol dt, #subCol dt {
+    font-size: 1em;
+  }
+}
+
+#mainCol dd.work-in-progress, #subCol dd.work-in-progress {
+  background: #fff9d8 url(../images/tab_yellow.gif) no-repeat left top;
+  border: none;
+  padding: 1.25em 1em 1.25em 48px;
+  margin-right: 0;
+  margin-top: 0.25em;
+}
+
+#mainCol dd.kindle, #subCol dd.kindle {
+  background: #d5e9f6 url(../images/tab_info.gif) no-repeat left top;
+  border: none;
+  padding: 1.25em 1em 1.25em 48px;
+  margin-right: 0;
+  margin-top: 0.25em;
+}
+
+#mainCol div.warning, #subCol dd.warning {
+  background: #f9d9d8 url(../images/tab_red.gif) no-repeat left top;
+  border: none;
+  padding: 1.25em 1.25em 0.25em 48px;
+  margin-right: 0;
+  margin-top: 0.25em;
+}
+
+#subCol .chapters {color: #980905;}
+#subCol .chapters a {font-weight: bold;}
+#subCol .chapters ul a {font-weight: normal;}
+#subCol .chapters li {margin-bottom: 0.75em;}
+#subCol h3.chapter {margin-top: 0.25em;}
+#subCol h3.chapter img {vertical-align: text-bottom;}
+#subCol .chapters ul {margin-right: 0; margin-top: 0.5em;}
+#subCol .chapters ul li {
+  list-style: none;
+  padding: 0 1em 0 0;
+  background: url(../images/bullet.gif) no-repeat right 0.45em;
+  margin-right: 0;
+  font-size: 1em;
+  font-weight: normal;
+}
+
+#subCol li ul, li ol { margin:0 1.5em; }
+
+div.code_container {
+  background: #EEE url(../images/tab_grey.gif) no-repeat right top;
+  padding: 0.25em 48px 0.5em 1em;
+}
+
+.note {
+  background: #fff9d8 url(../images/tab_note.gif) no-repeat right top;
+  border: none;
+  padding: 1em 48px 0.25em 1em;
+  margin: 0.25em 0 1.5em 0;
+}
+
+.info {
+  background: #d5e9f6 url(../images/tab_info.gif) no-repeat right top;
+  border: none;
+  padding: 1em 48px 0.25em 1em;
+  margin: 0.25em 0 1.5em 0;
+}
+
+#mainCol div.todo {
+  background: #fff9d8 url(../images/tab_yellow.gif) no-repeat right top;
+  border: none;
+  padding: 1em 48px 0.25em 1em;
+  margin: 0.25em 0 1.5em 0;
+}
+
+.note code, .info code, .todo code {
+  background: #fff;
+}
+
+#mainCol ul li {
+  list-style:none;
+  background: url(../images/grey_bullet.gif) no-repeat right 0.5em;
+  padding-right: 1em;
+  margin-right: 0;
+}
+
+#subCol .content {
+  font-size: 0.7857em;
+  line-height: 1.5em;
+}
+
+#subCol .content li {
+  font-weight: normal;
+  background: none;
+  padding: 0 0 1em;
+  font-size: 1.1667em;
+}
+
+/* Clearing
+--------------------------------------- */
+
+.clearfix:after {
+  content: ".";
+  display: block;
+  height: 0;
+  clear: both;
+  visibility: hidden;
+}
+
+* html .clearfix {height: 1%;}
+.clearfix {display: block;}
+
+/* Same bottom margin for special boxes than for regular paragraphs, this way
+intermediate whitespace looks uniform. */
+div.code_container, div.important, div.caution, div.warning, div.note, div.info {
+  margin-bottom: 1.5em;
+}
+
+/* Remove bottom margin of paragraphs in special boxes, otherwise they get a
+spurious blank area below with the box background. */
+div.important p, div.caution p, div.warning p, div.note p, div.info p {
+  margin-bottom: 1em;
+}
+
+/* Edge Badge
+--------------------------------------- */
+
+#edge-badge {
+  position: fixed;
+  right: 0px;
+  top: 0px;
+  z-index: 100;
+  border: none;
+}
+
+/* Foundation v2.1.4 http://foundation.zurb.com */
+/* Artfully masterminded by ZURB  */
+
+/* Mobile */
+@media only screen and (max-width: 767px) {
+  table.responsive { margin-bottom: 0; }
+
+  .pinned { position: absolute; right: 0; top: 0; background: #fff; width: 35%; overflow: hidden; overflow-x: scroll; border-left: 1px solid #ccc; border-right: 1px solid #ccc; }
+  .pinned table { border-left: none; border-right: none; width: 100%; }
+  .pinned table th, .pinned table td { white-space: nowrap; }
+  .pinned td:last-child { border-bottom: 0; }
+
+  div.table-wrapper { position: relative; margin-bottom: 20px; overflow: hidden; border-left: 1px solid #ccc; }
+  div.table-wrapper div.scrollable table { margin-right: 35%; }
+  div.table-wrapper div.scrollable { overflow: scroll; overflow-y: hidden; }
+
+  table.responsive td, table.responsive th { position: relative; white-space: nowrap; overflow: hidden; }
+  table.responsive th:first-child, table.responsive td:first-child, table.responsive td:first-child, table.responsive.pinned td { display: none; }
+
+}

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -25,5 +25,6 @@ RailsGuides::Generator.new(
   all:      env_flag["ALL"],
   only:     env_value["ONLY"],
   kindle:   env_flag["KINDLE"],
-  language: env_value["GUIDES_LANGUAGE"]
+  language: env_value["GUIDES_LANGUAGE"],
+  rtl:      env_value["RTL"]
 ).generate

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -17,13 +17,14 @@ module RailsGuides
   class Generator
     GUIDES_RE = /\.(?:erb|md)\z/
 
-    def initialize(edge:, version:, all:, only:, kindle:, language:)
+    def initialize(edge:, version:, all:, only:, kindle:, language:, rtl: false)
       @edge     = edge
       @version  = version
       @all      = all
       @only     = only
       @kindle   = kindle
       @language = language
+      @rtl      = rtl
 
       if @kindle
         check_for_kindlegen
@@ -116,6 +117,10 @@ module RailsGuides
 
       def copy_assets
         FileUtils.cp_r(Dir.glob("#{@guides_dir}/assets/*"), @output_dir)
+        if (@rtl)
+          FileUtils.rm(Dir.glob("#{@output_dir}/stylesheets/main.css"))
+          FileUtils.mv("#{@output_dir}/stylesheets/main.rtl.css", "#{@output_dir}/stylesheets/main.css")
+        end
       end
 
       def output_file_for(guide)
@@ -198,7 +203,7 @@ module RailsGuides
       def check_fragment_identifiers(html, anchors)
         html.scan(/<a\s+href="#([^"]+)/).flatten.each do |fragment_identifier|
           next if fragment_identifier == "mainCol" # in layout, jumps to some DIV
-          unless anchors.member?(fragment_identifier)
+          unless anchors.member?(CGI.unescape(fragment_identifier))
             guess = anchors.min { |a, b|
               Levenshtein.distance(fragment_identifier, a) <=> Levenshtein.distance(fragment_identifier, b)
             }


### PR DESCRIPTION
### Summary

Adding ability to specify rtl for guides that will generate right to left guides with appropriate styling.

### Other Information

Guides will still generate left-to-right by default. A new environment variable will be checked 'RTL=true' which will generate the guides with right to left styling.

The new stylesheet `main.rtl.css` is copied from `main.css` with right and left swapped as well as some other updates to padding and margin. When the switch is passed - `main.css` will be deleted and `main.rtl.css` with be renamed to `main.css`. While changes to main.css will have to be also ported to main.rtl.css, manipulating the file itself from the generator did not seem right.

The anchor comparison was updated to unescaped since html escapes the Hebrew chars and the comparison fails.

Here are some basic examples, not fully translated:

<img width="1440" alt="screen shot 2018-11-18 at 2 46 48 pm" src="https://user-images.githubusercontent.com/1580589/48672676-916c5e00-eb41-11e8-9bd8-c1bcb85ceb1d.png">

<img width="1322" alt="screen shot 2018-11-18 at 2 50 33 pm" src="https://user-images.githubusercontent.com/1580589/48672680-9c26f300-eb41-11e8-83be-4a478d677bb0.png">
