### PR TITLE
Allow spaces in postgres table names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow spaces in postgres table names.
+
+    Fixes issue where "user post" is misinterpreted as "\"user\".\"post\"" when quoting table names with the postgres adapter.
+
+    *Gannon McGibbon*
+
 *   Cached columns_hash fields should be excluded from ResultSet#column_types
 
     PR #34528 addresses the inconsistent behaviour when attribute is defined for an ignored column. The following test

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         # * <tt>"schema_name".table_name</tt>
         # * <tt>"schema.name"."table name"</tt>
         def extract_schema_qualified_name(string)
-          schema, table = string.scan(/[^".\s]+|"[^"]*"/)
+          schema, table = string.scan(/[^".]+|"[^"]*"/)
           if table.nil?
             table = schema
             schema = nil

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -39,6 +39,11 @@ module ActiveRecord
           type = OID::Bit.new
           assert_nil @conn.quote(type.serialize(value))
         end
+
+        def test_quote_table_name_with_spaces
+          value = "user posts"
+          assert_equal "\"user posts\"", @conn.quote_table_name(value)
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34540.

Allows spaces in postgres table names.
