### PR TITLE
Add if_exists option for PG remove_column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -632,6 +632,13 @@ module ActiveRecord
         end
 
         private
+
+          def remove_column_for_alter(table_name, column_name, type = nil, options = {})
+            sql = +"DROP COLUMN "
+            sql << "IF EXISTS " if options[:if_exists]
+            sql << quote_column_name(column_name)
+          end
+
           def schema_creation
             PostgreSQL::SchemaCreation.new(self)
           end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -434,6 +434,20 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.reset_pk_sequence! table_name
   end
 
+  def test_remove_single_field_with_if_exists_option
+    assert_no_column Thing1, :stuff
+    @connection.add_column Thing1.table_name, :stuff, :string
+    assert_column Thing1, :stuff
+
+    @connection.remove_column Thing1.table_name, :stuff
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @connection.remove_column Thing1.table_name, :stuff
+    end
+
+    @connection.remove_column Thing1.table_name, :stuff, nil, if_exists: true
+    assert_no_column Thing1, :stuff
+  end
+
   private
     def columns(table_name)
       @connection.send(:column_definitions, table_name).map do |name, type, default|


### PR DESCRIPTION
### Summary

It's rather convenient using `if_exists` option for `drop_table` method in migrations. Unfortunately, this option is not allowed for `remove_column`, but can be implemented for PostgreSQL adapter. SQlite3 allows removing column twice without complaints. MySQL would still raise an error on second attempt to delete the same column as it doesn't support this option.

This PR adds possibility to pass `if_exists` option to `remove_column` method in migrations for PostgreSQL. So that it's possible to write a migration deletes a column and its `down` step doesn't matter:

```ruby
class RemoveUserName < ActiveRecord::Migration[5.2]
  def change
    remove_column :users, :name, nil, if_exists: true
  end
end
```