### PR TITLE
Test ActiveSupport::Deprecation.deprecate_methods

### DIFF
--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -21,6 +21,13 @@ class MethodWrappersTest < ActiveSupport::TestCase
     end
   end
 
+  def test_deprecate_methods_without_alternate_method
+    warning = /old_method is deprecated and will be removed from Rails \d.\d./
+    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method)
+
+    assert_deprecated(warning) { assert_equal "abc", @klass.new.old_method }
+  end
+
   def test_deprecate_methods_warning_default
     warning = /old_method is deprecated and will be removed from Rails \d.\d \(use new_method instead\)/
     ActiveSupport::Deprecation.deprecate_methods(@klass, old_method: :new_method)


### PR DESCRIPTION
`ActiveSupport::Deprecation.deprecate_methods` without alternate method name is not tested.