### PR TITLE
Fix integer regex deprecation warnings for Ruby 2.6.0

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -580,7 +580,7 @@ module ActionView
 
         if priority_zones
           if priority_zones.is_a?(Regexp)
-            priority_zones = zones.select { |z| z.to_s =~ priority_zones }
+            priority_zones = zones.select { |z| z =~ priority_zones }
           end
 
           zone_options.safe_concat options_for_select(convert_zones[priority_zones], selected)

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -580,7 +580,7 @@ module ActionView
 
         if priority_zones
           if priority_zones.is_a?(Regexp)
-            priority_zones = zones.select { |z| z =~ priority_zones }
+            priority_zones = zones.select { |z| z.to_s =~ priority_zones }
           end
 
           zone_options.safe_concat options_for_select(convert_zones[priority_zones], selected)

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -228,7 +228,7 @@ module ActionView
       #   pluralize(2, 'Person', locale: :de)
       #   # => 2 Personen
       def pluralize(count, singular, plural_arg = nil, plural: plural_arg, locale: I18n.locale)
-        word = if count == 1 || count =~ /^1(\.0+)?$/
+        word = if count == 1 || count.to_s =~ /^1(\.0+)?$/
           singular
         else
           plural || singular.pluralize(locale)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -36,7 +36,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   module FakeZones
     FakeZone = Struct.new(:name) do
       def to_s; name; end
-      def =~(re); re === name || re === ActiveSupport::TimeZone::MAPPING[name]; end
+      def =~(_re); end
     end
 
     module ClassMethods

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -36,6 +36,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   module FakeZones
     FakeZone = Struct.new(:name) do
       def to_s; name; end
+      def =~(re); re === name || re === ActiveSupport::TimeZone::MAPPING[name]; end
     end
 
     module ClassMethods


### PR DESCRIPTION
### Summary

Fixes #34718 

From the description given in the issue, matching regexes for Integers or classes will always return nil in Ruby 2.6.0.

Therefore, this pull request calls to_s before matching regexes to make sure they are actually being validated.
