### PR TITLE
[WIP] Add public_service_url for public assets.

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -134,6 +134,15 @@ class ActiveStorage::Blob < ActiveRecord::Base
       disposition: forced_disposition_for_service_url || disposition, **options
   end
 
+  # Returns the URL of the blob on the service. This URL is intended to be long-lived and can be used directly
+  # with users. Use +public_service_url+ when exposing public assets and not for anything sensitive.
+  def public_service_url(disposition: :inline, filename: nil, **options)
+    filename = ActiveStorage::Filename.wrap(filename || self.filename)
+
+    service.public_url key, filename: filename, content_type: content_type_for_service_url,
+      disposition: forced_disposition_for_service_url || disposition, **options
+  end
+
   # Returns a URL that can be used to directly upload a file for this blob on the service. This URL is intended to be
   # short-lived for security and only generated on-demand by the client-side JavaScript responsible for doing the uploading.
   def service_url_for_direct_upload(expires_in: ActiveStorage.service_urls_expire_in)

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -116,6 +116,22 @@ module ActiveStorage
       end
     end
 
+    def public_url(key, filename:, disposition:, content_type:)
+      instrument :url, key: key do |payload|
+        generated_url = signer.signed_uri(
+          uri_for(key), false,
+          service: "b",
+          permissions: "r",
+          content_disposition: content_disposition_with(type: disposition, filename: filename),
+          content_type: content_type,
+        ).to_s
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def headers_for_direct_upload(key, content_type:, checksum:, **)
       { "Content-Type" => content_type, "Content-MD5" => checksum, "x-ms-blob-type" => "BlockBlob" }
     end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -123,6 +123,32 @@ module ActiveStorage
       end
     end
 
+    def public_url(key, filename:, content_type:, disposition:)
+      instrument :url, key: key do |payload|
+        content_disposition = content_disposition_with(type: disposition, filename: filename)
+        verified_key = ActiveStorage.verifier.generate(
+          {
+            key: key,
+            disposition: content_disposition,
+            content_type: content_type,
+          },
+          {
+            purpose: :blob_key
+          },
+        )
+
+        generated_url = url_helpers.rails_disk_service_url(verified_key,
+          host: current_host,
+          disposition: content_disposition,
+          content_type: content_type,
+          filename: filename,
+        )
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def headers_for_direct_upload(key, content_type:, **)
       { "Content-Type" => content_type }
     end

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -114,6 +114,16 @@ module ActiveStorage
       end
     end
 
+    def public_url(key, **)
+      instrument :url, key: key do |payload|
+        generated_url = file_for(key).public_url
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def headers_for_direct_upload(key, checksum:, **)
       { "Content-MD5" => checksum }
     end

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -95,6 +95,16 @@ module ActiveStorage
       end
     end
 
+    def public_url(key, **)
+      instrument :url, key: key do |payload|
+        generated_url = object_for(key).public_url
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def headers_for_direct_upload(key, content_type:, checksum:, **)
       { "Content-Type" => content_type, "Content-MD5" => checksum }
     end

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -17,6 +17,13 @@ if SERVICE_CONFIGURATIONS[:azure]
       assert_match SERVICE_CONFIGURATIONS[:azure][:container], url
     end
 
+    test "public URL generation" do
+      url = @service.public_url(@key, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+
+      assert_match(/(\S+)&rscd=inline%3B\+filename%3D%22avatar\.png%22%3B\+filename\*%3DUTF-8%27%27avatar\.png&rsct=image%2Fpng/, url)
+      assert_match SERVICE_CONFIGURATIONS[:azure][:container], url
+    end
+
     test "uploading a tempfile" do
       begin
         key  = SecureRandom.base58(24)

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -12,6 +12,11 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
       @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
+  test "public url generation" do
+    assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
+      @service.public_url(@key, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+  end
+
   test "headers_for_direct_upload generation" do
     assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
   end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -84,6 +84,12 @@ if SERVICE_CONFIGURATIONS[:gcs]
       assert_match(/storage\.googleapis\.com\/.*response-content-disposition=inline.*test\.txt.*response-content-type=text%2Fplain/,
         @service.url(@key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
     end
+
+    test "public URL generation" do
+      url = @service.public_url(@key)
+
+      assert_match(/storage\.googleapis\.com\/.*\/#{@key}/, url)
+    end
   end
 else
   puts "Skipping GCS Service tests because no GCS configuration was supplied"

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -46,6 +46,13 @@ if SERVICE_CONFIGURATIONS[:s3]
       assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
     end
 
+    test "public URL generation" do
+      url = @service.public_url(@key)
+
+      assert_match(/s3(-[-a-z0-9]+)?\.(\S+)?amazonaws.com.*\/#{@key}/, url)
+      assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
+    end
+
     test "uploading with server-side encryption" do
       config  = SERVICE_CONFIGURATIONS.deep_merge(s3: { upload: { server_side_encryption: "AES256" } })
       service = ActiveStorage::Service.configure(:s3, config)

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -393,6 +393,12 @@ jobs, Cronjobs, etc.), you can access the rails_blob_path like this:
 Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true)
 ```
 
+You may also want to link to assets directly from a service (eg. public images hosted on Amazon S3). `ActiveStorage::Blob#public_service_url` provides an easy way to retrieve unsigned links from your service backend:
+
+```
+image_tag(user.avatar.public_service_url)
+```
+
 Downloading Files
 -----------------
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34552.

Adds `ActiveStorage::Blob#service_url` example to guides.
