### PR TITLE
Pass the `connection` to the `@instrumenter.instrument` method call

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -481,7 +481,8 @@ module ActiveRecord
           :name           => name,
           :connection_id  => object_id,
           :statement_name => statement_name,
-          :binds          => binds) { yield }
+          :binds          => binds,
+          :connection     => self) { yield }
       rescue => e
         raise translate_exception_class(e, sql)
       end


### PR DESCRIPTION
### Summary

Pass the `connection` to the `@instrumenter.instrument` call in the `ActiveRecord::ConnectionAdapters#log` method.

## Why we need that ?

Because you already pass the `object_id` (`:connection_id  => object_id`) of the `ActiveRecord::ConnectionAdapters` instance which will then force us to use `ObjectSpace._id2ref` function to retrieve this instance but:
 1. `ObjectSpace._id2ref` is not accessible in JRuby
 2. @headius said this: "_id2ref should never be use by any code anywhere. It isn't even safe on MRI.". Here: https://twitter.com/headius/status/1068188351012966402

So when you pass `:connection_id  => object_id`, it's not that useful. 😕
Passing directly the reference of the object is better for users.

It'll allow us to cleanly solve this issue in the Datadog instrumenter: https://github.com/DataDog/dd-trace-rb/issues/640

WDYT ?


