### PR TITLE
Use ActiveSupport.on_load instead of reopening

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -742,16 +742,14 @@ during the test are complete and you won't receive an error from Active Storage
 saying it can't find a file.
 
 ```ruby
-module ActionDispatch
-  class IntegrationTest
-    def remove_uploaded_files
-      FileUtils.rm_rf(Rails.root.join('tmp', 'storage'))
-    end
+ActiveSupport.on_load(:action_dispatch_integration_test) do
+  def remove_uploaded_files
+    FileUtils.rm_rf(Rails.root.join('tmp', 'storage'))
+  end
 
-    def after_teardown
-      super
-      remove_uploaded_files
-    end
+  def after_teardown
+    super
+    remove_uploaded_files
   end
 end
 ```

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -479,7 +479,7 @@ number passed to the parallelize method.
 To enable parallelization add the following to your `test_helper.rb`:
 
 ```ruby
-class ActiveSupport::TestCase
+ActiveSupport.on_load'(:active_support_test_case) do
   parallelize(workers: 2)
 end
 ```
@@ -507,7 +507,7 @@ The `parallelize_setup` method is called right after the processes are forked. T
 is called right before the processes are closed.
 
 ```ruby
-class ActiveSupport::TestCase
+ActiveSupport.on_load(:active_support_test_case) do
   parallelize_setup do |worker|
     # setup databases
   end
@@ -530,7 +530,7 @@ parallelizer is backed by Minitest's `Parallel::Executor`.
 To change the parallelization method to use threads over forks put the following in your `test_helper.rb`
 
 ```ruby
-class ActiveSupport::TestCase
+ActiveSupport.on_load(:active_support_test_case) do
   parallelize(workers: 2, with: :threads)
 end
 ```
@@ -1377,7 +1377,7 @@ module SignInHelper
   end
 end
 
-class ActionDispatch::IntegrationTest
+ActiveSupport.on_load(:active_support_integration_test) do
   include SignInHelper
 end
 ```

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -2,7 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 
-class ActiveSupport::TestCase
+ActiveSupport.on_load(:active_support_test_case) do
   # Run tests in parallel with specified workers
 <% if defined?(JRUBY_VERSION) || Gem.win_platform? -%>
   parallelize(workers: 2, with: :threads)


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This leverages `ActiveSupport.on_load` in the guides and generated `test_helper.rb`, rather than reopen classes. This practice can help safeguard against load order issues.

Spin off from [discussion](https://github.com/rails/rails/pull/34563#discussion_r237374753) with @Edouard-chin, @gmcgibbon, & @rafaelfranca in #34563.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

- [ ] Update CHANGELOG (does updating the generated `test_helper.rb` warrant this?)
- [ ] Either update #34563 after merging this, or update this after merging #34563
