### PR TITLE
Pass the `connection` to the `@instrumenter.instrument` method call

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -631,7 +631,8 @@ module ActiveRecord
             binds:             binds,
             type_casted_binds: type_casted_binds,
             statement_name:    statement_name,
-            connection_id:     object_id) do
+            connection_id:     object_id,
+            connection:        self) do
             begin
               @lock.synchronize do
                 yield


### PR DESCRIPTION
See #34568