### PR TITLE
Pass the test reporter by reference

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -23,6 +23,7 @@ module ActiveSupport
         end
 
         def <<(o)
+          o[2] = DRbObject.new(o[2]) if o
           @queue << o
         end
 


### PR DESCRIPTION
This prevents the array from being dumped as a DRbObject so we can reduce
communication with the server.

In DRb, if `Marshal.dump` fails, `Marshal.dump` is executed again after converting the object to `DRbObject`. This also possible to reduce the execution of `Marshal.dump` by converting to a format that can be marshalized in advance using `DRbObject`.
This is the same approach to Action Pack's parallel test. Ref: 5751b7ea58d7cf259dda30fb42fff51fc6ae93d5

