### PR TITLE
Additional types of ResultSet should not contain keys of #attributes_to_define_after_schema_loads

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -40,7 +40,8 @@ module ActiveRecord
     def find_by_sql(sql, binds = [], preparable: nil, &block)
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable)
       column_types = result_set.column_types.dup
-      columns_hash.each_key { |k| column_types.delete k }
+      cached_columns_hash = connection.schema_cache.columns_hash(table_name)
+      cached_columns_hash.each_key { |k| column_types.delete k }
       message_bus = ActiveSupport::Notifications.instrumenter
 
       payload = {

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1447,6 +1447,14 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_respond_to developer, :first_name=
   end
 
+  test "when ignored attribute is loaded, cast type should be preferred over DB type" do
+    developer = AttributedDeveloper.create
+    developer.update_column :name, "name"
+
+    loaded_developer = AttributedDeveloper.where(id: developer.id).select("*").first
+    assert_equal "Developer: name", loaded_developer.name
+  end
+
   test "ignored columns not included in SELECT" do
     query = Developer.all.to_sql.downcase
 

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -5,6 +5,10 @@ require "models/book"
 
 module ActiveRecord
   class InstrumentationTest < ActiveRecord::TestCase
+    def setup
+      ActiveRecord::Base.connection.schema_cache.add(Book.table_name)
+    end
+
     def test_payload_name_on_load
       Book.create(name: "test book")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -279,3 +279,17 @@ class DeveloperWithIncorrectlyOrderedHasManyThrough < ActiveRecord::Base
   has_many :companies, through: :contracts
   has_many :contracts, foreign_key: :developer_id
 end
+
+class DeveloperName < ActiveRecord::Type::String
+  def deserialize(value)
+    "Developer: #{value}"
+  end
+end
+
+class AttributedDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+
+  attribute :name, DeveloperName.new
+
+  self.ignored_columns += ["name"]
+end


### PR DESCRIPTION
First of all, let me explain my use case: I have a heavy JSONB DB column which I want to exclude from most of the queries, that's why I've decided to use [ignored_columns](https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_column) feature. This column is populated via DB trigger, and sometimes I do want to have it loaded, in such cases I explicitly load it (for instance, using `.select("*")`). Also, I have a custom `ActiveRecord::Type` to make interactions with the underlying JSON easier. The problem is that with this combination the value I get when I call that accessor is a _value from the DB_, custom type is completely ignored.

Here is a simplier example with a string instead of JSON:

```ruby
class DeveloperName < ActiveRecord::Type::String
  def deserialize(value)
    "Developer: #{value}"
  end
end

class AttributedDeveloper < ActiveRecord::Base
  self.table_name = "developers"

  attribute :name, DeveloperName.new

  self.ignored_columns += ["name"]
end

developer = AttributedDeveloper.create
developer.update_column :name, "name"

loaded_developer = AttributedDeveloper.where(id: developer.id).select("*").first
puts loaded_developer.name # should be "Developer: name" but it's just "name"
```

Here is a reason why it happens:
1. `ignored_columns` removes the column from the column_hash
2. `#select_all` can fill `column_types` for the result set when DB provides the types (only PostgreSQL does it, so other tests for other DBs cannot reproduce the problem)
3. when `#find_by_sql` prepares the `ActiveRecord::Result`, it uses `column_hash` to remove all the types coming from the DB because we know how to handle them
4. Ignored columns are not in the `column_hash` so `#find_by_sql` defines the accessor method with the DB-provided type and custom `attribute` is ignored

My solution is to remove `attributes_to_define_after_schema_loads` keys from the `column_types` along with `column_hash` keys because having the custom attributes means that we do know how to deserialize this field.