### PR TITLE
Compare transaction records by identity when adding to callback list

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Compare transaction records by identity when adding to callback list.
+
+    *Gannon McGibbon*
+
 *   Fix join table column quoting with SQLite.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -116,7 +116,7 @@ module ActiveRecord
       end
 
       def rollback_records
-        ite = records.uniq
+        ite = records.uniq(&:object_id)
         while record = ite.shift
           record.rolledback!(force_restore_state: full_rollback?)
         end
@@ -127,11 +127,11 @@ module ActiveRecord
       end
 
       def before_commit_records
-        records.uniq.each(&:before_committed!) if @run_commit_callbacks
+        records.uniq(&:object_id).each(&:before_committed!) if @run_commit_callbacks
       end
 
       def commit_records
-        ite = records.uniq
+        ite = records.uniq(&:object_id)
         while record = ite.shift
           if @run_commit_callbacks
             record.committed!

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -419,6 +419,22 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert flag
   end
 
+  def test_use_runs_callbacks_accross_instances
+    klass = Pet.dup
+    klass.class_eval do
+      class_attribute :update_commit_called, default: false
+      class_attribute :destroy_commit_called, default: false
+      after_update_commit { self.class.update_commit_called = true }
+      after_destroy_commit { self.class.destroy_commit_called = true }
+    end
+    klass.transaction do
+      klass.last.update(name: "test")
+      klass.last.destroy
+    end
+    assert_predicate klass, :update_commit_called
+    assert_predicate klass, :destroy_commit_called
+  end
+
   private
 
     def add_transaction_execution_blocks(record)


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34644.

`Array#uniq` favours the first result in the array. Sometimes this backfires when more than one of the same ActiveRecord object is added to the callback list of a transaction with different states. I think we should be using the last (latest) record as opposed to the first one.
