### PR TITLE
Fix minor Active Storage docs typo [ci skip]

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -40,7 +40,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   end
 
   class << self
-    # You can used the signed ID of a blob to refer to it on the client side without fear of tampering.
+    # You can use the signed ID of a blob to refer to it on the client side without fear of tampering.
     # This is particularly helpful for direct uploads where the client-side needs to refer to the blob
     # that was created ahead of the upload itself on form submission.
     #


### PR DESCRIPTION
### Summary

Just a small typo in Active Storage docs. 😃 
