### PR TITLE
Part 7: Multi db improvements, Add ability to block writes to a database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add the ability to prevent writes to a database for the duration of a block.
+
+    Allows the application to prevent writes to a database. This can be useful when
+    you're building out multiple databases and want to make sure you're not sending
+    writes when you want a read.
+
+    If `while_preventing_writes` is called and the query is considered a write
+    query the database will raise an exception regardless of whether the database
+    user is able to write.
+
+    This is not meant to be a catch-all for write queries but rather a way to enforce
+    read-only queries without opening a second connection. One purpose of this is to
+    catch accidental writes, not all writes.
+
+    *Eileen M. Uchitelle*
+
 *   Allow aliased attributes to be used in `#update_columns` and `#update`.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -98,6 +98,11 @@ module ActiveRecord
         exec_query(sql, name).rows
       end
 
+      # Determines whether the SQL statement is a write query.
+      def write_query?(sql)
+        raise NotImplementedError
+      end
+
       # Executes the SQL statement in the context of this connection and returns
       # the raw result from the connection adapter.
       # Note: depending on your database connector, the result returned by this

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -573,6 +573,62 @@ module ActiveRecord
         end
       end
 
+      def test_errors_when_an_insert_query_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @conn.while_preventing_writes do
+              @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+            end
+          end
+        end
+      end
+
+      def test_errors_when_an_update_query_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @conn.while_preventing_writes do
+              @conn.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'")
+            end
+          end
+        end
+      end
+
+      def test_errors_when_a_delete_query_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @conn.while_preventing_writes do
+              @conn.execute("DELETE FROM ex where data = '138853948594'")
+            end
+          end
+        end
+      end
+
+      def test_errors_when_a_replace_query_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @conn.while_preventing_writes do
+              @conn.execute("REPLACE INTO ex (data) VALUES ('249823948')")
+            end
+          end
+        end
+      end
+
+      def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          @conn.while_preventing_writes do
+            assert_equal 1, @conn.execute("SELECT data from ex WHERE data = '138853948594'").count
+          end
+        end
+      end
+
       private
 
         def assert_logged(logs)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1488,4 +1488,40 @@ class BasicsTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.protected_environments = previous_protected_environments
   end
+
+  test "creating a record raises if preventing writes" do
+    assert_raises ActiveRecord::StatementInvalid do
+      ActiveRecord::Base.connection.while_preventing_writes do
+        bird = Bird.create! name: "Bluejay"
+      end
+    end
+  end
+
+  test "updating a record raises if preventing writes" do
+    bird = Bird.create! name: "Bluejay"
+
+    assert_raises ActiveRecord::StatementInvalid do
+      ActiveRecord::Base.connection.while_preventing_writes do
+        bird.update! name: "Robin"
+      end
+    end
+  end
+
+  test "deleting a record raises if preventing writes" do
+    bird = Bird.create! name: "Bluejay"
+
+    assert_raises ActiveRecord::StatementInvalid do
+      ActiveRecord::Base.connection.while_preventing_writes do
+        bird.destroy!
+      end
+    end
+  end
+
+  test "selecting a record does not raise if preventing writes" do
+    bird = Bird.create! name: "Bluejay"
+
+    ActiveRecord::Base.connection.while_preventing_writes do
+      assert_equal bird, Bird.where(name: "Bluejay").first
+    end
+  end
 end


### PR DESCRIPTION
We use this at GH but I'm not 100% sure whether others will find this useful. Thoughts?

The other open question I have is whether the `write_query?` should be defined by "is a query that writes" or "is a query that is not reading" (ie not select, etc). For now I chose some common write queries to demonstrate the goals of this feature but I'd love input into what @rafaelfranca @tenderlove and @matthewd think about this.

---

This PR adds the ability to block writes to a database even if the
database user is able to write (ie the database is a primary and not a
replica).

This is useful for a few reasons: 1) when converting your database from
a single db to a primary/replica setup - you can fix all the writes on
reads early on, 2) when we implement automatic database switching or
when an app is manually switching connections this feature can be used
to ensure reads are reading and writes are writing. We want to make sure
we raise if we ever try to write in read mode, regardless of database
type.

This should be used in conjunction with `connected_to` in write mode.
For example:

```ruby
ActiveRecord::Base.connected_to(role: :writing) do
  Dog.connection.while_blocking_writes do
    Dog.create! # will raise because we're blocking writes
  end
end

ActiveRecord::Base.connected_to(role: :reading) do
  Dog.connection.while_blocking_writes do
    Dog.first # will not raise because we're not writing
  end
end
```