### PR TITLE
A bug in generated scaffold controllers may be solved

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -29,7 +29,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
 
     if @<%= orm_instance.save %>
-      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
     else
       render :new
     end
@@ -38,7 +38,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # PATCH/PUT <%= route_url %>/1
   def update
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
-      redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
+      redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
     else
       render :edit
     end


### PR DESCRIPTION
When I generate a scaffold controller ( for example with the model name "post") I always get the same on the lines 32 and 41:
```
32 redirect_to [, @post], notice: 'Post was successfully created.'
41 redirect_to [, @post], notice: 'Post was successfully updated.'
```
This correction may solve this mistake or not. Check if I am doing right, please.
