### PR TITLE
rubyonrails.org has been ready for https

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.author   = "David Heinemeier Hansson"
   s.email    = "david@loudthinking.com"
-  s.homepage = "http://rubyonrails.org"
+  s.homepage = "https://rubyonrails.org"
 
   s.files = ["README.md"]
 


### PR DESCRIPTION
### Summary

Change the homepage link to https.