### PR TITLE
html.erb example does not match explanation text

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1145,7 +1145,7 @@ You can also pass local variables into partials, making them even more powerful 
     <% end %>
     ```
 
-Although the same partial will be rendered into both views, Action View's submit helper will return "Create Zone" for the new action and "Update Zone" for the edit action.
+Although the same partial will be rendered into both views, Action View's submit helper will return "New zone" for the new action and "Editing zone" for the edit action.
 
 To pass a local variable to a partial in only specific cases use the `local_assigns`.
 


### PR DESCRIPTION
In the text in the h1 tag, which is called out in the explanation text does not match. I've changed the explanation (below the html.erb examples, #L1123, #L1130) to match the h1 tags. But, this change could easily go the other way.

### Summary
There was a simple error in the guide text, which referenced the wrong text (possible due to the example html.erb files changing). The text was close, but not correct. I have changed the text to match the html.erb h1 tag titles.
