### PR TITLE
Fix the scoping with query methods in the scope block

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -8,7 +8,7 @@ module ActiveRecord
   module SpawnMethods
     # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
-      clone
+      @delegate_to_klass ? klass.all : clone
     end
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -254,9 +254,14 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
-  def test_scoping_works_in_the_scope_block
+  def test_scoping_with_klass_method_works_in_the_scope_block
     expected = SpecialPostWithDefaultScope.unscoped.to_a
     assert_equal expected, SpecialPostWithDefaultScope.unscoped_all
+  end
+
+  def test_scoping_with_query_method_works_in_the_scope_block
+    expected = SpecialPostWithDefaultScope.unscoped.where(author_id: 0).to_a
+    assert_equal expected, SpecialPostWithDefaultScope.authorless
   end
 
   def test_circular_joins_with_scoping_does_not_crash

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -254,6 +254,7 @@ class SpecialPostWithDefaultScope < ActiveRecord::Base
   self.table_name = "posts"
   default_scope { where(id: [1, 5, 6]) }
   scope :unscoped_all, -> { unscoped { all } }
+  scope :authorless, -> { unscoped { where(author_id: 0) } }
 end
 
 class PostThatLoadsCommentsInAnAfterSaveHook < ActiveRecord::Base


### PR DESCRIPTION
Follow up #33394.

#33394 only fixes the case of scoping with klass methods in the scope
block which invokes `klass.all`.
Query methods in the scope block also need to invoke `klass.all` to be
affected by the scoping.