### PR TITLE
Add rails db:system command

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def adapter
+        config["adapter"]
+      end
+
       def url_config?
         false
       end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `rails db:system` command to display an app's database for a given environment.
+
+    ```
+    bin/rails db:system -e production
+    postgresql
+    ```
+
+    *Gannon McGibbon*
+
 *   Add `rails db:system:change` command for changing databases.
 
     ```

--- a/railties/lib/rails/commands/db/system/system_command.rb
+++ b/railties/lib/rails/commands/db/system/system_command.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails/command/environment_argument"
+
+module Rails
+  module Db
+    class System # :nodoc:
+      attr_reader :environment
+
+      def initialize(options = {})
+        @environment = options.fetch("environment", rails_env)
+      end
+
+      def to_s
+        if configurations.one?
+          configurations.first.adapter
+        else
+          configurations.map do |config|
+            [config.spec_name, config.adapter].join(" => ")
+          end.join("\n")
+        end
+      end
+
+      private
+        def rails_env
+          Rails.try(:env)&.to_s || ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+        end
+
+        def configurations
+          @configurations ||= ActiveRecord::Base.configurations.configs_for(
+            env_name: @environment
+          )
+        end
+    end
+  end
+
+  module Command
+    module Db
+      class SystemCommand < Base # :nodoc:
+        include EnvironmentArgument
+
+        def perform
+          extract_environment_option_from_argument
+
+          require_application_and_environment!
+          say Rails::Db::System.new(options)
+        end
+      end
+    end
+  end
+end

--- a/railties/test/commands/db/system_test.rb
+++ b/railties/test/commands/db/system_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "minitest/mock"
+require "rails/command"
+require "rails/commands/db/system/system_command"
+
+class Rails::Db::SystemTest < ActiveSupport::TestCase
+  test "to_s with single config" do
+    config = {
+      "test" => {
+        "primary" => {
+          "adapter" => "sqlite3"
+        }
+      }
+    }
+
+    app_db_config(config) do
+      assert_equal "sqlite3", Rails::Db::System.new.to_s
+    end
+  end
+
+
+  test "to_s with multiple configs" do
+    config = {
+      "test" => {
+        "primary" => {
+          "adapter" => "postgresql"
+        },
+        "secondary" => {
+          "adapter" => "mysql2"
+        }
+      }
+    }
+
+    app_db_config(config) do
+      assert_equal <<~OUTPUT.chomp, Rails::Db::System.new.to_s
+        primary => postgresql
+        secondary => mysql2
+      OUTPUT
+    end
+  end
+
+  test "environment via parameter" do
+    system = Rails::Db::System.new("environment" => "production")
+    assert_equal "production", system.environment
+  end
+
+  test "environment via current Rails.env" do
+    assert_equal "test", Rails::Db::System.new.environment
+  end
+
+  test "environment via environment variables" do
+    ENV["RAILS_ENV"] = nil
+    ENV["RACK_ENV"] = nil
+
+    Rails.stub(:respond_to?, false) do
+      assert_equal "development", Rails::Db::System.new.environment
+
+      ENV["RACK_ENV"] = "rack_env"
+      assert_equal "rack_env", Rails::Db::System.new.environment
+
+      ENV["RAILS_ENV"] = "rails_env"
+      assert_equal "rails_env", Rails::Db::System.new.environment
+    end
+  ensure
+    ENV["RAILS_ENV"] = "test"
+    ENV["RACK_ENV"] = nil
+  end
+
+  test "command" do
+    config = {
+      "test" => {
+        "adapter" => "mysql2"
+      }
+    }
+
+    app_db_config(config) do
+      output = capture(:stdout) do
+        Rails::Command.invoke("db:system")
+      end
+      assert_equal "mysql2", output.chomp
+    end
+  end
+
+  test "command with environment" do
+    config = {
+      "development" => {
+        "adapter" => "sqlite3"
+      },
+      "test" => {
+        "adapter" => "mysql2"
+      },
+      "production" => {
+        "adapter" => "postgresql"
+      }
+    }
+
+    app_db_config(config) do
+      output = capture(:stdout) do
+        Rails::Command.invoke("db:system", ["-e", "production"])
+      end
+      assert_equal "postgresql", output.chomp
+    end
+  end
+
+  private
+
+    def app_db_config(config)
+      old_configurations = ActiveRecord::Base.configurations
+      new_configurations = ActiveRecord::DatabaseConfigurations.new(config || {})
+      ActiveRecord::Base.configurations = new_configurations
+      yield
+    ensure
+      ActiveRecord::Base.configurations = old_configurations
+    end
+end


### PR DESCRIPTION
### Summary

Add `rails db:system` command to display an app's DBMS for a given environment.

Part one of https://github.com/rails/rails/issues/34710.

cc @dhh, @kaspth 