### PR TITLE
Single nest config in configuration guides

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1404,7 +1404,7 @@ Custom configuration
 You can configure your own code through the Rails configuration object with
 custom configuration under either the `config.x` namespace, or `config` directly.
 The key difference between these two is that you should be using `config.x` if you
-are defining _nested_ configuration (ex: `config.x.nested.nested.hi`), and just
+are defining _nested_ configuration (ex: `config.x.nested.hi`), and just
 `config` for _single level_ configuration (ex: `config.hello`).
 
   ```ruby


### PR DESCRIPTION
Double nesting of configuration is **not supported** (without using an intermediate object), even though the **docs suggest it is**. This corrects the docs.

Personally, I think it would be great if it **was** supported, but that's a whole other can of worms/PR 😅 