### PR TITLE
Move MailDeliveryJob default to 6.0 defaults

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -461,7 +461,7 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
+    class_attribute :delivery_job, default: ::ActionMailer::DeliveryJob
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -145,9 +145,17 @@ module ActionMailer
           if processed?
             super
           else
-            job  = @mailer_class.delivery_job
+            job  = delivery_job_class
             args = arguments_for(job, delivery_method)
             job.set(options).perform_later(*args)
+          end
+        end
+
+        def delivery_job_class
+          if @mailer_class.delivery_job <= MailDeliveryJob
+            @mailer_class.delivery_job
+          else
+            Parameterized::DeliveryJob
           end
         end
 

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -46,6 +46,10 @@ module ActionMailer
         register_preview_interceptors(options.delete(:preview_interceptors))
         register_observers(options.delete(:observers))
 
+        if delivery_job = options.delete(:delivery_job)
+          self.delivery_job = delivery_job.constantize
+        end
+
         options.each { |k, v| send("#{k}=", v) }
       end
 

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -33,6 +33,8 @@ I18n.enforce_available_locales = false
 FIXTURE_LOAD_PATH = File.expand_path("fixtures", __dir__)
 ActionMailer::Base.view_paths = FIXTURE_LOAD_PATH
 
+ActionMailer::Base.delivery_job = ActionMailer::MailDeliveryJob
+
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 

--- a/actionmailer/test/legacy_delivery_job_test.rb
+++ b/actionmailer/test/legacy_delivery_job_test.rb
@@ -11,9 +11,6 @@ class LegacyDeliveryJobTest < ActiveSupport::TestCase
   class LegacyDeliveryJob < ActionMailer::DeliveryJob
   end
 
-  class LegacyParmeterizedDeliveryJob < ActionMailer::Parameterized::DeliveryJob
-  end
-
   setup do
     @previous_logger = ActiveJob::Base.logger
     ActiveJob::Base.logger = Logger.new(nil)
@@ -42,9 +39,9 @@ class LegacyDeliveryJobTest < ActiveSupport::TestCase
       { inviter: "david@basecamp.com", invitee: "jason@basecamp.com" },
     ]
 
-    with_delivery_job(LegacyParmeterizedDeliveryJob) do
+    with_delivery_job(LegacyDeliveryJob) do
       assert_deprecated do
-        assert_performed_with(job: LegacyParmeterizedDeliveryJob, args: args) do
+        assert_performed_with(job: ActionMailer::Parameterized::DeliveryJob, args: args) do
           mail.deliver_later
         end
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -130,6 +130,10 @@ module Rails
             action_dispatch.use_cookies_with_metadata = true
           end
 
+          if respond_to?(:action_mailer)
+            action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+          end
+
           if respond_to?(:active_job)
             active_job.return_false_on_aborted_enqueue = true
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -22,3 +22,12 @@
 # Send Active Storage analysis and purge jobs to dedicated queues.
 # Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
 # Rails.application.config.active_storage.queues.purge    = :active_storage_purge
+
+# Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
+#
+# The default delivery job (ActionMailer::DeliveryJob), will be removed in Rails 6.1.
+# This setting is not backwards compatible with earlier Rails versions.
+# If you send mail in the background, job workers need to have a copy of
+# MailDeliveryJob to ensure all delivery jobs are processed properly.
+# Make sure your entire app is migrated and stable on 6.0 before using this setting.
+# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2325,6 +2325,33 @@ module ApplicationTests
       assert_equal :another_queue, ActionMailbox.queues[:routing]
     end
 
+    test "ActionMailer::Base.delivery_job is ActionMailer::MailDeliveryJob by default" do
+      app "development"
+
+      assert_equal ActionMailer::MailDeliveryJob, ActionMailer::Base.delivery_job
+    end
+
+    test "ActionMailer::Base.delivery_job is ActionMailer::DeliveryJob in the 5.x defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "5.2"'
+
+      app "development"
+
+      assert_equal ActionMailer::DeliveryJob, ActionMailer::Base.delivery_job
+    end
+
+    test "ActionMailer::Base.delivery_job can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_6_0.rb", <<-RUBY
+        Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+      RUBY
+
+      app "development"
+
+      assert_equal ActionMailer::MailDeliveryJob, ActionMailer::Base.delivery_job
+    end
+
     test "ActiveRecord::Base.filter_attributes should equal to filter_parameters" do
       app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
         Rails.application.config.filter_parameters += [ :password, :credit_card_number ]


### PR DESCRIPTION
### Summary

Followup on https://github.com/rails/rails/pull/34591. This moves the setting of using `ActionMailer::MailDeliveryJob` as the default delivery job to defaults only applied to new 6.0 apps. Upgraded apps need to upgrade this manually to avoid having issues on deployment discussed [here](https://github.com/rails/rails/pull/34591#issuecomment-444157404).

cc @rafaelfranca, @Edouard-chin, @eileencodes 
