### PR TITLE
Rename header of the gzip paragraph

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1101,7 +1101,7 @@ Windows you have a JavaScript runtime installed in your operating system.
 
 
 
-### Serving GZipped version of assets
+### GZipping your assets
 
 By default, gzipped version of compiled assets will be generated, along with
 the non-gzipped version of assets. Gzipped assets help reduce the transmission
@@ -1110,6 +1110,8 @@ of data over the wire. You can configure this by setting the `gzip` flag.
 ```ruby
 config.assets.gzip = false # disable gzipped assets generation
 ```
+
+Refer to your web server's documentation for instructions on how to serve gzipped assets.
 
 ### Using Your Own Compressor
 


### PR DESCRIPTION
### Summary

IMO the previous header (_Serving GZipped version of assets_) was misleading, because it was suggesting that the config will enable us serving the gzipped version of assets out of the box, which is not true, because we need to configure it on a server, e.g. nginx.

In fact, the paragraph is explaining how to enable/disable gzipping assets in the config and I believe that my change will be more straightforward for readers.