### PR TITLE
Add missing authorship to ActionCable changelog entry

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -2,6 +2,8 @@
     `ActionCable.adapters.WebSocket` property rather than the `WebSocket` global
     variable, matching the behavior of `ActionCable.Connection#open`.
 
+    *Richard Macklin*
+
 *   The ActionCable javascript package has been converted from CoffeeScript
     to ES2015, and we now publish the source code in the npm distribution.
 


### PR DESCRIPTION
### Summary

I accidentally forgot to add the author line to my changelog entry from 2bb4fdef5efc70327c018e982ff809a29ac6708b (#34590). Sorry about that 😳

