### PR TITLE
Remove redundant suffixes on generated helpers.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove redundant suffixes on generated helpers.
+
+    *Gannon McGibbon*
+
 *   Fix boolean interaction in scaffold system tests.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/generators/rails/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/rails/helper/helper_generator.rb
@@ -10,6 +10,11 @@ module Rails
       end
 
       hook_for :test_framework
+
+      private
+        def file_name
+          @_file_name ||= super.sub(/_helper\z/i, "")
+        end
     end
   end
 end

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -38,4 +38,11 @@ class HelperGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  def test_helper_suffix_is_not_duplicated
+    run_generator %w(products_helper)
+
+    assert_no_file "app/helpers/products_helper_helper.rb"
+    assert_file "app/helpers/products_helper.rb"
+  end
 end


### PR DESCRIPTION
### Summary

Remove redundant suffixes on generated helpers.
