### PR TITLE
Return enumerator for fetch_multi without block

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -407,9 +407,7 @@ module ActiveSupport
       # the cache with the given keys, then that data is returned. Otherwise,
       # the supplied block is called for each key for which there was no data,
       # and the result will be written to the cache and returned.
-      # Therefore, you need to pass a block that returns the data to be written
-      # to the cache. If you do not want to write the cache when the cache is
-      # not found, use #read_multi.
+      # If the block is ommitted, an enumerator is returned.
       #
       # Returns a hash with the data for each of the names. For example:
       #
@@ -432,7 +430,7 @@ module ActiveSupport
       #   cache.read("fizz")
       #   # => nil
       def fetch_multi(*names)
-        raise ArgumentError, "Missing block: `Cache#fetch_multi` requires a block." unless block_given?
+        return to_enum(__method__, *names) unless block_given?
 
         options = names.extract_options!
         options = merged_options(options)

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -143,9 +143,9 @@ module CacheStoreBehavior
   end
 
   def test_fetch_multi_without_block
-    assert_raises(ArgumentError) do
-      @cache.fetch_multi("foo")
-    end
+    values = @cache.fetch_multi("foo", "bar").with_index { |value, i| value + i.to_s }
+
+    assert_equal({ "foo" => "foo0", "bar" => "bar1" }, values)
   end
 
   # Use strings that are guaranteed to compress well, so we can easily tell if


### PR DESCRIPTION
### Summary

Modifies the behavior of `Rails.cache.fetch_multi` to return an enumerator instead of raising `ArgumentError` when the expected block is omitted.

A common use case for this behavior would be to chain enumerators to add behavior, like lazy enumeration, or amend the block parameters, as with with_index. This would also be consistent with many common `Enumerable` methods as well as other batching mechanisms in Rails, like `find_in_batches`.