### PR TITLE
Require Ruby 2.5 for Rails 6.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,21 +64,11 @@ env:
     - "GEM=ac:integration"
 
 rvm:
-  - 2.4.5
   - 2.5.3
   - ruby-head
 
 matrix:
   include:
-    - rvm: 2.4.5
-      env: "GEM=railties"
-      sudo: required
-      before_install:
-        - "rm ${BUNDLE_GEMFILE}.lock"
-        - "travis_retry gem update --system"
-        - "travis_retry gem install bundler"
-        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
-        - "sudo service postgresql restart 10"
     - rvm: 2.5.3
       env: "GEM=railties"
       sudo: required
@@ -99,19 +89,6 @@ matrix:
         - "sudo service postgresql restart 10"
     - rvm: 2.5.3
       env: "GEM=av:ujs"
-    - rvm: 2.4.5
-      sudo: required
-      env: "GEM=aj:integration"
-      services:
-        - memcached
-        - redis-server
-        - rabbitmq
-      before_install:
-        - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
-        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
-        - "sudo service postgresql restart 10"
-        - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/beanstalkd/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
-        - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
     - rvm: 2.5.3
       sudo: required
       env: "GEM=aj:integration"
@@ -138,13 +115,6 @@ matrix:
         - "sudo service postgresql restart 10"
         - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/beanstalkd/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
         - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
-    - rvm: 2.4.5
-      env: "GEM=ar:mysql2"
-      sudo: required
-      before_install:
-        - "sudo mysql -e \"use mysql; update user set authentication_string='' where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;\""
-        - "sudo mysql_upgrade"
-        - "sudo service mysql restart"
     - rvm: 2.5.3
       env: "GEM=ar:mysql2"
       sudo: required
@@ -167,12 +137,6 @@ matrix:
     - rvm: 2.5.3
       env:
         - "GEM=ar:sqlite3_mem"
-    - rvm: 2.4.5
-      env: "GEM=ar:postgresql"
-      sudo: required
-      before_install:
-        - "sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/10/main/postgresql.conf"
-        - "sudo service postgresql restart 10"
     - rvm: 2.5.3
       env: "GEM=ar:postgresql"
       sudo: required

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -66,9 +66,9 @@
 
     *Ilia Kasianenko*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "WebSocket framework for Rails."
   s.description = "Structure many real-time application concerns into channels over a single WebSocket connection."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -57,9 +57,9 @@
 
     *Claudio Ortolina*, *Kota Miyake*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Email composition, delivery, and receiving framework (part of Rails)."
   s.description = "Email on Rails. Compose, deliver, receive, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -193,9 +193,9 @@
 
     *Derek Prior*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Web-flow and rendering framework putting the VC in MVC (part of Rails)."
   s.description = "Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -175,9 +175,9 @@
 
     *Rui Onodera*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rendering framework putting the V in MVC (part of Rails)."
   s.description = "Simple, battle-tested conventions and helpers for building web pages."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -107,9 +107,9 @@
 
     *Andrew White*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 *   Add support to define custom argument serializers.
 

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Job framework with pluggable queues."
   s.description = "Declare job classes that can be run by a variety of queuing backends."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -54,9 +54,9 @@
 
     *Martin Larochelle*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit for building modeling frameworks (part of Rails)."
   s.description = "A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -466,9 +466,9 @@
 
     *Tan Huynh*, *Yukio Mizuta*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 *   Deprecate `update_attributes`/`!` in favor of `update`/`!`.
 

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Object-relational mapper framework (part of Rails)."
   s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -123,9 +123,9 @@
 
     *Janko Marohnić*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Local and cloud file storage framework."
   s.description = "Attach cloud and local files in Rails applications."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -282,9 +282,9 @@
 
     *Jeremy Daer*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 *   Adds parallel testing to Rails.
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework."
   s.description = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -1,29 +1,6 @@
 # frozen_string_literal: true
 
 class Hash
-  # Slices a hash to include only the given keys. Returns a hash containing
-  # the given keys.
-  #
-  #   { a: 1, b: 2, c: 3, d: 4 }.slice(:a, :b)
-  #   # => {:a=>1, :b=>2}
-  #
-  # This is useful for limiting an options hash to valid keys before
-  # passing to a method:
-  #
-  #   def search(criteria = {})
-  #     criteria.assert_valid_keys(:mass, :velocity, :time)
-  #   end
-  #
-  #   search(options.slice(:mass, :velocity, :time))
-  #
-  # If you have an array of keys you want to limit to, you should splat them:
-  #
-  #   valid_keys = [:mass, :velocity, :time]
-  #   search(options.slice(*valid_keys))
-  def slice(*keys)
-    keys.each_with_object(Hash.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
-  end unless method_defined?(:slice)
-
   # Replaces the hash with only the given keys.
   # Returns a hash containing the removed key/value pairs.
   #

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -35,18 +35,16 @@ module ActiveSupport
           assert_called(object, method_name, message, times: 0, &block)
         end
 
-        # TODO: No need to resort to #send once support for Ruby 2.4 is
-        # dropped.
         def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)
           times_called = 0
-          klass.send(:define_method, "stubbed_#{method_name}") do |*|
+          klass.define_method("stubbed_#{method_name}") do |*|
             times_called += 1
 
             returns
           end
 
-          klass.send(:alias_method, "original_#{method_name}", method_name)
-          klass.send(:alias_method, method_name, "stubbed_#{method_name}")
+          klass.alias_method "original_#{method_name}", method_name
+          klass.alias_method method_name, "stubbed_#{method_name}"
 
           yield
 
@@ -55,9 +53,9 @@ module ActiveSupport
 
           assert_equal times, times_called, error
         ensure
-          klass.send(:alias_method, method_name, "original_#{method_name}")
-          klass.send(:undef_method, "original_#{method_name}")
-          klass.send(:undef_method, "stubbed_#{method_name}")
+          klass.alias_method method_name, "original_#{method_name}"
+          klass.undef_method "original_#{method_name}"
+          klass.undef_method "stubbed_#{method_name}"
         end
 
         def assert_not_called_on_instance_of(klass, method_name, message = nil, &block)

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -2,9 +2,9 @@
 
     *Xavier Noria*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -90,7 +90,7 @@ $ ruby -v
 ruby 2.5.0
 ```
 
-Rails requires Ruby version 2.4.1 or later. If the version number returned is
+Rails requires Ruby version 2.5.0 or later. If the version number returned is
 less than that number, you'll need to install a fresh copy of Ruby.
 
 TIP: To quickly install Ruby and Ruby on Rails on your system in Windows, you can use

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -35,7 +35,7 @@ You can find a list of all released Rails versions [here](https://rubygems.org/g
 
 Rails generally stays close to the latest released Ruby version when it's released:
 
-* Rails 6 requires Ruby 2.4.1 or newer.
+* Rails 6 requires Ruby 2.5.0 or newer.
 * Rails 5 requires Ruby 2.2.2 or newer.
 * Rails 4 prefers Ruby 2.0 and requires 1.9.3 or newer.
 * Rails 3.2.x is the last branch to support Ruby 1.8.7.

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Full-stack web application framework."
   s.description = "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration."
 
-  s.required_ruby_version     = ">= 2.4.1"
+  s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 1.8.11"
 
   s.license = "MIT"

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -241,9 +241,9 @@
 
     *Benoit Tigeot*
 
-*   Rails 6 requires Ruby 2.4.1 or newer.
+*   Rails 6 requires Ruby 2.5.0 or newer.
 
-    *Jeremy Daer*
+    *Jeremy Daer*, *Kasper Timm Hansen*
 
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.1") && RUBY_ENGINE == "ruby"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0") && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 6 requires Ruby 2.4.1 or newer.
+    Rails 6 requires Ruby 2.5.0 or newer.
 
     You're running
       #{desc}
 
-    Please upgrade to Ruby 2.4.1 or newer to continue.
+    Please upgrade to Ruby 2.5.0 or newer to continue.
 
   end_message
 end

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Tools for creating, working with, and running Rails applications."
   s.description = "Rails internals: application bootup, plugins, generators, and rake tasks."
 
-  s.required_ruby_version = ">= 2.4.1"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.license = "MIT"
 


### PR DESCRIPTION
Generally followed the pattern for https://github.com/rails/rails/pull/32034

* Removes needless CI configs for 2.4
* Targets 2.5 in rubocop
* Updates existing CHANGELOG entries for fewer merge conflicts
* Removes Hash#slice extension as that's inlined on Ruby 2.5.
* Removes the need for send on define_method in MethodCallAssertions.

cc @jeremy @matthewd @dhh