### PR TITLE
Use direction instead of rtl flag

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -20,11 +20,11 @@ version = env_value["RAILS_VERSION"]
 edge    = `git rev-parse HEAD`.strip unless version
 
 RailsGuides::Generator.new(
-  edge:     edge,
-  version:  version,
-  all:      env_flag["ALL"],
-  only:     env_value["ONLY"],
-  kindle:   env_flag["KINDLE"],
-  language: env_value["GUIDES_LANGUAGE"],
-  rtl:      env_value["RTL"]
+  edge:      edge,
+  version:   version,
+  all:       env_flag["ALL"],
+  only:      env_value["ONLY"],
+  kindle:    env_flag["KINDLE"],
+  language:  env_value["GUIDES_LANGUAGE"],
+  direction: env_value["DIRECTION"].to_sym
 ).generate

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -17,14 +17,14 @@ module RailsGuides
   class Generator
     GUIDES_RE = /\.(?:erb|md)\z/
 
-    def initialize(edge:, version:, all:, only:, kindle:, language:, rtl: false)
-      @edge     = edge
-      @version  = version
-      @all      = all
-      @only     = only
-      @kindle   = kindle
-      @language = language
-      @rtl      = rtl
+    def initialize(edge:, version:, all:, only:, kindle:, language:, direction: :ltr)
+      @edge      = edge
+      @version   = version
+      @all       = all
+      @only      = only
+      @kindle    = kindle
+      @language  = language
+      @direction = direction
 
       if @kindle
         check_for_kindlegen
@@ -118,10 +118,13 @@ module RailsGuides
       def copy_assets
         FileUtils.cp_r(Dir.glob("#{@guides_dir}/assets/*"), @output_dir)
 
-        if @rtl
-          FileUtils.rm(Dir.glob("#{@output_dir}/stylesheets/main.css"))
-          FileUtils.mv("#{@output_dir}/stylesheets/main.rtl.css", "#{@output_dir}/stylesheets/main.css")
+        if @direction == :rtl
+          overwrite_css_with_right_to_left_direction
         end
+      end
+
+      def overwrite_css_with_right_to_left_direction
+        FileUtils.mv("#{@output_dir}/stylesheets/main.rtl.css", "#{@output_dir}/stylesheets/main.css")
       end
 
       def output_file_for(guide)


### PR DESCRIPTION
### Summary
This patch improves readability by using `direction`  instead of `rtl`flag, as [CSS does](https://developer.mozilla.org/en-US/docs/Web/CSS/direction).

I have also took the chance to:
* Use `.to_sym` when getting direction's `env_value` as it could be a String.
* Removed the call to `FileUtils.rm` as `FileUtils.mv` [already overwrites](https://ruby-doc.org/stdlib-2.5.1/libdoc/fileutils/rdoc/FileUtils.html#method-c-mv) the assets if it exists 

### Other Information
Continues: #34486
Gives credit to @paracycle

r? @rafaelfranca 