### PR TITLE
Use cache_key_with_version instead of cache_key for the example in Low-Level Caching [ci skip]

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -295,7 +295,7 @@ Consider the following example. An application has a `Product` model with an ins
 ```ruby
 class Product < ApplicationRecord
   def competing_price
-    Rails.cache.fetch("#{cache_key}/competing_price", expires_in: 12.hours) do
+    Rails.cache.fetch("#{cache_key_with_version}/competing_price", expires_in: 12.hours) do
       Competitor::API.find_price(id)
     end
   end


### PR DESCRIPTION
### Summary

`ActiveRecord::Base#cache_key` will now return a stable key without a timestamp.
So we should use `cache_key_with_version` for the example in `1.7 Low-Level Caching`.

Sorry, this is a missing fix for [my pull request I submitted before](https://github.com/rails/rails/pull/34363).
