### PR TITLE
Return result_set with payload, to use in ActiveSupport::Notifications

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -46,7 +46,8 @@ module ActiveRecord
 
       payload = {
         record_count: result_set.length,
-        class_name: name
+        class_name: name,
+        result_set: result_set
       }
 
       message_bus.instrument("instantiation.active_record", payload) do


### PR DESCRIPTION
Hello, I am requesting the inclusion of result_set with payload, to use in ActiveSupport::Notifications pub/sub. Currently, I am required to use class_eval to extend ActiveRecord, but would prefer a cleaner solution.
