### PR TITLE
Update bundler to 2.0.0.pre.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ bundler_args: --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"
-  - "travis_retry gem install bundler"
+  - "travis_retry gem install bundler -v '2.0.0.pre.2'"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"
   - "[[ $GEM != 'ac:integration' ]] || yarn install"
   - "[[ $GEM != 'av:ujs' ]] || nvm install node"


### PR DESCRIPTION
### Summary

👋 I'm the release manager for Bundler and i'm currently preparing for the release of Bundler 2. I wanted to test Bundler 2 on Rails' test suite and make sure I didn't break anything. After talking with @rafaelfranca, we agreed that we should update the repo to the use the latest pre-release.

Once the final release is made, I'll make another PR to update Travis to pull the latest stable release.

\cc @rafaelfranca 
