### PR TITLE
Allow aliased attributes in update backport

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow aliased attributes to be used in `#update_columns` and `#update`.
+
+    *Gannon McGibbon*
+
 *   Allow spaces in postgres table names.
 
     Fixes issue where "user post" is misinterpreted as "\"user\".\"post\"" when quoting table names with the postgres adapter.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -120,9 +120,13 @@ module ActiveRecord
       end
 
       private
-        def write_attribute_without_type_cast(attr_name, _)
-          result = super
-          clear_attribute_change(attr_name)
+        def write_attribute_without_type_cast(attr_name, value)
+          name = attr_name.to_s
+          if self.class.attribute_alias?(name)
+            name = self.class.attribute_alias(name)
+          end
+          result = super(name, value)
+          clear_attribute_change(name)
           result
         end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -329,6 +329,12 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_raises(ActiveModel::UnknownAttributeError) { topic.update(no_column_exists: "Hello!") }
   end
 
+  test "write_attribute allows writing to aliased attributes" do
+    topic = Topic.first
+    assert_nothing_raised { topic.update_columns(heading: "Hello!") }
+    assert_nothing_raised { topic.update(heading: "Hello!") }
+  end
+
   test "read_attribute" do
     topic = Topic.new
     topic.title = "Don't change the topic"


### PR DESCRIPTION
### Summary

Backport of https://github.com/rails/rails/pull/34569 to `5-2-stable`.