### PR TITLE
Optimize performance of PostgreSQL timestamptz type

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -12,6 +12,7 @@ class PostgresqlTimestampTest < ActiveRecord::PostgreSQLTestCase
   setup do
     @connection = ActiveRecord::Base.connection
     @connection.execute("INSERT INTO postgresql_timestamp_with_zones (id, time) VALUES (1, '2010-01-01 10:00:00-1')")
+    @connection.execute("INSERT INTO postgresql_timestamp_with_zones (id, time) VALUES (2, '2010-01-01 10:00:00.123456-01')")
   end
 
   teardown do
@@ -24,6 +25,10 @@ class PostgresqlTimestampTest < ActiveRecord::PostgreSQLTestCase
 
       timestamp = PostgresqlTimestampWithZone.find(1)
       assert_equal Time.utc(2010, 1, 1, 11, 0, 0), timestamp.time
+      assert_instance_of Time, timestamp.time
+
+      timestamp = PostgresqlTimestampWithZone.find(2)
+      assert_equal Time.utc(2010, 1, 1, 11, 0, 0, 123456), timestamp.time
       assert_instance_of Time, timestamp.time
     end
   ensure
@@ -38,6 +43,10 @@ class PostgresqlTimestampTest < ActiveRecord::PostgreSQLTestCase
 
       timestamp = PostgresqlTimestampWithZone.find(1)
       assert_equal Time.utc(2010, 1, 1, 11, 0, 0), timestamp.time
+      assert_instance_of Time, timestamp.time
+
+      timestamp = PostgresqlTimestampWithZone.find(2)
+      assert_equal Time.utc(2010, 1, 1, 11, 0, 0, 123456), timestamp.time
       assert_instance_of Time, timestamp.time
     end
   ensure


### PR DESCRIPTION
ActiveModel's `fast_string_to_time` optimizes the parsing of ISO
timestamps. However, the fallback mechanism for parsing a value from
PostgreSQL's `timestamp with time zone` is a bit slow because
`Date::_parse` requires a number of unnecessary memory allocations.

We can speed this up and reduce memory allocations by using a regular
expression to parse. Note that time zones in hh:mm format will not be
any faster because the regular expression slows down the common cases.

```ruby
require 'active_record'
require 'active_support'
require 'active_record/connection_adapters/postgresql_adapter'
require 'benchmark/ips'

module ActiveRecord
  module ConnectionAdapters
    module PostgreSQL
      module OID # :nodoc:
        class DateTimeFast < DateTime # :nodoc:
          ISO_DATETIME_TZ = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?([+|-]\d\d)?\z/

          private

          def fast_string_to_time(string)
            if string =~ ISO_DATETIME_TZ
              microsec = parse_microseconds($7)
              offset = parse_offset($8)
              new_time $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, microsec, offset
            end
          end

          def parse_microseconds(microsec_part)
            if microsec_part && microsec_part.start_with?(".") && microsec_part.length == 7
              microsec_part[0] = ""
              microsec_part.to_i
            else
              (microsec_part.to_r * 1_000_000).to_i
            end
          end

          def parse_offset(offset_part)
            if offset_part
              offset_part.to_i * 3600
            else
              nil
            end
          end
        end
      end
    end
  end
end

timestamps = ['2016-01-02 12:34:56.123456+06',
              '2016-01-02 12:34:56.123456',
              '2016-01-02 12:34:56',
              '2016-01-02 12:34:56.123456+06:30',
              '2016-01-02 12:34:56.123456+0630']

timestamps.each do |timestamp|
  Benchmark.ips do |x|
    x.report("orig") {
      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime.new.send(:cast_value, timestamp)
    }

    x.report("new") {
      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTimeFast.new.send(:cast_value, timestamp)
    }

    x.compare!
  end
end
```

````
Warming up --------------------------------------
                orig     3.539k i/100ms
                 new    11.820k i/100ms
Calculating -------------------------------------
                orig     40.713k (± 1.9%) i/s -    205.262k in   5.043505s
                 new    131.824k (± 2.5%) i/s -    661.920k in   5.024375s

Comparison:
                 new:   131823.9 i/s
                orig:    40713.5 i/s - 3.24x  slower

Warming up --------------------------------------
                orig    14.334k i/100ms
                 new    14.039k i/100ms
Calculating -------------------------------------
                orig    150.395k (± 2.6%) i/s -    759.702k in   5.054721s
                 new    149.746k (± 2.2%) i/s -    758.106k in   5.064994s

Comparison:
                orig:   150395.3 i/s
                 new:   149746.1 i/s - same-ish: difference falls within error

Warming up --------------------------------------
                orig    14.983k i/100ms
                 new    14.349k i/100ms
Calculating -------------------------------------
                orig    153.344k (± 3.7%) i/s -    779.116k in   5.088030s
                 new    154.053k (± 2.3%) i/s -    774.846k in   5.032427s

Comparison:
                 new:   154053.5 i/s
                orig:   153344.1 i/s - same-ish: difference falls within error

Warming up --------------------------------------
                orig     3.964k i/100ms
                 new     3.910k i/100ms
Calculating -------------------------------------
                orig     39.842k (± 3.5%) i/s -    202.164k in   5.080392s
                 new     38.030k (± 3.6%) i/s -    191.590k in   5.044700s

Comparison:
                orig:    39841.8 i/s
                 new:    38029.7 i/s - same-ish: difference falls within error

Warming up --------------------------------------
                orig     3.722k i/100ms
                 new     3.831k i/100ms
Calculating -------------------------------------
                orig     39.551k (± 5.1%) i/s -    197.266k in   5.001564s
                 new     38.824k (± 7.5%) i/s -    195.381k in   5.065277s

Comparison:
                orig:    39551.0 i/s
                 new:    38824.3 i/s - same-ish: difference falls within error
```
