### PR TITLE
Don’t log recipients when sending mail

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -588,6 +588,7 @@ module ActionMailer
     private
 
       def set_payload_for_mail(payload, mail)
+        payload[:mail]               = mail.encoded
         payload[:mailer]             = name
         payload[:message_id]         = mail.message_id
         payload[:subject]            = mail.subject
@@ -596,7 +597,6 @@ module ActionMailer
         payload[:bcc]                = mail.bcc if mail.bcc.present?
         payload[:cc]                 = mail.cc  if mail.cc.present?
         payload[:date]               = mail.date
-        payload[:mail]               = mail.encoded
         payload[:perform_deliveries] = mail.perform_deliveries
       end
 

--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -10,11 +10,10 @@ module ActionMailer
     def deliver(event)
       info do
         perform_deliveries = event.payload[:perform_deliveries]
-        recipients = Array(event.payload[:to]).join(", ")
         if perform_deliveries
-          "Sent mail to #{recipients} (#{event.duration.round(1)}ms)"
+          "Delivered mail (#{event.duration.round(1)}ms)"
         else
-          "Skipped sending mail to #{recipients} as `perform_deliveries` is false"
+          "Skipped mail delivery as `perform_deliveries` is false"
         end
       end
 

--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -11,9 +11,9 @@ module ActionMailer
       info do
         perform_deliveries = event.payload[:perform_deliveries]
         if perform_deliveries
-          "Delivered mail (#{event.duration.round(1)}ms)"
+          "Delivered mail #{event.payload[:message_id]} (#{event.duration.round(1)}ms)"
         else
-          "Skipped mail delivery as `perform_deliveries` is false"
+          "Skipped delivery of mail #{event.payload[:message_id]} as `perform_deliveries` is false"
         end
       end
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -915,6 +915,23 @@ class BaseTest < ActiveSupport::TestCase
     end
   end
 
+  test "notification for deliver" do
+    begin
+      events = []
+      ActiveSupport::Notifications.subscribe("deliver.action_mailer") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      BaseMailer.welcome(body: "Hello there").deliver_now
+
+      assert_equal 1, events.length
+      assert_equal "deliver.action_mailer", events[0].name
+      assert_not_nil events[0].payload[:message_id]
+    ensure
+      ActiveSupport::Notifications.unsubscribe "deliver.action_mailer"
+    end
+  end
+
   private
 
     # Execute the block setting the given values and restoring old values after

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -28,7 +28,7 @@ class AMLogSubscriberTest < ActionMailer::TestCase
     wait
 
     assert_equal(1, @logger.logged(:info).size)
-    assert_match(/Sent mail to system@test\.lindsaar\.net/, @logger.logged(:info).first)
+    assert_match(/Delivered mail/, @logger.logged(:info).first)
 
     assert_equal(2, @logger.logged(:debug).size)
     assert_match(/BaseMailer#welcome: processed outbound mail in [\d.]+ms/, @logger.logged(:debug).first)
@@ -42,7 +42,7 @@ class AMLogSubscriberTest < ActionMailer::TestCase
     wait
 
     assert_equal(1, @logger.logged(:info).size)
-    assert_match("Skipped sending mail to system@test.lindsaar.net as `perform_deliveries` is false", @logger.logged(:info).first)
+    assert_match("Skipped mail delivery as `perform_deliveries` is false", @logger.logged(:info).first)
 
     assert_equal(2, @logger.logged(:debug).size)
     assert_match(/BaseMailer#welcome_without_deliveries: processed outbound mail in [\d.]+ms/, @logger.logged(:debug).first)

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -24,11 +24,11 @@ class AMLogSubscriberTest < ActionMailer::TestCase
   end
 
   def test_deliver_is_notified
-    BaseMailer.welcome.deliver_now
+    BaseMailer.welcome(message_id: "123@abc").deliver_now
     wait
 
     assert_equal(1, @logger.logged(:info).size)
-    assert_match(/Delivered mail/, @logger.logged(:info).first)
+    assert_match(/Delivered mail 123@abc/, @logger.logged(:info).first)
 
     assert_equal(2, @logger.logged(:debug).size)
     assert_match(/BaseMailer#welcome: processed outbound mail in [\d.]+ms/, @logger.logged(:debug).first)
@@ -38,11 +38,11 @@ class AMLogSubscriberTest < ActionMailer::TestCase
   end
 
   def test_deliver_message_when_perform_deliveries_is_false
-    BaseMailer.welcome_without_deliveries.deliver_now
+    BaseMailer.welcome_without_deliveries(message_id: "123@abc").deliver_now
     wait
 
     assert_equal(1, @logger.logged(:info).size)
-    assert_match("Skipped mail delivery as `perform_deliveries` is false", @logger.logged(:info).first)
+    assert_match("Skipped delivery of mail 123@abc as `perform_deliveries` is false", @logger.logged(:info).first)
 
     assert_equal(2, @logger.logged(:debug).size)
     assert_match(/BaseMailer#welcome_without_deliveries: processed outbound mail in [\d.]+ms/, @logger.logged(:debug).first)

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -21,8 +21,8 @@ class BaseMailer < ActionMailer::Base
     mail(template_name: "welcome", template_path: path)
   end
 
-  def welcome_without_deliveries
-    mail(template_name: "welcome")
+  def welcome_without_deliveries(hash = {})
+    mail({ template_name: "welcome" }.merge!(hash))
     mail.perform_deliveries = false
   end
 


### PR DESCRIPTION
Since production applications typically run with log level info and email adresses should be considered as sensitive data (or personal data under GDPR) we want to prevent them from ending up in the logs. In development mode (with log level debug) they are still logged as part of the Mail::Message object.

While we could add another config option for this (#19293) I propose we fix the privacy issue by doing the right thing by default, and custom log subscribers could be written to restore the old functionality.

(As a bonus, the wording in the logs is now consistent with the event name ;))