### PR TITLE
Action Cable: allow multiple instances of Server::Base with different configs

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Allow passing custom configuration to `ActionCable::Server::Base`.
+
+    You can now create a standalone Action Cable server with a custom configuration
+    (e.g. to run it in isolation from the default one):
+
+    ```ruby
+    config = ActionCable::Server::Configuration.new
+    config.cable = { adapter: "redis", channel_prefix: "custom_" }
+
+    CUSTOM_CABLE = ActionCable::Server::Base.new(config: config)
+    ```
+
+    Then you can mount it in the `routes.rb` file:
+
+    ```ruby
+    Rails.application.routes.draw do
+      mount CUSTOM_CABLE => "/custom_cable"
+      # ...
+    end
+    ```
+
+    *Vladimir Dementyev*
+
 *   Add `:action_cable_connection` and `:action_cable_channel` load hooks.
 
     You can use them to extend `ActionCable::Connection::Base` and `ActionCable::Channel::Base`

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -12,14 +12,17 @@ module ActionCable
       include ActionCable::Server::Broadcasting
       include ActionCable::Server::Connections
 
-      cattr_accessor :config, instance_accessor: true, default: ActionCable::Server::Configuration.new
+      cattr_accessor :config, instance_accessor: false, default: ActionCable::Server::Configuration.new
+
+      attr_reader :config
 
       def self.logger; config.logger; end
       delegate :logger, to: :config
 
       attr_reader :mutex
 
-      def initialize
+      def initialize(config: self.class.config)
+        @config = config
         @mutex = Monitor.new
         @remote_connections = @event_loop = @worker_pool = @pubsub = nil
       end

--- a/actioncable/test/subscription_adapter/channel_prefix.rb
+++ b/actioncable/test/subscription_adapter/channel_prefix.rb
@@ -2,17 +2,9 @@
 
 require "test_helper"
 
-class ActionCable::Server::WithIndependentConfig < ActionCable::Server::Base
-  # ActionCable::Server::Base defines config as a class variable.
-  # Need config to be an instance variable here as we're testing 2 separate configs
-  def config
-    @config ||= ActionCable::Server::Configuration.new
-  end
-end
-
 module ChannelPrefixTest
   def test_channel_prefix
-    server2 = ActionCable::Server::WithIndependentConfig.new
+    server2 = ActionCable::Server::Base.new(config: ActionCable::Server::Configuration.new)
     server2.config.cable = alt_cable_config
     server2.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 


### PR DESCRIPTION
### Context

When trying to create a separate _cable_ instance (e.g. within an engine), we faced a problem of `ActionCable::Server::Base` relying on the _global_ configuration (i.e. `ActionCable::Server::Base.config`). 

We want our engine to have a separate, isolated, Cable server instance with its own configuration.

See the example app using this patch: https://github.com/palkan/engine-cable-app

### Summary

- Add ability to pass a config as a `Server.new` argument.

### Other Information

This problem has been already discussed here: https://github.com/rails/rails/pull/27425#discussion_r96065280 (we've adjusted the test from that PR as well).

The related issue not included into this patch (separate PR?): currently, only the Redis adapter supports channels prefixes.  With the ability to have _engined_ cables we'll need to isolate streams for all _distributed_ adapters (e.g. `postgresql`, `async`/`inline` adapters do not share anything).

One potential caveat of using multiples cables within the app is the lack of isolation for channel classes, i.e. it is possible to subscribe (or at least try to) to any channel from any connection (see https://github.com/rails/rails/blob/v5.2.2/actioncable/lib/action_cable/connection/subscriptions.rb#L35).

One possible solution is to add `config.base_channel_class` parameter and use it instead of a `ActionCable::Channel::Base` (i.e. `config.base_channel_class >= subscription_klass`).

Another way is to get away from using Ruby class names as identifiers, and build a per-connection registry/map of identifiers->class (like it's done in https://github.com/palkan/litecable).

P.S. Thanks to @composerinteralia for pairing with me on this feature.