### PR TITLE
SQLite 3.7.16+ returns the order of the primary key columns

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -354,7 +354,6 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_composite_primary_key_out_of_order
-    skip if current_adapter?(:SQLite3Adapter)
     assert_equal ["code", "region"], @connection.primary_keys("barcodes_reverse")
   end
 
@@ -376,7 +375,6 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_dumping_composite_primary_key_out_of_order
-    skip if current_adapter?(:SQLite3Adapter)
     schema = dump_table_schema "barcodes_reverse"
     assert_match %r{create_table "barcodes_reverse", primary_key: \["code", "region"\]}, schema
   end


### PR DESCRIPTION
### Summary
This pull request executes `test_composite_primary_key_out_of_order` with sqlite3 adapter.

https://www.sqlite.org/releaselog/3_7_16.html

> 9 Enhance the PRAGMA table_info command so that the "pk" column is an increasing integer to show the order of columns in the primary key.

Rails 6 supports SQLite 3.8 then we can remove this skip condition.

