### PR TITLE
Updating the Testing Guide to Reflect Emails Enqueued With ActiveJob

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -26,15 +26,22 @@ module ActiveRecord
     end
 
     def self.run
-      ActiveRecord::Base.connection_handler.connection_pool_list.
-        reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
+      pools = []
+
+      ActiveRecord::Base.connection_handlers.each do |key, handler|
+        pools << handler.connection_pool_list.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
+      end
+
+      pools.flatten
     end
 
     def self.complete(pools)
       pools.each { |pool| pool.disable_query_cache! }
 
-      ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
-        pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+      ActiveRecord::Base.connection_handlers.each do |_, handler|
+        handler.connection_pool_list.each do |pool|
+          pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+        end
       end
     end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -55,6 +55,22 @@ class QueryCacheTest < ActiveRecord::TestCase
     assert_cache :off
   end
 
+  def test_query_cache_is_applied_to_connections_in_all_handlers
+    ActiveRecord::Base.connected_to(role: :reading) do
+      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
+    end
+
+    mw = middleware { |env|
+      ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
+      assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
+      assert_predicate ro_conn, :query_cache_enabled
+    }
+
+    mw.call({})
+  ensure
+    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+  end
+
   def test_query_cache_across_threads
     with_temporary_connection_pool do
       begin

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1602,8 +1602,6 @@ Unit testing allows us to test the email body, and recipients. In functional and
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
-  include ActionMailer::TestHelper
-
   test "invite friend" do
     # Asserts the difference in the ActionMailer::Base.deliveries
     assert_emails 1 do
@@ -1615,10 +1613,10 @@ end
 
 ```ruby
 # System Test
-require "application_system_test_case"
+require 'test_helper'
 
-class UsersTest < ApplicationSystemTestCase
-  include ActionMailer::TestHelper
+class UsersTest < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome
 
   test "inviting a friend" do
     visit invite_users_url
@@ -1630,9 +1628,7 @@ class UsersTest < ApplicationSystemTestCase
 end
 ```
 
-NOTE: These examples take advantage of the `ActionMailer::TestHelper`. For emails we expect to be delivered immediately with the `deliver_now` method, we can use the `assert_emails` method. For emails we expect to be delivered as an ActiveJob with the `deliver_later` method, we can use the `assert_enqueued_emails` method. More information can be found in the  [documentation here](https://api.rubyonrails.org/classes/ActionMailer/TestHelper.html).
-
-
+NOTE: The `assert_emails` method is not tied to a particular deliver method and will work with emails delivered with either the `deliver_now` or `deliver_later` method. If we explicitly want to assert that the email has been enqueued we can use the `assert_enqueued_emails` method. More information can be found in the  [documentation here](https://api.rubyonrails.org/classes/ActionMailer/TestHelper.html).
 
 Testing Jobs
 ------------

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1593,26 +1593,46 @@ NOTE: The `ActionMailer::Base.deliveries` array is only reset automatically in
 If you want to have a clean slate outside these test cases, you can reset it
 manually with: `ActionMailer::Base.deliveries.clear`
 
-### Functional Testing
+### Functional and System Testing
 
-Functional testing for mailers involves more than just checking that the email body, recipients, and so forth are correct. In functional mail tests you call the mail deliver methods and check that the appropriate emails have been appended to the delivery list. It is fairly safe to assume that the deliver methods themselves do their job. You are probably more interested in whether your own business logic is sending emails when you expect them to go out. For example, you can check that the invite friend operation is sending an email appropriately:
+Unit testing allows us to test the email body, and recipients. In functional and system tests, we test whether user interactions appropriately trigger email to be delivered. For example, you can check that the invite friend operation is sending an email appropriately:
 
 ```ruby
+# Integration Test
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
+  include ActionMailer::TestHelper
+
   test "invite friend" do
-    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+    # Asserts the difference in the ActionMailer::Base.deliveries
+    assert_emails 1 do
       post invite_friend_url, params: { email: 'friend@example.com' }
     end
-    invite_email = ActionMailer::Base.deliveries.last
-
-    assert_equal "You have been invited by me@example.com", invite_email.subject
-    assert_equal 'friend@example.com', invite_email.to[0]
-    assert_match(/Hi friend@example\.com/, invite_email.body.to_s)
   end
 end
 ```
+
+```ruby
+# System Test
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  include ActionMailer::TestHelper
+
+  test "inviting a friend" do
+    visit invite_users_url
+    fill_in 'Email', with: 'friend@example.com'
+    assert_emails 1 do
+      click_on 'Invite'
+    end
+  end
+end
+```
+
+NOTE: These examples take advantage of the `ActionMailer::TestHelper`. For emails we expect to be delivered immediately with the `deliver_now` method, we can use the `assert_emails` method. For emails we expect to be delivered as an ActiveJob with the `deliver_later` method, we can use the `assert_enqueued_emails` method. More information can be found in the  [documentation here](https://api.rubyonrails.org/classes/ActionMailer/TestHelper.html).
+
+
 
 Testing Jobs
 ------------


### PR DESCRIPTION
…nqueued with ActiveJobs.

### Summary
I've updated the Rails Guide on Testing to reflect testing emails that have been delivered with the `deliver_later` method. The example provided in the original guide does not take that that into account or show the more recent assertions that can be used in functional and system tests.

### Other Information
This is my first PR, so please let me know how I could make this better!