### PR TITLE
Make test_helper.rb file more verbose about parallel testing configuration

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -7,7 +7,7 @@ class ActiveSupport::TestCase
 <% if defined?(JRUBY_VERSION) || Gem.win_platform? -%>
   parallelize(workers: :number_of_processors, with: :threads)
 <%- else -%>
-  parallelize(workers: :number_of_processors)
+  parallelize(workers: :number_of_processors, with: :processes)
 <% end -%>
 
 <% unless options[:skip_active_record] -%>


### PR DESCRIPTION
Despite `parallelize` method without arguments makes the same things
as `parallelize(workers: :number_of_processors, with: :processes)`
we can set extended form of it by default in `test/test_helper.rb`
for newly generated rails apps.
It can be useful for users, especially for new rails users since it
would explain about itself very well.

See discussion https://github.com/rails/rails/pull/34735#discussion_r242766594
