### PR TITLE
Fix acceptance validator module inclusion leak

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix incremental inclusion using acceptance validator's lazy attributes module.
+
+    *Gannon McGibbon*
+
 *   Fix numericality equality validation of `BigDecimal` and `Float`
     by casting to `BigDecimal` on both ends of the validation.
 

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -40,6 +40,13 @@ class AcceptanceValidationTest < ActiveModel::TestCase
     assert_predicate t, :valid?
   end
 
+  def test_lazy_attribute_module_included_once_per_validation
+    assert_difference -> { Topic.ancestors.count }, 2 do
+      10.times { Topic.validates_acceptance_of(:something_to_accept) }
+      10.times { Topic.validates_acceptance_of(:something_else_to_accept) }
+    end
+  end
+
   def test_terms_of_service_agreement_with_accept_value
     Topic.validates_acceptance_of(:terms_of_service, accept: "I agree.")
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34659.

Fix incremental inclusion using acceptance validator's lazy attributes module. This patch may not be necessary as I can't think of a real world example where the current code would cause issues (aside from minuscule memory bloat). Regardless, this adds comparison to lazy attribute definitions so we don't include them more than once.
