### PR TITLE
Ruby 2.6 suport for 5-2-stable branch

### DIFF
--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -200,7 +200,7 @@ module ActionCable::StreamTests
       end
 
       def receive(connection, command:, identifiers:, channel: "ActionCable::StreamTests::ChatChannel")
-        identifier = JSON.generate(channel: channel, **identifiers)
+        identifier = JSON.generate(identifiers.merge(channel: channel))
         connection.dispatch_websocket_message JSON.generate(command: command, identifier: identifier)
         wait_for_async
       end

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -71,11 +71,16 @@ module ActionView
 
       private
         def find_template(finder, *args)
+          name = args.first
+          prefixes = args[1] || []
+          partial = args[2] || false
+          keys = args[3] || []
+          options = args[4] || {}
           finder.disable_cache do
             if format = finder.rendered_format
-              finder.find_all(*args, formats: [format]).first || finder.find_all(*args).first
+              finder.find_all(name, prefixes, partial, keys, options.merge(formats: [format])).first || finder.find_all(name, prefixes, partial, keys, options).first
             else
-              finder.find_all(*args).first
+              finder.find_all(name, prefixes, partial, keys, options).first
             end
           end
         end

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -70,18 +70,11 @@ module ActionView
       end
 
       private
-        def find_template(finder, *args)
-          name = args.first
-          prefixes = args[1] || []
-          partial = args[2] || false
-          keys = args[3] || []
-          options = args[4] || {}
+        def find_template(finder, name, prefixes, partial, keys)
           finder.disable_cache do
-            if format = finder.rendered_format
-              finder.find_all(name, prefixes, partial, keys, options.merge(formats: [format])).first || finder.find_all(name, prefixes, partial, keys, options).first
-            else
-              finder.find_all(name, prefixes, partial, keys, options).first
-            end
+            format = finder.rendered_format
+            result = finder.find_all(name, prefixes, partial, keys, formats: [format]).first if format
+            result || finder.find_all(name, prefixes, partial, keys).first
           end
         end
     end

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1971,7 +1971,7 @@ module ActionView
 
         convert_to_legacy_options(options)
 
-        fields_for(scope || model, model, **options, &block)
+        fields_for(scope || model, model, options, &block)
       end
 
       # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -305,8 +305,7 @@ module ActiveRecord
         yield td if block_given?
 
         if options[:force]
-          drop_opts = { if_exists: true }.merge(**options)
-          drop_table(table_name, drop_opts)
+          drop_table(table_name, options.merge(if_exists: true))
         end
 
         result = execute schema_creation.accept td

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -305,7 +305,8 @@ module ActiveRecord
         yield td if block_given?
 
         if options[:force]
-          drop_table(table_name, **options, if_exists: true)
+          drop_opts = { if_exists: true }.merge(**options)
+          drop_table(table_name, drop_opts)
         end
 
         result = execute schema_creation.accept td
@@ -899,7 +900,7 @@ module ActiveRecord
             foreign_key_options = { to_table: reference_name }
           end
           foreign_key_options[:column] ||= "#{ref_name}_id"
-          remove_foreign_key(table_name, **foreign_key_options)
+          remove_foreign_key(table_name, foreign_key_options)
         end
 
         remove_column(table_name, "#{ref_name}_id")

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -4,9 +4,6 @@
     `Range#===`. `Range#===` works correctly on Ruby 2.6. `Range#include?` is moved
     into a new file, with these two methods.
 
-    *Requiring active_support/core_ext/range/include_range is now deprecated.*
-    *Use `require "active_support/core_ext/range/compare_range"` instead.*
-
     *utilum*
 
 *   If the same block is `included` multiple times for a Concern, an exception is no longer raised.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow Range#=== and Range#cover? on Range
+
+    `Range#cover?` can now accept a range argument like `Range#include?` and
+    `Range#===`. `Range#===` works correctly on Ruby 2.6. `Range#include?` is moved
+    into a new file, with these two methods.
+
+    *Requiring active_support/core_ext/range/include_range is now deprecated.*
+    *Use `require "active_support/core_ext/range/compare_range"` instead.*
+
+    *utilum*
+
 *   If the same block is `included` multiple times for a Concern, an exception is no longer raised.
 
     *Mark J. Titorenko*, *Vlad Bokov*

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/range/conversions"
-require "active_support/core_ext/range/include_range"
+require "active_support/core_ext/range/compare_range"
 require "active_support/core_ext/range/include_time_with_zone"
 require "active_support/core_ext/range/overlaps"
 require "active_support/core_ext/range/each"

--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module CompareWithRange #:nodoc:
+    # Extends the default Range#=== to support range comparisons.
+    #  (1..5) === (1..5) # => true
+    #  (1..5) === (2..3) # => true
+    #  (1..5) === (2..6) # => false
+    #
+    # The native Range#=== behavior is untouched.
+    #  ('a'..'f') === ('c') # => true
+    #  (5..9) === (11) # => false
+    def ===(value)
+      if value.is_a?(::Range)
+        # 1...10 includes 1..9 but it does not include 1..10.
+        operator = exclude_end? && !value.exclude_end? ? :< : :<=
+        super(value.first) && value.last.send(operator, last)
+      else
+        super
+      end
+    end
+
+    # Extends the default Range#include? to support range comparisons.
+    #  (1..5).include?(1..5) # => true
+    #  (1..5).include?(2..3) # => true
+    #  (1..5).include?(2..6) # => false
+    #
+    # The native Range#include? behavior is untouched.
+    #  ('a'..'f').include?('c') # => true
+    #  (5..9).include?(11) # => false
+    def include?(value)
+      if value.is_a?(::Range)
+        # 1...10 includes 1..9 but it does not include 1..10.
+        operator = exclude_end? && !value.exclude_end? ? :< : :<=
+        super(value.first) && value.last.send(operator, last)
+      else
+        super
+      end
+    end
+
+    # Extends the default Range#cover? to support range comparisons.
+    #  (1..5).cover?(1..5) # => true
+    #  (1..5).cover?(2..3) # => true
+    #  (1..5).cover?(2..6) # => false
+    #
+    # The native Range#cover? behavior is untouched.
+    #  ('a'..'f').cover?('c') # => true
+    #  (5..9).cover?(11) # => false
+    def cover?(value)
+      if value.is_a?(::Range)
+        # 1...10 covers 1..9 but it does not cover 1..10.
+        operator = exclude_end? && !value.exclude_end? ? :< : :<=
+        super(value.first) && value.last.send(operator, last)
+      else
+        super
+      end
+    end
+  end
+end
+
+Range.prepend(ActiveSupport::CompareWithRange)

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,25 +1,9 @@
 # frozen_string_literal: true
 
-module ActiveSupport
-  module IncludeWithRange #:nodoc:
-    # Extends the default Range#include? to support range comparisons.
-    #  (1..5).include?(1..5) # => true
-    #  (1..5).include?(2..3) # => true
-    #  (1..5).include?(2..6) # => false
-    #
-    # The native Range#include? behavior is untouched.
-    #  ('a'..'f').include?('c') # => true
-    #  (5..9).include?(11) # => false
-    def include?(value)
-      if value.is_a?(::Range)
-        # 1...10 includes 1..9 but it does not include 1..10.
-        operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        super(value.first) && value.last.send(operator, last)
-      else
-        super
-      end
-    end
-  end
-end
+require "active_support/deprecation"
 
-Range.prepend(ActiveSupport::IncludeWithRange)
+ActiveSupport::Deprecation.warn "You have required `active_support/core_ext/range/include_range`. " \
+"This file will be removed in Rails 6.1. You should require `active_support/core_ext/range/compare_range` " \
+  "instead."
+
+require "active_support/core_ext/range/compare_range"

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,9 +1,3 @@
 # frozen_string_literal: true
 
-require "active_support/deprecation"
-
-ActiveSupport::Deprecation.warn "You have required `active_support/core_ext/range/include_range`. " \
-"This file will be removed in Rails 6.1. You should require `active_support/core_ext/range/compare_range` " \
-  "instead."
-
 require "active_support/core_ext/range/compare_range"

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -454,8 +454,8 @@ module CacheStoreBehavior
 
     def assert_compression(should_compress, value, **options)
       freeze_time do
-        @cache.write("actual", value, **options)
-        @cache.write("uncompressed", value, **options, compress: false)
+        @cache.write("actual", value, options)
+        @cache.write("uncompressed", value, options.merge(compress: false))
       end
 
       if value.nil?

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2927,9 +2927,9 @@ As the example depicts, the `:db` format generates a `BETWEEN` SQL clause. That 
 
 NOTE: Defined in `active_support/core_ext/range/conversions.rb`.
 
-### `include?`
+### `===`, `include?`, and `cover?`
 
-The methods `Range#include?` and `Range#===` say whether some value falls between the ends of a given instance:
+The methods `Range#===`, `Range#include?`, and `Range#cover?` say whether some value falls between the ends of a given instance:
 
 ```ruby
 (2..3).include?(Math::E) # => true
@@ -2938,18 +2938,23 @@ The methods `Range#include?` and `Range#===` say whether some value falls betwee
 Active Support extends these methods so that the argument may be another range in turn. In that case we test whether the ends of the argument range belong to the receiver themselves:
 
 ```ruby
+(1..10) === (3..7)  # => true
+(1..10) === (0..7)  # => false
+(1..10) === (3..11) # => false
+(1...9) === (3..9)  # => false
+
 (1..10).include?(3..7)  # => true
 (1..10).include?(0..7)  # => false
 (1..10).include?(3..11) # => false
 (1...9).include?(3..9)  # => false
 
-(1..10) === (3..7)  # => true
-(1..10) === (0..7)  # => false
-(1..10) === (3..11) # => false
-(1...9) === (3..9)  # => false
+(1..10).cover?(3..7)  # => true
+(1..10).cover?(0..7)  # => false
+(1..10).cover?(3..11) # => false
+(1...9).cover?(3..9)  # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/range/include_range.rb`.
+NOTE: Defined in `active_support/core_ext/range/compare_range.rb`.
 
 ### `overlaps?`
 


### PR DESCRIPTION
### Summary

[Ruby 2.6.0-rc2 Released](https://www.ruby-lang.org/en/news/2018/12/15/ruby-2-6-0-rc2-released/) and Ruby 2.6 will be released on this December 25. I expect Rails 5.2 should run with Ruby 2.6 without errors/warnings.

This pull request backports changes to 5-2-stable branch to suppress errors and warnings which have been already addressed in the master branch. I'm wondering if these kinds of backporting should be done by Rails committers and/or release manager. Let me open a pull request first.

### Other Information

There are some errors remained. One can be "fixed" but it needs to backport pull requests with CHANGELOG. Another one, I do not know why it fails with 5-2-stable.

* It has been addressed by #32938 to master branch. It has changelog entry then I did not backport it to this pull request.

```ruby
$ cd activesupport
$ bundle exec ruby -w -Itest test/core_ext/range_ext_test.rb -n /test_should_compare/
Run options: -n /test_should_compare/ --seed 24989

# Running:

F

Failure:
RangeTest#test_should_compare_other_with_exclusive_end [test/core_ext/range_ext_test.rb:72]:
Expected false to be truthy.


bin/rails test test/core_ext/range_ext_test.rb:71

F

Failure:
RangeTest#test_should_compare_identical_exclusive [test/core_ext/range_ext_test.rb:68]:
Expected false to be truthy.


bin/rails test test/core_ext/range_ext_test.rb:67

F

Failure:
RangeTest#test_should_compare_identical_inclusive [test/core_ext/range_ext_test.rb:64]:
Expected false to be truthy.


bin/rails test test/core_ext/range_ext_test.rb:63



Finished in 0.001701s, 1763.5357 runs/s, 1763.5357 assertions/s.
3 runs, 3 assertions, 3 failures, 0 errors, 0 skips
```

* `test_restart_rails_server_with_custom_pid_file_path` fails 
It passes with the master branch. 

```ruby
$ cd railties
$ bundle exec ruby -w -Itest test/application/server_test.rb -n test_restart_rails_server_with_custom_pid_file_path
Run options: -n test_restart_rails_server_with_custom_pid_file_path --seed 41272

# Running:

F

Failure:
ApplicationTests::ServerTest#test_restart_rails_server_with_custom_pid_file_path [test/application/server_test.rb:53]:
"Inherited" expected, but got:

...
Traceback (most recent call last):
	2: from bin/rails:4:in `<main>'
	1: from /home/yahonda/.rbenv/versions/2.6.0-rc2/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/home/yahonda/.rbenv/versions/2.6.0-rc2/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- rails/commands (LoadError)
.
Expected "...\r\n\e[1mTraceback\e[m (most recent call last):\r\n\t2: from bin/rails:4:in `<main>'\r\n\t1: from /home/yahonda/.rbenv/versions/2.6.0-rc2/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'\r\n/home/yahonda/.rbenv/versions/2.6.0-rc2/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': \e[1mcannot load such file -- rails/commands (\e[1;4mLoadError\e[m\e[1m)\e[m\r\n" to include "Inherited".


bin/rails test test/application/server_test.rb:35



Finished in 14.595938s, 0.0685 runs/s, 0.4111 assertions/s.
1 runs, 6 assertions, 1 failures, 0 errors, 0 skips
```