### PR TITLE
Remove tmp directories from yarn workspaces configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "workspaces": [
     "actioncable",
     "activestorage",
-    "actionview",
-    "tmp/templates/app_template",
-    "railties/test/fixtures/tmp/bukkits/**/test/dummy",
-    "railties/test/fixtures/tmp/bukkits/**/spec/dummy"
+    "actionview"
   ],
   "dependencies": {
     "webpack": "^4.17.1"


### PR DESCRIPTION
### Summary

Having these directories configured as yarn workspaces can cause you to generate an incorrect root yarn.lock when you run `yarn install` if you have stale files in these directories. This can be particularly troubling because the directories are ignored by git so it's not immediately obvious that you have files there which could be causing an invalid lockfile to be generated.

Additionally, [@lsylvester said](https://github.com/rails/rails/pull/34588#issuecomment-443547937) that his initial motiviation for including these directories was resolved by relaxing the requirements in the package.json template used by the app generator.

See this thread for more information on the problems this caused: https://github.com/rails/rails/pull/34588#issuecomment-443511651