### PR TITLE
Use String for direction of RailsGuides::Generator#new

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -26,5 +26,5 @@ RailsGuides::Generator.new(
   only:      env_value["ONLY"],
   kindle:    env_flag["KINDLE"],
   language:  env_value["GUIDES_LANGUAGE"],
-  direction: env_value["DIRECTION"].to_sym
+  direction: env_value["DIRECTION"]
 ).generate

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -17,7 +17,7 @@ module RailsGuides
   class Generator
     GUIDES_RE = /\.(?:erb|md)\z/
 
-    def initialize(edge:, version:, all:, only:, kindle:, language:, direction: :ltr)
+    def initialize(edge:, version:, all:, only:, kindle:, language:, direction: "ltr")
       @edge      = edge
       @version   = version
       @all       = all
@@ -118,7 +118,7 @@ module RailsGuides
       def copy_assets
         FileUtils.cp_r(Dir.glob("#{@guides_dir}/assets/*"), @output_dir)
 
-        if @direction == :rtl
+        if @direction == "rtl"
           overwrite_css_with_right_to_left_direction
         end
       end


### PR DESCRIPTION
According to [Ruby on Rails Guides Guidelines](https://guides.rubyonrails.org/ruby_on_rails_guides_guidelines.html#html-guides-generation), environment variable `DIRECTION` is't necessary to give in order to generate Rails Guides.  But, `bundle exec rake guides:generate` gives me errors below.

```
ysksn at T460s in ~/Projects/rails/guides on master using 2.5.3
 ± bundle exec rake guides:generate
/home/ysksn/.rbenv/versions/2.5.3/bin/ruby rails_guides.rb
Traceback (most recent call last):
rails_guides.rb:29:in `<main>': undefined method `to_sym' for nil:NilClass (NoMethodError)
rake aborted!
Command failed with status (1): [/home/ysksn/.rbenv/versions/2.5.3/bin/ruby...]
/home/ysksn/Projects/rails/guides/Rakefile:24:in `block (3 levels) in <top (required)>'
/home/ysksn/Projects/rails/vendor/bundle/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/home/ysksn/.rbenv/versions/2.5.3/bin/bundle:23:in `load'
/home/ysksn/.rbenv/versions/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => guides:generate => guides:generate:html
(See full trace by running task with --trace)
```
So, I've changed that if environment variable `DIRECTION` isn't given, set `:ltr` as default value.

Thanks :)