### PR TITLE
Make `deprecate` work for non-exists methods

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -52,27 +52,37 @@ module ActiveSupport
         options = method_names.extract_options!
         deprecator = options.delete(:deprecator) || self
         method_names += options.keys
+        mod = Module.new
 
         method_names.each do |method_name|
-          aliased_method, punctuation = method_name.to_s.sub(/([?!=])$/, ""), $1
-          with_method = "#{aliased_method}_with_deprecation#{punctuation}"
-          without_method = "#{aliased_method}_without_deprecation#{punctuation}"
+          if target_module.method_defined?(method_name) || target_module.private_method_defined?(method_name)
+            aliased_method, punctuation = method_name.to_s.sub(/([?!=])$/, ""), $1
+            with_method = "#{aliased_method}_with_deprecation#{punctuation}"
+            without_method = "#{aliased_method}_without_deprecation#{punctuation}"
 
-          target_module.send(:define_method, with_method) do |*args, &block|
-            deprecator.deprecation_warning(method_name, options[method_name])
-            send(without_method, *args, &block)
-          end
+            target_module.send(:define_method, with_method) do |*args, &block|
+              deprecator.deprecation_warning(method_name, options[method_name])
+              send(without_method, *args, &block)
+            end
 
-          target_module.send(:alias_method, without_method, method_name)
-          target_module.send(:alias_method, method_name, with_method)
+            target_module.send(:alias_method, without_method, method_name)
+            target_module.send(:alias_method, method_name, with_method)
 
-          case
-          when target_module.protected_method_defined?(without_method)
-            target_module.send(:protected, method_name)
-          when target_module.private_method_defined?(without_method)
-            target_module.send(:private, method_name)
+            case
+            when target_module.protected_method_defined?(without_method)
+              target_module.send(:protected, method_name)
+            when target_module.private_method_defined?(without_method)
+              target_module.send(:private, method_name)
+            end
+          else
+            mod.send(:define_method, method_name) do |*args, &block|
+              deprecator.deprecation_warning(method_name, options[method_name])
+              super(*args, &block)
+            end
           end
         end
+
+        target_module.prepend(mod) unless mod.instance_methods(false).empty?
       end
     end
   end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -31,6 +31,9 @@ class Deprecatee
   def f=(v); end
   deprecate :f=
 
+  deprecate :g
+  def g ;end
+
   module B
     C = 1
   end
@@ -423,6 +426,10 @@ class DeprecationTest < ActiveSupport::TestCase
     deprecator.send(:deprecated_method_warning, :deprecated_method, "You are calling deprecated method").tap do |message|
       assert_match(/is deprecated and will be removed from Custom/, message)
     end
+  end
+
+  def test_deprecate_work_before_define_method
+    assert_deprecated { @dtc.g }
   end
 
   private


### PR DESCRIPTION
Before #33325, `deprecate` works for non-exist methods.
This is necessary, for example, if want to deprecate dynamically defined
methods like attributes methods.

Fixes #34646