### PR TITLE
[perf] use #match?

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -378,7 +378,7 @@ module ActionView
           # This regex match does double duty of finding only files which match
           # details (instead of just matching the prefix) and also filtering for
           # case-insensitive file systems.
-          !filename.match(regex) ||
+          !regex.match?(filename) ||
             File.directory?(filename)
         end.sort_by do |filename|
           # Because we scanned the directory, instead of checking for files

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -98,15 +98,15 @@ module ActiveModel
       end
 
       def is_integer?(raw_value)
-        INTEGER_REGEX === raw_value.to_s
+        INTEGER_REGEX.match? raw_value.to_s
       end
 
       def is_decimal?(raw_value)
-        DECIMAL_REGEX === raw_value.to_s
+        DECIMAL_REGEX.match? raw_value.to_s
       end
 
       def is_hexadecimal_literal?(raw_value)
-        /\A0[xX]/ === raw_value
+        /\A0[xX]/.match? raw_value
       end
 
       def filtered_options(value)


### PR DESCRIPTION
### Summary
no need to set backreferences, in these cases using match? is more appropriate

### Other Information
```
INTEGER_REGEX
             ===    656.097k (± 5.1%) i/s -      3.311M in   5.060584s
            match?   2.673M (± 4.0%) i/s -     13.432M in   5.034181s
```
