### PR TITLE
Check MEMCACHE_SERVERS in connect to memchached server

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -67,7 +67,8 @@ module ActiveSupport
       def self.build_mem_cache(*addresses) # :nodoc:
         addresses = addresses.flatten
         options = addresses.extract_options!
-        addresses = ["localhost:11211"] if addresses.empty?
+        addresses = ["localhost:11211"] if addresses.empty? && ENV["MEMCACHE_SERVERS"].nil?
+        addresses = nil if addresses.empty?
         pool_options = retrieve_pool_options(options)
 
         if pool_options.empty?

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -25,8 +25,8 @@ end
 
 class MemCacheStoreTest < ActiveSupport::TestCase
   begin
-    ss = Dalli::Client.new("localhost:11211").stats
-    raise Dalli::DalliError unless ss["localhost:11211"]
+    ss = Dalli::Client.new.stats
+    raise Dalli::DalliError unless ss[ss.keys.first]
 
     MEMCACHE_UP = true
   rescue Dalli::DalliError


### PR DESCRIPTION
### Summary
Dalli uses `ENV["MEMCACHE_SERVERS"]` to default memchached server address when not any address passed in client.new .

But ActiveSupport uses `localhost:11211` in `ActiveSupport::Cache::MemCacheStoreTest.build_mem_cache` called
without arguments.
Its behavior can't overwrite by environment variable "MEMCACHE_SERVERS".

If address passed, use this.
Else, check "MEMCACHE_SERVERS" then it has value, use this.
If neither, use nil to initialize `Dalli::Client` .

### Other Information
I found this problem when run ActiveSupport test by memcached that running other host. 

In my opinion, ActiveSupport has to respects to Dalli behavior to use MEMCACHE_SERVER environment variable. :wink: 
