### PR TITLE
Expand documentation for Hash#slice!

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -27,8 +27,9 @@ class Hash
   # Replaces the hash with only the given keys.
   # Returns a hash containing the removed key/value pairs.
   #
-  #   { a: 1, b: 2, c: 3, d: 4 }.slice!(:a, :b)
-  #   # => {:c=>3, :d=>4}
+  #   hash = { a: 1, b: 2, c: 3, d: 4 }
+  #   hash.slice!(:a, :b)  # => {:c=>3, :d=>4 }
+  #   hash                 # => {:a=>1, :b=>2 }
   def slice!(*keys)
     omit = slice(*self.keys - keys)
     hash = slice(*keys)


### PR DESCRIPTION
### Summary

Expand the documentation for `slice!` method in order to make explicit what it really does.

Taking ActiveSuport::Multibyte as example.

https://github.com/rails/rails/blob/4800fd072f2a8349e92cf9386da4b66de712a669/activesupport/lib/active_support/multibyte/chars.rb#L96 