### PR TITLE
Remove `as_json` from value and tests

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -91,7 +91,7 @@ module ActiveSupport
             when String
               EscapedString.new(value)
             when Numeric, NilClass, TrueClass, FalseClass
-              value.as_json
+              value
             when Hash
               Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
             when Array

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -443,26 +443,6 @@ EXPECTED
     assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
   end
 
-  class InfiniteNumber
-    def as_json(options = nil)
-      { "number" => Float::INFINITY }
-    end
-  end
-
-  def test_to_json_works_when_as_json_returns_infinite_number
-    assert_equal '{"number":null}', InfiniteNumber.new.to_json
-  end
-
-  class NaNNumber
-    def as_json(options = nil)
-      { "number" => Float::NAN }
-    end
-  end
-
-  def test_to_json_works_when_as_json_returns_NaN_number
-    assert_equal '{"number":null}', NaNNumber.new.to_json
-  end
-
   def test_to_json_works_on_io_objects
     assert_equal STDOUT.to_s.to_json, STDOUT.to_json
   end


### PR DESCRIPTION
TL;DR `as_json` is slow. We're trying to replace JSON with Yajl but are hitting problem with the weirdness that are the monkey patches around JSON in AS. We found that some JSON is getting parsed 3 times! and one of the calls was supposed to be [deprecated awhile ago](https://github.com/rails/rails/pull/26933#issuecomment-260185056). Can we remove this without deprecation? If not can we deprecate it in 5.2 even though that's non-standard?

---

Removing `as_json` here revealed that these tests failed because they
return a non-json compliant value of NaNNumber and InfinitNumber.

While we've supported this for awhile one of the issues with this
support is that once we hit `jsonify` all the values _should_ already be
json-compliant values. These tests I removed were added in #26933 - but
in the comments on that PR they were supposed to be deprecated and
removed in the next cycle - but that work never happened. See
https://github.com/rails/rails/pull/26933#issuecomment-260185056

We want to remove this `as_json` here because Rails JSON is very slow.
One of the reasons it's slow is because in some cases we actually loop
over the JSON we're parsing 3 times!

Here are the passes:

1. Call as_json on a tree of objects
  1a. Special objects pass the options down. These are
  Object, Struct, Enumerable, Array, Hash
  1b. This first pass eliminates Structs, Enumerables, and Objects
  Structs replaced with hashes, Enumerables -> Arrays, Objects -> Hash
  1c. New tree contains only: String, Number, Hash, Array, nil, true,
  false
2. Tree is walked again
  2a. Convert Strings to EscapedStrings
  2b. Can retun bad values from as_json (like the infinity and nan)
3. Convert to json

By removing this `as_json` we reduce one of the passes for this case.
The argument here is that the first pass should never have returned a
bad value so we shouldn't have to walk those values a second time - the
value should be `nil` (which it what it will be on pass 3).

[Eileen M. Uchitelle & Aaron Patterson]

cc/ @rafaelfranca @tenderlove @matthewd @jeremy (who else is json knowledgable?)