### PR TITLE
Upgrade Rubocop to 0.61.1 and fix offenses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
     retriable (3.1.2)
-    rubocop (0.60.0)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -79,108 +79,108 @@ module ActionDispatch
 
         private
 
-        def add_params(path, params)
-          params = { params: params } unless params.is_a?(Hash)
-          params.reject! { |_, v| v.to_param.nil? }
-          query = params.to_query
-          path << "?#{query}" unless query.empty?
-        end
-
-        def add_anchor(path, anchor)
-          if anchor
-            path << "##{Journey::Router::Utils.escape_fragment(anchor.to_param)}"
-          end
-        end
-
-        def extract_domain_from(host, tld_length)
-          host.split(".").last(1 + tld_length).join(".")
-        end
-
-        def extract_subdomains_from(host, tld_length)
-          parts = host.split(".")
-          parts[0..-(tld_length + 2)]
-        end
-
-        def add_trailing_slash(path)
-          if path.include?("?")
-            path.sub!(/\?/, '/\&')
-          elsif !path.include?(".")
-            path.sub!(/[^\/]\z|\A\z/, '\&/')
-          end
-        end
-
-        def build_host_url(host, port, protocol, options, path)
-          if match = host.match(HOST_REGEXP)
-            protocol ||= match[1] unless protocol == false
-            host       = match[2]
-            port       = match[3] unless options.key? :port
+          def add_params(path, params)
+            params = { params: params } unless params.is_a?(Hash)
+            params.reject! { |_, v| v.to_param.nil? }
+            query = params.to_query
+            path << "?#{query}" unless query.empty?
           end
 
-          protocol = normalize_protocol protocol
-          host     = normalize_host(host, options)
-
-          result = protocol.dup
-
-          if options[:user] && options[:password]
-            result << "#{Rack::Utils.escape(options[:user])}:#{Rack::Utils.escape(options[:password])}@"
+          def add_anchor(path, anchor)
+            if anchor
+              path << "##{Journey::Router::Utils.escape_fragment(anchor.to_param)}"
+            end
           end
 
-          result << host
-          normalize_port(port, protocol) { |normalized_port|
-            result << ":#{normalized_port}"
-          }
-
-          result.concat path
-        end
-
-        def named_host?(host)
-          IP_HOST_REGEXP !~ host
-        end
-
-        def normalize_protocol(protocol)
-          case protocol
-          when nil
-            "http://"
-          when false, "//"
-            "//"
-          when PROTOCOL_REGEXP
-            "#{$1}://"
-          else
-            raise ArgumentError, "Invalid :protocol option: #{protocol.inspect}"
+          def extract_domain_from(host, tld_length)
+            host.split(".").last(1 + tld_length).join(".")
           end
-        end
 
-        def normalize_host(_host, options)
-          return _host unless named_host?(_host)
-
-          tld_length = options[:tld_length] || @@tld_length
-          subdomain  = options.fetch :subdomain, true
-          domain     = options[:domain]
-
-          host = +""
-          if subdomain == true
-            return _host if domain.nil?
-
-            host << extract_subdomains_from(_host, tld_length).join(".")
-          elsif subdomain
-            host << subdomain.to_param
+          def extract_subdomains_from(host, tld_length)
+            parts = host.split(".")
+            parts[0..-(tld_length + 2)]
           end
-          host << "." unless host.empty?
-          host << (domain || extract_domain_from(_host, tld_length))
-          host
-        end
 
-        def normalize_port(port, protocol)
-          return unless port
-
-          case protocol
-          when "//" then yield port
-          when "https://"
-            yield port unless port.to_i == 443
-          else
-            yield port unless port.to_i == 80
+          def add_trailing_slash(path)
+            if path.include?("?")
+              path.sub!(/\?/, '/\&')
+            elsif !path.include?(".")
+              path.sub!(/[^\/]\z|\A\z/, '\&/')
+            end
           end
-        end
+
+          def build_host_url(host, port, protocol, options, path)
+            if match = host.match(HOST_REGEXP)
+              protocol ||= match[1] unless protocol == false
+              host       = match[2]
+              port       = match[3] unless options.key? :port
+            end
+
+            protocol = normalize_protocol protocol
+            host     = normalize_host(host, options)
+
+            result = protocol.dup
+
+            if options[:user] && options[:password]
+              result << "#{Rack::Utils.escape(options[:user])}:#{Rack::Utils.escape(options[:password])}@"
+            end
+
+            result << host
+            normalize_port(port, protocol) { |normalized_port|
+              result << ":#{normalized_port}"
+            }
+
+            result.concat path
+          end
+
+          def named_host?(host)
+            IP_HOST_REGEXP !~ host
+          end
+
+          def normalize_protocol(protocol)
+            case protocol
+            when nil
+              "http://"
+            when false, "//"
+              "//"
+            when PROTOCOL_REGEXP
+              "#{$1}://"
+            else
+              raise ArgumentError, "Invalid :protocol option: #{protocol.inspect}"
+            end
+          end
+
+          def normalize_host(_host, options)
+            return _host unless named_host?(_host)
+
+            tld_length = options[:tld_length] || @@tld_length
+            subdomain  = options.fetch :subdomain, true
+            domain     = options[:domain]
+
+            host = +""
+            if subdomain == true
+              return _host if domain.nil?
+
+              host << extract_subdomains_from(_host, tld_length).join(".")
+            elsif subdomain
+              host << subdomain.to_param
+            end
+            host << "." unless host.empty?
+            host << (domain || extract_domain_from(_host, tld_length))
+            host
+          end
+
+          def normalize_port(port, protocol)
+            return unless port
+
+            case protocol
+            when "//" then yield port
+            when "https://"
+              yield port unless port.to_i == 443
+            else
+              yield port unless port.to_i == 80
+            end
+          end
       end
 
       def initialize

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -573,49 +573,49 @@ module ActiveRecord
 
       private
 
-      def read_and_insert(fixtures_directory, fixture_files, class_names, connection) # :nodoc:
-        fixtures_map = {}
-        fixture_sets = fixture_files.map do |fixture_set_name|
-          klass = class_names[fixture_set_name]
-          fixtures_map[fixture_set_name] = new( # ActiveRecord::FixtureSet.new
-            nil,
-            fixture_set_name,
-            klass,
-            ::File.join(fixtures_directory, fixture_set_name)
-          )
-        end
-        update_all_loaded_fixtures(fixtures_map)
+        def read_and_insert(fixtures_directory, fixture_files, class_names, connection) # :nodoc:
+          fixtures_map = {}
+          fixture_sets = fixture_files.map do |fixture_set_name|
+            klass = class_names[fixture_set_name]
+            fixtures_map[fixture_set_name] = new( # ActiveRecord::FixtureSet.new
+              nil,
+              fixture_set_name,
+              klass,
+              ::File.join(fixtures_directory, fixture_set_name)
+            )
+          end
+          update_all_loaded_fixtures(fixtures_map)
 
-        insert(fixture_sets, connection)
+          insert(fixture_sets, connection)
 
-        fixtures_map
-      end
-
-      def insert(fixture_sets, connection) # :nodoc:
-        fixture_sets_by_connection = fixture_sets.group_by do |fixture_set|
-          fixture_set.model_class&.connection || connection
+          fixtures_map
         end
 
-        fixture_sets_by_connection.each do |conn, set|
-          table_rows_for_connection = Hash.new { |h, k| h[k] = [] }
+        def insert(fixture_sets, connection) # :nodoc:
+          fixture_sets_by_connection = fixture_sets.group_by do |fixture_set|
+            fixture_set.model_class&.connection || connection
+          end
 
-          set.each do |fixture_set|
-            fixture_set.table_rows.each do |table, rows|
-              table_rows_for_connection[table].unshift(*rows)
+          fixture_sets_by_connection.each do |conn, set|
+            table_rows_for_connection = Hash.new { |h, k| h[k] = [] }
+
+            set.each do |fixture_set|
+              fixture_set.table_rows.each do |table, rows|
+                table_rows_for_connection[table].unshift(*rows)
+              end
+            end
+            conn.insert_fixtures_set(table_rows_for_connection, table_rows_for_connection.keys)
+
+            # Cap primary key sequences to max(pk).
+            if conn.respond_to?(:reset_pk_sequence!)
+              set.each { |fs| conn.reset_pk_sequence!(fs.table_name) }
             end
           end
-          conn.insert_fixtures_set(table_rows_for_connection, table_rows_for_connection.keys)
-
-          # Cap primary key sequences to max(pk).
-          if conn.respond_to?(:reset_pk_sequence!)
-            set.each { |fs| conn.reset_pk_sequence!(fs.table_name) }
-          end
         end
-      end
 
-      def update_all_loaded_fixtures(fixtures_map) # :nodoc:
-        all_loaded_fixtures.update(fixtures_map)
-      end
+        def update_all_loaded_fixtures(fixtures_map) # :nodoc:
+          all_loaded_fixtures.update(fixtures_map)
+        end
     end
 
     attr_reader :table_name, :name, :fixtures, :model_class, :config

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -48,9 +48,9 @@ module ActiveRecord
 
       private
 
-      def current_adapter_name
-        ActiveRecord::Base.connection.adapter_name.downcase.to_sym
-      end
+        def current_adapter_name
+          ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+        end
     end
 
     BigInteger = ActiveModel::Type::BigInteger

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -13,34 +13,34 @@ module ARTest
 
     private
 
-    def config_file
-      Pathname.new(ENV["ARCONFIG"] || TEST_ROOT + "/config.yml")
-    end
-
-    def read_config
-      unless config_file.exist?
-        FileUtils.cp TEST_ROOT + "/config.example.yml", config_file
+      def config_file
+        Pathname.new(ENV["ARCONFIG"] || TEST_ROOT + "/config.yml")
       end
 
-      erb = ERB.new(config_file.read)
-      expand_config(YAML.parse(erb.result(binding)).transform)
-    end
-
-    def expand_config(config)
-      config["connections"].each do |adapter, connection|
-        dbs = [["arunit", "activerecord_unittest"], ["arunit2", "activerecord_unittest2"],
-               ["arunit_without_prepared_statements", "activerecord_unittest"]]
-        dbs.each do |name, dbname|
-          unless connection[name].is_a?(Hash)
-            connection[name] = { "database" => connection[name] }
-          end
-
-          connection[name]["database"] ||= dbname
-          connection[name]["adapter"]  ||= adapter
+      def read_config
+        unless config_file.exist?
+          FileUtils.cp TEST_ROOT + "/config.example.yml", config_file
         end
+
+        erb = ERB.new(config_file.read)
+        expand_config(YAML.parse(erb.result(binding)).transform)
       end
 
-      config
-    end
+      def expand_config(config)
+        config["connections"].each do |adapter, connection|
+          dbs = [["arunit", "activerecord_unittest"], ["arunit2", "activerecord_unittest2"],
+                 ["arunit_without_prepared_statements", "activerecord_unittest"]]
+          dbs.each do |name, dbname|
+            unless connection[name].is_a?(Hash)
+              connection[name] = { "database" => connection[name] }
+            end
+
+            connection[name]["database"] ||= dbname
+            connection[name]["adapter"]  ||= adapter
+          end
+        end
+
+        config
+      end
   end
 end

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -38,12 +38,13 @@ module ActiveSupport
       end
 
       private
-      def accumulate_descendants(klass, acc)
-        if direct_descendants = @@direct_descendants[klass]
-          acc.concat(direct_descendants)
-          direct_descendants.each { |direct_descendant| accumulate_descendants(direct_descendant, acc) }
+
+        def accumulate_descendants(klass, acc)
+          if direct_descendants = @@direct_descendants[klass]
+            acc.concat(direct_descendants)
+            direct_descendants.each { |direct_descendant| accumulate_descendants(direct_descendant, acc) }
+          end
         end
-      end
     end
 
     def inherited(base)

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -45,32 +45,32 @@ module ActiveSupport
 
       private
 
-      def convert_dates_from(data)
-        case data
-        when nil
-          nil
-        when DATE_REGEX
-          begin
-            Date.parse(data)
-          rescue ArgumentError
+        def convert_dates_from(data)
+          case data
+          when nil
+            nil
+          when DATE_REGEX
+            begin
+              Date.parse(data)
+            rescue ArgumentError
+              data
+            end
+          when DATETIME_REGEX
+            begin
+              Time.zone.parse(data)
+            rescue ArgumentError
+              data
+            end
+          when Array
+            data.map! { |d| convert_dates_from(d) }
+          when Hash
+            data.each do |key, value|
+              data[key] = convert_dates_from(value)
+            end
+          else
             data
           end
-        when DATETIME_REGEX
-          begin
-            Time.zone.parse(data)
-          rescue ArgumentError
-            data
-          end
-        when Array
-          data.map! { |d| convert_dates_from(d) }
-        when Hash
-          data.each do |key, value|
-            data[key] = convert_dates_from(value)
-          end
-        else
-          data
         end
-      end
     end
   end
 end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -39,23 +39,23 @@ module Rails
 
         private
 
-        # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
-        # when declaring options curly brackets should be used
-        def parse_type_and_options(type)
-          case type
-          when /(string|text|binary|integer)\{(\d+)\}/
-            return $1, limit: $2.to_i
-          when /decimal\{(\d+)[,.-](\d+)\}/
-            return :decimal, precision: $1.to_i, scale: $2.to_i
-          when /(references|belongs_to)\{(.+)\}/
-            type = $1
-            provided_options = $2.split(/[,.-]/)
-            options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
-            return type, options
-          else
-            return type, {}
+          # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
+          # when declaring options curly brackets should be used
+          def parse_type_and_options(type)
+            case type
+            when /(string|text|binary|integer)\{(\d+)\}/
+              return $1, limit: $2.to_i
+            when /decimal\{(\d+)[,.-](\d+)\}/
+              return :decimal, precision: $1.to_i, scale: $2.to_i
+            when /(references|belongs_to)\{(.+)\}/
+              type = $1
+              provided_options = $2.split(/[,.-]/)
+              options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
+              return type, options
+            else
+              return type, {}
+            end
           end
-        end
       end
 
       def initialize(name, type = nil, index_type = false, attr_options = {})


### PR DESCRIPTION
### Summary

This simple pull request upgrades Rubocop to 0.61.1 and fixes the remaining issues.

All of them were related to indentation after private / protect, which, as described in the [Contributing to Rails Guide] should be of 2 spaces.

[Contributing to Rails Guide]: https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html

