### PR TITLE
Increase ramfs size before install for CI against 5-2-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - "[[ $GEM != 'av:ujs' ]] || nvm install node"
   - "[[ $GEM != 'av:ujs' ]] || node --version"
   - "[[ $GEM != 'av:ujs' ]] || (cd actionview && npm install)"
+  - "[[ $GEM != 'ar:postgresql' ]] || sudo mount -o remount,size=50% /var/ramfs"
 
 before_script:
   # Set Sauce Labs username and access key. Obfuscated, purposefully not encrypted.

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -158,7 +158,6 @@ results = {}
 
 ENV["GEM"].split(",").each do |gem|
   [false, true].each do |isolated|
-    next if ENV["TRAVIS_PULL_REQUEST"] && ENV["TRAVIS_PULL_REQUEST"] != "false" && isolated
     next if RUBY_VERSION < "2.5" && isolated
     next if gem == "railties" && isolated
     next if gem == "ac" && isolated

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -158,6 +158,7 @@ results = {}
 
 ENV["GEM"].split(",").each do |gem|
   [false, true].each do |isolated|
+    next if ENV["TRAVIS_PULL_REQUEST"] && ENV["TRAVIS_PULL_REQUEST"] != "false" && isolated
     next if RUBY_VERSION < "2.5" && isolated
     next if gem == "railties" && isolated
     next if gem == "ac" && isolated


### PR DESCRIPTION
### Summary

This pull request attempts to fix #34664 by increasing ramfs size before installing for CI against 5-2-stable.

For master branch, https://github.com/rails/rails/pull/33861 has been merged, which depends on https://github.com/rails/rails/pull/33608. #33608 has not and should not be backported to 5-2-stable. Increasing ramfs should be a better way to address #34664 for 5-2-stable.

cc @y-yagi 