### PR TITLE
Fix elapsed time calculations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -166,9 +166,9 @@ module ActiveRecord
 
       def explain(arel, binds = [])
         sql     = "EXPLAIN #{to_sql(arel, binds)}"
-        start   = Time.now
+        start   = Concurrent.monotonic_time
         result  = exec_query(sql, "EXPLAIN", binds)
-        elapsed = Time.now - start
+        elapsed = Concurrent.monotonic_time - start
 
         MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
       end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -62,13 +62,13 @@ module ActiveSupport
         return if pruning?
         @pruning = true
         begin
-          start_time = Time.now
+          start_time = Concurrent.monotonic_time
           cleanup
           instrument(:prune, target_size, from: @cache_size) do
             keys = synchronize { @key_access.keys.sort { |a, b| @key_access[a].to_f <=> @key_access[b].to_f } }
             keys.each do |key|
               delete_entry(key, options)
-              return if @cache_size <= target_size || (max_time && Time.now - start_time > max_time)
+              return if @cache_size <= target_size || (max_time && Concurrent.monotonic_time - start_time > max_time)
             end
           end
         ensure

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -137,7 +137,7 @@ module ActiveSupport
 
       private
         def now
-          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          Concurrent.monotonic_time
         end
 
         if clock_gettime_supported?


### PR DESCRIPTION
Hello,

I've found a few places in Rails code base where I think it makes sense to calculate elapsed time more precisely by using `Concurrent.monotonic_time`:

- `ActiveSupport::Cache::MemoryStore#prune`
- `ActiveRecord::ConnectionAdapters::ConnectionPool::Queue#wait_poll`
- `ActiveRecord::ConnectionAdapters::ConnectionPool#attempt_to_checkout_all_existing_connections`
- `ActiveRecord::ConnectionAdapters::Mysql2Adapter#explain`

See
https://docs.ruby-lang.org/en/2.5.0/Process.html#method-c-clock_gettime
https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way

Related to 7c4542146f0dde962205e5a90839349631ae60fb

<del>
Add private `ActiveSupport::ProcessClock` module

In the codebase, we use `Process::CLOCK_PROCESS_CPUTIME_ID`,
but it doesn't work on Windows so we should add conditions
to support Windows. It is a good idea to handle all those cases
in one place to prevent spreading those conditions in the codebase.

Related to #34374, #34410
</del>