### PR TITLE
Allow nil params on controller HTTP test methods

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow nil params on controller HTTP test methods
+
+    *Ryo Nakamura*
+
 *   Introduce ActionDispatch::HostAuthorization
 
     This is a new middleware that guards against DNS rebinding attacks by

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -457,7 +457,7 @@ module ActionController
       # respectively which will make tests more expressive.
       #
       # Note that the request method is not verified.
-      def process(action, method: "GET", params: {}, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
+      def process(action, method: "GET", params: nil, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
         check_required_ivars
 
         http_method = method.to_s.upcase
@@ -485,7 +485,7 @@ module ActionController
           format ||= as
         end
 
-        parameters = params.symbolize_keys
+        parameters = (params || {}).symbolize_keys
 
         if format
           parameters[:format] = format

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -478,6 +478,18 @@ XML
     )
   end
 
+  def test_nil_params
+    get :test_params, params: nil
+    parsed_params = JSON.parse(@response.body)
+    assert_equal(
+      {
+        "action" => "test_params",
+        "controller" => "test_case_test/test"
+      },
+      parsed_params
+    )
+  end
+
   def test_query_param_named_action
     get :test_query_parameters, params: { action: "foobar" }
     parsed_params = JSON.parse(@response.body)


### PR DESCRIPTION
## Summary

The following controller test code works fine on Rails 5.0.7:

```rb
get :index, params: nil
```

but on Rails 5.1 or the later versions, NoMethodError is raised with the following error message:

```
NoMethodError: undefined method `symbolize_keys' for nil:NilClass
```

I think this behavior was changed at https://github.com/rails/rails/commit/98b8309569a326910a723f521911e54994b112fb.

## Other Information

Here is an example code to reproduce this error:

```rb
# controller_params_test.rb
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  # gem 'rails', '5.0.7'
  gem 'rails', '5.1.6'
end

require 'action_controller/railtie'
require 'minitest/autorun'
require 'rails/test_help'

class TestApp < Rails::Application
  secrets.secret_key_base = 'secret_key_base'

  ::Rails.logger = ::Logger.new(nil)

  routes.draw do
    get '/' => 'test#index'
  end
end

class TestController < ActionController::Base
  include ::Rails.application.routes.url_helpers

  def index
    head(200)
  end
end

class ControllerParamsTest < ActionController::TestCase
  def setup
    super
    @controller = ::TestController.new
  end

  def test_params_with_empty_hash
    get :index, params: {}
    assert_equal 200, response.status
  end

  def test_params_with_nil
    get :index, params: nil
    assert_equal 200, response.status
  end
end
```

### Expected

```
$ ruby controller_params_test.rb
Run options: --seed 8188

# Running:

..

Finished in 0.069279s, 28.8688 runs/s, 28.8688 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

### Actual

```
$ ruby controller_params_test.rb
Run options: --seed 46396

# Running:

.E

Error:
ControllerParamsTest#test_params_with_nil:
NoMethodError: undefined method `symbolize_keys' for nil:NilClass



bin/rails test controller_params_test.rb:43



Finished in 0.065820s, 30.3859 runs/s, 15.1930 assertions/s.
2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
```

### FYI

ActionDispatch::IntegrationTest can take nil params like this:

```rb
class RequestParamsTest < ActionDispatch::IntegrationTest
  def test_params_with_nil
    get '/', params: nil
    assert_equal 200, response.status
  end
end
```
