### PR TITLE
Log exceptions atomically

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -183,9 +183,9 @@ module ActionDispatch
           message = []
           message << "  "
           message << "#{exception.class} (#{exception.message}):"
-          message += exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+          message.concat(exception.annoted_source_code) if exception.respond_to?(:annoted_source_code)
           message << "  "
-          message += trace
+          message.concat(trace)
 
           log_array(logger, message)
         end

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -180,11 +180,14 @@ module ActionDispatch
         trace = wrapper.framework_trace if trace.empty?
 
         ActiveSupport::Deprecation.silence do
-          logger.fatal "  "
-          logger.fatal "#{exception.class} (#{exception.message}):"
-          log_array logger, exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
-          logger.fatal "  "
-          log_array logger, trace
+          message = []
+          message << "  "
+          message << "#{exception.class} (#{exception.message}):"
+          message += exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+          message << "  "
+          message += trace
+
+          log_array(logger, message)
         end
       end
 


### PR DESCRIPTION
When distributed over multiple logger calls the lines can become intermixed with other log statements. Combining them into a single logger call makes sure they always get logged together.