### PR TITLE
Patch load error in case GemSpecError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -174,12 +174,12 @@ module ActiveRecord
             if e.path == path_to_adapter
               # We can assume that a non-builtin adapter was specified, so it's
               # either misspelled or missing from Gemfile.
-              raise e.class, "Could not load the '#{spec[:adapter]}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
+              raise LoadError, "Could not load the '#{spec[:adapter]}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
 
             # Bubbled up from the adapter require. Prefix the exception message
             # with some guidance about how to address it and reraise.
             else
-              raise e.class, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+              raise LoadError, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
             end
           end
 


### PR DESCRIPTION
### Summary
I stumbled upon this error while trying to make a basic.  

```
2.3.4 :008 > ActiveRecord::Base.establish_connection(                                                                                          
2.3.4 :009 >       "adapter"  => "sqlite3",                                                                                                    
2.3.4 :010 >       "database" => "path/to/dbfile"                                                                                              
2.3.4 :011?>     )       
```
And it gave out a:
```
ArgumentError: wrong number of arguments (given 1, expected 2)                                                                                                                                  
        from /Users/sergio/.rvm/rubies/ruby-2.3.4/lib/ruby/site_ruby/2.3.0/rubygems/errors.rb:28:in `initialize'                                                                                
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/connection_specification.rb:203:in `exception'                                  
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/connection_specification.rb:203:in `raise'                                      
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/connection_specification.rb:203:in `rescue in spec'                             
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/connection_specification.rb:190:in `spec'                                       
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:950:in `establish_connection'                       
        from /Users/sergio/.rvm/gems/ruby-2.3.4/gems/activerecord-5.2.1.1/lib/active_record/connection_handling.rb:60:in `establish_connection'                                                 
        from (irb):21                                                                                                                                                                           
        from /Users/sergio/.rvm/rubies/ruby-2.3.4/bin/irb:11:in `<main>'                                                                                  
```

It seems that I was missing a dependency (sqlite3 _sigh_) , and Gem `MissingSpecError` has some problems here in initialisation -- it requires 2 arguments . 

I replicated the offending line:
```
(byebug) raise e.class, "Hello", e.backtrace
*** ArgumentError Exception: wrong number of arguments (given 1, expected 2)

nil
```


It seems like `LoadError` also catches `MissingSpecError`. The last one requires 2 arguments, and fails to provide a meaningful error message. -- http://ruby-doc.org/stdlib-2.4.0_preview1/libdoc/rubygems/rdoc/Gem/MissingSpecError.html

In this PR we would be casting that error to a `LoadError` instead when rescuing and re-raising a `MissingSpecError` (since we would need more complex arguments)  

The alternative would be to create some convoluted logic for handling these 2 types of exceptions