### PR TITLE
Replace reference to WebSocket global with ActionCable.adapters.WebSocket

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionCable.Connection#getState` now references the configurable
+    `ActionCable.adapters.WebSocket` property rather than the `WebSocket` global
+    variable, matching the behavior of `ActionCable.Connection#open`.
+
 *   The ActionCable javascript package has been converted from CoffeeScript
     to ES2015, and we now publish the source code in the npm distribution.
 

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -224,8 +224,8 @@
     };
     Connection.prototype.getState = function getState() {
       if (this.webSocket) {
-        for (var state in WebSocket) {
-          if (WebSocket[state] === this.webSocket.readyState) {
+        for (var state in adapters.WebSocket) {
+          if (adapters.WebSocket[state] === this.webSocket.readyState) {
             return state.toLowerCase();
           }
         }

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -88,8 +88,8 @@ class Connection {
 
   getState() {
     if (this.webSocket) {
-      for (let state in WebSocket) {
-        if (WebSocket[state] === this.webSocket.readyState) {
+      for (let state in adapters.WebSocket) {
+        if (adapters.WebSocket[state] === this.webSocket.readyState) {
           return state.toLowerCase()
         }
       }

--- a/actioncable/test/javascript/src/test.js
+++ b/actioncable/test/javascript/src/test.js
@@ -1,5 +1,6 @@
 import "./test_helpers/index"
 import "./unit/action_cable_test"
+import "./unit/connection_test"
 import "./unit/consumer_test"
 import "./unit/subscription_test"
 import "./unit/subscriptions_test"

--- a/actioncable/test/javascript/src/unit/connection_test.js
+++ b/actioncable/test/javascript/src/unit/connection_test.js
@@ -1,0 +1,28 @@
+import * as ActionCable from "../../../../app/javascript/action_cable/index"
+
+const {module, test} = QUnit
+
+module("ActionCable.Connection", () => {
+  module("#getState", () => {
+    test("uses the configured WebSocket adapter", assert => {
+      ActionCable.adapters.WebSocket = { foo: 1, BAR: "42" }
+      const connection = new ActionCable.Connection({})
+      connection.webSocket = {}
+      connection.webSocket.readyState = 1
+      assert.equal(connection.getState(), "foo")
+      connection.webSocket.readyState = "42"
+      assert.equal(connection.getState(), "bar")
+    })
+  })
+
+  module("#open", () => {
+    test("uses the configured WebSocket adapter", assert => {
+      const FakeWebSocket = function() {}
+      ActionCable.adapters.WebSocket = FakeWebSocket
+      const connection = new ActionCable.Connection({})
+      connection.monitor = { start() {} }
+      connection.open()
+      assert.equal(connection.webSocket instanceof FakeWebSocket, true)
+    })
+  })
+})


### PR DESCRIPTION
### Summary

The `WebSocket` dependency of `ActionCable.Connection` was made configurable in 66901c1849efae74c8a58fe0cb36afd487c067cc

However, the reference in `Connection#getState` was not updated to use the configurable property. This change remedies that and adds a test to verify it. Additionally, it backfills a test to ensure that `Connection#open` uses the configurable property.

Resolves #34589