### PR TITLE
Add Missing ActiveSupport::Rescuable to ActionCable::Channel

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "set"
+require "active_support/rescuable"
 
 module ActionCable
   module Channel
@@ -99,6 +100,7 @@ module ActionCable
       include Streams
       include Naming
       include Broadcasting
+      include ActiveSupport::Rescuable
 
       attr_reader :params, :connection, :identifier
       delegate :logger, to: :connection
@@ -267,6 +269,8 @@ module ActionCable
           else
             public_send action
           end
+        rescue Exception => exception
+          rescue_with_handler(exception) || raise
         end
 
         def action_signature(action, data)


### PR DESCRIPTION
The second attempt  :)
The previous one: https://github.com/rails/rails/pull/25369 by @timthez.