### PR TITLE
Pluralized enum raises error when attempting to modify

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Values of enum are frozen, raising an error when attempting to modify them.
+
+    *Emmanuel Byrd*
+
 *   Move `ActiveRecord::StatementInvalid` SQL to error property and include binds as separate error property.
 
     `ActiveRecord::ConnectionAdapters::AbstractAdapter#translate_exception_class` now requires `binds` to be passed as the last argument.

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -199,6 +199,7 @@ module ActiveRecord
             klass.scope value_method_name, -> { where(attr => value) }
           end
         end
+        enum_values.freeze
       end
     end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -438,6 +438,20 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal ["drafted", "uploaded"], book2.status_change
   end
 
+  test "attempting to modify enum raises error" do
+    e = assert_raises(RuntimeError) do
+      Book.statuses["bad_enum"] = 40
+    end
+
+    assert_match(/can't modify frozen/, e.message)
+
+    e = assert_raises(RuntimeError) do
+      Book.statuses.delete("published")
+    end
+
+    assert_match(/can't modify frozen/, e.message)
+  end
+
   test "declare multiple enums at a time" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34514

The pluralized method created to access each enum now raises an error when attempting to modify the original.

Problem being addresed:
```ruby
expected_copy = Model.states # {'foo'=>0, 'bar'=>1, 'baz'=>2}

# All the application would be silently affected with the following lines
expected_copy.delete('foo') # previously deleted foo from Model.states
expected_copy['bad_key'] = 10 # previously added a new key on Model.states
```
