### PR TITLE
Prepend module in ActiveStorage overview

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -742,16 +742,22 @@ during the test are complete and you won't receive an error from Active Storage
 saying it can't find a file.
 
 ```ruby
+module RemoveUploadedFiles
+  def after_teardown
+    super
+    remove_uploaded_files
+  end
+
+  private
+
+  def remove_uploaded_files
+    FileUtils.rm_rf(Rails.root.join('tmp', 'storage'))
+  end
+end
+
 module ActionDispatch
   class IntegrationTest
-    def remove_uploaded_files
-      FileUtils.rm_rf(Rails.root.join('tmp', 'storage'))
-    end
-
-    def after_teardown
-      super
-      remove_uploaded_files
-    end
+    prepend RemoveUploadedFiles
   end
 end
 ```


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This updates the ActiveStorage overview documentation to prepend a module onto `IntegrationTest`, rather than straight overriding the `after_teardown` method, as per [this discussion with @rafaelfranca in #34619](https://github.com/rails/rails/pull/34619#discussion_r238882327)