### PR TITLE
Remove redundant suffixes on generated integration tests.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove redundant suffixes on generated integration tests.
+
+    *Gannon McGibbon*
+
 *   Fix boolean interaction in scaffold system tests.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
+++ b/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
@@ -10,6 +10,12 @@ module TestUnit # :nodoc:
       def create_test_files
         template "integration_test.rb", File.join("test/integration", class_path, "#{file_name}_test.rb")
       end
+
+      private
+
+        def file_name
+          @_file_name ||= super.sub(/_test\z/i, "")
+        end
     end
   end
 end

--- a/railties/test/generators/integration_test_generator_test.rb
+++ b/railties/test/generators/integration_test_generator_test.rb
@@ -15,4 +15,11 @@ class IntegrationTestGeneratorTest < Rails::Generators::TestCase
     run_generator %w(iguchi/integration)
     assert_file "test/integration/iguchi/integration_test.rb", /class Iguchi::IntegrationTest < ActionDispatch::IntegrationTest/
   end
+
+  def test_test_suffix_is_not_duplicated
+    run_generator %w(integration_test)
+
+    assert_no_file "test/integration/integration_test_test.rb"
+    assert_file "test/integration/integration_test.rb"
+  end
 end


### PR DESCRIPTION
### Summary

Remove redundant suffixes on generated integration tests.
