### PR TITLE
Make ActionCable url dynamic

### DIFF
--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -32,6 +32,14 @@ export default class Consumer {
     this.url = url
     this.subscriptions = new Subscriptions(this)
     this.connection = new Connection(this)
+
+    Object.defineProperty(this, 'url', {
+      get: function() {
+        const token = Storage.get('token');
+        const email = Storage.get('email');
+        return `${cableUrl}?token=${token}&email=${email}`;
+      },
+    });
   }
 
   send(data) {


### PR DESCRIPTION
Implements #33064

> When using the actioncable javascript package, if you want to pass an authorization token you need to do so when creating the cable consumer. However, this is not dynamic, ideally you could modify this token after the consumer is created so if the token expires or is refreshed it could be updated.

Now you can update the authorization token in cable consumers.