### PR TITLE
added presence methods on OpenStruct class

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "concurrent/map"
+require "ostruct"
 
 class Object
   # An object is blank if it's false, empty, or a whitespace string.
@@ -128,6 +129,18 @@ class String
       rescue Encoding::CompatibilityError
         ENCODED_BLANKS[self.encoding].match?(self)
       end
+  end
+end
+
+class OpenStruct
+  # An open struct is blank if it has no keys:
+  #
+  #   OpenStruct.new.blank?                    # => true
+  #   OpenStruct.new({ key: 'value' }).blank?  # => false
+  #
+  # @return [true, false]
+  def blank?
+    each_pair.count == 0
   end
 end
 

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,8 +16,8 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE") ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE"), OpenStruct.new ]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE"), OpenStruct.new(id: 0) ]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }


### PR DESCRIPTION
### Summary

All native DS support `blank?` and `present?` except `OpenStruct`. I have added an implementation for `OpenStruct`. Any reason this was left out?

My argument for this would be, since it is a `Hash` like DS, it should have the presence methods as well, just like a `Hash` does