### PR TITLE
Add advanced test helpers docs to guides

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1397,6 +1397,56 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
 end
 ```
 
+#### Using Separate Files
+
+If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files. One good place to store them is `lib/test`.
+
+```ruby
+# lib/test/multiple_assertions.rb
+module MultipleAssertions
+  def assert_multiple_of_fourty_two(number)
+    assert (number % 42 == 0), 'expected #{number} to be a multiple of 42'
+  end
+end
+```
+
+These helpers can then be explicitly required as needed and included as needed
+
+```ruby
+require 'test_helper'
+require 'test/multiple_assertions'
+
+class NumberTest < ActiveSupport::TestCase
+  include MultipleAssertions
+
+  test '420 is a multiple of fourty two' do
+    assert_multiple_of_fourty_two 420
+  end
+end
+```
+
+or they can continue to be included directly into the relevant parent classes
+
+```ruby
+# test/test_helper.rb
+require 'test/sign_in_helper'
+
+class ActionDispatch::IntegrationTest
+  include SignInHelper
+end
+```
+
+#### Eagerly Requiring Helpers
+
+You may find it convenient to eagerly require helpers in `test_helper.rb` so your test files have implicit access to them. This can be accomplished using globbing, as follows
+
+```ruby
+# test/test_helper.rb
+Dir[Rails.root.join('lib', 'test', '**', '*.rb')].each { |file| require file }
+```
+
+This has the downside of increasing the boot-up time, as opposed to manually requiring only the necessary files in your individual tests.
+
 Testing Routes
 --------------
 


### PR DESCRIPTION
### Summary

This updates the guides to include examples of useful patterns for organizing _test helpers_, and preventing `test_helpers.rb` from getting bloated. It adds two sections:

- **Extracting Files**, which discusses extracting modules and where they could be put
- **Eagerly Requiring Helpers**, which discusses how to easily require these modules for convenience

### Motivation

I was unable to find good documentation on how to organize test helpers or custom assertions. Unfortunately, the existing documentation's pattern of adding directly to `test_helper.rb` can lead to that file becoming bloated. The closest related information I could find was [RSpec's documentation on the use of `spec/support`](https://github.com/rspec/rspec-rails/blob/8c3a238f8cb26b5821dc4ccaacff2f2088bf2adc/lib/generators/rspec/install/templates/spec/rails_helper.rb#L10-L23).

### Why not `test/support`?

In my discussion with @rafaelfranca, I had originally leaned towards `test/support`. However, in the event that the helpers are complex enough to warrant tests, it is not obvious how this should be handled:

- Should the tests be in `test/support`, and explicitly ignored when eagerly requiring the contents of that directory?
- Should the tests be in another folder, such as `test/unit`?

@rafaelfranca's suggestion of promoting the helpers to the `lib/test` directory has an obvious test location of `test/lib`, making it a good fit for a recommended pattern.

----

- [ ] Either update #34619 after merging this, or update this after merging #34619