### PR TITLE
Fix doc formatting

### DIFF
--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -64,10 +64,11 @@ module ActionView
     # An instance of a view class. The default view class is ActionView::Base.
     #
     # The view class must have the following methods:
-    # View.new[lookup_context, assigns, controller]
-    #   Create a new ActionView instance for a controller and we can also pass the arguments.
-    # View#render(option)
-    #   Returns String with the rendered template
+    #
+    # * <tt>View.new[lookup_context, assigns, controller]</tt> — Create a new
+    #   ActionView instance for a controller and we can also pass the arguments.
+    #
+    # * <tt>View#render(option)</tt> — Returns String with the rendered template.
     #
     # Override this method in a module to change the default behavior.
     def view_context


### PR DESCRIPTION
Fixes the rdoc formatting for this block.

Before:

![ruby on rails api 2018-12-17 15-58-27](https://user-images.githubusercontent.com/308724/50115769-60517d00-0216-11e9-9983-0c1d791c6b31.png)

After:

![actionview rendering 2018-12-17 16-09-29](https://user-images.githubusercontent.com/308724/50115776-65aec780-0216-11e9-9a39-166111f3a4e5.png)
