### PR TITLE
Allow using parsed_body in ActionController::TestCase

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Allow using `parsed_body` in `ActionController::TestCase`.
+
+    In addition to `ActionDispatch::IntegrationTest`, allow using
+    `parsed_body` in `ActionController::TestCase`:
+
+    ```
+    class SomeControllerTest < ActionController::TestCase
+      def test_some_action
+        post :action, body: { foo: 'bar' }
+        assert_equal({ "foo" => "bar" }, response.parsed_body)
+      end
+    end
+    ```
+
+    Fixes #34676.
+
+    *Tobias Bühlmann*
+
 *   Raise an error on root route naming conflicts.
 
     Raises an ArgumentError when multiple root routes are defined in the

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -14,11 +14,6 @@ module ActionDispatch
       new response.status, response.headers, response.body
     end
 
-    def initialize(*) # :nodoc:
-      super
-      @response_parser = RequestEncoder.parser(content_type)
-    end
-
     # Was the response successful?
     def success?
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -47,7 +42,11 @@ module ActionDispatch
     end
 
     def parsed_body
-      @parsed_body ||= @response_parser.call(body)
+      @parsed_body ||= response_parser.call(body)
+    end
+
+    def response_parser
+      @response_parser ||= RequestEncoder.parser(content_type)
     end
   end
 end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -156,6 +156,10 @@ XML
       render html: '<body class="foo"></body>'.html_safe
     end
 
+    def render_json
+      render json: request.raw_post
+    end
+
     def boom
       raise "boom!"
     end
@@ -964,6 +968,16 @@ XML
       params: { q: "test2" }
 
     assert_equal "q=test2", @response.body
+  end
+
+  def test_parsed_body_without_as_option
+    post :render_json, body: { foo: "heyo" }
+    assert_equal({ "foo" => "heyo" }, response.parsed_body)
+  end
+
+  def test_parsed_body_with_as_option
+    post :render_json, body: { foo: "heyo" }, as: :json
+    assert_equal({ "foo" => "heyo" }, response.parsed_body)
   end
 end
 


### PR DESCRIPTION
### Summary

Allow using `parsed_body` in `ActionController::TestCase` by switching the initialzation of an appropriate response parser
in `ActionDispatch::TestResponse` from eagerly to lazily.

By doing so, the response parser can be correctly set for
`ActionController::TestCase`, which doesn't include
the content type header in the constructor but only sets it at
a later time.

Fixes #34676.