### PR TITLE
Finding Orphan Records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Find orphans by looking for missing relations through chaining `where.missing`:
+
+    Before:
+
+    ```ruby
+    Post.left_joins(:author).where(authors: { id: nil })
+    ```
+
+    After:
+
+    ```ruby
+    Post.where.missing(:author)
+    ```
+
+    *Tom Rossi*
+
 *   Ensure `:reading` connections always raise if a write is attempted.
 
     Now Rails will raise an `ActiveRecord::ReadOnlyError` if any connection on the reading handler attempts to make a write. If your reading role needs to write you should name the role something other than `:reading`.

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -2,15 +2,28 @@
 
 require "cases/helper"
 require "models/post"
+require "models/author"
 require "models/comment"
+require "models/categorization"
+
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :authors
 
     def setup
       super
       @name = "title"
+    end
+
+    def test_missing_with_association
+      assert posts(:authorless).author.blank?
+      assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
+    end
+
+    def test_missing_with_multiple_association
+      assert posts(:authorless).comments.empty?
+      assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a
     end
 
     def test_not_inverts_where_clause


### PR DESCRIPTION
### Summary
As discussed [here](https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/sT8uzQb8Oa8), I would like to introduce a way for simplifying the search for orphan records within ActiveRecord.

Currently you would do something like this:
`Post.left_joins(:author).where(authors: { id: nil })`

I would like to introduce an API like this:
`Post.where.missing(:author)`

### Other Information
I've gotten started, but could use some feedback and direction from someone more experienced with the innards of ActiveRecord. I've modeled the `missing` method after the `not` method in the `query_methods.rb`:

```
  def missing(*args)
    args.each do |arg|
      opts = { arg => { id: nil } }
      @scope.left_joins(arg)
      @scope.references!(PredicateBuilder.references(opts))
      @scope.where_clause += @scope.where(opts)
    end
    @scope
  end
```
#### 1. Adding the left join
In order to add the join to the current scope, I am just calling the `left_joins` method, but that doesn't appear to actually modify the scope. Should I be looking at the `spawn` method?

#### 2. References in the where clause
I copied the `references!` call from the `not` method, but I'm not sure what it is actually doing. That is where my error is currently pointing. ☹️