### PR TITLE
Added option to create migration only with indexed attribute

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       end
 
       private
-        attr_reader :migration_action, :join_tables
+        attr_reader :migration_action, :join_tables, :attribute
 
         # Sets the default migration template that is being used for the generation of the migration.
         # Depending on command line arguments, the migration template and the table name instance
@@ -25,6 +25,10 @@ module ActiveRecord
         def set_local_assigns!
           @migration_template = "migration.rb"
           case file_name
+          when /^(add_indexed)_(.*)_to_(.*)/
+            @migration_action = $1
+            @attribute = $2
+            @table_name = $3
           when /^(add)_.*_to_(.*)/, /^(remove)_.*?_from_(.*)/
             @migration_action = $1
             @table_name       = normalize_table_name($2)

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -1,5 +1,9 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
-<%- if migration_action == 'add' -%>
+<%- if migration_action == 'add_indexed' -%>
+  def change
+    add_index :<%= table_name %>, :<%= attribute %>
+  end
+<%- elsif migration_action == 'add' -%>
   def change
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>


### PR DESCRIPTION
### Summary

New migration generator action 'add_indexed'. 

This will generate migration file only with add_index :table_name, :attribute section

Usage: `rails generate migration add_indexed_email_to_users` 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
