### PR TITLE
Remove `report-uri` directive when `nil`

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -175,7 +175,7 @@ module ActionDispatch #:nodoc:
     end
 
     def report_uri(uri)
-      @directives["report-uri"] = [uri]
+      @directives["report-uri"] = [uri] if uri
     end
 
     def require_sri_for(*types)

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -171,6 +171,12 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_match %r{report-uri /violations}, @policy.build
   end
 
+  def test_reporting_directives_when_nil
+    @policy.report_uri nil
+    @policy.default_src :self
+    assert_no_match %r{report-uri}, @policy.build
+  end
+
   def test_other_directives
     @policy.block_all_mixed_content
     assert_match %r{block-all-mixed-content}, @policy.build


### PR DESCRIPTION
Updates the CSP `report_uri` method to only include the `report-uri`
directive if the value provided to it isn't `nil`. This allows end users
to omit the directive if they don't want it outputted.

Fixes #34703