### PR TITLE
Fix attribute decoration leak on serialized attribute test

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -13,6 +13,10 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   MyObject = Struct.new :attribute1, :attribute2
 
+  # NOTE: Use a duplicate of Topic so attribute
+  # changes don't bleed into other tests
+  Topic = ::Topic.dup
+
   teardown do
     Topic.serialize("content")
   end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34555.

`SerializedAttributeTest` appears to leak attribute decorations triggered by [this line](https://github.com/rails/rails/blob/00638f31d1f5c914bac32c5f00cb0e0693274b99/activerecord/test/cases/serialized_attribute_test.rb#L17) when placed in the test's teardown block. This makes it so the next test that uses an instance of `Topic` is unable to cast its time attributes properly because `Time.zone` is nil by default in the AR test suite.
