### PR TITLE
Extract `ActiveSupport::DeepTransformObject`

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deep_transform_object"
+
 class Hash
   # Returns a new hash with all values converted by the block operation.
   # This includes the values from the root hash and from all
@@ -10,37 +12,13 @@ class Hash
   #  hash.deep_transform_values{ |value| value.to_s.upcase }
   #  # => {person: {name: "ROB", age: "28"}}
   def deep_transform_values(&block)
-    _deep_transform_values_in_object(self, &block)
+    ActiveSupport::DeepTransformObject.deep_transform_values(self, &block)
   end
 
   # Destructively converts all values by using the block operation.
   # This includes the values from the root hash and from all
   # nested hashes and arrays.
   def deep_transform_values!(&block)
-    _deep_transform_values_in_object!(self, &block)
+    ActiveSupport::DeepTransformObject.deep_transform_values!(self, &block)
   end
-
-  private
-    # Support methods for deep transforming nested hashes and arrays.
-    def _deep_transform_values_in_object(object, &block)
-      case object
-      when Hash
-        object.transform_values { |value| _deep_transform_values_in_object(value, &block) }
-      when Array
-        object.map { |e| _deep_transform_values_in_object(e, &block) }
-      else
-        yield(object)
-      end
-    end
-
-    def _deep_transform_values_in_object!(object, &block)
-      case object
-      when Hash
-        object.transform_values! { |value| _deep_transform_values_in_object!(value, &block) }
-      when Array
-        object.map! { |e| _deep_transform_values_in_object!(e, &block) }
-      else
-        yield(object)
-      end
-    end
 end

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deep_transform_object"
+
 class Hash
   # Returns a new hash with all keys converted to strings.
   #
@@ -63,14 +65,14 @@ class Hash
   #  hash.deep_transform_keys{ |key| key.to_s.upcase }
   #  # => {"PERSON"=>{"NAME"=>"Rob", "AGE"=>"28"}}
   def deep_transform_keys(&block)
-    _deep_transform_keys_in_object(self, &block)
+    ActiveSupport::DeepTransformObject.deep_transform_keys(self, &block)
   end
 
   # Destructively converts all keys by using the block operation.
   # This includes the keys from the root hash and from all
   # nested hashes and arrays.
   def deep_transform_keys!(&block)
-    _deep_transform_keys_in_object!(self, &block)
+    ActiveSupport::DeepTransformObject.deep_transform_keys!(self, &block)
   end
 
   # Returns a new hash with all keys converted to strings.
@@ -110,34 +112,4 @@ class Hash
   def deep_symbolize_keys!
     deep_transform_keys! { |key| key.to_sym rescue key }
   end
-
-  private
-    # Support methods for deep transforming nested hashes and arrays.
-    def _deep_transform_keys_in_object(object, &block)
-      case object
-      when Hash
-        object.each_with_object({}) do |(key, value), result|
-          result[yield(key)] = _deep_transform_keys_in_object(value, &block)
-        end
-      when Array
-        object.map { |e| _deep_transform_keys_in_object(e, &block) }
-      else
-        object
-      end
-    end
-
-    def _deep_transform_keys_in_object!(object, &block)
-      case object
-      when Hash
-        object.keys.each do |key|
-          value = object.delete(key)
-          object[yield(key)] = _deep_transform_keys_in_object!(value, &block)
-        end
-        object
-      when Array
-        object.map! { |e| _deep_transform_keys_in_object!(e, &block) }
-      else
-        object
-      end
-    end
 end

--- a/activesupport/lib/active_support/deep_transform_object.rb
+++ b/activesupport/lib/active_support/deep_transform_object.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module DeepTransformObject # :nodoc:
+    module_function
+
+    def deep_transform_keys(object, &block)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          result[yield(key)] = deep_transform_keys(value, &block)
+        end
+      when Array
+        object.map { |e| deep_transform_keys(e, &block) }
+      else
+        object
+      end
+    end
+
+    def deep_transform_keys!(object, &block)
+      case object
+      when Hash
+        object.keys.each do |key|
+          value = object.delete(key)
+          object[yield(key)] = deep_transform_keys!(value, &block)
+        end
+        object
+      when Array
+        object.map! { |e| deep_transform_keys!(e, &block) }
+      else
+        object
+      end
+    end
+
+    def deep_transform_values(object, &block)
+      case object
+      when Hash
+        object.transform_values { |value| deep_transform_values(value, &block) }
+      when Array
+        object.map { |e| deep_transform_values(e, &block) }
+      else
+        yield(object)
+      end
+    end
+
+    def deep_transform_values!(object, &block)
+      case object
+      when Hash
+        object.transform_values! { |value| deep_transform_values!(value, &block) }
+      when Array
+        object.map! { |e| deep_transform_values!(e, &block) }
+      else
+        yield(object)
+      end
+    end
+  end
+end


### PR DESCRIPTION
An alternative of #24721.

People sometimes need to deep transform keys against JSON array.
To reuse the deep transform code, I'd like to extract that as the
`ActiveSupport::DeepTransformObject`.