### PR TITLE
Adapt Decimal#cast_value to latest 2.6 BigDecimal

### DIFF
--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -23,7 +23,7 @@ module ActiveModel
       private
 
         def cast_value(value)
-          casted_value = \
+          casted_value =
             case value
             when ::Float
               convert_float_to_big_decimal(value)
@@ -31,9 +31,9 @@ module ActiveModel
               BigDecimal(value, precision || BIGDECIMAL_PRECISION)
             when ::String
               begin
-                value.to_d
+                BigDecimal(value)
               rescue ArgumentError
-                BigDecimal(0)
+                BigDecimal(value.to_f.to_s)
               end
             else
               if value.respond_to?(:to_d)


### PR DESCRIPTION
Before [ruby/ruby@a0e438c#diff-6b866d482baf2bdfd8433893fb1f6d36R144](bigdecimal-1.4.0.pre-20181130a) `BigDecimal("123_non_numeric")` returns `0.123e3`. After that commit, it raises. This causes `Decimal.type_cast("123_non_numeric")` to `rescue` and return `0.0`.

This patch conserves current behavior.

See test failure in CI: https://travis-ci.org/rails/rails/jobs/462532922#L4501