### PR TITLE
Insert SQLite binary as blob

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix binary insert type casting with SQLite.
+
+    *Gannon McGibbon*
+
 *   Fix join table column quoting with SQLite.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -49,6 +49,8 @@ module ActiveRecord
 
           def _type_cast(value)
             case value
+            when Type::Binary::Data
+              ::SQLite3::Blob.new(value.to_s)
             when BigDecimal
               value.to_f
             when String

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -42,5 +42,11 @@ unless current_adapter?(:DB2Adapter)
         assert_equal data, bin.reload.data, "Reloaded data differs from original"
       end
     end
+
+    def test_arel_find
+      binary = Binary.create!(data: "some binary data")
+
+      assert_equal [binary], Binary.where(Binary.arel_table[:data].eq(binary.data)).to_a
+    end
   end
 end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34701.

Inserts SQLite binary columns as blobs. This way, they can be found by their type casted hex value.

https://github.com/sparklemotion/sqlite3-ruby/blob/master/faq/faq.md#how-do-i-insert-binary-data-into-the-database