### PR TITLE
Follow up #34754

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -2,4 +2,4 @@
 
 require "active_support/deprecation"
 
-ActiveSupport::Deprecation.warn "Ruby 2.4+ (required by Rails 6) provides Hash#compact and Hash#compact! natively, so requiring active_support/core_ext/hash/compact is no longer necessary. Requiring it will raise LoadError in Rails 6.1."
+ActiveSupport::Deprecation.warn "Ruby 2.5+ (required by Rails 6) provides Hash#compact and Hash#compact! natively, so requiring active_support/core_ext/hash/compact is no longer necessary. Requiring it will raise LoadError in Rails 6.1."

--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -2,4 +2,4 @@
 
 require "active_support/deprecation"
 
-ActiveSupport::Deprecation.warn "Ruby 2.4+ (required by Rails 6) provides Hash#transform_values natively, so requiring active_support/core_ext/hash/transform_values is no longer necessary. Requiring it will raise LoadError in Rails 6.1."
+ActiveSupport::Deprecation.warn "Ruby 2.5+ (required by Rails 6) provides Hash#transform_values natively, so requiring active_support/core_ext/hash/transform_values is no longer necessary. Requiring it will raise LoadError in Rails 6.1."

--- a/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
@@ -2,4 +2,4 @@
 
 require "active_support/deprecation"
 
-ActiveSupport::Deprecation.warn "Ruby 2.4+ (required by Rails 6) provides Numeric#positive? and Numeric#negative? natively, so requiring active_support/core_ext/numeric/inquiry is no longer necessary. Requiring it will raise LoadError in Rails 6.1."
+ActiveSupport::Deprecation.warn "Ruby 2.5+ (required by Rails 6) provides Numeric#positive? and Numeric#negative? natively, so requiring active_support/core_ext/numeric/inquiry is no longer necessary. Requiring it will raise LoadError in Rails 6.1."

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -310,30 +310,16 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, merged
   end
 
-  def test_slice
-    original = { a: "x", b: "y", c: 10 }
-    expected = { a: "x", b: "y" }
-
-    # Should return a new hash with only the given keys.
-    assert_equal expected, original.slice(:a, :b)
-    assert_not_equal expected, original
-  end
-
   def test_slice_inplace
     original = { a: "x", b: "y", c: 10 }
-    expected = { c: 10 }
+    expected_return = { c: 10 }
+    expected_original = { a: "x", b: "y" }
+
+    # Should return a hash containing the removed key/value pairs.
+    assert_equal expected_return, original.slice!(:a, :b)
 
     # Should replace the hash with only the given keys.
-    assert_equal expected, original.slice!(:a, :b)
-  end
-
-  def test_slice_with_an_array_key
-    original = { :a => "x", :b => "y", :c => 10, [:a, :b] => "an array key" }
-    expected = { [:a, :b] => "an array key", :c => 10 }
-
-    # Should return a new hash with only the given keys when given an array key.
-    assert_equal expected, original.slice([:a, :b], :c)
-    assert_not_equal expected, original
+    assert_equal expected_original, original
   end
 
   def test_slice_inplace_with_an_array_key
@@ -342,14 +328,6 @@ class HashExtTest < ActiveSupport::TestCase
 
     # Should replace the hash with only the given keys when given an array key.
     assert_equal expected, original.slice!([:a, :b], :c)
-  end
-
-  def test_slice_with_splatted_keys
-    original = { :a => "x", :b => "y", :c => 10, [:a, :b] => "an array key" }
-    expected = { a: "x", b: "y" }
-
-    # Should grab each of the splatted keys.
-    assert_equal expected, original.slice(*[:a, :b])
   end
 
   def test_slice_bang_does_not_override_default

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2729,26 +2729,7 @@ NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
 
 ### Slicing
 
-Ruby has built-in support for taking slices out of strings and arrays. Active Support extends slicing to hashes:
-
-```ruby
-{a: 1, b: 2, c: 3}.slice(:a, :c)
-# => {:a=>1, :c=>3}
-
-{a: 1, b: 2, c: 3}.slice(:b, :X)
-# => {:b=>2} # non-existing keys are ignored
-```
-
-If the receiver responds to `convert_key` keys are normalized:
-
-```ruby
-{a: 1, b: 2}.with_indifferent_access.slice("a")
-# => {:a=>1}
-```
-
-NOTE. Slicing may come in handy for sanitizing option hashes with a white list of keys.
-
-There's also `slice!` which in addition to perform a slice in place returns what's removed:
+The method `slice!` replaces the hash with only the given keys and returns a hash containing the removed key/value pairs.
 
 ```ruby
 hash = {a: 1, b: 2}


### PR DESCRIPTION
- Fix a few deprecation warnings
- Remove testing of `Hash#slice`
- Improve test of `Hash#slice!`
- Remove mention about `Hash#slice` from the guide
