### PR TITLE
Part 6: Multi db improvements, Make connection handler per thread instead of per fiber

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -129,11 +129,11 @@ module ActiveRecord
       self.filter_attributes = []
 
       def self.connection_handler
-        ActiveRecord::RuntimeRegistry.connection_handler || default_connection_handler
+        Thread.current.thread_variable_get("ar_connection_handler") || default_connection_handler
       end
 
       def self.connection_handler=(handler)
-        ActiveRecord::RuntimeRegistry.connection_handler = handler
+        Thread.current.thread_variable_set("ar_connection_handler", handler)
       end
 
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new


### PR DESCRIPTION
The connection handler was using the RuntimeRegistry which kind of
implies it's a per thread registry. But it's actually per fiber.

If you have an application that uses fibers and you're using multiple
databases, when you switch the connection handler to swap connections
new fibers running on the same thread used to get a different connection
id. This PR changes the code to actually use a thread so that we get
the same connection.

Fixes https://github.com/rails/rails/issues/30047

cc/ @tenderlove @arthurnn @matthewd @rafaelfranca 