### PR TITLE
Prevent TextHelper#word_wrap from stripping white space on the left side of long lines; Fixes #34487

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Prevent `ActionView::TextHelper#word_wrap` from unexpectedly stripping white space from the _left_ side of lines.
+
+    For example, given input like this:
+
+    ```
+        This is a paragraph with an initial indent,
+    followed by additional lines that are not indented,
+    and finally terminated with a blockquote:
+      "A pithy saying"
+    ```
+
+    Calling `word_wrap` should not trim the indents on the first and last lines.
+
+    Fixes #34487
+
+    *Lyle Mullican*
+
+
 *   Add allocations to template rendering instrumentation.
 
     Adds the allocations for template and partial rendering to the server output on render.

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -259,7 +259,7 @@ module ActionView
       #   # => Once\r\nupon\r\na\r\ntime
       def word_wrap(text, line_width: 80, break_sequence: "\n")
         text.split("\n").collect! do |line|
-          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").strip : line
+          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").rstrip : line
         end * break_sequence
       end
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -361,6 +361,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("my very very\nvery long\nstring\n\nwith another\nline", word_wrap("my very very very long string\n\nwith another line", line_width: 15))
   end
 
+  def test_word_wrap_with_leading_spaces
+    assert_equal("  This is a paragraph\nthat includes some\nindented lines:\n  Like this sample\n  blockquote", word_wrap("  This is a paragraph that includes some\nindented lines:\n  Like this sample\n  blockquote", line_width: 25))
+  end
+
   def test_word_wrap_does_not_modify_the_options_hash
     options = { line_width: 15 }
     passed_options = options.dup


### PR DESCRIPTION
When `word_wrap` processes a block of text in which some lines are indented with white space, it strips white space from both sides of long lines. For example, a paragraph which begins with an initial indent will have that indent removed when wrapped. See example input in #34487.
