### PR TITLE
Pluralized enum method returns copy of enum_values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Pluralized enum method returns a copy of the enum_values, preventing modifications on the original.
+    
+    *Emmanuel Byrd*
+
 *   Move `ActiveRecord::StatementInvalid` SQL to error property and include binds as separate error property.
 
     `ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class` now requires `binds` to be passed as the last argument.

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -157,7 +157,7 @@ module ActiveRecord
 
         # def self.statuses() statuses end
         detect_enum_conflict!(name, name.pluralize, true)
-        singleton_class.send(:define_method, name.pluralize) { enum_values }
+        singleton_class.send(:define_method, name.pluralize) { enum_values.dup }
         defined_enums[name] = enum_values
 
         detect_enum_conflict!(name, name)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -437,6 +437,24 @@ class EnumTest < ActiveRecord::TestCase
     book2.status = :uploaded
     assert_equal ["drafted", "uploaded"], book2.status_change
   end
+  
+  test "pluralized enum method cannot create new key" do 
+    initial = Book.statuses.dup 
+    
+    copy = Book.statuses 
+    copy['bad_enum'] = 42
+    
+    assert_equal Book.statuses, initial
+  end
+  
+  test "pluralized enum method cannot delete existing member" do 
+    initial = Book.statuses.dup 
+    
+    copy = Book.statuses 
+    copy.delete('published')
+    
+    assert_equal Book.statuses, initial
+  end
 
   test "declare multiple enums at a time" do
     klass = Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34514

The pluralized method created to access each enum now returns a copy of `enum_values`, preventing modifications on the original. 

Problem being addresed:
```ruby
expected_copy = Model.states # {'foo'=>0, 'bar'=>1, 'baz'=>2}

# All the application would be silently affected with the following lines
expected_copy.delete('foo') # previously deleted foo from Model.states
expected_copy['bad_key'] = 10 # previously added a new key on Model.states
```

