### PR TITLE
 Remove redundant suffixes on generated system tests.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove redundant suffixes on generated system tests.
+
+    *Gannon McGibbon*
+
 *   Add an `abort_on_failure` boolean option to the generator method that shell
     out (`generate`, `rake`, `rails_command`) to abort the generator if the
     command fails.

--- a/railties/lib/rails/generators/test_unit/system/system_generator.rb
+++ b/railties/lib/rails/generators/test_unit/system/system_generator.rb
@@ -14,6 +14,11 @@ module TestUnit # :nodoc:
 
         template "system_test.rb", File.join("test/system", class_path, "#{file_name.pluralize}_test.rb")
       end
+
+      private
+        def file_name
+          @_file_name ||= super.sub(/_test\z/i, "")
+        end
     end
   end
 end

--- a/railties/test/generators/system_test_generator_test.rb
+++ b/railties/test/generators/system_test_generator_test.rb
@@ -16,4 +16,18 @@ class SystemTestGeneratorTest < Rails::Generators::TestCase
     run_generator %w(admin/user)
     assert_file "test/system/admin/users_test.rb", /class Admin::UsersTest < ApplicationSystemTestCase/
   end
+
+  def test_test_name_is_pluralized
+    run_generator %w(user)
+
+    assert_no_file "test/system/user_test.rb"
+    assert_file "test/system/users_test.rb"
+  end
+
+  def test_test_suffix_is_not_duplicated
+    run_generator %w(users_test)
+
+    assert_no_file "test/system/users_test_test.rb"
+    assert_file "test/system/users_test.rb"
+  end
 end


### PR DESCRIPTION
### Summary

Removes redundant `_test` suffix on generated system tests.
