### PR TITLE
ActionCable: Same origin match against X-FORWARDED-HOST when proxying

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -200,7 +200,8 @@ module ActionCable
           return true if server.config.disable_request_forgery_protection
 
           proto = Rack::Request.new(env).ssl? ? "https" : "http"
-          if server.config.allow_same_origin_as_host && env["HTTP_ORIGIN"] == "#{proto}://#{env['HTTP_HOST']}"
+          host = env["HTTP_X_FORWARDED_HOST"].blank? ? env["HTTP_HOST"] : env["HTTP_X_FORWARDED_HOST"].split(/,\s*/).first
+          if server.config.allow_same_origin_as_host && env["HTTP_ORIGIN"] == "#{proto}://#{host}"
             true
           elsif Array(server.config.allowed_request_origins).any? { |allowed_origin|  allowed_origin === env["HTTP_ORIGIN"] }
             true


### PR DESCRIPTION
When using `allow_same_origin_as_host` with a reverse proxy the `HOST` header is set to the proxy host which will cause the CSRF protection to forbid the request. Each time a request hits a reverse proxy, it
updated the HOST header and also prepends the host from the previous request to the `X-FORWARDED-FOR` header. When the request finally hits the server where ActionCable is running, the first host in the header will be the right one for us.

I am proposing to change my original idea introduced in 268c340 to test against the first element of this header when it is set.