### PR TITLE
[WIP] Allow relative_url_root in env config

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -44,7 +44,7 @@ module ActionController
           options[:original_script_name] = original_script_name
         else
           if same_origin
-            options[:script_name] = request.script_name.empty? ? "" : request.script_name.dup
+            options[:script_name] = request.script_name.dup unless request.script_name.empty?
           else
             options[:script_name] = script_name
           end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -574,15 +574,6 @@ module Rails
       config.autoload_once_paths.freeze
     end
 
-    initializer :add_routing_paths do |app|
-      routing_paths = paths["config/routes.rb"].existent
-
-      if routes? || routing_paths.any?
-        app.routes_reloader.paths.unshift(*routing_paths)
-        app.routes_reloader.route_sets << routes
-      end
-    end
-
     # I18n load paths are a special case since the ones added
     # later have higher priority.
     initializer :add_locales do
@@ -612,6 +603,15 @@ module Rails
     initializer :load_config_initializers do
       config.paths["config/initializers"].existent.sort.each do |initializer|
         load_config_initializer(initializer)
+      end
+    end
+
+    initializer :add_routing_paths do |app|
+      routing_paths = paths["config/routes.rb"].existent
+
+      if routes? || routing_paths.any?
+        app.routes_reloader.paths.unshift(*routing_paths)
+        app.routes_reloader.route_sets << routes
       end
     end
 

--- a/railties/test/relative_url_root_test.rb
+++ b/railties/test/relative_url_root_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+module RailtiesTest
+  class EngineTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    setup do
+      build_app
+
+      app_file "app/controllers/application_controller.rb", <<-RUBY
+        class ApplicationController < ActionController::Base
+          def welcome
+            render plain: root_path
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: "application#welcome"
+        end
+      RUBY
+    end
+
+    teardown do
+      teardown_app
+    end
+
+    test "application routes are properly generated when relative_url_root is set" do
+      add_to_env_config "development", "config.relative_url_root = '/foo'"
+      boot_rails
+
+      root_path = rails("runner", "p Rails.application.routes.url_helpers.root_path").chomp
+
+      assert_equal "\"/foo/\"", root_path
+    end
+
+    test "controller routes are properly generated when relative_url_root is set" do
+      add_to_env_config "development", "config.relative_url_root = '/foo'"
+      boot_rails
+
+      get "/"
+      assert_equal "/foo/", last_response.body
+    end
+
+  private
+    def boot_rails
+      require "#{app_path}/config/environment"
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Allow `relative_url_root` configuration option to be used in route helpers when placed in `config/environments/*.rb`.
