### PR TITLE
Fix `ArgumentError` when uploading to amazon s3

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `ArgumentError` when uploading to amazon s3
+
+    *Hiroki Sanpei*
+
 *   Add progressive JPG to default list of variable content types
 
     *Maurice Kühlborn*

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -16,7 +16,7 @@ module ActiveStorage
       @upload_options = upload
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         begin
           object_for(key).put(upload_options.merge(body: io, content_md5: checksum))


### PR DESCRIPTION
### Summary

I fixed lack of modification the following commit.
https://github.com/rails/rails/commit/54ed6ad8d7468dc3a0b690e629c7c18497552eb8

In rails 5.2.1.1, when I uploaded object using `#attach` to amazon s3, `ArgumentError: unknown keyword: content_type` was occurred.