### PR TITLE
add require 'database/setup' in activestorage/test/service/s3_service_test.rb

### DIFF
--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -2,6 +2,7 @@
 
 require "service/shared_service_tests"
 require "net/http"
+require "database/setup"
 
 if SERVICE_CONFIGURATIONS[:s3]
   class ActiveStorage::Service::S3ServiceTest < ActiveSupport::TestCase


### PR DESCRIPTION
I added "require 'database/setup'" in the `activestorage/test/service/s3_service_test.rb` file to test it in isolation as discussed in [this](https://github.com/rails/rails/pull/33795#issuecomment-435152682) commentary.