### PR TITLE
Single Pass JSON emitter

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -13,6 +13,7 @@ require "time"
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/date_time/conversions"
 require "active_support/core_ext/date/conversions"
+require "active_support/json/as_json_encoder"
 
 #--
 # The JSON gem adds a few modules to Ruby core classes containing :to_json definition, overwriting
@@ -43,6 +44,12 @@ module ActiveSupport
       end
     end
   end
+
+  module AsJSON
+    def as_json(options = nil)
+      ActiveSupport::JSON::AsJSONEncoder.encode self, options
+    end
+  end
 end
 
 [Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass, Enumerable].reverse_each do |klass|
@@ -50,179 +57,5 @@ end
 end
 
 class Object
-  def as_json(options = nil) #:nodoc:
-    if respond_to?(:to_hash)
-      to_hash.as_json(options)
-    else
-      instance_values.as_json(options)
-    end
-  end
-end
-
-class Struct #:nodoc:
-  def as_json(options = nil)
-    Hash[members.zip(values)].as_json(options)
-  end
-end
-
-class TrueClass
-  def as_json(options = nil) #:nodoc:
-    self
-  end
-end
-
-class FalseClass
-  def as_json(options = nil) #:nodoc:
-    self
-  end
-end
-
-class NilClass
-  def as_json(options = nil) #:nodoc:
-    self
-  end
-end
-
-class String
-  def as_json(options = nil) #:nodoc:
-    self
-  end
-end
-
-class Symbol
-  def as_json(options = nil) #:nodoc:
-    to_s
-  end
-end
-
-class Numeric
-  def as_json(options = nil) #:nodoc:
-    self
-  end
-end
-
-class Float
-  # Encoding Infinity or NaN to JSON should return "null". The default returns
-  # "Infinity" or "NaN" which are not valid JSON.
-  def as_json(options = nil) #:nodoc:
-    finite? ? self : nil
-  end
-end
-
-class BigDecimal
-  # A BigDecimal would be naturally represented as a JSON number. Most libraries,
-  # however, parse non-integer JSON numbers directly as floats. Clients using
-  # those libraries would get in general a wrong number and no way to recover
-  # other than manually inspecting the string with the JSON code itself.
-  #
-  # That's why a JSON string is returned. The JSON literal is not numeric, but
-  # if the other end knows by contract that the data is supposed to be a
-  # BigDecimal, it still has the chance to post-process the string and get the
-  # real value.
-  def as_json(options = nil) #:nodoc:
-    finite? ? to_s : nil
-  end
-end
-
-class Regexp
-  def as_json(options = nil) #:nodoc:
-    to_s
-  end
-end
-
-module Enumerable
-  def as_json(options = nil) #:nodoc:
-    to_a.as_json(options)
-  end
-end
-
-class IO
-  def as_json(options = nil) #:nodoc:
-    to_s
-  end
-end
-
-class Range
-  def as_json(options = nil) #:nodoc:
-    to_s
-  end
-end
-
-class Array
-  def as_json(options = nil) #:nodoc:
-    map { |v| options ? v.as_json(options.dup) : v.as_json }
-  end
-end
-
-class Hash
-  def as_json(options = nil) #:nodoc:
-    # create a subset of the hash by applying :only or :except
-    subset = if options
-      if attrs = options[:only]
-        slice(*Array(attrs))
-      elsif attrs = options[:except]
-        except(*Array(attrs))
-      else
-        self
-      end
-    else
-      self
-    end
-
-    Hash[subset.map { |k, v| [k.to_s, options ? v.as_json(options.dup) : v.as_json] }]
-  end
-end
-
-class Time
-  def as_json(options = nil) #:nodoc:
-    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-      xmlschema(ActiveSupport::JSON::Encoding.time_precision)
-    else
-      %(#{strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
-    end
-  end
-end
-
-class Date
-  def as_json(options = nil) #:nodoc:
-    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-      strftime("%Y-%m-%d")
-    else
-      strftime("%Y/%m/%d")
-    end
-  end
-end
-
-class DateTime
-  def as_json(options = nil) #:nodoc:
-    if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-      xmlschema(ActiveSupport::JSON::Encoding.time_precision)
-    else
-      strftime("%Y/%m/%d %H:%M:%S %z")
-    end
-  end
-end
-
-class URI::Generic #:nodoc:
-  def as_json(options = nil)
-    to_s
-  end
-end
-
-class Pathname #:nodoc:
-  def as_json(options = nil)
-    to_s
-  end
-end
-
-class Process::Status #:nodoc:
-  def as_json(options = nil)
-    { exitstatus: exitstatus, pid: pid }
-  end
-end
-
-class Exception
-  def as_json(options = nil)
-    to_s
-  end
+  include ActiveSupport::AsJSON
 end

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -47,7 +47,7 @@ module ActiveSupport
 
   module AsJSON
     def as_json(options = nil)
-      ActiveSupport::JSON::AsJSONEncoder.encode self, options
+      ActiveSupport::JSON::AsJSONEncoder.encode_next self, options
     end
   end
 end

--- a/activesupport/lib/active_support/json/as_json_encoder.rb
+++ b/activesupport/lib/active_support/json/as_json_encoder.rb
@@ -10,7 +10,7 @@ module ActiveSupport
       end
 
       def self.internal_as_json?(object)
-        object.respond_to?(:as_json) &&
+        !object.respond_to?(:as_json) ||
           object.method(:as_json).owner == ActiveSupport::AsJSON
       end
 

--- a/activesupport/lib/active_support/json/as_json_encoder.rb
+++ b/activesupport/lib/active_support/json/as_json_encoder.rb
@@ -1,0 +1,152 @@
+module ActiveSupport
+  module JSON
+    class AsJSONEncoder
+      def self.encode(object, options)
+        if internal_as_json? object
+          new(options).encode object
+        else
+          # Someone called `super` from `as_json` in to us
+          new(options).visit object
+        end
+      end
+
+      def self.internal_as_json?(object)
+        object.respond_to?(:as_json) &&
+          object.method(:as_json).owner == ActiveSupport::AsJSON
+      end
+
+      def initialize(as_json_options)
+        @as_json_options = as_json_options
+      end
+
+      def encode(object)
+        if AsJSONEncoder.internal_as_json?(object)
+          visit object
+        else
+          encode object.as_json
+        end
+      end
+
+      def visit(object)
+        case object
+        when Hash            then handle_Hash           object
+        when Array           then handle_Array          object
+        when Float           then handle_Float          object
+        when BigDecimal      then handle_Float          object
+        when Struct          then handle_Struct         object
+        when FalseClass      then identity              object
+        when TrueClass       then identity              object
+        when NilClass        then identity              object
+        when String          then identity              object
+        when Numeric         then identity              object
+        when Symbol          then to_string             object
+        when Regexp          then to_string             object
+        when IO              then to_string             object
+        when Range           then to_string             object
+        when Exception       then to_string             object
+        when Pathname        then to_string             object
+        when URI::Generic    then to_string             object
+        when DateTime        then handle_DateTime       object
+        when Time            then handle_Time           object
+        when Date            then handle_Date           object
+        when Process::Status then handle_Process_Status object
+        when Enumerable      then handle_Enumerable     object
+        else
+          handle_default object
+        end
+      end
+
+      private
+
+        def handle_default object
+          if object.respond_to?(:to_hash)
+            encode object.to_hash
+          else
+            encode object.instance_values
+          end
+        end
+
+        # A BigDecimal would be naturally represented as a JSON number. Most libraries,
+        # however, parse non-integer JSON numbers directly as floats. Clients using
+        # those libraries would get in general a wrong number and no way to recover
+        # other than manually inspecting the string with the JSON code itself.
+        #
+        # That's why a JSON string is returned. The JSON literal is not numeric, but
+        # if the other end knows by contract that the data is supposed to be a
+        # BigDecimal, it still has the chance to post-process the string and get the
+        # real value.
+
+        # Encoding Infinity or NaN to JSON should return "null". The default returns
+        # "Infinity" or "NaN" which are not valid JSON.
+        def handle_Float(object)
+          object.finite? ? object : nil
+        end
+
+        def handle_Process_Status(object)
+          encode({ exitstatus: object.exitstatus, pid: object.pid })
+        end
+
+        def handle_Struct(object)
+          encode Hash[object.members.zip(object.values)]
+        end
+
+        def handle_Date(object)
+          if ActiveSupport::JSON::Encoding.use_standard_json_time_format
+            object.strftime("%Y-%m-%d")
+          else
+            object.strftime("%Y/%m/%d")
+          end
+        end
+
+        def handle_DateTime(object)
+          if ActiveSupport::JSON::Encoding.use_standard_json_time_format
+            object.xmlschema(ActiveSupport::JSON::Encoding.time_precision)
+          else
+            object.strftime("%Y/%m/%d %H:%M:%S %z")
+          end
+        end
+
+        def handle_Time(object)
+          if ActiveSupport::JSON::Encoding.use_standard_json_time_format
+            object.xmlschema(ActiveSupport::JSON::Encoding.time_precision)
+          else
+            %(#{object.strftime("%Y/%m/%d %H:%M:%S")} #{object.formatted_offset(false)})
+          end
+        end
+
+        def identity(object)
+          object
+        end
+
+        def to_string(object)
+          object.to_s
+        end
+
+        def handle_Enumerable(object)
+          encode object.to_a
+        end
+
+        def handle_Array(object)
+          object.map { |v| encode v }
+        end
+
+        def handle_Hash(object)
+          options = @as_json_options
+          # create a subset of the hash by applying :only or :except
+          subset = if options
+            if attrs = options[:only]
+              object.slice(*Array(attrs))
+            elsif attrs = options[:except]
+              object.except(*Array(attrs))
+            else
+              object
+            end
+          else
+            object
+          end
+
+          Hash[subset.map { |k, v| [k.to_s, encode(v)] } ]
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/json/as_json_encoder.rb
+++ b/activesupport/lib/active_support/json/as_json_encoder.rb
@@ -22,7 +22,13 @@ module ActiveSupport
         if AsJSONEncoder.internal_as_json?(object)
           visit object
         else
-          encode object.as_json
+          # **ONLY** top level objects implementing as_json should
+          # get the options hash
+          if !@as_json_options.nil?
+            self.class.new(nil).encode object.as_json(@as_json_options.dup)
+          else
+            self.class.new(nil).encode object.as_json
+          end
         end
       end
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -32,75 +32,11 @@ module ActiveSupport
 
         # Encode the given object into a JSON string
         def encode(value)
-          stringify jsonify value.as_json(options.dup)
+          json_tree = ActiveSupport::JSON::EscapedAsJSONEncoder.encode(value, options.dup)
+          stringify json_tree
         end
 
         private
-          # Rails does more escaping than the JSON gem natively does (we
-          # escape \u2028 and \u2029 and optionally >, <, & to work around
-          # certain browser problems).
-          ESCAPED_CHARS = {
-            "\u2028" => '\u2028',
-            "\u2029" => '\u2029',
-            ">"      => '\u003e',
-            "<"      => '\u003c',
-            "&"      => '\u0026',
-            }
-
-          ESCAPE_REGEX_WITH_HTML_ENTITIES = /[\u2028\u2029><&]/u
-          ESCAPE_REGEX_WITHOUT_HTML_ENTITIES = /[\u2028\u2029]/u
-
-          # This class wraps all the strings we see and does the extra escaping
-          class EscapedString < String #:nodoc:
-            def to_json(*)
-              if Encoding.escape_html_entities_in_json
-                s = super
-                s.gsub! ESCAPE_REGEX_WITH_HTML_ENTITIES, ESCAPED_CHARS
-                s
-              else
-                s = super
-                s.gsub! ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, ESCAPED_CHARS
-                s
-              end
-            end
-
-            def to_s
-              self
-            end
-          end
-
-          # Mark these as private so we don't leak encoding-specific constructs
-          private_constant :ESCAPED_CHARS, :ESCAPE_REGEX_WITH_HTML_ENTITIES,
-            :ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, :EscapedString
-
-          # Convert an object into a "JSON-ready" representation composed of
-          # primitives like Hash, Array, String, Numeric,
-          # and +true+/+false+/+nil+.
-          # Recursively calls #as_json to the object to recursively build a
-          # fully JSON-ready object.
-          #
-          # This allows developers to implement #as_json without having to
-          # worry about what base types of objects they are allowed to return
-          # or having to remember to call #as_json recursively.
-          #
-          # Note: the +options+ hash passed to +object.to_json+ is only passed
-          # to +object.as_json+, not any of this method's recursive +#as_json+
-          # calls.
-          def jsonify(value)
-            case value
-            when String
-              EscapedString.new(value)
-            when Numeric, NilClass, TrueClass, FalseClass
-              value.as_json
-            when Hash
-              Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
-            when Array
-              value.map { |v| jsonify(v) }
-            else
-              jsonify value.as_json
-            end
-          end
-
           # Encode a "jsonified" Ruby data structure using the JSON gem
           def stringify(jsonified)
             ::JSON.generate(jsonified, quirks_mode: true, max_nesting: false)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -217,7 +217,7 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
   end
 
-  People = Class.new(BasicObject) do
+  People = Class.new(Object) do
     include Enumerable
     def initialize
       @people = [
@@ -301,12 +301,12 @@ class TestJSONEncoding < ActiveSupport::TestCase
 
   def test_hash_as_json_without_options
     json = { foo: OptionsTest.new }.as_json
-    assert_equal({ "foo" => :default }, json)
+    assert_equal({ "foo" => "default" }, json)
   end
 
   def test_array_as_json_without_options
     json = [ OptionsTest.new ].as_json
-    assert_equal([:default], json)
+    assert_equal(["default"], json)
   end
 
   def test_struct_encoding


### PR DESCRIPTION
This switches the "as_json" pattern to use a visitor instead of monkey patching core classes.  Since we are using a visitor it means we can switch implementations when dumping JSON and still get [escaped string support](
https://github.com/rails/rails/blob/b802e08273f899d5f3b199f7c6a4f5d514c1b0e1/activesupport/lib/active_support/json/encoding.rb#L92) in one pass of the object graph.

Refs: https://github.com/rails/rails/pull/34578