### PR TITLE
HashWithIndifferentAccess#initialize performance improvement

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -69,7 +69,7 @@ module ActiveSupport
         super()
         update(constructor)
 
-        hash = constructor.to_hash
+        hash = constructor.is_a?(Hash) ? constructor : constructor.to_hash
         self.default = hash.default if hash.default
         self.default_proc = hash.default_proc if hash.default_proc
       else

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -828,4 +828,32 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal 3, hash_wia[:foo]
     assert_equal 3, hash_wia[:bar]
   end
+
+  def test_default_of_non_hash
+    non_hash = Object.new
+
+    def non_hash.to_hash
+      h = { foo: :bar }
+      h.default = :baz
+      h
+    end
+
+    hash_wia = HashWithIndifferentAccess.new(non_hash)
+    assert_equal :bar, hash_wia[:foo]
+    assert_equal :baz, hash_wia[:missing]
+  end
+
+  def test_default_proc_of_non_hash
+    non_hash = Object.new
+
+    def non_hash.to_hash
+      h = { foo: :bar }
+      h.default_proc = ->(hash, key) { hash[key] = :baz }
+      h
+    end
+
+    hash_wia = HashWithIndifferentAccess.new(non_hash)
+    assert_equal :bar, hash_wia[:foo]
+    assert_equal :baz, hash_wia[:missing]
+  end
 end


### PR DESCRIPTION
Rails 4 -> Rails 5 introduced a #to_hash call in HashWithIndifferentAccess#initialize to guarantee access to the #default and #default_proc methods.  This can be an expensive operation for very large HashWithIndifferentAccess objects.

This commit bypasses this #to_hash call if it is already a Hash, giving a performance boost to the copy constructor of huge HWIAs.