### PR TITLE
fixes performance regression with AR relations

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -297,6 +297,13 @@ module ActiveRecord
       @cache_keys[timestamp_column] ||= @klass.collection_cache_key(self, timestamp_column)
     end
 
+    # cache_version is not yet implemented for Active Record relations
+    # but without a (nil) cache_version, it may cause a performance hit
+    # even when cache versioning is switched off
+    def cache_version(timestamp_column = :updated_at)
+      nil
+    end
+
     # Scope all queries to the current scope.
     #
     #   Comment.where(post_id: 1).scoping do

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -171,5 +171,10 @@ module ActiveRecord
 
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
+
+    test "cache_version is nil for relations" do
+      developers = Developer.select("name AS dev_name").order("dev_name DESC").limit(5)
+      assert_nil(developers.cache_version)
+    end
   end
 end


### PR DESCRIPTION
* See https://github.com/rails/rails/pull/29092#issuecomment-437572543
* After introducing cache versioning, even with cache versioning off
  there's a performance regression when passing an Active Record
  relation to cache
* This happens in ActiveSupport::Cache inside `normalize_version`
* This method would check if the relation responds to cache_version
  and if not, would recrusively normalize it with `to_a`
* This would lead to the relation being retrieved from database and
  enumerated, causing the performance regression
* This fix simply adds `cache_version` returning `nil` to Active Record
  relations
* This is a temporary stopgap, until relation cache versioning is
  implemented. See https://github.com/rails/rails/pull/34378