### PR TITLE
Rename error that occurs when writing on a read

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         # Executes the SQL statement in the context of this connection.
         def execute(sql, name = nil)
           if preventing_writes? && write_query?(sql)
-            raise ActiveRecord::StatementInvalid, "Write query attempted while in readonly mode: #{sql}"
+            raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
 
           # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -80,7 +80,7 @@ module ActiveRecord
         # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)
           if preventing_writes? && write_query?(sql)
-            raise ActiveRecord::StatementInvalid, "Write query attempted while in readonly mode: #{sql}"
+            raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
 
           materialize_transactions

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -265,7 +265,7 @@ module ActiveRecord
 
       def execute(sql, name = nil) #:nodoc:
         if preventing_writes? && write_query?(sql)
-          raise ActiveRecord::StatementInvalid, "Write query attempted while in readonly mode: #{sql}"
+          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
         end
 
         materialize_transactions

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -49,6 +49,10 @@ module ActiveRecord
   class ConnectionNotEstablished < ActiveRecordError
   end
 
+  # Raised when a write to the database is attempted on a read only connection.
+  class ReadOnlyError < ActiveRecordError
+  end
+
   # Raised when Active Record cannot find a record by given id or set of ids.
   class RecordNotFound < ActiveRecordError
     attr_reader :model, :primary_key, :id

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -70,7 +70,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_errors_when_an_insert_query_is_called_while_preventing_writes
-    assert_raises(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::ReadOnlyError) do
       @conn.while_preventing_writes do
         @conn.insert("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
       end
@@ -80,7 +80,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   def test_errors_when_an_update_query_is_called_while_preventing_writes
     @conn.insert("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
 
-    assert_raises(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::ReadOnlyError) do
       @conn.while_preventing_writes do
         @conn.update("UPDATE `engines` SET `engines`.`car_id` = '9989' WHERE `engines`.`car_id` = '138853948594'")
       end
@@ -90,7 +90,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   def test_errors_when_a_delete_query_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
 
-    assert_raises(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::ReadOnlyError) do
       @conn.while_preventing_writes do
         @conn.execute("DELETE FROM `engines` where `engines`.`car_id` = '138853948594'")
       end
@@ -100,7 +100,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   def test_errors_when_a_replace_query_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
 
-    assert_raises(ActiveRecord::StatementInvalid) do
+    assert_raises(ActiveRecord::ReadOnlyError) do
       @conn.while_preventing_writes do
         @conn.execute("REPLACE INTO `engines` SET `engines`.`car_id` = '249823948'")
       end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -378,7 +378,7 @@ module ActiveRecord
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes
         with_example_table do
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @connection.while_preventing_writes do
               @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
             end
@@ -390,7 +390,7 @@ module ActiveRecord
         with_example_table do
           @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
 
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @connection.while_preventing_writes do
               @connection.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'")
             end
@@ -402,7 +402,7 @@ module ActiveRecord
         with_example_table do
           @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
 
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @connection.while_preventing_writes do
               @connection.execute("DELETE FROM ex where data = '138853948594'")
             end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -575,7 +575,7 @@ module ActiveRecord
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes
         with_example_table "id int, data string" do
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @conn.while_preventing_writes do
               @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
             end
@@ -587,7 +587,7 @@ module ActiveRecord
         with_example_table "id int, data string" do
           @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
 
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @conn.while_preventing_writes do
               @conn.execute("UPDATE ex SET data = '9989' WHERE data = '138853948594'")
             end
@@ -599,7 +599,7 @@ module ActiveRecord
         with_example_table "id int, data string" do
           @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
 
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @conn.while_preventing_writes do
               @conn.execute("DELETE FROM ex where data = '138853948594'")
             end
@@ -611,7 +611,7 @@ module ActiveRecord
         with_example_table "id int, data string" do
           @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
 
-          assert_raises(ActiveRecord::StatementInvalid) do
+          assert_raises(ActiveRecord::ReadOnlyError) do
             @conn.while_preventing_writes do
               @conn.execute("REPLACE INTO ex (data) VALUES ('249823948')")
             end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1490,7 +1490,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "creating a record raises if preventing writes" do
-    assert_raises ActiveRecord::StatementInvalid do
+    assert_raises ActiveRecord::ReadOnlyError do
       ActiveRecord::Base.connection.while_preventing_writes do
         Bird.create! name: "Bluejay"
       end
@@ -1500,7 +1500,7 @@ class BasicsTest < ActiveRecord::TestCase
   test "updating a record raises if preventing writes" do
     bird = Bird.create! name: "Bluejay"
 
-    assert_raises ActiveRecord::StatementInvalid do
+    assert_raises ActiveRecord::ReadOnlyError do
       ActiveRecord::Base.connection.while_preventing_writes do
         bird.update! name: "Robin"
       end
@@ -1510,7 +1510,7 @@ class BasicsTest < ActiveRecord::TestCase
   test "deleting a record raises if preventing writes" do
     bird = Bird.create! name: "Bluejay"
 
-    assert_raises ActiveRecord::StatementInvalid do
+    assert_raises ActiveRecord::ReadOnlyError do
       ActiveRecord::Base.connection.while_preventing_writes do
         bird.destroy!
       end


### PR DESCRIPTION
I originally named this `StatementInvalid` because that's what we do in
GitHub, but `@tenderlove` pointed out that this means apps can't test
for or explitly rescue this error. `StatementInvalid` is pretty broad so
I've renamed this to `InvalidWriteOnRead`.

I also changed the `while_preventing_writes` block to reset to false -
we always want to turn this feature off at the end of the block.

cc/ @rafaelfranca @matthewd @tenderlove - thoughts on the error name?