### PR TITLE
Test when using MySQL `exec_query` returns `ActiveRecord::Result` all…

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -33,11 +33,19 @@ module ActiveRecord
 
           if without_prepared_statement?(binds)
             execute_and_free(sql, name) do |result|
-              ActiveRecord::Result.new(result.fields, result.to_a) if result
+              if result
+                ActiveRecord::Result.new(result.fields, result.to_a)
+              else
+                ActiveRecord::Result.new([], [])
+              end
             end
           else
             exec_stmt_and_free(sql, name, binds, cache_stmt: prepare) do |_, result|
-              ActiveRecord::Result.new(result.fields, result.to_a) if result
+              if result
+                ActiveRecord::Result.new(result.fields, result.to_a)
+              else
+                ActiveRecord::Result.new([], [])
+              end
             end
           end
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -109,6 +109,11 @@ module ActiveRecord
       end
     end
 
+    def test_exec_query_returns_an_empty_result
+      result = @connection.exec_query "INSERT INTO subscribers(nick) VALUES('me')"
+      assert_instance_of(ActiveRecord::Result, result)
+    end
+
     if current_adapter?(:Mysql2Adapter)
       def test_charset
         assert_not_nil @connection.charset


### PR DESCRIPTION
Fixes #34506 - When running `exec_query` with INSERT (or other write commands), MySQL returns `ActiveRecord::Result`