### PR TITLE
Remove unnecessary reduce in Duration#inspect

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -373,7 +373,6 @@ module ActiveSupport
       return "0 seconds" if parts.empty?
 
       parts.
-        reduce(::Hash.new(0)) { |h, (l, r)| h[l] += r; h }.
         sort_by { |unit,  _ | PARTS.index(unit) }.
         map     { |unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}" }.
         to_sentence(locale: ::I18n.default_locale)


### PR DESCRIPTION
When the `Duration` class was introduced in 276c9f29, the `parts` were
represented as an array of arrays
(for example `[[:seconds, 5], [:days, 3], [:seconds, 7]]`).
At that time the `reduce` in `#inspect` made sense,
since we would need to get the totals for each part
(the example would become `{ seconds: 12, days: 3 }`).

With the current version of `Duration` we call `to_h` on the `parts`
[immediately on initialize](https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/duration.rb#L211) (see 32f215c3 for details on why we do that),
so now the `reduce` doesn't seem to be doing
anything meaningful.

(I was looking at this method because I was pondering https://github.com/rails/rails/issues/34369)