### PR TITLE
Stop using unnamed roots on conflict

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise an error on root route naming conflicts.
+
+    Raises an ArgumentError when multiple root routes are defined in the
+    same context instead of assigning nil names to subsequent roots.
+
+    *Gannon McGibbon*
+
 *   Allow rescue from parameter parse errors:
 
     ```

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -656,7 +656,7 @@ module ActionDispatch
 
         # Query if the following named route was already defined.
         def has_named_route?(name)
-          @set.named_routes.key? name
+          @set.named_routes.key?(name)
         end
 
         private
@@ -1952,9 +1952,7 @@ module ActionDispatch
           end
 
           def match_root_route(options)
-            name = has_named_route?(name_for_action(:root, nil)) ? nil : :root
-            args = ["/", { as: name, via: :get }.merge!(options)]
-
+            args = ["/", { as: :root, via: :get }.merge(options)]
             match(*args)
           end
       end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3698,15 +3698,25 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_multiple_roots
-    draw do
-      namespace :foo do
+  def test_multiple_roots_raises_error
+    ex = assert_raises(ArgumentError) {
+      draw do
         root "pages#index", constraints: { host: "www.example.com" }
         root "admin/pages#index", constraints: { host: "admin.example.com" }
       end
+    }
+    assert_match(/Invalid route name, already in use: 'root'/, ex.message)
+  end
+
+  def test_multiple_named_roots
+    draw do
+      namespace :foo do
+        root "pages#index", constraints: { host: "www.example.com" }
+        root "admin/pages#index", constraints: { host: "admin.example.com" }, as: :admin_root
+      end
 
       root "pages#index", constraints: { host: "www.example.com" }
-      root "admin/pages#index", constraints: { host: "admin.example.com" }
+      root "admin/pages#index", constraints: { host: "admin.example.com" },  as: :admin_root
     end
 
     get "http://www.example.com/foo"


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34479.

Disallows multiple uses of `root` within the same routing context without `as:`.

The referenced issue maps the first `root` to `/form/:foo`, and a second one to `/`. When calling `root_path` in the template rendered by `/`, Rails knows to call the first root path (because it is the one with the name). The second root is not used, and can't be referenced by a named route helper because it doesn't have a name.

This whole situation can be avoided by not assuming a root route should be unnamed if one already exists.

r? @rafaelfranca 