### PR TITLE
Colorize the unpermitted params log message

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -56,7 +56,7 @@ module ActionController
     def unpermitted_parameters(event)
       debug do
         unpermitted_keys = event.payload[:keys]
-        "Unpermitted parameter#{'s' if unpermitted_keys.size > 1}: #{unpermitted_keys.map { |e| ":#{e}" }.join(", ")}"
+        color("Unpermitted parameter#{'s' if unpermitted_keys.size > 1}: #{unpermitted_keys.map { |e| ":#{e}" }.join(", ")}", RED)
       end
     end
 


### PR DESCRIPTION
### Summary

This small change simply colorizes the unpermitted params warning/error log output to make it easier for scanning and identifying issues with strong params. I've been helping out some junior/beginner engineers with rails and more than a few times they've run into issues where they're just overlooking the log message. Not ashamed to say that this still gets me every once in a while, mostly because I feel like I've scanned the log and I don't see the message, so I go looking elsewhere.

[It seems like moving the default to `:raise` instead of `:log` is probably a good idea](https://github.com/rails/rails/pull/32206), but regardless if we'd raise an error, it seems like colorizing the log message makes sense as a parallel.