### PR TITLE
Added mutex to synchronize transaction state of ActiveRecord object

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -404,6 +404,7 @@ module ActiveRecord
       @new_record               = true
       @destroyed                = false
       @_start_transaction_state = {}
+      @_start_transaction_state_mutex = Mutex.new
       @transaction_state        = nil
 
       super
@@ -566,6 +567,7 @@ module ActiveRecord
         @destroyed_by_association = nil
         @new_record               = true
         @_start_transaction_state = {}
+        @_start_transaction_state_mutex = Mutex.new
         @transaction_state        = nil
       end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -402,13 +402,19 @@ module ActiveRecord
 
       # Clear the new record state and id of a record.
       def clear_transaction_record_state
-        @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
-        force_clear_transaction_record_state if @_start_transaction_state[:level] < 1
+        level = nil
+        @_start_transaction_state_mutex.synchronize do
+          @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) - 1
+          level = @_start_transaction_state[:level]
+        end
+        force_clear_transaction_record_state if level < 1
       end
 
       # Force to clear the transaction record state.
       def force_clear_transaction_record_state
-        @_start_transaction_state.clear
+        @_start_transaction_state_mutex.synchronize do
+          @_start_transaction_state.clear
+        end
       end
 
       # Restore the new record state and id of a record that was previously saved by a call to save_record_state.


### PR DESCRIPTION
### Summary

Problem occurs in the following scenario for **jruby**-
When 2 threads are trying to access the same ActiveRecord object, one of the thread is updating an attribute while the other one is trying to read an attribute.

Fixes #34615

### Script to reproduce
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  ruby "2.5.0", engine: 'jruby', engine_version: '9.2.3.0'

  gem "rails"
  gem "activerecord-jdbcsqlite3-adapter"
  gem "parallel"
end

require "active_record"
require "minitest/autorun"
require "logger"
require 'parallel'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "bug_test", pool: 5000)
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :name
  end
end

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_concurrency_issue
    post = Post.create!

    tasks = []

    10000.times.each do
      tasks << Proc.new do
        j = post.name
      end
    end
    10000.times.each do
      tasks << Proc.new do
        post.update!(name: 'random')
      end
    end

    Parallel.each(tasks.shuffle, in_threads: 6) do |task|
      task.call
    end; nil
  end
end

```
#### System configuration
**Ruby version**: 2.5.0
**engine**: jruby
**jruby-version**: 9.2.3.0


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->