### PR TITLE
Add cache_key_prefix option to session cache store

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -9,13 +9,16 @@ module ActionDispatch
     # of time.
     #
     # ==== Options
-    # * <tt>cache</tt>         - The cache to use. If it is not specified, <tt>Rails.cache</tt> will be used.
-    # * <tt>expire_after</tt>  - The length of time a session will be stored before automatically expiring.
+    # * <tt>cache</tt>            - The cache to use. If it is not specified, <tt>Rails.cache</tt> will be used.
+    # * <tt>expire_after</tt>     - The length of time a session will be stored before automatically expiring.
     #   By default, the <tt>:expires_in</tt> option of the cache is used.
+    # * <tt>cache_key_prefix</tt> - The string prepended to the session id to form the cache key.
+    #   Defaults to <tt>'_session_id:'</tt>
     class CacheStore < AbstractStore
       def initialize(app, options = {})
         @cache = options[:cache] || Rails.cache
         options[:expire_after] ||= @cache.options[:expires_in]
+        @cache_key_prefix = options[:cache_key_prefix] || "_session_id:"
         super
       end
 
@@ -47,7 +50,7 @@ module ActionDispatch
       private
         # Turn the session id into a cache key.
         def cache_key(sid)
-          "_session_id:#{sid}"
+          "#{@cache_key_prefix}#{sid}"
         end
     end
   end

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -162,8 +162,17 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_setting_cache_key_prefix
+    with_test_route_set("test_cache_key_prefix:") do
+      get "/set_session_value"
+
+      assert_response :success
+      assert_equal({ "foo" => "bar" }, @cache.read("test_cache_key_prefix:#{cookies['_session_id']}"))
+    end
+  end
+
   private
-    def with_test_route_set
+    def with_test_route_set(cache_key_prefix = "_session_id:")
       with_routing do |set|
         set.draw do
           ActiveSupport::Deprecation.silence do
@@ -173,7 +182,8 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
 
         @app = self.class.build_app(set) do |middleware|
           @cache = ActiveSupport::Cache::MemoryStore.new
-          middleware.use ActionDispatch::Session::CacheStore, key: "_session_id", cache: @cache
+          middleware.use ActionDispatch::Session::CacheStore, key: "_session_id", cache: @cache,
+                                                              cache_key_prefix: cache_key_prefix
           middleware.delete ActionDispatch::ShowExceptions
         end
 


### PR DESCRIPTION
### Summary

This is to assist upgrades from the [redis-session-store gem](https://github.com/roidrage/redis-session-store) to the rails session cache store. The session cache store uses the hardcoded cache key prefix `_session_id:` and apps using redis-session-store will lose user session data on deployment if they switch.