### PR TITLE
Improve performance when plucking a single attribute on a loaded relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -182,8 +182,12 @@ module ActiveRecord
     # See also #ids.
     #
     def pluck(*column_names)
-      if loaded? && (column_names.map(&:to_s) - @klass.attribute_names - @klass.attribute_aliases.keys).empty?
-        return records.pluck(*column_names)
+      if loaded?
+        if column_names.length == 1 && @klass.has_attribute?(column_names.first.to_s)
+          return records.map { |r| r._read_attribute(column_names.first) }
+        elsif (column_names.map(&:to_s) - @klass.attribute_names - @klass.attribute_aliases.keys).empty?
+          return records.pluck(*column_names)
+        end
       end
 
       if has_include?(column_names.first)


### PR DESCRIPTION
### Summary

In my app I noticed that calling `pluck(attr)` on a relation was significantly slower than `map(&:attr)`, which surprised me:

```ruby
collection = User.limit(1) # small collection for test's sake

Benchmark.ips do |x|
  x.report('map') { collection.map(&:name) }
  x.report('pluck') { collection.pluck(:name) }
  x.compare!
end

# Calculating -------------------------------------
#                  map    772.148k (± 4.1%) i/s -      3.900M in   5.059659s
#                pluck    121.877k (± 3.6%) i/s -    619.812k in   5.092067s
# 
# Comparison:
#                  map:   772148.4 i/s
#                pluck:   121876.7 i/s - 6.34x  slower
```

On a loaded relation, pluck ends up calling `Enumerable#pluck`, which makes the `pluck` call equivalent to `collection.map{ |i| i[:name] }`. Drilling down further, calling `#[]` on an `ActiveRecord` calls `read_attribute`, whereas the attribute method (ie. `.name`) calls `_read_attribute`, which is quite faster:

```ruby
Benchmark.ips do |x|
  x.report('read_attribute') { user.read_attribute(:name) }
  x.report('_read_attribute') { user._read_attribute(:name) }
  x.compare!
end

# Calculating -------------------------------------
#       read_attribute      1.207M (± 4.4%) i/s -      6.043M in   5.017097s
#      _read_attribute      2.355M (± 4.8%) i/s -     11.750M in   5.001814s

# Comparison:
#      _read_attribute:  2354831.7 i/s
#       read_attribute:  1206808.2 i/s - 1.95x  slower
```

I thought we could create a special case when plucking a single attribute on a loaded relation, and have it map _read_attribute directly instead of going through the various layers of `Enumerable#pluck`. Running my first benchmark I routinely get _slightly better_ performance from `pluck` than from `map`:

```
Calculating -------------------------------------
                 map    772.365k (± 2.6%) i/s -      3.897M in   5.049130s
               pluck    813.136k (± 2.1%) i/s -      4.097M in   5.040997s

Comparison:
               pluck:   813135.6 i/s
                 map:   772364.7 i/s - 1.05x  slower
```

### Other Information

There are probably edge cases that I'm not thinking of, or further special cases that can be improved upon, but this change will fall back to the previous behaviour for anything other than the case I'm handling.

Only one test in `activerecord/test/cases/calculations_test.rb` makes use of this change (`test_pluck_loaded_relation`)

Looking forward to any feedback!