### PR TITLE
Includes doesn't trigger more queries when already included

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -113,6 +113,8 @@ module ActiveRecord
     # the actual table name.
     def includes(*args)
       check_if_method_has_arguments!(:includes, args)
+
+      return self if self.includes_values == args.reject(&:blank?).flatten
       spawn.includes!(*args)
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1916,6 +1916,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_empty authors
   end
 
+  test "#includes does not trigger more queries if the association is already included" do
+    relation = Comment.includes(:post)
+    relation.load
+
+    assert_no_queries do
+      relation.includes(:post).load
+    end
+  end
+
   private
     def custom_post_relation(alias_name = "omg_posts")
       table_alias = Post.arel_table.alias(alias_name)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1917,11 +1917,11 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "#includes does not trigger more queries if the association is already included" do
-    relation = Comment.includes(:post)
+    relation = Comment.includes(:parent, post: { author: [:post_about_thinking, :serialized_posts] })
     relation.load
 
     assert_no_queries do
-      relation.includes(:post).load
+      relation.includes(post: { author: :post_about_thinking }).load
     end
   end
 


### PR DESCRIPTION
### Summary

This PR ensures that ActiveRecord's `includes` returns the same
`ActiveRecord_Relation` without doing any change if the association is already included.

With the previous implementation we were needlessly triggering extra queries in the following case:
```rb
comments = Comment.includes(:post)
comment.first # triggers queries
comments.includes(:post)
comment.first # triggers queries again needlessly
```

This doesn't break compatibility of any documented behaviour.

### Motivation - Use case

Let's say that we have a class that depends on an `ActiveRecord_Relation`like the following report:

```rb
class UsersReport
  def initialize(users)
    @users = users
  end

  def some_method_with_posts
    users.map do |user|
      user.posts.. 
    end
  end
end
```

The constructor of this class expects a `User::ActiveRecord_Relation` as its only argument but it's not explicit about what associations should be loaded into that relation in order to avoid N+1 queries. There's an implicit dependency: `users` should include `posts`.

A very common practice in the Ruby community is to be "tolerant" with the input but coerce the received values to the type of object you want to deal with. See: http://avdi.org/talks/confident-code-rubymidwest-2011/confident-code.html

How can we coerce an `ActiveRecord_Relation` to make sure that it includes all the associations that are needed?

I'd like to be able to do something like:
```rb
class UsersReport
  def initialize(users)
    @users = users.includes(:posts)
  end
```

With this PR this is now possible without any extra cost.

With the previous implementation, it was possible but it had an extra cost: if the association was already loaded queries would be triggered twice.