### PR TITLE
Part 5: Multi db improvements, Fix query cache for multiple connections

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -26,15 +26,22 @@ module ActiveRecord
     end
 
     def self.run
-      ActiveRecord::Base.connection_handler.connection_pool_list.
-        reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
+      pools = []
+
+      ActiveRecord::Base.connection_handlers.each do |key, handler|
+        pools << handler.connection_pool_list.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
+      end
+
+      pools.flatten
     end
 
     def self.complete(pools)
       pools.each { |pool| pool.disable_query_cache! }
 
-      ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
-        pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+      ActiveRecord::Base.connection_handlers.each do |_, handler|
+        handler.connection_pool_list.each do |pool|
+          pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+        end
       end
     end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -55,6 +55,22 @@ class QueryCacheTest < ActiveRecord::TestCase
     assert_cache :off
   end
 
+  def test_query_cache_is_applied_to_connections_in_all_handlers
+    ActiveRecord::Base.connected_to(role: :reading) do
+      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
+    end
+
+    mw = middleware { |env|
+      ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
+      assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
+      assert_predicate ro_conn, :query_cache_enabled
+    }
+
+    mw.call({})
+  ensure
+    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+  end
+
   def test_query_cache_across_threads
     with_temporary_connection_pool do
       begin


### PR DESCRIPTION
Currently the query cache is only aware of one handler so once we added
multiple databases switching on the handler we broke query cache for
those reading connections.

While #34054 is the proper fix, that fix is not straight forward and I
want to make sure that the query cache isn't just broken for all other
connections not in the main handler.

cc/ @rafaelfranca @matthewd @tenderlove 