### PR TITLE
Add or to WhereChain to support simple, flexible conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add another way to combine WHERE conditions with OR operator
+
+    This makes it easier to write simple/flexible conditions with OR logic
+    without repeating the scope. This method takes a list of arguments, each one
+    of which could be used in `where`. From these, it constructs a compount WHERE
+    statement, connecting those conditions with the OR operator.
+
+    Example:
+
+        Post.where.or({ title: 'Good day' }, ["created_at < ?", Date.today], 'active = true')
+
+    *Nick Davies*
+
 *   Cached columns_hash fields should be excluded from ResultSet#column_types
 
     PR #34528 addresses the inconsistent behaviour when attribute is defined for an ignored column. The following test


### PR DESCRIPTION
This adds a new method `or` to WhereChain. This can be used to more easily write WHERE clauses that use the OR operator, using familiar hash/array/string arguments that `where` takes. But unlike the existing ActiveRecord::Relation `or`, this will not require repeating the scope.

For example, where you previously would have had to go with one of these options:
```ruby
Post.where(title: 'Goodbye').or(Post.where(active: true))
Post.where("title = 'Goodbye' OR active = true")
```
Now you can define the two (or more) operands using the same types of arguments passed to `where`:
```ruby
Post.where.or("active = true", ["created_at > ?", Date.today], { title: 'Goodbye' })
```
This is good for simple "OR" scenarios, where repeating the starting scope would make things messier. If the conditions that need to be combined with "OR" are more complex, then defining two scopes and combining them using the existing `or` method is probably the better option.

Making this a method on WhereChain ought to alleviate the concerns in #9052 about how a more flexible `or` method would affect what comes before or after it in a method chain. In this implementation, the "OR" operator only gets applied to the conditions included in its own arguments.

This new method is currently written to use the existing ActiveRecord `or` method under the hood, but I'm open to alternatives.
