### PR TITLE
Add missing keys to ActiveSupport#instrumentation guide [skip ci]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -255,13 +255,16 @@ Active Record
 
 ### sql.active_record
 
-| Key              | Value                                    |
-| ---------------- | ---------------------------------------- |
-| `:sql`           | SQL statement                            |
-| `:name`          | Name of the operation                    |
-| `:connection_id` | `self.object_id`                         |
-| `:binds`         | Bind parameters                          |
-| `:cached`        | `true` is added when cached queries used |
+| Key                  | Value                                    |
+| -------------------- | ---------------------------------------- |
+| `:sql`               | SQL statement                            |
+| `:name`              | Name of the operation                    |
+| `:connection_id`     | Object ID of the connection object       |
+| `:connection`        | Connection object                        |
+| `:binds`             | Bind parameters                          |
+| `:type_casted_binds` | Typecasted bind parameters               |
+| `:statement_name`    | SQL Statement name                       |
+| `:cached`            | `true` is added when cached queries used |
 
 INFO. The adapters will add their own data as well.
 
@@ -270,7 +273,10 @@ INFO. The adapters will add their own data as well.
   sql: "SELECT \"posts\".* FROM \"posts\" ",
   name: "Post Load",
   connection_id: 70307250813140,
-  binds: []
+  connection: #<ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x00007f9f7a838850>,
+  binds: [#<ActiveModel::Attribute::WithCastValue:0x00007fe19d15dc00>],
+  type_casted_binds: [11],
+  statement_name: nil
 }
 ```
 


### PR DESCRIPTION
### Summary
Add missing keys type_casted_binds & statement_name

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L625.