### PR TITLE
Add a test with extra keys to active_storage Service#upload

### DIFF
--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -46,6 +46,25 @@ module ActiveStorage::Service::SharedServiceTests
       end
     end
 
+    test "uploading with integrity and multiple keys" do
+      begin
+        key  = SecureRandom.base58(24)
+        data = "Something else entirely!"
+        @service.upload(
+          key,
+          StringIO.new(data),
+          checksum: Digest::MD5.base64digest(data),
+          filename: "racecar.jpg",
+          content_type: "image/jpg",
+          metadata: { metadata: true }
+        )
+
+        assert_equal data, @service.download(key)
+      ensure
+        @service.delete key
+      end
+    end
+
     test "downloading" do
       assert_equal FIXTURE_DATA, @service.download(@key)
     end


### PR DESCRIPTION
### Summary

`S3Service#upload` was broken in `5.2.1.1` and got fixed in https://github.com/rails/rails/pull/34550

This adds a shared test ensuring that the `upload` method accepts the extra hash for all the services.

This takes the keys present in the documentation around `attachments.attach`
