### PR TITLE
Add ability to use IF NOT EXISTS syntax on PostgreSQL when creating indices

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -738,7 +738,7 @@ module ActiveRecord
       #
       # ====== Creating an index if it does not exist
       #
-      #   add_index(:accounts, :name, :if_not_exists: true)
+      #   add_index(:accounts, :name, if_not_exists: true)
       #
       # generates:
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -736,6 +736,16 @@ module ActiveRecord
       #
       # Note: Partial indexes are only supported for PostgreSQL and SQLite 3.8.0+.
       #
+      # ====== Creating an index if it does not exist
+      #
+      #   add_index(:accounts, :name, :if_not_exists: true)
+      #
+      # generates:
+      #
+      #   CREATE INDEX IF NOT EXISTS index_accounts_on_name ON accounts(name)
+      #
+      # Note: IF NOT EXISTS is only supported for PostgreSQL from 9.5 onward
+      #
       # ====== Creating an index with a specific method
       #
       #   add_index(:developers, :name, using: 'btree')

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -462,8 +462,8 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, options = {}) #:nodoc:
-          index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using, comment = add_index_options(table_name, column_name, options)
-          execute("CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}").tap do
+          index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using, index_if_not_exists, comment = add_index_options(table_name, column_name, options)
+          execute("CREATE #{index_type} INDEX #{index_if_not_exists}#{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}").tap do
             execute "COMMENT ON INDEX #{quote_column_name(index_name)} IS #{quote(comment)}" if comment
           end
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -208,6 +208,12 @@ module ActiveRecord
           connection.remove_index("testings", "last_name")
           assert_not connection.index_exists?("testings", "last_name")
         end
+
+        def test_double_add_index_if_not_exists
+          connection.add_index(table_name, [:foo], name: "some_idx")
+          # should not raise error
+          connection.add_index(table_name, [:foo], name: "some_idx", if_not_exists: true)
+        end
       end
 
       private

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -214,6 +214,13 @@ module ActiveRecord
           # should not raise error
           connection.add_index(table_name, [:foo], name: "some_idx", if_not_exists: true)
         end
+
+        def test_double_add_index_if_not_exists_false
+          connection.add_index(table_name, [:foo], name: "some_idx")
+          assert_raises(ArgumentError) {
+            connection.add_index(table_name, [:foo], name: "some_idx", if_not_exists: false)
+          }
+        end
       end
 
       private


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Similar to #34566  this adds the ability to make use of PostgreSQL's graceful index creation, which silently succeeds if the index already exists with the same name

### Other Information

There's an edge case where someone might pass :if_not_exists on a different database engine and not get the ArgumentError check, but still have the attempt to add the duplicate index fail.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
