### PR TITLE
Fix NumericData.average test on 2.6.0-dev

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -57,8 +57,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 3, value
   end
 
-  def test_should_return_nil_as_average
-    assert_nil NumericData.average(:bank_balance)
+  def test_should_return_nil_to_d_as_average
+    if nil.respond_to?(:to_d)
+      assert_equal BigDecimal(0), NumericData.average(:bank_balance)
+    else
+      assert_nil NumericData.average(:bank_balance)
+    end
   end
 
   def test_should_get_maximum_of_field


### PR DESCRIPTION
Fixes #34600 

### Summary

NumericData.average was returning nil on ruby versions <= ruby 2.6.0dev (2018-12-03 trunk 66154)

Now it returns 0.0 instead of nil