### PR TITLE
Fix rollback attribute state

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveModel::Dirty#rewind_attribute_assignments` to reset attribute state to what it was before last save.
+
+    *Gannon McGibbon*
+
 *   Fix numericality equality validation of `BigDecimal` and `Float`
     by casting to `BigDecimal` on both ends of the validation.
 

--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -6,6 +6,8 @@ module ActiveModel
   class AttributeMutationTracker # :nodoc:
     OPTION_NOT_GIVEN = Object.new
 
+    attr_reader :attributes
+
     def initialize(attributes)
       @attributes = attributes
       @forced_changes = Set.new
@@ -70,7 +72,7 @@ module ActiveModel
     end
 
     private
-      attr_reader :attributes, :forced_changes
+      attr_reader :forced_changes
 
       def attr_names
         attributes.keys

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rewind attribute assignments for saved records when transactions are rolled back.
+
+    *Gannon McGibbon*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#add_transaction_record` in favor of `add_transaction_callback_record`.
 
     *Gannon McGibbon*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#add_transaction_record` in favor of `add_transaction_callback_record`.
+
+    *Gannon McGibbon*
+
 *   Fix join table column quoting with SQLite.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -30,6 +30,7 @@ module ActiveRecord
       def reload(*)
         super.tap do
           @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
+          @mutations_before_first_save = nil
           @mutations_before_last_save = nil
           @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
           @mutations_from_database = nil

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -281,10 +281,21 @@ module ActiveRecord
         @transaction_manager = ConnectionAdapters::TransactionManager.new(self)
       end
 
-      # Register a record with the current transaction so that its after_commit and after_rollback callbacks
-      # can be called.
-      def add_transaction_record(record)
+      # Register a record with the current transaction so that its
+      # after_commit and after_rollback callbacks can be called.
+      def add_transaction_callback_record(record)
         current_transaction.add_record(record)
+      end
+
+      # Register a record with the current transaction so that its
+      # after_commit and after_rollback callbacks can be called.
+      def add_transaction_record(record)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `ActiveRecord::ConnectionAdapters::DatabaseStatements#add_transaction_record`
+          has been renamed to `add_transaction_callback_record`.
+          `add_transaction_record` is deprecated and will be removed in Rails 6.1.
+        MSG
+        add_transaction_callback_record(record)
       end
 
       def transaction_state

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -284,7 +284,13 @@ module ActiveRecord
       # Register a record with the current transaction so that its
       # after_commit and after_rollback callbacks can be called.
       def add_transaction_callback_record(record)
-        current_transaction.add_record(record)
+        current_transaction.add_callback_record(record)
+      end
+
+      # Register a record with the current transaction so that its
+      # state can be cleaned if a rollback occurs during the transaction.
+      def add_transaction_saved_record(record)
+        current_transaction.add_saved_record(record)
       end
 
       # Register a record with the current transaction so that its

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -137,7 +137,7 @@ module ActiveRecord
             record.committed!
           else
             # if not running callbacks, only adds the record to the parent transaction
-            connection.add_transaction_record(record)
+            connection.add_transaction_callback_record(record)
           end
         end
       ensure

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -340,7 +340,7 @@ module ActiveRecord
     def destroy
       _raise_readonly_record_error if readonly?
       destroy_associations
-      self.class.connection.add_transaction_record(self)
+      self.class.connection.add_transaction_callback_record(self)
       @_trigger_destroy_callback = if persisted?
         destroy_row > 0
       else

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -708,6 +708,7 @@ module ActiveRecord
     def create_or_update(*args, &block)
       _raise_readonly_record_error if readonly?
       return false if destroyed?
+      self.class.connection.add_transaction_saved_record(self)
       result = new_record? ? _create_record(&block) : _update_record(*args, &block)
       result != false
     end

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       @_touch_time = current_time_from_proper_timezone
 
       surreptitiously_touch @_defer_touch_attrs
-      self.class.connection.add_transaction_record self
+      self.class.connection.add_transaction_callback_record(self)
 
       # touch the parents as we are not calling the after_save callbacks
       self.class.reflect_on_all_associations(:belongs_to).each do |r|

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -409,6 +409,7 @@ module ActiveRecord
       # Force to clear the transaction record state.
       def force_clear_transaction_record_state
         @_start_transaction_state.clear
+        @mutations_before_first_save = nil
       end
 
       # Restore the new record state and id of a record that was previously saved by a call to save_record_state.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -353,7 +353,7 @@ module ActiveRecord
     # can be called.
     def add_to_transaction
       if has_transactional_callbacks?
-        self.class.connection.add_transaction_record(self)
+        self.class.connection.add_transaction_callback_record(self)
       else
         sync_with_transaction_state
         set_transaction_state(self.class.connection.transaction_state)

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -586,7 +586,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
         @topic.content = "foo"
         @topic.save!
       end
-      @topic.class.connection.add_transaction_record(@topic)
+      @topic.class.connection.add_transaction_callback_record(@topic)
     end
     assert_equal [:before_commit, :after_commit], @topic.history
   end
@@ -596,7 +596,7 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
       @topic.transaction(requires_new: true) do
         @topic.content = "foo"
         @topic.save!
-        @topic.class.connection.add_transaction_record(@topic)
+        @topic.class.connection.add_transaction_callback_record(@topic)
       end
     end
     assert_equal [:before_commit, :after_commit], @topic.history
@@ -617,10 +617,16 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
         @topic.content = "foo"
         @topic.save!
       end
-      @topic.class.connection.add_transaction_record(@topic)
+      @topic.class.connection.add_transaction_callback_record(@topic)
       raise ActiveRecord::Rollback
     end
     assert_equal [:rollback], @topic.history
+  end
+
+  def test_add_transaction_record_deprecated
+    assert_deprecated do
+      @topic.class.connection.add_transaction_record(@topic)
+    end
   end
 end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -18,6 +18,55 @@ class TransactionTest < ActiveRecord::TestCase
     @first, @second = Topic.find(1, 2).sort_by(&:id)
   end
 
+  def test_rollback_dirty_reset
+    topic = topics(:fifth)
+
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Ruby on Rails")
+      raise ActiveRecord::Rollback
+    end
+
+    title_change = ["The Fifth Topic of the day", "Ruby on Rails"]
+    assert_equal title_change, topic.changes["title"]
+  end
+
+  def test_rollback_dirty_reset_multiple_saves
+    topic = topics(:fifth)
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Ruby on Rails")
+      topic.update(title: "Another Title")
+      topic.update(title: "Yet another Title")
+      raise ActiveRecord::Rollback
+    end
+    title_change = ["The Fifth Topic of the day", "Yet another Title"]
+    assert_equal title_change, topic.changes["title"]
+  end
+
+  def test_rollback_dirty_reset_retry_save
+    topic = topics(:fifth)
+
+    ActiveRecord::Base.transaction do
+      topic.assign_attributes(title: "Ruby on Rails")
+      topic.save
+      raise ActiveRecord::Rollback
+    end
+
+    topic.save
+
+    assert_equal topic.title, topic.reload.title
+  end
+
+  def test_rollback_dirty_reset_retry_save_on_new_record
+    topic = Topic.create!(title: "Tenth")
+    ActiveRecord::Base.transaction do
+      topic.assign_attributes(title: "Ruby on Rails")
+      topic.save
+      raise ActiveRecord::Rollback
+    end
+    topic.update!(title: "Seventeenth")
+    assert_equal topic.title, topic.reload.title
+  end
+
   def test_persisted_in_a_model_with_custom_primary_key_after_failed_save
     movie = Movie.create
     assert_not_predicate movie, :persisted?


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34358.

Restore attribute tracking on saved records of a transaction when they've been rolled back.

TODO:
- [x] Add deprecation notice for `add_transaction_record `.
- [x] Create public methods to make `#unsave_records` less of a hack.
- [x] Address test failures that check for nil IDs after rollback.
- [x] Add a changelog entry.

r? @rafaelfranca 
