### PR TITLE
add: object instance include

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/include.rb
+++ b/activesupport/lib/active_support/core_ext/object/include.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Object
+  # Includes a module into the singleton class of an object
+  def include(mod)
+    self.singleton_class.include(mod)
+  end
+end

--- a/activesupport/test/core_ext/object/include_test.rb
+++ b/activesupport/test/core_ext/object/include_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/object/include"
+
+class ObjectIncludeTest < ActiveSupport::TestCase
+  module A
+    def a
+      "it works"
+    end
+  end
+
+  class B
+  end
+
+  def test_include
+    b = B.new
+    
+    refute b.respond_to?(:a)
+
+    b.include(A)
+
+    assert b.respond_to?(:a)
+    assert_equal "it works", b.a
+
+    refute B.new.respond_to?(:a)
+  end
+end


### PR DESCRIPTION
### Summary

Defines `Object#include` that allows for including a module on an instance level. This is facilitated by including the module on the instance's singleton class.

A practical use for this is to provide controller-specific validations to a model:

```ruby
module SpecialUserValidations
  extend ActiveSupport::Concern

  included do
    validates :name, presence: :true
  end
end

class FooController
  def update
    @user = User.find(params[:id])
    @user.include(SpecialUserValidations)
    # ... @user now requires name to be set
  end
end
```
    
