### PR TITLE
Keep part when scope option has value

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Keep part when scope option has value
+
+    When a route was defined within an optional scope, if that route didn't
+    take parameters the scope was lost when using path helpers. This commit
+    ensures scope is kept both when the route takes parameters or when it
+    doesn't.
+
+    Fixes #33219
+
+    *Alberto Almagro*
+
 *   Added `deep_transform_keys` and `deep_transform_keys!` methods to ActionController::Parameters.
 
     *Gustavo Gutierrez*

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -67,7 +67,7 @@ module ActionDispatch
           parameterized_parts = recall.merge(options)
 
           keys_to_keep = route.parts.reverse_each.drop_while { |part|
-            !options.key?(part) || (options[part] || recall[part]).nil?
+            !(options.key?(part) || route.scope_options.key?(part)) || (options[part] || recall[part]).nil?
           } | route.required_parts
 
           parameterized_parts.delete_if do |bad_key, _|

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -4,9 +4,9 @@ module ActionDispatch
   # :stopdoc:
   module Journey
     class Route
-      attr_reader :app, :path, :defaults, :name, :precedence
+      attr_reader :app, :path, :defaults, :name, :precedence, :constraints,
+                  :internal, :scope_options
 
-      attr_reader :constraints, :internal
       alias :conditions :constraints
 
       module VerbMatchers
@@ -51,13 +51,13 @@ module ActionDispatch
 
       def self.build(name, app, path, constraints, required_defaults, defaults)
         request_method_match = verb_matcher(constraints.delete(:request_method))
-        new name, app, path, constraints, required_defaults, defaults, request_method_match, 0
+        new name, app, path, constraints, required_defaults, defaults, request_method_match, 0, {}
       end
 
       ##
       # +path+ is a path constraint.
       # +constraints+ is a hash of constraints to be applied to this route.
-      def initialize(name, app, path, constraints, required_defaults, defaults, request_method_match, precedence, internal = false)
+      def initialize(name, app, path, constraints, required_defaults, defaults, request_method_match, precedence, scope_options, internal = false)
         @name        = name
         @app         = app
         @path        = path
@@ -72,6 +72,7 @@ module ActionDispatch
         @decorated_ast     = nil
         @precedence        = precedence
         @path_formatter    = @path.build_formatter
+        @scope_options     = scope_options
         @internal          = internal
       end
 

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -50,14 +50,15 @@ module ActionDispatch
       end
 
       def self.build(name, app, path, constraints, required_defaults, defaults)
-        request_method_match = verb_matcher(constraints.delete(:request_method))
-        new name, app, path, constraints, required_defaults, defaults, request_method_match, 0, {}
+        new name: name, app: app, path: path, constraints: constraints,
+            required_defaults: required_defaults, defaults: defaults,
+            request_method_match: verb_matcher(constraints.delete(:request_method))
       end
 
       ##
       # +path+ is a path constraint.
       # +constraints+ is a hash of constraints to be applied to this route.
-      def initialize(name, app, path, constraints, required_defaults, defaults, request_method_match, precedence, scope_options, internal = false)
+      def initialize(name:, app:, path:, constraints:, required_defaults:, defaults:, request_method_match:, precedence: 0, scope_options: {}, internal: false)
         @name        = name
         @app         = app
         @path        = path

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -49,16 +49,10 @@ module ActionDispatch
         end
       end
 
-      def self.build(name, app, path, constraints, required_defaults, defaults)
-        new name: name, app: app, path: path, constraints: constraints,
-            required_defaults: required_defaults, defaults: defaults,
-            request_method_match: verb_matcher(constraints.delete(:request_method))
-      end
-
       ##
       # +path+ is a path constraint.
       # +constraints+ is a hash of constraints to be applied to this route.
-      def initialize(name:, app:, path:, constraints:, required_defaults:, defaults:, request_method_match:, precedence: 0, scope_options: {}, internal: false)
+      def initialize(name:, app: nil, path:, constraints: {}, required_defaults: [], defaults: {}, request_method_match: nil, precedence: 0, scope_options: {}, internal: false)
         @name        = name
         @app         = app
         @path        = path

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -70,17 +70,17 @@ module ActionDispatch
         ANCHOR_CHARACTERS_REGEX = %r{\A(\\A|\^)|(\\Z|\\z|\$)\Z}
         OPTIONAL_FORMAT_REGEX = %r{(?:\(\.:format\)+|\.:format|/)\Z}
 
-        attr_reader :requirements, :defaults
-        attr_reader :to, :default_controller, :default_action
-        attr_reader :required_defaults, :ast
+        attr_reader :requirements, :defaults, :to, :default_controller,
+                    :default_action, :required_defaults, :ast, :scope_options
 
         def self.build(scope, set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)
           options = scope[:options].merge(options) if scope[:options]
 
           defaults = (scope[:defaults] || {}).dup
           scope_constraints = scope[:constraints] || {}
+          scope_options = scope[:options] || {}
 
-          new set, ast, defaults, controller, default_action, scope[:module], to, formatted, scope_constraints, scope[:blocks] || [], via, options_constraints, anchor, options
+          new set, ast, defaults, controller, default_action, scope[:module], to, formatted, scope_constraints, scope_options, scope[:blocks] || [], via, options_constraints, anchor, options
         end
 
         def self.check_via(via)
@@ -111,7 +111,7 @@ module ActionDispatch
           format != false && path !~ OPTIONAL_FORMAT_REGEX
         end
 
-        def initialize(set, ast, defaults, controller, default_action, modyoule, to, formatted, scope_constraints, blocks, via, options_constraints, anchor, options)
+        def initialize(set, ast, defaults, controller, default_action, modyoule, to, formatted, scope_constraints, scope_options, blocks, via, options_constraints, anchor, options)
           @defaults = defaults
           @set = set
 
@@ -122,6 +122,7 @@ module ActionDispatch
           @anchor             = anchor
           @via                = via
           @internal           = options.delete(:internal)
+          @scope_options      = scope_options
 
           path_params = ast.find_all(&:symbol?).map(&:to_sym)
 
@@ -161,7 +162,7 @@ module ActionDispatch
 
         def make_route(name, precedence)
           Journey::Route.new(name, application, path, conditions, required_defaults,
-                             defaults, request_method, precedence, @internal)
+                             defaults, request_method, precedence, scope_options, @internal)
         end
 
         def application

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -161,8 +161,10 @@ module ActionDispatch
         end
 
         def make_route(name, precedence)
-          Journey::Route.new(name, application, path, conditions, required_defaults,
-                             defaults, request_method, precedence, scope_options, @internal)
+          Journey::Route.new(name: name, app: application, path: path, constraints: conditions,
+                             required_defaults: required_defaults, defaults: defaults,
+                             request_method_match: request_method, precedence: precedence,
+                             scope_options: scope_options, internal: @internal)
         end
 
         def application

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -74,13 +74,17 @@ module ActionDispatch
                     :default_action, :required_defaults, :ast, :scope_options
 
         def self.build(scope, set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)
-          options = scope[:options].merge(options) if scope[:options]
+          scope_params = {
+            blocks: scope[:blocks] || [],
+            constraints: scope[:constraints] || {},
+            defaults: (scope[:defaults] || {}).dup,
+            module: scope[:module],
+            options: scope[:options] || {}
+          }
 
-          defaults = (scope[:defaults] || {}).dup
-          scope_constraints = scope[:constraints] || {}
-          scope_options = scope[:options] || {}
-
-          new set, ast, defaults, controller, default_action, scope[:module], to, formatted, scope_constraints, scope_options, scope[:blocks] || [], via, options_constraints, anchor, options
+          new set: set, ast: ast, controller: controller, default_action: default_action,
+              to: to, formatted: formatted, via: via, options_constraints: options_constraints,
+              anchor: anchor, scope_params: scope_params, options: scope_params[:options].merge(options)
         end
 
         def self.check_via(via)
@@ -111,10 +115,9 @@ module ActionDispatch
           format != false && path !~ OPTIONAL_FORMAT_REGEX
         end
 
-        def initialize(set, ast, defaults, controller, default_action, modyoule, to, formatted, scope_constraints, scope_options, blocks, via, options_constraints, anchor, options)
-          @defaults = defaults
-          @set = set
-
+        def initialize(set:, ast:, controller:, default_action:, to:, formatted:, via:, options_constraints:, anchor:, scope_params:, options:)
+          @defaults           = scope_params[:defaults]
+          @set                = set
           @to                 = intern(to)
           @default_controller = intern(controller)
           @default_action     = intern(default_action)
@@ -122,23 +125,23 @@ module ActionDispatch
           @anchor             = anchor
           @via                = via
           @internal           = options.delete(:internal)
-          @scope_options      = scope_options
+          @scope_options      = scope_params[:options]
 
           path_params = ast.find_all(&:symbol?).map(&:to_sym)
 
           options = add_wildcard_options(options, formatted, ast)
 
-          options = normalize_options!(options, path_params, modyoule)
+          options = normalize_options!(options, path_params, scope_params[:module])
 
           split_options = constraints(options, path_params)
 
-          constraints = scope_constraints.merge Hash[split_options[:constraints] || []]
+          constraints = scope_params[:constraints].merge Hash[split_options[:constraints] || []]
 
           if options_constraints.is_a?(Hash)
             @defaults = Hash[options_constraints.find_all { |key, default|
               URL_OPTIONS.include?(key) && (String === default || Integer === default)
             }].merge @defaults
-            @blocks = blocks
+            @blocks = scope_params[:blocks]
             constraints.merge! options_constraints
           else
             @blocks = blocks(options_constraints)


### PR DESCRIPTION
### Summary
When a route was defined within an optional scope, if that route didn't take parameters the scope was lost when using path helpers. This patch ensures scope is kept both when the route takes parameters or when it doesn't.

Fixes #33219 

r? @gmcgibbon 