### PR TITLE
Preserve key order of #fetch_multi

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Preserve key order passed to `ActiveSupport::CacheStore#fetch_multi`.
+
+    `fetch_multi(*names)` now returns its results in the same order as the `*names` requested, rather than returning cache hits followed by cache misses.
+
+    *Gannon McGibbon*
+
 *   If the same block is `included` multiple times for a Concern, an exception is no longer raised.
 
     *Mark J. Titorenko*, *Vlad Bokov*

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -130,7 +130,7 @@ module CacheStoreBehavior
     assert_equal("fufu", @cache.read("fu"))
   end
 
-  def test_multi_with_objects
+  def test_fetch_multi_with_objects
     cache_struct = Struct.new(:cache_key, :title)
     foo = cache_struct.new("foo", "FOO!")
     bar = cache_struct.new("bar")
@@ -140,6 +140,14 @@ module CacheStoreBehavior
     values = @cache.fetch_multi(foo, bar) { |object| object.title }
 
     assert_equal({ foo => "FOO!", bar => "BAM!" }, values)
+  end
+
+  def test_fetch_multi_returns_ordered_names
+    @cache.write("bam", "BAM")
+
+    values = @cache.fetch_multi("foo", "bar", "bam") { |key| key.upcase }
+
+    assert_equal(%w(foo bar bam), values.keys)
   end
 
   def test_fetch_multi_without_block


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34694.

Preserves order of keys passed to `#fetch_multi`.

If for some reason the current functionality is intended, I'll refactor this PR to document the behaviour.
