### PR TITLE
Removed some misleading text regarding subdirectory deployment [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1177,8 +1177,7 @@ Passenger makes it easy to run your application in a subdirectory. You can find 
 
 #### Using a Reverse Proxy
 
-In this case, you would need to configure the proxy server (NGINX, Apache, etc) to forward connections to your application server (Puma, Unicorn, etc.). Check your proxy server's documentation how to map subdirectories.
-
+In this case, you would need to configure the proxy server to forward connections to your application server (Puma, Unicorn, etc). Check your proxy server's documentation ([NGINX](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/), [Apache](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html)) for instructions on how to map application servers to paths.
 
 Rails Environment Settings
 --------------------------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1171,51 +1171,13 @@ config.relative_url_root = "/app1"
 alternatively you can set the `RAILS_RELATIVE_URL_ROOT` environment
 variable.
 
-Rails will now prepend "/app1" when generating links.
-
 #### Using Passenger
 
 Passenger makes it easy to run your application in a subdirectory. You can find the relevant configuration in the [Passenger manual](https://www.phusionpassenger.com/library/deploy/apache/deploy/ruby/#deploying-an-app-to-a-sub-uri-or-subdirectory).
 
 #### Using a Reverse Proxy
 
-Deploying your application using a reverse proxy has definite advantages over traditional deploys. They allow you to have more control over your server by layering the components required by your application.
-
-Many modern web servers can be used as a proxy server to balance third-party elements such as caching servers or application servers.
-
-One such application server you can use is [Unicorn](https://bogomips.org/unicorn/) to run behind a reverse proxy.
-
-In this case, you would need to configure the proxy server (NGINX, Apache, etc) to accept connections from your application server (Unicorn). By default Unicorn will listen for TCP connections on port 8080, but you can change the port or configure it to use sockets instead.
-
-You can find more information in the [Unicorn readme](https://bogomips.org/unicorn/README.html) and understand the [philosophy](https://bogomips.org/unicorn/PHILOSOPHY.html) behind it.
-
-Once you've configured the application server, you must proxy requests to it by configuring your web server appropriately. For example your NGINX config may include:
-
-```
-upstream application_server {
-  server 0.0.0.0:8080;
-}
-
-server {
-  listen 80;
-  server_name localhost;
-
-  root /root/path/to/your_app/public;
-
-  try_files $uri/index.html $uri.html @app;
-
-  location @app {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_redirect off;
-    proxy_pass http://application_server;
-  }
-
-  # some other configuration
-}
-```
-
-Be sure to read the [NGINX documentation](https://nginx.org/en/docs/) for the most up-to-date information.
+In this case, you would need to configure the proxy server (NGINX, Apache, etc) to forward connections to your application server (Puma, Unicorn, etc.). Check your proxy server's documentation how to map subdirectories.
 
 
 Rails Environment Settings


### PR DESCRIPTION
### Summary

1. When using `config.relative_url_root`, Rails will prepend some of the links (e.g. assets), but not all. Removed misleading sentence.
2. Section "Using a Reverse Proxy" was just a general discussion about deployment with NGINX + Unicorn, not related to subdirectory deployment at all. Removed

### Notes

IMHO, there's currently no usable documentation about 
* what's the use case of `config.relative_url_root`
* what's the exact effect of `config.relative_url_root`
* what's the difference to `config.assets.prefix`
* what's the difference to a route scope

Current section in the guide creates more confusion than help, so I suggest to remove most of it.