### PR TITLE
UJS: Migrate tests to QUnit 2.8

### DIFF
--- a/actionview/test/ujs/public/test/call-ajax.js
+++ b/actionview/test/ujs/public/test/call-ajax.js
@@ -1,26 +1,28 @@
 (function() {
 
-module('call-ajax', {
-  setup: function() {
+QUnit.module('call-ajax', {
+  beforeEach: function() {
     $('#qunit-fixture')
       .append($('<a />', { href: '#' }))
   }
 })
 
-asyncTest('call ajax without "ajax:beforeSend"', 1, function() {
+QUnit.test('call ajax without "ajax:beforeSend"', function(assert) {
+  var done = assert.async()
+
   var link = $('#qunit-fixture a')
   link.bindNative('click', function() {
     Rails.ajax({
       type: 'get',
       url: '/',
       success: function() {
-        ok(true, 'calling request in ajax:success')
+        assert.ok(true, 'calling request in ajax:success')
       }
     })
   })
 
   link.triggerNative('click')
-  setTimeout(function() { start() }, 50)
+  setTimeout(function() { done() }, 50)
 })
 
 })()

--- a/actionview/test/ujs/public/test/call-remote-callbacks.js
+++ b/actionview/test/ujs/public/test/call-remote-callbacks.js
@@ -3,7 +3,7 @@
 QUnit.module('call-remote-callbacks', {
   beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
-      action: '/echo', method: 'get', 'data-remote': 'true', class: 'rails-ujs-target'
+      action: '/echo', method: 'get', 'data-remote': 'true', class: 'qunit-target'
     }))
   },
   afterEach: function() {
@@ -17,7 +17,7 @@ QUnit.module('call-remote-callbacks', {
 })
 
 function submit(done, fn) {
-  var form = $('form.rails-ujs-target')
+  var form = $('form.qunit-target')
 
   if (fn) fn(form)
   form.triggerNative('submit')
@@ -28,7 +28,7 @@ function submit(done, fn) {
 QUnit.test('modifying form fields with "ajax:before" sends modified data in request', function(assert) {
   assert.expect(3)
   var done = assert.async()
-  $('form.rails-ujs-target[data-remote]')
+  $('form.qunit-target[data-remote]')
     .append($('<input type="text" name="user_name" value="john">'))
     .append($('<input type="text" name="removed_user_name" value="john">'))
     .bindNative('ajax:before', function() {
@@ -52,7 +52,7 @@ QUnit.test('modifying form fields with "ajax:before" sends modified data in requ
 QUnit.test('modifying data("type") with "ajax:before" requests new dataType in request', function(assert) {
   assert.expect(1)
   var done = assert.async()
-  $('form.rails-ujs-target[data-remote]').data('type', 'html')
+  $('form.qunit-target[data-remote]').data('type', 'html')
     .bindNative('ajax:before', function() {
       this.setAttribute('data-type', 'xml')
     })
@@ -67,7 +67,7 @@ QUnit.test('modifying data("type") with "ajax:before" requests new dataType in r
 QUnit.test('setting data("with-credentials",true) with "ajax:before" uses new setting in request', function(assert) {
   assert.expect(1)
   var done = assert.async()
-  $('form.rails-ujs-target[data-remote]').data('with-credentials', false)
+  $('form.qunit-target[data-remote]').data('with-credentials', false)
     .bindNative('ajax:before', function() {
       this.setAttribute('data-with-credentials', true)
     })
@@ -106,7 +106,7 @@ function skipIt() {
   QUnit.test('non-blank file form input field should abort remote request, but submit normally', function(assert) {
   assert.expect(5)
   var done = assert.async()
-    var form = $('form.rails-ujs-target[data-remote]')
+    var form = $('form.qunit-target[data-remote]')
           .append($('<input type="file" name="attachment" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
             assert.ok(false, 'ajax:beforeSend should not run')
@@ -131,7 +131,7 @@ function skipIt() {
   QUnit.test('file form input field should not abort remote request if file form input does not have a name attribute', function(assert) {
   assert.expect(5)
   var done = assert.async()
-    var form = $('form.rails-ujs-target[data-remote]')
+    var form = $('form.qunit-target[data-remote]')
           .append($('<input type="file" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
             assert.ok(true, 'ajax:beforeSend should run')
@@ -154,7 +154,7 @@ function skipIt() {
   QUnit.test('blank file input field should abort request entirely if handler bound to "ajax:aborted:file" event that returns false', function(assert) {
   assert.expect(1)
   var done = assert.async()
-    var form = $('form.rails-ujs-target[data-remote]')
+    var form = $('form.qunit-target[data-remote]')
           .append($('<input type="file" name="attachment" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
             assert.ok(false, 'ajax:beforeSend should not run')
@@ -253,7 +253,7 @@ QUnit.test('binding to ajax callbacks via .delegate() triggers handlers properly
     .delegate('form[data-remote]', 'ajax:complete', function() {
       assert.ok(true, 'ajax:complete handler is triggered')
     })
-  $('form.rails-ujs-target[data-remote]').triggerNative('submit')
+  $('form.qunit-target[data-remote]').triggerNative('submit')
 
   setTimeout(function() { done() }, 13)
 })

--- a/actionview/test/ujs/public/test/call-remote-callbacks.js
+++ b/actionview/test/ujs/public/test/call-remote-callbacks.js
@@ -1,12 +1,12 @@
 (function() {
 
-module('call-remote-callbacks', {
-  setup: function() {
+QUnit.module('call-remote-callbacks', {
+  beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
-      action: '/echo', method: 'get', 'data-remote': 'true'
+      action: '/echo', method: 'get', 'data-remote': 'true', class: 'rails-ujs-target'
     }))
   },
-  teardown: function() {
+  afterEach: function() {
     $(document).undelegate('form[data-remote]', 'ajax:beforeSend')
     $(document).undelegate('form[data-remote]', 'ajax:before')
     $(document).undelegate('form[data-remote]', 'ajax:send')
@@ -16,17 +16,19 @@ module('call-remote-callbacks', {
   }
 })
 
-function submit(fn) {
-  var form = $('form')
+function submit(done, fn) {
+  var form = $('form.rails-ujs-target')
 
   if (fn) fn(form)
   form.triggerNative('submit')
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 }
 
-asyncTest('modifying form fields with "ajax:before" sends modified data in request', 3, function() {
-  $('form[data-remote]')
+QUnit.test('modifying form fields with "ajax:before" sends modified data in request', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+  $('form.rails-ujs-target[data-remote]')
     .append($('<input type="text" name="user_name" value="john">'))
     .append($('<input type="text" name="removed_user_name" value="john">'))
     .bindNative('ajax:before', function() {
@@ -38,55 +40,61 @@ asyncTest('modifying form fields with "ajax:before" sends modified data in reque
         .find('input[name="user_name"]').val('steve')
     })
 
-  submit(function(form) {
+  submit(done, function(form) {
     form.bindNative('ajax:success', function(e, data, status, xhr) {
-      equal(data.params.user_name, 'steve', 'modified field value should have been submitted')
-      equal(data.params.other_user_name, 'jonathan', 'added field value should have been submitted')
-      equal(data.params.removed_user_name, undefined, 'removed field value should be undefined')
+      assert.equal(data.params.user_name, 'steve', 'modified field value should have been submitted')
+      assert.equal(data.params.other_user_name, 'jonathan', 'added field value should have been submitted')
+      assert.equal(data.params.removed_user_name, undefined, 'removed field value should be undefined')
     })
   })
 })
 
-asyncTest('modifying data("type") with "ajax:before" requests new dataType in request', 1, function() {
-  $('form[data-remote]').data('type', 'html')
+QUnit.test('modifying data("type") with "ajax:before" requests new dataType in request', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+  $('form.rails-ujs-target[data-remote]').data('type', 'html')
     .bindNative('ajax:before', function() {
       this.setAttribute('data-type', 'xml')
     })
 
-  submit(function(form) {
+  submit(done, function(form) {
     form.bindNative('ajax:beforeSend', function(e, xhr, settings) {
-      equal(settings.dataType, 'xml', 'modified dataType should have been requested')
+      assert.equal(settings.dataType, 'xml', 'modified dataType should have been requested')
     })
   })
 })
 
-asyncTest('setting data("with-credentials",true) with "ajax:before" uses new setting in request', 1, function() {
-  $('form[data-remote]').data('with-credentials', false)
+QUnit.test('setting data("with-credentials",true) with "ajax:before" uses new setting in request', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+  $('form.rails-ujs-target[data-remote]').data('with-credentials', false)
     .bindNative('ajax:before', function() {
       this.setAttribute('data-with-credentials', true)
     })
 
-  submit(function(form) {
+  submit(done, function(form) {
     form.bindNative('ajax:beforeSend', function(e, xhr, settings) {
-      equal(settings.withCredentials, true, 'setting modified in ajax:before should have forced withCredentials request')
+      assert.equal(settings.withCredentials, true, 'setting modified in ajax:before should have forced withCredentials request')
     })
   })
 })
 
-asyncTest('stopping the "ajax:beforeSend" event aborts the request', 1, function() {
-  submit(function(form) {
+QUnit.test('stopping the "ajax:beforeSend" event aborts the request', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+  submit(done, function(form) {
     form.bindNative('ajax:beforeSend', function(e) {
-      ok(true, 'aborting request in ajax:beforeSend')
+      assert.ok(true, 'aborting request in ajax:beforeSend')
       e.preventDefault()
     })
     form.unbind('ajax:send').bindNative('ajax:send', function() {
-      ok(false, 'ajax:send should not run')
+      assert.ok(false, 'ajax:send should not run')
     })
     form.bindNative('ajax:error', function(e, response, status, xhr) {
-      ok(false, 'ajax:error should not run')
+      assert.ok(false, 'ajax:error should not run')
     })
     form.bindNative('ajax:complete', function() {
-      ok(false, 'ajax:complete should not run')
+      assert.ok(false, 'ajax:complete should not run')
     })
   })
 })
@@ -95,19 +103,21 @@ function skipIt() {
   // This test cannot work due to the security feature in browsers which makes the value
   // attribute of file input fields readonly, so it cannot be set with default value.
   // This is what the test would look like though if browsers let us automate this test.
-  asyncTest('non-blank file form input field should abort remote request, but submit normally', 5, function() {
-    var form = $('form[data-remote]')
+  QUnit.test('non-blank file form input field should abort remote request, but submit normally', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+    var form = $('form.rails-ujs-target[data-remote]')
           .append($('<input type="file" name="attachment" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
-            ok(false, 'ajax:beforeSend should not run')
+            assert.ok(false, 'ajax:beforeSend should not run')
           })
           .bind('iframe:loading', function() {
-            ok(true, 'form should get submitted')
+            assert.ok(true, 'form should get submitted')
           })
           .bindNative('ajax:aborted:file', function(e, data) {
-            ok(data.length == 1, 'ajax:aborted:file event is passed all non-blank file inputs (jQuery objects)')
-            ok(data.first().is('input[name="attachment"]'), 'ajax:aborted:file adds non-blank file input to data')
-            ok(true, 'ajax:aborted:file event should run')
+            assert.ok(data.length == 1, 'ajax:aborted:file event is passed all non-blank file inputs (jQuery objects)')
+            assert.ok(data.first().is('input[name="attachment"]'), 'ajax:aborted:file adds non-blank file input to data')
+            assert.ok(true, 'ajax:aborted:file event should run')
           })
           .triggerNative('submit')
 
@@ -118,17 +128,19 @@ function skipIt() {
     }, 13)
   })
 
-  asyncTest('file form input field should not abort remote request if file form input does not have a name attribute', 5, function() {
-    var form = $('form[data-remote]')
+  QUnit.test('file form input field should not abort remote request if file form input does not have a name attribute', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+    var form = $('form.rails-ujs-target[data-remote]')
           .append($('<input type="file" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
-            ok(true, 'ajax:beforeSend should run')
+            assert.ok(true, 'ajax:beforeSend should run')
           })
           .bind('iframe:loading', function() {
-            ok(true, 'form should get submitted')
+            assert.ok(true, 'form should get submitted')
           })
           .bindNative('ajax:aborted:file', function(e, data) {
-            ok(false, 'ajax:aborted:file should not run')
+            assert.ok(false, 'ajax:aborted:file should not run')
           })
           .triggerNative('submit')
 
@@ -139,14 +151,16 @@ function skipIt() {
     }, 13)
   })
 
-  asyncTest('blank file input field should abort request entirely if handler bound to "ajax:aborted:file" event that returns false', 1, function() {
-    var form = $('form[data-remote]')
+  QUnit.test('blank file input field should abort request entirely if handler bound to "ajax:aborted:file" event that returns false', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+    var form = $('form.rails-ujs-target[data-remote]')
           .append($('<input type="file" name="attachment" value="default.png">'))
           .bindNative('ajax:beforeSend', function() {
-            ok(false, 'ajax:beforeSend should not run')
+            assert.ok(false, 'ajax:beforeSend should not run')
           })
           .bind('iframe:loading', function() {
-            ok(false, 'form should not get submitted')
+            assert.ok(false, 'form should not get submitted')
           })
           .bindNative('ajax:aborted:file', function(e) {
             e.preventDefault()
@@ -161,79 +175,87 @@ function skipIt() {
   })
 }
 
-asyncTest('"ajax:beforeSend" can be observed and stopped with event delegation', 1, function() {
+QUnit.test('"ajax:beforeSend" can be observed and stopped with event delegation', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
   $(document).delegate('form[data-remote]', 'ajax:beforeSend', function(e) {
-    ok(true, 'ajax:beforeSend observed with event delegation')
+    assert.ok(true, 'ajax:beforeSend observed with event delegation')
     e.preventDefault()
   })
 
-  submit(function(form) {
+  submit(done, function(form) {
     form.unbind('ajax:send').bindNative('ajax:send', function() {
-      ok(false, 'ajax:send should not run')
+      assert.ok(false, 'ajax:send should not run')
     })
     form.bindNative('ajax:complete', function() {
-      ok(false, 'ajax:complete should not run')
+      assert.ok(false, 'ajax:complete should not run')
     })
   })
 })
 
-asyncTest('"ajax:beforeSend", "ajax:send", "ajax:success" and "ajax:complete" are triggered', 8, function() {
-  submit(function(form) {
+QUnit.test('"ajax:beforeSend", "ajax:send", "ajax:success" and "ajax:complete" are triggered', function(assert) {
+  assert.expect(8)
+  var done = assert.async()
+  submit(done, function(form) {
     form.bindNative('ajax:beforeSend', function(e, xhr, settings) {
-      ok(xhr.setRequestHeader, 'first argument to "ajax:beforeSend" should be an XHR object')
-      equal(settings.url, '/echo', 'second argument to "ajax:beforeSend" should be a settings object')
+      assert.ok(xhr.setRequestHeader, 'first argument to "ajax:beforeSend" should be an XHR object')
+      assert.equal(settings.url, '/echo', 'second argument to "ajax:beforeSend" should be a settings object')
     })
     form.bindNative('ajax:send', function(e, xhr) {
-      ok(xhr.abort, 'first argument to "ajax:send" should be an XHR object')
+      assert.ok(xhr.abort, 'first argument to "ajax:send" should be an XHR object')
     })
     form.bindNative('ajax:success', function(e, data, status, xhr) {
-      ok(data.REQUEST_METHOD, 'first argument to ajax:success should be a data object')
-      equal(status, 'OK', 'second argument to ajax:success should be a status string')
-      ok(xhr.getResponseHeader, 'third argument to "ajax:success" should be an XHR object')
+      assert.ok(data.REQUEST_METHOD, 'first argument to ajax:success should be a data object')
+      assert.equal(status, 'OK', 'second argument to ajax:success should be a status string')
+      assert.ok(xhr.getResponseHeader, 'third argument to "ajax:success" should be an XHR object')
     })
     form.bindNative('ajax:complete', function(e, xhr, status) {
-      ok(xhr.getResponseHeader, 'first argument to "ajax:complete" should be an XHR object')
-      equal(status, 'OK', 'second argument to ajax:complete should be a status string')
+      assert.ok(xhr.getResponseHeader, 'first argument to "ajax:complete" should be an XHR object')
+      assert.equal(status, 'OK', 'second argument to ajax:complete should be a status string')
     })
   })
 })
 
-asyncTest('"ajax:beforeSend", "ajax:send", "ajax:error" and "ajax:complete" are triggered on error', 8, function() {
-  submit(function(form) {
+QUnit.test('"ajax:beforeSend", "ajax:send", "ajax:error" and "ajax:complete" are triggered on error', function(assert) {
+  assert.expect(8)
+  var done = assert.async()
+  submit(done, function(form) {
     form.attr('action', '/error')
-    form.bindNative('ajax:beforeSend', function(arg) { ok(true, 'ajax:beforeSend') })
-    form.bindNative('ajax:send', function(arg) { ok(true, 'ajax:send') })
+    form.bindNative('ajax:beforeSend', function(arg) { assert.ok(true, 'ajax:beforeSend') })
+    form.bindNative('ajax:send', function(arg) { assert.ok(true, 'ajax:send') })
     form.bindNative('ajax:error', function(e, response, status, xhr) {
-      equal(response, '', 'first argument to ajax:error should be an HTTP status response')
-      equal(status, 'Forbidden', 'second argument to ajax:error should be a status string')
-      ok(xhr.getResponseHeader, 'third argument to "ajax:error" should be an XHR object')
+      assert.equal(response, '', 'first argument to ajax:error should be an HTTP status response')
+      assert.equal(status, 'Forbidden', 'second argument to ajax:error should be a status string')
+      assert.ok(xhr.getResponseHeader, 'third argument to "ajax:error" should be an XHR object')
       // Opera returns "0" for HTTP code
-      equal(xhr.status, window.opera ? 0 : 403, 'status code should be 403')
+      assert.equal(xhr.status, window.opera ? 0 : 403, 'status code should be 403')
     })
     form.bindNative('ajax:complete', function(e, xhr, status) {
-      ok(xhr.getResponseHeader, 'first argument to "ajax:complete" should be an XHR object')
-      equal(status, 'Forbidden', 'second argument to ajax:complete should be a status string')
+      assert.ok(xhr.getResponseHeader, 'first argument to "ajax:complete" should be an XHR object')
+      assert.equal(status, 'Forbidden', 'second argument to ajax:complete should be a status string')
     })
   })
 })
 
-asyncTest('binding to ajax callbacks via .delegate() triggers handlers properly', 4, function() {
+QUnit.test('binding to ajax callbacks via .delegate() triggers handlers properly', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
   $(document)
     .delegate('form[data-remote]', 'ajax:beforeSend', function() {
-      ok(true, 'ajax:beforeSend handler is triggered')
+      assert.ok(true, 'ajax:beforeSend handler is triggered')
     })
     .delegate('form[data-remote]', 'ajax:send', function() {
-      ok(true, 'ajax:send handler is triggered')
+      assert.ok(true, 'ajax:send handler is triggered')
     })
     .delegate('form[data-remote]', 'ajax:success', function() {
-      ok(true, 'ajax:success handler is triggered')
+      assert.ok(true, 'ajax:success handler is triggered')
     })
     .delegate('form[data-remote]', 'ajax:complete', function() {
-      ok(true, 'ajax:complete handler is triggered')
+      assert.ok(true, 'ajax:complete handler is triggered')
     })
-  $('form[data-remote]').triggerNative('submit')
+  $('form.rails-ujs-target[data-remote]').triggerNative('submit')
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
 })()

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -1,16 +1,16 @@
 (function() {
 
 function buildForm(attrs) {
-  attrs = $.extend({ action: '/echo', 'data-remote': 'true', class: 'rails-ujs-target' }, attrs)
+  attrs = $.extend({ action: '/echo', 'data-remote': 'true', class: 'qunit-target' }, attrs)
 
   $('#qunit-fixture').append($('<form />', attrs))
-    .find('form.rails-ujs-target').append($('<input type="text" name="user_name" value="john">'))
+    .find('form.qunit-target').append($('<input type="text" name="user_name" value="john">'))
 }
 
 QUnit.module('call-remote')
 
 function submit(done, fn) {
-  $('form.rails-ujs-target')
+  $('form.qunit-target')
     .bindNative('ajax:success', fn)
     .bindNative('ajax:complete', function() { done() })
     .triggerNative('submit')
@@ -45,7 +45,7 @@ QUnit.test('form method is read from submit button "formmethod" if submit is tri
   var submitButton = $('<input type="submit" formmethod="get">')
   buildForm({ method: 'post' })
 
-  $('#qunit-fixture').find('form.rails-ujs-target').append(submitButton)
+  $('#qunit-fixture').find('form.qunit-target').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
       App.assertGetRequest(assert, data)
     })
@@ -94,7 +94,7 @@ QUnit.test('form url is read from submit button "formaction" if submit is trigge
   var submitButton = $('<input type="submit" formaction="/echo">')
   buildForm({ method: 'post', href: '/echo2' })
 
-  $('#qunit-fixture').find('form.rails-ujs-target').append(submitButton)
+  $('#qunit-fixture').find('form.qunit-target').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
       App.assertRequestPath(assert, data, '/echo')
     })
@@ -125,8 +125,8 @@ QUnit.test('JS code should be executed', function(assert) {
     assert.ok(true, 'remote code should be run')
   }
 
-  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/javascript">')
-  $('form.rails-ujs-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
+  $('form.qunit-target').append('<input type="text" name="content_type" value="text/javascript">')
+  $('form.qunit-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
 
   submit(done)
 })
@@ -141,8 +141,8 @@ QUnit.test('ecmascript code should be executed', function(assert) {
     assert.ok(true, 'remote code should be run')
   }
 
-  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="application/ecmascript">')
-  $('form.rails-ujs-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
+  $('form.qunit-target').append('<input type="text" name="content_type" value="application/ecmascript">')
+  $('form.qunit-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
 
   submit(done)
 })
@@ -158,8 +158,8 @@ QUnit.test('execution of JS code does not modify current DOM', function(assert) 
 
   buildForm({ method: 'post', 'data-type': 'script' })
 
-  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/javascript">')
-  $('form.rails-ujs-target').append('<input type="text" name="content" value="\'remote code should be run\'">')
+  $('form.qunit-target').append('<input type="text" name="content_type" value="text/javascript">')
+  $('form.qunit-target').append('<input type="text" name="content" value="\'remote code should be run\'">')
 
   docLength = getDocLength()
 
@@ -175,8 +175,8 @@ QUnit.test('HTML content should be plain-text', function(assert) {
 
   buildForm({ method: 'post', 'data-type': 'html' })
 
-  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/html">')
-  $('form.rails-ujs-target').append('<input type="text" name="content" value="<p>hello</p>">')
+  $('form.qunit-target').append('<input type="text" name="content_type" value="text/html">')
+  $('form.qunit-target').append('<input type="text" name="content" value="<p>hello</p>">')
 
   submit(done, function(e, data, status, xhr) {
     assert.ok(data === '<p>hello</p>', 'returned data should be a plain-text string')
@@ -189,8 +189,8 @@ QUnit.test('XML document should be parsed', function(assert) {
 
   buildForm({ method: 'post', 'data-type': 'html' })
 
-  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="application/xml">')
-  $('form.rails-ujs-target').append('<input type="text" name="content" value="<p>hello</p>">')
+  $('form.qunit-target').append('<input type="text" name="content_type" value="application/xml">')
+  $('form.qunit-target').append('<input type="text" name="content" value="<p>hello</p>">')
 
   submit(done, function(e, data, status, xhr) {
     assert.ok(data instanceof Document, 'returned data should be an XML document')
@@ -212,7 +212,7 @@ QUnit.test('allow empty "data-remote" attribute', function(assert) {
   assert.expect(1)
   var done = assert.async()
 
-  var form = $('#qunit-fixture').append($('<form class=\'rails-ujs-target\' action="/echo" data-remote />')).find('form.rails-ujs-target')
+  var form = $('#qunit-fixture').append($('<form class=\'qunit-target\' action="/echo" data-remote />')).find('form.qunit-target')
 
   submit(done, function() {
     assert.ok(true, 'form with empty "data-remote" attribute is also allowed')
@@ -277,7 +277,7 @@ QUnit.test('allow empty form "action"', function(assert) {
 
   buildForm({ action: '' })
 
-  $('#qunit-fixture').find('form.rails-ujs-target')
+  $('#qunit-fixture').find('form.qunit-target')
     .bindNative('ajax:beforeSend', function(evt, xhr, settings) {
       // Get current location (the same way jQuery does)
       try {
@@ -325,7 +325,7 @@ QUnit.test('intelligently guesses crossDomain behavior when target URL has a dif
   buildForm({ action: 'http://www.alfajango.com' })
   $('#qunit-fixture').append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae" />')
 
-  $('#qunit-fixture').find('form.rails-ujs-target')
+  $('#qunit-fixture').find('form.qunit-target')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
       assert.equal(settings.crossDomain, true, 'crossDomain should be set to true')
@@ -347,7 +347,7 @@ QUnit.test('intelligently guesses crossDomain behavior when target URL consists 
   buildForm({ action: '/just/a/path' })
   $('#qunit-fixture').append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae" />')
 
-  $('#qunit-fixture').find('form.rails-ujs-target')
+  $('#qunit-fixture').find('form.qunit-target')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
       assert.equal(settings.crossDomain, false, 'crossDomain should be set to false')

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -213,7 +213,6 @@ QUnit.test('allow empty "data-remote" attribute', function(assert) {
   var done = assert.async()
 
   var form = $('#qunit-fixture').append($('<form class=\'rails-ujs-target\' action="/echo" data-remote />')).find('form.rails-ujs-target')
-  window._debug = form
 
   submit(done, function() {
     assert.ok(true, 'form with empty "data-remote" attribute is also allowed')

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -45,7 +45,7 @@ QUnit.test('form method is read from submit button "formmethod" if submit is tri
   var submitButton = $('<input type="submit" formmethod="get">')
   buildForm({ method: 'post' })
 
-  $('#qunit-fixture').find('form').append(submitButton)
+  $('#qunit-fixture').find('form.rails-ujs-target').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
       App.assertGetRequest(assert, data)
     })
@@ -94,7 +94,7 @@ QUnit.test('form url is read from submit button "formaction" if submit is trigge
   var submitButton = $('<input type="submit" formaction="/echo">')
   buildForm({ method: 'post', href: '/echo2' })
 
-  $('#qunit-fixture').find('form').append(submitButton)
+  $('#qunit-fixture').find('form.rails-ujs-target').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
       App.assertRequestPath(assert, data, '/echo')
     })
@@ -277,7 +277,7 @@ QUnit.test('allow empty form "action"', function(assert) {
 
   buildForm({ action: '' })
 
-  $('#qunit-fixture').find('form')
+  $('#qunit-fixture').find('form.rails-ujs-target')
     .bindNative('ajax:beforeSend', function(evt, xhr, settings) {
       // Get current location (the same way jQuery does)
       try {
@@ -325,7 +325,7 @@ QUnit.test('intelligently guesses crossDomain behavior when target URL has a dif
   buildForm({ action: 'http://www.alfajango.com' })
   $('#qunit-fixture').append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae" />')
 
-  $('#qunit-fixture').find('form')
+  $('#qunit-fixture').find('form.rails-ujs-target')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
       assert.equal(settings.crossDomain, true, 'crossDomain should be set to true')
@@ -347,7 +347,7 @@ QUnit.test('intelligently guesses crossDomain behavior when target URL consists 
   buildForm({ action: '/just/a/path' })
   $('#qunit-fixture').append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae" />')
 
-  $('#qunit-fixture').find('form')
+  $('#qunit-fixture').find('form.rails-ujs-target')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
       assert.equal(settings.crossDomain, false, 'crossDomain should be set to false')

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -1,115 +1,156 @@
 (function() {
 
 function buildForm(attrs) {
-  attrs = $.extend({ action: '/echo', 'data-remote': 'true' }, attrs)
+  attrs = $.extend({ action: '/echo', 'data-remote': 'true', class: 'rails-ujs-target' }, attrs)
 
   $('#qunit-fixture').append($('<form />', attrs))
-    .find('form').append($('<input type="text" name="user_name" value="john">'))
+    .find('form.rails-ujs-target').append($('<input type="text" name="user_name" value="john">'))
 }
 
-module('call-remote')
+QUnit.module('call-remote')
 
-function submit(fn) {
-  $('form')
+function submit(done, fn) {
+  $('form.rails-ujs-target')
     .bindNative('ajax:success', fn)
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('submit')
 }
 
-asyncTest('form method is read from "method" and not from "data-method"', 1, function() {
+QUnit.test('form method is read from "method" and not from "data-method"', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-method': 'get' })
 
-  submit(function(e, data, status, xhr) {
-    App.assertPostRequest(data)
+  submit(done, function(e, data, status, xhr) {
+    App.assertPostRequest(assert, data)
   })
 })
 
-asyncTest('form method is not read from "data-method" attribute in case of missing "method"', 1, function() {
+QUnit.test('form method is not read from "data-method" attribute in case of missing "method"', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ 'data-method': 'put' })
 
-  submit(function(e, data, status, xhr) {
-    App.assertGetRequest(data)
+  submit(done, function(e, data, status, xhr) {
+    App.assertGetRequest(assert, data)
   })
 })
 
-asyncTest('form method is read from submit button "formmethod" if submit is triggered by that button', 1, function() {
+QUnit.test('form method is read from submit button "formmethod" if submit is triggered by that button', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var submitButton = $('<input type="submit" formmethod="get">')
   buildForm({ method: 'post' })
 
   $('#qunit-fixture').find('form').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertGetRequest(data)
+      App.assertGetRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
 
   submitButton.triggerNative('click')
 })
 
-asyncTest('form default method is GET', 1, function() {
+QUnit.test('form default method is GET', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm()
 
-  submit(function(e, data, status, xhr) {
-    App.assertGetRequest(data)
+  submit(done, function(e, data, status, xhr) {
+    App.assertGetRequest(assert, data)
   })
 })
 
-asyncTest('form url is picked up from "action"', 1, function() {
+QUnit.test('form url is picked up from "action"', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post' })
 
-  submit(function(e, data, status, xhr) {
-    App.assertRequestPath(data, '/echo')
+  submit(done, function(e, data, status, xhr) {
+    App.assertRequestPath(assert, data, '/echo')
   })
 })
 
-asyncTest('form url is read from "action" not "href"', 1, function() {
+QUnit.test('form url is read from "action" not "href"', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', href: '/echo2' })
 
-  submit(function(e, data, status, xhr) {
-    App.assertRequestPath(data, '/echo')
+  submit(done, function(e, data, status, xhr) {
+    App.assertRequestPath(assert, data, '/echo')
   })
 })
 
-asyncTest('form url is read from submit button "formaction" if submit is triggered by that button', 1, function() {
+QUnit.test('form url is read from submit button "formaction" if submit is triggered by that button', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var submitButton = $('<input type="submit" formaction="/echo">')
   buildForm({ method: 'post', href: '/echo2' })
 
   $('#qunit-fixture').find('form').append(submitButton)
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertRequestPath(data, '/echo')
+      App.assertRequestPath(assert, data, '/echo')
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
 
   submitButton.triggerNative('click')
 })
 
-asyncTest('prefer JS, but accept any format', 1, function() {
+QUnit.test('prefer JS, but accept any format', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post' })
 
-  submit(function(e, data, status, xhr) {
+  submit(done, function(e, data, status, xhr) {
     var accept = data.HTTP_ACCEPT
-    ok(accept.match(/text\/javascript.+\*\/\*/), 'Accept: ' + accept)
+    assert.ok(accept.match(/text\/javascript.+\*\/\*/), 'Accept: ' + accept)
   })
 })
 
-asyncTest('JS code should be executed', 1, function() {
+QUnit.test('JS code should be executed', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-type': 'script' })
 
-  $('form').append('<input type="text" name="content_type" value="text/javascript">')
-  $('form').append('<input type="text" name="content" value="ok(true, \'remote code should be run\')">')
+  window._callRemoteCallback = function() {
+    assert.ok(true, 'remote code should be run')
+  }
 
-  submit()
+  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/javascript">')
+  $('form.rails-ujs-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
+
+  submit(done)
 })
 
-asyncTest('ecmascript code should be executed', 1, function() {
+QUnit.test('ecmascript code should be executed', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-type': 'script' })
 
-  $('form').append('<input type="text" name="content_type" value="application/ecmascript">')
-  $('form').append('<input type="text" name="content" value="ok(true, \'remote code should be run\')">')
+  window._callRemoteCallback = function() {
+    assert.ok(true, 'remote code should be run')
+  }
 
-  submit()
+  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="application/ecmascript">')
+  $('form.rails-ujs-target').append('<input type="text" name="content" value="window._callRemoteCallback()">')
+
+  submit(done)
 })
 
-asyncTest('execution of JS code does not modify current DOM', 1, function() {
+QUnit.test('execution of JS code does not modify current DOM', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var docLength, newDocLength
   function getDocLength() {
     return document.documentElement.outerHTML.length
@@ -117,94 +158,122 @@ asyncTest('execution of JS code does not modify current DOM', 1, function() {
 
   buildForm({ method: 'post', 'data-type': 'script' })
 
-  $('form').append('<input type="text" name="content_type" value="text/javascript">')
-  $('form').append('<input type="text" name="content" value="\'remote code should be run\'">')
+  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/javascript">')
+  $('form.rails-ujs-target').append('<input type="text" name="content" value="\'remote code should be run\'">')
 
   docLength = getDocLength()
 
-  submit(function() {
+  submit(done, function() {
     newDocLength = getDocLength()
-    ok(docLength === newDocLength, 'executed JS should not present in the document')
+    assert.ok(docLength === newDocLength, 'executed JS should not present in the document')
   })
 })
 
-asyncTest('HTML content should be plain-text', 1, function() {
+QUnit.test('HTML content should be plain-text', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-type': 'html' })
 
-  $('form').append('<input type="text" name="content_type" value="text/html">')
-  $('form').append('<input type="text" name="content" value="<p>hello</p>">')
+  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="text/html">')
+  $('form.rails-ujs-target').append('<input type="text" name="content" value="<p>hello</p>">')
 
-  submit(function(e, data, status, xhr) {
-    ok(data === '<p>hello</p>', 'returned data should be a plain-text string')
+  submit(done, function(e, data, status, xhr) {
+    assert.ok(data === '<p>hello</p>', 'returned data should be a plain-text string')
   })
 })
 
-asyncTest('XML document should be parsed', 1, function() {
+QUnit.test('XML document should be parsed', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-type': 'html' })
 
-  $('form').append('<input type="text" name="content_type" value="application/xml">')
-  $('form').append('<input type="text" name="content" value="<p>hello</p>">')
+  $('form.rails-ujs-target').append('<input type="text" name="content_type" value="application/xml">')
+  $('form.rails-ujs-target').append('<input type="text" name="content" value="<p>hello</p>">')
 
-  submit(function(e, data, status, xhr) {
-    ok(data instanceof Document, 'returned data should be an XML document')
+  submit(done, function(e, data, status, xhr) {
+    assert.ok(data instanceof Document, 'returned data should be an XML document')
   })
 })
 
-asyncTest('accept application/json if "data-type" is json', 1, function() {
+QUnit.test('accept application/json if "data-type" is json', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post', 'data-type': 'json' })
 
-  submit(function(e, data, status, xhr) {
-    equal(data.HTTP_ACCEPT, 'application/json, text/javascript, */*; q=0.01')
+  submit(done, function(e, data, status, xhr) {
+    assert.equal(data.HTTP_ACCEPT, 'application/json, text/javascript, */*; q=0.01')
   })
 })
 
-asyncTest('allow empty "data-remote" attribute', 1, function() {
-  var form = $('#qunit-fixture').append($('<form action="/echo" data-remote />')).find('form')
+QUnit.test('allow empty "data-remote" attribute', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
 
-  submit(function() {
-    ok(true, 'form with empty "data-remote" attribute is also allowed')
+  var form = $('#qunit-fixture').append($('<form class=\'rails-ujs-target\' action="/echo" data-remote />')).find('form.rails-ujs-target')
+  window._debug = form
+
+  submit(done, function() {
+    assert.ok(true, 'form with empty "data-remote" attribute is also allowed')
   })
 })
 
-asyncTest('query string in form action should be stripped in a GET request in normal submit', 1, function() {
+QUnit.test('query string in form action should be stripped in a GET request in normal submit', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ action: '/echo?param1=abc', 'data-remote': 'false' })
 
   $(document).one('iframe:loaded', function(e, data) {
-    equal(data.params.param1, undefined, '"param1" should not be passed to server')
-    start()
+    assert.equal(data.params.param1, undefined, '"param1" should not be passed to server')
+    done()
   })
 
   $('#qunit-fixture form').triggerNative('submit')
 })
 
-asyncTest('query string in form action should be stripped in a GET request in ajax submit', 1, function() {
+QUnit.test('query string in form action should be stripped in a GET request in ajax submit', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ action: '/echo?param1=abc' })
 
-  submit(function(e, data, status, xhr) {
-    equal(data.params.param1, undefined, '"param1" should not be passed to server')
+  submit(done, function(e, data, status, xhr) {
+    assert.equal(data.params.param1, undefined, '"param1" should not be passed to server')
   })
 })
 
-asyncTest('query string in form action should not be stripped in a POST request in normal submit', 1, function() {
+QUnit.test('query string in form action should not be stripped in a POST request in normal submit', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ action: '/echo?param1=abc', method: 'post', 'data-remote': 'false' })
 
   $(document).one('iframe:loaded', function(e, data) {
-    equal(data.params.param1, 'abc', '"param1" should be passed to server')
-    start()
+    assert.equal(data.params.param1, 'abc', '"param1" should be passed to server')
+    done()
   })
 
   $('#qunit-fixture form').triggerNative('submit')
 })
 
-asyncTest('query string in form action should not be stripped in a POST request in ajax submit', 1, function() {
+QUnit.test('query string in form action should not be stripped in a POST request in ajax submit', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ action: '/echo?param1=abc', method: 'post' })
 
-  submit(function(e, data, status, xhr) {
-    equal(data.params.param1, 'abc', '"param1" should be passed to server')
+  submit(done, function(e, data, status, xhr) {
+    assert.equal(data.params.param1, 'abc', '"param1" should be passed to server')
   })
 })
 
-asyncTest('allow empty form "action"', 1, function() {
+QUnit.test('allow empty form "action"', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var currentLocation, ajaxLocation
 
   buildForm({ action: '' })
@@ -225,7 +294,7 @@ asyncTest('allow empty form "action"', 1, function() {
       // HACK: can no longer use settings.data below to see what was appended to URL, as of
       // jQuery 1.6.3 (see http://bugs.jquery.com/ticket/10202 and https://github.com/jquery/jquery/pull/544)
       ajaxLocation = settings.url.replace('user_name=john', '').replace(/&$/, '').replace(/\?$/, '')
-      equal(ajaxLocation.match(/^(.*)/)[1], currentLocation, 'URL should be current page by default')
+      assert.equal(ajaxLocation.match(/^(.*)/)[1], currentLocation, 'URL should be current page by default')
 
       // Prevent the request from actually getting sent to the current page and
       // causing an error.
@@ -233,19 +302,25 @@ asyncTest('allow empty form "action"', 1, function() {
     })
     .triggerNative('submit')
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('sends CSRF token in custom header', 1, function() {
+QUnit.test('sends CSRF token in custom header', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   buildForm({ method: 'post' })
   $('#qunit-fixture').append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae" />')
 
-  submit(function(e, data, status, xhr) {
-    equal(data.HTTP_X_CSRF_TOKEN, 'cf50faa3fe97702ca1ae', 'X-CSRF-Token header should be sent')
+  submit(done, function(e, data, status, xhr) {
+    assert.equal(data.HTTP_X_CSRF_TOKEN, 'cf50faa3fe97702ca1ae', 'X-CSRF-Token header should be sent')
   })
 })
 
-asyncTest('intelligently guesses crossDomain behavior when target URL has a different protocol and/or hostname', 1, function() {
+QUnit.test('intelligently guesses crossDomain behavior when target URL has a different protocol and/or hostname', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
 
   // Don't set data-cross-domain here, just set action to be a different domain than localhost
   buildForm({ action: 'http://www.alfajango.com' })
@@ -254,17 +329,20 @@ asyncTest('intelligently guesses crossDomain behavior when target URL has a diff
   $('#qunit-fixture').find('form')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
-      equal(settings.crossDomain, true, 'crossDomain should be set to true')
+      assert.equal(settings.crossDomain, true, 'crossDomain should be set to true')
 
       // prevent request from actually getting sent off-domain
       evt.preventDefault()
     })
     .triggerNative('submit')
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('intelligently guesses crossDomain behavior when target URL consists of only a path', 1, function() {
+QUnit.test('intelligently guesses crossDomain behavior when target URL consists of only a path', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
 
   // Don't set data-cross-domain here, just set action to be a different domain than localhost
   buildForm({ action: '/just/a/path' })
@@ -273,14 +351,14 @@ asyncTest('intelligently guesses crossDomain behavior when target URL consists o
   $('#qunit-fixture').find('form')
     .bindNative('ajax:beforeSend', function(evt, req, settings) {
 
-      equal(settings.crossDomain, false, 'crossDomain should be set to false')
+      assert.equal(settings.crossDomain, false, 'crossDomain should be set to false')
 
       // prevent request from actually getting sent off-domain
       evt.preventDefault()
     })
     .triggerNative('submit')
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
 })()

--- a/actionview/test/ujs/public/test/csrf-refresh.js
+++ b/actionview/test/ujs/public/test/csrf-refresh.js
@@ -1,8 +1,11 @@
 (function() {
 
-module('csrf-refresh', {})
+QUnit.module('csrf-refresh', {})
 
-asyncTest('refresh all csrf tokens', 1, function() {
+QUnit.test('refresh all csrf tokens', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var correctToken = 'cf50faa3fe97702ca1ae'
 
   var form = $('<form />')
@@ -17,8 +20,8 @@ asyncTest('refresh all csrf tokens', 1, function() {
   $.rails.refreshCSRFTokens()
   currentToken = $('#qunit-fixture #authenticity_token').val()
 
-  start()
-  equal(currentToken, correctToken)
+  assert.equal(currentToken, correctToken)
+  done()
 })
 
 })()

--- a/actionview/test/ujs/public/test/csrf-token.js
+++ b/actionview/test/ujs/public/test/csrf-token.js
@@ -1,27 +1,33 @@
 (function() {
 
-module('csrf-token', {})
+QUnit.module('csrf-token', {})
 
-asyncTest('find csrf token', 1, function() {
+QUnit.test('find csrf token', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var correctToken = 'cf50faa3fe97702ca1ae'
 
   $('#qunit-fixture').append('<meta name="csrf-token" content="' + correctToken + '"/>')
 
   currentToken = $.rails.csrfToken()
 
-  start()
-  equal(currentToken, correctToken)
+  assert.equal(currentToken, correctToken)
+  done()
 })
 
-asyncTest('find csrf param', 1, function() {
+QUnit.test('find csrf param', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var correctParam = 'authenticity_token'
 
   $('#qunit-fixture').append('<meta name="csrf-param" content="' + correctParam + '"/>')
 
   currentParam = $.rails.csrfParam()
 
-  start()
-  equal(currentParam, correctParam)
+  assert.equal(currentParam, correctParam)
+  done()
 })
 
 })()

--- a/actionview/test/ujs/public/test/data-confirm.js
+++ b/actionview/test/ujs/public/test/data-confirm.js
@@ -1,5 +1,5 @@
-module('data-confirm', {
-  setup: function() {
+QUnit.module('data-confirm', {
+  beforeEach: function() {
     $('#qunit-fixture').append($('<a />', {
       href: '/echo',
       'data-remote': 'true',
@@ -35,224 +35,257 @@ module('data-confirm', {
 
     this.windowConfirm = window.confirm
   },
-  teardown: function() {
+  afterEach: function() {
     window.confirm = this.windowConfirm
   }
 })
 
-asyncTest('clicking on a link with data-confirm attribute. Confirm yes.', 6, function() {
+QUnit.test('clicking on a link with data-confirm attribute. Confirm yes.', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var message
   // auto-confirm:
   window.confirm = function(msg) { message = msg; return true }
 
   $('a[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == true, 'confirm:complete passes in confirm answer (true)')
     })
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      App.assertGetRequest(assert, data)
 
-      equal(message, 'Are you absolutely sure?')
-      start()
+      assert.equal(message, 'Are you absolutely sure?')
+      done()
     })
     .triggerNative('click')
 })
 
-asyncTest('clicking on a button with data-confirm attribute. Confirm yes.', 6, function() {
+QUnit.test('clicking on a button with data-confirm attribute. Confirm yes.', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var message
   // auto-confirm:
   window.confirm = function(msg) { message = msg; return true }
 
   $('button[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == true, 'confirm:complete passes in confirm answer (true)')
     })
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      App.assertGetRequest(assert, data)
 
-      equal(message, 'Are you absolutely sure?')
-      start()
+      assert.equal(message, 'Are you absolutely sure?')
+      done()
     })
     .triggerNative('click')
 })
 
-asyncTest('clicking on a link with data-confirm attribute. Confirm No.', 3, function() {
+QUnit.test('clicking on a link with data-confirm attribute. Confirm No.', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
   var message
   // auto-decline:
   window.confirm = function(msg) { message = msg; return false }
 
   $('a[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == false, 'confirm:complete passes in confirm answer (false)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == false, 'confirm:complete passes in confirm answer (false)')
     })
     .bindNative('ajax:beforeSend', function(e, data, status, xhr) {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    equal(message, 'Are you absolutely sure?')
-    start()
+    assert.equal(message, 'Are you absolutely sure?')
+    done()
   }, 50)
 })
 
-asyncTest('clicking on a button with data-confirm attribute. Confirm No.', 3, function() {
+QUnit.test('clicking on a button with data-confirm attribute. Confirm No.', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
   var message
   // auto-decline:
   window.confirm = function(msg) { message = msg; return false }
 
   $('button[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == false, 'confirm:complete passes in confirm answer (false)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == false, 'confirm:complete passes in confirm answer (false)')
     })
     .bindNative('ajax:beforeSend', function(e, data, status, xhr) {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    equal(message, 'Are you absolutely sure?')
-    start()
+    assert.equal(message, 'Are you absolutely sure?')
+    done()
   }, 50)
 })
 
-asyncTest('clicking on a button with data-confirm attribute. Confirm error.', 3, function() {
+QUnit.test('clicking on a button with data-confirm attribute. Confirm error.', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
   var message
   // auto-decline:
   window.confirm = function(msg) { message = msg; throw 'some random error' }
 
   $('button[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == false, 'confirm:complete passes in confirm answer (false)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == false, 'confirm:complete passes in confirm answer (false)')
     })
     .bindNative('ajax:beforeSend', function(e, data, status, xhr) {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    equal(message, 'Are you absolutely sure?')
-    start()
+    assert.equal(message, 'Are you absolutely sure?')
+    done()
   }, 50)
 })
 
-asyncTest('clicking on a submit button with form and data-confirm attributes. Confirm No.', 3, function() {
+QUnit.test('clicking on a submit button with form and data-confirm attributes. Confirm No.', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
   var message
   // auto-decline:
   window.confirm = function(msg) { message = msg; return false }
 
   $('input[type=submit][form]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == false, 'confirm:complete passes in confirm answer (false)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == false, 'confirm:complete passes in confirm answer (false)')
     })
     .bindNative('ajax:beforeSend', function(e, data, status, xhr) {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    equal(message, 'Are you absolutely sure?')
-    start()
+    assert.equal(message, 'Are you absolutely sure?')
+    done()
   }, 50)
 })
 
-asyncTest('binding to confirm event of a link and returning false', 1, function() {
+QUnit.test('binding to confirm event of a link and returning false', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   // redefine confirm function so we can make sure it's not called
   window.confirm = function(msg) {
-    ok(false, 'confirm dialog should not be called')
+    assert.ok(false, 'confirm dialog should not be called')
   }
 
   $('a[data-confirm]')
     .bindNative('confirm', function(e) {
-      App.assertCallbackInvoked('confirm')
+      App.assertCallbackInvoked(assert, 'confirm')
       e.preventDefault()
     })
     .bindNative('confirm:complete', function() {
-      App.assertCallbackNotInvoked('confirm:complete')
+      App.assertCallbackNotInvoked(assert, 'confirm:complete')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 50)
 })
 
-asyncTest('binding to confirm event of a button and returning false', 1, function() {
+QUnit.test('binding to confirm event of a button and returning false', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   // redefine confirm function so we can make sure it's not called
   window.confirm = function(msg) {
-    ok(false, 'confirm dialog should not be called')
+    assert.ok(false, 'confirm dialog should not be called')
   }
 
   $('button[data-confirm]')
     .bindNative('confirm', function(e) {
-      App.assertCallbackInvoked('confirm')
+      App.assertCallbackInvoked(assert, 'confirm')
       e.preventDefault()
     })
     .bindNative('confirm:complete', function() {
-      App.assertCallbackNotInvoked('confirm:complete')
+      App.assertCallbackNotInvoked(assert, 'confirm:complete')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 50)
 })
 
-asyncTest('binding to confirm:complete event of a link and returning false', 2, function() {
+QUnit.test('binding to confirm:complete event of a link and returning false', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   // auto-confirm:
   window.confirm = function(msg) {
-    ok(true, 'confirm dialog should be called')
+    assert.ok(true, 'confirm dialog should be called')
     return true
   }
 
   $('a[data-confirm]')
     .bindNative('confirm:complete', function(e) {
-      App.assertCallbackInvoked('confirm:complete')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
       e.preventDefault()
     })
     .bindNative('ajax:beforeSend', function() {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 50)
 })
 
-asyncTest('binding to confirm:complete event of a button and returning false', 2, function() {
+QUnit.test('binding to confirm:complete event of a button and returning false', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   // auto-confirm:
   window.confirm = function(msg) {
-    ok(true, 'confirm dialog should be called')
+    assert.ok(true, 'confirm dialog should be called')
     return true
   }
 
   $('button[data-confirm]')
     .bindNative('confirm:complete', function(e) {
-      App.assertCallbackInvoked('confirm:complete')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
       e.preventDefault()
     })
     .bindNative('ajax:beforeSend', function() {
-      App.assertCallbackNotInvoked('ajax:beforeSend')
+      App.assertCallbackNotInvoked(assert, 'ajax:beforeSend')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 50)
 })
 
-asyncTest('a button inside a form only confirms once', 1, function() {
+QUnit.test('a button inside a form only confirms once', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var confirmations = 0
   window.confirm = function(msg) {
     confirmations++
@@ -267,11 +300,14 @@ asyncTest('a button inside a form only confirms once', 1, function() {
 
   $('form > button[data-confirm]').triggerNative('click')
 
-  ok(confirmations === 1, 'confirmation counter should be 1, but it was ' + confirmations)
-  start()
+  assert.ok(confirmations === 1, 'confirmation counter should be 1, but it was ' + confirmations)
+  done()
 })
 
-asyncTest('clicking on the children of a link should also trigger a confirm', 6, function() {
+QUnit.test('clicking on the children of a link should also trigger a confirm', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var message
   // auto-confirm:
   window.confirm = function(msg) { message = msg; return true }
@@ -279,22 +315,25 @@ asyncTest('clicking on the children of a link should also trigger a confirm', 6,
   $('a[data-confirm]')
     .html('<strong>Click me</strong>')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == true, 'confirm:complete passes in confirm answer (true)')
     })
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      App.assertGetRequest(assert, data)
 
-      equal(message, 'Are you absolutely sure?')
-      start()
+      assert.equal(message, 'Are you absolutely sure?')
+      done()
     })
     .find('strong')
     .triggerNative('click')
 })
 
-asyncTest('clicking on the children of a disabled button should not trigger a confirm.', 1, function() {
+QUnit.test('clicking on the children of a disabled button should not trigger a confirm.', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var message
   // auto-decline:
   window.confirm = function(msg) { message = msg; return false }
@@ -302,41 +341,44 @@ asyncTest('clicking on the children of a disabled button should not trigger a co
   $('button[data-confirm][disabled]')
     .html('<strong>Click me</strong>')
     .bindNative('confirm', function() {
-      App.assertCallbackNotInvoked('confirm')
+      App.assertCallbackNotInvoked(assert, 'confirm')
     })
     .find('strong')
     .bindNative('click', function() {
-      App.assertCallbackInvoked('click')
+      App.assertCallbackInvoked(assert, 'click')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 50)
 })
 
-asyncTest('clicking on a link with data-confirm attribute with custom confirm handler. Confirm yes.', 7, function() {
+QUnit.test('clicking on a link with data-confirm attribute with custom confirm handler. Confirm yes.', function(assert) {
+  assert.expect(7)
+  var done = assert.async()
+
   var message, element
   // redefine confirm function so we can make sure it's not called
   window.confirm = function(msg) {
-    ok(false, 'confirm dialog should not be called')
+    assert.ok(false, 'confirm dialog should not be called')
   }
   // custom auto-confirm:
   Rails.confirm = function(msg, elem) { message = msg; element = elem; return true }
 
   $('a[data-confirm]')
     .bindNative('confirm:complete', function(e, data) {
-      App.assertCallbackInvoked('confirm:complete')
-      ok(data == true, 'confirm:complete passes in confirm answer (true)')
+      App.assertCallbackInvoked(assert, 'confirm:complete')
+      assert.ok(data == true, 'confirm:complete passes in confirm answer (true)')
     })
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      App.assertGetRequest(assert, data)
 
-      equal(message, 'Are you absolutely sure?')
-      equal(element, $('a[data-confirm]').get(0))
-      start()
+      assert.equal(message, 'Are you absolutely sure?')
+      assert.equal(element, $('a[data-confirm]').get(0))
+      done()
     })
     .triggerNative('click')
 })

--- a/actionview/test/ujs/public/test/data-disable-with.js
+++ b/actionview/test/ujs/public/test/data-disable-with.js
@@ -1,14 +1,16 @@
-module('data-disable-with', {
-  setup: function() {
+QUnit.module('data-disable-with', {
+  beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
+      class: 'rails-ujs-target',
       action: '/echo',
       'data-remote': 'true',
       method: 'post'
     }))
-      .find('form')
+      .find('form.rails-ujs-target')
       .append($('<input type="text" data-disable-with="processing ..." name="user_name" value="john" />'))
 
     $('#qunit-fixture').append($('<form />', {
+      class: 'rails-ujs-target',
       action: '/echo',
       method: 'post',
       id: 'not_remote'
@@ -38,106 +40,122 @@ module('data-disable-with', {
       'data-disable-with': 'clicking...'
     }))
   },
-  teardown: function() {
+  afterEach: function() {
     $(document).unbind('iframe:loaded')
   }
 })
 
-asyncTest('form input field with "data-disable-with" attribute', 7, function() {
-  var form = $('form[data-remote]'), input = form.find('input[type=text]')
+QUnit.test('form input field with "data-disable-with" attribute', function(assert) {
+  assert.expect(7)
+  var done = assert.async()
 
-  App.checkEnabledState(input, 'john')
+  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
+
+  App.checkEnabledState(assert, input, 'john')
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      App.checkEnabledState(input, 'john')
-      equal(data.params.user_name, 'john')
-      start()
+      App.checkEnabledState(assert, input, 'john')
+      assert.equal(data.params.user_name, 'john')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(input, 'processing ...')
+  App.checkDisabledState(assert, input, 'processing ...')
 })
 
-asyncTest('blank form input field with "data-disable-with" attribute', 7, function() {
-  var form = $('form[data-remote]'), input = form.find('input[type=text]')
+QUnit.test('blank form input field with "data-disable-with" attribute', function(assert) {
+  assert.expect(7)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
 
   input.val('')
-  App.checkEnabledState(input, '')
+  App.checkEnabledState(assert, input, '')
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      App.checkEnabledState(input, '')
-      equal(data.params.user_name, '')
-      start()
+      App.checkEnabledState(assert, input, '')
+      assert.equal(data.params.user_name, '')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(input, 'processing ...')
+  App.checkDisabledState(assert, input, 'processing ...')
 })
 
-asyncTest('form button with "data-disable-with" attribute', 6, function() {
-  var form = $('form[data-remote]'), button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>')
+QUnit.test('form button with "data-disable-with" attribute', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'), button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>')
   form.append(button)
 
-  App.checkEnabledState(button, 'Submit')
+  App.checkEnabledState(assert, button, 'Submit')
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      App.checkEnabledState(button, 'Submit')
-      start()
+      App.checkEnabledState(assert, button, 'Submit')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(button, 'submitting ...')
+  App.checkDisabledState(assert, button, 'submitting ...')
 })
 
-asyncTest('a[data-remote][data-disable-with] within a form disables and re-enables', 6, function() {
-  var form = $('form:not([data-remote])'),
+QUnit.test('a[data-remote][data-disable-with] within a form disables and re-enables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target:not([data-remote])'),
       link = $('<a data-remote="true" data-disable-with="clicking...">Click me</a>')
   form.append(link)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:beforeSend', function() {
-      App.checkDisabledState(link, 'clicking...')
+      App.checkDisabledState(assert, link, 'clicking...')
     })
     .bindNative('ajax:complete', function() {
       setTimeout( function() {
-        App.checkEnabledState(link, 'Click me')
+        App.checkEnabledState(assert, link, 'Click me')
         link.remove()
-        start()
+        done()
       }, 15)
     })
     .triggerNative('click')
 })
 
-asyncTest('form input[type=submit][data-disable-with] disables', 6, function() {
-  var form = $('form:not([data-remote])'), input = form.find('input[type=submit]')
+QUnit.test('form input[type=submit][data-disable-with] disables', function(assert) {
+  assert.expect(6)
+  var done = assert.async(2)
 
-  App.checkEnabledState(input, 'Submit')
+  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
+
+  App.checkEnabledState(assert, input, 'Submit')
 
   $(document).bind('iframe:loaded', function(e, data) {
     setTimeout(function() {
-      App.checkDisabledState(input, 'submitting ...')
-      start()
+      App.checkDisabledState(assert, input, 'submitting ...')
+      done()
     }, 30)
   })
   form.triggerNative('submit')
 
   setTimeout(function() {
-    App.checkDisabledState(input, 'submitting ...')
+    App.checkDisabledState(assert, input, 'submitting ...')
+    done()
   }, 30)
 })
 
-test('form input[type=submit][data-disable-with] re-enables when `pageshow` event is triggered', function() {
-  var form = $('form:not([data-remote])'), input = form.find('input[type=submit]')
+QUnit.test('form input[type=submit][data-disable-with] re-enables when `pageshow` event is triggered', function(assert) {
+  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
 
-  App.checkEnabledState(input, 'Submit')
+  App.checkEnabledState(assert, input, 'Submit')
 
   // Emulate the disabled state without submitting the form at all, what is the
   // state after going back on firefox after submitting a form.
@@ -145,14 +163,17 @@ test('form input[type=submit][data-disable-with] re-enables when `pageshow` even
   // See https://github.com/rails/jquery-ujs/issues/357
   $.rails.disableElement(form[0])
 
-  App.checkDisabledState(input, 'submitting ...')
+  App.checkDisabledState(assert, input, 'submitting ...')
 
   $(window).triggerNative('pageshow')
 
-  App.checkEnabledState(input, 'Submit')
+  App.checkEnabledState(assert, input, 'Submit')
 })
 
-asyncTest('form[data-remote] input[type=submit][data-disable-with] is replaced in ajax callback', 2, function() {
+QUnit.test('form[data-remote] input[type=submit][data-disable-with] is replaced in ajax callback', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   var form = $('#qunit-fixture form:not([data-remote])').attr('data-remote', 'true'),
       origFormContents = form.html()
 
@@ -161,13 +182,16 @@ asyncTest('form[data-remote] input[type=submit][data-disable-with] is replaced i
 
     setTimeout(function() {
       var input = form.find('input[type=submit]')
-      App.checkEnabledState(input, 'Submit')
-      start()
+      App.checkEnabledState(assert, input, 'Submit')
+      done()
     }, 30)
   }).triggerNative('submit')
 })
 
-asyncTest('form[data-remote] input[data-disable-with] is replaced with disabled field in ajax callback', 2, function() {
+QUnit.test('form[data-remote] input[data-disable-with] is replaced with disabled field in ajax callback', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   var form = $('#qunit-fixture form:not([data-remote])').attr('data-remote', 'true'),
       input = form.find('input[type=submit]'),
       newDisabledInput = input.clone().attr('disabled', 'disabled')
@@ -176,140 +200,164 @@ asyncTest('form[data-remote] input[data-disable-with] is replaced with disabled 
     input.replaceWith(newDisabledInput)
 
     setTimeout(function() {
-      App.checkEnabledState(newDisabledInput, 'Submit')
-      start()
+      App.checkEnabledState(assert, newDisabledInput, 'Submit')
+      done()
     }, 30)
   }).triggerNative('submit')
 })
 
-asyncTest('form input[type=submit][data-disable-with] using "form" attribute disables', 6, function() {
+QUnit.test('form input[type=submit][data-disable-with] using "form" attribute disables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var form = $('#not_remote'), input = $('input[form=not_remote]')
-  App.checkEnabledState(input, 'Form Attr Submit')
+  App.checkEnabledState(assert, input, 'Form Attr Submit')
 
   $(document).bind('iframe:loaded', function(e, data) {
     setTimeout(function() {
-      App.checkDisabledState(input, 'form attr submitting')
-      start()
+      App.checkDisabledState(assert, input, 'form attr submitting')
+      done()
     }, 30)
   })
   form.triggerNative('submit')
 
   setTimeout(function() {
-    App.checkDisabledState(input, 'form attr submitting')
+    App.checkDisabledState(assert, input, 'form attr submitting')
   }, 30)
 
 })
 
-asyncTest('form[data-remote] textarea[data-disable-with] attribute', 3, function() {
-  var form = $('form[data-remote]'),
+QUnit.test('form[data-remote] textarea[data-disable-with] attribute', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'),
       textarea = $('<textarea data-disable-with="processing ..." name="user_bio">born, lived, died.</textarea>').appendTo(form)
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      equal(data.params.user_bio, 'born, lived, died.')
-      start()
+      assert.equal(data.params.user_bio, 'born, lived, died.')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(textarea, 'processing ...')
+  App.checkDisabledState(assert, textarea, 'processing ...')
 })
 
-asyncTest('a[data-disable-with] disables', 4, function() {
+QUnit.test('a[data-disable-with] disables', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click')
-  App.checkDisabledState(link, 'clicking...')
-  start()
+  App.checkDisabledState(assert, link, 'clicking...')
+  done()
 })
 
-test('a[data-disable-with] re-enables when `pageshow` event is triggered', function() {
+QUnit.test('a[data-disable-with] re-enables when `pageshow` event is triggered', function(assert) {
   var link = $('a[data-disable-with]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click')
-  App.checkDisabledState(link, 'clicking...')
+  App.checkDisabledState(assert, link, 'clicking...')
 
   $(window).triggerNative('pageshow')
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 })
 
-asyncTest('a[data-remote][data-disable-with] disables and re-enables', 6, function() {
+QUnit.test('a[data-remote][data-disable-with] disables and re-enables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:beforeSend', function() {
-      App.checkDisabledState(link, 'clicking...')
+      App.checkDisabledState(assert, link, 'clicking...')
     })
     .bindNative('ajax:complete', function() {
       setTimeout( function() {
-        App.checkEnabledState(link, 'Click me')
-        start()
+        App.checkEnabledState(assert, link, 'Click me')
+        done()
       }, 15)
     })
     .triggerNative('click')
 })
 
-asyncTest('a[data-remote][data-disable-with] re-enables when `ajax:before` event is cancelled', 6, function() {
+QUnit.test('a[data-remote][data-disable-with] re-enables when `ajax:before` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:before', function(e) {
-      App.checkDisabledState(link, 'clicking...')
+      App.checkDisabledState(assert, link, 'clicking...')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('a[data-remote][data-disable-with] re-enables when `ajax:beforeSend` event is cancelled', 6, function() {
+QUnit.test('a[data-remote][data-disable-with] re-enables when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:beforeSend', function(e) {
-      App.checkDisabledState(link, 'clicking...')
+      App.checkDisabledState(assert, link, 'clicking...')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('a[data-remote][data-disable-with] re-enables when `ajax:error` event is triggered', 6, function() {
+QUnit.test('a[data-remote][data-disable-with] re-enables when `ajax:error` event is triggered', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]').attr('data-remote', true).attr('href', '/error')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:beforeSend', function() {
-      App.checkDisabledState(link, 'clicking...')
+      App.checkDisabledState(assert, link, 'clicking...')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('form[data-remote] input|button|textarea[data-disable-with] does not disable when `ajax:beforeSend` event is cancelled', 8, function() {
-  var form = $('form[data-remote]'),
+QUnit.test('form[data-remote] input|button|textarea[data-disable-with] does not disable when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(8)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'),
       input = form.find('input:text'),
       button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>').appendTo(form),
       textarea = $('<textarea data-disable-with="processing ..." name="user_bio">born, lived, died.</textarea>').appendTo(form),
@@ -322,113 +370,131 @@ asyncTest('form[data-remote] input|button|textarea[data-disable-with] does not d
     })
     .triggerNative('submit')
 
-  App.checkEnabledState(input, 'john')
-  App.checkEnabledState(button, 'Submit')
-  App.checkEnabledState(textarea, 'born, lived, died.')
-  App.checkEnabledState(submit, 'Submit')
+  App.checkEnabledState(assert, input, 'john')
+  App.checkEnabledState(assert, button, 'Submit')
+  App.checkEnabledState(assert, textarea, 'born, lived, died.')
+  App.checkEnabledState(assert, submit, 'Submit')
 
-  start()
+  done()
 })
 
-asyncTest('ctrl-clicking on a link does not disable the link', 6, function() {
+QUnit.test('ctrl-clicking on a link does not disable the link', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { metaKey: true })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { metaKey: true })
-  App.checkEnabledState(link, 'Click me')
-  start()
+  App.checkEnabledState(assert, link, 'Click me')
+  done()
 })
 
-asyncTest('right/mouse-wheel-clicking on a link does not disable the link', 10, function() {
+QUnit.test('right/mouse-wheel-clicking on a link does not disable the link', function(assert) {
+  assert.expect(10)
+  var done = assert.async()
+
   var link = $('a[data-disable-with]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 1 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 1 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 2 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 2 })
-  App.checkEnabledState(link, 'Click me')
-  start()
+  App.checkEnabledState(assert, link, 'Click me')
+  done()
 })
 
-asyncTest('button[data-remote][data-disable-with] disables and re-enables', 6, function() {
+QUnit.test('button[data-remote][data-disable-with] disables and re-enables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable-with]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(button, 'clicking...')
+      App.checkDisabledState(assert, button, 'clicking...')
     })
     .bindNative('ajax:complete', function() {
       setTimeout( function() {
-        App.checkEnabledState(button, 'Click me')
-        start()
+        App.checkEnabledState(assert, button, 'Click me')
+        done()
       }, 15)
     })
     .triggerNative('click')
 })
 
-asyncTest('button[data-remote][data-disable-with] re-enables when `ajax:before` event is cancelled', 6, function() {
+QUnit.test('button[data-remote][data-disable-with] re-enables when `ajax:before` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable-with]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:before', function(e) {
-      App.checkDisabledState(button, 'clicking...')
+      App.checkDisabledState(assert, button, 'clicking...')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('button[data-remote][data-disable-with] re-enables when `ajax:beforeSend` event is cancelled', 6, function() {
+QUnit.test('button[data-remote][data-disable-with] re-enables when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable-with]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:beforeSend', function(e) {
-      App.checkDisabledState(button, 'clicking...')
+      App.checkDisabledState(assert, button, 'clicking...')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('button[data-remote][data-disable-with] re-enables when `ajax:error` event is triggered', 6, function() {
+QUnit.test('button[data-remote][data-disable-with] re-enables when `ajax:error` event is triggered', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('a[data-disable-with]').attr('data-remote', true).attr('href', '/error')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(button, 'clicking...')
+      App.checkDisabledState(assert, button, 'clicking...')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })

--- a/actionview/test/ujs/public/test/data-disable-with.js
+++ b/actionview/test/ujs/public/test/data-disable-with.js
@@ -1,16 +1,16 @@
 QUnit.module('data-disable-with', {
   beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
-      class: 'rails-ujs-target',
+      class: 'qunit-target',
       action: '/echo',
       'data-remote': 'true',
       method: 'post'
     }))
-      .find('form.rails-ujs-target')
+      .find('form.qunit-target')
       .append($('<input type="text" data-disable-with="processing ..." name="user_name" value="john" />'))
 
     $('#qunit-fixture').append($('<form />', {
-      class: 'rails-ujs-target',
+      class: 'qunit-target',
       action: '/echo',
       method: 'post',
       id: 'not_remote'
@@ -49,7 +49,7 @@ QUnit.test('form input field with "data-disable-with" attribute', function(asser
   assert.expect(7)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
+  var form = $('form.qunit-target[data-remote]'), input = form.find('input[type=text]')
 
   App.checkEnabledState(assert, input, 'john')
 
@@ -69,7 +69,7 @@ QUnit.test('blank form input field with "data-disable-with" attribute', function
   assert.expect(7)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
+  var form = $('form.qunit-target[data-remote]'), input = form.find('input[type=text]')
 
   input.val('')
   App.checkEnabledState(assert, input, '')
@@ -90,7 +90,7 @@ QUnit.test('form button with "data-disable-with" attribute', function(assert) {
   assert.expect(6)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'), button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>')
+  var form = $('form.qunit-target[data-remote]'), button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>')
   form.append(button)
 
   App.checkEnabledState(assert, button, 'Submit')
@@ -110,7 +110,7 @@ QUnit.test('a[data-remote][data-disable-with] within a form disables and re-enab
   assert.expect(6)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target:not([data-remote])'),
+  var form = $('form.qunit-target:not([data-remote])'),
       link = $('<a data-remote="true" data-disable-with="clicking...">Click me</a>')
   form.append(link)
 
@@ -134,7 +134,7 @@ QUnit.test('form input[type=submit][data-disable-with] disables', function(asser
   assert.expect(6)
   var done = assert.async(2)
 
-  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
+  var form = $('form.qunit-target:not([data-remote])'), input = form.find('input[type=submit]')
 
   App.checkEnabledState(assert, input, 'Submit')
 
@@ -153,7 +153,7 @@ QUnit.test('form input[type=submit][data-disable-with] disables', function(asser
 })
 
 QUnit.test('form input[type=submit][data-disable-with] re-enables when `pageshow` event is triggered', function(assert) {
-  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
+  var form = $('form.qunit-target:not([data-remote])'), input = form.find('input[type=submit]')
 
   App.checkEnabledState(assert, input, 'Submit')
 
@@ -231,7 +231,7 @@ QUnit.test('form[data-remote] textarea[data-disable-with] attribute', function(a
   assert.expect(3)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'),
+  var form = $('form.qunit-target[data-remote]'),
       textarea = $('<textarea data-disable-with="processing ..." name="user_bio">born, lived, died.</textarea>').appendTo(form)
 
   form.bindNative('ajax:success', function(e, data) {
@@ -357,7 +357,7 @@ QUnit.test('form[data-remote] input|button|textarea[data-disable-with] does not 
   assert.expect(8)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'),
+  var form = $('form.qunit-target[data-remote]'),
       input = form.find('input:text'),
       button = $('<button data-disable-with="submitting ..." name="submit2">Submit</button>').appendTo(form),
       textarea = $('<textarea data-disable-with="processing ..." name="user_bio">born, lived, died.</textarea>').appendTo(form),

--- a/actionview/test/ujs/public/test/data-disable.js
+++ b/actionview/test/ujs/public/test/data-disable.js
@@ -1,14 +1,16 @@
-module('data-disable', {
-  setup: function() {
+QUnit.module('data-disable', {
+  beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
+      class: 'rails-ujs-target',
       action: '/echo',
       'data-remote': 'true',
       method: 'post'
     }))
-      .find('form')
+      .find('form.rails-ujs-target')
       .append($('<input type="text" data-disable name="user_name" value="john" />'))
 
-    $('#qunit-fixture').append($('<form />', {
+    $('#qunit-fixture').append($('<form  />', {
+      class: 'rails-ujs-target',
       action: '/echo',
       method: 'post'
     }))
@@ -29,68 +31,80 @@ module('data-disable', {
       'data-disable': 'true'
     }))
   },
-  teardown: function() {
+  afterEach: function() {
     $(document).unbind('iframe:loaded')
   }
 })
 
-asyncTest('form input field with "data-disable" attribute', 7, function() {
-  var form = $('form[data-remote]'), input = form.find('input[type=text]')
+QUnit.test('form input field with "data-disable" attribute', function(assert) {
+  assert.expect(7)
+  var done = assert.async()
 
-  App.checkEnabledState(input, 'john')
+  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
+
+  App.checkEnabledState(assert, input, 'john')
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      App.checkEnabledState(input, 'john')
-      equal(data.params.user_name, 'john')
-      start()
+      App.checkEnabledState(assert, input, 'john')
+      assert.equal(data.params.user_name, 'john')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(input, 'john')
+  App.checkDisabledState(assert, input, 'john')
 })
 
-asyncTest('form button with "data-disable" attribute', 7, function() {
-  var form = $('form[data-remote]'), button = $('<button data-disable name="submit2">Submit</button>')
+QUnit.test('form button with "data-disable" attribute', function(assert) {
+  assert.expect(7)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'), button = $('<button data-disable name="submit2">Submit</button>')
   form.append(button)
 
-  App.checkEnabledState(button, 'Submit')
+  App.checkEnabledState(assert, button, 'Submit')
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      App.checkEnabledState(button, 'Submit')
-      start()
+      App.checkEnabledState(assert, button, 'Submit')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(button, 'Submit')
-  equal(button.data('ujs:enable-with'), undefined)
+  App.checkDisabledState(assert, button, 'Submit')
+  assert.equal(button.data('ujs:enable-with'), undefined)
 })
 
-asyncTest('form input[type=submit][data-disable] disables', 6, function() {
-  var form = $('form:not([data-remote])'), input = form.find('input[type=submit]')
+QUnit.test('form input[type=submit][data-disable] disables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
 
-  App.checkEnabledState(input, 'Submit')
+  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
+
+  App.checkEnabledState(assert, input, 'Submit')
 
   // WEEIRDD: attaching this handler makes the test work in IE7
   $(document).bind('iframe:loading', function(e, f) {})
 
   $(document).bind('iframe:loaded', function(e, data) {
     setTimeout(function() {
-      App.checkDisabledState(input, 'Submit')
-      start()
+      App.checkDisabledState(assert, input, 'Submit')
+      done()
     }, 30)
   })
   form.triggerNative('submit')
 
   setTimeout(function() {
-    App.checkDisabledState(input, 'Submit')
+    App.checkDisabledState(assert, input, 'Submit')
   }, 30)
 })
 
-asyncTest('form[data-remote] input[type=submit][data-disable] is replaced in ajax callback', 2, function() {
+QUnit.test('form[data-remote] input[type=submit][data-disable] is replaced in ajax callback', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   var form = $('#qunit-fixture form:not([data-remote])').attr('data-remote', 'true'), origFormContents = form.html()
 
   form.bindNative('ajax:success', function() {
@@ -98,13 +112,16 @@ asyncTest('form[data-remote] input[type=submit][data-disable] is replaced in aja
 
     setTimeout(function() {
       var input = form.find('input[type=submit]')
-      App.checkEnabledState(input, 'Submit')
-      start()
+      App.checkEnabledState(assert, input, 'Submit')
+      done()
     }, 30)
   }).triggerNative('submit')
 })
 
-asyncTest('form[data-remote] input[data-disable] is replaced with disabled field in ajax callback', 2, function() {
+QUnit.test('form[data-remote] input[data-disable] is replaced with disabled field in ajax callback', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   var form = $('#qunit-fixture form:not([data-remote])').attr('data-remote', 'true'), input = form.find('input[type=submit]'),
       newDisabledInput = input.clone().attr('disabled', 'disabled')
 
@@ -112,111 +129,132 @@ asyncTest('form[data-remote] input[data-disable] is replaced with disabled field
     input.replaceWith(newDisabledInput)
 
     setTimeout(function() {
-      App.checkEnabledState(newDisabledInput, 'Submit')
-      start()
+      App.checkEnabledState(assert, newDisabledInput, 'Submit')
+      done()
     }, 30)
   }).triggerNative('submit')
 })
 
-asyncTest('form[data-remote] textarea[data-disable] attribute', 3, function() {
-  var form = $('form[data-remote]'),
+QUnit.test('form[data-remote] textarea[data-disable] attribute', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'),
       textarea = $('<textarea data-disable name="user_bio">born, lived, died.</textarea>').appendTo(form)
 
   form.bindNative('ajax:success', function(e, data) {
     setTimeout(function() {
-      equal(data.params.user_bio, 'born, lived, died.')
-      start()
+      assert.equal(data.params.user_bio, 'born, lived, died.')
+      done()
     }, 13)
   })
   form.triggerNative('submit')
 
-  App.checkDisabledState(textarea, 'born, lived, died.')
+  App.checkDisabledState(assert, textarea, 'born, lived, died.')
 })
 
-asyncTest('a[data-disable] disables', 5, function() {
+QUnit.test('a[data-disable] disables', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+
   var link = $('a[data-disable]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click')
-  App.checkDisabledState(link, 'Click me')
-  equal(link.data('ujs:enable-with'), undefined)
-  start()
+  App.checkDisabledState(assert, link, 'Click me')
+  assert.equal(link.data('ujs:enable-with'), undefined)
+  done()
 })
 
-asyncTest('a[data-remote][data-disable] disables and re-enables', 6, function() {
+QUnit.test('a[data-remote][data-disable] disables and re-enables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(link, 'Click me')
+      App.checkDisabledState(assert, link, 'Click me')
     })
     .bindNative('ajax:complete', function() {
       setTimeout( function() {
-        App.checkEnabledState(link, 'Click me')
-        start()
+        App.checkEnabledState(assert, link, 'Click me')
+        done()
       }, 15)
     })
     .triggerNative('click')
 })
 
-asyncTest('a[data-remote][data-disable] re-enables when `ajax:before` event is cancelled', 6, function() {
+QUnit.test('a[data-remote][data-disable] re-enables when `ajax:before` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:before', function(e) {
-      App.checkDisabledState(link, 'Click me')
+      App.checkDisabledState(assert, link, 'Click me')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('a[data-remote][data-disable] re-enables when `ajax:beforeSend` event is cancelled', 6, function() {
+QUnit.test('a[data-remote][data-disable] re-enables when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]').attr('data-remote', true)
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:beforeSend', function(e) {
-      App.checkDisabledState(link, 'Click me')
+      App.checkDisabledState(assert, link, 'Click me')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('a[data-remote][data-disable] re-enables when `ajax:error` event is triggered', 6, function() {
+QUnit.test('a[data-remote][data-disable] re-enables when `ajax:error` event is triggered', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]').attr('data-remote', true).attr('href', '/error')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(link, 'Click me')
+      App.checkDisabledState(assert, link, 'Click me')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(link, 'Click me')
-    start()
+    App.checkEnabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('form[data-remote] input|button|textarea[data-disable] does not disable when `ajax:beforeSend` event is cancelled', 8, function() {
-  var form = $('form[data-remote]'),
+QUnit.test('form[data-remote] input|button|textarea[data-disable] does not disable when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(8)
+  var done = assert.async()
+
+  var form = $('form.rails-ujs-target[data-remote]'),
       input = form.find('input:text'),
       button = $('<button data-disable="submitting ..." name="submit2">Submit</button>').appendTo(form),
       textarea = $('<textarea data-disable name="user_bio">born, lived, died.</textarea>').appendTo(form),
@@ -229,130 +267,151 @@ asyncTest('form[data-remote] input|button|textarea[data-disable] does not disabl
     })
     .triggerNative('submit')
 
-  App.checkEnabledState(input, 'john')
-  App.checkEnabledState(button, 'Submit')
-  App.checkEnabledState(textarea, 'born, lived, died.')
-  App.checkEnabledState(submit, 'Submit')
+  App.checkEnabledState(assert, input, 'john')
+  App.checkEnabledState(assert, button, 'Submit')
+  App.checkEnabledState(assert, textarea, 'born, lived, died.')
+  App.checkEnabledState(assert, submit, 'Submit')
 
-  start()
+  done()
 })
 
-asyncTest('ctrl-clicking on a link does not disables the link', 6, function() {
+QUnit.test('ctrl-clicking on a link does not disables the link', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { metaKey: true })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { ctrlKey: true })
-  App.checkEnabledState(link, 'Click me')
-  start()
+  App.checkEnabledState(assert, link, 'Click me')
+  done()
 })
 
-asyncTest('right/mouse-wheel-clicking on a link does not disable the link', 10, function() {
+QUnit.test('right/mouse-wheel-clicking on a link does not disable the link', function(assert) {
+  assert.expect(10)
+  var done = assert.async()
+
   var link = $('a[data-disable]')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 1 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 1 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 2 })
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link.triggerNative('click', { button: 2 })
-  App.checkEnabledState(link, 'Click me')
-  start()
+  App.checkEnabledState(assert, link, 'Click me')
+  done()
 })
 
-asyncTest('button[data-remote][data-disable] disables and re-enables', 6, function() {
+QUnit.test('button[data-remote][data-disable] disables and re-enables', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(button, 'Click me')
+      App.checkDisabledState(assert, button, 'Click me')
     })
     .bindNative('ajax:complete', function() {
       setTimeout( function() {
-        App.checkEnabledState(button, 'Click me')
-        start()
+        App.checkEnabledState(assert, button, 'Click me')
+        done()
       }, 15)
     })
     .triggerNative('click')
 })
 
-asyncTest('button[data-remote][data-disable] re-enables when `ajax:before` event is cancelled', 6, function() {
+QUnit.test('button[data-remote][data-disable] re-enables when `ajax:before` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:before', function(e) {
-      App.checkDisabledState(button, 'Click me')
+      App.checkDisabledState(assert, button, 'Click me')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('button[data-remote][data-disable] re-enables when `ajax:beforeSend` event is cancelled', 6, function() {
+QUnit.test('button[data-remote][data-disable] re-enables when `ajax:beforeSend` event is cancelled', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('button[data-remote][data-disable]')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:beforeSend', function(e) {
-      App.checkDisabledState(button, 'Click me')
+      App.checkDisabledState(assert, button, 'Click me')
       e.preventDefault()
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('button[data-remote][data-disable] re-enables when `ajax:error` event is triggered', 6, function() {
+QUnit.test('button[data-remote][data-disable] re-enables when `ajax:error` event is triggered', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var button = $('a[data-disable]').attr('data-remote', true).attr('href', '/error')
 
-  App.checkEnabledState(button, 'Click me')
+  App.checkEnabledState(assert, button, 'Click me')
 
   button
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(button, 'Click me')
+      App.checkDisabledState(assert, button, 'Click me')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkEnabledState(button, 'Click me')
-    start()
+    App.checkEnabledState(assert, button, 'Click me')
+    done()
   }, 30)
 })
 
-asyncTest('do not enable elements for XHR redirects', 6, function() {
+QUnit.test('do not enable elements for XHR redirects', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   var link = $('a[data-disable]').attr('data-remote', true).attr('href', '/echo?with_xhr_redirect=true')
 
-  App.checkEnabledState(link, 'Click me')
+  App.checkEnabledState(assert, link, 'Click me')
 
   link
     .bindNative('ajax:send', function() {
-      App.checkDisabledState(link, 'Click me')
+      App.checkDisabledState(assert, link, 'Click me')
     })
     .triggerNative('click')
 
   setTimeout(function() {
-    App.checkDisabledState(link, 'Click me')
-    start()
+    App.checkDisabledState(assert, link, 'Click me')
+    done()
   }, 30)
 })

--- a/actionview/test/ujs/public/test/data-disable.js
+++ b/actionview/test/ujs/public/test/data-disable.js
@@ -1,16 +1,16 @@
 QUnit.module('data-disable', {
   beforeEach: function() {
     $('#qunit-fixture').append($('<form />', {
-      class: 'rails-ujs-target',
+      class: 'qunit-target',
       action: '/echo',
       'data-remote': 'true',
       method: 'post'
     }))
-      .find('form.rails-ujs-target')
+      .find('form.qunit-target')
       .append($('<input type="text" data-disable name="user_name" value="john" />'))
 
     $('#qunit-fixture').append($('<form  />', {
-      class: 'rails-ujs-target',
+      class: 'qunit-target',
       action: '/echo',
       method: 'post'
     }))
@@ -40,7 +40,7 @@ QUnit.test('form input field with "data-disable" attribute', function(assert) {
   assert.expect(7)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'), input = form.find('input[type=text]')
+  var form = $('form.qunit-target[data-remote]'), input = form.find('input[type=text]')
 
   App.checkEnabledState(assert, input, 'john')
 
@@ -60,7 +60,7 @@ QUnit.test('form button with "data-disable" attribute', function(assert) {
   assert.expect(7)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'), button = $('<button data-disable name="submit2">Submit</button>')
+  var form = $('form.qunit-target[data-remote]'), button = $('<button data-disable name="submit2">Submit</button>')
   form.append(button)
 
   App.checkEnabledState(assert, button, 'Submit')
@@ -81,7 +81,7 @@ QUnit.test('form input[type=submit][data-disable] disables', function(assert) {
   assert.expect(6)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target:not([data-remote])'), input = form.find('input[type=submit]')
+  var form = $('form.qunit-target:not([data-remote])'), input = form.find('input[type=submit]')
 
   App.checkEnabledState(assert, input, 'Submit')
 
@@ -139,7 +139,7 @@ QUnit.test('form[data-remote] textarea[data-disable] attribute', function(assert
   assert.expect(3)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'),
+  var form = $('form.qunit-target[data-remote]'),
       textarea = $('<textarea data-disable name="user_bio">born, lived, died.</textarea>').appendTo(form)
 
   form.bindNative('ajax:success', function(e, data) {
@@ -254,7 +254,7 @@ QUnit.test('form[data-remote] input|button|textarea[data-disable] does not disab
   assert.expect(8)
   var done = assert.async()
 
-  var form = $('form.rails-ujs-target[data-remote]'),
+  var form = $('form.qunit-target[data-remote]'),
       input = form.find('input:text'),
       button = $('<button data-disable="submitting ..." name="submit2">Submit</button>').appendTo(form),
       textarea = $('<textarea data-disable name="user_bio">born, lived, died.</textarea>').appendTo(form),

--- a/actionview/test/ujs/public/test/data-method.js
+++ b/actionview/test/ujs/public/test/data-method.js
@@ -1,62 +1,77 @@
 (function() {
 
-module('data-method', {
-  setup: function() {
+QUnit.module('data-method', {
+  beforeEach: function() {
     $('#qunit-fixture').append($('<a />', {
       href: '/echo', 'data-method': 'delete', text: 'destroy!'
     }))
   },
-  teardown: function() {
+  afterEach: function() {
     $(document).unbind('iframe:loaded')
   }
 })
 
-function submit(fn, options) {
+function submit(done, fn, options) {
   $(document).bind('iframe:loaded', function(e, data) {
     fn(data)
-    start()
+    done()
   })
 
   $('#qunit-fixture').find('a')
     .triggerNative('click')
 }
 
-asyncTest('link with "data-method" set to "delete"', 3, function() {
-  submit(function(data) {
-    equal(data.REQUEST_METHOD, 'DELETE')
-    strictEqual(data.params.authenticity_token, undefined)
-    strictEqual(data.HTTP_X_CSRF_TOKEN, undefined)
+QUnit.test('link with "data-method" set to "delete"', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
+  submit(done, function(data) {
+    assert.equal(data.REQUEST_METHOD, 'DELETE')
+    assert.strictEqual(data.params.authenticity_token, undefined)
+    assert.strictEqual(data.HTTP_X_CSRF_TOKEN, undefined)
   })
 })
 
-asyncTest('click on the child of link with "data-method"', 3, function() {
+QUnit.test('click on the child of link with "data-method"', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
   $(document).bind('iframe:loaded', function(e, data) {
-    equal(data.REQUEST_METHOD, 'DELETE')
-    strictEqual(data.params.authenticity_token, undefined)
-    strictEqual(data.HTTP_X_CSRF_TOKEN, undefined)
-    start()
+    assert.equal(data.REQUEST_METHOD, 'DELETE')
+    assert.strictEqual(data.params.authenticity_token, undefined)
+    assert.strictEqual(data.HTTP_X_CSRF_TOKEN, undefined)
+    done()
   })
   $('#qunit-fixture a').html('<strong>destroy!</strong>').find('strong').triggerNative('click')
 })
 
-asyncTest('link with "data-method" and CSRF', 1, function() {
+QUnit.test('link with "data-method" and CSRF', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   $('#qunit-fixture')
     .append('<meta name="csrf-param" content="authenticity_token"/>')
     .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>')
 
-  submit(function(data) {
-    equal(data.params.authenticity_token, 'cf50faa3fe97702ca1ae')
+  submit(done, function(data) {
+    assert.equal(data.params.authenticity_token, 'cf50faa3fe97702ca1ae')
   })
 })
 
-asyncTest('link "target" should be carried over to generated form', 1, function() {
+QUnit.test('link "target" should be carried over to generated form', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   $('a[data-method]').attr('target', 'super-special-frame')
-  submit(function(data) {
-    equal(data.params._target, 'super-special-frame')
+  submit(done, function(data) {
+    assert.equal(data.params._target, 'super-special-frame')
   })
 })
 
-asyncTest('link with "data-method" and cross origin', 1, function() {
+QUnit.test('link with "data-method" and cross origin', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var data = {}
 
   $('#qunit-fixture')
@@ -77,9 +92,9 @@ asyncTest('link with "data-method" and cross origin', 1, function() {
 
   link.triggerNative('click')
 
-  start()
+  done()
 
-  notEqual(data.authenticity_token, 'cf50faa3fe97702ca1ae')
+  assert.notEqual(data.authenticity_token, 'cf50faa3fe97702ca1ae')
 })
 
 })()

--- a/actionview/test/ujs/public/test/data-method.js
+++ b/actionview/test/ujs/public/test/data-method.js
@@ -78,7 +78,7 @@ QUnit.test('link with "data-method" and cross origin', function(assert) {
     .append('<meta name="csrf-param" content="authenticity_token"/>')
     .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>')
 
-  $(document).on('submit', 'form.rails-ujs-target', function(e) {
+  $(document).on('submit', 'form.qunit-target', function(e) {
     $(e.currentTarget).serializeArray().map(function(item) {
       data[item.name] = item.value
     })

--- a/actionview/test/ujs/public/test/data-method.js
+++ b/actionview/test/ujs/public/test/data-method.js
@@ -78,7 +78,7 @@ QUnit.test('link with "data-method" and cross origin', function(assert) {
     .append('<meta name="csrf-param" content="authenticity_token"/>')
     .append('<meta name="csrf-token" content="cf50faa3fe97702ca1ae"/>')
 
-  $(document).on('submit', 'form', function(e) {
+  $(document).on('submit', 'form.rails-ujs-target', function(e) {
     $(e.currentTarget).serializeArray().map(function(item) {
       data[item.name] = item.value
     })

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -12,8 +12,8 @@ function buildSelect(attrs) {
   )
 }
 
-module('data-remote', {
-  setup: function() {
+QUnit.module('data-remote', {
+  beforeEach: function() {
     $('#qunit-fixture')
       .append($('<a />', {
         href: '/echo',
@@ -39,12 +39,15 @@ module('data-remote', {
         disabled: 'disabled',
         text: 'Disabed link'
       }))
-      .find('form').append($('<input type="text" name="user_name" value="john">'))
+      .find('form#my-remote-form').append($('<input type="text" name="user_name" value="john">'))
 
   }
 })
 
-asyncTest('ctrl-clicking on a link does not fire ajaxyness', 0, function() {
+QUnit.test('ctrl-clicking on a link does not fire ajaxyness', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   var link = $('a[data-remote]')
 
   // Ideally, we'd setup an iframe to intercept normal link clicks
@@ -54,16 +57,19 @@ asyncTest('ctrl-clicking on a link does not fire ajaxyness', 0, function() {
   link
     .removeAttr('data-params')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
 
   link.triggerNative('click', { metaKey: true })
   link.triggerNative('click', { ctrlKey: true })
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('right/mouse-wheel-clicking on a link does not fire ajaxyness', 0, function() {
+QUnit.test('right/mouse-wheel-clicking on a link does not fire ajaxyness', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   var link = $('a[data-remote]')
 
   // Ideally, we'd setup an iframe to intercept normal link clicks
@@ -73,23 +79,26 @@ asyncTest('right/mouse-wheel-clicking on a link does not fire ajaxyness', 0, fun
   link
     .removeAttr('data-params')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
 
   link.triggerNative('click', { button: 1 })
   link.triggerNative('click', { button: 2 })
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('ctrl-clicking on a link still fires ajax for non-GET links and for links with "data-params"', 2, function() {
+QUnit.test('ctrl-clicking on a link still fires ajax for non-GET links and for links with "data-params"', function(assert) {
+  assert.expect(2)
+  var done = assert.async()
+
   var link = $('a[data-remote]')
 
   link
     .removeAttr('data-params')
     .attr('data-method', 'POST')
     .bindNative('ajax:beforeSend', function() {
-      ok(true, 'ajax should be triggered')
+      assert.ok(true, 'ajax should be triggered')
     })
     .triggerNative('click', { metaKey: true })
 
@@ -98,76 +107,94 @@ asyncTest('ctrl-clicking on a link still fires ajax for non-GET links and for li
     .attr('data-params', 'name=steve')
     .triggerNative('click', { metaKey: true })
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('clicking on a link with data-remote attribute', 5, function() {
+QUnit.test('clicking on a link with data-remote attribute', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+
   $('a[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
-      equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
+      assert.equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
+      App.assertGetRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('click')
 })
 
-asyncTest('clicking on a link with both query string in href and data-params', 4, function() {
+QUnit.test('clicking on a link with both query string in href and data-params', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
+
   $('a[data-remote]')
     .attr('href', '/echo?data3=value3')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertGetRequest(data)
-      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
-      equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
-      equal(data.params.data3, 'value3', 'query string in url should be passed to server with right value')
+      App.assertGetRequest(assert, data)
+      assert.equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
+      assert.equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
+      assert.equal(data.params.data3, 'value3', 'query string in url should be passed to server with right value')
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('click')
 })
 
-asyncTest('clicking on a link with both query string in href and data-params with POST method', 4, function() {
+QUnit.test('clicking on a link with both query string in href and data-params with POST method', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
+
   $('a[data-remote]')
     .attr('href', '/echo?data3=value3')
     .attr('data-method', 'post')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertPostRequest(data)
-      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
-      equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
-      equal(data.params.data3, 'value3', 'query string in url should be passed to server with right value')
+      App.assertPostRequest(assert, data)
+      assert.equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
+      assert.equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
+      assert.equal(data.params.data3, 'value3', 'query string in url should be passed to server with right value')
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('click')
 })
 
-asyncTest('clicking on a link with disabled attribute', 0, function() {
+QUnit.test('clicking on a link with disabled attribute', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   $('a[disabled]')
   .bindNative('ajax:before', function(e, data, status, xhr) {
-    App.assertCallbackNotInvoked('ajax:success')
+    App.assertCallbackNotInvoked(assert, 'ajax:success')
   })
-  .bindNative('ajax:complete', function() { start() })
+  .bindNative('ajax:complete', function() { done() })
   .triggerNative('click')
 
   setTimeout(function() {
-    start()
+    done()
   }, 13)
 })
 
-asyncTest('clicking on a button with data-remote attribute', 5, function() {
+QUnit.test('clicking on a button with data-remote attribute', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+
   $('button[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
-      equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
+      assert.equal(data.params.data2, 'value2', 'ajax arguments should have key data2 with right value')
+      App.assertGetRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('click')
 })
 
-asyncTest('right/mouse-wheel-clicking on a button with data-remote attribute does not fire ajaxyness', 0, function() {
+QUnit.test('right/mouse-wheel-clicking on a button with data-remote attribute does not fire ajaxyness', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   var button = $('button[data-remote]')
 
   // Ideally, we'd setup an iframe to intercept normal link clicks
@@ -177,86 +204,101 @@ asyncTest('right/mouse-wheel-clicking on a button with data-remote attribute doe
   button
     .removeAttr('data-params')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
 
   button.triggerNative('click', { button: 1 })
   button.triggerNative('click', { button: 2 })
 
-  setTimeout(function() { start() }, 13)
+  setTimeout(function() { done() }, 13)
 })
 
-asyncTest('changing a select option with data-remote attribute', 5, function() {
+QUnit.test('changing a select option with data-remote attribute', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+
   buildSelect()
 
   $('select[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.user_data, 'optionValue2', 'ajax arguments should have key term with right value')
-      equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
-      App.assertGetRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.user_data, 'optionValue2', 'ajax arguments should have key term with right value')
+      assert.equal(data.params.data1, 'value1', 'ajax arguments should have key data1 with right value')
+      App.assertGetRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .val('optionValue2')
     .triggerNative('change')
 })
 
-asyncTest('submitting form with data-remote attribute', 4, function() {
-  $('form[data-remote]')
+QUnit.test('submitting form with data-remote attribute', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
+
+  $('form#my-remote-form[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
-      App.assertPostRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
+      App.assertPostRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('submit')
 })
 
-asyncTest('submitting form with data-remote attribute should include inputs in a fieldset only once', 3, function() {
-  $('form[data-remote]')
+QUnit.test('submitting form with data-remote attribute should include inputs in a fieldset only once', function(assert) {
+  assert.expect(3)
+  var done = assert.async()
+
+  $('form#my-remote-form[data-remote]')
     .append('<fieldset><input name="items[]" value="Item" /></fieldset>')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      equal(data.params.items.length, 1, 'ajax arguments should only have the item once')
-      App.assertPostRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      assert.equal(data.params.items.length, 1, 'ajax arguments should only have the item once')
+      App.assertPostRequest(assert, data)
     })
     .bindNative('ajax:complete', function() {
       $('form[data-remote], fieldset').remove()
-      start()
+      done()
     })
     .triggerNative('submit')
 })
 
-asyncTest('submitting form with data-remote attribute submits input with matching [form] attribute', 6, function() {
+QUnit.test('submitting form with data-remote attribute submits input with matching [form] attribute', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
   $('#qunit-fixture')
     .append($('<input type="text" name="user_data" value="value1" form="my-remote-form">'))
     .append($('<input type="text" name="user_email" value="from@example.com" disabled="disabled" form="my-remote-form">'))
 
-  $('form[data-remote]')
+  $('form#my-remote-form[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
-      equal(data.params.user_data, 'value1', 'ajax arguments should have key user_data with right value')
-      equal(data.params.user_email, undefined, 'ajax arguments should not have disabled field')
-      App.assertPostRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
+      assert.equal(data.params.user_data, 'value1', 'ajax arguments should have key user_data with right value')
+      assert.equal(data.params.user_email, undefined, 'ajax arguments should not have disabled field')
+      App.assertPostRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
     .triggerNative('submit')
 })
 
-asyncTest('submitting form with data-remote attribute by clicking button with matching [form] attribute', 5, function() {
-  $('form[data-remote]')
+QUnit.test('submitting form with data-remote attribute by clicking button with matching [form] attribute', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
+
+  $('form#my-remote-form[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      App.assertCallbackInvoked('ajax:success')
-      App.assertRequestPath(data, '/echo')
-      equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
-      equal(data.params.user_data, 'value2', 'ajax arguments should have key user_data with right value')
-      App.assertPostRequest(data)
+      App.assertCallbackInvoked(assert, 'ajax:success')
+      App.assertRequestPath(assert, data, '/echo')
+      assert.equal(data.params.user_name, 'john', 'ajax arguments should have key user_name with right value')
+      assert.equal(data.params.user_data, 'value2', 'ajax arguments should have key user_data with right value')
+      App.assertPostRequest(assert, data)
     })
-    .bindNative('ajax:complete', function() { start() })
+    .bindNative('ajax:complete', function() { done() })
 
   $('<button />', {
         type: 'submit',
@@ -276,24 +318,27 @@ asyncTest('submitting form with data-remote attribute by clicking button with ma
     .triggerNative('click')
 })
 
-asyncTest('form\'s submit bindings in browsers that don\'t support submit bubbling', 5, function() {
-  var form = $('form[data-remote]'), directBindingCalled = false
+QUnit.test('form\'s submit bindings in browsers that don\'t support submit bubbling', function(assert) {
+  assert.expect(5)
+  var done = assert.async()
 
-  ok(!directBindingCalled, 'nothing is called')
+  var form = $('form#my-remote-form[data-remote]'), directBindingCalled = false
+
+  assert.ok(!directBindingCalled, 'nothing is called')
 
   form
     .append($('<input type="submit" />'))
     .bindNative('submit', function(event) {
-      ok(event.type == 'submit', 'submit event handlers are called with submit event')
-      ok(true, 'binding handler is called')
+      assert.ok(event.type == 'submit', 'submit event handlers are called with submit event')
+      assert.ok(true, 'binding handler is called')
       directBindingCalled = true
     })
     .bindNative('ajax:beforeSend', function() {
-      ok(true, 'form being submitted via ajax')
-      ok(directBindingCalled, 'binding handler already called')
+      assert.ok(true, 'form being submitted via ajax')
+      assert.ok(directBindingCalled, 'binding handler already called')
     })
     .bindNative('ajax:complete', function() {
-      start()
+      done()
     })
 
     if(!$.support.submitBubbles) {
@@ -305,18 +350,21 @@ asyncTest('form\'s submit bindings in browsers that don\'t support submit bubbli
     }
 })
 
-asyncTest('returning false in form\'s submit bindings in non-submit-bubbling browsers', 1, function() {
-  var form = $('form[data-remote]')
+QUnit.test('returning false in form\'s submit bindings in non-submit-bubbling browsers', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
+  var form = $('form#my-remote-form[data-remote]')
 
   form
     .append($('<input type="submit" />'))
     .bindNative('submit', function(e) {
-      ok(true, 'binding handler is called')
+      assert.ok(true, 'binding handler is called')
       e.preventDefault()
       e.stopPropagation()
     })
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'form should not be submitted')
+      assert.ok(false, 'form should not be submitted')
     })
 
     if (!$.support.submitBubbles) {
@@ -326,24 +374,30 @@ asyncTest('returning false in form\'s submit bindings in non-submit-bubbling bro
       form.triggerNative('submit')
     }
 
-    setTimeout(function() { start() }, 13)
+    setTimeout(function() { done() }, 13)
 })
 
-asyncTest('clicking on a link with falsy "data-remote" attribute does not fire ajaxyness', 0, function() {
+QUnit.test('clicking on a link with falsy "data-remote" attribute does not fire ajaxyness', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   $('a[data-remote]')
     .attr('data-remote', 'false')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
     .bindNative('click', function(e) {
       e.preventDefault()
     })
     .triggerNative('click')
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
-asyncTest('ctrl-clicking on a link with falsy "data-remote" attribute does not fire ajaxyness even if "data-params" present', 0, function() {
+QUnit.test('ctrl-clicking on a link with falsy "data-remote" attribute does not fire ajaxyness even if "data-params" present', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   var link = $('a[data-remote]')
 
   link
@@ -351,7 +405,7 @@ asyncTest('ctrl-clicking on a link with falsy "data-remote" attribute does not f
     .attr('data-remote', 'false')
     .attr('data-method', 'POST')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
     .bindNative('click', function(e) {
       e.preventDefault()
@@ -363,52 +417,64 @@ asyncTest('ctrl-clicking on a link with falsy "data-remote" attribute does not f
     .attr('data-params', 'name=steve')
     .triggerNative('click', { metaKey: true })
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
-asyncTest('clicking on a button with falsy "data-remote" attribute', 0, function() {
+QUnit.test('clicking on a button with falsy "data-remote" attribute', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   $('button[data-remote]:first')
     .attr('data-remote', 'false')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
     .bindNative('click', function(e) {
       e.preventDefault()
     })
     .triggerNative('click')
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
-asyncTest('submitting a form with falsy "data-remote" attribute', 0, function() {
+QUnit.test('submitting a form with falsy "data-remote" attribute', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   $('form[data-remote]:first')
     .attr('data-remote', 'false')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
     .bindNative('submit', function(e) {
       e.preventDefault()
     })
     .triggerNative('submit')
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
-asyncTest('changing a select option with falsy "data-remote" attribute', 0, function() {
+QUnit.test('changing a select option with falsy "data-remote" attribute', function(assert) {
+  assert.expect(0)
+  var done = assert.async()
+
   buildSelect({'data-remote': 'false'})
 
   $('select[data-remote=false]:first')
     .bindNative('ajax:beforeSend', function() {
-      ok(false, 'ajax should not be triggered')
+      assert.ok(false, 'ajax should not be triggered')
     })
     .val('optionValue2')
     .triggerNative('change')
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
-asyncTest('form should be serialized correctly', 6, function() {
-  $('form')
+QUnit.test('form should be serialized correctly', function(assert) {
+  assert.expect(6)
+  var done = assert.async()
+
+  $('form#my-remote-form[data-remote]')
     .append('<textarea name="textarea">textarea</textarea>')
     .append('<input type="checkbox" name="checkbox[]" value="0" />')
     .append('<input type="checkbox" checked="checked" name="checkbox[]" value="1" />')
@@ -421,35 +487,41 @@ asyncTest('form should be serialized correctly', 6, function() {
       <option selected>4</option>\
     </select>')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      equal(data.params.checkbox.length, 1)
-      equal(data.params.checkbox[0], '1')
-      equal(data.params.radio, '0')
-      equal(data.params.select.length, 3)
-      equal(data.params.select[2], '4')
-      equal(data.params.textarea, 'textarea')
+      assert.equal(data.params.checkbox.length, 1)
+      assert.equal(data.params.checkbox[0], '1')
+      assert.equal(data.params.radio, '0')
+      assert.equal(data.params.select.length, 3)
+      assert.equal(data.params.select[2], '4')
+      assert.equal(data.params.textarea, 'textarea')
 
-      start()
+      done()
     })
     .triggerNative('submit')
 })
 
-asyncTest('form buttons should only be serialized when clicked', 4, function() {
-  $('form')
+QUnit.test('form buttons should only be serialized when clicked', function(assert) {
+  assert.expect(4)
+  var done = assert.async()
+
+  $('form#my-remote-form[data-remote]')
     .append('<input type="submit" name="submit1" value="submit1" />')
     .append('<button name="submit2" value="submit2" />')
     .append('<button name="submit3" value="submit3" />')
     .bindNative('ajax:success', function(e, data, status, xhr) {
-      equal(data.params.submit1, undefined)
-      equal(data.params.submit2, 'submit2')
-      equal(data.params.submit3, undefined)
-      equal(data['rack.request.form_vars'], 'user_name=john&submit2=submit2')
+      assert.equal(data.params.submit1, undefined)
+      assert.equal(data.params.submit2, 'submit2')
+      assert.equal(data.params.submit3, undefined)
+      assert.equal(data['rack.request.form_vars'], 'user_name=john&submit2=submit2')
 
-      start()
+      done()
     })
     .find('[name=submit2]').triggerNative('click')
 })
 
-asyncTest('changing a select option without "data-url" attribute still fires ajax request to current location', 1, function() {
+QUnit.test('changing a select option without "data-url" attribute still fires ajax request to current location', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   var currentLocation, ajaxLocation
 
   buildSelect({'data-url': ''})
@@ -466,14 +538,14 @@ asyncTest('changing a select option without "data-url" attribute still fires aja
       }
 
       ajaxLocation = settings.url.replace(settings.data, '').replace(/&$/, '').replace(/\?$/, '')
-      equal(ajaxLocation, currentLocation, 'URL should be current page by default')
+      assert.equal(ajaxLocation, currentLocation, 'URL should be current page by default')
 
       e.preventDefault()
     })
     .val('optionValue2')
     .triggerNative('change')
 
-  setTimeout(function() { start() }, 20)
+  setTimeout(function() { done() }, 20)
 })
 
 })()

--- a/actionview/test/ujs/public/test/override.js
+++ b/actionview/test/ujs/public/test/override.js
@@ -2,55 +2,70 @@
 
 var realHref
 
-module('override', {
-  setup: function() {
+QUnit.module('override', {
+  beforeEach: function() {
     realHref = $.rails.href
     $('#qunit-fixture')
       .append($('<a />', {
         href: '/real/href', 'data-remote': 'true', 'data-method': 'delete', 'data-href': '/data/href'
       }))
   },
-  teardown: function() {
+  afterEach: function() {
     $.rails.href = realHref
   }
 })
 
-asyncTest('the getter for an element\'s href is publicly accessible', 1, function() {
-  ok($.rails.href)
-  start()
+QUnit.test('the getter for an element\'s href is publicly accessible', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
+  assert.ok($.rails.href)
+  done()
 })
 
-asyncTest('the getter for an element\'s href is overridable', 1, function() {
+QUnit.test('the getter for an element\'s href is overridable', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   $.rails.href = function(element) { return $(element).data('href') }
   $('#qunit-fixture a')
     .bindNative('ajax:beforeSend', function(e, xhr, options) {
-      equal('/data/href', options.url)
+      assert.equal('/data/href', options.url)
       e.preventDefault()
     })
     .triggerNative('click')
-  start()
+  done()
 })
 
-asyncTest('the getter for an element\'s href works normally if not overridden', 1, function() {
+QUnit.test('the getter for an element\'s href works normally if not overridden', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
   $('#qunit-fixture a')
     .bindNative('ajax:beforeSend', function(e, xhr, options) {
-      equal(location.protocol + '//' + location.host + '/real/href', options.url)
+      assert.equal(location.protocol + '//' + location.host + '/real/href', options.url)
       e.preventDefault()
     })
     .triggerNative('click')
-  start()
+  done()
 })
 
-asyncTest('the event selector strings are overridable', 1, function() {
-  ok($.rails.linkClickSelector.indexOf(', a[data-custom-remote-link]') != -1, 'linkClickSelector contains custom selector')
-  start()
+QUnit.test('the event selector strings are overridable', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
+  assert.ok($.rails.linkClickSelector.indexOf(', a[data-custom-remote-link]') != -1, 'linkClickSelector contains custom selector')
+  done()
 })
 
-asyncTest('including rails-ujs multiple times throws error', 1, function() {
-  throws(function() {
+QUnit.test('including rails-ujs multiple times throws error', function(assert) {
+  assert.expect(1)
+  var done = assert.async()
+
+  assert.throws(function() {
     Rails.start()
   }, 'appending rails.js again throws error')
-  setTimeout(function() { start() }, 50)
+  setTimeout(function() { done() }, 50)
 })
 
 })()

--- a/actionview/test/ujs/public/test/settings.js
+++ b/actionview/test/ujs/public/test/settings.js
@@ -1,24 +1,24 @@
 var App = App || {}
 var Turbolinks = Turbolinks || {}
 
-App.assertCallbackInvoked = function(callbackName) {
-  ok(true, callbackName + ' callback should have been invoked')
+App.assertCallbackInvoked = function(assert, callbackName) {
+  assert.ok(true, callbackName + ' callback should have been invoked')
 }
 
-App.assertCallbackNotInvoked = function(callbackName) {
-  ok(false, callbackName + ' callback should not have been invoked')
+App.assertCallbackNotInvoked = function(assert, callbackName) {
+  assert.ok(false, callbackName + ' callback should not have been invoked')
 }
 
-App.assertGetRequest = function(requestEnv) {
-  equal(requestEnv['REQUEST_METHOD'], 'GET', 'request type should be GET')
+App.assertGetRequest = function(assert, requestEnv) {
+  assert.equal(requestEnv['REQUEST_METHOD'], 'GET', 'request type should be GET')
 }
 
-App.assertPostRequest = function(requestEnv) {
-  equal(requestEnv['REQUEST_METHOD'], 'POST', 'request type should be POST')
+App.assertPostRequest = function(assert, requestEnv) {
+  assert.equal(requestEnv['REQUEST_METHOD'], 'POST', 'request type should be POST')
 }
 
-App.assertRequestPath = function(requestEnv, path) {
-  equal(requestEnv['PATH_INFO'], path, 'request should be sent to right url')
+App.assertRequestPath = function(assert, requestEnv, path) {
+  assert.equal(requestEnv['PATH_INFO'], path, 'request should be sent to right url')
 }
 
 App.getVal = function(el) {
@@ -31,14 +31,14 @@ App.disabled = function(el) {
     $.rails.getData(el[0], 'ujs:disabled')
 }
 
-App.checkEnabledState = function(el, text) {
-  ok(!App.disabled(el), el.get(0).tagName + ' should not be disabled')
-  equal(App.getVal(el), text, el.get(0).tagName + ' text should be original value')
+App.checkEnabledState = function(assert, el, text) {
+  assert.ok(!App.disabled(el), el.get(0).tagName + ' should not be disabled')
+  assert.equal(App.getVal(el), text, el.get(0).tagName + ' text should be original value')
 }
 
-App.checkDisabledState = function(el, text) {
-  ok(App.disabled(el), el.get(0).tagName + ' should be disabled')
-  equal(App.getVal(el), text, el.get(0).tagName + ' text should be disabled value')
+App.checkDisabledState = function(assert, el, text) {
+  assert.ok(App.disabled(el), el.get(0).tagName + ' should be disabled')
+  assert.equal(App.getVal(el), text, el.get(0).tagName + ' text should be disabled value')
 }
 
 // hijacks normal form submit; lets it submit to an iframe to prevent

--- a/actionview/test/ujs/public/vendor/qunit.css
+++ b/actionview/test/ujs/public/vendor/qunit.css
@@ -1,33 +1,33 @@
 /*!
- * QUnit 1.14.0
- * http://qunitjs.com/
+ * QUnit 2.8.0
+ * https://qunitjs.com/
  *
- * Copyright 2013 jQuery Foundation and other contributors
+ * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
- * Date: 2014-01-31T16:40Z
+ * Date: 2018-11-02T16:17Z
  */
 
 /** Font Family and Sizes */
 
-#qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult {
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-filteredTest, #qunit-userAgent, #qunit-testresult {
 	font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
 }
 
-#qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult, #qunit-tests li { font-size: small; }
+#qunit-testrunner-toolbar, #qunit-filteredTest, #qunit-userAgent, #qunit-testresult, #qunit-tests li { font-size: small; }
 #qunit-tests { font-size: smaller; }
 
 
 /** Resets */
 
-#qunit-tests, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult, #qunit-modulefilter {
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-filteredTest, #qunit-userAgent, #qunit-testresult, #qunit-modulefilter {
 	margin: 0;
 	padding: 0;
 }
 
 
-/** Header */
+/** Header (excluding toolbar) */
 
 #qunit-header {
 	padding: 0.5em 0 0.5em 1em;
@@ -52,32 +52,160 @@
 	color: #FFF;
 }
 
-#qunit-testrunner-toolbar label {
-	display: inline-block;
-	padding: 0 0.5em 0 0.1em;
-}
-
 #qunit-banner {
 	height: 5px;
 }
 
-#qunit-testrunner-toolbar {
-	padding: 0.5em 0 0.5em 2em;
-	color: #5E740B;
-	background-color: #EEE;
-	overflow: hidden;
+#qunit-filteredTest {
+	padding: 0.5em 1em 0.5em 1em;
+	color: #366097;
+	background-color: #F4FF77;
 }
 
 #qunit-userAgent {
-	padding: 0.5em 0 0.5em 2.5em;
-	background-color: #2B81AF;
+	padding: 0.5em 1em 0.5em 1em;
 	color: #FFF;
+	background-color: #2B81AF;
 	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
 }
 
-#qunit-modulefilter-container {
-	float: right;
+
+/** Toolbar */
+
+#qunit-testrunner-toolbar {
+	padding: 0.5em 1em 0.5em 1em;
+	color: #5E740B;
+	background-color: #EEE;
 }
+
+#qunit-testrunner-toolbar .clearfix {
+	height: 0;
+	clear: both;
+}
+
+#qunit-testrunner-toolbar label {
+	display: inline-block;
+}
+
+#qunit-testrunner-toolbar input[type=checkbox],
+#qunit-testrunner-toolbar input[type=radio] {
+	margin: 3px;
+	vertical-align: -2px;
+}
+
+#qunit-testrunner-toolbar input[type=text] {
+	box-sizing: border-box;
+	height: 1.6em;
+}
+
+.qunit-url-config,
+.qunit-filter,
+#qunit-modulefilter {
+	display: inline-block;
+	line-height: 2.1em;
+}
+
+.qunit-filter,
+#qunit-modulefilter {
+	float: right;
+	position: relative;
+	margin-left: 1em;
+}
+
+.qunit-url-config label {
+	margin-right: 0.5em;
+}
+
+#qunit-modulefilter-search {
+	box-sizing: border-box;
+	width: 400px;
+}
+
+#qunit-modulefilter-search-container:after {
+	position: absolute;
+	right: 0.3em;
+	content: "\25bc";
+	color: black;
+}
+
+#qunit-modulefilter-dropdown {
+	/* align with #qunit-modulefilter-search */
+	box-sizing: border-box;
+	width: 400px;
+	position: absolute;
+	right: 0;
+	top: 50%;
+	margin-top: 0.8em;
+
+	border: 1px solid #D3D3D3;
+	border-top: none;
+	border-radius: 0 0 .25em .25em;
+	color: #000;
+	background-color: #F5F5F5;
+	z-index: 99;
+}
+
+#qunit-modulefilter-dropdown a {
+	color: inherit;
+	text-decoration: none;
+}
+
+#qunit-modulefilter-dropdown .clickable.checked {
+	font-weight: bold;
+	color: #000;
+	background-color: #D2E0E6;
+}
+
+#qunit-modulefilter-dropdown .clickable:hover {
+	color: #FFF;
+	background-color: #0D3349;
+}
+
+#qunit-modulefilter-actions {
+	display: block;
+	overflow: auto;
+
+	/* align with #qunit-modulefilter-dropdown-list */
+	font: smaller/1.5em sans-serif;
+}
+
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > * {
+	box-sizing: border-box;
+	max-height: 2.8em;
+	display: block;
+	padding: 0.4em;
+}
+
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > button {
+	float: right;
+	font: inherit;
+}
+
+#qunit-modulefilter-dropdown #qunit-modulefilter-actions > :last-child {
+	/* insert padding to align with checkbox margins */
+	padding-left: 3px;
+}
+
+#qunit-modulefilter-dropdown-list {
+	max-height: 200px;
+	overflow-y: auto;
+	margin: 0;
+	border-top: 2px groove threedhighlight;
+	padding: 0.4em 0 0;
+	font: smaller/1.5em sans-serif;
+}
+
+#qunit-modulefilter-dropdown-list li {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#qunit-modulefilter-dropdown-list .clickable {
+	display: block;
+	padding-left: 0.15em;
+}
+
 
 /** Tests: Pass/Fail */
 
@@ -86,23 +214,55 @@
 }
 
 #qunit-tests li {
-	padding: 0.4em 0.5em 0.4em 2.5em;
+	padding: 0.4em 1em 0.4em 1em;
 	border-bottom: 1px solid #FFF;
 	list-style-position: inside;
 }
 
-#qunit-tests.hidepass li.pass, #qunit-tests.hidepass li.running  {
+#qunit-tests > li {
 	display: none;
+}
+
+#qunit-tests li.running,
+#qunit-tests li.pass,
+#qunit-tests li.fail,
+#qunit-tests li.skipped,
+#qunit-tests li.aborted {
+	display: list-item;
+}
+
+#qunit-tests.hidepass {
+	position: relative;
+}
+
+#qunit-tests.hidepass li.running,
+#qunit-tests.hidepass li.pass:not(.todo) {
+	visibility: hidden;
+	position: absolute;
+	width:   0;
+	height:  0;
+	padding: 0;
+	border:  0;
+	margin:  0;
 }
 
 #qunit-tests li strong {
 	cursor: pointer;
 }
 
+#qunit-tests li.skipped strong {
+	cursor: default;
+}
+
 #qunit-tests li a {
 	padding: 0.5em;
 	color: #C2CCD1;
 	text-decoration: none;
+}
+
+#qunit-tests li p a {
+	padding: 0.25em;
+	color: #6B6464;
 }
 #qunit-tests li a:hover,
 #qunit-tests li a:focus {
@@ -121,6 +281,10 @@
 	background-color: #FFF;
 
 	border-radius: 5px;
+}
+
+.qunit-source {
+	margin: 0.6em 0 0.3em;
 }
 
 .qunit-collapsed {
@@ -149,14 +313,14 @@
 }
 
 #qunit-tests del {
-	background-color: #E0F2BE;
 	color: #374E0C;
+	background-color: #E0F2BE;
 	text-decoration: none;
 }
 
 #qunit-tests ins {
-	background-color: #FFCACA;
 	color: #500;
+	background-color: #FFCACA;
 	text-decoration: none;
 }
 
@@ -212,18 +376,53 @@
 #qunit-banner.qunit-fail                    { background-color: #EE5757; }
 
 
+/*** Aborted tests */
+#qunit-tests .aborted { color: #000; background-color: orange; }
+/*** Skipped tests */
+
+#qunit-tests .skipped {
+	background-color: #EBECE9;
+}
+
+#qunit-tests .qunit-todo-label,
+#qunit-tests .qunit-skipped-label {
+	background-color: #F4FF77;
+	display: inline-block;
+	font-style: normal;
+	color: #366097;
+	line-height: 1.8em;
+	padding: 0 0.5em;
+	margin: -0.4em 0.4em -0.4em 0;
+}
+
+#qunit-tests .qunit-todo-label {
+	background-color: #EEE;
+}
+
 /** Result */
 
 #qunit-testresult {
-	padding: 0.5em 0.5em 0.5em 2.5em;
-
 	color: #2B81AF;
 	background-color: #D2E0E6;
 
 	border-bottom: 1px solid #FFF;
 }
+#qunit-testresult .clearfix {
+	height: 0;
+	clear: both;
+}
 #qunit-testresult .module-name {
 	font-weight: 700;
+}
+#qunit-testresult-display {
+	padding: 0.5em 1em 0.5em 1em;
+	width: 85%;
+	float:left;
+}
+#qunit-testresult-controls {
+	padding: 0.5em 1em 0.5em 1em;
+  width: 10%;
+	float:left;
 }
 
 /** Fixture */

--- a/actionview/test/ujs/public/vendor/qunit.js
+++ b/actionview/test/ujs/public/vendor/qunit.js
@@ -1,2288 +1,6566 @@
 /*!
- * QUnit 1.14.0
- * http://qunitjs.com/
+ * QUnit 2.8.0
+ * https://qunitjs.com/
  *
- * Copyright 2013 jQuery Foundation and other contributors
+ * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
- * Date: 2014-01-31T16:40Z
+ * Date: 2018-11-02T16:17Z
  */
+(function (global$1) {
+  'use strict';
 
-(function( window ) {
-
-var QUnit,
-	assert,
-	config,
-	onErrorFnPrev,
-	testId = 0,
-	fileName = (sourceFromStacktrace( 0 ) || "" ).replace(/(:\d+)+\)?/, "").replace(/.+\//, ""),
-	toString = Object.prototype.toString,
-	hasOwn = Object.prototype.hasOwnProperty,
-	// Keep a local reference to Date (GH-283)
-	Date = window.Date,
-	setTimeout = window.setTimeout,
-	clearTimeout = window.clearTimeout,
-	defined = {
-		document: typeof window.document !== "undefined",
-		setTimeout: typeof window.setTimeout !== "undefined",
-		sessionStorage: (function() {
-			var x = "qunit-test-string";
-			try {
-				sessionStorage.setItem( x, x );
-				sessionStorage.removeItem( x );
-				return true;
-			} catch( e ) {
-				return false;
-			}
-		}())
-	},
-	/**
-	 * Provides a normalized error string, correcting an issue
-	 * with IE 7 (and prior) where Error.prototype.toString is
-	 * not properly implemented
-	 *
-	 * Based on https://es5.github.io/#x15.11.4.4
-	 *
-	 * @param {String|Error} error
-	 * @return {String} error message
-	 */
-	errorString = function( error ) {
-		var name, message,
-			errorString = error.toString();
-		if ( errorString.substring( 0, 7 ) === "[object" ) {
-			name = error.name ? error.name.toString() : "Error";
-			message = error.message ? error.message.toString() : "";
-			if ( name && message ) {
-				return name + ": " + message;
-			} else if ( name ) {
-				return name;
-			} else if ( message ) {
-				return message;
-			} else {
-				return "Error";
-			}
-		} else {
-			return errorString;
-		}
-	},
-	/**
-	 * Makes a clone of an object using only Array or Object as base,
-	 * and copies over the own enumerable properties.
-	 *
-	 * @param {Object} obj
-	 * @return {Object} New object with only the own properties (recursively).
-	 */
-	objectValues = function( obj ) {
-		// Grunt 0.3.x uses an older version of jshint that still has jshint/jshint#392.
-		/*jshint newcap: false */
-		var key, val,
-			vals = QUnit.is( "array", obj ) ? [] : {};
-		for ( key in obj ) {
-			if ( hasOwn.call( obj, key ) ) {
-				val = obj[key];
-				vals[key] = val === Object(val) ? objectValues(val) : val;
-			}
-		}
-		return vals;
-	};
-
-
-// Root QUnit object.
-// `QUnit` initialized at top of scope
-QUnit = {
-
-	// call on start of module test to prepend name to all tests
-	module: function( name, testEnvironment ) {
-		config.currentModule = name;
-		config.currentModuleTestEnvironment = testEnvironment;
-		config.modules[name] = true;
-	},
-
-	asyncTest: function( testName, expected, callback ) {
-		if ( arguments.length === 2 ) {
-			callback = expected;
-			expected = null;
-		}
-
-		QUnit.test( testName, expected, callback, true );
-	},
-
-	test: function( testName, expected, callback, async ) {
-		var test,
-			nameHtml = "<span class='test-name'>" + escapeText( testName ) + "</span>";
-
-		if ( arguments.length === 2 ) {
-			callback = expected;
-			expected = null;
-		}
-
-		if ( config.currentModule ) {
-			nameHtml = "<span class='module-name'>" + escapeText( config.currentModule ) + "</span>: " + nameHtml;
-		}
-
-		test = new Test({
-			nameHtml: nameHtml,
-			testName: testName,
-			expected: expected,
-			async: async,
-			callback: callback,
-			module: config.currentModule,
-			moduleTestEnvironment: config.currentModuleTestEnvironment,
-			stack: sourceFromStacktrace( 2 )
-		});
-
-		if ( !validTest( test ) ) {
-			return;
-		}
-
-		test.queue();
-	},
-
-	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
-	expect: function( asserts ) {
-		if (arguments.length === 1) {
-			config.current.expected = asserts;
-		} else {
-			return config.current.expected;
-		}
-	},
-
-	start: function( count ) {
-		// QUnit hasn't been initialized yet.
-		// Note: RequireJS (et al) may delay onLoad
-		if ( config.semaphore === undefined ) {
-			QUnit.begin(function() {
-				// This is triggered at the top of QUnit.load, push start() to the event loop, to allow QUnit.load to finish first
-				setTimeout(function() {
-					QUnit.start( count );
-				});
-			});
-			return;
-		}
-
-		config.semaphore -= count || 1;
-		// don't start until equal number of stop-calls
-		if ( config.semaphore > 0 ) {
-			return;
-		}
-		// ignore if start is called more often then stop
-		if ( config.semaphore < 0 ) {
-			config.semaphore = 0;
-			QUnit.pushFailure( "Called start() while already started (QUnit.config.semaphore was 0 already)", null, sourceFromStacktrace(2) );
-			return;
-		}
-		// A slight delay, to avoid any current callbacks
-		if ( defined.setTimeout ) {
-			setTimeout(function() {
-				if ( config.semaphore > 0 ) {
-					return;
-				}
-				if ( config.timeout ) {
-					clearTimeout( config.timeout );
-				}
-
-				config.blocking = false;
-				process( true );
-			}, 13);
-		} else {
-			config.blocking = false;
-			process( true );
-		}
-	},
-
-	stop: function( count ) {
-		config.semaphore += count || 1;
-		config.blocking = true;
-
-		if ( config.testTimeout && defined.setTimeout ) {
-			clearTimeout( config.timeout );
-			config.timeout = setTimeout(function() {
-				QUnit.ok( false, "Test timed out" );
-				config.semaphore = 1;
-				QUnit.start();
-			}, config.testTimeout );
-		}
-	}
-};
-
-// We use the prototype to distinguish between properties that should
-// be exposed as globals (and in exports) and those that shouldn't
-(function() {
-	function F() {}
-	F.prototype = QUnit;
-	QUnit = new F();
-	// Make F QUnit's constructor so that we can add to the prototype later
-	QUnit.constructor = F;
-}());
-
-/**
- * Config object: Maintain internal state
- * Later exposed as QUnit.config
- * `config` initialized at top of scope
- */
-config = {
-	// The queue of tests to run
-	queue: [],
-
-	// block until document ready
-	blocking: true,
-
-	// when enabled, show only failing tests
-	// gets persisted through sessionStorage and can be changed in UI via checkbox
-	hidepassed: false,
-
-	// by default, run previously failed tests first
-	// very useful in combination with "Hide passed tests" checked
-	reorder: true,
-
-	// by default, modify document.title when suite is done
-	altertitle: true,
-
-	// by default, scroll to top of the page when suite is done
-	scrolltop: true,
-
-	// when enabled, all tests must call expect()
-	requireExpects: false,
-
-	// add checkboxes that are persisted in the query-string
-	// when enabled, the id is set to `true` as a `QUnit.config` property
-	urlConfig: [
-		{
-			id: "noglobals",
-			label: "Check for Globals",
-			tooltip: "Enabling this will test if any test introduces new properties on the `window` object. Stored as query-strings."
-		},
-		{
-			id: "notrycatch",
-			label: "No try-catch",
-			tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging exceptions in IE reasonable. Stored as query-strings."
-		}
-	],
-
-	// Set of all modules.
-	modules: {},
-
-	// logging callback queues
-	begin: [],
-	done: [],
-	log: [],
-	testStart: [],
-	testDone: [],
-	moduleStart: [],
-	moduleDone: []
-};
-
-// Initialize more QUnit.config and QUnit.urlParams
-(function() {
-	var i, current,
-		location = window.location || { search: "", protocol: "file:" },
-		params = location.search.slice( 1 ).split( "&" ),
-		length = params.length,
-		urlParams = {};
-
-	if ( params[ 0 ] ) {
-		for ( i = 0; i < length; i++ ) {
-			current = params[ i ].split( "=" );
-			current[ 0 ] = decodeURIComponent( current[ 0 ] );
-
-			// allow just a key to turn on a flag, e.g., test.html?noglobals
-			current[ 1 ] = current[ 1 ] ? decodeURIComponent( current[ 1 ] ) : true;
-			if ( urlParams[ current[ 0 ] ] ) {
-				urlParams[ current[ 0 ] ] = [].concat( urlParams[ current[ 0 ] ], current[ 1 ] );
-			} else {
-				urlParams[ current[ 0 ] ] = current[ 1 ];
-			}
-		}
-	}
-
-	QUnit.urlParams = urlParams;
-
-	// String search anywhere in moduleName+testName
-	config.filter = urlParams.filter;
-
-	// Exact match of the module name
-	config.module = urlParams.module;
-
-	config.testNumber = [];
-	if ( urlParams.testNumber ) {
-
-		// Ensure that urlParams.testNumber is an array
-		urlParams.testNumber = [].concat( urlParams.testNumber );
-		for ( i = 0; i < urlParams.testNumber.length; i++ ) {
-			current = urlParams.testNumber[ i ];
-			config.testNumber.push( parseInt( current, 10 ) );
-		}
-	}
-
-	// Figure out if we're running the tests from a server or not
-	QUnit.isLocal = location.protocol === "file:";
-}());
-
-extend( QUnit, {
-
-	config: config,
-
-	// Initialize the configuration options
-	init: function() {
-		extend( config, {
-			stats: { all: 0, bad: 0 },
-			moduleStats: { all: 0, bad: 0 },
-			started: +new Date(),
-			updateRate: 1000,
-			blocking: false,
-			autostart: true,
-			autorun: false,
-			filter: "",
-			queue: [],
-			semaphore: 1
-		});
-
-		var tests, banner, result,
-			qunit = id( "qunit" );
-
-		if ( qunit ) {
-			qunit.innerHTML =
-				"<h1 id='qunit-header'>" + escapeText( document.title ) + "</h1>" +
-				"<h2 id='qunit-banner'></h2>" +
-				"<div id='qunit-testrunner-toolbar'></div>" +
-				"<h2 id='qunit-userAgent'></h2>" +
-				"<ol id='qunit-tests'></ol>";
-		}
-
-		tests = id( "qunit-tests" );
-		banner = id( "qunit-banner" );
-		result = id( "qunit-testresult" );
-
-		if ( tests ) {
-			tests.innerHTML = "";
-		}
-
-		if ( banner ) {
-			banner.className = "";
-		}
-
-		if ( result ) {
-			result.parentNode.removeChild( result );
-		}
-
-		if ( tests ) {
-			result = document.createElement( "p" );
-			result.id = "qunit-testresult";
-			result.className = "result";
-			tests.parentNode.insertBefore( result, tests );
-			result.innerHTML = "Running...<br/>&nbsp;";
-		}
-	},
-
-	// Resets the test setup. Useful for tests that modify the DOM.
-	/*
-	DEPRECATED: Use multiple tests instead of resetting inside a test.
-	Use testStart or testDone for custom cleanup.
-	This method will throw an error in 2.0, and will be removed in 2.1
-	*/
-	reset: function() {
-		var fixture = id( "qunit-fixture" );
-		if ( fixture ) {
-			fixture.innerHTML = config.fixture;
-		}
-	},
-
-	// Safe object type checking
-	is: function( type, obj ) {
-		return QUnit.objectType( obj ) === type;
-	},
-
-	objectType: function( obj ) {
-		if ( typeof obj === "undefined" ) {
-			return "undefined";
-		}
-
-		// Consider: typeof null === object
-		if ( obj === null ) {
-			return "null";
-		}
-
-		var match = toString.call( obj ).match(/^\[object\s(.*)\]$/),
-			type = match && match[1] || "";
-
-		switch ( type ) {
-			case "Number":
-				if ( isNaN(obj) ) {
-					return "nan";
-				}
-				return "number";
-			case "String":
-			case "Boolean":
-			case "Array":
-			case "Date":
-			case "RegExp":
-			case "Function":
-				return type.toLowerCase();
-		}
-		if ( typeof obj === "object" ) {
-			return "object";
-		}
-		return undefined;
-	},
-
-	push: function( result, actual, expected, message ) {
-		if ( !config.current ) {
-			throw new Error( "assertion outside test context, was " + sourceFromStacktrace() );
-		}
-
-		var output, source,
-			details = {
-				module: config.current.module,
-				name: config.current.testName,
-				result: result,
-				message: message,
-				actual: actual,
-				expected: expected
-			};
-
-		message = escapeText( message ) || ( result ? "okay" : "failed" );
-		message = "<span class='test-message'>" + message + "</span>";
-		output = message;
-
-		if ( !result ) {
-			expected = escapeText( QUnit.jsDump.parse(expected) );
-			actual = escapeText( QUnit.jsDump.parse(actual) );
-			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
-
-			if ( actual !== expected ) {
-				output += "<tr class='test-actual'><th>Result: </th><td><pre>" + actual + "</pre></td></tr>";
-				output += "<tr class='test-diff'><th>Diff: </th><td><pre>" + QUnit.diff( expected, actual ) + "</pre></td></tr>";
-			}
-
-			source = sourceFromStacktrace();
-
-			if ( source ) {
-				details.source = source;
-				output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
-			}
-
-			output += "</table>";
-		}
-
-		runLoggingCallbacks( "log", QUnit, details );
-
-		config.current.assertions.push({
-			result: !!result,
-			message: output
-		});
-	},
-
-	pushFailure: function( message, source, actual ) {
-		if ( !config.current ) {
-			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
-		}
-
-		var output,
-			details = {
-				module: config.current.module,
-				name: config.current.testName,
-				result: false,
-				message: message
-			};
-
-		message = escapeText( message ) || "error";
-		message = "<span class='test-message'>" + message + "</span>";
-		output = message;
-
-		output += "<table>";
-
-		if ( actual ) {
-			output += "<tr class='test-actual'><th>Result: </th><td><pre>" + escapeText( actual ) + "</pre></td></tr>";
-		}
-
-		if ( source ) {
-			details.source = source;
-			output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText( source ) + "</pre></td></tr>";
-		}
-
-		output += "</table>";
-
-		runLoggingCallbacks( "log", QUnit, details );
-
-		config.current.assertions.push({
-			result: false,
-			message: output
-		});
-	},
-
-	url: function( params ) {
-		params = extend( extend( {}, QUnit.urlParams ), params );
-		var key,
-			querystring = "?";
-
-		for ( key in params ) {
-			if ( hasOwn.call( params, key ) ) {
-				querystring += encodeURIComponent( key ) + "=" +
-					encodeURIComponent( params[ key ] ) + "&";
-			}
-		}
-		return window.location.protocol + "//" + window.location.host +
-			window.location.pathname + querystring.slice( 0, -1 );
-	},
-
-	extend: extend,
-	id: id,
-	addEvent: addEvent,
-	addClass: addClass,
-	hasClass: hasClass,
-	removeClass: removeClass
-	// load, equiv, jsDump, diff: Attached later
-});
-
-/**
- * @deprecated: Created for backwards compatibility with test runner that set the hook function
- * into QUnit.{hook}, instead of invoking it and passing the hook function.
- * QUnit.constructor is set to the empty F() above so that we can add to it's prototype here.
- * Doing this allows us to tell if the following methods have been overwritten on the actual
- * QUnit object.
- */
-extend( QUnit.constructor.prototype, {
-
-	// Logging callbacks; all receive a single argument with the listed properties
-	// run test/logs.html for any related changes
-	begin: registerLoggingCallback( "begin" ),
-
-	// done: { failed, passed, total, runtime }
-	done: registerLoggingCallback( "done" ),
-
-	// log: { result, actual, expected, message }
-	log: registerLoggingCallback( "log" ),
-
-	// testStart: { name }
-	testStart: registerLoggingCallback( "testStart" ),
-
-	// testDone: { name, failed, passed, total, runtime }
-	testDone: registerLoggingCallback( "testDone" ),
-
-	// moduleStart: { name }
-	moduleStart: registerLoggingCallback( "moduleStart" ),
-
-	// moduleDone: { name, failed, passed, total }
-	moduleDone: registerLoggingCallback( "moduleDone" )
-});
-
-if ( !defined.document || document.readyState === "complete" ) {
-	config.autorun = true;
-}
-
-QUnit.load = function() {
-	runLoggingCallbacks( "begin", QUnit, {} );
-
-	// Initialize the config, saving the execution queue
-	var banner, filter, i, j, label, len, main, ol, toolbar, val, selection,
-		urlConfigContainer, moduleFilter, userAgent,
-		numModules = 0,
-		moduleNames = [],
-		moduleFilterHtml = "",
-		urlConfigHtml = "",
-		oldconfig = extend( {}, config );
-
-	QUnit.init();
-	extend(config, oldconfig);
-
-	config.blocking = false;
-
-	len = config.urlConfig.length;
-
-	for ( i = 0; i < len; i++ ) {
-		val = config.urlConfig[i];
-		if ( typeof val === "string" ) {
-			val = {
-				id: val,
-				label: val
-			};
-		}
-		config[ val.id ] = QUnit.urlParams[ val.id ];
-		if ( !val.value || typeof val.value === "string" ) {
-			urlConfigHtml += "<input id='qunit-urlconfig-" + escapeText( val.id ) +
-				"' name='" + escapeText( val.id ) +
-				"' type='checkbox'" +
-				( val.value ? " value='" + escapeText( val.value ) + "'" : "" ) +
-				( config[ val.id ] ? " checked='checked'" : "" ) +
-				" title='" + escapeText( val.tooltip ) +
-				"'><label for='qunit-urlconfig-" + escapeText( val.id ) +
-				"' title='" + escapeText( val.tooltip ) + "'>" + val.label + "</label>";
-		} else {
-			urlConfigHtml += "<label for='qunit-urlconfig-" + escapeText( val.id ) +
-				"' title='" + escapeText( val.tooltip ) +
-				"'>" + val.label +
-				": </label><select id='qunit-urlconfig-" + escapeText( val.id ) +
-				"' name='" + escapeText( val.id ) +
-				"' title='" + escapeText( val.tooltip ) +
-				"'><option></option>";
-			selection = false;
-			if ( QUnit.is( "array", val.value ) ) {
-				for ( j = 0; j < val.value.length; j++ ) {
-					urlConfigHtml += "<option value='" + escapeText( val.value[j] ) + "'" +
-						( config[ val.id ] === val.value[j] ?
-							(selection = true) && " selected='selected'" :
-							"" ) +
-						">" + escapeText( val.value[j] ) + "</option>";
-				}
-			} else {
-				for ( j in val.value ) {
-					if ( hasOwn.call( val.value, j ) ) {
-						urlConfigHtml += "<option value='" + escapeText( j ) + "'" +
-							( config[ val.id ] === j ?
-								(selection = true) && " selected='selected'" :
-								"" ) +
-							">" + escapeText( val.value[j] ) + "</option>";
-					}
-				}
-			}
-			if ( config[ val.id ] && !selection ) {
-				urlConfigHtml += "<option value='" + escapeText( config[ val.id ] ) +
-					"' selected='selected' disabled='disabled'>" +
-					escapeText( config[ val.id ] ) +
-					"</option>";
-			}
-			urlConfigHtml += "</select>";
-		}
-	}
-	for ( i in config.modules ) {
-		if ( config.modules.hasOwnProperty( i ) ) {
-			moduleNames.push(i);
-		}
-	}
-	numModules = moduleNames.length;
-	moduleNames.sort( function( a, b ) {
-		return a.localeCompare( b );
-	});
-	moduleFilterHtml += "<label for='qunit-modulefilter'>Module: </label><select id='qunit-modulefilter' name='modulefilter'><option value='' " +
-		( config.module === undefined  ? "selected='selected'" : "" ) +
-		">< All Modules ></option>";
-
-
-	for ( i = 0; i < numModules; i++) {
-			moduleFilterHtml += "<option value='" + escapeText( encodeURIComponent(moduleNames[i]) ) + "' " +
-				( config.module === moduleNames[i] ? "selected='selected'" : "" ) +
-				">" + escapeText(moduleNames[i]) + "</option>";
-	}
-	moduleFilterHtml += "</select>";
-
-	// `userAgent` initialized at top of scope
-	userAgent = id( "qunit-userAgent" );
-	if ( userAgent ) {
-		userAgent.innerHTML = navigator.userAgent;
-	}
-
-	// `banner` initialized at top of scope
-	banner = id( "qunit-header" );
-	if ( banner ) {
-		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined, module: undefined, testNumber: undefined }) + "'>" + banner.innerHTML + "</a> ";
-	}
-
-	// `toolbar` initialized at top of scope
-	toolbar = id( "qunit-testrunner-toolbar" );
-	if ( toolbar ) {
-		// `filter` initialized at top of scope
-		filter = document.createElement( "input" );
-		filter.type = "checkbox";
-		filter.id = "qunit-filter-pass";
-
-		addEvent( filter, "click", function() {
-			var tmp,
-				ol = id( "qunit-tests" );
-
-			if ( filter.checked ) {
-				ol.className = ol.className + " hidepass";
-			} else {
-				tmp = " " + ol.className.replace( /[\n\t\r]/g, " " ) + " ";
-				ol.className = tmp.replace( / hidepass /, " " );
-			}
-			if ( defined.sessionStorage ) {
-				if (filter.checked) {
-					sessionStorage.setItem( "qunit-filter-passed-tests", "true" );
-				} else {
-					sessionStorage.removeItem( "qunit-filter-passed-tests" );
-				}
-			}
-		});
-
-		if ( config.hidepassed || defined.sessionStorage && sessionStorage.getItem( "qunit-filter-passed-tests" ) ) {
-			filter.checked = true;
-			// `ol` initialized at top of scope
-			ol = id( "qunit-tests" );
-			ol.className = ol.className + " hidepass";
-		}
-		toolbar.appendChild( filter );
-
-		// `label` initialized at top of scope
-		label = document.createElement( "label" );
-		label.setAttribute( "for", "qunit-filter-pass" );
-		label.setAttribute( "title", "Only show tests and assertions that fail. Stored in sessionStorage." );
-		label.innerHTML = "Hide passed tests";
-		toolbar.appendChild( label );
-
-		urlConfigContainer = document.createElement("span");
-		urlConfigContainer.innerHTML = urlConfigHtml;
-		// For oldIE support:
-		// * Add handlers to the individual elements instead of the container
-		// * Use "click" instead of "change" for checkboxes
-		// * Fallback from event.target to event.srcElement
-		addEvents( urlConfigContainer.getElementsByTagName("input"), "click", function( event ) {
-			var params = {},
-				target = event.target || event.srcElement;
-			params[ target.name ] = target.checked ?
-				target.defaultValue || true :
-				undefined;
-			window.location = QUnit.url( params );
-		});
-		addEvents( urlConfigContainer.getElementsByTagName("select"), "change", function( event ) {
-			var params = {},
-				target = event.target || event.srcElement;
-			params[ target.name ] = target.options[ target.selectedIndex ].value || undefined;
-			window.location = QUnit.url( params );
-		});
-		toolbar.appendChild( urlConfigContainer );
-
-		if (numModules > 1) {
-			moduleFilter = document.createElement( "span" );
-			moduleFilter.setAttribute( "id", "qunit-modulefilter-container" );
-			moduleFilter.innerHTML = moduleFilterHtml;
-			addEvent( moduleFilter.lastChild, "change", function() {
-				var selectBox = moduleFilter.getElementsByTagName("select")[0],
-					selectedModule = decodeURIComponent(selectBox.options[selectBox.selectedIndex].value);
-
-				window.location = QUnit.url({
-					module: ( selectedModule === "" ) ? undefined : selectedModule,
-					// Remove any existing filters
-					filter: undefined,
-					testNumber: undefined
-				});
-			});
-			toolbar.appendChild(moduleFilter);
-		}
-	}
-
-	// `main` initialized at top of scope
-	main = id( "qunit-fixture" );
-	if ( main ) {
-		config.fixture = main.innerHTML;
-	}
-
-	if ( config.autostart ) {
-		QUnit.start();
-	}
-};
-
-if ( defined.document ) {
-	addEvent( window, "load", QUnit.load );
-}
-
-// `onErrorFnPrev` initialized at top of scope
-// Preserve other handlers
-onErrorFnPrev = window.onerror;
-
-// Cover uncaught exceptions
-// Returning true will suppress the default browser handler,
-// returning false will let it run.
-window.onerror = function ( error, filePath, linerNr ) {
-	var ret = false;
-	if ( onErrorFnPrev ) {
-		ret = onErrorFnPrev( error, filePath, linerNr );
-	}
-
-	// Treat return value as window.onerror itself does,
-	// Only do our handling if not suppressed.
-	if ( ret !== true ) {
-		if ( QUnit.config.current ) {
-			if ( QUnit.config.current.ignoreGlobalErrors ) {
-				return true;
-			}
-			QUnit.pushFailure( error, filePath + ":" + linerNr );
-		} else {
-			QUnit.test( "global failure", extend( function() {
-				QUnit.pushFailure( error, filePath + ":" + linerNr );
-			}, { validTest: validTest } ) );
-		}
-		return false;
-	}
-
-	return ret;
-};
-
-function done() {
-	config.autorun = true;
-
-	// Log the last module results
-	if ( config.previousModule ) {
-		runLoggingCallbacks( "moduleDone", QUnit, {
-			name: config.previousModule,
-			failed: config.moduleStats.bad,
-			passed: config.moduleStats.all - config.moduleStats.bad,
-			total: config.moduleStats.all
-		});
-	}
-	delete config.previousModule;
-
-	var i, key,
-		banner = id( "qunit-banner" ),
-		tests = id( "qunit-tests" ),
-		runtime = +new Date() - config.started,
-		passed = config.stats.all - config.stats.bad,
-		html = [
-			"Tests completed in ",
-			runtime,
-			" milliseconds.<br/>",
-			"<span class='passed'>",
-			passed,
-			"</span> assertions of <span class='total'>",
-			config.stats.all,
-			"</span> passed, <span class='failed'>",
-			config.stats.bad,
-			"</span> failed."
-		].join( "" );
-
-	if ( banner ) {
-		banner.className = ( config.stats.bad ? "qunit-fail" : "qunit-pass" );
-	}
-
-	if ( tests ) {
-		id( "qunit-testresult" ).innerHTML = html;
-	}
-
-	if ( config.altertitle && defined.document && document.title ) {
-		// show ✖ for good, ✔ for bad suite result in title
-		// use escape sequences in case file gets loaded with non-utf-8-charset
-		document.title = [
-			( config.stats.bad ? "\u2716" : "\u2714" ),
-			document.title.replace( /^[\u2714\u2716] /i, "" )
-		].join( " " );
-	}
-
-	// clear own sessionStorage items if all tests passed
-	if ( config.reorder && defined.sessionStorage && config.stats.bad === 0 ) {
-		// `key` & `i` initialized at top of scope
-		for ( i = 0; i < sessionStorage.length; i++ ) {
-			key = sessionStorage.key( i++ );
-			if ( key.indexOf( "qunit-test-" ) === 0 ) {
-				sessionStorage.removeItem( key );
-			}
-		}
-	}
-
-	// scroll back to top to show results
-	if ( config.scrolltop && window.scrollTo ) {
-		window.scrollTo(0, 0);
-	}
-
-	runLoggingCallbacks( "done", QUnit, {
-		failed: config.stats.bad,
-		passed: passed,
-		total: config.stats.all,
-		runtime: runtime
-	});
-}
-
-/** @return Boolean: true if this test should be ran */
-function validTest( test ) {
-	var include,
-		filter = config.filter && config.filter.toLowerCase(),
-		module = config.module && config.module.toLowerCase(),
-		fullName = ( test.module + ": " + test.testName ).toLowerCase();
-
-	// Internally-generated tests are always valid
-	if ( test.callback && test.callback.validTest === validTest ) {
-		delete test.callback.validTest;
-		return true;
-	}
-
-	if ( config.testNumber.length > 0 ) {
-		if ( inArray( test.testNumber, config.testNumber ) < 0 ) {
-			return false;
-		}
-	}
-
-	if ( module && ( !test.module || test.module.toLowerCase() !== module ) ) {
-		return false;
-	}
-
-	if ( !filter ) {
-		return true;
-	}
-
-	include = filter.charAt( 0 ) !== "!";
-	if ( !include ) {
-		filter = filter.slice( 1 );
-	}
-
-	// If the filter matches, we need to honour include
-	if ( fullName.indexOf( filter ) !== -1 ) {
-		return include;
-	}
-
-	// Otherwise, do the opposite
-	return !include;
-}
-
-// so far supports only Firefox, Chrome and Opera (buggy), Safari (for real exceptions)
-// Later Safari and IE10 are supposed to support error.stack as well
-// See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
-function extractStacktrace( e, offset ) {
-	offset = offset === undefined ? 3 : offset;
-
-	var stack, include, i;
-
-	if ( e.stacktrace ) {
-		// Opera
-		return e.stacktrace.split( "\n" )[ offset + 3 ];
-	} else if ( e.stack ) {
-		// Firefox, Chrome
-		stack = e.stack.split( "\n" );
-		if (/^error$/i.test( stack[0] ) ) {
-			stack.shift();
-		}
-		if ( fileName ) {
-			include = [];
-			for ( i = offset; i < stack.length; i++ ) {
-				if ( stack[ i ].indexOf( fileName ) !== -1 ) {
-					break;
-				}
-				include.push( stack[ i ] );
-			}
-			if ( include.length ) {
-				return include.join( "\n" );
-			}
-		}
-		return stack[ offset ];
-	} else if ( e.sourceURL ) {
-		// Safari, PhantomJS
-		// hopefully one day Safari provides actual stacktraces
-		// exclude useless self-reference for generated Error objects
-		if ( /qunit.js$/.test( e.sourceURL ) ) {
-			return;
-		}
-		// for actual exceptions, this is useful
-		return e.sourceURL + ":" + e.line;
-	}
-}
-function sourceFromStacktrace( offset ) {
-	try {
-		throw new Error();
-	} catch ( e ) {
-		return extractStacktrace( e, offset );
-	}
-}
-
-/**
- * Escape text for attribute or text content.
- */
-function escapeText( s ) {
-	if ( !s ) {
-		return "";
-	}
-	s = s + "";
-	// Both single quotes and double quotes (for attributes)
-	return s.replace( /['"<>&]/g, function( s ) {
-		switch( s ) {
-			case "'":
-				return "&#039;";
-			case "\"":
-				return "&quot;";
-			case "<":
-				return "&lt;";
-			case ">":
-				return "&gt;";
-			case "&":
-				return "&amp;";
-		}
-	});
-}
-
-function synchronize( callback, last ) {
-	config.queue.push( callback );
-
-	if ( config.autorun && !config.blocking ) {
-		process( last );
-	}
-}
-
-function process( last ) {
-	function next() {
-		process( last );
-	}
-	var start = new Date().getTime();
-	config.depth = config.depth ? config.depth + 1 : 1;
-
-	while ( config.queue.length && !config.blocking ) {
-		if ( !defined.setTimeout || config.updateRate <= 0 || ( ( new Date().getTime() - start ) < config.updateRate ) ) {
-			config.queue.shift()();
-		} else {
-			setTimeout( next, 13 );
-			break;
-		}
-	}
-	config.depth--;
-	if ( last && !config.blocking && !config.queue.length && config.depth === 0 ) {
-		done();
-	}
-}
-
-function saveGlobal() {
-	config.pollution = [];
-
-	if ( config.noglobals ) {
-		for ( var key in window ) {
-			if ( hasOwn.call( window, key ) ) {
-				// in Opera sometimes DOM element ids show up here, ignore them
-				if ( /^qunit-test-output/.test( key ) ) {
-					continue;
-				}
-				config.pollution.push( key );
-			}
-		}
-	}
-}
-
-function checkPollution() {
-	var newGlobals,
-		deletedGlobals,
-		old = config.pollution;
-
-	saveGlobal();
-
-	newGlobals = diff( config.pollution, old );
-	if ( newGlobals.length > 0 ) {
-		QUnit.pushFailure( "Introduced global variable(s): " + newGlobals.join(", ") );
-	}
-
-	deletedGlobals = diff( old, config.pollution );
-	if ( deletedGlobals.length > 0 ) {
-		QUnit.pushFailure( "Deleted global variable(s): " + deletedGlobals.join(", ") );
-	}
-}
-
-// returns a new Array with the elements that are in a but not in b
-function diff( a, b ) {
-	var i, j,
-		result = a.slice();
-
-	for ( i = 0; i < result.length; i++ ) {
-		for ( j = 0; j < b.length; j++ ) {
-			if ( result[i] === b[j] ) {
-				result.splice( i, 1 );
-				i--;
-				break;
-			}
-		}
-	}
-	return result;
-}
-
-function extend( a, b ) {
-	for ( var prop in b ) {
-		if ( hasOwn.call( b, prop ) ) {
-			// Avoid "Member not found" error in IE8 caused by messing with window.constructor
-			if ( !( prop === "constructor" && a === window ) ) {
-				if ( b[ prop ] === undefined ) {
-					delete a[ prop ];
-				} else {
-					a[ prop ] = b[ prop ];
-				}
-			}
-		}
-	}
-
-	return a;
-}
-
-/**
- * @param {HTMLElement} elem
- * @param {string} type
- * @param {Function} fn
- */
-function addEvent( elem, type, fn ) {
-	if ( elem.addEventListener ) {
-
-		// Standards-based browsers
-		elem.addEventListener( type, fn, false );
-	} else if ( elem.attachEvent ) {
-
-		// support: IE <9
-		elem.attachEvent( "on" + type, fn );
-	} else {
-
-		// Caller must ensure support for event listeners is present
-		throw new Error( "addEvent() was called in a context without event listener support" );
-	}
-}
-
-/**
- * @param {Array|NodeList} elems
- * @param {string} type
- * @param {Function} fn
- */
-function addEvents( elems, type, fn ) {
-	var i = elems.length;
-	while ( i-- ) {
-		addEvent( elems[i], type, fn );
-	}
-}
-
-function hasClass( elem, name ) {
-	return (" " + elem.className + " ").indexOf(" " + name + " ") > -1;
-}
-
-function addClass( elem, name ) {
-	if ( !hasClass( elem, name ) ) {
-		elem.className += (elem.className ? " " : "") + name;
-	}
-}
-
-function removeClass( elem, name ) {
-	var set = " " + elem.className + " ";
-	// Class name may appear multiple times
-	while ( set.indexOf(" " + name + " ") > -1 ) {
-		set = set.replace(" " + name + " " , " ");
-	}
-	// If possible, trim it for prettiness, but not necessarily
-	elem.className = typeof set.trim === "function" ? set.trim() : set.replace(/^\s+|\s+$/g, "");
-}
-
-function id( name ) {
-	return defined.document && document.getElementById && document.getElementById( name );
-}
-
-function registerLoggingCallback( key ) {
-	return function( callback ) {
-		config[key].push( callback );
-	};
-}
-
-// Supports deprecated method of completely overwriting logging callbacks
-function runLoggingCallbacks( key, scope, args ) {
-	var i, callbacks;
-	if ( QUnit.hasOwnProperty( key ) ) {
-		QUnit[ key ].call(scope, args );
-	} else {
-		callbacks = config[ key ];
-		for ( i = 0; i < callbacks.length; i++ ) {
-			callbacks[ i ].call( scope, args );
-		}
-	}
-}
-
-// from jquery.js
-function inArray( elem, array ) {
-	if ( array.indexOf ) {
-		return array.indexOf( elem );
-	}
-
-	for ( var i = 0, length = array.length; i < length; i++ ) {
-		if ( array[ i ] === elem ) {
-			return i;
-		}
-	}
-
-	return -1;
-}
-
-function Test( settings ) {
-	extend( this, settings );
-	this.assertions = [];
-	this.testNumber = ++Test.count;
-}
-
-Test.count = 0;
-
-Test.prototype = {
-	init: function() {
-		var a, b, li,
-			tests = id( "qunit-tests" );
-
-		if ( tests ) {
-			b = document.createElement( "strong" );
-			b.innerHTML = this.nameHtml;
-
-			// `a` initialized at top of scope
-			a = document.createElement( "a" );
-			a.innerHTML = "Rerun";
-			a.href = QUnit.url({ testNumber: this.testNumber });
-
-			li = document.createElement( "li" );
-			li.appendChild( b );
-			li.appendChild( a );
-			li.className = "running";
-			li.id = this.id = "qunit-test-output" + testId++;
-
-			tests.appendChild( li );
-		}
-	},
-	setup: function() {
-		if (
-			// Emit moduleStart when we're switching from one module to another
-			this.module !== config.previousModule ||
-				// They could be equal (both undefined) but if the previousModule property doesn't
-				// yet exist it means this is the first test in a suite that isn't wrapped in a
-				// module, in which case we'll just emit a moduleStart event for 'undefined'.
-				// Without this, reporters can get testStart before moduleStart  which is a problem.
-				!hasOwn.call( config, "previousModule" )
-		) {
-			if ( hasOwn.call( config, "previousModule" ) ) {
-				runLoggingCallbacks( "moduleDone", QUnit, {
-					name: config.previousModule,
-					failed: config.moduleStats.bad,
-					passed: config.moduleStats.all - config.moduleStats.bad,
-					total: config.moduleStats.all
-				});
-			}
-			config.previousModule = this.module;
-			config.moduleStats = { all: 0, bad: 0 };
-			runLoggingCallbacks( "moduleStart", QUnit, {
-				name: this.module
-			});
-		}
-
-		config.current = this;
-
-		this.testEnvironment = extend({
-			setup: function() {},
-			teardown: function() {}
-		}, this.moduleTestEnvironment );
-
-		this.started = +new Date();
-		runLoggingCallbacks( "testStart", QUnit, {
-			name: this.testName,
-			module: this.module
-		});
-
-		/*jshint camelcase:false */
-
-
-		/**
-		 * Expose the current test environment.
-		 *
-		 * @deprecated since 1.12.0: Use QUnit.config.current.testEnvironment instead.
-		 */
-		QUnit.current_testEnvironment = this.testEnvironment;
-
-		/*jshint camelcase:true */
-
-		if ( !config.pollution ) {
-			saveGlobal();
-		}
-		if ( config.notrycatch ) {
-			this.testEnvironment.setup.call( this.testEnvironment, QUnit.assert );
-			return;
-		}
-		try {
-			this.testEnvironment.setup.call( this.testEnvironment, QUnit.assert );
-		} catch( e ) {
-			QUnit.pushFailure( "Setup failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
-		}
-	},
-	run: function() {
-		config.current = this;
-
-		var running = id( "qunit-testresult" );
-
-		if ( running ) {
-			running.innerHTML = "Running: <br/>" + this.nameHtml;
-		}
-
-		if ( this.async ) {
-			QUnit.stop();
-		}
-
-		this.callbackStarted = +new Date();
-
-		if ( config.notrycatch ) {
-			this.callback.call( this.testEnvironment, QUnit.assert );
-			this.callbackRuntime = +new Date() - this.callbackStarted;
-			return;
-		}
-
-		try {
-			this.callback.call( this.testEnvironment, QUnit.assert );
-			this.callbackRuntime = +new Date() - this.callbackStarted;
-		} catch( e ) {
-			this.callbackRuntime = +new Date() - this.callbackStarted;
-
-			QUnit.pushFailure( "Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + ( e.message || e ), extractStacktrace( e, 0 ) );
-			// else next test will carry the responsibility
-			saveGlobal();
-
-			// Restart the tests if they're blocking
-			if ( config.blocking ) {
-				QUnit.start();
-			}
-		}
-	},
-	teardown: function() {
-		config.current = this;
-		if ( config.notrycatch ) {
-			if ( typeof this.callbackRuntime === "undefined" ) {
-				this.callbackRuntime = +new Date() - this.callbackStarted;
-			}
-			this.testEnvironment.teardown.call( this.testEnvironment, QUnit.assert );
-			return;
-		} else {
-			try {
-				this.testEnvironment.teardown.call( this.testEnvironment, QUnit.assert );
-			} catch( e ) {
-				QUnit.pushFailure( "Teardown failed on " + this.testName + ": " + ( e.message || e ), extractStacktrace( e, 1 ) );
-			}
-		}
-		checkPollution();
-	},
-	finish: function() {
-		config.current = this;
-		if ( config.requireExpects && this.expected === null ) {
-			QUnit.pushFailure( "Expected number of assertions to be defined, but expect() was not called.", this.stack );
-		} else if ( this.expected !== null && this.expected !== this.assertions.length ) {
-			QUnit.pushFailure( "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack );
-		} else if ( this.expected === null && !this.assertions.length ) {
-			QUnit.pushFailure( "Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.", this.stack );
-		}
-
-		var i, assertion, a, b, time, li, ol,
-			test = this,
-			good = 0,
-			bad = 0,
-			tests = id( "qunit-tests" );
-
-		this.runtime = +new Date() - this.started;
-		config.stats.all += this.assertions.length;
-		config.moduleStats.all += this.assertions.length;
-
-		if ( tests ) {
-			ol = document.createElement( "ol" );
-			ol.className = "qunit-assert-list";
-
-			for ( i = 0; i < this.assertions.length; i++ ) {
-				assertion = this.assertions[i];
-
-				li = document.createElement( "li" );
-				li.className = assertion.result ? "pass" : "fail";
-				li.innerHTML = assertion.message || ( assertion.result ? "okay" : "failed" );
-				ol.appendChild( li );
-
-				if ( assertion.result ) {
-					good++;
-				} else {
-					bad++;
-					config.stats.bad++;
-					config.moduleStats.bad++;
-				}
-			}
-
-			// store result when possible
-			if ( QUnit.config.reorder && defined.sessionStorage ) {
-				if ( bad ) {
-					sessionStorage.setItem( "qunit-test-" + this.module + "-" + this.testName, bad );
-				} else {
-					sessionStorage.removeItem( "qunit-test-" + this.module + "-" + this.testName );
-				}
-			}
-
-			if ( bad === 0 ) {
-				addClass( ol, "qunit-collapsed" );
-			}
-
-			// `b` initialized at top of scope
-			b = document.createElement( "strong" );
-			b.innerHTML = this.nameHtml + " <b class='counts'>(<b class='failed'>" + bad + "</b>, <b class='passed'>" + good + "</b>, " + this.assertions.length + ")</b>";
-
-			addEvent(b, "click", function() {
-				var next = b.parentNode.lastChild,
-					collapsed = hasClass( next, "qunit-collapsed" );
-				( collapsed ? removeClass : addClass )( next, "qunit-collapsed" );
-			});
-
-			addEvent(b, "dblclick", function( e ) {
-				var target = e && e.target ? e.target : window.event.srcElement;
-				if ( target.nodeName.toLowerCase() === "span" || target.nodeName.toLowerCase() === "b" ) {
-					target = target.parentNode;
-				}
-				if ( window.location && target.nodeName.toLowerCase() === "strong" ) {
-					window.location = QUnit.url({ testNumber: test.testNumber });
-				}
-			});
-
-			// `time` initialized at top of scope
-			time = document.createElement( "span" );
-			time.className = "runtime";
-			time.innerHTML = this.runtime + " ms";
-
-			// `li` initialized at top of scope
-			li = id( this.id );
-			li.className = bad ? "fail" : "pass";
-			li.removeChild( li.firstChild );
-			a = li.firstChild;
-			li.appendChild( b );
-			li.appendChild( a );
-			li.appendChild( time );
-			li.appendChild( ol );
-
-		} else {
-			for ( i = 0; i < this.assertions.length; i++ ) {
-				if ( !this.assertions[i].result ) {
-					bad++;
-					config.stats.bad++;
-					config.moduleStats.bad++;
-				}
-			}
-		}
-
-		runLoggingCallbacks( "testDone", QUnit, {
-			name: this.testName,
-			module: this.module,
-			failed: bad,
-			passed: this.assertions.length - bad,
-			total: this.assertions.length,
-			runtime: this.runtime,
-			// DEPRECATED: this property will be removed in 2.0.0, use runtime instead
-			duration: this.runtime
-		});
-
-		QUnit.reset();
-
-		config.current = undefined;
-	},
-
-	queue: function() {
-		var bad,
-			test = this;
-
-		synchronize(function() {
-			test.init();
-		});
-		function run() {
-			// each of these can by async
-			synchronize(function() {
-				test.setup();
-			});
-			synchronize(function() {
-				test.run();
-			});
-			synchronize(function() {
-				test.teardown();
-			});
-			synchronize(function() {
-				test.finish();
-			});
-		}
-
-		// `bad` initialized at top of scope
-		// defer when previous test run passed, if storage is available
-		bad = QUnit.config.reorder && defined.sessionStorage &&
-						+sessionStorage.getItem( "qunit-test-" + this.module + "-" + this.testName );
-
-		if ( bad ) {
-			run();
-		} else {
-			synchronize( run, true );
-		}
-	}
-};
-
-// `assert` initialized at top of scope
-// Assert helpers
-// All of these must either call QUnit.push() or manually do:
-// - runLoggingCallbacks( "log", .. );
-// - config.current.assertions.push({ .. });
-assert = QUnit.assert = {
-	/**
-	 * Asserts rough true-ish result.
-	 * @name ok
-	 * @function
-	 * @example ok( "asdfasdf".length > 5, "There must be at least 5 chars" );
-	 */
-	ok: function( result, msg ) {
-		if ( !config.current ) {
-			throw new Error( "ok() assertion outside test context, was " + sourceFromStacktrace(2) );
-		}
-		result = !!result;
-		msg = msg || ( result ? "okay" : "failed" );
-
-		var source,
-			details = {
-				module: config.current.module,
-				name: config.current.testName,
-				result: result,
-				message: msg
-			};
-
-		msg = "<span class='test-message'>" + escapeText( msg ) + "</span>";
-
-		if ( !result ) {
-			source = sourceFromStacktrace( 2 );
-			if ( source ) {
-				details.source = source;
-				msg += "<table><tr class='test-source'><th>Source: </th><td><pre>" +
-					escapeText( source ) +
-					"</pre></td></tr></table>";
-			}
-		}
-		runLoggingCallbacks( "log", QUnit, details );
-		config.current.assertions.push({
-			result: result,
-			message: msg
-		});
-	},
-
-	/**
-	 * Assert that the first two arguments are equal, with an optional message.
-	 * Prints out both actual and expected values.
-	 * @name equal
-	 * @function
-	 * @example equal( format( "Received {0} bytes.", 2), "Received 2 bytes.", "format() replaces {0} with next argument" );
-	 */
-	equal: function( actual, expected, message ) {
-		/*jshint eqeqeq:false */
-		QUnit.push( expected == actual, actual, expected, message );
-	},
-
-	/**
-	 * @name notEqual
-	 * @function
-	 */
-	notEqual: function( actual, expected, message ) {
-		/*jshint eqeqeq:false */
-		QUnit.push( expected != actual, actual, expected, message );
-	},
-
-	/**
-	 * @name propEqual
-	 * @function
-	 */
-	propEqual: function( actual, expected, message ) {
-		actual = objectValues(actual);
-		expected = objectValues(expected);
-		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
-	},
-
-	/**
-	 * @name notPropEqual
-	 * @function
-	 */
-	notPropEqual: function( actual, expected, message ) {
-		actual = objectValues(actual);
-		expected = objectValues(expected);
-		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
-	},
-
-	/**
-	 * @name deepEqual
-	 * @function
-	 */
-	deepEqual: function( actual, expected, message ) {
-		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
-	},
-
-	/**
-	 * @name notDeepEqual
-	 * @function
-	 */
-	notDeepEqual: function( actual, expected, message ) {
-		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
-	},
-
-	/**
-	 * @name strictEqual
-	 * @function
-	 */
-	strictEqual: function( actual, expected, message ) {
-		QUnit.push( expected === actual, actual, expected, message );
-	},
-
-	/**
-	 * @name notStrictEqual
-	 * @function
-	 */
-	notStrictEqual: function( actual, expected, message ) {
-		QUnit.push( expected !== actual, actual, expected, message );
-	},
-
-	"throws": function( block, expected, message ) {
-		var actual,
-			expectedOutput = expected,
-			ok = false;
-
-		// 'expected' is optional
-		if ( !message && typeof expected === "string" ) {
-			message = expected;
-			expected = null;
-		}
-
-		config.current.ignoreGlobalErrors = true;
-		try {
-			block.call( config.current.testEnvironment );
-		} catch (e) {
-			actual = e;
-		}
-		config.current.ignoreGlobalErrors = false;
-
-		if ( actual ) {
-
-			// we don't want to validate thrown error
-			if ( !expected ) {
-				ok = true;
-				expectedOutput = null;
-
-			// expected is an Error object
-			} else if ( expected instanceof Error ) {
-				ok = actual instanceof Error &&
-					 actual.name === expected.name &&
-					 actual.message === expected.message;
-
-			// expected is a regexp
-			} else if ( QUnit.objectType( expected ) === "regexp" ) {
-				ok = expected.test( errorString( actual ) );
-
-			// expected is a string
-			} else if ( QUnit.objectType( expected ) === "string" ) {
-				ok = expected === errorString( actual );
-
-			// expected is a constructor
-			} else if ( actual instanceof expected ) {
-				ok = true;
-
-			// expected is a validation function which returns true is validation passed
-			} else if ( expected.call( {}, actual ) === true ) {
-				expectedOutput = null;
-				ok = true;
-			}
-
-			QUnit.push( ok, actual, expectedOutput, message );
-		} else {
-			QUnit.pushFailure( message, null, "No exception was thrown." );
-		}
-	}
-};
-
-/**
- * @deprecated since 1.8.0
- * Kept assertion helpers in root for backwards compatibility.
- */
-extend( QUnit.constructor.prototype, assert );
-
-/**
- * @deprecated since 1.9.0
- * Kept to avoid TypeErrors for undefined methods.
- */
-QUnit.constructor.prototype.raises = function() {
-	QUnit.push( false, false, false, "QUnit.raises has been deprecated since 2012 (fad3c1ea), use QUnit.throws instead" );
-};
-
-/**
- * @deprecated since 1.0.0, replaced with error pushes since 1.3.0
- * Kept to avoid TypeErrors for undefined methods.
- */
-QUnit.constructor.prototype.equals = function() {
-	QUnit.push( false, false, false, "QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead" );
-};
-QUnit.constructor.prototype.same = function() {
-	QUnit.push( false, false, false, "QUnit.same has been deprecated since 2009 (e88049a0), use QUnit.deepEqual instead" );
-};
-
-// Test for equality any JavaScript type.
-// Author: Philippe Rathé <prathe@gmail.com>
-QUnit.equiv = (function() {
-
-	// Call the o related callback with the given arguments.
-	function bindCallbacks( o, callbacks, args ) {
-		var prop = QUnit.objectType( o );
-		if ( prop ) {
-			if ( QUnit.objectType( callbacks[ prop ] ) === "function" ) {
-				return callbacks[ prop ].apply( callbacks, args );
-			} else {
-				return callbacks[ prop ]; // or undefined
-			}
-		}
-	}
-
-	// the real equiv function
-	var innerEquiv,
-		// stack to decide between skip/abort functions
-		callers = [],
-		// stack to avoiding loops from circular referencing
-		parents = [],
-		parentsB = [],
-
-		getProto = Object.getPrototypeOf || function ( obj ) {
-			/*jshint camelcase:false */
-			return obj.__proto__;
-		},
-		callbacks = (function () {
-
-			// for string, boolean, number and null
-			function useStrictEquality( b, a ) {
-				/*jshint eqeqeq:false */
-				if ( b instanceof a.constructor || a instanceof b.constructor ) {
-					// to catch short annotation VS 'new' annotation of a
-					// declaration
-					// e.g. var i = 1;
-					// var j = new Number(1);
-					return a == b;
-				} else {
-					return a === b;
-				}
-			}
-
-			return {
-				"string": useStrictEquality,
-				"boolean": useStrictEquality,
-				"number": useStrictEquality,
-				"null": useStrictEquality,
-				"undefined": useStrictEquality,
-
-				"nan": function( b ) {
-					return isNaN( b );
-				},
-
-				"date": function( b, a ) {
-					return QUnit.objectType( b ) === "date" && a.valueOf() === b.valueOf();
-				},
-
-				"regexp": function( b, a ) {
-					return QUnit.objectType( b ) === "regexp" &&
-						// the regex itself
-						a.source === b.source &&
-						// and its modifiers
-						a.global === b.global &&
-						// (gmi) ...
-						a.ignoreCase === b.ignoreCase &&
-						a.multiline === b.multiline &&
-						a.sticky === b.sticky;
-				},
-
-				// - skip when the property is a method of an instance (OOP)
-				// - abort otherwise,
-				// initial === would have catch identical references anyway
-				"function": function() {
-					var caller = callers[callers.length - 1];
-					return caller !== Object && typeof caller !== "undefined";
-				},
-
-				"array": function( b, a ) {
-					var i, j, len, loop, aCircular, bCircular;
-
-					// b could be an object literal here
-					if ( QUnit.objectType( b ) !== "array" ) {
-						return false;
-					}
-
-					len = a.length;
-					if ( len !== b.length ) {
-						// safe and faster
-						return false;
-					}
-
-					// track reference to avoid circular references
-					parents.push( a );
-					parentsB.push( b );
-					for ( i = 0; i < len; i++ ) {
-						loop = false;
-						for ( j = 0; j < parents.length; j++ ) {
-							aCircular = parents[j] === a[i];
-							bCircular = parentsB[j] === b[i];
-							if ( aCircular || bCircular ) {
-								if ( a[i] === b[i] || aCircular && bCircular ) {
-									loop = true;
-								} else {
-									parents.pop();
-									parentsB.pop();
-									return false;
-								}
-							}
-						}
-						if ( !loop && !innerEquiv(a[i], b[i]) ) {
-							parents.pop();
-							parentsB.pop();
-							return false;
-						}
-					}
-					parents.pop();
-					parentsB.pop();
-					return true;
-				},
-
-				"object": function( b, a ) {
-					/*jshint forin:false */
-					var i, j, loop, aCircular, bCircular,
-						// Default to true
-						eq = true,
-						aProperties = [],
-						bProperties = [];
-
-					// comparing constructors is more strict than using
-					// instanceof
-					if ( a.constructor !== b.constructor ) {
-						// Allow objects with no prototype to be equivalent to
-						// objects with Object as their constructor.
-						if ( !(( getProto(a) === null && getProto(b) === Object.prototype ) ||
-							( getProto(b) === null && getProto(a) === Object.prototype ) ) ) {
-								return false;
-						}
-					}
-
-					// stack constructor before traversing properties
-					callers.push( a.constructor );
-
-					// track reference to avoid circular references
-					parents.push( a );
-					parentsB.push( b );
-
-					// be strict: don't ensure hasOwnProperty and go deep
-					for ( i in a ) {
-						loop = false;
-						for ( j = 0; j < parents.length; j++ ) {
-							aCircular = parents[j] === a[i];
-							bCircular = parentsB[j] === b[i];
-							if ( aCircular || bCircular ) {
-								if ( a[i] === b[i] || aCircular && bCircular ) {
-									loop = true;
-								} else {
-									eq = false;
-									break;
-								}
-							}
-						}
-						aProperties.push(i);
-						if ( !loop && !innerEquiv(a[i], b[i]) ) {
-							eq = false;
-							break;
-						}
-					}
-
-					parents.pop();
-					parentsB.pop();
-					callers.pop(); // unstack, we are done
-
-					for ( i in b ) {
-						bProperties.push( i ); // collect b's properties
-					}
-
-					// Ensures identical properties name
-					return eq && innerEquiv( aProperties.sort(), bProperties.sort() );
-				}
-			};
-		}());
-
-	innerEquiv = function() { // can take multiple arguments
-		var args = [].slice.apply( arguments );
-		if ( args.length < 2 ) {
-			return true; // end transition
-		}
-
-		return (function( a, b ) {
-			if ( a === b ) {
-				return true; // catch the most you can
-			} else if ( a === null || b === null || typeof a === "undefined" ||
-					typeof b === "undefined" ||
-					QUnit.objectType(a) !== QUnit.objectType(b) ) {
-				return false; // don't lose time with error prone cases
-			} else {
-				return bindCallbacks(a, callbacks, [ b, a ]);
-			}
-
-			// apply transition with (1..n) arguments
-		}( args[0], args[1] ) && innerEquiv.apply( this, args.splice(1, args.length - 1 )) );
-	};
-
-	return innerEquiv;
-}());
-
-/**
- * jsDump Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com |
- * http://flesler.blogspot.com Licensed under BSD
- * (http://www.opensource.org/licenses/bsd-license.php) Date: 5/15/2008
- *
- * @projectDescription Advanced and extensible data dumping for Javascript.
- * @version 1.0.0
- * @author Ariel Flesler
- * @link {http://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html}
- */
-QUnit.jsDump = (function() {
-	function quote( str ) {
-		return "\"" + str.toString().replace( /"/g, "\\\"" ) + "\"";
-	}
-	function literal( o ) {
-		return o + "";
-	}
-	function join( pre, arr, post ) {
-		var s = jsDump.separator(),
-			base = jsDump.indent(),
-			inner = jsDump.indent(1);
-		if ( arr.join ) {
-			arr = arr.join( "," + s + inner );
-		}
-		if ( !arr ) {
-			return pre + post;
-		}
-		return [ pre, inner + arr, base + post ].join(s);
-	}
-	function array( arr, stack ) {
-		var i = arr.length, ret = new Array(i);
-		this.up();
-		while ( i-- ) {
-			ret[i] = this.parse( arr[i] , undefined , stack);
-		}
-		this.down();
-		return join( "[", ret, "]" );
-	}
-
-	var reName = /^function (\w+)/,
-		jsDump = {
-			// type is used mostly internally, you can fix a (custom)type in advance
-			parse: function( obj, type, stack ) {
-				stack = stack || [ ];
-				var inStack, res,
-					parser = this.parsers[ type || this.typeOf(obj) ];
-
-				type = typeof parser;
-				inStack = inArray( obj, stack );
-
-				if ( inStack !== -1 ) {
-					return "recursion(" + (inStack - stack.length) + ")";
-				}
-				if ( type === "function" )  {
-					stack.push( obj );
-					res = parser.call( this, obj, stack );
-					stack.pop();
-					return res;
-				}
-				return ( type === "string" ) ? parser : this.parsers.error;
-			},
-			typeOf: function( obj ) {
-				var type;
-				if ( obj === null ) {
-					type = "null";
-				} else if ( typeof obj === "undefined" ) {
-					type = "undefined";
-				} else if ( QUnit.is( "regexp", obj) ) {
-					type = "regexp";
-				} else if ( QUnit.is( "date", obj) ) {
-					type = "date";
-				} else if ( QUnit.is( "function", obj) ) {
-					type = "function";
-				} else if ( typeof obj.setInterval !== undefined && typeof obj.document !== "undefined" && typeof obj.nodeType === "undefined" ) {
-					type = "window";
-				} else if ( obj.nodeType === 9 ) {
-					type = "document";
-				} else if ( obj.nodeType ) {
-					type = "node";
-				} else if (
-					// native arrays
-					toString.call( obj ) === "[object Array]" ||
-					// NodeList objects
-					( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item(0) === obj[0] : ( obj.item( 0 ) === null && typeof obj[0] === "undefined" ) ) )
-				) {
-					type = "array";
-				} else if ( obj.constructor === Error.prototype.constructor ) {
-					type = "error";
-				} else {
-					type = typeof obj;
-				}
-				return type;
-			},
-			separator: function() {
-				return this.multiline ?	this.HTML ? "<br />" : "\n" : this.HTML ? "&nbsp;" : " ";
-			},
-			// extra can be a number, shortcut for increasing-calling-decreasing
-			indent: function( extra ) {
-				if ( !this.multiline ) {
-					return "";
-				}
-				var chr = this.indentChar;
-				if ( this.HTML ) {
-					chr = chr.replace( /\t/g, "   " ).replace( / /g, "&nbsp;" );
-				}
-				return new Array( this.depth + ( extra || 0 ) ).join(chr);
-			},
-			up: function( a ) {
-				this.depth += a || 1;
-			},
-			down: function( a ) {
-				this.depth -= a || 1;
-			},
-			setParser: function( name, parser ) {
-				this.parsers[name] = parser;
-			},
-			// The next 3 are exposed so you can use them
-			quote: quote,
-			literal: literal,
-			join: join,
-			//
-			depth: 1,
-			// This is the list of parsers, to modify them, use jsDump.setParser
-			parsers: {
-				window: "[Window]",
-				document: "[Document]",
-				error: function(error) {
-					return "Error(\"" + error.message + "\")";
-				},
-				unknown: "[Unknown]",
-				"null": "null",
-				"undefined": "undefined",
-				"function": function( fn ) {
-					var ret = "function",
-						// functions never have name in IE
-						name = "name" in fn ? fn.name : (reName.exec(fn) || [])[1];
-
-					if ( name ) {
-						ret += " " + name;
-					}
-					ret += "( ";
-
-					ret = [ ret, QUnit.jsDump.parse( fn, "functionArgs" ), "){" ].join( "" );
-					return join( ret, QUnit.jsDump.parse(fn,"functionCode" ), "}" );
-				},
-				array: array,
-				nodelist: array,
-				"arguments": array,
-				object: function( map, stack ) {
-					/*jshint forin:false */
-					var ret = [ ], keys, key, val, i;
-					QUnit.jsDump.up();
-					keys = [];
-					for ( key in map ) {
-						keys.push( key );
-					}
-					keys.sort();
-					for ( i = 0; i < keys.length; i++ ) {
-						key = keys[ i ];
-						val = map[ key ];
-						ret.push( QUnit.jsDump.parse( key, "key" ) + ": " + QUnit.jsDump.parse( val, undefined, stack ) );
-					}
-					QUnit.jsDump.down();
-					return join( "{", ret, "}" );
-				},
-				node: function( node ) {
-					var len, i, val,
-						open = QUnit.jsDump.HTML ? "&lt;" : "<",
-						close = QUnit.jsDump.HTML ? "&gt;" : ">",
-						tag = node.nodeName.toLowerCase(),
-						ret = open + tag,
-						attrs = node.attributes;
-
-					if ( attrs ) {
-						for ( i = 0, len = attrs.length; i < len; i++ ) {
-							val = attrs[i].nodeValue;
-							// IE6 includes all attributes in .attributes, even ones not explicitly set.
-							// Those have values like undefined, null, 0, false, "" or "inherit".
-							if ( val && val !== "inherit" ) {
-								ret += " " + attrs[i].nodeName + "=" + QUnit.jsDump.parse( val, "attribute" );
-							}
-						}
-					}
-					ret += close;
-
-					// Show content of TextNode or CDATASection
-					if ( node.nodeType === 3 || node.nodeType === 4 ) {
-						ret += node.nodeValue;
-					}
-
-					return ret + open + "/" + tag + close;
-				},
-				// function calls it internally, it's the arguments part of the function
-				functionArgs: function( fn ) {
-					var args,
-						l = fn.length;
-
-					if ( !l ) {
-						return "";
-					}
-
-					args = new Array(l);
-					while ( l-- ) {
-						// 97 is 'a'
-						args[l] = String.fromCharCode(97+l);
-					}
-					return " " + args.join( ", " ) + " ";
-				},
-				// object calls it internally, the key part of an item in a map
-				key: quote,
-				// function calls it internally, it's the content of the function
-				functionCode: "[code]",
-				// node calls it internally, it's an html attribute value
-				attribute: quote,
-				string: quote,
-				date: quote,
-				regexp: literal,
-				number: literal,
-				"boolean": literal
-			},
-			// if true, entities are escaped ( <, >, \t, space and \n )
-			HTML: false,
-			// indentation unit
-			indentChar: "  ",
-			// if true, items in a collection, are separated by a \n, else just a space.
-			multiline: true
-		};
-
-	return jsDump;
-}());
-
-/*
- * Javascript Diff Algorithm
- *  By John Resig (http://ejohn.org/)
- *  Modified by Chu Alan "sprite"
- *
- * Released under the MIT license.
- *
- * More Info:
- *  http://ejohn.org/projects/javascript-diff-algorithm/
- *
- * Usage: QUnit.diff(expected, actual)
- *
- * QUnit.diff( "the quick brown fox jumped over", "the quick fox jumps over" ) == "the  quick <del>brown </del> fox <del>jumped </del><ins>jumps </ins> over"
- */
-QUnit.diff = (function() {
-	/*jshint eqeqeq:false, eqnull:true */
-	function diff( o, n ) {
-		var i,
-			ns = {},
-			os = {};
-
-		for ( i = 0; i < n.length; i++ ) {
-			if ( !hasOwn.call( ns, n[i] ) ) {
-				ns[ n[i] ] = {
-					rows: [],
-					o: null
-				};
-			}
-			ns[ n[i] ].rows.push( i );
-		}
-
-		for ( i = 0; i < o.length; i++ ) {
-			if ( !hasOwn.call( os, o[i] ) ) {
-				os[ o[i] ] = {
-					rows: [],
-					n: null
-				};
-			}
-			os[ o[i] ].rows.push( i );
-		}
-
-		for ( i in ns ) {
-			if ( hasOwn.call( ns, i ) ) {
-				if ( ns[i].rows.length === 1 && hasOwn.call( os, i ) && os[i].rows.length === 1 ) {
-					n[ ns[i].rows[0] ] = {
-						text: n[ ns[i].rows[0] ],
-						row: os[i].rows[0]
-					};
-					o[ os[i].rows[0] ] = {
-						text: o[ os[i].rows[0] ],
-						row: ns[i].rows[0]
-					};
-				}
-			}
-		}
-
-		for ( i = 0; i < n.length - 1; i++ ) {
-			if ( n[i].text != null && n[ i + 1 ].text == null && n[i].row + 1 < o.length && o[ n[i].row + 1 ].text == null &&
-						n[ i + 1 ] == o[ n[i].row + 1 ] ) {
-
-				n[ i + 1 ] = {
-					text: n[ i + 1 ],
-					row: n[i].row + 1
-				};
-				o[ n[i].row + 1 ] = {
-					text: o[ n[i].row + 1 ],
-					row: i + 1
-				};
-			}
-		}
-
-		for ( i = n.length - 1; i > 0; i-- ) {
-			if ( n[i].text != null && n[ i - 1 ].text == null && n[i].row > 0 && o[ n[i].row - 1 ].text == null &&
-						n[ i - 1 ] == o[ n[i].row - 1 ]) {
-
-				n[ i - 1 ] = {
-					text: n[ i - 1 ],
-					row: n[i].row - 1
-				};
-				o[ n[i].row - 1 ] = {
-					text: o[ n[i].row - 1 ],
-					row: i - 1
-				};
-			}
-		}
-
-		return {
-			o: o,
-			n: n
-		};
-	}
-
-	return function( o, n ) {
-		o = o.replace( /\s+$/, "" );
-		n = n.replace( /\s+$/, "" );
-
-		var i, pre,
-			str = "",
-			out = diff( o === "" ? [] : o.split(/\s+/), n === "" ? [] : n.split(/\s+/) ),
-			oSpace = o.match(/\s+/g),
-			nSpace = n.match(/\s+/g);
-
-		if ( oSpace == null ) {
-			oSpace = [ " " ];
-		}
-		else {
-			oSpace.push( " " );
-		}
-
-		if ( nSpace == null ) {
-			nSpace = [ " " ];
-		}
-		else {
-			nSpace.push( " " );
-		}
-
-		if ( out.n.length === 0 ) {
-			for ( i = 0; i < out.o.length; i++ ) {
-				str += "<del>" + out.o[i] + oSpace[i] + "</del>";
-			}
-		}
-		else {
-			if ( out.n[0].text == null ) {
-				for ( n = 0; n < out.o.length && out.o[n].text == null; n++ ) {
-					str += "<del>" + out.o[n] + oSpace[n] + "</del>";
-				}
-			}
-
-			for ( i = 0; i < out.n.length; i++ ) {
-				if (out.n[i].text == null) {
-					str += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
-				}
-				else {
-					// `pre` initialized at top of scope
-					pre = "";
-
-					for ( n = out.n[i].row + 1; n < out.o.length && out.o[n].text == null; n++ ) {
-						pre += "<del>" + out.o[n] + oSpace[n] + "</del>";
-					}
-					str += " " + out.n[i].text + nSpace[i] + pre;
-				}
-			}
-		}
-
-		return str;
-	};
-}());
-
-// For browser, export only select globals
-if ( typeof window !== "undefined" ) {
-	extend( window, QUnit.constructor.prototype );
-	window.QUnit = QUnit;
-}
-
-// For CommonJS environments, export everything
-if ( typeof module !== "undefined" && module.exports ) {
-	module.exports = QUnit;
-}
-
-
-// Get a reference to the global object, like window in browsers
-}( (function() {
-	return this;
-})() ));
+  global$1 = global$1 && global$1.hasOwnProperty('default') ? global$1['default'] : global$1;
+
+  var window$1 = global$1.window;
+  var self$1 = global$1.self;
+  var console = global$1.console;
+  var setTimeout$1 = global$1.setTimeout;
+  var clearTimeout = global$1.clearTimeout;
+
+  var document$1 = window$1 && window$1.document;
+  var navigator = window$1 && window$1.navigator;
+
+  var localSessionStorage = function () {
+  	var x = "qunit-test-string";
+  	try {
+  		global$1.sessionStorage.setItem(x, x);
+  		global$1.sessionStorage.removeItem(x);
+  		return global$1.sessionStorage;
+  	} catch (e) {
+  		return undefined;
+  	}
+  }();
+
+  /**
+   * Returns a function that proxies to the given method name on the globals
+   * console object. The proxy will also detect if the console doesn't exist and
+   * will appropriately no-op. This allows support for IE9, which doesn't have a
+   * console if the developer tools are not open.
+   */
+  function consoleProxy(method) {
+  	return function () {
+  		if (console) {
+  			console[method].apply(console, arguments);
+  		}
+  	};
+  }
+
+  var Logger = {
+  	warn: consoleProxy("warn")
+  };
+
+  var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
+    return typeof obj;
+  } : function (obj) {
+    return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+  };
+
+
+
+
+
+
+
+
+
+
+
+  var classCallCheck = function (instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  };
+
+  var createClass = function () {
+    function defineProperties(target, props) {
+      for (var i = 0; i < props.length; i++) {
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+      }
+    }
+
+    return function (Constructor, protoProps, staticProps) {
+      if (protoProps) defineProperties(Constructor.prototype, protoProps);
+      if (staticProps) defineProperties(Constructor, staticProps);
+      return Constructor;
+    };
+  }();
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  var toConsumableArray = function (arr) {
+    if (Array.isArray(arr)) {
+      for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+      return arr2;
+    } else {
+      return Array.from(arr);
+    }
+  };
+
+  var toString = Object.prototype.toString;
+  var hasOwn = Object.prototype.hasOwnProperty;
+  var now = Date.now || function () {
+  	return new Date().getTime();
+  };
+
+  var hasPerformanceApi = detectPerformanceApi();
+  var performance = hasPerformanceApi ? window$1.performance : undefined;
+  var performanceNow = hasPerformanceApi ? performance.now.bind(performance) : now;
+
+  function detectPerformanceApi() {
+  	return window$1 && typeof window$1.performance !== "undefined" && typeof window$1.performance.mark === "function" && typeof window$1.performance.measure === "function";
+  }
+
+  function measure(comment, startMark, endMark) {
+
+  	// `performance.measure` may fail if the mark could not be found.
+  	// reasons a specific mark could not be found include: outside code invoking `performance.clearMarks()`
+  	try {
+  		performance.measure(comment, startMark, endMark);
+  	} catch (ex) {
+  		Logger.warn("performance.measure could not be executed because of ", ex.message);
+  	}
+  }
+
+  var defined = {
+  	document: window$1 && window$1.document !== undefined,
+  	setTimeout: setTimeout$1 !== undefined
+  };
+
+  // Returns a new Array with the elements that are in a but not in b
+  function diff(a, b) {
+  	var i,
+  	    j,
+  	    result = a.slice();
+
+  	for (i = 0; i < result.length; i++) {
+  		for (j = 0; j < b.length; j++) {
+  			if (result[i] === b[j]) {
+  				result.splice(i, 1);
+  				i--;
+  				break;
+  			}
+  		}
+  	}
+  	return result;
+  }
+
+  /**
+   * Determines whether an element exists in a given array or not.
+   *
+   * @method inArray
+   * @param {Any} elem
+   * @param {Array} array
+   * @return {Boolean}
+   */
+  function inArray(elem, array) {
+  	return array.indexOf(elem) !== -1;
+  }
+
+  /**
+   * Makes a clone of an object using only Array or Object as base,
+   * and copies over the own enumerable properties.
+   *
+   * @param {Object} obj
+   * @return {Object} New object with only the own properties (recursively).
+   */
+  function objectValues(obj) {
+  	var key,
+  	    val,
+  	    vals = is("array", obj) ? [] : {};
+  	for (key in obj) {
+  		if (hasOwn.call(obj, key)) {
+  			val = obj[key];
+  			vals[key] = val === Object(val) ? objectValues(val) : val;
+  		}
+  	}
+  	return vals;
+  }
+
+  function extend(a, b, undefOnly) {
+  	for (var prop in b) {
+  		if (hasOwn.call(b, prop)) {
+  			if (b[prop] === undefined) {
+  				delete a[prop];
+  			} else if (!(undefOnly && typeof a[prop] !== "undefined")) {
+  				a[prop] = b[prop];
+  			}
+  		}
+  	}
+
+  	return a;
+  }
+
+  function objectType(obj) {
+  	if (typeof obj === "undefined") {
+  		return "undefined";
+  	}
+
+  	// Consider: typeof null === object
+  	if (obj === null) {
+  		return "null";
+  	}
+
+  	var match = toString.call(obj).match(/^\[object\s(.*)\]$/),
+  	    type = match && match[1];
+
+  	switch (type) {
+  		case "Number":
+  			if (isNaN(obj)) {
+  				return "nan";
+  			}
+  			return "number";
+  		case "String":
+  		case "Boolean":
+  		case "Array":
+  		case "Set":
+  		case "Map":
+  		case "Date":
+  		case "RegExp":
+  		case "Function":
+  		case "Symbol":
+  			return type.toLowerCase();
+  		default:
+  			return typeof obj === "undefined" ? "undefined" : _typeof(obj);
+  	}
+  }
+
+  // Safe object type checking
+  function is(type, obj) {
+  	return objectType(obj) === type;
+  }
+
+  // Based on Java's String.hashCode, a simple but not
+  // rigorously collision resistant hashing function
+  function generateHash(module, testName) {
+  	var str = module + "\x1C" + testName;
+  	var hash = 0;
+
+  	for (var i = 0; i < str.length; i++) {
+  		hash = (hash << 5) - hash + str.charCodeAt(i);
+  		hash |= 0;
+  	}
+
+  	// Convert the possibly negative integer hash code into an 8 character hex string, which isn't
+  	// strictly necessary but increases user understanding that the id is a SHA-like hash
+  	var hex = (0x100000000 + hash).toString(16);
+  	if (hex.length < 8) {
+  		hex = "0000000" + hex;
+  	}
+
+  	return hex.slice(-8);
+  }
+
+  // Test for equality any JavaScript type.
+  // Authors: Philippe Rathé <prathe@gmail.com>, David Chan <david@troi.org>
+  var equiv = (function () {
+
+  	// Value pairs queued for comparison. Used for breadth-first processing order, recursion
+  	// detection and avoiding repeated comparison (see below for details).
+  	// Elements are { a: val, b: val }.
+  	var pairs = [];
+
+  	var getProto = Object.getPrototypeOf || function (obj) {
+  		return obj.__proto__;
+  	};
+
+  	function useStrictEquality(a, b) {
+
+  		// This only gets called if a and b are not strict equal, and is used to compare on
+  		// the primitive values inside object wrappers. For example:
+  		// `var i = 1;`
+  		// `var j = new Number(1);`
+  		// Neither a nor b can be null, as a !== b and they have the same type.
+  		if ((typeof a === "undefined" ? "undefined" : _typeof(a)) === "object") {
+  			a = a.valueOf();
+  		}
+  		if ((typeof b === "undefined" ? "undefined" : _typeof(b)) === "object") {
+  			b = b.valueOf();
+  		}
+
+  		return a === b;
+  	}
+
+  	function compareConstructors(a, b) {
+  		var protoA = getProto(a);
+  		var protoB = getProto(b);
+
+  		// Comparing constructors is more strict than using `instanceof`
+  		if (a.constructor === b.constructor) {
+  			return true;
+  		}
+
+  		// Ref #851
+  		// If the obj prototype descends from a null constructor, treat it
+  		// as a null prototype.
+  		if (protoA && protoA.constructor === null) {
+  			protoA = null;
+  		}
+  		if (protoB && protoB.constructor === null) {
+  			protoB = null;
+  		}
+
+  		// Allow objects with no prototype to be equivalent to
+  		// objects with Object as their constructor.
+  		if (protoA === null && protoB === Object.prototype || protoB === null && protoA === Object.prototype) {
+  			return true;
+  		}
+
+  		return false;
+  	}
+
+  	function getRegExpFlags(regexp) {
+  		return "flags" in regexp ? regexp.flags : regexp.toString().match(/[gimuy]*$/)[0];
+  	}
+
+  	function isContainer(val) {
+  		return ["object", "array", "map", "set"].indexOf(objectType(val)) !== -1;
+  	}
+
+  	function breadthFirstCompareChild(a, b) {
+
+  		// If a is a container not reference-equal to b, postpone the comparison to the
+  		// end of the pairs queue -- unless (a, b) has been seen before, in which case skip
+  		// over the pair.
+  		if (a === b) {
+  			return true;
+  		}
+  		if (!isContainer(a)) {
+  			return typeEquiv(a, b);
+  		}
+  		if (pairs.every(function (pair) {
+  			return pair.a !== a || pair.b !== b;
+  		})) {
+
+  			// Not yet started comparing this pair
+  			pairs.push({ a: a, b: b });
+  		}
+  		return true;
+  	}
+
+  	var callbacks = {
+  		"string": useStrictEquality,
+  		"boolean": useStrictEquality,
+  		"number": useStrictEquality,
+  		"null": useStrictEquality,
+  		"undefined": useStrictEquality,
+  		"symbol": useStrictEquality,
+  		"date": useStrictEquality,
+
+  		"nan": function nan() {
+  			return true;
+  		},
+
+  		"regexp": function regexp(a, b) {
+  			return a.source === b.source &&
+
+  			// Include flags in the comparison
+  			getRegExpFlags(a) === getRegExpFlags(b);
+  		},
+
+  		// abort (identical references / instance methods were skipped earlier)
+  		"function": function _function() {
+  			return false;
+  		},
+
+  		"array": function array(a, b) {
+  			var i, len;
+
+  			len = a.length;
+  			if (len !== b.length) {
+
+  				// Safe and faster
+  				return false;
+  			}
+
+  			for (i = 0; i < len; i++) {
+
+  				// Compare non-containers; queue non-reference-equal containers
+  				if (!breadthFirstCompareChild(a[i], b[i])) {
+  					return false;
+  				}
+  			}
+  			return true;
+  		},
+
+  		// Define sets a and b to be equivalent if for each element aVal in a, there
+  		// is some element bVal in b such that aVal and bVal are equivalent. Element
+  		// repetitions are not counted, so these are equivalent:
+  		// a = new Set( [ {}, [], [] ] );
+  		// b = new Set( [ {}, {}, [] ] );
+  		"set": function set$$1(a, b) {
+  			var innerEq,
+  			    outerEq = true;
+
+  			if (a.size !== b.size) {
+
+  				// This optimization has certain quirks because of the lack of
+  				// repetition counting. For instance, adding the same
+  				// (reference-identical) element to two equivalent sets can
+  				// make them non-equivalent.
+  				return false;
+  			}
+
+  			a.forEach(function (aVal) {
+
+  				// Short-circuit if the result is already known. (Using for...of
+  				// with a break clause would be cleaner here, but it would cause
+  				// a syntax error on older Javascript implementations even if
+  				// Set is unused)
+  				if (!outerEq) {
+  					return;
+  				}
+
+  				innerEq = false;
+
+  				b.forEach(function (bVal) {
+  					var parentPairs;
+
+  					// Likewise, short-circuit if the result is already known
+  					if (innerEq) {
+  						return;
+  					}
+
+  					// Swap out the global pairs list, as the nested call to
+  					// innerEquiv will clobber its contents
+  					parentPairs = pairs;
+  					if (innerEquiv(bVal, aVal)) {
+  						innerEq = true;
+  					}
+
+  					// Replace the global pairs list
+  					pairs = parentPairs;
+  				});
+
+  				if (!innerEq) {
+  					outerEq = false;
+  				}
+  			});
+
+  			return outerEq;
+  		},
+
+  		// Define maps a and b to be equivalent if for each key-value pair (aKey, aVal)
+  		// in a, there is some key-value pair (bKey, bVal) in b such that
+  		// [ aKey, aVal ] and [ bKey, bVal ] are equivalent. Key repetitions are not
+  		// counted, so these are equivalent:
+  		// a = new Map( [ [ {}, 1 ], [ {}, 1 ], [ [], 1 ] ] );
+  		// b = new Map( [ [ {}, 1 ], [ [], 1 ], [ [], 1 ] ] );
+  		"map": function map(a, b) {
+  			var innerEq,
+  			    outerEq = true;
+
+  			if (a.size !== b.size) {
+
+  				// This optimization has certain quirks because of the lack of
+  				// repetition counting. For instance, adding the same
+  				// (reference-identical) key-value pair to two equivalent maps
+  				// can make them non-equivalent.
+  				return false;
+  			}
+
+  			a.forEach(function (aVal, aKey) {
+
+  				// Short-circuit if the result is already known. (Using for...of
+  				// with a break clause would be cleaner here, but it would cause
+  				// a syntax error on older Javascript implementations even if
+  				// Map is unused)
+  				if (!outerEq) {
+  					return;
+  				}
+
+  				innerEq = false;
+
+  				b.forEach(function (bVal, bKey) {
+  					var parentPairs;
+
+  					// Likewise, short-circuit if the result is already known
+  					if (innerEq) {
+  						return;
+  					}
+
+  					// Swap out the global pairs list, as the nested call to
+  					// innerEquiv will clobber its contents
+  					parentPairs = pairs;
+  					if (innerEquiv([bVal, bKey], [aVal, aKey])) {
+  						innerEq = true;
+  					}
+
+  					// Replace the global pairs list
+  					pairs = parentPairs;
+  				});
+
+  				if (!innerEq) {
+  					outerEq = false;
+  				}
+  			});
+
+  			return outerEq;
+  		},
+
+  		"object": function object(a, b) {
+  			var i,
+  			    aProperties = [],
+  			    bProperties = [];
+
+  			if (compareConstructors(a, b) === false) {
+  				return false;
+  			}
+
+  			// Be strict: don't ensure hasOwnProperty and go deep
+  			for (i in a) {
+
+  				// Collect a's properties
+  				aProperties.push(i);
+
+  				// Skip OOP methods that look the same
+  				if (a.constructor !== Object && typeof a.constructor !== "undefined" && typeof a[i] === "function" && typeof b[i] === "function" && a[i].toString() === b[i].toString()) {
+  					continue;
+  				}
+
+  				// Compare non-containers; queue non-reference-equal containers
+  				if (!breadthFirstCompareChild(a[i], b[i])) {
+  					return false;
+  				}
+  			}
+
+  			for (i in b) {
+
+  				// Collect b's properties
+  				bProperties.push(i);
+  			}
+
+  			// Ensures identical properties name
+  			return typeEquiv(aProperties.sort(), bProperties.sort());
+  		}
+  	};
+
+  	function typeEquiv(a, b) {
+  		var type = objectType(a);
+
+  		// Callbacks for containers will append to the pairs queue to achieve breadth-first
+  		// search order. The pairs queue is also used to avoid reprocessing any pair of
+  		// containers that are reference-equal to a previously visited pair (a special case
+  		// this being recursion detection).
+  		//
+  		// Because of this approach, once typeEquiv returns a false value, it should not be
+  		// called again without clearing the pair queue else it may wrongly report a visited
+  		// pair as being equivalent.
+  		return objectType(b) === type && callbacks[type](a, b);
+  	}
+
+  	function innerEquiv(a, b) {
+  		var i, pair;
+
+  		// We're done when there's nothing more to compare
+  		if (arguments.length < 2) {
+  			return true;
+  		}
+
+  		// Clear the global pair queue and add the top-level values being compared
+  		pairs = [{ a: a, b: b }];
+
+  		for (i = 0; i < pairs.length; i++) {
+  			pair = pairs[i];
+
+  			// Perform type-specific comparison on any pairs that are not strictly
+  			// equal. For container types, that comparison will postpone comparison
+  			// of any sub-container pair to the end of the pair queue. This gives
+  			// breadth-first search order. It also avoids the reprocessing of
+  			// reference-equal siblings, cousins etc, which can have a significant speed
+  			// impact when comparing a container of small objects each of which has a
+  			// reference to the same (singleton) large object.
+  			if (pair.a !== pair.b && !typeEquiv(pair.a, pair.b)) {
+  				return false;
+  			}
+  		}
+
+  		// ...across all consecutive argument pairs
+  		return arguments.length === 2 || innerEquiv.apply(this, [].slice.call(arguments, 1));
+  	}
+
+  	return function () {
+  		var result = innerEquiv.apply(undefined, arguments);
+
+  		// Release any retained objects
+  		pairs.length = 0;
+  		return result;
+  	};
+  })();
+
+  /**
+   * Config object: Maintain internal state
+   * Later exposed as QUnit.config
+   * `config` initialized at top of scope
+   */
+  var config = {
+
+  	// The queue of tests to run
+  	queue: [],
+
+  	// Block until document ready
+  	blocking: true,
+
+  	// By default, run previously failed tests first
+  	// very useful in combination with "Hide passed tests" checked
+  	reorder: true,
+
+  	// By default, modify document.title when suite is done
+  	altertitle: true,
+
+  	// HTML Reporter: collapse every test except the first failing test
+  	// If false, all failing tests will be expanded
+  	collapse: true,
+
+  	// By default, scroll to top of the page when suite is done
+  	scrolltop: true,
+
+  	// Depth up-to which object will be dumped
+  	maxDepth: 5,
+
+  	// When enabled, all tests must call expect()
+  	requireExpects: false,
+
+  	// Placeholder for user-configurable form-exposed URL parameters
+  	urlConfig: [],
+
+  	// Set of all modules.
+  	modules: [],
+
+  	// The first unnamed module
+  	currentModule: {
+  		name: "",
+  		tests: [],
+  		childModules: [],
+  		testsRun: 0,
+  		unskippedTestsRun: 0,
+  		hooks: {
+  			before: [],
+  			beforeEach: [],
+  			afterEach: [],
+  			after: []
+  		}
+  	},
+
+  	callbacks: {},
+
+  	// The storage module to use for reordering tests
+  	storage: localSessionStorage
+  };
+
+  // take a predefined QUnit.config and extend the defaults
+  var globalConfig = window$1 && window$1.QUnit && window$1.QUnit.config;
+
+  // only extend the global config if there is no QUnit overload
+  if (window$1 && window$1.QUnit && !window$1.QUnit.version) {
+  	extend(config, globalConfig);
+  }
+
+  // Push a loose unnamed module to the modules collection
+  config.modules.push(config.currentModule);
+
+  // Based on jsDump by Ariel Flesler
+  // http://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html
+  var dump = (function () {
+  	function quote(str) {
+  		return "\"" + str.toString().replace(/\\/g, "\\\\").replace(/"/g, "\\\"") + "\"";
+  	}
+  	function literal(o) {
+  		return o + "";
+  	}
+  	function join(pre, arr, post) {
+  		var s = dump.separator(),
+  		    base = dump.indent(),
+  		    inner = dump.indent(1);
+  		if (arr.join) {
+  			arr = arr.join("," + s + inner);
+  		}
+  		if (!arr) {
+  			return pre + post;
+  		}
+  		return [pre, inner + arr, base + post].join(s);
+  	}
+  	function array(arr, stack) {
+  		var i = arr.length,
+  		    ret = new Array(i);
+
+  		if (dump.maxDepth && dump.depth > dump.maxDepth) {
+  			return "[object Array]";
+  		}
+
+  		this.up();
+  		while (i--) {
+  			ret[i] = this.parse(arr[i], undefined, stack);
+  		}
+  		this.down();
+  		return join("[", ret, "]");
+  	}
+
+  	function isArray(obj) {
+  		return (
+
+  			//Native Arrays
+  			toString.call(obj) === "[object Array]" ||
+
+  			// NodeList objects
+  			typeof obj.length === "number" && obj.item !== undefined && (obj.length ? obj.item(0) === obj[0] : obj.item(0) === null && obj[0] === undefined)
+  		);
+  	}
+
+  	var reName = /^function (\w+)/,
+  	    dump = {
+
+  		// The objType is used mostly internally, you can fix a (custom) type in advance
+  		parse: function parse(obj, objType, stack) {
+  			stack = stack || [];
+  			var res,
+  			    parser,
+  			    parserType,
+  			    objIndex = stack.indexOf(obj);
+
+  			if (objIndex !== -1) {
+  				return "recursion(" + (objIndex - stack.length) + ")";
+  			}
+
+  			objType = objType || this.typeOf(obj);
+  			parser = this.parsers[objType];
+  			parserType = typeof parser === "undefined" ? "undefined" : _typeof(parser);
+
+  			if (parserType === "function") {
+  				stack.push(obj);
+  				res = parser.call(this, obj, stack);
+  				stack.pop();
+  				return res;
+  			}
+  			return parserType === "string" ? parser : this.parsers.error;
+  		},
+  		typeOf: function typeOf(obj) {
+  			var type;
+
+  			if (obj === null) {
+  				type = "null";
+  			} else if (typeof obj === "undefined") {
+  				type = "undefined";
+  			} else if (is("regexp", obj)) {
+  				type = "regexp";
+  			} else if (is("date", obj)) {
+  				type = "date";
+  			} else if (is("function", obj)) {
+  				type = "function";
+  			} else if (obj.setInterval !== undefined && obj.document !== undefined && obj.nodeType === undefined) {
+  				type = "window";
+  			} else if (obj.nodeType === 9) {
+  				type = "document";
+  			} else if (obj.nodeType) {
+  				type = "node";
+  			} else if (isArray(obj)) {
+  				type = "array";
+  			} else if (obj.constructor === Error.prototype.constructor) {
+  				type = "error";
+  			} else {
+  				type = typeof obj === "undefined" ? "undefined" : _typeof(obj);
+  			}
+  			return type;
+  		},
+
+  		separator: function separator() {
+  			if (this.multiline) {
+  				return this.HTML ? "<br />" : "\n";
+  			} else {
+  				return this.HTML ? "&#160;" : " ";
+  			}
+  		},
+
+  		// Extra can be a number, shortcut for increasing-calling-decreasing
+  		indent: function indent(extra) {
+  			if (!this.multiline) {
+  				return "";
+  			}
+  			var chr = this.indentChar;
+  			if (this.HTML) {
+  				chr = chr.replace(/\t/g, "   ").replace(/ /g, "&#160;");
+  			}
+  			return new Array(this.depth + (extra || 0)).join(chr);
+  		},
+  		up: function up(a) {
+  			this.depth += a || 1;
+  		},
+  		down: function down(a) {
+  			this.depth -= a || 1;
+  		},
+  		setParser: function setParser(name, parser) {
+  			this.parsers[name] = parser;
+  		},
+
+  		// The next 3 are exposed so you can use them
+  		quote: quote,
+  		literal: literal,
+  		join: join,
+  		depth: 1,
+  		maxDepth: config.maxDepth,
+
+  		// This is the list of parsers, to modify them, use dump.setParser
+  		parsers: {
+  			window: "[Window]",
+  			document: "[Document]",
+  			error: function error(_error) {
+  				return "Error(\"" + _error.message + "\")";
+  			},
+  			unknown: "[Unknown]",
+  			"null": "null",
+  			"undefined": "undefined",
+  			"function": function _function(fn) {
+  				var ret = "function",
+
+
+  				// Functions never have name in IE
+  				name = "name" in fn ? fn.name : (reName.exec(fn) || [])[1];
+
+  				if (name) {
+  					ret += " " + name;
+  				}
+  				ret += "(";
+
+  				ret = [ret, dump.parse(fn, "functionArgs"), "){"].join("");
+  				return join(ret, dump.parse(fn, "functionCode"), "}");
+  			},
+  			array: array,
+  			nodelist: array,
+  			"arguments": array,
+  			object: function object(map, stack) {
+  				var keys,
+  				    key,
+  				    val,
+  				    i,
+  				    nonEnumerableProperties,
+  				    ret = [];
+
+  				if (dump.maxDepth && dump.depth > dump.maxDepth) {
+  					return "[object Object]";
+  				}
+
+  				dump.up();
+  				keys = [];
+  				for (key in map) {
+  					keys.push(key);
+  				}
+
+  				// Some properties are not always enumerable on Error objects.
+  				nonEnumerableProperties = ["message", "name"];
+  				for (i in nonEnumerableProperties) {
+  					key = nonEnumerableProperties[i];
+  					if (key in map && !inArray(key, keys)) {
+  						keys.push(key);
+  					}
+  				}
+  				keys.sort();
+  				for (i = 0; i < keys.length; i++) {
+  					key = keys[i];
+  					val = map[key];
+  					ret.push(dump.parse(key, "key") + ": " + dump.parse(val, undefined, stack));
+  				}
+  				dump.down();
+  				return join("{", ret, "}");
+  			},
+  			node: function node(_node) {
+  				var len,
+  				    i,
+  				    val,
+  				    open = dump.HTML ? "&lt;" : "<",
+  				    close = dump.HTML ? "&gt;" : ">",
+  				    tag = _node.nodeName.toLowerCase(),
+  				    ret = open + tag,
+  				    attrs = _node.attributes;
+
+  				if (attrs) {
+  					for (i = 0, len = attrs.length; i < len; i++) {
+  						val = attrs[i].nodeValue;
+
+  						// IE6 includes all attributes in .attributes, even ones not explicitly
+  						// set. Those have values like undefined, null, 0, false, "" or
+  						// "inherit".
+  						if (val && val !== "inherit") {
+  							ret += " " + attrs[i].nodeName + "=" + dump.parse(val, "attribute");
+  						}
+  					}
+  				}
+  				ret += close;
+
+  				// Show content of TextNode or CDATASection
+  				if (_node.nodeType === 3 || _node.nodeType === 4) {
+  					ret += _node.nodeValue;
+  				}
+
+  				return ret + open + "/" + tag + close;
+  			},
+
+  			// Function calls it internally, it's the arguments part of the function
+  			functionArgs: function functionArgs(fn) {
+  				var args,
+  				    l = fn.length;
+
+  				if (!l) {
+  					return "";
+  				}
+
+  				args = new Array(l);
+  				while (l--) {
+
+  					// 97 is 'a'
+  					args[l] = String.fromCharCode(97 + l);
+  				}
+  				return " " + args.join(", ") + " ";
+  			},
+
+  			// Object calls it internally, the key part of an item in a map
+  			key: quote,
+
+  			// Function calls it internally, it's the content of the function
+  			functionCode: "[code]",
+
+  			// Node calls it internally, it's a html attribute value
+  			attribute: quote,
+  			string: quote,
+  			date: quote,
+  			regexp: literal,
+  			number: literal,
+  			"boolean": literal,
+  			symbol: function symbol(sym) {
+  				return sym.toString();
+  			}
+  		},
+
+  		// If true, entities are escaped ( <, >, \t, space and \n )
+  		HTML: false,
+
+  		// Indentation unit
+  		indentChar: "  ",
+
+  		// If true, items in a collection, are separated by a \n, else just a space.
+  		multiline: true
+  	};
+
+  	return dump;
+  })();
+
+  var SuiteReport = function () {
+  	function SuiteReport(name, parentSuite) {
+  		classCallCheck(this, SuiteReport);
+
+  		this.name = name;
+  		this.fullName = parentSuite ? parentSuite.fullName.concat(name) : [];
+
+  		this.tests = [];
+  		this.childSuites = [];
+
+  		if (parentSuite) {
+  			parentSuite.pushChildSuite(this);
+  		}
+  	}
+
+  	createClass(SuiteReport, [{
+  		key: "start",
+  		value: function start(recordTime) {
+  			if (recordTime) {
+  				this._startTime = performanceNow();
+
+  				if (performance) {
+  					var suiteLevel = this.fullName.length;
+  					performance.mark("qunit_suite_" + suiteLevel + "_start");
+  				}
+  			}
+
+  			return {
+  				name: this.name,
+  				fullName: this.fullName.slice(),
+  				tests: this.tests.map(function (test) {
+  					return test.start();
+  				}),
+  				childSuites: this.childSuites.map(function (suite) {
+  					return suite.start();
+  				}),
+  				testCounts: {
+  					total: this.getTestCounts().total
+  				}
+  			};
+  		}
+  	}, {
+  		key: "end",
+  		value: function end(recordTime) {
+  			if (recordTime) {
+  				this._endTime = performanceNow();
+
+  				if (performance) {
+  					var suiteLevel = this.fullName.length;
+  					performance.mark("qunit_suite_" + suiteLevel + "_end");
+
+  					var suiteName = this.fullName.join(" – ");
+
+  					measure(suiteLevel === 0 ? "QUnit Test Run" : "QUnit Test Suite: " + suiteName, "qunit_suite_" + suiteLevel + "_start", "qunit_suite_" + suiteLevel + "_end");
+  				}
+  			}
+
+  			return {
+  				name: this.name,
+  				fullName: this.fullName.slice(),
+  				tests: this.tests.map(function (test) {
+  					return test.end();
+  				}),
+  				childSuites: this.childSuites.map(function (suite) {
+  					return suite.end();
+  				}),
+  				testCounts: this.getTestCounts(),
+  				runtime: this.getRuntime(),
+  				status: this.getStatus()
+  			};
+  		}
+  	}, {
+  		key: "pushChildSuite",
+  		value: function pushChildSuite(suite) {
+  			this.childSuites.push(suite);
+  		}
+  	}, {
+  		key: "pushTest",
+  		value: function pushTest(test) {
+  			this.tests.push(test);
+  		}
+  	}, {
+  		key: "getRuntime",
+  		value: function getRuntime() {
+  			return this._endTime - this._startTime;
+  		}
+  	}, {
+  		key: "getTestCounts",
+  		value: function getTestCounts() {
+  			var counts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { passed: 0, failed: 0, skipped: 0, todo: 0, total: 0 };
+
+  			counts = this.tests.reduce(function (counts, test) {
+  				if (test.valid) {
+  					counts[test.getStatus()]++;
+  					counts.total++;
+  				}
+
+  				return counts;
+  			}, counts);
+
+  			return this.childSuites.reduce(function (counts, suite) {
+  				return suite.getTestCounts(counts);
+  			}, counts);
+  		}
+  	}, {
+  		key: "getStatus",
+  		value: function getStatus() {
+  			var _getTestCounts = this.getTestCounts(),
+  			    total = _getTestCounts.total,
+  			    failed = _getTestCounts.failed,
+  			    skipped = _getTestCounts.skipped,
+  			    todo = _getTestCounts.todo;
+
+  			if (failed) {
+  				return "failed";
+  			} else {
+  				if (skipped === total) {
+  					return "skipped";
+  				} else if (todo === total) {
+  					return "todo";
+  				} else {
+  					return "passed";
+  				}
+  			}
+  		}
+  	}]);
+  	return SuiteReport;
+  }();
+
+  var focused = false;
+
+  var moduleStack = [];
+
+  function createModule(name, testEnvironment, modifiers) {
+  	var parentModule = moduleStack.length ? moduleStack.slice(-1)[0] : null;
+  	var moduleName = parentModule !== null ? [parentModule.name, name].join(" > ") : name;
+  	var parentSuite = parentModule ? parentModule.suiteReport : globalSuite;
+
+  	var skip = parentModule !== null && parentModule.skip || modifiers.skip;
+  	var todo = parentModule !== null && parentModule.todo || modifiers.todo;
+
+  	var module = {
+  		name: moduleName,
+  		parentModule: parentModule,
+  		tests: [],
+  		moduleId: generateHash(moduleName),
+  		testsRun: 0,
+  		unskippedTestsRun: 0,
+  		childModules: [],
+  		suiteReport: new SuiteReport(name, parentSuite),
+
+  		// Pass along `skip` and `todo` properties from parent module, in case
+  		// there is one, to childs. And use own otherwise.
+  		// This property will be used to mark own tests and tests of child suites
+  		// as either `skipped` or `todo`.
+  		skip: skip,
+  		todo: skip ? false : todo
+  	};
+
+  	var env = {};
+  	if (parentModule) {
+  		parentModule.childModules.push(module);
+  		extend(env, parentModule.testEnvironment);
+  	}
+  	extend(env, testEnvironment);
+  	module.testEnvironment = env;
+
+  	config.modules.push(module);
+  	return module;
+  }
+
+  function processModule(name, options, executeNow) {
+  	var modifiers = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  	if (objectType(options) === "function") {
+  		executeNow = options;
+  		options = undefined;
+  	}
+
+  	var module = createModule(name, options, modifiers);
+
+  	// Move any hooks to a 'hooks' object
+  	var testEnvironment = module.testEnvironment;
+  	var hooks = module.hooks = {};
+
+  	setHookFromEnvironment(hooks, testEnvironment, "before");
+  	setHookFromEnvironment(hooks, testEnvironment, "beforeEach");
+  	setHookFromEnvironment(hooks, testEnvironment, "afterEach");
+  	setHookFromEnvironment(hooks, testEnvironment, "after");
+
+  	var moduleFns = {
+  		before: setHookFunction(module, "before"),
+  		beforeEach: setHookFunction(module, "beforeEach"),
+  		afterEach: setHookFunction(module, "afterEach"),
+  		after: setHookFunction(module, "after")
+  	};
+
+  	var currentModule = config.currentModule;
+  	if (objectType(executeNow) === "function") {
+  		moduleStack.push(module);
+  		config.currentModule = module;
+  		executeNow.call(module.testEnvironment, moduleFns);
+  		moduleStack.pop();
+  		module = module.parentModule || currentModule;
+  	}
+
+  	config.currentModule = module;
+
+  	function setHookFromEnvironment(hooks, environment, name) {
+  		var potentialHook = environment[name];
+  		hooks[name] = typeof potentialHook === "function" ? [potentialHook] : [];
+  		delete environment[name];
+  	}
+
+  	function setHookFunction(module, hookName) {
+  		return function setHook(callback) {
+  			module.hooks[hookName].push(callback);
+  		};
+  	}
+  }
+
+  function module$1(name, options, executeNow) {
+  	if (focused) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow);
+  }
+
+  module$1.only = function () {
+  	if (focused) {
+  		return;
+  	}
+
+  	config.modules.length = 0;
+  	config.queue.length = 0;
+
+  	module$1.apply(undefined, arguments);
+
+  	focused = true;
+  };
+
+  module$1.skip = function (name, options, executeNow) {
+  	if (focused) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow, { skip: true });
+  };
+
+  module$1.todo = function (name, options, executeNow) {
+  	if (focused) {
+  		return;
+  	}
+
+  	processModule(name, options, executeNow, { todo: true });
+  };
+
+  var LISTENERS = Object.create(null);
+  var SUPPORTED_EVENTS = ["runStart", "suiteStart", "testStart", "assertion", "testEnd", "suiteEnd", "runEnd"];
+
+  /**
+   * Emits an event with the specified data to all currently registered listeners.
+   * Callbacks will fire in the order in which they are registered (FIFO). This
+   * function is not exposed publicly; it is used by QUnit internals to emit
+   * logging events.
+   *
+   * @private
+   * @method emit
+   * @param {String} eventName
+   * @param {Object} data
+   * @return {Void}
+   */
+  function emit(eventName, data) {
+  	if (objectType(eventName) !== "string") {
+  		throw new TypeError("eventName must be a string when emitting an event");
+  	}
+
+  	// Clone the callbacks in case one of them registers a new callback
+  	var originalCallbacks = LISTENERS[eventName];
+  	var callbacks = originalCallbacks ? [].concat(toConsumableArray(originalCallbacks)) : [];
+
+  	for (var i = 0; i < callbacks.length; i++) {
+  		callbacks[i](data);
+  	}
+  }
+
+  /**
+   * Registers a callback as a listener to the specified event.
+   *
+   * @public
+   * @method on
+   * @param {String} eventName
+   * @param {Function} callback
+   * @return {Void}
+   */
+  function on(eventName, callback) {
+  	if (objectType(eventName) !== "string") {
+  		throw new TypeError("eventName must be a string when registering a listener");
+  	} else if (!inArray(eventName, SUPPORTED_EVENTS)) {
+  		var events = SUPPORTED_EVENTS.join(", ");
+  		throw new Error("\"" + eventName + "\" is not a valid event; must be one of: " + events + ".");
+  	} else if (objectType(callback) !== "function") {
+  		throw new TypeError("callback must be a function when registering a listener");
+  	}
+
+  	if (!LISTENERS[eventName]) {
+  		LISTENERS[eventName] = [];
+  	}
+
+  	// Don't register the same callback more than once
+  	if (!inArray(callback, LISTENERS[eventName])) {
+  		LISTENERS[eventName].push(callback);
+  	}
+  }
+
+  function objectOrFunction(x) {
+    var type = typeof x === 'undefined' ? 'undefined' : _typeof(x);
+    return x !== null && (type === 'object' || type === 'function');
+  }
+
+  function isFunction(x) {
+    return typeof x === 'function';
+  }
+
+
+
+  var _isArray = void 0;
+  if (Array.isArray) {
+    _isArray = Array.isArray;
+  } else {
+    _isArray = function _isArray(x) {
+      return Object.prototype.toString.call(x) === '[object Array]';
+    };
+  }
+
+  var isArray = _isArray;
+
+  var len = 0;
+  var vertxNext = void 0;
+  var customSchedulerFn = void 0;
+
+  var asap = function asap(callback, arg) {
+    queue[len] = callback;
+    queue[len + 1] = arg;
+    len += 2;
+    if (len === 2) {
+      // If len is 2, that means that we need to schedule an async flush.
+      // If additional callbacks are queued before the queue is flushed, they
+      // will be processed by this flush that we are scheduling.
+      if (customSchedulerFn) {
+        customSchedulerFn(flush);
+      } else {
+        scheduleFlush();
+      }
+    }
+  };
+
+  function setScheduler(scheduleFn) {
+    customSchedulerFn = scheduleFn;
+  }
+
+  function setAsap(asapFn) {
+    asap = asapFn;
+  }
+
+  var browserWindow = typeof window !== 'undefined' ? window : undefined;
+  var browserGlobal = browserWindow || {};
+  var BrowserMutationObserver = browserGlobal.MutationObserver || browserGlobal.WebKitMutationObserver;
+  var isNode = typeof self === 'undefined' && typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
+
+  // test for web worker but not in IE10
+  var isWorker = typeof Uint8ClampedArray !== 'undefined' && typeof importScripts !== 'undefined' && typeof MessageChannel !== 'undefined';
+
+  // node
+  function useNextTick() {
+    // node version 0.10.x displays a deprecation warning when nextTick is used recursively
+    // see https://github.com/cujojs/when/issues/410 for details
+    return function () {
+      return process.nextTick(flush);
+    };
+  }
+
+  // vertx
+  function useVertxTimer() {
+    if (typeof vertxNext !== 'undefined') {
+      return function () {
+        vertxNext(flush);
+      };
+    }
+
+    return useSetTimeout();
+  }
+
+  function useMutationObserver() {
+    var iterations = 0;
+    var observer = new BrowserMutationObserver(flush);
+    var node = document.createTextNode('');
+    observer.observe(node, { characterData: true });
+
+    return function () {
+      node.data = iterations = ++iterations % 2;
+    };
+  }
+
+  // web worker
+  function useMessageChannel() {
+    var channel = new MessageChannel();
+    channel.port1.onmessage = flush;
+    return function () {
+      return channel.port2.postMessage(0);
+    };
+  }
+
+  function useSetTimeout() {
+    // Store setTimeout reference so es6-promise will be unaffected by
+    // other code modifying setTimeout (like sinon.useFakeTimers())
+    var globalSetTimeout = setTimeout;
+    return function () {
+      return globalSetTimeout(flush, 1);
+    };
+  }
+
+  var queue = new Array(1000);
+  function flush() {
+    for (var i = 0; i < len; i += 2) {
+      var callback = queue[i];
+      var arg = queue[i + 1];
+
+      callback(arg);
+
+      queue[i] = undefined;
+      queue[i + 1] = undefined;
+    }
+
+    len = 0;
+  }
+
+  function attemptVertx() {
+    try {
+      var vertx = Function('return this')().require('vertx');
+      vertxNext = vertx.runOnLoop || vertx.runOnContext;
+      return useVertxTimer();
+    } catch (e) {
+      return useSetTimeout();
+    }
+  }
+
+  var scheduleFlush = void 0;
+  // Decide what async method to use to triggering processing of queued callbacks:
+  if (isNode) {
+    scheduleFlush = useNextTick();
+  } else if (BrowserMutationObserver) {
+    scheduleFlush = useMutationObserver();
+  } else if (isWorker) {
+    scheduleFlush = useMessageChannel();
+  } else if (browserWindow === undefined && typeof require === 'function') {
+    scheduleFlush = attemptVertx();
+  } else {
+    scheduleFlush = useSetTimeout();
+  }
+
+  function then(onFulfillment, onRejection) {
+    var parent = this;
+
+    var child = new this.constructor(noop);
+
+    if (child[PROMISE_ID] === undefined) {
+      makePromise(child);
+    }
+
+    var _state = parent._state;
+
+
+    if (_state) {
+      var callback = arguments[_state - 1];
+      asap(function () {
+        return invokeCallback(_state, child, callback, parent._result);
+      });
+    } else {
+      subscribe(parent, child, onFulfillment, onRejection);
+    }
+
+    return child;
+  }
+
+  /**
+    `Promise.resolve` returns a promise that will become resolved with the
+    passed `value`. It is shorthand for the following:
+
+    ```javascript
+    let promise = new Promise(function(resolve, reject){
+      resolve(1);
+    });
+
+    promise.then(function(value){
+      // value === 1
+    });
+    ```
+
+    Instead of writing the above, your code now simply becomes the following:
+
+    ```javascript
+    let promise = Promise.resolve(1);
+
+    promise.then(function(value){
+      // value === 1
+    });
+    ```
+
+    @method resolve
+    @static
+    @param {Any} value value that the returned promise will be resolved with
+    Useful for tooling.
+    @return {Promise} a promise that will become fulfilled with the given
+    `value`
+  */
+  function resolve$1(object) {
+    /*jshint validthis:true */
+    var Constructor = this;
+
+    if (object && (typeof object === 'undefined' ? 'undefined' : _typeof(object)) === 'object' && object.constructor === Constructor) {
+      return object;
+    }
+
+    var promise = new Constructor(noop);
+    resolve(promise, object);
+    return promise;
+  }
+
+  var PROMISE_ID = Math.random().toString(36).substring(2);
+
+  function noop() {}
+
+  var PENDING = void 0;
+  var FULFILLED = 1;
+  var REJECTED = 2;
+
+  var TRY_CATCH_ERROR = { error: null };
+
+  function selfFulfillment() {
+    return new TypeError("You cannot resolve a promise with itself");
+  }
+
+  function cannotReturnOwn() {
+    return new TypeError('A promises callback cannot return that same promise.');
+  }
+
+  function getThen(promise) {
+    try {
+      return promise.then;
+    } catch (error) {
+      TRY_CATCH_ERROR.error = error;
+      return TRY_CATCH_ERROR;
+    }
+  }
+
+  function tryThen(then$$1, value, fulfillmentHandler, rejectionHandler) {
+    try {
+      then$$1.call(value, fulfillmentHandler, rejectionHandler);
+    } catch (e) {
+      return e;
+    }
+  }
+
+  function handleForeignThenable(promise, thenable, then$$1) {
+    asap(function (promise) {
+      var sealed = false;
+      var error = tryThen(then$$1, thenable, function (value) {
+        if (sealed) {
+          return;
+        }
+        sealed = true;
+        if (thenable !== value) {
+          resolve(promise, value);
+        } else {
+          fulfill(promise, value);
+        }
+      }, function (reason) {
+        if (sealed) {
+          return;
+        }
+        sealed = true;
+
+        reject(promise, reason);
+      }, 'Settle: ' + (promise._label || ' unknown promise'));
+
+      if (!sealed && error) {
+        sealed = true;
+        reject(promise, error);
+      }
+    }, promise);
+  }
+
+  function handleOwnThenable(promise, thenable) {
+    if (thenable._state === FULFILLED) {
+      fulfill(promise, thenable._result);
+    } else if (thenable._state === REJECTED) {
+      reject(promise, thenable._result);
+    } else {
+      subscribe(thenable, undefined, function (value) {
+        return resolve(promise, value);
+      }, function (reason) {
+        return reject(promise, reason);
+      });
+    }
+  }
+
+  function handleMaybeThenable(promise, maybeThenable, then$$1) {
+    if (maybeThenable.constructor === promise.constructor && then$$1 === then && maybeThenable.constructor.resolve === resolve$1) {
+      handleOwnThenable(promise, maybeThenable);
+    } else {
+      if (then$$1 === TRY_CATCH_ERROR) {
+        reject(promise, TRY_CATCH_ERROR.error);
+        TRY_CATCH_ERROR.error = null;
+      } else if (then$$1 === undefined) {
+        fulfill(promise, maybeThenable);
+      } else if (isFunction(then$$1)) {
+        handleForeignThenable(promise, maybeThenable, then$$1);
+      } else {
+        fulfill(promise, maybeThenable);
+      }
+    }
+  }
+
+  function resolve(promise, value) {
+    if (promise === value) {
+      reject(promise, selfFulfillment());
+    } else if (objectOrFunction(value)) {
+      handleMaybeThenable(promise, value, getThen(value));
+    } else {
+      fulfill(promise, value);
+    }
+  }
+
+  function publishRejection(promise) {
+    if (promise._onerror) {
+      promise._onerror(promise._result);
+    }
+
+    publish(promise);
+  }
+
+  function fulfill(promise, value) {
+    if (promise._state !== PENDING) {
+      return;
+    }
+
+    promise._result = value;
+    promise._state = FULFILLED;
+
+    if (promise._subscribers.length !== 0) {
+      asap(publish, promise);
+    }
+  }
+
+  function reject(promise, reason) {
+    if (promise._state !== PENDING) {
+      return;
+    }
+    promise._state = REJECTED;
+    promise._result = reason;
+
+    asap(publishRejection, promise);
+  }
+
+  function subscribe(parent, child, onFulfillment, onRejection) {
+    var _subscribers = parent._subscribers;
+    var length = _subscribers.length;
+
+
+    parent._onerror = null;
+
+    _subscribers[length] = child;
+    _subscribers[length + FULFILLED] = onFulfillment;
+    _subscribers[length + REJECTED] = onRejection;
+
+    if (length === 0 && parent._state) {
+      asap(publish, parent);
+    }
+  }
+
+  function publish(promise) {
+    var subscribers = promise._subscribers;
+    var settled = promise._state;
+
+    if (subscribers.length === 0) {
+      return;
+    }
+
+    var child = void 0,
+        callback = void 0,
+        detail = promise._result;
+
+    for (var i = 0; i < subscribers.length; i += 3) {
+      child = subscribers[i];
+      callback = subscribers[i + settled];
+
+      if (child) {
+        invokeCallback(settled, child, callback, detail);
+      } else {
+        callback(detail);
+      }
+    }
+
+    promise._subscribers.length = 0;
+  }
+
+  function tryCatch(callback, detail) {
+    try {
+      return callback(detail);
+    } catch (e) {
+      TRY_CATCH_ERROR.error = e;
+      return TRY_CATCH_ERROR;
+    }
+  }
+
+  function invokeCallback(settled, promise, callback, detail) {
+    var hasCallback = isFunction(callback),
+        value = void 0,
+        error = void 0,
+        succeeded = void 0,
+        failed = void 0;
+
+    if (hasCallback) {
+      value = tryCatch(callback, detail);
+
+      if (value === TRY_CATCH_ERROR) {
+        failed = true;
+        error = value.error;
+        value.error = null;
+      } else {
+        succeeded = true;
+      }
+
+      if (promise === value) {
+        reject(promise, cannotReturnOwn());
+        return;
+      }
+    } else {
+      value = detail;
+      succeeded = true;
+    }
+
+    if (promise._state !== PENDING) {
+      // noop
+    } else if (hasCallback && succeeded) {
+      resolve(promise, value);
+    } else if (failed) {
+      reject(promise, error);
+    } else if (settled === FULFILLED) {
+      fulfill(promise, value);
+    } else if (settled === REJECTED) {
+      reject(promise, value);
+    }
+  }
+
+  function initializePromise(promise, resolver) {
+    try {
+      resolver(function resolvePromise(value) {
+        resolve(promise, value);
+      }, function rejectPromise(reason) {
+        reject(promise, reason);
+      });
+    } catch (e) {
+      reject(promise, e);
+    }
+  }
+
+  var id = 0;
+  function nextId() {
+    return id++;
+  }
+
+  function makePromise(promise) {
+    promise[PROMISE_ID] = id++;
+    promise._state = undefined;
+    promise._result = undefined;
+    promise._subscribers = [];
+  }
+
+  function validationError() {
+    return new Error('Array Methods must be provided an Array');
+  }
+
+  var Enumerator = function () {
+    function Enumerator(Constructor, input) {
+      classCallCheck(this, Enumerator);
+
+      this._instanceConstructor = Constructor;
+      this.promise = new Constructor(noop);
+
+      if (!this.promise[PROMISE_ID]) {
+        makePromise(this.promise);
+      }
+
+      if (isArray(input)) {
+        this.length = input.length;
+        this._remaining = input.length;
+
+        this._result = new Array(this.length);
+
+        if (this.length === 0) {
+          fulfill(this.promise, this._result);
+        } else {
+          this.length = this.length || 0;
+          this._enumerate(input);
+          if (this._remaining === 0) {
+            fulfill(this.promise, this._result);
+          }
+        }
+      } else {
+        reject(this.promise, validationError());
+      }
+    }
+
+    createClass(Enumerator, [{
+      key: '_enumerate',
+      value: function _enumerate(input) {
+        for (var i = 0; this._state === PENDING && i < input.length; i++) {
+          this._eachEntry(input[i], i);
+        }
+      }
+    }, {
+      key: '_eachEntry',
+      value: function _eachEntry(entry, i) {
+        var c = this._instanceConstructor;
+        var resolve$$1 = c.resolve;
+
+
+        if (resolve$$1 === resolve$1) {
+          var _then = getThen(entry);
+
+          if (_then === then && entry._state !== PENDING) {
+            this._settledAt(entry._state, i, entry._result);
+          } else if (typeof _then !== 'function') {
+            this._remaining--;
+            this._result[i] = entry;
+          } else if (c === Promise$2) {
+            var promise = new c(noop);
+            handleMaybeThenable(promise, entry, _then);
+            this._willSettleAt(promise, i);
+          } else {
+            this._willSettleAt(new c(function (resolve$$1) {
+              return resolve$$1(entry);
+            }), i);
+          }
+        } else {
+          this._willSettleAt(resolve$$1(entry), i);
+        }
+      }
+    }, {
+      key: '_settledAt',
+      value: function _settledAt(state, i, value) {
+        var promise = this.promise;
+
+
+        if (promise._state === PENDING) {
+          this._remaining--;
+
+          if (state === REJECTED) {
+            reject(promise, value);
+          } else {
+            this._result[i] = value;
+          }
+        }
+
+        if (this._remaining === 0) {
+          fulfill(promise, this._result);
+        }
+      }
+    }, {
+      key: '_willSettleAt',
+      value: function _willSettleAt(promise, i) {
+        var enumerator = this;
+
+        subscribe(promise, undefined, function (value) {
+          return enumerator._settledAt(FULFILLED, i, value);
+        }, function (reason) {
+          return enumerator._settledAt(REJECTED, i, reason);
+        });
+      }
+    }]);
+    return Enumerator;
+  }();
+
+  /**
+    `Promise.all` accepts an array of promises, and returns a new promise which
+    is fulfilled with an array of fulfillment values for the passed promises, or
+    rejected with the reason of the first passed promise to be rejected. It casts all
+    elements of the passed iterable to promises as it runs this algorithm.
+
+    Example:
+
+    ```javascript
+    let promise1 = resolve(1);
+    let promise2 = resolve(2);
+    let promise3 = resolve(3);
+    let promises = [ promise1, promise2, promise3 ];
+
+    Promise.all(promises).then(function(array){
+      // The array here would be [ 1, 2, 3 ];
+    });
+    ```
+
+    If any of the `promises` given to `all` are rejected, the first promise
+    that is rejected will be given as an argument to the returned promises's
+    rejection handler. For example:
+
+    Example:
+
+    ```javascript
+    let promise1 = resolve(1);
+    let promise2 = reject(new Error("2"));
+    let promise3 = reject(new Error("3"));
+    let promises = [ promise1, promise2, promise3 ];
+
+    Promise.all(promises).then(function(array){
+      // Code here never runs because there are rejected promises!
+    }, function(error) {
+      // error.message === "2"
+    });
+    ```
+
+    @method all
+    @static
+    @param {Array} entries array of promises
+    @param {String} label optional string for labeling the promise.
+    Useful for tooling.
+    @return {Promise} promise that is fulfilled when all `promises` have been
+    fulfilled, or rejected if any of them become rejected.
+    @static
+  */
+  function all(entries) {
+    return new Enumerator(this, entries).promise;
+  }
+
+  /**
+    `Promise.race` returns a new promise which is settled in the same way as the
+    first passed promise to settle.
+
+    Example:
+
+    ```javascript
+    let promise1 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 1');
+      }, 200);
+    });
+
+    let promise2 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 2');
+      }, 100);
+    });
+
+    Promise.race([promise1, promise2]).then(function(result){
+      // result === 'promise 2' because it was resolved before promise1
+      // was resolved.
+    });
+    ```
+
+    `Promise.race` is deterministic in that only the state of the first
+    settled promise matters. For example, even if other promises given to the
+    `promises` array argument are resolved, but the first settled promise has
+    become rejected before the other promises became fulfilled, the returned
+    promise will become rejected:
+
+    ```javascript
+    let promise1 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        resolve('promise 1');
+      }, 200);
+    });
+
+    let promise2 = new Promise(function(resolve, reject){
+      setTimeout(function(){
+        reject(new Error('promise 2'));
+      }, 100);
+    });
+
+    Promise.race([promise1, promise2]).then(function(result){
+      // Code here never runs
+    }, function(reason){
+      // reason.message === 'promise 2' because promise 2 became rejected before
+      // promise 1 became fulfilled
+    });
+    ```
+
+    An example real-world use case is implementing timeouts:
+
+    ```javascript
+    Promise.race([ajax('foo.json'), timeout(5000)])
+    ```
+
+    @method race
+    @static
+    @param {Array} promises array of promises to observe
+    Useful for tooling.
+    @return {Promise} a promise which settles in the same way as the first passed
+    promise to settle.
+  */
+  function race(entries) {
+    /*jshint validthis:true */
+    var Constructor = this;
+
+    if (!isArray(entries)) {
+      return new Constructor(function (_, reject) {
+        return reject(new TypeError('You must pass an array to race.'));
+      });
+    } else {
+      return new Constructor(function (resolve, reject) {
+        var length = entries.length;
+        for (var i = 0; i < length; i++) {
+          Constructor.resolve(entries[i]).then(resolve, reject);
+        }
+      });
+    }
+  }
+
+  /**
+    `Promise.reject` returns a promise rejected with the passed `reason`.
+    It is shorthand for the following:
+
+    ```javascript
+    let promise = new Promise(function(resolve, reject){
+      reject(new Error('WHOOPS'));
+    });
+
+    promise.then(function(value){
+      // Code here doesn't run because the promise is rejected!
+    }, function(reason){
+      // reason.message === 'WHOOPS'
+    });
+    ```
+
+    Instead of writing the above, your code now simply becomes the following:
+
+    ```javascript
+    let promise = Promise.reject(new Error('WHOOPS'));
+
+    promise.then(function(value){
+      // Code here doesn't run because the promise is rejected!
+    }, function(reason){
+      // reason.message === 'WHOOPS'
+    });
+    ```
+
+    @method reject
+    @static
+    @param {Any} reason value that the returned promise will be rejected with.
+    Useful for tooling.
+    @return {Promise} a promise rejected with the given `reason`.
+  */
+  function reject$1(reason) {
+    /*jshint validthis:true */
+    var Constructor = this;
+    var promise = new Constructor(noop);
+    reject(promise, reason);
+    return promise;
+  }
+
+  function needsResolver() {
+    throw new TypeError('You must pass a resolver function as the first argument to the promise constructor');
+  }
+
+  function needsNew() {
+    throw new TypeError("Failed to construct 'Promise': Please use the 'new' operator, this object constructor cannot be called as a function.");
+  }
+
+  /**
+    Promise objects represent the eventual result of an asynchronous operation. The
+    primary way of interacting with a promise is through its `then` method, which
+    registers callbacks to receive either a promise's eventual value or the reason
+    why the promise cannot be fulfilled.
+
+    Terminology
+    -----------
+
+    - `promise` is an object or function with a `then` method whose behavior conforms to this specification.
+    - `thenable` is an object or function that defines a `then` method.
+    - `value` is any legal JavaScript value (including undefined, a thenable, or a promise).
+    - `exception` is a value that is thrown using the throw statement.
+    - `reason` is a value that indicates why a promise was rejected.
+    - `settled` the final resting state of a promise, fulfilled or rejected.
+
+    A promise can be in one of three states: pending, fulfilled, or rejected.
+
+    Promises that are fulfilled have a fulfillment value and are in the fulfilled
+    state.  Promises that are rejected have a rejection reason and are in the
+    rejected state.  A fulfillment value is never a thenable.
+
+    Promises can also be said to *resolve* a value.  If this value is also a
+    promise, then the original promise's settled state will match the value's
+    settled state.  So a promise that *resolves* a promise that rejects will
+    itself reject, and a promise that *resolves* a promise that fulfills will
+    itself fulfill.
+
+
+    Basic Usage:
+    ------------
+
+    ```js
+    let promise = new Promise(function(resolve, reject) {
+      // on success
+      resolve(value);
+
+      // on failure
+      reject(reason);
+    });
+
+    promise.then(function(value) {
+      // on fulfillment
+    }, function(reason) {
+      // on rejection
+    });
+    ```
+
+    Advanced Usage:
+    ---------------
+
+    Promises shine when abstracting away asynchronous interactions such as
+    `XMLHttpRequest`s.
+
+    ```js
+    function getJSON(url) {
+      return new Promise(function(resolve, reject){
+        let xhr = new XMLHttpRequest();
+
+        xhr.open('GET', url);
+        xhr.onreadystatechange = handler;
+        xhr.responseType = 'json';
+        xhr.setRequestHeader('Accept', 'application/json');
+        xhr.send();
+
+        function handler() {
+          if (this.readyState === this.DONE) {
+            if (this.status === 200) {
+              resolve(this.response);
+            } else {
+              reject(new Error('getJSON: `' + url + '` failed with status: [' + this.status + ']'));
+            }
+          }
+        };
+      });
+    }
+
+    getJSON('/posts.json').then(function(json) {
+      // on fulfillment
+    }, function(reason) {
+      // on rejection
+    });
+    ```
+
+    Unlike callbacks, promises are great composable primitives.
+
+    ```js
+    Promise.all([
+      getJSON('/posts'),
+      getJSON('/comments')
+    ]).then(function(values){
+      values[0] // => postsJSON
+      values[1] // => commentsJSON
+
+      return values;
+    });
+    ```
+
+    @class Promise
+    @param {Function} resolver
+    Useful for tooling.
+    @constructor
+  */
+
+  var Promise$2 = function () {
+    function Promise(resolver) {
+      classCallCheck(this, Promise);
+
+      this[PROMISE_ID] = nextId();
+      this._result = this._state = undefined;
+      this._subscribers = [];
+
+      if (noop !== resolver) {
+        typeof resolver !== 'function' && needsResolver();
+        this instanceof Promise ? initializePromise(this, resolver) : needsNew();
+      }
+    }
+
+    /**
+    The primary way of interacting with a promise is through its `then` method,
+    which registers callbacks to receive either a promise's eventual value or the
+    reason why the promise cannot be fulfilled.
+     ```js
+    findUser().then(function(user){
+      // user is available
+    }, function(reason){
+      // user is unavailable, and you are given the reason why
+    });
+    ```
+     Chaining
+    --------
+     The return value of `then` is itself a promise.  This second, 'downstream'
+    promise is resolved with the return value of the first promise's fulfillment
+    or rejection handler, or rejected if the handler throws an exception.
+     ```js
+    findUser().then(function (user) {
+      return user.name;
+    }, function (reason) {
+      return 'default name';
+    }).then(function (userName) {
+      // If `findUser` fulfilled, `userName` will be the user's name, otherwise it
+      // will be `'default name'`
+    });
+     findUser().then(function (user) {
+      throw new Error('Found user, but still unhappy');
+    }, function (reason) {
+      throw new Error('`findUser` rejected and we're unhappy');
+    }).then(function (value) {
+      // never reached
+    }, function (reason) {
+      // if `findUser` fulfilled, `reason` will be 'Found user, but still unhappy'.
+      // If `findUser` rejected, `reason` will be '`findUser` rejected and we're unhappy'.
+    });
+    ```
+    If the downstream promise does not specify a rejection handler, rejection reasons will be propagated further downstream.
+     ```js
+    findUser().then(function (user) {
+      throw new PedagogicalException('Upstream error');
+    }).then(function (value) {
+      // never reached
+    }).then(function (value) {
+      // never reached
+    }, function (reason) {
+      // The `PedgagocialException` is propagated all the way down to here
+    });
+    ```
+     Assimilation
+    ------------
+     Sometimes the value you want to propagate to a downstream promise can only be
+    retrieved asynchronously. This can be achieved by returning a promise in the
+    fulfillment or rejection handler. The downstream promise will then be pending
+    until the returned promise is settled. This is called *assimilation*.
+     ```js
+    findUser().then(function (user) {
+      return findCommentsByAuthor(user);
+    }).then(function (comments) {
+      // The user's comments are now available
+    });
+    ```
+     If the assimliated promise rejects, then the downstream promise will also reject.
+     ```js
+    findUser().then(function (user) {
+      return findCommentsByAuthor(user);
+    }).then(function (comments) {
+      // If `findCommentsByAuthor` fulfills, we'll have the value here
+    }, function (reason) {
+      // If `findCommentsByAuthor` rejects, we'll have the reason here
+    });
+    ```
+     Simple Example
+    --------------
+     Synchronous Example
+     ```javascript
+    let result;
+     try {
+      result = findResult();
+      // success
+    } catch(reason) {
+      // failure
+    }
+    ```
+     Errback Example
+     ```js
+    findResult(function(result, err){
+      if (err) {
+        // failure
+      } else {
+        // success
+      }
+    });
+    ```
+     Promise Example;
+     ```javascript
+    findResult().then(function(result){
+      // success
+    }, function(reason){
+      // failure
+    });
+    ```
+     Advanced Example
+    --------------
+     Synchronous Example
+     ```javascript
+    let author, books;
+     try {
+      author = findAuthor();
+      books  = findBooksByAuthor(author);
+      // success
+    } catch(reason) {
+      // failure
+    }
+    ```
+     Errback Example
+     ```js
+     function foundBooks(books) {
+     }
+     function failure(reason) {
+     }
+     findAuthor(function(author, err){
+      if (err) {
+        failure(err);
+        // failure
+      } else {
+        try {
+          findBoooksByAuthor(author, function(books, err) {
+            if (err) {
+              failure(err);
+            } else {
+              try {
+                foundBooks(books);
+              } catch(reason) {
+                failure(reason);
+              }
+            }
+          });
+        } catch(error) {
+          failure(err);
+        }
+        // success
+      }
+    });
+    ```
+     Promise Example;
+     ```javascript
+    findAuthor().
+      then(findBooksByAuthor).
+      then(function(books){
+        // found books
+    }).catch(function(reason){
+      // something went wrong
+    });
+    ```
+     @method then
+    @param {Function} onFulfilled
+    @param {Function} onRejected
+    Useful for tooling.
+    @return {Promise}
+    */
+
+    /**
+    `catch` is simply sugar for `then(undefined, onRejection)` which makes it the same
+    as the catch block of a try/catch statement.
+    ```js
+    function findAuthor(){
+    throw new Error('couldn't find that author');
+    }
+    // synchronous
+    try {
+    findAuthor();
+    } catch(reason) {
+    // something went wrong
+    }
+    // async with promises
+    findAuthor().catch(function(reason){
+    // something went wrong
+    });
+    ```
+    @method catch
+    @param {Function} onRejection
+    Useful for tooling.
+    @return {Promise}
+    */
+
+
+    createClass(Promise, [{
+      key: 'catch',
+      value: function _catch(onRejection) {
+        return this.then(null, onRejection);
+      }
+
+      /**
+        `finally` will be invoked regardless of the promise's fate just as native
+        try/catch/finally behaves
+      
+        Synchronous example:
+      
+        ```js
+        findAuthor() {
+          if (Math.random() > 0.5) {
+            throw new Error();
+          }
+          return new Author();
+        }
+      
+        try {
+          return findAuthor(); // succeed or fail
+        } catch(error) {
+          return findOtherAuther();
+        } finally {
+          // always runs
+          // doesn't affect the return value
+        }
+        ```
+      
+        Asynchronous example:
+      
+        ```js
+        findAuthor().catch(function(reason){
+          return findOtherAuther();
+        }).finally(function(){
+          // author was either found, or not
+        });
+        ```
+      
+        @method finally
+        @param {Function} callback
+        @return {Promise}
+      */
+
+    }, {
+      key: 'finally',
+      value: function _finally(callback) {
+        var promise = this;
+        var constructor = promise.constructor;
+
+        if (isFunction(callback)) {
+          return promise.then(function (value) {
+            return constructor.resolve(callback()).then(function () {
+              return value;
+            });
+          }, function (reason) {
+            return constructor.resolve(callback()).then(function () {
+              throw reason;
+            });
+          });
+        }
+
+        return promise.then(callback, callback);
+      }
+    }]);
+    return Promise;
+  }();
+
+  Promise$2.prototype.then = then;
+  Promise$2.all = all;
+  Promise$2.race = race;
+  Promise$2.resolve = resolve$1;
+  Promise$2.reject = reject$1;
+  Promise$2._setScheduler = setScheduler;
+  Promise$2._setAsap = setAsap;
+  Promise$2._asap = asap;
+
+  /*global self*/
+  function polyfill() {
+    var local = void 0;
+
+    if (typeof global !== 'undefined') {
+      local = global;
+    } else if (typeof self !== 'undefined') {
+      local = self;
+    } else {
+      try {
+        local = Function('return this')();
+      } catch (e) {
+        throw new Error('polyfill failed because global object is unavailable in this environment');
+      }
+    }
+
+    var P = local.Promise;
+
+    if (P) {
+      var promiseToString = null;
+      try {
+        promiseToString = Object.prototype.toString.call(P.resolve());
+      } catch (e) {
+        // silently ignored
+      }
+
+      if (promiseToString === '[object Promise]' && !P.cast) {
+        return;
+      }
+    }
+
+    local.Promise = Promise$2;
+  }
+
+  // Strange compat..
+  Promise$2.polyfill = polyfill;
+  Promise$2.Promise = Promise$2;
+
+  var Promise$1 = typeof Promise !== "undefined" ? Promise : Promise$2;
+
+  // Register logging callbacks
+  function registerLoggingCallbacks(obj) {
+  	var i,
+  	    l,
+  	    key,
+  	    callbackNames = ["begin", "done", "log", "testStart", "testDone", "moduleStart", "moduleDone"];
+
+  	function registerLoggingCallback(key) {
+  		var loggingCallback = function loggingCallback(callback) {
+  			if (objectType(callback) !== "function") {
+  				throw new Error("QUnit logging methods require a callback function as their first parameters.");
+  			}
+
+  			config.callbacks[key].push(callback);
+  		};
+
+  		return loggingCallback;
+  	}
+
+  	for (i = 0, l = callbackNames.length; i < l; i++) {
+  		key = callbackNames[i];
+
+  		// Initialize key collection of logging callback
+  		if (objectType(config.callbacks[key]) === "undefined") {
+  			config.callbacks[key] = [];
+  		}
+
+  		obj[key] = registerLoggingCallback(key);
+  	}
+  }
+
+  function runLoggingCallbacks(key, args) {
+  	var callbacks = config.callbacks[key];
+
+  	// Handling 'log' callbacks separately. Unlike the other callbacks,
+  	// the log callback is not controlled by the processing queue,
+  	// but rather used by asserts. Hence to promisfy the 'log' callback
+  	// would mean promisfying each step of a test
+  	if (key === "log") {
+  		callbacks.map(function (callback) {
+  			return callback(args);
+  		});
+  		return;
+  	}
+
+  	// ensure that each callback is executed serially
+  	return callbacks.reduce(function (promiseChain, callback) {
+  		return promiseChain.then(function () {
+  			return Promise$1.resolve(callback(args));
+  		});
+  	}, Promise$1.resolve([]));
+  }
+
+  // Doesn't support IE9, it will return undefined on these browsers
+  // See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
+  var fileName = (sourceFromStacktrace(0) || "").replace(/(:\d+)+\)?/, "").replace(/.+\//, "");
+
+  function extractStacktrace(e, offset) {
+  	offset = offset === undefined ? 4 : offset;
+
+  	var stack, include, i;
+
+  	if (e && e.stack) {
+  		stack = e.stack.split("\n");
+  		if (/^error$/i.test(stack[0])) {
+  			stack.shift();
+  		}
+  		if (fileName) {
+  			include = [];
+  			for (i = offset; i < stack.length; i++) {
+  				if (stack[i].indexOf(fileName) !== -1) {
+  					break;
+  				}
+  				include.push(stack[i]);
+  			}
+  			if (include.length) {
+  				return include.join("\n");
+  			}
+  		}
+  		return stack[offset];
+  	}
+  }
+
+  function sourceFromStacktrace(offset) {
+  	var error = new Error();
+
+  	// Support: Safari <=7 only, IE <=10 - 11 only
+  	// Not all browsers generate the `stack` property for `new Error()`, see also #636
+  	if (!error.stack) {
+  		try {
+  			throw error;
+  		} catch (err) {
+  			error = err;
+  		}
+  	}
+
+  	return extractStacktrace(error, offset);
+  }
+
+  var priorityCount = 0;
+  var unitSampler = void 0;
+
+  // This is a queue of functions that are tasks within a single test.
+  // After tests are dequeued from config.queue they are expanded into
+  // a set of tasks in this queue.
+  var taskQueue = [];
+
+  /**
+   * Advances the taskQueue to the next task. If the taskQueue is empty,
+   * process the testQueue
+   */
+  function advance() {
+  	advanceTaskQueue();
+
+  	if (!taskQueue.length && !config.blocking && !config.current) {
+  		advanceTestQueue();
+  	}
+  }
+
+  /**
+   * Advances the taskQueue with an increased depth
+   */
+  function advanceTaskQueue() {
+  	var start = now();
+  	config.depth = (config.depth || 0) + 1;
+
+  	processTaskQueue(start);
+
+  	config.depth--;
+  }
+
+  /**
+   * Process the first task on the taskQueue as a promise.
+   * Each task is a function returned by https://github.com/qunitjs/qunit/blob/master/src/test.js#L381
+   */
+  function processTaskQueue(start) {
+  	if (taskQueue.length && !config.blocking) {
+  		var elapsedTime = now() - start;
+
+  		if (!defined.setTimeout || config.updateRate <= 0 || elapsedTime < config.updateRate) {
+  			var task = taskQueue.shift();
+  			Promise$1.resolve(task()).then(function () {
+  				if (!taskQueue.length) {
+  					advance();
+  				} else {
+  					processTaskQueue(start);
+  				}
+  			});
+  		} else {
+  			setTimeout$1(advance);
+  		}
+  	}
+  }
+
+  /**
+   * Advance the testQueue to the next test to process. Call done() if testQueue completes.
+   */
+  function advanceTestQueue() {
+  	if (!config.blocking && !config.queue.length && config.depth === 0) {
+  		done();
+  		return;
+  	}
+
+  	var testTasks = config.queue.shift();
+  	addToTaskQueue(testTasks());
+
+  	if (priorityCount > 0) {
+  		priorityCount--;
+  	}
+
+  	advance();
+  }
+
+  /**
+   * Enqueue the tasks for a test into the task queue.
+   * @param {Array} tasksArray
+   */
+  function addToTaskQueue(tasksArray) {
+  	taskQueue.push.apply(taskQueue, toConsumableArray(tasksArray));
+  }
+
+  /**
+   * Return the number of tasks remaining in the task queue to be processed.
+   * @return {Number}
+   */
+  function taskQueueLength() {
+  	return taskQueue.length;
+  }
+
+  /**
+   * Adds a test to the TestQueue for execution.
+   * @param {Function} testTasksFunc
+   * @param {Boolean} prioritize
+   * @param {String} seed
+   */
+  function addToTestQueue(testTasksFunc, prioritize, seed) {
+  	if (prioritize) {
+  		config.queue.splice(priorityCount++, 0, testTasksFunc);
+  	} else if (seed) {
+  		if (!unitSampler) {
+  			unitSampler = unitSamplerGenerator(seed);
+  		}
+
+  		// Insert into a random position after all prioritized items
+  		var index = Math.floor(unitSampler() * (config.queue.length - priorityCount + 1));
+  		config.queue.splice(priorityCount + index, 0, testTasksFunc);
+  	} else {
+  		config.queue.push(testTasksFunc);
+  	}
+  }
+
+  /**
+   * Creates a seeded "sample" generator which is used for randomizing tests.
+   */
+  function unitSamplerGenerator(seed) {
+
+  	// 32-bit xorshift, requires only a nonzero seed
+  	// http://excamera.com/sphinx/article-xorshift.html
+  	var sample = parseInt(generateHash(seed), 16) || -1;
+  	return function () {
+  		sample ^= sample << 13;
+  		sample ^= sample >>> 17;
+  		sample ^= sample << 5;
+
+  		// ECMAScript has no unsigned number type
+  		if (sample < 0) {
+  			sample += 0x100000000;
+  		}
+
+  		return sample / 0x100000000;
+  	};
+  }
+
+  /**
+   * This function is called when the ProcessingQueue is done processing all
+   * items. It handles emitting the final run events.
+   */
+  function done() {
+  	var storage = config.storage;
+
+  	ProcessingQueue.finished = true;
+
+  	var runtime = now() - config.started;
+  	var passed = config.stats.all - config.stats.bad;
+
+  	if (config.stats.all === 0) {
+
+  		if (config.filter && config.filter.length) {
+  			throw new Error("No tests matched the filter \"" + config.filter + "\".");
+  		}
+
+  		if (config.module && config.module.length) {
+  			throw new Error("No tests matched the module \"" + config.module + "\".");
+  		}
+
+  		if (config.moduleId && config.moduleId.length) {
+  			throw new Error("No tests matched the moduleId \"" + config.moduleId + "\".");
+  		}
+
+  		if (config.testId && config.testId.length) {
+  			throw new Error("No tests matched the testId \"" + config.testId + "\".");
+  		}
+
+  		throw new Error("No tests were run.");
+  	}
+
+  	emit("runEnd", globalSuite.end(true));
+  	runLoggingCallbacks("done", {
+  		passed: passed,
+  		failed: config.stats.bad,
+  		total: config.stats.all,
+  		runtime: runtime
+  	}).then(function () {
+
+  		// Clear own storage items if all tests passed
+  		if (storage && config.stats.bad === 0) {
+  			for (var i = storage.length - 1; i >= 0; i--) {
+  				var key = storage.key(i);
+
+  				if (key.indexOf("qunit-test-") === 0) {
+  					storage.removeItem(key);
+  				}
+  			}
+  		}
+  	});
+  }
+
+  var ProcessingQueue = {
+  	finished: false,
+  	add: addToTestQueue,
+  	advance: advance,
+  	taskCount: taskQueueLength
+  };
+
+  var TestReport = function () {
+  	function TestReport(name, suite, options) {
+  		classCallCheck(this, TestReport);
+
+  		this.name = name;
+  		this.suiteName = suite.name;
+  		this.fullName = suite.fullName.concat(name);
+  		this.runtime = 0;
+  		this.assertions = [];
+
+  		this.skipped = !!options.skip;
+  		this.todo = !!options.todo;
+
+  		this.valid = options.valid;
+
+  		this._startTime = 0;
+  		this._endTime = 0;
+
+  		suite.pushTest(this);
+  	}
+
+  	createClass(TestReport, [{
+  		key: "start",
+  		value: function start(recordTime) {
+  			if (recordTime) {
+  				this._startTime = performanceNow();
+  				if (performance) {
+  					performance.mark("qunit_test_start");
+  				}
+  			}
+
+  			return {
+  				name: this.name,
+  				suiteName: this.suiteName,
+  				fullName: this.fullName.slice()
+  			};
+  		}
+  	}, {
+  		key: "end",
+  		value: function end(recordTime) {
+  			if (recordTime) {
+  				this._endTime = performanceNow();
+  				if (performance) {
+  					performance.mark("qunit_test_end");
+
+  					var testName = this.fullName.join(" – ");
+
+  					measure("QUnit Test: " + testName, "qunit_test_start", "qunit_test_end");
+  				}
+  			}
+
+  			return extend(this.start(), {
+  				runtime: this.getRuntime(),
+  				status: this.getStatus(),
+  				errors: this.getFailedAssertions(),
+  				assertions: this.getAssertions()
+  			});
+  		}
+  	}, {
+  		key: "pushAssertion",
+  		value: function pushAssertion(assertion) {
+  			this.assertions.push(assertion);
+  		}
+  	}, {
+  		key: "getRuntime",
+  		value: function getRuntime() {
+  			return this._endTime - this._startTime;
+  		}
+  	}, {
+  		key: "getStatus",
+  		value: function getStatus() {
+  			if (this.skipped) {
+  				return "skipped";
+  			}
+
+  			var testPassed = this.getFailedAssertions().length > 0 ? this.todo : !this.todo;
+
+  			if (!testPassed) {
+  				return "failed";
+  			} else if (this.todo) {
+  				return "todo";
+  			} else {
+  				return "passed";
+  			}
+  		}
+  	}, {
+  		key: "getFailedAssertions",
+  		value: function getFailedAssertions() {
+  			return this.assertions.filter(function (assertion) {
+  				return !assertion.passed;
+  			});
+  		}
+  	}, {
+  		key: "getAssertions",
+  		value: function getAssertions() {
+  			return this.assertions.slice();
+  		}
+
+  		// Remove actual and expected values from assertions. This is to prevent
+  		// leaking memory throughout a test suite.
+
+  	}, {
+  		key: "slimAssertions",
+  		value: function slimAssertions() {
+  			this.assertions = this.assertions.map(function (assertion) {
+  				delete assertion.actual;
+  				delete assertion.expected;
+  				return assertion;
+  			});
+  		}
+  	}]);
+  	return TestReport;
+  }();
+
+  var focused$1 = false;
+
+  function Test(settings) {
+  	var i, l;
+
+  	++Test.count;
+
+  	this.expected = null;
+  	this.assertions = [];
+  	this.semaphore = 0;
+  	this.module = config.currentModule;
+  	this.stack = sourceFromStacktrace(3);
+  	this.steps = [];
+  	this.timeout = undefined;
+
+  	// If a module is skipped, all its tests and the tests of the child suites
+  	// should be treated as skipped even if they are defined as `only` or `todo`.
+  	// As for `todo` module, all its tests will be treated as `todo` except for
+  	// tests defined as `skip` which will be left intact.
+  	//
+  	// So, if a test is defined as `todo` and is inside a skipped module, we should
+  	// then treat that test as if was defined as `skip`.
+  	if (this.module.skip) {
+  		settings.skip = true;
+  		settings.todo = false;
+
+  		// Skipped tests should be left intact
+  	} else if (this.module.todo && !settings.skip) {
+  		settings.todo = true;
+  	}
+
+  	extend(this, settings);
+
+  	this.testReport = new TestReport(settings.testName, this.module.suiteReport, {
+  		todo: settings.todo,
+  		skip: settings.skip,
+  		valid: this.valid()
+  	});
+
+  	// Register unique strings
+  	for (i = 0, l = this.module.tests; i < l.length; i++) {
+  		if (this.module.tests[i].name === this.testName) {
+  			this.testName += " ";
+  		}
+  	}
+
+  	this.testId = generateHash(this.module.name, this.testName);
+
+  	this.module.tests.push({
+  		name: this.testName,
+  		testId: this.testId,
+  		skip: !!settings.skip
+  	});
+
+  	if (settings.skip) {
+
+  		// Skipped tests will fully ignore any sent callback
+  		this.callback = function () {};
+  		this.async = false;
+  		this.expected = 0;
+  	} else {
+  		if (typeof this.callback !== "function") {
+  			var method = this.todo ? "todo" : "test";
+
+  			// eslint-disable-next-line max-len
+  			throw new TypeError("You must provide a function as a test callback to QUnit." + method + "(\"" + settings.testName + "\")");
+  		}
+
+  		this.assert = new Assert(this);
+  	}
+  }
+
+  Test.count = 0;
+
+  function getNotStartedModules(startModule) {
+  	var module = startModule,
+  	    modules = [];
+
+  	while (module && module.testsRun === 0) {
+  		modules.push(module);
+  		module = module.parentModule;
+  	}
+
+  	// The above push modules from the child to the parent
+  	// return a reversed order with the top being the top most parent module
+  	return modules.reverse();
+  }
+
+  Test.prototype = {
+  	before: function before() {
+  		var _this = this;
+
+  		var module = this.module,
+  		    notStartedModules = getNotStartedModules(module);
+
+  		// ensure the callbacks are executed serially for each module
+  		var callbackPromises = notStartedModules.reduce(function (promiseChain, startModule) {
+  			return promiseChain.then(function () {
+  				startModule.stats = { all: 0, bad: 0, started: now() };
+  				emit("suiteStart", startModule.suiteReport.start(true));
+  				return runLoggingCallbacks("moduleStart", {
+  					name: startModule.name,
+  					tests: startModule.tests
+  				});
+  			});
+  		}, Promise$1.resolve([]));
+
+  		return callbackPromises.then(function () {
+  			config.current = _this;
+
+  			_this.testEnvironment = extend({}, module.testEnvironment);
+
+  			_this.started = now();
+  			emit("testStart", _this.testReport.start(true));
+  			return runLoggingCallbacks("testStart", {
+  				name: _this.testName,
+  				module: module.name,
+  				testId: _this.testId,
+  				previousFailure: _this.previousFailure
+  			}).then(function () {
+  				if (!config.pollution) {
+  					saveGlobal();
+  				}
+  			});
+  		});
+  	},
+
+  	run: function run() {
+  		var promise;
+
+  		config.current = this;
+
+  		this.callbackStarted = now();
+
+  		if (config.notrycatch) {
+  			runTest(this);
+  			return;
+  		}
+
+  		try {
+  			runTest(this);
+  		} catch (e) {
+  			this.pushFailure("Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + (e.message || e), extractStacktrace(e, 0));
+
+  			// Else next test will carry the responsibility
+  			saveGlobal();
+
+  			// Restart the tests if they're blocking
+  			if (config.blocking) {
+  				internalRecover(this);
+  			}
+  		}
+
+  		function runTest(test) {
+  			promise = test.callback.call(test.testEnvironment, test.assert);
+  			test.resolvePromise(promise);
+
+  			// If the test has a "lock" on it, but the timeout is 0, then we push a
+  			// failure as the test should be synchronous.
+  			if (test.timeout === 0 && test.semaphore !== 0) {
+  				pushFailure("Test did not finish synchronously even though assert.timeout( 0 ) was used.", sourceFromStacktrace(2));
+  			}
+  		}
+  	},
+
+  	after: function after() {
+  		checkPollution();
+  	},
+
+  	queueHook: function queueHook(hook, hookName, hookOwner) {
+  		var _this2 = this;
+
+  		var callHook = function callHook() {
+  			var promise = hook.call(_this2.testEnvironment, _this2.assert);
+  			_this2.resolvePromise(promise, hookName);
+  		};
+
+  		var runHook = function runHook() {
+  			if (hookName === "before") {
+  				if (hookOwner.unskippedTestsRun !== 0) {
+  					return;
+  				}
+
+  				_this2.preserveEnvironment = true;
+  			}
+
+  			// The 'after' hook should only execute when there are not tests left and
+  			// when the 'after' and 'finish' tasks are the only tasks left to process
+  			if (hookName === "after" && hookOwner.unskippedTestsRun !== numberOfUnskippedTests(hookOwner) - 1 && (config.queue.length > 0 || ProcessingQueue.taskCount() > 2)) {
+  				return;
+  			}
+
+  			config.current = _this2;
+  			if (config.notrycatch) {
+  				callHook();
+  				return;
+  			}
+  			try {
+  				callHook();
+  			} catch (error) {
+  				_this2.pushFailure(hookName + " failed on " + _this2.testName + ": " + (error.message || error), extractStacktrace(error, 0));
+  			}
+  		};
+
+  		return runHook;
+  	},
+
+
+  	// Currently only used for module level hooks, can be used to add global level ones
+  	hooks: function hooks(handler) {
+  		var hooks = [];
+
+  		function processHooks(test, module) {
+  			if (module.parentModule) {
+  				processHooks(test, module.parentModule);
+  			}
+
+  			if (module.hooks[handler].length) {
+  				for (var i = 0; i < module.hooks[handler].length; i++) {
+  					hooks.push(test.queueHook(module.hooks[handler][i], handler, module));
+  				}
+  			}
+  		}
+
+  		// Hooks are ignored on skipped tests
+  		if (!this.skip) {
+  			processHooks(this, this.module);
+  		}
+
+  		return hooks;
+  	},
+
+
+  	finish: function finish() {
+  		config.current = this;
+
+  		// Release the test callback to ensure that anything referenced has been
+  		// released to be garbage collected.
+  		this.callback = undefined;
+
+  		if (this.steps.length) {
+  			var stepsList = this.steps.join(", ");
+  			this.pushFailure("Expected assert.verifySteps() to be called before end of test " + ("after using assert.step(). Unverified steps: " + stepsList), this.stack);
+  		}
+
+  		if (config.requireExpects && this.expected === null) {
+  			this.pushFailure("Expected number of assertions to be defined, but expect() was " + "not called.", this.stack);
+  		} else if (this.expected !== null && this.expected !== this.assertions.length) {
+  			this.pushFailure("Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack);
+  		} else if (this.expected === null && !this.assertions.length) {
+  			this.pushFailure("Expected at least one assertion, but none were run - call " + "expect(0) to accept zero assertions.", this.stack);
+  		}
+
+  		var i,
+  		    module = this.module,
+  		    moduleName = module.name,
+  		    testName = this.testName,
+  		    skipped = !!this.skip,
+  		    todo = !!this.todo,
+  		    bad = 0,
+  		    storage = config.storage;
+
+  		this.runtime = now() - this.started;
+
+  		config.stats.all += this.assertions.length;
+  		module.stats.all += this.assertions.length;
+
+  		for (i = 0; i < this.assertions.length; i++) {
+  			if (!this.assertions[i].result) {
+  				bad++;
+  				config.stats.bad++;
+  				module.stats.bad++;
+  			}
+  		}
+
+  		notifyTestsRan(module, skipped);
+
+  		// Store result when possible
+  		if (storage) {
+  			if (bad) {
+  				storage.setItem("qunit-test-" + moduleName + "-" + testName, bad);
+  			} else {
+  				storage.removeItem("qunit-test-" + moduleName + "-" + testName);
+  			}
+  		}
+
+  		// After emitting the js-reporters event we cleanup the assertion data to
+  		// avoid leaking it. It is not used by the legacy testDone callbacks.
+  		emit("testEnd", this.testReport.end(true));
+  		this.testReport.slimAssertions();
+
+  		return runLoggingCallbacks("testDone", {
+  			name: testName,
+  			module: moduleName,
+  			skipped: skipped,
+  			todo: todo,
+  			failed: bad,
+  			passed: this.assertions.length - bad,
+  			total: this.assertions.length,
+  			runtime: skipped ? 0 : this.runtime,
+
+  			// HTML Reporter use
+  			assertions: this.assertions,
+  			testId: this.testId,
+
+  			// Source of Test
+  			source: this.stack
+  		}).then(function () {
+  			if (module.testsRun === numberOfTests(module)) {
+  				var completedModules = [module];
+
+  				// Check if the parent modules, iteratively, are done. If that the case,
+  				// we emit the `suiteEnd` event and trigger `moduleDone` callback.
+  				var parent = module.parentModule;
+  				while (parent && parent.testsRun === numberOfTests(parent)) {
+  					completedModules.push(parent);
+  					parent = parent.parentModule;
+  				}
+
+  				return completedModules.reduce(function (promiseChain, completedModule) {
+  					return promiseChain.then(function () {
+  						return logSuiteEnd(completedModule);
+  					});
+  				}, Promise$1.resolve([]));
+  			}
+  		}).then(function () {
+  			config.current = undefined;
+  		});
+
+  		function logSuiteEnd(module) {
+
+  			// Reset `module.hooks` to ensure that anything referenced in these hooks
+  			// has been released to be garbage collected.
+  			module.hooks = {};
+
+  			emit("suiteEnd", module.suiteReport.end(true));
+  			return runLoggingCallbacks("moduleDone", {
+  				name: module.name,
+  				tests: module.tests,
+  				failed: module.stats.bad,
+  				passed: module.stats.all - module.stats.bad,
+  				total: module.stats.all,
+  				runtime: now() - module.stats.started
+  			});
+  		}
+  	},
+
+  	preserveTestEnvironment: function preserveTestEnvironment() {
+  		if (this.preserveEnvironment) {
+  			this.module.testEnvironment = this.testEnvironment;
+  			this.testEnvironment = extend({}, this.module.testEnvironment);
+  		}
+  	},
+
+  	queue: function queue() {
+  		var test = this;
+
+  		if (!this.valid()) {
+  			return;
+  		}
+
+  		function runTest() {
+  			return [function () {
+  				return test.before();
+  			}].concat(toConsumableArray(test.hooks("before")), [function () {
+  				test.preserveTestEnvironment();
+  			}], toConsumableArray(test.hooks("beforeEach")), [function () {
+  				test.run();
+  			}], toConsumableArray(test.hooks("afterEach").reverse()), toConsumableArray(test.hooks("after").reverse()), [function () {
+  				test.after();
+  			}, function () {
+  				return test.finish();
+  			}]);
+  		}
+
+  		var previousFailCount = config.storage && +config.storage.getItem("qunit-test-" + this.module.name + "-" + this.testName);
+
+  		// Prioritize previously failed tests, detected from storage
+  		var prioritize = config.reorder && !!previousFailCount;
+
+  		this.previousFailure = !!previousFailCount;
+
+  		ProcessingQueue.add(runTest, prioritize, config.seed);
+
+  		// If the queue has already finished, we manually process the new test
+  		if (ProcessingQueue.finished) {
+  			ProcessingQueue.advance();
+  		}
+  	},
+
+
+  	pushResult: function pushResult(resultInfo) {
+  		if (this !== config.current) {
+  			throw new Error("Assertion occurred after test had finished.");
+  		}
+
+  		// Destructure of resultInfo = { result, actual, expected, message, negative }
+  		var source,
+  		    details = {
+  			module: this.module.name,
+  			name: this.testName,
+  			result: resultInfo.result,
+  			message: resultInfo.message,
+  			actual: resultInfo.actual,
+  			testId: this.testId,
+  			negative: resultInfo.negative || false,
+  			runtime: now() - this.started,
+  			todo: !!this.todo
+  		};
+
+  		if (hasOwn.call(resultInfo, "expected")) {
+  			details.expected = resultInfo.expected;
+  		}
+
+  		if (!resultInfo.result) {
+  			source = resultInfo.source || sourceFromStacktrace();
+
+  			if (source) {
+  				details.source = source;
+  			}
+  		}
+
+  		this.logAssertion(details);
+
+  		this.assertions.push({
+  			result: !!resultInfo.result,
+  			message: resultInfo.message
+  		});
+  	},
+
+  	pushFailure: function pushFailure(message, source, actual) {
+  		if (!(this instanceof Test)) {
+  			throw new Error("pushFailure() assertion outside test context, was " + sourceFromStacktrace(2));
+  		}
+
+  		this.pushResult({
+  			result: false,
+  			message: message || "error",
+  			actual: actual || null,
+  			source: source
+  		});
+  	},
+
+  	/**
+    * Log assertion details using both the old QUnit.log interface and
+    * QUnit.on( "assertion" ) interface.
+    *
+    * @private
+    */
+  	logAssertion: function logAssertion(details) {
+  		runLoggingCallbacks("log", details);
+
+  		var assertion = {
+  			passed: details.result,
+  			actual: details.actual,
+  			expected: details.expected,
+  			message: details.message,
+  			stack: details.source,
+  			todo: details.todo
+  		};
+  		this.testReport.pushAssertion(assertion);
+  		emit("assertion", assertion);
+  	},
+
+
+  	resolvePromise: function resolvePromise(promise, phase) {
+  		var then,
+  		    resume,
+  		    message,
+  		    test = this;
+  		if (promise != null) {
+  			then = promise.then;
+  			if (objectType(then) === "function") {
+  				resume = internalStop(test);
+  				if (config.notrycatch) {
+  					then.call(promise, function () {
+  						resume();
+  					});
+  				} else {
+  					then.call(promise, function () {
+  						resume();
+  					}, function (error) {
+  						message = "Promise rejected " + (!phase ? "during" : phase.replace(/Each$/, "")) + " \"" + test.testName + "\": " + (error && error.message || error);
+  						test.pushFailure(message, extractStacktrace(error, 0));
+
+  						// Else next test will carry the responsibility
+  						saveGlobal();
+
+  						// Unblock
+  						internalRecover(test);
+  					});
+  				}
+  			}
+  		}
+  	},
+
+  	valid: function valid() {
+  		var filter = config.filter,
+  		    regexFilter = /^(!?)\/([\w\W]*)\/(i?$)/.exec(filter),
+  		    module = config.module && config.module.toLowerCase(),
+  		    fullName = this.module.name + ": " + this.testName;
+
+  		function moduleChainNameMatch(testModule) {
+  			var testModuleName = testModule.name ? testModule.name.toLowerCase() : null;
+  			if (testModuleName === module) {
+  				return true;
+  			} else if (testModule.parentModule) {
+  				return moduleChainNameMatch(testModule.parentModule);
+  			} else {
+  				return false;
+  			}
+  		}
+
+  		function moduleChainIdMatch(testModule) {
+  			return inArray(testModule.moduleId, config.moduleId) || testModule.parentModule && moduleChainIdMatch(testModule.parentModule);
+  		}
+
+  		// Internally-generated tests are always valid
+  		if (this.callback && this.callback.validTest) {
+  			return true;
+  		}
+
+  		if (config.moduleId && config.moduleId.length > 0 && !moduleChainIdMatch(this.module)) {
+
+  			return false;
+  		}
+
+  		if (config.testId && config.testId.length > 0 && !inArray(this.testId, config.testId)) {
+
+  			return false;
+  		}
+
+  		if (module && !moduleChainNameMatch(this.module)) {
+  			return false;
+  		}
+
+  		if (!filter) {
+  			return true;
+  		}
+
+  		return regexFilter ? this.regexFilter(!!regexFilter[1], regexFilter[2], regexFilter[3], fullName) : this.stringFilter(filter, fullName);
+  	},
+
+  	regexFilter: function regexFilter(exclude, pattern, flags, fullName) {
+  		var regex = new RegExp(pattern, flags);
+  		var match = regex.test(fullName);
+
+  		return match !== exclude;
+  	},
+
+  	stringFilter: function stringFilter(filter, fullName) {
+  		filter = filter.toLowerCase();
+  		fullName = fullName.toLowerCase();
+
+  		var include = filter.charAt(0) !== "!";
+  		if (!include) {
+  			filter = filter.slice(1);
+  		}
+
+  		// If the filter matches, we need to honour include
+  		if (fullName.indexOf(filter) !== -1) {
+  			return include;
+  		}
+
+  		// Otherwise, do the opposite
+  		return !include;
+  	}
+  };
+
+  function pushFailure() {
+  	if (!config.current) {
+  		throw new Error("pushFailure() assertion outside test context, in " + sourceFromStacktrace(2));
+  	}
+
+  	// Gets current test obj
+  	var currentTest = config.current;
+
+  	return currentTest.pushFailure.apply(currentTest, arguments);
+  }
+
+  function saveGlobal() {
+  	config.pollution = [];
+
+  	if (config.noglobals) {
+  		for (var key in global$1) {
+  			if (hasOwn.call(global$1, key)) {
+
+  				// In Opera sometimes DOM element ids show up here, ignore them
+  				if (/^qunit-test-output/.test(key)) {
+  					continue;
+  				}
+  				config.pollution.push(key);
+  			}
+  		}
+  	}
+  }
+
+  function checkPollution() {
+  	var newGlobals,
+  	    deletedGlobals,
+  	    old = config.pollution;
+
+  	saveGlobal();
+
+  	newGlobals = diff(config.pollution, old);
+  	if (newGlobals.length > 0) {
+  		pushFailure("Introduced global variable(s): " + newGlobals.join(", "));
+  	}
+
+  	deletedGlobals = diff(old, config.pollution);
+  	if (deletedGlobals.length > 0) {
+  		pushFailure("Deleted global variable(s): " + deletedGlobals.join(", "));
+  	}
+  }
+
+  // Will be exposed as QUnit.test
+  function test(testName, callback) {
+  	if (focused$1) {
+  		return;
+  	}
+
+  	var newTest = new Test({
+  		testName: testName,
+  		callback: callback
+  	});
+
+  	newTest.queue();
+  }
+
+  function todo(testName, callback) {
+  	if (focused$1) {
+  		return;
+  	}
+
+  	var newTest = new Test({
+  		testName: testName,
+  		callback: callback,
+  		todo: true
+  	});
+
+  	newTest.queue();
+  }
+
+  // Will be exposed as QUnit.skip
+  function skip(testName) {
+  	if (focused$1) {
+  		return;
+  	}
+
+  	var test = new Test({
+  		testName: testName,
+  		skip: true
+  	});
+
+  	test.queue();
+  }
+
+  // Will be exposed as QUnit.only
+  function only(testName, callback) {
+  	if (focused$1) {
+  		return;
+  	}
+
+  	config.queue.length = 0;
+  	focused$1 = true;
+
+  	var newTest = new Test({
+  		testName: testName,
+  		callback: callback
+  	});
+
+  	newTest.queue();
+  }
+
+  // Put a hold on processing and return a function that will release it.
+  function internalStop(test) {
+  	test.semaphore += 1;
+  	config.blocking = true;
+
+  	// Set a recovery timeout, if so configured.
+  	if (defined.setTimeout) {
+  		var timeoutDuration = void 0;
+
+  		if (typeof test.timeout === "number") {
+  			timeoutDuration = test.timeout;
+  		} else if (typeof config.testTimeout === "number") {
+  			timeoutDuration = config.testTimeout;
+  		}
+
+  		if (typeof timeoutDuration === "number" && timeoutDuration > 0) {
+  			clearTimeout(config.timeout);
+  			config.timeout = setTimeout$1(function () {
+  				pushFailure("Test took longer than " + timeoutDuration + "ms; test timed out.", sourceFromStacktrace(2));
+  				internalRecover(test);
+  			}, timeoutDuration);
+  		}
+  	}
+
+  	var released = false;
+  	return function resume() {
+  		if (released) {
+  			return;
+  		}
+
+  		released = true;
+  		test.semaphore -= 1;
+  		internalStart(test);
+  	};
+  }
+
+  // Forcefully release all processing holds.
+  function internalRecover(test) {
+  	test.semaphore = 0;
+  	internalStart(test);
+  }
+
+  // Release a processing hold, scheduling a resumption attempt if no holds remain.
+  function internalStart(test) {
+
+  	// If semaphore is non-numeric, throw error
+  	if (isNaN(test.semaphore)) {
+  		test.semaphore = 0;
+
+  		pushFailure("Invalid value on test.semaphore", sourceFromStacktrace(2));
+  		return;
+  	}
+
+  	// Don't start until equal number of stop-calls
+  	if (test.semaphore > 0) {
+  		return;
+  	}
+
+  	// Throw an Error if start is called more often than stop
+  	if (test.semaphore < 0) {
+  		test.semaphore = 0;
+
+  		pushFailure("Tried to restart test while already started (test's semaphore was 0 already)", sourceFromStacktrace(2));
+  		return;
+  	}
+
+  	// Add a slight delay to allow more assertions etc.
+  	if (defined.setTimeout) {
+  		if (config.timeout) {
+  			clearTimeout(config.timeout);
+  		}
+  		config.timeout = setTimeout$1(function () {
+  			if (test.semaphore > 0) {
+  				return;
+  			}
+
+  			if (config.timeout) {
+  				clearTimeout(config.timeout);
+  			}
+
+  			begin();
+  		});
+  	} else {
+  		begin();
+  	}
+  }
+
+  function collectTests(module) {
+  	var tests = [].concat(module.tests);
+  	var modules = [].concat(toConsumableArray(module.childModules));
+
+  	// Do a breadth-first traversal of the child modules
+  	while (modules.length) {
+  		var nextModule = modules.shift();
+  		tests.push.apply(tests, nextModule.tests);
+  		modules.push.apply(modules, toConsumableArray(nextModule.childModules));
+  	}
+
+  	return tests;
+  }
+
+  function numberOfTests(module) {
+  	return collectTests(module).length;
+  }
+
+  function numberOfUnskippedTests(module) {
+  	return collectTests(module).filter(function (test) {
+  		return !test.skip;
+  	}).length;
+  }
+
+  function notifyTestsRan(module, skipped) {
+  	module.testsRun++;
+  	if (!skipped) {
+  		module.unskippedTestsRun++;
+  	}
+  	while (module = module.parentModule) {
+  		module.testsRun++;
+  		if (!skipped) {
+  			module.unskippedTestsRun++;
+  		}
+  	}
+  }
+
+  var Assert = function () {
+  	function Assert(testContext) {
+  		classCallCheck(this, Assert);
+
+  		this.test = testContext;
+  	}
+
+  	// Assert helpers
+
+  	createClass(Assert, [{
+  		key: "timeout",
+  		value: function timeout(duration) {
+  			if (typeof duration !== "number") {
+  				throw new Error("You must pass a number as the duration to assert.timeout");
+  			}
+
+  			this.test.timeout = duration;
+  		}
+
+  		// Documents a "step", which is a string value, in a test as a passing assertion
+
+  	}, {
+  		key: "step",
+  		value: function step(message) {
+  			var assertionMessage = message;
+  			var result = !!message;
+
+  			this.test.steps.push(message);
+
+  			if (objectType(message) === "undefined" || message === "") {
+  				assertionMessage = "You must provide a message to assert.step";
+  			} else if (objectType(message) !== "string") {
+  				assertionMessage = "You must provide a string value to assert.step";
+  				result = false;
+  			}
+
+  			this.pushResult({
+  				result: result,
+  				message: assertionMessage
+  			});
+  		}
+
+  		// Verifies the steps in a test match a given array of string values
+
+  	}, {
+  		key: "verifySteps",
+  		value: function verifySteps(steps, message) {
+
+  			// Since the steps array is just string values, we can clone with slice
+  			var actualStepsClone = this.test.steps.slice();
+  			this.deepEqual(actualStepsClone, steps, message);
+  			this.test.steps.length = 0;
+  		}
+
+  		// Specify the number of expected assertions to guarantee that failed test
+  		// (no assertions are run at all) don't slip through.
+
+  	}, {
+  		key: "expect",
+  		value: function expect(asserts) {
+  			if (arguments.length === 1) {
+  				this.test.expected = asserts;
+  			} else {
+  				return this.test.expected;
+  			}
+  		}
+
+  		// Put a hold on processing and return a function that will release it a maximum of once.
+
+  	}, {
+  		key: "async",
+  		value: function async(count) {
+  			var test$$1 = this.test;
+
+  			var popped = false,
+  			    acceptCallCount = count;
+
+  			if (typeof acceptCallCount === "undefined") {
+  				acceptCallCount = 1;
+  			}
+
+  			var resume = internalStop(test$$1);
+
+  			return function done() {
+  				if (config.current !== test$$1) {
+  					throw Error("assert.async callback called after test finished.");
+  				}
+
+  				if (popped) {
+  					test$$1.pushFailure("Too many calls to the `assert.async` callback", sourceFromStacktrace(2));
+  					return;
+  				}
+
+  				acceptCallCount -= 1;
+  				if (acceptCallCount > 0) {
+  					return;
+  				}
+
+  				popped = true;
+  				resume();
+  			};
+  		}
+
+  		// Exports test.push() to the user API
+  		// Alias of pushResult.
+
+  	}, {
+  		key: "push",
+  		value: function push(result, actual, expected, message, negative) {
+  			Logger.warn("assert.push is deprecated and will be removed in QUnit 3.0." + " Please use assert.pushResult instead (https://api.qunitjs.com/assert/pushResult).");
+
+  			var currentAssert = this instanceof Assert ? this : config.current.assert;
+  			return currentAssert.pushResult({
+  				result: result,
+  				actual: actual,
+  				expected: expected,
+  				message: message,
+  				negative: negative
+  			});
+  		}
+  	}, {
+  		key: "pushResult",
+  		value: function pushResult(resultInfo) {
+
+  			// Destructure of resultInfo = { result, actual, expected, message, negative }
+  			var assert = this;
+  			var currentTest = assert instanceof Assert && assert.test || config.current;
+
+  			// Backwards compatibility fix.
+  			// Allows the direct use of global exported assertions and QUnit.assert.*
+  			// Although, it's use is not recommended as it can leak assertions
+  			// to other tests from async tests, because we only get a reference to the current test,
+  			// not exactly the test where assertion were intended to be called.
+  			if (!currentTest) {
+  				throw new Error("assertion outside test context, in " + sourceFromStacktrace(2));
+  			}
+
+  			if (!(assert instanceof Assert)) {
+  				assert = currentTest.assert;
+  			}
+
+  			return assert.test.pushResult(resultInfo);
+  		}
+  	}, {
+  		key: "ok",
+  		value: function ok(result, message) {
+  			if (!message) {
+  				message = result ? "okay" : "failed, expected argument to be truthy, was: " + dump.parse(result);
+  			}
+
+  			this.pushResult({
+  				result: !!result,
+  				actual: result,
+  				expected: true,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "notOk",
+  		value: function notOk(result, message) {
+  			if (!message) {
+  				message = !result ? "okay" : "failed, expected argument to be falsy, was: " + dump.parse(result);
+  			}
+
+  			this.pushResult({
+  				result: !result,
+  				actual: result,
+  				expected: false,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "equal",
+  		value: function equal(actual, expected, message) {
+
+  			// eslint-disable-next-line eqeqeq
+  			var result = expected == actual;
+
+  			this.pushResult({
+  				result: result,
+  				actual: actual,
+  				expected: expected,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "notEqual",
+  		value: function notEqual(actual, expected, message) {
+
+  			// eslint-disable-next-line eqeqeq
+  			var result = expected != actual;
+
+  			this.pushResult({
+  				result: result,
+  				actual: actual,
+  				expected: expected,
+  				message: message,
+  				negative: true
+  			});
+  		}
+  	}, {
+  		key: "propEqual",
+  		value: function propEqual(actual, expected, message) {
+  			actual = objectValues(actual);
+  			expected = objectValues(expected);
+
+  			this.pushResult({
+  				result: equiv(actual, expected),
+  				actual: actual,
+  				expected: expected,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "notPropEqual",
+  		value: function notPropEqual(actual, expected, message) {
+  			actual = objectValues(actual);
+  			expected = objectValues(expected);
+
+  			this.pushResult({
+  				result: !equiv(actual, expected),
+  				actual: actual,
+  				expected: expected,
+  				message: message,
+  				negative: true
+  			});
+  		}
+  	}, {
+  		key: "deepEqual",
+  		value: function deepEqual(actual, expected, message) {
+  			this.pushResult({
+  				result: equiv(actual, expected),
+  				actual: actual,
+  				expected: expected,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "notDeepEqual",
+  		value: function notDeepEqual(actual, expected, message) {
+  			this.pushResult({
+  				result: !equiv(actual, expected),
+  				actual: actual,
+  				expected: expected,
+  				message: message,
+  				negative: true
+  			});
+  		}
+  	}, {
+  		key: "strictEqual",
+  		value: function strictEqual(actual, expected, message) {
+  			this.pushResult({
+  				result: expected === actual,
+  				actual: actual,
+  				expected: expected,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "notStrictEqual",
+  		value: function notStrictEqual(actual, expected, message) {
+  			this.pushResult({
+  				result: expected !== actual,
+  				actual: actual,
+  				expected: expected,
+  				message: message,
+  				negative: true
+  			});
+  		}
+  	}, {
+  		key: "throws",
+  		value: function throws(block, expected, message) {
+  			var actual = void 0,
+  			    result = false;
+
+  			var currentTest = this instanceof Assert && this.test || config.current;
+
+  			// 'expected' is optional unless doing string comparison
+  			if (objectType(expected) === "string") {
+  				if (message == null) {
+  					message = expected;
+  					expected = null;
+  				} else {
+  					throw new Error("throws/raises does not accept a string value for the expected argument.\n" + "Use a non-string object value (e.g. regExp) instead if it's necessary.");
+  				}
+  			}
+
+  			currentTest.ignoreGlobalErrors = true;
+  			try {
+  				block.call(currentTest.testEnvironment);
+  			} catch (e) {
+  				actual = e;
+  			}
+  			currentTest.ignoreGlobalErrors = false;
+
+  			if (actual) {
+  				var expectedType = objectType(expected);
+
+  				// We don't want to validate thrown error
+  				if (!expected) {
+  					result = true;
+  					expected = null;
+
+  					// Expected is a regexp
+  				} else if (expectedType === "regexp") {
+  					result = expected.test(errorString(actual));
+
+  					// Expected is a constructor, maybe an Error constructor
+  				} else if (expectedType === "function" && actual instanceof expected) {
+  					result = true;
+
+  					// Expected is an Error object
+  				} else if (expectedType === "object") {
+  					result = actual instanceof expected.constructor && actual.name === expected.name && actual.message === expected.message;
+
+  					// Expected is a validation function which returns true if validation passed
+  				} else if (expectedType === "function" && expected.call({}, actual) === true) {
+  					expected = null;
+  					result = true;
+  				}
+  			}
+
+  			currentTest.assert.pushResult({
+  				result: result,
+  				actual: actual,
+  				expected: expected,
+  				message: message
+  			});
+  		}
+  	}, {
+  		key: "rejects",
+  		value: function rejects(promise, expected, message) {
+  			var result = false;
+
+  			var currentTest = this instanceof Assert && this.test || config.current;
+
+  			// 'expected' is optional unless doing string comparison
+  			if (objectType(expected) === "string") {
+  				if (message === undefined) {
+  					message = expected;
+  					expected = undefined;
+  				} else {
+  					message = "assert.rejects does not accept a string value for the expected " + "argument.\nUse a non-string object value (e.g. validator function) instead " + "if necessary.";
+
+  					currentTest.assert.pushResult({
+  						result: false,
+  						message: message
+  					});
+
+  					return;
+  				}
+  			}
+
+  			var then = promise && promise.then;
+  			if (objectType(then) !== "function") {
+  				var _message = "The value provided to `assert.rejects` in " + "\"" + currentTest.testName + "\" was not a promise.";
+
+  				currentTest.assert.pushResult({
+  					result: false,
+  					message: _message,
+  					actual: promise
+  				});
+
+  				return;
+  			}
+
+  			var done = this.async();
+
+  			return then.call(promise, function handleFulfillment() {
+  				var message = "The promise returned by the `assert.rejects` callback in " + "\"" + currentTest.testName + "\" did not reject.";
+
+  				currentTest.assert.pushResult({
+  					result: false,
+  					message: message,
+  					actual: promise
+  				});
+
+  				done();
+  			}, function handleRejection(actual) {
+  				var expectedType = objectType(expected);
+
+  				// We don't want to validate
+  				if (expected === undefined) {
+  					result = true;
+  					expected = actual;
+
+  					// Expected is a regexp
+  				} else if (expectedType === "regexp") {
+  					result = expected.test(errorString(actual));
+
+  					// Expected is a constructor, maybe an Error constructor
+  				} else if (expectedType === "function" && actual instanceof expected) {
+  					result = true;
+
+  					// Expected is an Error object
+  				} else if (expectedType === "object") {
+  					result = actual instanceof expected.constructor && actual.name === expected.name && actual.message === expected.message;
+
+  					// Expected is a validation function which returns true if validation passed
+  				} else {
+  					if (expectedType === "function") {
+  						result = expected.call({}, actual) === true;
+  						expected = null;
+
+  						// Expected is some other invalid type
+  					} else {
+  						result = false;
+  						message = "invalid expected value provided to `assert.rejects` " + "callback in \"" + currentTest.testName + "\": " + expectedType + ".";
+  					}
+  				}
+
+  				currentTest.assert.pushResult({
+  					result: result,
+  					actual: actual,
+  					expected: expected,
+  					message: message
+  				});
+
+  				done();
+  			});
+  		}
+  	}]);
+  	return Assert;
+  }();
+
+  // Provide an alternative to assert.throws(), for environments that consider throws a reserved word
+  // Known to us are: Closure Compiler, Narwhal
+  // eslint-disable-next-line dot-notation
+
+
+  Assert.prototype.raises = Assert.prototype["throws"];
+
+  /**
+   * Converts an error into a simple string for comparisons.
+   *
+   * @param {Error} error
+   * @return {String}
+   */
+  function errorString(error) {
+  	var resultErrorString = error.toString();
+
+  	if (resultErrorString.substring(0, 7) === "[object") {
+  		var name = error.name ? error.name.toString() : "Error";
+  		var message = error.message ? error.message.toString() : "";
+
+  		if (name && message) {
+  			return name + ": " + message;
+  		} else if (name) {
+  			return name;
+  		} else if (message) {
+  			return message;
+  		} else {
+  			return "Error";
+  		}
+  	} else {
+  		return resultErrorString;
+  	}
+  }
+
+  /* global module, exports, define */
+  function exportQUnit(QUnit) {
+
+  	if (defined.document) {
+
+  		// QUnit may be defined when it is preconfigured but then only QUnit and QUnit.config may be defined.
+  		if (window$1.QUnit && window$1.QUnit.version) {
+  			throw new Error("QUnit has already been defined.");
+  		}
+
+  		window$1.QUnit = QUnit;
+  	}
+
+  	// For nodejs
+  	if (typeof module !== "undefined" && module && module.exports) {
+  		module.exports = QUnit;
+
+  		// For consistency with CommonJS environments' exports
+  		module.exports.QUnit = QUnit;
+  	}
+
+  	// For CommonJS with exports, but without module.exports, like Rhino
+  	if (typeof exports !== "undefined" && exports) {
+  		exports.QUnit = QUnit;
+  	}
+
+  	if (typeof define === "function" && define.amd) {
+  		define(function () {
+  			return QUnit;
+  		});
+  		QUnit.config.autostart = false;
+  	}
+
+  	// For Web/Service Workers
+  	if (self$1 && self$1.WorkerGlobalScope && self$1 instanceof self$1.WorkerGlobalScope) {
+  		self$1.QUnit = QUnit;
+  	}
+  }
+
+  // Handle an unhandled exception. By convention, returns true if further
+  // error handling should be suppressed and false otherwise.
+  // In this case, we will only suppress further error handling if the
+  // "ignoreGlobalErrors" configuration option is enabled.
+  function onError(error) {
+  	for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+  		args[_key - 1] = arguments[_key];
+  	}
+
+  	if (config.current) {
+  		if (config.current.ignoreGlobalErrors) {
+  			return true;
+  		}
+  		pushFailure.apply(undefined, [error.message, error.stacktrace || error.fileName + ":" + error.lineNumber].concat(args));
+  	} else {
+  		test("global failure", extend(function () {
+  			pushFailure.apply(undefined, [error.message, error.stacktrace || error.fileName + ":" + error.lineNumber].concat(args));
+  		}, { validTest: true }));
+  	}
+
+  	return false;
+  }
+
+  // Handle an unhandled rejection
+  function onUnhandledRejection(reason) {
+  	var resultInfo = {
+  		result: false,
+  		message: reason.message || "error",
+  		actual: reason,
+  		source: reason.stack || sourceFromStacktrace(3)
+  	};
+
+  	var currentTest = config.current;
+  	if (currentTest) {
+  		currentTest.assert.pushResult(resultInfo);
+  	} else {
+  		test("global failure", extend(function (assert) {
+  			assert.pushResult(resultInfo);
+  		}, { validTest: true }));
+  	}
+  }
+
+  var QUnit = {};
+  var globalSuite = new SuiteReport();
+
+  // The initial "currentModule" represents the global (or top-level) module that
+  // is not explicitly defined by the user, therefore we add the "globalSuite" to
+  // it since each module has a suiteReport associated with it.
+  config.currentModule.suiteReport = globalSuite;
+
+  var globalStartCalled = false;
+  var runStarted = false;
+
+  // Figure out if we're running the tests from a server or not
+  QUnit.isLocal = !(defined.document && window$1.location.protocol !== "file:");
+
+  // Expose the current QUnit version
+  QUnit.version = "2.8.0";
+
+  extend(QUnit, {
+  	on: on,
+
+  	module: module$1,
+
+  	test: test,
+
+  	todo: todo,
+
+  	skip: skip,
+
+  	only: only,
+
+  	start: function start(count) {
+  		var globalStartAlreadyCalled = globalStartCalled;
+
+  		if (!config.current) {
+  			globalStartCalled = true;
+
+  			if (runStarted) {
+  				throw new Error("Called start() while test already started running");
+  			} else if (globalStartAlreadyCalled || count > 1) {
+  				throw new Error("Called start() outside of a test context too many times");
+  			} else if (config.autostart) {
+  				throw new Error("Called start() outside of a test context when " + "QUnit.config.autostart was true");
+  			} else if (!config.pageLoaded) {
+
+  				// The page isn't completely loaded yet, so we set autostart and then
+  				// load if we're in Node or wait for the browser's load event.
+  				config.autostart = true;
+
+  				// Starts from Node even if .load was not previously called. We still return
+  				// early otherwise we'll wind up "beginning" twice.
+  				if (!defined.document) {
+  					QUnit.load();
+  				}
+
+  				return;
+  			}
+  		} else {
+  			throw new Error("QUnit.start cannot be called inside a test context.");
+  		}
+
+  		scheduleBegin();
+  	},
+
+  	config: config,
+
+  	is: is,
+
+  	objectType: objectType,
+
+  	extend: extend,
+
+  	load: function load() {
+  		config.pageLoaded = true;
+
+  		// Initialize the configuration options
+  		extend(config, {
+  			stats: { all: 0, bad: 0 },
+  			started: 0,
+  			updateRate: 1000,
+  			autostart: true,
+  			filter: ""
+  		}, true);
+
+  		if (!runStarted) {
+  			config.blocking = false;
+
+  			if (config.autostart) {
+  				scheduleBegin();
+  			}
+  		}
+  	},
+
+  	stack: function stack(offset) {
+  		offset = (offset || 0) + 2;
+  		return sourceFromStacktrace(offset);
+  	},
+
+  	onError: onError,
+
+  	onUnhandledRejection: onUnhandledRejection
+  });
+
+  QUnit.pushFailure = pushFailure;
+  QUnit.assert = Assert.prototype;
+  QUnit.equiv = equiv;
+  QUnit.dump = dump;
+
+  registerLoggingCallbacks(QUnit);
+
+  function scheduleBegin() {
+
+  	runStarted = true;
+
+  	// Add a slight delay to allow definition of more modules and tests.
+  	if (defined.setTimeout) {
+  		setTimeout$1(function () {
+  			begin();
+  		});
+  	} else {
+  		begin();
+  	}
+  }
+
+  function unblockAndAdvanceQueue() {
+  	config.blocking = false;
+  	ProcessingQueue.advance();
+  }
+
+  function begin() {
+  	var i,
+  	    l,
+  	    modulesLog = [];
+
+  	// If the test run hasn't officially begun yet
+  	if (!config.started) {
+
+  		// Record the time of the test run's beginning
+  		config.started = now();
+
+  		// Delete the loose unnamed module if unused.
+  		if (config.modules[0].name === "" && config.modules[0].tests.length === 0) {
+  			config.modules.shift();
+  		}
+
+  		// Avoid unnecessary information by not logging modules' test environments
+  		for (i = 0, l = config.modules.length; i < l; i++) {
+  			modulesLog.push({
+  				name: config.modules[i].name,
+  				tests: config.modules[i].tests
+  			});
+  		}
+
+  		// The test run is officially beginning now
+  		emit("runStart", globalSuite.start(true));
+  		runLoggingCallbacks("begin", {
+  			totalTests: Test.count,
+  			modules: modulesLog
+  		}).then(unblockAndAdvanceQueue);
+  	} else {
+  		unblockAndAdvanceQueue();
+  	}
+  }
+
+  exportQUnit(QUnit);
+
+  (function () {
+
+  	if (typeof window$1 === "undefined" || typeof document$1 === "undefined") {
+  		return;
+  	}
+
+  	var config = QUnit.config,
+  	    hasOwn = Object.prototype.hasOwnProperty;
+
+  	// Stores fixture HTML for resetting later
+  	function storeFixture() {
+
+  		// Avoid overwriting user-defined values
+  		if (hasOwn.call(config, "fixture")) {
+  			return;
+  		}
+
+  		var fixture = document$1.getElementById("qunit-fixture");
+  		if (fixture) {
+  			config.fixture = fixture.cloneNode(true);
+  		}
+  	}
+
+  	QUnit.begin(storeFixture);
+
+  	// Resets the fixture DOM element if available.
+  	function resetFixture() {
+  		if (config.fixture == null) {
+  			return;
+  		}
+
+  		var fixture = document$1.getElementById("qunit-fixture");
+  		var resetFixtureType = _typeof(config.fixture);
+  		if (resetFixtureType === "string") {
+
+  			// support user defined values for `config.fixture`
+  			var newFixture = document$1.createElement("div");
+  			newFixture.setAttribute("id", "qunit-fixture");
+  			newFixture.innerHTML = config.fixture;
+  			fixture.parentNode.replaceChild(newFixture, fixture);
+  		} else {
+  			var clonedFixture = config.fixture.cloneNode(true);
+  			fixture.parentNode.replaceChild(clonedFixture, fixture);
+  		}
+  	}
+
+  	QUnit.testStart(resetFixture);
+  })();
+
+  (function () {
+
+  	// Only interact with URLs via window.location
+  	var location = typeof window$1 !== "undefined" && window$1.location;
+  	if (!location) {
+  		return;
+  	}
+
+  	var urlParams = getUrlParams();
+
+  	QUnit.urlParams = urlParams;
+
+  	// Match module/test by inclusion in an array
+  	QUnit.config.moduleId = [].concat(urlParams.moduleId || []);
+  	QUnit.config.testId = [].concat(urlParams.testId || []);
+
+  	// Exact case-insensitive match of the module name
+  	QUnit.config.module = urlParams.module;
+
+  	// Regular expression or case-insenstive substring match against "moduleName: testName"
+  	QUnit.config.filter = urlParams.filter;
+
+  	// Test order randomization
+  	if (urlParams.seed === true) {
+
+  		// Generate a random seed if the option is specified without a value
+  		QUnit.config.seed = Math.random().toString(36).slice(2);
+  	} else if (urlParams.seed) {
+  		QUnit.config.seed = urlParams.seed;
+  	}
+
+  	// Add URL-parameter-mapped config values with UI form rendering data
+  	QUnit.config.urlConfig.push({
+  		id: "hidepassed",
+  		label: "Hide passed tests",
+  		tooltip: "Only show tests and assertions that fail. Stored as query-strings."
+  	}, {
+  		id: "noglobals",
+  		label: "Check for Globals",
+  		tooltip: "Enabling this will test if any test introduces new properties on the " + "global object (`window` in Browsers). Stored as query-strings."
+  	}, {
+  		id: "notrycatch",
+  		label: "No try-catch",
+  		tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging " + "exceptions in IE reasonable. Stored as query-strings."
+  	});
+
+  	QUnit.begin(function () {
+  		var i,
+  		    option,
+  		    urlConfig = QUnit.config.urlConfig;
+
+  		for (i = 0; i < urlConfig.length; i++) {
+
+  			// Options can be either strings or objects with nonempty "id" properties
+  			option = QUnit.config.urlConfig[i];
+  			if (typeof option !== "string") {
+  				option = option.id;
+  			}
+
+  			if (QUnit.config[option] === undefined) {
+  				QUnit.config[option] = urlParams[option];
+  			}
+  		}
+  	});
+
+  	function getUrlParams() {
+  		var i, param, name, value;
+  		var urlParams = Object.create(null);
+  		var params = location.search.slice(1).split("&");
+  		var length = params.length;
+
+  		for (i = 0; i < length; i++) {
+  			if (params[i]) {
+  				param = params[i].split("=");
+  				name = decodeQueryParam(param[0]);
+
+  				// Allow just a key to turn on a flag, e.g., test.html?noglobals
+  				value = param.length === 1 || decodeQueryParam(param.slice(1).join("="));
+  				if (name in urlParams) {
+  					urlParams[name] = [].concat(urlParams[name], value);
+  				} else {
+  					urlParams[name] = value;
+  				}
+  			}
+  		}
+
+  		return urlParams;
+  	}
+
+  	function decodeQueryParam(param) {
+  		return decodeURIComponent(param.replace(/\+/g, "%20"));
+  	}
+  })();
+
+  var stats = {
+  	passedTests: 0,
+  	failedTests: 0,
+  	skippedTests: 0,
+  	todoTests: 0
+  };
+
+  // Escape text for attribute or text content.
+  function escapeText(s) {
+  	if (!s) {
+  		return "";
+  	}
+  	s = s + "";
+
+  	// Both single quotes and double quotes (for attributes)
+  	return s.replace(/['"<>&]/g, function (s) {
+  		switch (s) {
+  			case "'":
+  				return "&#039;";
+  			case "\"":
+  				return "&quot;";
+  			case "<":
+  				return "&lt;";
+  			case ">":
+  				return "&gt;";
+  			case "&":
+  				return "&amp;";
+  		}
+  	});
+  }
+
+  (function () {
+
+  	// Don't load the HTML Reporter on non-browser environments
+  	if (typeof window$1 === "undefined" || !window$1.document) {
+  		return;
+  	}
+
+  	var config = QUnit.config,
+  	    hiddenTests = [],
+  	    document = window$1.document,
+  	    collapseNext = false,
+  	    hasOwn = Object.prototype.hasOwnProperty,
+  	    unfilteredUrl = setUrl({ filter: undefined, module: undefined,
+  		moduleId: undefined, testId: undefined }),
+  	    modulesList = [];
+
+  	function addEvent(elem, type, fn) {
+  		elem.addEventListener(type, fn, false);
+  	}
+
+  	function removeEvent(elem, type, fn) {
+  		elem.removeEventListener(type, fn, false);
+  	}
+
+  	function addEvents(elems, type, fn) {
+  		var i = elems.length;
+  		while (i--) {
+  			addEvent(elems[i], type, fn);
+  		}
+  	}
+
+  	function hasClass(elem, name) {
+  		return (" " + elem.className + " ").indexOf(" " + name + " ") >= 0;
+  	}
+
+  	function addClass(elem, name) {
+  		if (!hasClass(elem, name)) {
+  			elem.className += (elem.className ? " " : "") + name;
+  		}
+  	}
+
+  	function toggleClass(elem, name, force) {
+  		if (force || typeof force === "undefined" && !hasClass(elem, name)) {
+  			addClass(elem, name);
+  		} else {
+  			removeClass(elem, name);
+  		}
+  	}
+
+  	function removeClass(elem, name) {
+  		var set = " " + elem.className + " ";
+
+  		// Class name may appear multiple times
+  		while (set.indexOf(" " + name + " ") >= 0) {
+  			set = set.replace(" " + name + " ", " ");
+  		}
+
+  		// Trim for prettiness
+  		elem.className = typeof set.trim === "function" ? set.trim() : set.replace(/^\s+|\s+$/g, "");
+  	}
+
+  	function id(name) {
+  		return document.getElementById && document.getElementById(name);
+  	}
+
+  	function abortTests() {
+  		var abortButton = id("qunit-abort-tests-button");
+  		if (abortButton) {
+  			abortButton.disabled = true;
+  			abortButton.innerHTML = "Aborting...";
+  		}
+  		QUnit.config.queue.length = 0;
+  		return false;
+  	}
+
+  	function interceptNavigation(ev) {
+  		applyUrlParams();
+
+  		if (ev && ev.preventDefault) {
+  			ev.preventDefault();
+  		}
+
+  		return false;
+  	}
+
+  	function getUrlConfigHtml() {
+  		var i,
+  		    j,
+  		    val,
+  		    escaped,
+  		    escapedTooltip,
+  		    selection = false,
+  		    urlConfig = config.urlConfig,
+  		    urlConfigHtml = "";
+
+  		for (i = 0; i < urlConfig.length; i++) {
+
+  			// Options can be either strings or objects with nonempty "id" properties
+  			val = config.urlConfig[i];
+  			if (typeof val === "string") {
+  				val = {
+  					id: val,
+  					label: val
+  				};
+  			}
+
+  			escaped = escapeText(val.id);
+  			escapedTooltip = escapeText(val.tooltip);
+
+  			if (!val.value || typeof val.value === "string") {
+  				urlConfigHtml += "<label for='qunit-urlconfig-" + escaped + "' title='" + escapedTooltip + "'><input id='qunit-urlconfig-" + escaped + "' name='" + escaped + "' type='checkbox'" + (val.value ? " value='" + escapeText(val.value) + "'" : "") + (config[val.id] ? " checked='checked'" : "") + " title='" + escapedTooltip + "' />" + escapeText(val.label) + "</label>";
+  			} else {
+  				urlConfigHtml += "<label for='qunit-urlconfig-" + escaped + "' title='" + escapedTooltip + "'>" + val.label + ": </label><select id='qunit-urlconfig-" + escaped + "' name='" + escaped + "' title='" + escapedTooltip + "'><option></option>";
+
+  				if (QUnit.is("array", val.value)) {
+  					for (j = 0; j < val.value.length; j++) {
+  						escaped = escapeText(val.value[j]);
+  						urlConfigHtml += "<option value='" + escaped + "'" + (config[val.id] === val.value[j] ? (selection = true) && " selected='selected'" : "") + ">" + escaped + "</option>";
+  					}
+  				} else {
+  					for (j in val.value) {
+  						if (hasOwn.call(val.value, j)) {
+  							urlConfigHtml += "<option value='" + escapeText(j) + "'" + (config[val.id] === j ? (selection = true) && " selected='selected'" : "") + ">" + escapeText(val.value[j]) + "</option>";
+  						}
+  					}
+  				}
+  				if (config[val.id] && !selection) {
+  					escaped = escapeText(config[val.id]);
+  					urlConfigHtml += "<option value='" + escaped + "' selected='selected' disabled='disabled'>" + escaped + "</option>";
+  				}
+  				urlConfigHtml += "</select>";
+  			}
+  		}
+
+  		return urlConfigHtml;
+  	}
+
+  	// Handle "click" events on toolbar checkboxes and "change" for select menus.
+  	// Updates the URL with the new state of `config.urlConfig` values.
+  	function toolbarChanged() {
+  		var updatedUrl,
+  		    value,
+  		    tests,
+  		    field = this,
+  		    params = {};
+
+  		// Detect if field is a select menu or a checkbox
+  		if ("selectedIndex" in field) {
+  			value = field.options[field.selectedIndex].value || undefined;
+  		} else {
+  			value = field.checked ? field.defaultValue || true : undefined;
+  		}
+
+  		params[field.name] = value;
+  		updatedUrl = setUrl(params);
+
+  		// Check if we can apply the change without a page refresh
+  		if ("hidepassed" === field.name && "replaceState" in window$1.history) {
+  			QUnit.urlParams[field.name] = value;
+  			config[field.name] = value || false;
+  			tests = id("qunit-tests");
+  			if (tests) {
+  				var length = tests.children.length;
+  				var children = tests.children;
+
+  				if (field.checked) {
+  					for (var i = 0; i < length; i++) {
+  						var test = children[i];
+
+  						if (test && test.className.indexOf("pass") > -1) {
+  							hiddenTests.push(test);
+  						}
+  					}
+
+  					var _iteratorNormalCompletion = true;
+  					var _didIteratorError = false;
+  					var _iteratorError = undefined;
+
+  					try {
+  						for (var _iterator = hiddenTests[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+  							var hiddenTest = _step.value;
+
+  							tests.removeChild(hiddenTest);
+  						}
+  					} catch (err) {
+  						_didIteratorError = true;
+  						_iteratorError = err;
+  					} finally {
+  						try {
+  							if (!_iteratorNormalCompletion && _iterator.return) {
+  								_iterator.return();
+  							}
+  						} finally {
+  							if (_didIteratorError) {
+  								throw _iteratorError;
+  							}
+  						}
+  					}
+  				} else {
+  					while ((test = hiddenTests.pop()) != null) {
+  						tests.appendChild(test);
+  					}
+  				}
+  			}
+  			window$1.history.replaceState(null, "", updatedUrl);
+  		} else {
+  			window$1.location = updatedUrl;
+  		}
+  	}
+
+  	function setUrl(params) {
+  		var key,
+  		    arrValue,
+  		    i,
+  		    querystring = "?",
+  		    location = window$1.location;
+
+  		params = QUnit.extend(QUnit.extend({}, QUnit.urlParams), params);
+
+  		for (key in params) {
+
+  			// Skip inherited or undefined properties
+  			if (hasOwn.call(params, key) && params[key] !== undefined) {
+
+  				// Output a parameter for each value of this key
+  				// (but usually just one)
+  				arrValue = [].concat(params[key]);
+  				for (i = 0; i < arrValue.length; i++) {
+  					querystring += encodeURIComponent(key);
+  					if (arrValue[i] !== true) {
+  						querystring += "=" + encodeURIComponent(arrValue[i]);
+  					}
+  					querystring += "&";
+  				}
+  			}
+  		}
+  		return location.protocol + "//" + location.host + location.pathname + querystring.slice(0, -1);
+  	}
+
+  	function applyUrlParams() {
+  		var i,
+  		    selectedModules = [],
+  		    modulesList = id("qunit-modulefilter-dropdown-list").getElementsByTagName("input"),
+  		    filter = id("qunit-filter-input").value;
+
+  		for (i = 0; i < modulesList.length; i++) {
+  			if (modulesList[i].checked) {
+  				selectedModules.push(modulesList[i].value);
+  			}
+  		}
+
+  		window$1.location = setUrl({
+  			filter: filter === "" ? undefined : filter,
+  			moduleId: selectedModules.length === 0 ? undefined : selectedModules,
+
+  			// Remove module and testId filter
+  			module: undefined,
+  			testId: undefined
+  		});
+  	}
+
+  	function toolbarUrlConfigContainer() {
+  		var urlConfigContainer = document.createElement("span");
+
+  		urlConfigContainer.innerHTML = getUrlConfigHtml();
+  		addClass(urlConfigContainer, "qunit-url-config");
+
+  		addEvents(urlConfigContainer.getElementsByTagName("input"), "change", toolbarChanged);
+  		addEvents(urlConfigContainer.getElementsByTagName("select"), "change", toolbarChanged);
+
+  		return urlConfigContainer;
+  	}
+
+  	function abortTestsButton() {
+  		var button = document.createElement("button");
+  		button.id = "qunit-abort-tests-button";
+  		button.innerHTML = "Abort";
+  		addEvent(button, "click", abortTests);
+  		return button;
+  	}
+
+  	function toolbarLooseFilter() {
+  		var filter = document.createElement("form"),
+  		    label = document.createElement("label"),
+  		    input = document.createElement("input"),
+  		    button = document.createElement("button");
+
+  		addClass(filter, "qunit-filter");
+
+  		label.innerHTML = "Filter: ";
+
+  		input.type = "text";
+  		input.value = config.filter || "";
+  		input.name = "filter";
+  		input.id = "qunit-filter-input";
+
+  		button.innerHTML = "Go";
+
+  		label.appendChild(input);
+
+  		filter.appendChild(label);
+  		filter.appendChild(document.createTextNode(" "));
+  		filter.appendChild(button);
+  		addEvent(filter, "submit", interceptNavigation);
+
+  		return filter;
+  	}
+
+  	function moduleListHtml() {
+  		var i,
+  		    checked,
+  		    html = "";
+
+  		for (i = 0; i < config.modules.length; i++) {
+  			if (config.modules[i].name !== "") {
+  				checked = config.moduleId.indexOf(config.modules[i].moduleId) > -1;
+  				html += "<li><label class='clickable" + (checked ? " checked" : "") + "'><input type='checkbox' " + "value='" + config.modules[i].moduleId + "'" + (checked ? " checked='checked'" : "") + " />" + escapeText(config.modules[i].name) + "</label></li>";
+  			}
+  		}
+
+  		return html;
+  	}
+
+  	function toolbarModuleFilter() {
+  		var allCheckbox,
+  		    commit,
+  		    reset,
+  		    moduleFilter = document.createElement("form"),
+  		    label = document.createElement("label"),
+  		    moduleSearch = document.createElement("input"),
+  		    dropDown = document.createElement("div"),
+  		    actions = document.createElement("span"),
+  		    dropDownList = document.createElement("ul"),
+  		    dirty = false;
+
+  		moduleSearch.id = "qunit-modulefilter-search";
+  		moduleSearch.autocomplete = "off";
+  		addEvent(moduleSearch, "input", searchInput);
+  		addEvent(moduleSearch, "input", searchFocus);
+  		addEvent(moduleSearch, "focus", searchFocus);
+  		addEvent(moduleSearch, "click", searchFocus);
+
+  		label.id = "qunit-modulefilter-search-container";
+  		label.innerHTML = "Module: ";
+  		label.appendChild(moduleSearch);
+
+  		actions.id = "qunit-modulefilter-actions";
+  		actions.innerHTML = "<button style='display:none'>Apply</button>" + "<button type='reset' style='display:none'>Reset</button>" + "<label class='clickable" + (config.moduleId.length ? "" : " checked") + "'><input type='checkbox'" + (config.moduleId.length ? "" : " checked='checked'") + " />All modules</label>";
+  		allCheckbox = actions.lastChild.firstChild;
+  		commit = actions.firstChild;
+  		reset = commit.nextSibling;
+  		addEvent(commit, "click", applyUrlParams);
+
+  		dropDownList.id = "qunit-modulefilter-dropdown-list";
+  		dropDownList.innerHTML = moduleListHtml();
+
+  		dropDown.id = "qunit-modulefilter-dropdown";
+  		dropDown.style.display = "none";
+  		dropDown.appendChild(actions);
+  		dropDown.appendChild(dropDownList);
+  		addEvent(dropDown, "change", selectionChange);
+  		selectionChange();
+
+  		moduleFilter.id = "qunit-modulefilter";
+  		moduleFilter.appendChild(label);
+  		moduleFilter.appendChild(dropDown);
+  		addEvent(moduleFilter, "submit", interceptNavigation);
+  		addEvent(moduleFilter, "reset", function () {
+
+  			// Let the reset happen, then update styles
+  			window$1.setTimeout(selectionChange);
+  		});
+
+  		// Enables show/hide for the dropdown
+  		function searchFocus() {
+  			if (dropDown.style.display !== "none") {
+  				return;
+  			}
+
+  			dropDown.style.display = "block";
+  			addEvent(document, "click", hideHandler);
+  			addEvent(document, "keydown", hideHandler);
+
+  			// Hide on Escape keydown or outside-container click
+  			function hideHandler(e) {
+  				var inContainer = moduleFilter.contains(e.target);
+
+  				if (e.keyCode === 27 || !inContainer) {
+  					if (e.keyCode === 27 && inContainer) {
+  						moduleSearch.focus();
+  					}
+  					dropDown.style.display = "none";
+  					removeEvent(document, "click", hideHandler);
+  					removeEvent(document, "keydown", hideHandler);
+  					moduleSearch.value = "";
+  					searchInput();
+  				}
+  			}
+  		}
+
+  		// Processes module search box input
+  		function searchInput() {
+  			var i,
+  			    item,
+  			    searchText = moduleSearch.value.toLowerCase(),
+  			    listItems = dropDownList.children;
+
+  			for (i = 0; i < listItems.length; i++) {
+  				item = listItems[i];
+  				if (!searchText || item.textContent.toLowerCase().indexOf(searchText) > -1) {
+  					item.style.display = "";
+  				} else {
+  					item.style.display = "none";
+  				}
+  			}
+  		}
+
+  		// Processes selection changes
+  		function selectionChange(evt) {
+  			var i,
+  			    item,
+  			    checkbox = evt && evt.target || allCheckbox,
+  			    modulesList = dropDownList.getElementsByTagName("input"),
+  			    selectedNames = [];
+
+  			toggleClass(checkbox.parentNode, "checked", checkbox.checked);
+
+  			dirty = false;
+  			if (checkbox.checked && checkbox !== allCheckbox) {
+  				allCheckbox.checked = false;
+  				removeClass(allCheckbox.parentNode, "checked");
+  			}
+  			for (i = 0; i < modulesList.length; i++) {
+  				item = modulesList[i];
+  				if (!evt) {
+  					toggleClass(item.parentNode, "checked", item.checked);
+  				} else if (checkbox === allCheckbox && checkbox.checked) {
+  					item.checked = false;
+  					removeClass(item.parentNode, "checked");
+  				}
+  				dirty = dirty || item.checked !== item.defaultChecked;
+  				if (item.checked) {
+  					selectedNames.push(item.parentNode.textContent);
+  				}
+  			}
+
+  			commit.style.display = reset.style.display = dirty ? "" : "none";
+  			moduleSearch.placeholder = selectedNames.join(", ") || allCheckbox.parentNode.textContent;
+  			moduleSearch.title = "Type to filter list. Current selection:\n" + (selectedNames.join("\n") || allCheckbox.parentNode.textContent);
+  		}
+
+  		return moduleFilter;
+  	}
+
+  	function appendToolbar() {
+  		var toolbar = id("qunit-testrunner-toolbar");
+
+  		if (toolbar) {
+  			toolbar.appendChild(toolbarUrlConfigContainer());
+  			toolbar.appendChild(toolbarModuleFilter());
+  			toolbar.appendChild(toolbarLooseFilter());
+  			toolbar.appendChild(document.createElement("div")).className = "clearfix";
+  		}
+  	}
+
+  	function appendHeader() {
+  		var header = id("qunit-header");
+
+  		if (header) {
+  			header.innerHTML = "<a href='" + escapeText(unfilteredUrl) + "'>" + header.innerHTML + "</a> ";
+  		}
+  	}
+
+  	function appendBanner() {
+  		var banner = id("qunit-banner");
+
+  		if (banner) {
+  			banner.className = "";
+  		}
+  	}
+
+  	function appendTestResults() {
+  		var tests = id("qunit-tests"),
+  		    result = id("qunit-testresult"),
+  		    controls;
+
+  		if (result) {
+  			result.parentNode.removeChild(result);
+  		}
+
+  		if (tests) {
+  			tests.innerHTML = "";
+  			result = document.createElement("p");
+  			result.id = "qunit-testresult";
+  			result.className = "result";
+  			tests.parentNode.insertBefore(result, tests);
+  			result.innerHTML = "<div id=\"qunit-testresult-display\">Running...<br />&#160;</div>" + "<div id=\"qunit-testresult-controls\"></div>" + "<div class=\"clearfix\"></div>";
+  			controls = id("qunit-testresult-controls");
+  		}
+
+  		if (controls) {
+  			controls.appendChild(abortTestsButton());
+  		}
+  	}
+
+  	function appendFilteredTest() {
+  		var testId = QUnit.config.testId;
+  		if (!testId || testId.length <= 0) {
+  			return "";
+  		}
+  		return "<div id='qunit-filteredTest'>Rerunning selected tests: " + escapeText(testId.join(", ")) + " <a id='qunit-clearFilter' href='" + escapeText(unfilteredUrl) + "'>Run all tests</a></div>";
+  	}
+
+  	function appendUserAgent() {
+  		var userAgent = id("qunit-userAgent");
+
+  		if (userAgent) {
+  			userAgent.innerHTML = "";
+  			userAgent.appendChild(document.createTextNode("QUnit " + QUnit.version + "; " + navigator.userAgent));
+  		}
+  	}
+
+  	function appendInterface() {
+  		var qunit = id("qunit");
+
+  		if (qunit) {
+  			qunit.innerHTML = "<h1 id='qunit-header'>" + escapeText(document.title) + "</h1>" + "<h2 id='qunit-banner'></h2>" + "<div id='qunit-testrunner-toolbar'></div>" + appendFilteredTest() + "<h2 id='qunit-userAgent'></h2>" + "<ol id='qunit-tests'></ol>";
+  		}
+
+  		appendHeader();
+  		appendBanner();
+  		appendTestResults();
+  		appendUserAgent();
+  		appendToolbar();
+  	}
+
+  	function appendTest(name, testId, moduleName) {
+  		var title,
+  		    rerunTrigger,
+  		    testBlock,
+  		    assertList,
+  		    tests = id("qunit-tests");
+
+  		if (!tests) {
+  			return;
+  		}
+
+  		title = document.createElement("strong");
+  		title.innerHTML = getNameHtml(name, moduleName);
+
+  		rerunTrigger = document.createElement("a");
+  		rerunTrigger.innerHTML = "Rerun";
+  		rerunTrigger.href = setUrl({ testId: testId });
+
+  		testBlock = document.createElement("li");
+  		testBlock.appendChild(title);
+  		testBlock.appendChild(rerunTrigger);
+  		testBlock.id = "qunit-test-output-" + testId;
+
+  		assertList = document.createElement("ol");
+  		assertList.className = "qunit-assert-list";
+
+  		testBlock.appendChild(assertList);
+
+  		tests.appendChild(testBlock);
+  	}
+
+  	// HTML Reporter initialization and load
+  	QUnit.begin(function (details) {
+  		var i, moduleObj;
+
+  		// Sort modules by name for the picker
+  		for (i = 0; i < details.modules.length; i++) {
+  			moduleObj = details.modules[i];
+  			if (moduleObj.name) {
+  				modulesList.push(moduleObj.name);
+  			}
+  		}
+  		modulesList.sort(function (a, b) {
+  			return a.localeCompare(b);
+  		});
+
+  		// Initialize QUnit elements
+  		appendInterface();
+  	});
+
+  	QUnit.done(function (details) {
+  		var banner = id("qunit-banner"),
+  		    tests = id("qunit-tests"),
+  		    abortButton = id("qunit-abort-tests-button"),
+  		    totalTests = stats.passedTests + stats.skippedTests + stats.todoTests + stats.failedTests,
+  		    html = [totalTests, " tests completed in ", details.runtime, " milliseconds, with ", stats.failedTests, " failed, ", stats.skippedTests, " skipped, and ", stats.todoTests, " todo.<br />", "<span class='passed'>", details.passed, "</span> assertions of <span class='total'>", details.total, "</span> passed, <span class='failed'>", details.failed, "</span> failed."].join(""),
+  		    test,
+  		    assertLi,
+  		    assertList;
+
+  		// Update remaing tests to aborted
+  		if (abortButton && abortButton.disabled) {
+  			html = "Tests aborted after " + details.runtime + " milliseconds.";
+
+  			for (var i = 0; i < tests.children.length; i++) {
+  				test = tests.children[i];
+  				if (test.className === "" || test.className === "running") {
+  					test.className = "aborted";
+  					assertList = test.getElementsByTagName("ol")[0];
+  					assertLi = document.createElement("li");
+  					assertLi.className = "fail";
+  					assertLi.innerHTML = "Test aborted.";
+  					assertList.appendChild(assertLi);
+  				}
+  			}
+  		}
+
+  		if (banner && (!abortButton || abortButton.disabled === false)) {
+  			banner.className = stats.failedTests ? "qunit-fail" : "qunit-pass";
+  		}
+
+  		if (abortButton) {
+  			abortButton.parentNode.removeChild(abortButton);
+  		}
+
+  		if (tests) {
+  			id("qunit-testresult-display").innerHTML = html;
+  		}
+
+  		if (config.altertitle && document.title) {
+
+  			// Show ✖ for good, ✔ for bad suite result in title
+  			// use escape sequences in case file gets loaded with non-utf-8
+  			// charset
+  			document.title = [stats.failedTests ? "\u2716" : "\u2714", document.title.replace(/^[\u2714\u2716] /i, "")].join(" ");
+  		}
+
+  		// Scroll back to top to show results
+  		if (config.scrolltop && window$1.scrollTo) {
+  			window$1.scrollTo(0, 0);
+  		}
+  	});
+
+  	function getNameHtml(name, module) {
+  		var nameHtml = "";
+
+  		if (module) {
+  			nameHtml = "<span class='module-name'>" + escapeText(module) + "</span>: ";
+  		}
+
+  		nameHtml += "<span class='test-name'>" + escapeText(name) + "</span>";
+
+  		return nameHtml;
+  	}
+
+  	QUnit.testStart(function (details) {
+  		var running, bad;
+
+  		appendTest(details.name, details.testId, details.module);
+
+  		running = id("qunit-testresult-display");
+
+  		if (running) {
+  			addClass(running, "running");
+
+  			bad = QUnit.config.reorder && details.previousFailure;
+
+  			running.innerHTML = [bad ? "Rerunning previously failed test: <br />" : "Running: <br />", getNameHtml(details.name, details.module)].join("");
+  		}
+  	});
+
+  	function stripHtml(string) {
+
+  		// Strip tags, html entity and whitespaces
+  		return string.replace(/<\/?[^>]+(>|$)/g, "").replace(/&quot;/g, "").replace(/\s+/g, "");
+  	}
+
+  	QUnit.log(function (details) {
+  		var assertList,
+  		    assertLi,
+  		    message,
+  		    expected,
+  		    actual,
+  		    diff,
+  		    showDiff = false,
+  		    testItem = id("qunit-test-output-" + details.testId);
+
+  		if (!testItem) {
+  			return;
+  		}
+
+  		message = escapeText(details.message) || (details.result ? "okay" : "failed");
+  		message = "<span class='test-message'>" + message + "</span>";
+  		message += "<span class='runtime'>@ " + details.runtime + " ms</span>";
+
+  		// The pushFailure doesn't provide details.expected
+  		// when it calls, it's implicit to also not show expected and diff stuff
+  		// Also, we need to check details.expected existence, as it can exist and be undefined
+  		if (!details.result && hasOwn.call(details, "expected")) {
+  			if (details.negative) {
+  				expected = "NOT " + QUnit.dump.parse(details.expected);
+  			} else {
+  				expected = QUnit.dump.parse(details.expected);
+  			}
+
+  			actual = QUnit.dump.parse(details.actual);
+  			message += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + escapeText(expected) + "</pre></td></tr>";
+
+  			if (actual !== expected) {
+
+  				message += "<tr class='test-actual'><th>Result: </th><td><pre>" + escapeText(actual) + "</pre></td></tr>";
+
+  				if (typeof details.actual === "number" && typeof details.expected === "number") {
+  					if (!isNaN(details.actual) && !isNaN(details.expected)) {
+  						showDiff = true;
+  						diff = details.actual - details.expected;
+  						diff = (diff > 0 ? "+" : "") + diff;
+  					}
+  				} else if (typeof details.actual !== "boolean" && typeof details.expected !== "boolean") {
+  					diff = QUnit.diff(expected, actual);
+
+  					// don't show diff if there is zero overlap
+  					showDiff = stripHtml(diff).length !== stripHtml(expected).length + stripHtml(actual).length;
+  				}
+
+  				if (showDiff) {
+  					message += "<tr class='test-diff'><th>Diff: </th><td><pre>" + diff + "</pre></td></tr>";
+  				}
+  			} else if (expected.indexOf("[object Array]") !== -1 || expected.indexOf("[object Object]") !== -1) {
+  				message += "<tr class='test-message'><th>Message: </th><td>" + "Diff suppressed as the depth of object is more than current max depth (" + QUnit.config.maxDepth + ").<p>Hint: Use <code>QUnit.dump.maxDepth</code> to " + " run with a higher max depth or <a href='" + escapeText(setUrl({ maxDepth: -1 })) + "'>" + "Rerun</a> without max depth.</p></td></tr>";
+  			} else {
+  				message += "<tr class='test-message'><th>Message: </th><td>" + "Diff suppressed as the expected and actual results have an equivalent" + " serialization</td></tr>";
+  			}
+
+  			if (details.source) {
+  				message += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText(details.source) + "</pre></td></tr>";
+  			}
+
+  			message += "</table>";
+
+  			// This occurs when pushFailure is set and we have an extracted stack trace
+  		} else if (!details.result && details.source) {
+  			message += "<table>" + "<tr class='test-source'><th>Source: </th><td><pre>" + escapeText(details.source) + "</pre></td></tr>" + "</table>";
+  		}
+
+  		assertList = testItem.getElementsByTagName("ol")[0];
+
+  		assertLi = document.createElement("li");
+  		assertLi.className = details.result ? "pass" : "fail";
+  		assertLi.innerHTML = message;
+  		assertList.appendChild(assertLi);
+  	});
+
+  	QUnit.testDone(function (details) {
+  		var testTitle,
+  		    time,
+  		    testItem,
+  		    assertList,
+  		    status,
+  		    good,
+  		    bad,
+  		    testCounts,
+  		    skipped,
+  		    sourceName,
+  		    tests = id("qunit-tests");
+
+  		if (!tests) {
+  			return;
+  		}
+
+  		testItem = id("qunit-test-output-" + details.testId);
+
+  		removeClass(testItem, "running");
+
+  		if (details.failed > 0) {
+  			status = "failed";
+  		} else if (details.todo) {
+  			status = "todo";
+  		} else {
+  			status = details.skipped ? "skipped" : "passed";
+  		}
+
+  		assertList = testItem.getElementsByTagName("ol")[0];
+
+  		good = details.passed;
+  		bad = details.failed;
+
+  		// This test passed if it has no unexpected failed assertions
+  		var testPassed = details.failed > 0 ? details.todo : !details.todo;
+
+  		if (testPassed) {
+
+  			// Collapse the passing tests
+  			addClass(assertList, "qunit-collapsed");
+  		} else if (config.collapse) {
+  			if (!collapseNext) {
+
+  				// Skip collapsing the first failing test
+  				collapseNext = true;
+  			} else {
+
+  				// Collapse remaining tests
+  				addClass(assertList, "qunit-collapsed");
+  			}
+  		}
+
+  		// The testItem.firstChild is the test name
+  		testTitle = testItem.firstChild;
+
+  		testCounts = bad ? "<b class='failed'>" + bad + "</b>, " + "<b class='passed'>" + good + "</b>, " : "";
+
+  		testTitle.innerHTML += " <b class='counts'>(" + testCounts + details.assertions.length + ")</b>";
+
+  		if (details.skipped) {
+  			stats.skippedTests++;
+
+  			testItem.className = "skipped";
+  			skipped = document.createElement("em");
+  			skipped.className = "qunit-skipped-label";
+  			skipped.innerHTML = "skipped";
+  			testItem.insertBefore(skipped, testTitle);
+  		} else {
+  			addEvent(testTitle, "click", function () {
+  				toggleClass(assertList, "qunit-collapsed");
+  			});
+
+  			testItem.className = testPassed ? "pass" : "fail";
+
+  			if (details.todo) {
+  				var todoLabel = document.createElement("em");
+  				todoLabel.className = "qunit-todo-label";
+  				todoLabel.innerHTML = "todo";
+  				testItem.className += " todo";
+  				testItem.insertBefore(todoLabel, testTitle);
+  			}
+
+  			time = document.createElement("span");
+  			time.className = "runtime";
+  			time.innerHTML = details.runtime + " ms";
+  			testItem.insertBefore(time, assertList);
+
+  			if (!testPassed) {
+  				stats.failedTests++;
+  			} else if (details.todo) {
+  				stats.todoTests++;
+  			} else {
+  				stats.passedTests++;
+  			}
+  		}
+
+  		// Show the source of the test when showing assertions
+  		if (details.source) {
+  			sourceName = document.createElement("p");
+  			sourceName.innerHTML = "<strong>Source: </strong>" + details.source;
+  			addClass(sourceName, "qunit-source");
+  			if (testPassed) {
+  				addClass(sourceName, "qunit-collapsed");
+  			}
+  			addEvent(testTitle, "click", function () {
+  				toggleClass(sourceName, "qunit-collapsed");
+  			});
+  			testItem.appendChild(sourceName);
+  		}
+
+  		if (config.hidepassed && status === "passed") {
+
+  			// use removeChild instead of remove because of support
+  			hiddenTests.push(testItem);
+
+  			tests.removeChild(testItem);
+  		}
+  	});
+
+  	// Avoid readyState issue with phantomjs
+  	// Ref: #818
+  	var notPhantom = function (p) {
+  		return !(p && p.version && p.version.major > 0);
+  	}(window$1.phantom);
+
+  	if (notPhantom && document.readyState === "complete") {
+  		QUnit.load();
+  	} else {
+  		addEvent(window$1, "load", QUnit.load);
+  	}
+
+  	// Wrap window.onerror. We will call the original window.onerror to see if
+  	// the existing handler fully handles the error; if not, we will call the
+  	// QUnit.onError function.
+  	var originalWindowOnError = window$1.onerror;
+
+  	// Cover uncaught exceptions
+  	// Returning true will suppress the default browser handler,
+  	// returning false will let it run.
+  	window$1.onerror = function (message, fileName, lineNumber, columnNumber, errorObj) {
+  		var ret = false;
+  		if (originalWindowOnError) {
+  			for (var _len = arguments.length, args = Array(_len > 5 ? _len - 5 : 0), _key = 5; _key < _len; _key++) {
+  				args[_key - 5] = arguments[_key];
+  			}
+
+  			ret = originalWindowOnError.call.apply(originalWindowOnError, [this, message, fileName, lineNumber, columnNumber, errorObj].concat(args));
+  		}
+
+  		// Treat return value as window.onerror itself does,
+  		// Only do our handling if not suppressed.
+  		if (ret !== true) {
+  			var error = {
+  				message: message,
+  				fileName: fileName,
+  				lineNumber: lineNumber
+  			};
+
+  			// According to
+  			// https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror,
+  			// most modern browsers support an errorObj argument; use that to
+  			// get a full stack trace if it's available.
+  			if (errorObj && errorObj.stack) {
+  				error.stacktrace = extractStacktrace(errorObj, 0);
+  			}
+
+  			ret = QUnit.onError(error);
+  		}
+
+  		return ret;
+  	};
+
+  	// Listen for unhandled rejections, and call QUnit.onUnhandledRejection
+  	window$1.addEventListener("unhandledrejection", function (event) {
+  		QUnit.onUnhandledRejection(event.reason);
+  	});
+  })();
+
+  /*
+   * This file is a modified version of google-diff-match-patch's JavaScript implementation
+   * (https://code.google.com/p/google-diff-match-patch/source/browse/trunk/javascript/diff_match_patch_uncompressed.js),
+   * modifications are licensed as more fully set forth in LICENSE.txt.
+   *
+   * The original source of google-diff-match-patch is attributable and licensed as follows:
+   *
+   * Copyright 2006 Google Inc.
+   * https://code.google.com/p/google-diff-match-patch/
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   * https://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   *
+   * More Info:
+   *  https://code.google.com/p/google-diff-match-patch/
+   *
+   * Usage: QUnit.diff(expected, actual)
+   *
+   */
+  QUnit.diff = function () {
+  	function DiffMatchPatch() {}
+
+  	//  DIFF FUNCTIONS
+
+  	/**
+    * The data structure representing a diff is an array of tuples:
+    * [[DIFF_DELETE, 'Hello'], [DIFF_INSERT, 'Goodbye'], [DIFF_EQUAL, ' world.']]
+    * which means: delete 'Hello', add 'Goodbye' and keep ' world.'
+    */
+  	var DIFF_DELETE = -1,
+  	    DIFF_INSERT = 1,
+  	    DIFF_EQUAL = 0;
+
+  	/**
+    * Find the differences between two texts.  Simplifies the problem by stripping
+    * any common prefix or suffix off the texts before diffing.
+    * @param {string} text1 Old string to be diffed.
+    * @param {string} text2 New string to be diffed.
+    * @param {boolean=} optChecklines Optional speedup flag. If present and false,
+    *     then don't run a line-level diff first to identify the changed areas.
+    *     Defaults to true, which does a faster, slightly less optimal diff.
+    * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
+    */
+  	DiffMatchPatch.prototype.DiffMain = function (text1, text2, optChecklines) {
+  		var deadline, checklines, commonlength, commonprefix, commonsuffix, diffs;
+
+  		// The diff must be complete in up to 1 second.
+  		deadline = new Date().getTime() + 1000;
+
+  		// Check for null inputs.
+  		if (text1 === null || text2 === null) {
+  			throw new Error("Null input. (DiffMain)");
+  		}
+
+  		// Check for equality (speedup).
+  		if (text1 === text2) {
+  			if (text1) {
+  				return [[DIFF_EQUAL, text1]];
+  			}
+  			return [];
+  		}
+
+  		if (typeof optChecklines === "undefined") {
+  			optChecklines = true;
+  		}
+
+  		checklines = optChecklines;
+
+  		// Trim off common prefix (speedup).
+  		commonlength = this.diffCommonPrefix(text1, text2);
+  		commonprefix = text1.substring(0, commonlength);
+  		text1 = text1.substring(commonlength);
+  		text2 = text2.substring(commonlength);
+
+  		// Trim off common suffix (speedup).
+  		commonlength = this.diffCommonSuffix(text1, text2);
+  		commonsuffix = text1.substring(text1.length - commonlength);
+  		text1 = text1.substring(0, text1.length - commonlength);
+  		text2 = text2.substring(0, text2.length - commonlength);
+
+  		// Compute the diff on the middle block.
+  		diffs = this.diffCompute(text1, text2, checklines, deadline);
+
+  		// Restore the prefix and suffix.
+  		if (commonprefix) {
+  			diffs.unshift([DIFF_EQUAL, commonprefix]);
+  		}
+  		if (commonsuffix) {
+  			diffs.push([DIFF_EQUAL, commonsuffix]);
+  		}
+  		this.diffCleanupMerge(diffs);
+  		return diffs;
+  	};
+
+  	/**
+    * Reduce the number of edits by eliminating operationally trivial equalities.
+    * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
+    */
+  	DiffMatchPatch.prototype.diffCleanupEfficiency = function (diffs) {
+  		var changes, equalities, equalitiesLength, lastequality, pointer, preIns, preDel, postIns, postDel;
+  		changes = false;
+  		equalities = []; // Stack of indices where equalities are found.
+  		equalitiesLength = 0; // Keeping our own length var is faster in JS.
+  		/** @type {?string} */
+  		lastequality = null;
+
+  		// Always equal to diffs[equalities[equalitiesLength - 1]][1]
+  		pointer = 0; // Index of current position.
+
+  		// Is there an insertion operation before the last equality.
+  		preIns = false;
+
+  		// Is there a deletion operation before the last equality.
+  		preDel = false;
+
+  		// Is there an insertion operation after the last equality.
+  		postIns = false;
+
+  		// Is there a deletion operation after the last equality.
+  		postDel = false;
+  		while (pointer < diffs.length) {
+
+  			// Equality found.
+  			if (diffs[pointer][0] === DIFF_EQUAL) {
+  				if (diffs[pointer][1].length < 4 && (postIns || postDel)) {
+
+  					// Candidate found.
+  					equalities[equalitiesLength++] = pointer;
+  					preIns = postIns;
+  					preDel = postDel;
+  					lastequality = diffs[pointer][1];
+  				} else {
+
+  					// Not a candidate, and can never become one.
+  					equalitiesLength = 0;
+  					lastequality = null;
+  				}
+  				postIns = postDel = false;
+
+  				// An insertion or deletion.
+  			} else {
+
+  				if (diffs[pointer][0] === DIFF_DELETE) {
+  					postDel = true;
+  				} else {
+  					postIns = true;
+  				}
+
+  				/*
+       * Five types to be split:
+       * <ins>A</ins><del>B</del>XY<ins>C</ins><del>D</del>
+       * <ins>A</ins>X<ins>C</ins><del>D</del>
+       * <ins>A</ins><del>B</del>X<ins>C</ins>
+       * <ins>A</del>X<ins>C</ins><del>D</del>
+       * <ins>A</ins><del>B</del>X<del>C</del>
+       */
+  				if (lastequality && (preIns && preDel && postIns && postDel || lastequality.length < 2 && preIns + preDel + postIns + postDel === 3)) {
+
+  					// Duplicate record.
+  					diffs.splice(equalities[equalitiesLength - 1], 0, [DIFF_DELETE, lastequality]);
+
+  					// Change second copy to insert.
+  					diffs[equalities[equalitiesLength - 1] + 1][0] = DIFF_INSERT;
+  					equalitiesLength--; // Throw away the equality we just deleted;
+  					lastequality = null;
+  					if (preIns && preDel) {
+
+  						// No changes made which could affect previous entry, keep going.
+  						postIns = postDel = true;
+  						equalitiesLength = 0;
+  					} else {
+  						equalitiesLength--; // Throw away the previous equality.
+  						pointer = equalitiesLength > 0 ? equalities[equalitiesLength - 1] : -1;
+  						postIns = postDel = false;
+  					}
+  					changes = true;
+  				}
+  			}
+  			pointer++;
+  		}
+
+  		if (changes) {
+  			this.diffCleanupMerge(diffs);
+  		}
+  	};
+
+  	/**
+    * Convert a diff array into a pretty HTML report.
+    * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
+    * @param {integer} string to be beautified.
+    * @return {string} HTML representation.
+    */
+  	DiffMatchPatch.prototype.diffPrettyHtml = function (diffs) {
+  		var op,
+  		    data,
+  		    x,
+  		    html = [];
+  		for (x = 0; x < diffs.length; x++) {
+  			op = diffs[x][0]; // Operation (insert, delete, equal)
+  			data = diffs[x][1]; // Text of change.
+  			switch (op) {
+  				case DIFF_INSERT:
+  					html[x] = "<ins>" + escapeText(data) + "</ins>";
+  					break;
+  				case DIFF_DELETE:
+  					html[x] = "<del>" + escapeText(data) + "</del>";
+  					break;
+  				case DIFF_EQUAL:
+  					html[x] = "<span>" + escapeText(data) + "</span>";
+  					break;
+  			}
+  		}
+  		return html.join("");
+  	};
+
+  	/**
+    * Determine the common prefix of two strings.
+    * @param {string} text1 First string.
+    * @param {string} text2 Second string.
+    * @return {number} The number of characters common to the start of each
+    *     string.
+    */
+  	DiffMatchPatch.prototype.diffCommonPrefix = function (text1, text2) {
+  		var pointermid, pointermax, pointermin, pointerstart;
+
+  		// Quick check for common null cases.
+  		if (!text1 || !text2 || text1.charAt(0) !== text2.charAt(0)) {
+  			return 0;
+  		}
+
+  		// Binary search.
+  		// Performance analysis: https://neil.fraser.name/news/2007/10/09/
+  		pointermin = 0;
+  		pointermax = Math.min(text1.length, text2.length);
+  		pointermid = pointermax;
+  		pointerstart = 0;
+  		while (pointermin < pointermid) {
+  			if (text1.substring(pointerstart, pointermid) === text2.substring(pointerstart, pointermid)) {
+  				pointermin = pointermid;
+  				pointerstart = pointermin;
+  			} else {
+  				pointermax = pointermid;
+  			}
+  			pointermid = Math.floor((pointermax - pointermin) / 2 + pointermin);
+  		}
+  		return pointermid;
+  	};
+
+  	/**
+    * Determine the common suffix of two strings.
+    * @param {string} text1 First string.
+    * @param {string} text2 Second string.
+    * @return {number} The number of characters common to the end of each string.
+    */
+  	DiffMatchPatch.prototype.diffCommonSuffix = function (text1, text2) {
+  		var pointermid, pointermax, pointermin, pointerend;
+
+  		// Quick check for common null cases.
+  		if (!text1 || !text2 || text1.charAt(text1.length - 1) !== text2.charAt(text2.length - 1)) {
+  			return 0;
+  		}
+
+  		// Binary search.
+  		// Performance analysis: https://neil.fraser.name/news/2007/10/09/
+  		pointermin = 0;
+  		pointermax = Math.min(text1.length, text2.length);
+  		pointermid = pointermax;
+  		pointerend = 0;
+  		while (pointermin < pointermid) {
+  			if (text1.substring(text1.length - pointermid, text1.length - pointerend) === text2.substring(text2.length - pointermid, text2.length - pointerend)) {
+  				pointermin = pointermid;
+  				pointerend = pointermin;
+  			} else {
+  				pointermax = pointermid;
+  			}
+  			pointermid = Math.floor((pointermax - pointermin) / 2 + pointermin);
+  		}
+  		return pointermid;
+  	};
+
+  	/**
+    * Find the differences between two texts.  Assumes that the texts do not
+    * have any common prefix or suffix.
+    * @param {string} text1 Old string to be diffed.
+    * @param {string} text2 New string to be diffed.
+    * @param {boolean} checklines Speedup flag.  If false, then don't run a
+    *     line-level diff first to identify the changed areas.
+    *     If true, then run a faster, slightly less optimal diff.
+    * @param {number} deadline Time when the diff should be complete by.
+    * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffCompute = function (text1, text2, checklines, deadline) {
+  		var diffs, longtext, shorttext, i, hm, text1A, text2A, text1B, text2B, midCommon, diffsA, diffsB;
+
+  		if (!text1) {
+
+  			// Just add some text (speedup).
+  			return [[DIFF_INSERT, text2]];
+  		}
+
+  		if (!text2) {
+
+  			// Just delete some text (speedup).
+  			return [[DIFF_DELETE, text1]];
+  		}
+
+  		longtext = text1.length > text2.length ? text1 : text2;
+  		shorttext = text1.length > text2.length ? text2 : text1;
+  		i = longtext.indexOf(shorttext);
+  		if (i !== -1) {
+
+  			// Shorter text is inside the longer text (speedup).
+  			diffs = [[DIFF_INSERT, longtext.substring(0, i)], [DIFF_EQUAL, shorttext], [DIFF_INSERT, longtext.substring(i + shorttext.length)]];
+
+  			// Swap insertions for deletions if diff is reversed.
+  			if (text1.length > text2.length) {
+  				diffs[0][0] = diffs[2][0] = DIFF_DELETE;
+  			}
+  			return diffs;
+  		}
+
+  		if (shorttext.length === 1) {
+
+  			// Single character string.
+  			// After the previous speedup, the character can't be an equality.
+  			return [[DIFF_DELETE, text1], [DIFF_INSERT, text2]];
+  		}
+
+  		// Check to see if the problem can be split in two.
+  		hm = this.diffHalfMatch(text1, text2);
+  		if (hm) {
+
+  			// A half-match was found, sort out the return data.
+  			text1A = hm[0];
+  			text1B = hm[1];
+  			text2A = hm[2];
+  			text2B = hm[3];
+  			midCommon = hm[4];
+
+  			// Send both pairs off for separate processing.
+  			diffsA = this.DiffMain(text1A, text2A, checklines, deadline);
+  			diffsB = this.DiffMain(text1B, text2B, checklines, deadline);
+
+  			// Merge the results.
+  			return diffsA.concat([[DIFF_EQUAL, midCommon]], diffsB);
+  		}
+
+  		if (checklines && text1.length > 100 && text2.length > 100) {
+  			return this.diffLineMode(text1, text2, deadline);
+  		}
+
+  		return this.diffBisect(text1, text2, deadline);
+  	};
+
+  	/**
+    * Do the two texts share a substring which is at least half the length of the
+    * longer text?
+    * This speedup can produce non-minimal diffs.
+    * @param {string} text1 First string.
+    * @param {string} text2 Second string.
+    * @return {Array.<string>} Five element Array, containing the prefix of
+    *     text1, the suffix of text1, the prefix of text2, the suffix of
+    *     text2 and the common middle.  Or null if there was no match.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffHalfMatch = function (text1, text2) {
+  		var longtext, shorttext, dmp, text1A, text2B, text2A, text1B, midCommon, hm1, hm2, hm;
+
+  		longtext = text1.length > text2.length ? text1 : text2;
+  		shorttext = text1.length > text2.length ? text2 : text1;
+  		if (longtext.length < 4 || shorttext.length * 2 < longtext.length) {
+  			return null; // Pointless.
+  		}
+  		dmp = this; // 'this' becomes 'window' in a closure.
+
+  		/**
+     * Does a substring of shorttext exist within longtext such that the substring
+     * is at least half the length of longtext?
+     * Closure, but does not reference any external variables.
+     * @param {string} longtext Longer string.
+     * @param {string} shorttext Shorter string.
+     * @param {number} i Start index of quarter length substring within longtext.
+     * @return {Array.<string>} Five element Array, containing the prefix of
+     *     longtext, the suffix of longtext, the prefix of shorttext, the suffix
+     *     of shorttext and the common middle.  Or null if there was no match.
+     * @private
+     */
+  		function diffHalfMatchI(longtext, shorttext, i) {
+  			var seed, j, bestCommon, prefixLength, suffixLength, bestLongtextA, bestLongtextB, bestShorttextA, bestShorttextB;
+
+  			// Start with a 1/4 length substring at position i as a seed.
+  			seed = longtext.substring(i, i + Math.floor(longtext.length / 4));
+  			j = -1;
+  			bestCommon = "";
+  			while ((j = shorttext.indexOf(seed, j + 1)) !== -1) {
+  				prefixLength = dmp.diffCommonPrefix(longtext.substring(i), shorttext.substring(j));
+  				suffixLength = dmp.diffCommonSuffix(longtext.substring(0, i), shorttext.substring(0, j));
+  				if (bestCommon.length < suffixLength + prefixLength) {
+  					bestCommon = shorttext.substring(j - suffixLength, j) + shorttext.substring(j, j + prefixLength);
+  					bestLongtextA = longtext.substring(0, i - suffixLength);
+  					bestLongtextB = longtext.substring(i + prefixLength);
+  					bestShorttextA = shorttext.substring(0, j - suffixLength);
+  					bestShorttextB = shorttext.substring(j + prefixLength);
+  				}
+  			}
+  			if (bestCommon.length * 2 >= longtext.length) {
+  				return [bestLongtextA, bestLongtextB, bestShorttextA, bestShorttextB, bestCommon];
+  			} else {
+  				return null;
+  			}
+  		}
+
+  		// First check if the second quarter is the seed for a half-match.
+  		hm1 = diffHalfMatchI(longtext, shorttext, Math.ceil(longtext.length / 4));
+
+  		// Check again based on the third quarter.
+  		hm2 = diffHalfMatchI(longtext, shorttext, Math.ceil(longtext.length / 2));
+  		if (!hm1 && !hm2) {
+  			return null;
+  		} else if (!hm2) {
+  			hm = hm1;
+  		} else if (!hm1) {
+  			hm = hm2;
+  		} else {
+
+  			// Both matched.  Select the longest.
+  			hm = hm1[4].length > hm2[4].length ? hm1 : hm2;
+  		}
+
+  		// A half-match was found, sort out the return data.
+  		if (text1.length > text2.length) {
+  			text1A = hm[0];
+  			text1B = hm[1];
+  			text2A = hm[2];
+  			text2B = hm[3];
+  		} else {
+  			text2A = hm[0];
+  			text2B = hm[1];
+  			text1A = hm[2];
+  			text1B = hm[3];
+  		}
+  		midCommon = hm[4];
+  		return [text1A, text1B, text2A, text2B, midCommon];
+  	};
+
+  	/**
+    * Do a quick line-level diff on both strings, then rediff the parts for
+    * greater accuracy.
+    * This speedup can produce non-minimal diffs.
+    * @param {string} text1 Old string to be diffed.
+    * @param {string} text2 New string to be diffed.
+    * @param {number} deadline Time when the diff should be complete by.
+    * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffLineMode = function (text1, text2, deadline) {
+  		var a, diffs, linearray, pointer, countInsert, countDelete, textInsert, textDelete, j;
+
+  		// Scan the text on a line-by-line basis first.
+  		a = this.diffLinesToChars(text1, text2);
+  		text1 = a.chars1;
+  		text2 = a.chars2;
+  		linearray = a.lineArray;
+
+  		diffs = this.DiffMain(text1, text2, false, deadline);
+
+  		// Convert the diff back to original text.
+  		this.diffCharsToLines(diffs, linearray);
+
+  		// Eliminate freak matches (e.g. blank lines)
+  		this.diffCleanupSemantic(diffs);
+
+  		// Rediff any replacement blocks, this time character-by-character.
+  		// Add a dummy entry at the end.
+  		diffs.push([DIFF_EQUAL, ""]);
+  		pointer = 0;
+  		countDelete = 0;
+  		countInsert = 0;
+  		textDelete = "";
+  		textInsert = "";
+  		while (pointer < diffs.length) {
+  			switch (diffs[pointer][0]) {
+  				case DIFF_INSERT:
+  					countInsert++;
+  					textInsert += diffs[pointer][1];
+  					break;
+  				case DIFF_DELETE:
+  					countDelete++;
+  					textDelete += diffs[pointer][1];
+  					break;
+  				case DIFF_EQUAL:
+
+  					// Upon reaching an equality, check for prior redundancies.
+  					if (countDelete >= 1 && countInsert >= 1) {
+
+  						// Delete the offending records and add the merged ones.
+  						diffs.splice(pointer - countDelete - countInsert, countDelete + countInsert);
+  						pointer = pointer - countDelete - countInsert;
+  						a = this.DiffMain(textDelete, textInsert, false, deadline);
+  						for (j = a.length - 1; j >= 0; j--) {
+  							diffs.splice(pointer, 0, a[j]);
+  						}
+  						pointer = pointer + a.length;
+  					}
+  					countInsert = 0;
+  					countDelete = 0;
+  					textDelete = "";
+  					textInsert = "";
+  					break;
+  			}
+  			pointer++;
+  		}
+  		diffs.pop(); // Remove the dummy entry at the end.
+
+  		return diffs;
+  	};
+
+  	/**
+    * Find the 'middle snake' of a diff, split the problem in two
+    * and return the recursively constructed diff.
+    * See Myers 1986 paper: An O(ND) Difference Algorithm and Its Variations.
+    * @param {string} text1 Old string to be diffed.
+    * @param {string} text2 New string to be diffed.
+    * @param {number} deadline Time at which to bail if not yet complete.
+    * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffBisect = function (text1, text2, deadline) {
+  		var text1Length, text2Length, maxD, vOffset, vLength, v1, v2, x, delta, front, k1start, k1end, k2start, k2end, k2Offset, k1Offset, x1, x2, y1, y2, d, k1, k2;
+
+  		// Cache the text lengths to prevent multiple calls.
+  		text1Length = text1.length;
+  		text2Length = text2.length;
+  		maxD = Math.ceil((text1Length + text2Length) / 2);
+  		vOffset = maxD;
+  		vLength = 2 * maxD;
+  		v1 = new Array(vLength);
+  		v2 = new Array(vLength);
+
+  		// Setting all elements to -1 is faster in Chrome & Firefox than mixing
+  		// integers and undefined.
+  		for (x = 0; x < vLength; x++) {
+  			v1[x] = -1;
+  			v2[x] = -1;
+  		}
+  		v1[vOffset + 1] = 0;
+  		v2[vOffset + 1] = 0;
+  		delta = text1Length - text2Length;
+
+  		// If the total number of characters is odd, then the front path will collide
+  		// with the reverse path.
+  		front = delta % 2 !== 0;
+
+  		// Offsets for start and end of k loop.
+  		// Prevents mapping of space beyond the grid.
+  		k1start = 0;
+  		k1end = 0;
+  		k2start = 0;
+  		k2end = 0;
+  		for (d = 0; d < maxD; d++) {
+
+  			// Bail out if deadline is reached.
+  			if (new Date().getTime() > deadline) {
+  				break;
+  			}
+
+  			// Walk the front path one step.
+  			for (k1 = -d + k1start; k1 <= d - k1end; k1 += 2) {
+  				k1Offset = vOffset + k1;
+  				if (k1 === -d || k1 !== d && v1[k1Offset - 1] < v1[k1Offset + 1]) {
+  					x1 = v1[k1Offset + 1];
+  				} else {
+  					x1 = v1[k1Offset - 1] + 1;
+  				}
+  				y1 = x1 - k1;
+  				while (x1 < text1Length && y1 < text2Length && text1.charAt(x1) === text2.charAt(y1)) {
+  					x1++;
+  					y1++;
+  				}
+  				v1[k1Offset] = x1;
+  				if (x1 > text1Length) {
+
+  					// Ran off the right of the graph.
+  					k1end += 2;
+  				} else if (y1 > text2Length) {
+
+  					// Ran off the bottom of the graph.
+  					k1start += 2;
+  				} else if (front) {
+  					k2Offset = vOffset + delta - k1;
+  					if (k2Offset >= 0 && k2Offset < vLength && v2[k2Offset] !== -1) {
+
+  						// Mirror x2 onto top-left coordinate system.
+  						x2 = text1Length - v2[k2Offset];
+  						if (x1 >= x2) {
+
+  							// Overlap detected.
+  							return this.diffBisectSplit(text1, text2, x1, y1, deadline);
+  						}
+  					}
+  				}
+  			}
+
+  			// Walk the reverse path one step.
+  			for (k2 = -d + k2start; k2 <= d - k2end; k2 += 2) {
+  				k2Offset = vOffset + k2;
+  				if (k2 === -d || k2 !== d && v2[k2Offset - 1] < v2[k2Offset + 1]) {
+  					x2 = v2[k2Offset + 1];
+  				} else {
+  					x2 = v2[k2Offset - 1] + 1;
+  				}
+  				y2 = x2 - k2;
+  				while (x2 < text1Length && y2 < text2Length && text1.charAt(text1Length - x2 - 1) === text2.charAt(text2Length - y2 - 1)) {
+  					x2++;
+  					y2++;
+  				}
+  				v2[k2Offset] = x2;
+  				if (x2 > text1Length) {
+
+  					// Ran off the left of the graph.
+  					k2end += 2;
+  				} else if (y2 > text2Length) {
+
+  					// Ran off the top of the graph.
+  					k2start += 2;
+  				} else if (!front) {
+  					k1Offset = vOffset + delta - k2;
+  					if (k1Offset >= 0 && k1Offset < vLength && v1[k1Offset] !== -1) {
+  						x1 = v1[k1Offset];
+  						y1 = vOffset + x1 - k1Offset;
+
+  						// Mirror x2 onto top-left coordinate system.
+  						x2 = text1Length - x2;
+  						if (x1 >= x2) {
+
+  							// Overlap detected.
+  							return this.diffBisectSplit(text1, text2, x1, y1, deadline);
+  						}
+  					}
+  				}
+  			}
+  		}
+
+  		// Diff took too long and hit the deadline or
+  		// number of diffs equals number of characters, no commonality at all.
+  		return [[DIFF_DELETE, text1], [DIFF_INSERT, text2]];
+  	};
+
+  	/**
+    * Given the location of the 'middle snake', split the diff in two parts
+    * and recurse.
+    * @param {string} text1 Old string to be diffed.
+    * @param {string} text2 New string to be diffed.
+    * @param {number} x Index of split point in text1.
+    * @param {number} y Index of split point in text2.
+    * @param {number} deadline Time at which to bail if not yet complete.
+    * @return {!Array.<!DiffMatchPatch.Diff>} Array of diff tuples.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffBisectSplit = function (text1, text2, x, y, deadline) {
+  		var text1a, text1b, text2a, text2b, diffs, diffsb;
+  		text1a = text1.substring(0, x);
+  		text2a = text2.substring(0, y);
+  		text1b = text1.substring(x);
+  		text2b = text2.substring(y);
+
+  		// Compute both diffs serially.
+  		diffs = this.DiffMain(text1a, text2a, false, deadline);
+  		diffsb = this.DiffMain(text1b, text2b, false, deadline);
+
+  		return diffs.concat(diffsb);
+  	};
+
+  	/**
+    * Reduce the number of edits by eliminating semantically trivial equalities.
+    * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
+    */
+  	DiffMatchPatch.prototype.diffCleanupSemantic = function (diffs) {
+  		var changes, equalities, equalitiesLength, lastequality, pointer, lengthInsertions2, lengthDeletions2, lengthInsertions1, lengthDeletions1, deletion, insertion, overlapLength1, overlapLength2;
+  		changes = false;
+  		equalities = []; // Stack of indices where equalities are found.
+  		equalitiesLength = 0; // Keeping our own length var is faster in JS.
+  		/** @type {?string} */
+  		lastequality = null;
+
+  		// Always equal to diffs[equalities[equalitiesLength - 1]][1]
+  		pointer = 0; // Index of current position.
+
+  		// Number of characters that changed prior to the equality.
+  		lengthInsertions1 = 0;
+  		lengthDeletions1 = 0;
+
+  		// Number of characters that changed after the equality.
+  		lengthInsertions2 = 0;
+  		lengthDeletions2 = 0;
+  		while (pointer < diffs.length) {
+  			if (diffs[pointer][0] === DIFF_EQUAL) {
+  				// Equality found.
+  				equalities[equalitiesLength++] = pointer;
+  				lengthInsertions1 = lengthInsertions2;
+  				lengthDeletions1 = lengthDeletions2;
+  				lengthInsertions2 = 0;
+  				lengthDeletions2 = 0;
+  				lastequality = diffs[pointer][1];
+  			} else {
+  				// An insertion or deletion.
+  				if (diffs[pointer][0] === DIFF_INSERT) {
+  					lengthInsertions2 += diffs[pointer][1].length;
+  				} else {
+  					lengthDeletions2 += diffs[pointer][1].length;
+  				}
+
+  				// Eliminate an equality that is smaller or equal to the edits on both
+  				// sides of it.
+  				if (lastequality && lastequality.length <= Math.max(lengthInsertions1, lengthDeletions1) && lastequality.length <= Math.max(lengthInsertions2, lengthDeletions2)) {
+
+  					// Duplicate record.
+  					diffs.splice(equalities[equalitiesLength - 1], 0, [DIFF_DELETE, lastequality]);
+
+  					// Change second copy to insert.
+  					diffs[equalities[equalitiesLength - 1] + 1][0] = DIFF_INSERT;
+
+  					// Throw away the equality we just deleted.
+  					equalitiesLength--;
+
+  					// Throw away the previous equality (it needs to be reevaluated).
+  					equalitiesLength--;
+  					pointer = equalitiesLength > 0 ? equalities[equalitiesLength - 1] : -1;
+
+  					// Reset the counters.
+  					lengthInsertions1 = 0;
+  					lengthDeletions1 = 0;
+  					lengthInsertions2 = 0;
+  					lengthDeletions2 = 0;
+  					lastequality = null;
+  					changes = true;
+  				}
+  			}
+  			pointer++;
+  		}
+
+  		// Normalize the diff.
+  		if (changes) {
+  			this.diffCleanupMerge(diffs);
+  		}
+
+  		// Find any overlaps between deletions and insertions.
+  		// e.g: <del>abcxxx</del><ins>xxxdef</ins>
+  		//   -> <del>abc</del>xxx<ins>def</ins>
+  		// e.g: <del>xxxabc</del><ins>defxxx</ins>
+  		//   -> <ins>def</ins>xxx<del>abc</del>
+  		// Only extract an overlap if it is as big as the edit ahead or behind it.
+  		pointer = 1;
+  		while (pointer < diffs.length) {
+  			if (diffs[pointer - 1][0] === DIFF_DELETE && diffs[pointer][0] === DIFF_INSERT) {
+  				deletion = diffs[pointer - 1][1];
+  				insertion = diffs[pointer][1];
+  				overlapLength1 = this.diffCommonOverlap(deletion, insertion);
+  				overlapLength2 = this.diffCommonOverlap(insertion, deletion);
+  				if (overlapLength1 >= overlapLength2) {
+  					if (overlapLength1 >= deletion.length / 2 || overlapLength1 >= insertion.length / 2) {
+
+  						// Overlap found.  Insert an equality and trim the surrounding edits.
+  						diffs.splice(pointer, 0, [DIFF_EQUAL, insertion.substring(0, overlapLength1)]);
+  						diffs[pointer - 1][1] = deletion.substring(0, deletion.length - overlapLength1);
+  						diffs[pointer + 1][1] = insertion.substring(overlapLength1);
+  						pointer++;
+  					}
+  				} else {
+  					if (overlapLength2 >= deletion.length / 2 || overlapLength2 >= insertion.length / 2) {
+
+  						// Reverse overlap found.
+  						// Insert an equality and swap and trim the surrounding edits.
+  						diffs.splice(pointer, 0, [DIFF_EQUAL, deletion.substring(0, overlapLength2)]);
+
+  						diffs[pointer - 1][0] = DIFF_INSERT;
+  						diffs[pointer - 1][1] = insertion.substring(0, insertion.length - overlapLength2);
+  						diffs[pointer + 1][0] = DIFF_DELETE;
+  						diffs[pointer + 1][1] = deletion.substring(overlapLength2);
+  						pointer++;
+  					}
+  				}
+  				pointer++;
+  			}
+  			pointer++;
+  		}
+  	};
+
+  	/**
+    * Determine if the suffix of one string is the prefix of another.
+    * @param {string} text1 First string.
+    * @param {string} text2 Second string.
+    * @return {number} The number of characters common to the end of the first
+    *     string and the start of the second string.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffCommonOverlap = function (text1, text2) {
+  		var text1Length, text2Length, textLength, best, length, pattern, found;
+
+  		// Cache the text lengths to prevent multiple calls.
+  		text1Length = text1.length;
+  		text2Length = text2.length;
+
+  		// Eliminate the null case.
+  		if (text1Length === 0 || text2Length === 0) {
+  			return 0;
+  		}
+
+  		// Truncate the longer string.
+  		if (text1Length > text2Length) {
+  			text1 = text1.substring(text1Length - text2Length);
+  		} else if (text1Length < text2Length) {
+  			text2 = text2.substring(0, text1Length);
+  		}
+  		textLength = Math.min(text1Length, text2Length);
+
+  		// Quick check for the worst case.
+  		if (text1 === text2) {
+  			return textLength;
+  		}
+
+  		// Start by looking for a single character match
+  		// and increase length until no match is found.
+  		// Performance analysis: https://neil.fraser.name/news/2010/11/04/
+  		best = 0;
+  		length = 1;
+  		while (true) {
+  			pattern = text1.substring(textLength - length);
+  			found = text2.indexOf(pattern);
+  			if (found === -1) {
+  				return best;
+  			}
+  			length += found;
+  			if (found === 0 || text1.substring(textLength - length) === text2.substring(0, length)) {
+  				best = length;
+  				length++;
+  			}
+  		}
+  	};
+
+  	/**
+    * Split two texts into an array of strings.  Reduce the texts to a string of
+    * hashes where each Unicode character represents one line.
+    * @param {string} text1 First string.
+    * @param {string} text2 Second string.
+    * @return {{chars1: string, chars2: string, lineArray: !Array.<string>}}
+    *     An object containing the encoded text1, the encoded text2 and
+    *     the array of unique strings.
+    *     The zeroth element of the array of unique strings is intentionally blank.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffLinesToChars = function (text1, text2) {
+  		var lineArray, lineHash, chars1, chars2;
+  		lineArray = []; // E.g. lineArray[4] === 'Hello\n'
+  		lineHash = {}; // E.g. lineHash['Hello\n'] === 4
+
+  		// '\x00' is a valid character, but various debuggers don't like it.
+  		// So we'll insert a junk entry to avoid generating a null character.
+  		lineArray[0] = "";
+
+  		/**
+     * Split a text into an array of strings.  Reduce the texts to a string of
+     * hashes where each Unicode character represents one line.
+     * Modifies linearray and linehash through being a closure.
+     * @param {string} text String to encode.
+     * @return {string} Encoded string.
+     * @private
+     */
+  		function diffLinesToCharsMunge(text) {
+  			var chars, lineStart, lineEnd, lineArrayLength, line;
+  			chars = "";
+
+  			// Walk the text, pulling out a substring for each line.
+  			// text.split('\n') would would temporarily double our memory footprint.
+  			// Modifying text would create many large strings to garbage collect.
+  			lineStart = 0;
+  			lineEnd = -1;
+
+  			// Keeping our own length variable is faster than looking it up.
+  			lineArrayLength = lineArray.length;
+  			while (lineEnd < text.length - 1) {
+  				lineEnd = text.indexOf("\n", lineStart);
+  				if (lineEnd === -1) {
+  					lineEnd = text.length - 1;
+  				}
+  				line = text.substring(lineStart, lineEnd + 1);
+  				lineStart = lineEnd + 1;
+
+  				var lineHashExists = lineHash.hasOwnProperty ? lineHash.hasOwnProperty(line) : lineHash[line] !== undefined;
+
+  				if (lineHashExists) {
+  					chars += String.fromCharCode(lineHash[line]);
+  				} else {
+  					chars += String.fromCharCode(lineArrayLength);
+  					lineHash[line] = lineArrayLength;
+  					lineArray[lineArrayLength++] = line;
+  				}
+  			}
+  			return chars;
+  		}
+
+  		chars1 = diffLinesToCharsMunge(text1);
+  		chars2 = diffLinesToCharsMunge(text2);
+  		return {
+  			chars1: chars1,
+  			chars2: chars2,
+  			lineArray: lineArray
+  		};
+  	};
+
+  	/**
+    * Rehydrate the text in a diff from a string of line hashes to real lines of
+    * text.
+    * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
+    * @param {!Array.<string>} lineArray Array of unique strings.
+    * @private
+    */
+  	DiffMatchPatch.prototype.diffCharsToLines = function (diffs, lineArray) {
+  		var x, chars, text, y;
+  		for (x = 0; x < diffs.length; x++) {
+  			chars = diffs[x][1];
+  			text = [];
+  			for (y = 0; y < chars.length; y++) {
+  				text[y] = lineArray[chars.charCodeAt(y)];
+  			}
+  			diffs[x][1] = text.join("");
+  		}
+  	};
+
+  	/**
+    * Reorder and merge like edit sections.  Merge equalities.
+    * Any edit section can move as long as it doesn't cross an equality.
+    * @param {!Array.<!DiffMatchPatch.Diff>} diffs Array of diff tuples.
+    */
+  	DiffMatchPatch.prototype.diffCleanupMerge = function (diffs) {
+  		var pointer, countDelete, countInsert, textInsert, textDelete, commonlength, changes, diffPointer, position;
+  		diffs.push([DIFF_EQUAL, ""]); // Add a dummy entry at the end.
+  		pointer = 0;
+  		countDelete = 0;
+  		countInsert = 0;
+  		textDelete = "";
+  		textInsert = "";
+
+  		while (pointer < diffs.length) {
+  			switch (diffs[pointer][0]) {
+  				case DIFF_INSERT:
+  					countInsert++;
+  					textInsert += diffs[pointer][1];
+  					pointer++;
+  					break;
+  				case DIFF_DELETE:
+  					countDelete++;
+  					textDelete += diffs[pointer][1];
+  					pointer++;
+  					break;
+  				case DIFF_EQUAL:
+
+  					// Upon reaching an equality, check for prior redundancies.
+  					if (countDelete + countInsert > 1) {
+  						if (countDelete !== 0 && countInsert !== 0) {
+
+  							// Factor out any common prefixes.
+  							commonlength = this.diffCommonPrefix(textInsert, textDelete);
+  							if (commonlength !== 0) {
+  								if (pointer - countDelete - countInsert > 0 && diffs[pointer - countDelete - countInsert - 1][0] === DIFF_EQUAL) {
+  									diffs[pointer - countDelete - countInsert - 1][1] += textInsert.substring(0, commonlength);
+  								} else {
+  									diffs.splice(0, 0, [DIFF_EQUAL, textInsert.substring(0, commonlength)]);
+  									pointer++;
+  								}
+  								textInsert = textInsert.substring(commonlength);
+  								textDelete = textDelete.substring(commonlength);
+  							}
+
+  							// Factor out any common suffixies.
+  							commonlength = this.diffCommonSuffix(textInsert, textDelete);
+  							if (commonlength !== 0) {
+  								diffs[pointer][1] = textInsert.substring(textInsert.length - commonlength) + diffs[pointer][1];
+  								textInsert = textInsert.substring(0, textInsert.length - commonlength);
+  								textDelete = textDelete.substring(0, textDelete.length - commonlength);
+  							}
+  						}
+
+  						// Delete the offending records and add the merged ones.
+  						if (countDelete === 0) {
+  							diffs.splice(pointer - countInsert, countDelete + countInsert, [DIFF_INSERT, textInsert]);
+  						} else if (countInsert === 0) {
+  							diffs.splice(pointer - countDelete, countDelete + countInsert, [DIFF_DELETE, textDelete]);
+  						} else {
+  							diffs.splice(pointer - countDelete - countInsert, countDelete + countInsert, [DIFF_DELETE, textDelete], [DIFF_INSERT, textInsert]);
+  						}
+  						pointer = pointer - countDelete - countInsert + (countDelete ? 1 : 0) + (countInsert ? 1 : 0) + 1;
+  					} else if (pointer !== 0 && diffs[pointer - 1][0] === DIFF_EQUAL) {
+
+  						// Merge this equality with the previous one.
+  						diffs[pointer - 1][1] += diffs[pointer][1];
+  						diffs.splice(pointer, 1);
+  					} else {
+  						pointer++;
+  					}
+  					countInsert = 0;
+  					countDelete = 0;
+  					textDelete = "";
+  					textInsert = "";
+  					break;
+  			}
+  		}
+  		if (diffs[diffs.length - 1][1] === "") {
+  			diffs.pop(); // Remove the dummy entry at the end.
+  		}
+
+  		// Second pass: look for single edits surrounded on both sides by equalities
+  		// which can be shifted sideways to eliminate an equality.
+  		// e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
+  		changes = false;
+  		pointer = 1;
+
+  		// Intentionally ignore the first and last element (don't need checking).
+  		while (pointer < diffs.length - 1) {
+  			if (diffs[pointer - 1][0] === DIFF_EQUAL && diffs[pointer + 1][0] === DIFF_EQUAL) {
+
+  				diffPointer = diffs[pointer][1];
+  				position = diffPointer.substring(diffPointer.length - diffs[pointer - 1][1].length);
+
+  				// This is a single edit surrounded by equalities.
+  				if (position === diffs[pointer - 1][1]) {
+
+  					// Shift the edit over the previous equality.
+  					diffs[pointer][1] = diffs[pointer - 1][1] + diffs[pointer][1].substring(0, diffs[pointer][1].length - diffs[pointer - 1][1].length);
+  					diffs[pointer + 1][1] = diffs[pointer - 1][1] + diffs[pointer + 1][1];
+  					diffs.splice(pointer - 1, 1);
+  					changes = true;
+  				} else if (diffPointer.substring(0, diffs[pointer + 1][1].length) === diffs[pointer + 1][1]) {
+
+  					// Shift the edit over the next equality.
+  					diffs[pointer - 1][1] += diffs[pointer + 1][1];
+  					diffs[pointer][1] = diffs[pointer][1].substring(diffs[pointer + 1][1].length) + diffs[pointer + 1][1];
+  					diffs.splice(pointer + 1, 1);
+  					changes = true;
+  				}
+  			}
+  			pointer++;
+  		}
+
+  		// If shifts were made, the diff needs reordering and another shift sweep.
+  		if (changes) {
+  			this.diffCleanupMerge(diffs);
+  		}
+  	};
+
+  	return function (o, n) {
+  		var diff, output, text;
+  		diff = new DiffMatchPatch();
+  		output = diff.DiffMain(o, n);
+  		diff.diffCleanupEfficiency(output);
+  		text = diff.diffPrettyHtml(output);
+
+  		return text;
+  	};
+  }();
+
+}((function() { return this; }())));

--- a/actionview/test/ujs/server.rb
+++ b/actionview/test/ujs/server.rb
@@ -24,14 +24,14 @@ module UJS
     config.logger = Logger.new(STDOUT)
     config.log_level = :error
 
-    # config.content_security_policy do |policy|
-    #   policy.default_src :self, :https
-    #   policy.font_src    :self, :https, :data
-    #   policy.img_src     :self, :https, :data
-    #   policy.object_src  :none
-    #   policy.script_src  :self, :https
-    #   policy.style_src   :self, :https
-    # end
+    config.content_security_policy do |policy|
+      policy.default_src :self, :https
+      policy.font_src    :self, :https, :data
+      policy.img_src     :self, :https, :data
+      policy.object_src  :none
+      policy.script_src  :self, :https
+      policy.style_src   :self, :https
+    end
 
     config.content_security_policy_nonce_generator = ->(req) { SecureRandom.base64(16) }
   end

--- a/actionview/test/ujs/server.rb
+++ b/actionview/test/ujs/server.rb
@@ -24,14 +24,14 @@ module UJS
     config.logger = Logger.new(STDOUT)
     config.log_level = :error
 
-    config.content_security_policy do |policy|
-      policy.default_src :self, :https
-      policy.font_src    :self, :https, :data
-      policy.img_src     :self, :https, :data
-      policy.object_src  :none
-      policy.script_src  :self, :https
-      policy.style_src   :self, :https
-    end
+    # config.content_security_policy do |policy|
+    #   policy.default_src :self, :https
+    #   policy.font_src    :self, :https, :data
+    #   policy.img_src     :self, :https, :data
+    #   policy.object_src  :none
+    #   policy.script_src  :self, :https
+    #   policy.style_src   :self, :https
+    # end
 
     config.content_security_policy_nonce_generator = ->(req) { SecureRandom.base64(16) }
   end

--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -3,6 +3,17 @@
 require "qunit/selenium/test_runner"
 require "chromedriver-helper"
 
+QUnit::Selenium::TestRun.class_eval do
+  def completed?
+    @qunit_testresult.text =~ /Tests completed/i
+  end
+
+  def duration
+    match = /Tests completed in (?<milliseconds>\d+) milliseconds/i.match @qunit_testresult.text
+    match[:milliseconds].to_i / 1000
+  end
+end
+
 driver_options = Selenium::WebDriver::Chrome::Options.new
 driver_options.add_argument("--headless")
 driver_options.add_argument("--disable-gpu")


### PR DESCRIPTION
### Summary

UJS is currently using a version of QUnit that is about to celebrate it's fourth birthday. This PR upgrades it from v1.14.0 to v2.8.0.

### Other Information

- [x] Use QUnit 2.8 
- [x] Handle removed globals
- [x] Update matchers: matcher() -> assert.matcher()
- [x] New async test semantics
- [x] New module hooks
- [x] Specifically tag test forms to prevent tests from submitting qunit forms and trigger test reruns
- [x] Make all tests run
- [x] Make CI work 
- [x] Fix qunit-selenium

### What's not (yet) included

- Make sure assert.async() expects multiple done calls when multiple async assertions occur: I noticed some of the tests fire multiple evens, make assertions on each of the events and end the tests after a fixed time using setTimeout. Using QUnit 2.8 it's possible to expect multiple done() calls and therefore avoid hardcoding a timeout and instead call done() at the end of each event listener that performs assertions.
- The suite still uses a custom test server whereas ActionCable tests use karma.*
- We still ship with our own copy of jQuery/QUnit, I'd argue it makes sense to pull them in as npm dependencies.
- JQuery is still a dependency
- No build step / ES6 for the tests (i.e. babel)
- CSP doesn't allow qUnit.js

(*) If replacing qunit-selenium as the test runner makes sense, I'm ready to integrate the work into this PR.

### Previous work

This commit https://github.com/rails/rails/pull/28645 tried to upgrade to 2.0 but was (I assume) abandoned. However, it didn't handle multiple assertions within a test and doesn't seem to address some of the selector issues (QUnit 2(.8) has some new default forms for test selection and filtering, by default, the tests would've submitted these forms instead of the designated test forms and triggering endless reruns.)