### PR TITLE
Add rescue from ActiveRecord::RecordNotUnique

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -44,12 +44,18 @@ module ActiveRecord
     # with this when the validations module is mixed in, which it is by default.
     def save(options = {})
       perform_validations(options) ? super : false
+    rescue ActiveRecord::RecordNotUnique => e
+      raise unless handle_unique_error(e)
+      false
     end
 
     # Attempts to save the record just like {ActiveRecord::Base#save}[rdoc-ref:Base#save] but
     # will raise an ActiveRecord::RecordInvalid exception instead of returning +false+ if the record is not valid.
     def save!(options = {})
       perform_validations(options) ? super : raise_validation_error
+    rescue ActiveRecord::RecordNotUnique => e
+      raise unless handle_unique_error(e)
+      raise ActiveRecord::RecordInvalid, self
     end
 
     # Runs all the validations within the specified context. Returns +true+ if


### PR DESCRIPTION
### Summary

According to https://github.com/rails/rails/issues/34650 I have provided a PR which improves the behaviour of `ActiveRecord::Validations::UniquenessValidator`. Because the validator itself cannot guarantee the uniqueness we should have unique contstraints in the database. But having them will throw `ActiveRecord::RecordNotUnique` error with current implementation. In order to provide better experience with the framework, we should recognize such errors and process them properly like validation is failed. 

Relying on database constraints inside the framework seems a good idea after @dhh introduced [create_or_find_by](https://github.com/rails/rails/pull/31989). 