### PR TITLE
Do nothing when the same block is included again

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   If the same block is `included` multiple times for a Concern, an exception is no longer raised.
+
+    *Mark J. Titorenko*, *Vlad Bokov*
+
 *   Fix bug where `#to_options` for `ActiveSupport::HashWithIndifferentAccess`
     would not act as alias for `#symbolize_keys`.
 

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -125,9 +125,13 @@ module ActiveSupport
 
     def included(base = nil, &block)
       if base.nil?
-        raise MultipleIncludedBlocks if instance_variable_defined?(:@_included_block)
-
-        @_included_block = block
+        if instance_variable_defined?(:@_included_block)
+          if @_included_block.source_location != block.source_location
+            raise MultipleIncludedBlocks
+          end
+        else
+          @_included_block = block
+        end
       else
         super
       end

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -128,4 +128,12 @@ class ConcernTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_no_raise_on_same_included_call
+    assert_nothing_raised do
+      2.times do
+        load File.expand_path("../fixtures/concern/some_concern.rb", __FILE__)
+      end
+    end
+  end
 end

--- a/activesupport/test/fixtures/concern/some_concern.rb
+++ b/activesupport/test/fixtures/concern/some_concern.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module SomeConcern
+  extend ActiveSupport::Concern
+
+  included do
+    # shouldn't raise when module is loaded more than once
+  end
+end


### PR DESCRIPTION
If the same block is included multiple times, we no longer raise an exception or overwrite the included block instance variable.

Fixes #14802.