### PR TITLE
Improve parallel testing guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -474,12 +474,11 @@ takes your entire test suite to run.
 
 The default parallelization method is to fork processes using Ruby's DRb system. The processes
 are forked based on the number of workers provided. The default is 2, but can be changed by the
-number passed to the parallelize method. Active Record automatically handles creating and
-migrating a new database for each worker to use.
+number passed to the parallelize method.
 
 To enable parallelization add the following to your `test_helper.rb`:
 
-```
+```ruby
 class ActiveSupport::TestCase
   parallelize(workers: 2)
 end
@@ -489,32 +488,32 @@ The number of workers passed is the number of times the process will be forked. 
 parallelize your local test suite differently from your CI, so an environment variable is provided
 to be able to easily change the number of workers a test run should use:
 
-```
+```bash
 PARALLEL_WORKERS=15 rails test
 ```
 
-When parallelizing tests, Active Record automatically handles creating and migrating a database for each
+When parallelizing tests, Active Record automatically handles creating a database and loading the schema into the database for each
 process. The databases will be suffixed with the number corresponding to the worker. For example, if you
 have 2 workers the tests will create `test-database-0` and `test-database-1` respectively.
 
 If the number of workers passed is 1 or fewer the processes will not be forked and the tests will not
 be parallelized and the tests will use the original `test-database` database.
 
-Two hooks are provided, one runs when the process is forked, and one runs before the processes are closed.
+Two hooks are provided, one runs when the process is forked, and one runs before the forked process is closed.
 These can be useful if your app uses multiple databases or perform other tasks that depend on the number of
 workers.
 
 The `parallelize_setup` method is called right after the processes are forked. The `parallelize_teardown` method
 is called right before the processes are closed.
 
-```
+```ruby
 class ActiveSupport::TestCase
   parallelize_setup do |worker|
     # setup databases
   end
 
   parallelize_teardown do |worker|
-    # cleanup database
+    # cleanup databases
   end
 
   parallelize(workers: 2)
@@ -530,7 +529,7 @@ parallelizer is backed by Minitest's `Parallel::Executor`.
 
 To change the parallelization method to use threads over forks put the following in your `test_helper.rb`
 
-```
+```ruby
 class ActiveSupport::TestCase
   parallelize(workers: 2, with: :threads)
 end
@@ -542,7 +541,7 @@ The number of workers passed to `parallelize` determines the number of threads t
 want to parallelize your local test suite differently from your CI, so an environment variable is provided
 to be able to easily change the number of workers a test run should use:
 
-```
+```bash
 PARALLEL_WORKERS=15 rails test
 ```
 


### PR DESCRIPTION
- Fix formatting
- Don't repeat "Active Record automatically handles creating and migrating a new database for each worker to use."
- Tell that AR loads the schema to a database for each process(Related to #33479)
- Clarify that `parallelize_teardown` is executed for each process
