### PR TITLE
Reuse code in AR::Association#find_target

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -179,6 +179,23 @@ module ActiveRecord
       end
 
       private
+
+        def find_target
+          scope = self.scope
+          return scope.to_a if skip_statement_cache?(scope)
+
+          conn = klass.connection
+          sc = reflection.association_scope_cache(conn, owner) do |params|
+            as = AssociationScope.create { params.bind }
+            target_scope.merge!(as.scope(self))
+          end
+
+          binds = AssociationScope.get_bind_values(owner, reflection.chain)
+          sc.execute(binds, conn) do |record|
+            set_inverse_instance(record)
+          end
+        end
+
         # The scope for this association.
         #
         # Note that the association_scope is merged into the target_scope only when the

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -304,22 +304,6 @@ module ActiveRecord
 
       private
 
-        def find_target
-          scope = self.scope
-          return scope.to_a if skip_statement_cache?(scope)
-
-          conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do |params|
-            as = AssociationScope.create { params.bind }
-            target_scope.merge!(as.scope(self))
-          end
-
-          binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, conn) do |record|
-            set_inverse_instance(record)
-          end
-        end
-
         # We have some records loaded from the database (persisted) and some that are
         # in-memory (memory). The same record may be represented in the persisted array
         # and in the memory array.

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -31,24 +31,17 @@ module ActiveRecord
       end
 
       private
+
+        def target_scope
+          super.limit!(1)
+        end
+
         def scope_for_create
           super.except!(klass.primary_key)
         end
 
         def find_target
-          scope = self.scope
-          return scope.take if skip_statement_cache?(scope)
-
-          conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do |params|
-            as = AssociationScope.create { params.bind }
-            target_scope.merge!(as.scope(self)).limit(1)
-          end
-
-          binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, conn) do |record|
-            set_inverse_instance record
-          end.first
+          super.first
         rescue ::RangeError
           nil
         end


### PR DESCRIPTION
Before this patch, singular and collection associations
had different implementations of the #find_target method.
This patch reuses the code properly through extending the low level
methods.

