### PR TITLE
Move type method inside ActionDispatch::Journey::Nodes::Symbol

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -65,12 +65,12 @@ module ActionDispatch
         def literal?; false; end
       end
 
-      %w{ Symbol Slash Dot }.each do |t|
-        class_eval <<-eoruby, __FILE__, __LINE__ + 1
-          class #{t} < Terminal;
-            def type; :#{t.upcase}; end
-          end
-        eoruby
+      class Slash < Terminal # :nodoc:
+        def type; :SLASH; end
+      end
+
+      class Dot < Terminal # :nodoc:
+        def type; :DOT; end
       end
 
       class Symbol < Terminal # :nodoc:
@@ -89,6 +89,7 @@ module ActionDispatch
           regexp == DEFAULT_EXP
         end
 
+        def type; :SYMBOL; end
         def symbol?; true; end
       end
 


### PR DESCRIPTION
### Summary
`ActionDispatch::Journey::Nodes::Symbol#type` was generated dynamically with the help of an `each` block. While this is OK for classes like `ActionDispatch::Journey::Nodes::Slash` or `ActionDispatch::Journey::Nodes::Dot` which don't have further implementation, all other classes containing more logic have this method defined within their class' body.

This patch puts the definition of `ActionDispatch::Journey::Nodes::Symbol` in one place instead of having two separate places defining logic for this class.