### PR TITLE
Enable `Style/RedundantBegin` cop to avoid newly adding redundant begin block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,6 +187,9 @@ Lint/UriEscapeUnescape:
 Style/ParenthesesAroundCondition:
   Enabled: true
 
+Style/RedundantBegin:
+  Enabled: true
+
 Style/RedundantReturn:
   Enabled: true
   AllowMultipleReturnValues: true

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -56,14 +56,12 @@ module ActionCable
 
       def invoke(receiver, method, *args, connection:, &block)
         work(connection) do
-          begin
-            receiver.send method, *args, &block
-          rescue Exception => e
-            logger.error "There was an exception - #{e.class}(#{e.message})"
-            logger.error e.backtrace.join("\n")
+          receiver.send method, *args, &block
+        rescue Exception => e
+          logger.error "There was an exception - #{e.class}(#{e.message})"
+          logger.error e.backtrace.join("\n")
 
-            receiver.handle_exception if receiver.respond_to?(:handle_exception)
-          end
+          receiver.handle_exception if receiver.respond_to?(:handle_exception)
         end
       end
 

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -190,81 +190,73 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "notification for perform_action" do
-    begin
-      events = []
-      ActiveSupport::Notifications.subscribe "perform_action.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      data = { "action" => :speak, "content" => "hello" }
-      @channel.perform_action data
-
-      assert_equal 1, events.length
-      assert_equal "perform_action.action_cable", events[0].name
-      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-      assert_equal :speak, events[0].payload[:action]
-      assert_equal data, events[0].payload[:data]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "perform_action.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "perform_action.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    data = { "action" => :speak, "content" => "hello" }
+    @channel.perform_action data
+
+    assert_equal 1, events.length
+    assert_equal "perform_action.action_cable", events[0].name
+    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+    assert_equal :speak, events[0].payload[:action]
+    assert_equal data, events[0].payload[:data]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "perform_action.action_cable"
   end
 
   test "notification for transmit" do
-    begin
-      events = []
-      ActiveSupport::Notifications.subscribe "transmit.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      @channel.perform_action "action" => :get_latest
-      expected_data = { data: "latest" }
-
-      assert_equal 1, events.length
-      assert_equal "transmit.action_cable", events[0].name
-      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-      assert_equal expected_data, events[0].payload[:data]
-      assert_nil events[0].payload[:via]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "transmit.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "transmit.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    @channel.perform_action "action" => :get_latest
+    expected_data = { data: "latest" }
+
+    assert_equal 1, events.length
+    assert_equal "transmit.action_cable", events[0].name
+    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+    assert_equal expected_data, events[0].payload[:data]
+    assert_nil events[0].payload[:via]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "transmit.action_cable"
   end
 
   test "notification for transmit_subscription_confirmation" do
-    begin
-      @channel.subscribe_to_channel
+    @channel.subscribe_to_channel
 
-      events = []
-      ActiveSupport::Notifications.subscribe "transmit_subscription_confirmation.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      @channel.stub(:subscription_confirmation_sent?, false) do
-        @channel.send(:transmit_subscription_confirmation)
-
-        assert_equal 1, events.length
-        assert_equal "transmit_subscription_confirmation.action_cable", events[0].name
-        assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-      end
-    ensure
-      ActiveSupport::Notifications.unsubscribe "transmit_subscription_confirmation.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "transmit_subscription_confirmation.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    @channel.stub(:subscription_confirmation_sent?, false) do
+      @channel.send(:transmit_subscription_confirmation)
+
+      assert_equal 1, events.length
+      assert_equal "transmit_subscription_confirmation.action_cable", events[0].name
+      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+    end
+  ensure
+    ActiveSupport::Notifications.unsubscribe "transmit_subscription_confirmation.action_cable"
   end
 
   test "notification for transmit_subscription_rejection" do
-    begin
-      events = []
-      ActiveSupport::Notifications.subscribe "transmit_subscription_rejection.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      @channel.send(:transmit_subscription_rejection)
-
-      assert_equal 1, events.length
-      assert_equal "transmit_subscription_rejection.action_cable", events[0].name
-      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "transmit_subscription_rejection.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "transmit_subscription_rejection.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    @channel.send(:transmit_subscription_rejection)
+
+    assert_equal 1, events.length
+    assert_equal "transmit_subscription_rejection.action_cable", events[0].name
+    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "transmit_subscription_rejection.action_cable"
   end
 
   test "behaves like rescuable" do

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -13,50 +13,46 @@ class BroadcastingTest < ActionCable::TestCase
   end
 
   test "broadcast generates notification" do
-    begin
-      server = TestServer.new
+    server = TestServer.new
 
-      events = []
-      ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      broadcasting = "test_queue"
-      message = { body: "test message" }
-      server.broadcast(broadcasting, message)
-
-      assert_equal 1, events.length
-      assert_equal "broadcast.action_cable", events[0].name
-      assert_equal broadcasting, events[0].payload[:broadcasting]
-      assert_equal message, events[0].payload[:message]
-      assert_equal ActiveSupport::JSON, events[0].payload[:coder]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    broadcasting = "test_queue"
+    message = { body: "test message" }
+    server.broadcast(broadcasting, message)
+
+    assert_equal 1, events.length
+    assert_equal "broadcast.action_cable", events[0].name
+    assert_equal broadcasting, events[0].payload[:broadcasting]
+    assert_equal message, events[0].payload[:message]
+    assert_equal ActiveSupport::JSON, events[0].payload[:coder]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
   end
 
   test "broadcaster from broadcaster_for generates notification" do
-    begin
-      server = TestServer.new
+    server = TestServer.new
 
-      events = []
-      ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      broadcasting = "test_queue"
-      message = { body: "test message" }
-
-      broadcaster = server.broadcaster_for(broadcasting)
-      broadcaster.broadcast(message)
-
-      assert_equal 1, events.length
-      assert_equal "broadcast.action_cable", events[0].name
-      assert_equal broadcasting, events[0].payload[:broadcasting]
-      assert_equal message, events[0].payload[:message]
-      assert_equal ActiveSupport::JSON, events[0].payload[:coder]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
+    events = []
+    ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    broadcasting = "test_queue"
+    message = { body: "test message" }
+
+    broadcaster = server.broadcaster_for(broadcasting)
+    broadcaster.broadcast(message)
+
+    assert_equal 1, events.length
+    assert_equal "broadcast.action_cable", events[0].name
+    assert_equal broadcasting, events[0].payload[:broadcasting]
+    assert_equal message, events[0].payload[:message]
+    assert_equal ActiveSupport::JSON, events[0].payload[:coder]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
   end
 end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -897,22 +897,20 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "notification for process" do
-    begin
-      events = []
-      ActiveSupport::Notifications.subscribe("process.action_mailer") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      BaseMailer.welcome(body: "Hello there").deliver_now
-
-      assert_equal 1, events.length
-      assert_equal "process.action_mailer", events[0].name
-      assert_equal "BaseMailer", events[0].payload[:mailer]
-      assert_equal :welcome, events[0].payload[:action]
-      assert_equal [{ body: "Hello there" }], events[0].payload[:args]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "process.action_mailer"
+    events = []
+    ActiveSupport::Notifications.subscribe("process.action_mailer") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    BaseMailer.welcome(body: "Hello there").deliver_now
+
+    assert_equal 1, events.length
+    assert_equal "process.action_mailer", events[0].name
+    assert_equal "BaseMailer", events[0].payload[:mailer]
+    assert_equal :welcome, events[0].payload[:action]
+    assert_equal [{ body: "Hello there" }], events[0].payload[:args]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "process.action_mailer"
   end
 
   private

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -30,13 +30,11 @@ module ActionController
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)
 
       ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
-        begin
-          result = super
+        super.tap do
           payload[:status] = response.status
-          result
-        ensure
-          append_info_to_payload(payload)
         end
+      ensure
+        append_info_to_payload(payload)
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/callbacks.rb
+++ b/actionpack/lib/action_dispatch/middleware/callbacks.rb
@@ -24,10 +24,8 @@ module ActionDispatch
     def call(env)
       error = nil
       result = run_callbacks :call do
-        begin
-          @app.call(env)
-        rescue => error
-        end
+        @app.call(env)
+      rescue => error
       end
       raise error if error
       result

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -48,11 +48,9 @@ module ActionDispatch
         wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
 
         @interceptors.each do |interceptor|
-          begin
-            interceptor.call(request, exception)
-          rescue Exception
-            log_error(request, wrapper)
-          end
+          interceptor.call(request, exception)
+        rescue Exception
+          log_error(request, wrapper)
         end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -21,13 +21,11 @@ module ActionDispatch
 
       def allows?(host)
         @hosts.any? do |allowed|
-          begin
-            allowed === host
-          rescue
-            # IPAddr#=== raises an error if you give it a hostname instead of
-            # IP. Treat similar errors as blocked access.
-            false
-          end
+          allowed === host
+        rescue
+          # IPAddr#=== raises an error if you give it a hostname instead of
+          # IP. Treat similar errors as blocked access.
+          false
         end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -162,14 +162,12 @@ module ActionDispatch
         # Split the comma-separated list into an array of strings.
         ips = header.strip.split(/[,\s]+/)
         ips.select do |ip|
-          begin
-            # Only return IPs that are valid according to the IPAddr#new method.
-            range = IPAddr.new(ip).to_range
-            # We want to make sure nobody is sneaking a netmask in.
-            range.begin == range.end
-          rescue ArgumentError
-            nil
-          end
+          # Only return IPs that are valid according to the IPAddr#new method.
+          range = IPAddr.new(ip).to_range
+          # We want to make sure nobody is sneaking a netmask in.
+          range.begin == range.end
+        rescue ArgumentError
+          nil
         end
       end
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -276,16 +276,14 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
   end
 
   def test_assert_redirect_failure_message_with_protocol_relative_url
-    begin
-      process :redirect_external_protocol_relative
-      assert_redirected_to "/foo"
-    rescue ActiveSupport::TestCase::Assertion => ex
-      assert_no_match(
-        /#{request.protocol}#{request.host}\/\/www.rubyonrails.org/,
-        ex.message,
-        "protocol relative url was incorrectly normalized"
-      )
-    end
+    process :redirect_external_protocol_relative
+    assert_redirected_to "/foo"
+  rescue ActiveSupport::TestCase::Assertion => ex
+    assert_no_match(
+      /#{request.protocol}#{request.host}\/\/www.rubyonrails.org/,
+      ex.message,
+      "protocol relative url was incorrectly normalized"
+    )
   end
 
   def test_template_objects_exist

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -1000,16 +1000,12 @@ class YieldingAroundFiltersTest < ActionController::TestCase
   def test_nested_actions
     controller = ControllerWithNestedFilters
     assert_nothing_raised do
-      begin
-        test_process(controller, "raises_both")
-      rescue Before, After
-      end
+      test_process(controller, "raises_both")
+    rescue Before, After
     end
     assert_raise Before do
-      begin
-        test_process(controller, "raises_both")
-      rescue After
-      end
+      test_process(controller, "raises_both")
+    rescue After
     end
   end
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -365,17 +365,15 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted takes a default value when Parameters.permit_all_parameters is set" do
-    begin
-      ActionController::Parameters.permit_all_parameters = true
-      params = ActionController::Parameters.new(person: {
-        age: "32", name: { first: "David", last: "Heinemeier Hansson" }
-      })
+    ActionController::Parameters.permit_all_parameters = true
+    params = ActionController::Parameters.new(person: {
+      age: "32", name: { first: "David", last: "Heinemeier Hansson" }
+    })
 
-      assert_predicate params.slice(:person), :permitted?
-      assert_predicate params[:person][:name], :permitted?
-    ensure
-      ActionController::Parameters.permit_all_parameters = false
-    end
+    assert_predicate params.slice(:person), :permitted?
+    assert_predicate params[:person][:name], :permitted?
+  ensure
+    ActionController::Parameters.permit_all_parameters = false
   end
 
   test "permitting parameters as an array" do
@@ -396,16 +394,14 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_h returns converted hash when .permit_all_parameters is set" do
-    begin
-      ActionController::Parameters.permit_all_parameters = true
-      params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
+    ActionController::Parameters.permit_all_parameters = true
+    params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
 
-      assert_instance_of ActiveSupport::HashWithIndifferentAccess, params.to_h
-      assert_not_kind_of ActionController::Parameters, params.to_h
-      assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_h)
-    ensure
-      ActionController::Parameters.permit_all_parameters = false
-    end
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, params.to_h
+    assert_not_kind_of ActionController::Parameters, params.to_h
+    assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_h)
+  ensure
+    ActionController::Parameters.permit_all_parameters = false
   end
 
   test "to_hash raises UnfilteredParameters on unfiltered params" do
@@ -429,17 +425,15 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_hash returns converted hash when .permit_all_parameters is set" do
-    begin
-      ActionController::Parameters.permit_all_parameters = true
-      params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
+    ActionController::Parameters.permit_all_parameters = true
+    params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
 
-      assert_instance_of Hash, params.to_hash
-      assert_not_kind_of ActionController::Parameters, params.to_hash
-      assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_hash)
-      assert_equal({ "crab" => "Senjougahara Hitagi" }, params)
-    ensure
-      ActionController::Parameters.permit_all_parameters = false
-    end
+    assert_instance_of Hash, params.to_hash
+    assert_not_kind_of ActionController::Parameters, params.to_hash
+    assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_hash)
+    assert_equal({ "crab" => "Senjougahara Hitagi" }, params)
+  ensure
+    ActionController::Parameters.permit_all_parameters = false
   end
 
   test "to_unsafe_h returns unfiltered params" do

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -96,57 +96,47 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "custom type" do
-    begin
-      type = Mime::Type.register("image/foo", :foo)
-      assert_equal type, Mime[:foo]
-    ensure
-      Mime::Type.unregister(:foo)
-    end
+    type = Mime::Type.register("image/foo", :foo)
+    assert_equal type, Mime[:foo]
+  ensure
+    Mime::Type.unregister(:foo)
   end
 
   test "custom type with type aliases" do
-    begin
-      Mime::Type.register "text/foobar", :foobar, ["text/foo", "text/bar"]
-      %w[text/foobar text/foo text/bar].each do |type|
-        assert_equal Mime[:foobar], type
-      end
-    ensure
-      Mime::Type.unregister(:foobar)
+    Mime::Type.register "text/foobar", :foobar, ["text/foo", "text/bar"]
+    %w[text/foobar text/foo text/bar].each do |type|
+      assert_equal Mime[:foobar], type
     end
+  ensure
+    Mime::Type.unregister(:foobar)
   end
 
   test "register callbacks" do
-    begin
-      registered_mimes = []
-      Mime::Type.register_callback do |mime|
-        registered_mimes << mime
-      end
-
-      mime = Mime::Type.register("text/foo", :foo)
-      assert_equal [mime], registered_mimes
-    ensure
-      Mime::Type.unregister(:foo)
+    registered_mimes = []
+    Mime::Type.register_callback do |mime|
+      registered_mimes << mime
     end
+
+    mime = Mime::Type.register("text/foo", :foo)
+    assert_equal [mime], registered_mimes
+  ensure
+    Mime::Type.unregister(:foo)
   end
 
   test "custom type with extension aliases" do
-    begin
-      Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
-      %w[foobar foo bar].each do |extension|
-        assert_equal Mime[:foobar], Mime::EXTENSION_LOOKUP[extension]
-      end
-    ensure
-      Mime::Type.unregister(:foobar)
+    Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
+    %w[foobar foo bar].each do |extension|
+      assert_equal Mime[:foobar], Mime::EXTENSION_LOOKUP[extension]
     end
+  ensure
+    Mime::Type.unregister(:foobar)
   end
 
   test "register alias" do
-    begin
-      Mime::Type.register_alias "application/xhtml+xml", :foobar
-      assert_equal Mime[:html], Mime::EXTENSION_LOOKUP["foobar"]
-    ensure
-      Mime::Type.unregister(:foobar)
-    end
+    Mime::Type.register_alias "application/xhtml+xml", :foobar
+    assert_equal Mime[:html], Mime::EXTENSION_LOOKUP["foobar"]
+  ensure
+    Mime::Type.unregister(:foobar)
   end
 
   test "type should be equal to symbol" do

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -74,17 +74,15 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
 
   test "occurring a parse error if parsing unsuccessful" do
     with_test_routing do
-      begin
-        $stderr = StringIO.new # suppress the log
-        json = "[\"person]\": {\"name\": \"David\"}}"
-        exception = assert_raise(ActionDispatch::Http::Parameters::ParseError) do
-          post "/parse", params: json, headers: { "CONTENT_TYPE" => "application/json", "action_dispatch.show_exceptions" => false }
-        end
-        assert_equal JSON::ParserError, exception.cause.class
-        assert_equal exception.cause.message, exception.message
-      ensure
-        $stderr = STDERR
+      $stderr = StringIO.new # suppress the log
+      json = "[\"person]\": {\"name\": \"David\"}}"
+      exception = assert_raise(ActionDispatch::Http::Parameters::ParseError) do
+        post "/parse", params: json, headers: { "CONTENT_TYPE" => "application/json", "action_dispatch.show_exceptions" => false }
       end
+      assert_equal JSON::ParserError, exception.cause.class
+      assert_equal exception.cause.message, exception.message
+    ensure
+      $stderr = STDERR
     end
   end
 
@@ -157,31 +155,27 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   end
 
   test "parses json params after custom json mime type registered" do
-    begin
-      Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
-      assert_parses(
-        { "user" => { "username" => "meinac" }, "username" => "meinac" },
-        "{\"username\": \"meinac\"}", "CONTENT_TYPE" => "application/json"
-      )
-    ensure
-      Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
-    end
+    Mime::Type.unregister :json
+    Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
+    assert_parses(
+      { "user" => { "username" => "meinac" }, "username" => "meinac" },
+      "{\"username\": \"meinac\"}", "CONTENT_TYPE" => "application/json"
+    )
+  ensure
+    Mime::Type.unregister :json
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
   end
 
   test "parses json params after custom json mime type registered with synonym" do
-    begin
-      Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
-      assert_parses(
-        { "user" => { "username" => "meinac" }, "username" => "meinac" },
-        "{\"username\": \"meinac\"}", "CONTENT_TYPE" => "application/vnd.rails+json"
-      )
-    ensure
-      Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
-    end
+    Mime::Type.unregister :json
+    Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
+    assert_parses(
+      { "user" => { "username" => "meinac" }, "username" => "meinac" },
+      "{\"username\": \"meinac\"}", "CONTENT_TYPE" => "application/vnd.rails+json"
+    )
+  ensure
+    Mime::Type.unregister :json
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
   end
 
   private

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -41,22 +41,20 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
   end
 
   test "display_image return artifact format when specify RAILS_SYSTEM_TESTING_SCREENSHOT environment" do
-    begin
-      original_output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
-      ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "artifact"
+    original_output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
+    ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "artifact"
 
-      new_test = DrivenBySeleniumWithChrome.new("x")
+    new_test = DrivenBySeleniumWithChrome.new("x")
 
-      assert_equal "artifact", new_test.send(:output_type)
+    assert_equal "artifact", new_test.send(:output_type)
 
-      Rails.stub :root, Pathname.getwd do
-        new_test.stub :passed?, false do
-          assert_match %r|url=artifact://.+?tmp/screenshots/failures_x\.png|, new_test.send(:display_image)
-        end
+    Rails.stub :root, Pathname.getwd do
+      new_test.stub :passed?, false do
+        assert_match %r|url=artifact://.+?tmp/screenshots/failures_x\.png|, new_test.send(:display_image)
       end
-    ensure
-      ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
     end
+  ensure
+    ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
   end
 
   test "image path returns the absolute path from root" do

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -14,14 +14,12 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 
   test "allows to override default_formats with ActionView::Base.default_formats" do
-    begin
-      formats = ActionView::Base.default_formats
-      ActionView::Base.default_formats = [:foo, :bar]
+    formats = ActionView::Base.default_formats
+    ActionView::Base.default_formats = [:foo, :bar]
 
-      assert_equal [:foo, :bar], ActionView::LookupContext.new([]).default_formats
-    ensure
-      ActionView::Base.default_formats = formats
-    end
+    assert_equal [:foo, :bar], ActionView::LookupContext.new([]).default_formats
+  ensure
+    ActionView::Base.default_formats = formats
   end
 
   test "process view paths on initialization" do

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -68,11 +68,9 @@ def run_without_aborting(tasks)
   errors = []
 
   tasks.each do |task|
-    begin
-      Rake::Task[task].invoke
-    rescue Exception
-      errors << task
-    end
+    Rake::Task[task].invoke
+  rescue Exception
+    errors << task
   end
 
   abort "Errors running #{errors.join(', ')}" if errors.any?

--- a/activejob/test/cases/callbacks_test.rb
+++ b/activejob/test/cases/callbacks_test.rb
@@ -25,26 +25,22 @@ class CallbacksTest < ActiveSupport::TestCase
   end
 
   test "#enqueue returns false when before_enqueue aborts callback chain and return_false_on_aborted_enqueue = true" do
-    begin
-      prev = ActiveJob::Base.return_false_on_aborted_enqueue
-      ActiveJob::Base.return_false_on_aborted_enqueue = true
-      assert_equal false, AbortBeforeEnqueueJob.new.enqueue
-    ensure
-      ActiveJob::Base.return_false_on_aborted_enqueue = prev
-    end
+    prev = ActiveJob::Base.return_false_on_aborted_enqueue
+    ActiveJob::Base.return_false_on_aborted_enqueue = true
+    assert_equal false, AbortBeforeEnqueueJob.new.enqueue
+  ensure
+    ActiveJob::Base.return_false_on_aborted_enqueue = prev
   end
 
   test "#enqueue returns self when before_enqueue aborts callback chain and return_false_on_aborted_enqueue = false" do
-    begin
-      prev = ActiveJob::Base.return_false_on_aborted_enqueue
-      ActiveJob::Base.return_false_on_aborted_enqueue = false
-      job = AbortBeforeEnqueueJob.new
-      assert_deprecated do
-        assert_equal job, job.enqueue
-      end
-    ensure
-      ActiveJob::Base.return_false_on_aborted_enqueue = prev
+    prev = ActiveJob::Base.return_false_on_aborted_enqueue
+    ActiveJob::Base.return_false_on_aborted_enqueue = false
+    job = AbortBeforeEnqueueJob.new
+    assert_deprecated do
+      assert_equal job, job.enqueue
     end
+  ensure
+    ActiveJob::Base.return_false_on_aborted_enqueue = prev
   end
 
   test "#enqueue returns self when the job was enqueued" do

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -54,23 +54,19 @@ class ExceptionsTest < ActiveJob::TestCase
 
   test "failed retry job when exception kept occurring against defaults" do
     perform_enqueued_jobs do
-      begin
-        RetryJob.perform_later "DefaultsError", 6
-        assert_equal "Raised DefaultsError for the 5th time", JobBuffer.last_value
-      rescue DefaultsError
-        pass
-      end
+      RetryJob.perform_later "DefaultsError", 6
+      assert_equal "Raised DefaultsError for the 5th time", JobBuffer.last_value
+    rescue DefaultsError
+      pass
     end
   end
 
   test "failed retry job when exception kept occurring against higher limit" do
     perform_enqueued_jobs do
-      begin
-        RetryJob.perform_later "ShortWaitTenAttemptsError", 11
-        assert_equal "Raised ShortWaitTenAttemptsError for the 10th time", JobBuffer.last_value
-      rescue ShortWaitTenAttemptsError
-        pass
-      end
+      RetryJob.perform_later "ShortWaitTenAttemptsError", 11
+      assert_equal "Raised ShortWaitTenAttemptsError for the 10th time", JobBuffer.last_value
+    rescue ShortWaitTenAttemptsError
+      pass
     end
   end
 

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -187,11 +187,9 @@ class LoggingTest < ActiveSupport::TestCase
 
   def test_retry_stopped_logging_without_block
     perform_enqueued_jobs do
-      begin
-        RetryJob.perform_later "DefaultsError", 6
-      rescue DefaultsError
-        assert_match(/Stopped retrying RetryJob due to a DefaultsError, which reoccurred on \d+ attempts\./, @logger.messages)
-      end
+      RetryJob.perform_later "DefaultsError", 6
+    rescue DefaultsError
+      assert_match(/Stopped retrying RetryJob due to a DefaultsError, which reoccurred on \d+ attempts\./, @logger.messages)
     end
   end
 

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -20,12 +20,10 @@ class QueuingTest < ActiveSupport::TestCase
   end
 
   test "run queued job later" do
-    begin
-      result = HelloJob.set(wait_until: 1.second.ago).perform_later "Jamie"
-      assert result
-    rescue NotImplementedError
-      skip
-    end
+    result = HelloJob.set(wait_until: 1.second.ago).perform_later "Jamie"
+    assert result
+  rescue NotImplementedError
+    skip
   end
 
   test "job returned by enqueue has the arguments available" do
@@ -34,11 +32,9 @@ class QueuingTest < ActiveSupport::TestCase
   end
 
   test "job returned by perform_at has the timestamp available" do
-    begin
-      job = HelloJob.set(wait_until: Time.utc(2014, 1, 1)).perform_later
-      assert_equal Time.utc(2014, 1, 1).to_f, job.scheduled_at
-    rescue NotImplementedError
-      skip
-    end
+    job = HelloJob.set(wait_until: Time.utc(2014, 1, 1)).perform_later
+    assert_equal Time.utc(2014, 1, 1).to_f, job.scheduled_at
+  rescue NotImplementedError
+    skip
   end
 end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -60,25 +60,21 @@ class QueuingTest < ActiveSupport::TestCase
   end
 
   test "should not run job enqueued in the future" do
-    begin
-      TestJob.set(wait: 10.minutes).perform_later @id
-      wait_for_jobs_to_finish_for(5.seconds)
-      assert_not job_executed
-    rescue NotImplementedError
-      skip
-    end
+    TestJob.set(wait: 10.minutes).perform_later @id
+    wait_for_jobs_to_finish_for(5.seconds)
+    assert_not job_executed
+  rescue NotImplementedError
+    skip
   end
 
   test "should run job enqueued in the future at the specified time" do
-    begin
-      TestJob.set(wait: 5.seconds).perform_later @id
-      wait_for_jobs_to_finish_for(2.seconds)
-      assert_not job_executed
-      wait_for_jobs_to_finish_for(10.seconds)
-      assert job_executed
-    rescue NotImplementedError
-      skip
-    end
+    TestJob.set(wait: 5.seconds).perform_later @id
+    wait_for_jobs_to_finish_for(2.seconds)
+    assert_not job_executed
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert job_executed
+  rescue NotImplementedError
+    skip
   end
 
   test "should supply a provider_job_id when available for immediate jobs" do

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -33,14 +33,12 @@ module TestCaseHelpers
     end
 
     def wait_for_jobs_to_finish_for(seconds = 60)
-      begin
-        Timeout.timeout(seconds) do
-          while !job_executed do
-            sleep 0.25
-          end
+      Timeout.timeout(seconds) do
+        while !job_executed do
+          sleep 0.25
         end
-      rescue Timeout::Error
       end
+    rescue Timeout::Error
     end
 
     def job_file(id)

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -106,14 +106,12 @@ class AttributeMethodsTest < ActiveModel::TestCase
   end
 
   test "#define_attribute_method generates attribute method" do
-    begin
-      ModelWithAttributes.define_attribute_method(:foo)
+    ModelWithAttributes.define_attribute_method(:foo)
 
-      assert_respond_to ModelWithAttributes.new, :foo
-      assert_equal "value of foo", ModelWithAttributes.new.foo
-    ensure
-      ModelWithAttributes.undefine_attribute_methods
-    end
+    assert_respond_to ModelWithAttributes.new, :foo
+    assert_equal "value of foo", ModelWithAttributes.new.foo
+  ensure
+    ModelWithAttributes.undefine_attribute_methods
   end
 
   test "#define_attribute_method does not generate attribute method if already defined in attribute module" do
@@ -140,36 +138,30 @@ class AttributeMethodsTest < ActiveModel::TestCase
   end
 
   test "#define_attribute_method generates attribute method with invalid identifier characters" do
-    begin
-      ModelWithWeirdNamesAttributes.define_attribute_method(:'a?b')
+    ModelWithWeirdNamesAttributes.define_attribute_method(:'a?b')
 
-      assert_respond_to ModelWithWeirdNamesAttributes.new, :'a?b'
-      assert_equal "value of a?b", ModelWithWeirdNamesAttributes.new.send("a?b")
-    ensure
-      ModelWithWeirdNamesAttributes.undefine_attribute_methods
-    end
+    assert_respond_to ModelWithWeirdNamesAttributes.new, :'a?b'
+    assert_equal "value of a?b", ModelWithWeirdNamesAttributes.new.send("a?b")
+  ensure
+    ModelWithWeirdNamesAttributes.undefine_attribute_methods
   end
 
   test "#define_attribute_methods works passing multiple arguments" do
-    begin
-      ModelWithAttributes.define_attribute_methods(:foo, :baz)
+    ModelWithAttributes.define_attribute_methods(:foo, :baz)
 
-      assert_equal "value of foo", ModelWithAttributes.new.foo
-      assert_equal "value of baz", ModelWithAttributes.new.baz
-    ensure
-      ModelWithAttributes.undefine_attribute_methods
-    end
+    assert_equal "value of foo", ModelWithAttributes.new.foo
+    assert_equal "value of baz", ModelWithAttributes.new.baz
+  ensure
+    ModelWithAttributes.undefine_attribute_methods
   end
 
   test "#define_attribute_methods generates attribute methods" do
-    begin
-      ModelWithAttributes.define_attribute_methods(:foo)
+    ModelWithAttributes.define_attribute_methods(:foo)
 
-      assert_respond_to ModelWithAttributes.new, :foo
-      assert_equal "value of foo", ModelWithAttributes.new.foo
-    ensure
-      ModelWithAttributes.undefine_attribute_methods
-    end
+    assert_respond_to ModelWithAttributes.new, :foo
+    assert_equal "value of foo", ModelWithAttributes.new.foo
+  ensure
+    ModelWithAttributes.undefine_attribute_methods
   end
 
   test "#alias_attribute generates attribute_aliases lookup hash" do
@@ -182,38 +174,32 @@ class AttributeMethodsTest < ActiveModel::TestCase
   end
 
   test "#define_attribute_methods generates attribute methods with spaces in their names" do
-    begin
-      ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
+    ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
 
-      assert_respond_to ModelWithAttributesWithSpaces.new, :'foo bar'
-      assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.send(:'foo bar')
-    ensure
-      ModelWithAttributesWithSpaces.undefine_attribute_methods
-    end
+    assert_respond_to ModelWithAttributesWithSpaces.new, :'foo bar'
+    assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.send(:'foo bar')
+  ensure
+    ModelWithAttributesWithSpaces.undefine_attribute_methods
   end
 
   test "#alias_attribute works with attributes with spaces in their names" do
-    begin
-      ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
-      ModelWithAttributesWithSpaces.alias_attribute(:'foo_bar', :'foo bar')
+    ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
+    ModelWithAttributesWithSpaces.alias_attribute(:'foo_bar', :'foo bar')
 
-      assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.foo_bar
-    ensure
-      ModelWithAttributesWithSpaces.undefine_attribute_methods
-    end
+    assert_equal "value of foo bar", ModelWithAttributesWithSpaces.new.foo_bar
+  ensure
+    ModelWithAttributesWithSpaces.undefine_attribute_methods
   end
 
   test "#alias_attribute works with attributes named as a ruby keyword" do
-    begin
-      ModelWithRubyKeywordNamedAttributes.define_attribute_methods([:begin, :end])
-      ModelWithRubyKeywordNamedAttributes.alias_attribute(:from, :begin)
-      ModelWithRubyKeywordNamedAttributes.alias_attribute(:to, :end)
+    ModelWithRubyKeywordNamedAttributes.define_attribute_methods([:begin, :end])
+    ModelWithRubyKeywordNamedAttributes.alias_attribute(:from, :begin)
+    ModelWithRubyKeywordNamedAttributes.alias_attribute(:to, :end)
 
-      assert_equal "value of begin", ModelWithRubyKeywordNamedAttributes.new.from
-      assert_equal "value of end", ModelWithRubyKeywordNamedAttributes.new.to
-    ensure
-      ModelWithRubyKeywordNamedAttributes.undefine_attribute_methods
-    end
+    assert_equal "value of begin", ModelWithRubyKeywordNamedAttributes.new.from
+    assert_equal "value of end", ModelWithRubyKeywordNamedAttributes.new.to
+  ensure
+    ModelWithRubyKeywordNamedAttributes.undefine_attribute_methods
   end
 
   test "#undefine_attribute_methods removes attribute methods" do

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -206,16 +206,14 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   test "Password digest cost honors bcrypt cost attribute when min_cost is false" do
-    begin
-      original_bcrypt_cost = BCrypt::Engine.cost
-      ActiveModel::SecurePassword.min_cost = false
-      BCrypt::Engine.cost = 5
+    original_bcrypt_cost = BCrypt::Engine.cost
+    ActiveModel::SecurePassword.min_cost = false
+    BCrypt::Engine.cost = 5
 
-      @user.password = "secret"
-      assert_equal BCrypt::Engine.cost, @user.password_digest.cost
-    ensure
-      BCrypt::Engine.cost = original_bcrypt_cost
-    end
+    @user.password = "secret"
+    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
+  ensure
+    BCrypt::Engine.cost = original_bcrypt_cost
   end
 
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -26,20 +26,18 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "should include root in json if include_root_in_json is true" do
-    begin
-      original_include_root_in_json = Contact.include_root_in_json
-      Contact.include_root_in_json = true
-      json = @contact.to_json
+    original_include_root_in_json = Contact.include_root_in_json
+    Contact.include_root_in_json = true
+    json = @contact.to_json
 
-      assert_match %r{^\{"contact":\{}, json
-      assert_match %r{"name":"Konata Izumi"}, json
-      assert_match %r{"age":16}, json
-      assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
-      assert_match %r{"awesome":true}, json
-      assert_match %r{"preferences":\{"shows":"anime"\}}, json
-    ensure
-      Contact.include_root_in_json = original_include_root_in_json
-    end
+    assert_match %r{^\{"contact":\{}, json
+    assert_match %r{"name":"Konata Izumi"}, json
+    assert_match %r{"age":16}, json
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
+    assert_match %r{"awesome":true}, json
+    assert_match %r{"preferences":\{"shows":"anime"\}}, json
+  ensure
+    Contact.include_root_in_json = original_include_root_in_json
   end
 
   test "should include root in json (option) even if the default is set to false" do
@@ -134,19 +132,17 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "as_json should return a hash if include_root_in_json is true" do
-    begin
-      original_include_root_in_json = Contact.include_root_in_json
-      Contact.include_root_in_json = true
-      json = @contact.as_json
+    original_include_root_in_json = Contact.include_root_in_json
+    Contact.include_root_in_json = true
+    json = @contact.as_json
 
-      assert_kind_of Hash, json
-      assert_kind_of Hash, json["contact"]
-      %w(name age created_at awesome preferences).each do |field|
-        assert_equal @contact.send(field).as_json, json["contact"][field]
-      end
-    ensure
-      Contact.include_root_in_json = original_include_root_in_json
+    assert_kind_of Hash, json
+    assert_kind_of Hash, json["contact"]
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.send(field).as_json, json["contact"][field]
     end
+  ensure
+    Contact.include_root_in_json = original_include_root_in_json
   end
 
   test "from_json should work without a root (class attribute)" do

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -66,24 +66,22 @@ class ConfirmationValidationTest < ActiveModel::TestCase
   end
 
   def test_title_confirmation_with_i18n_attribute
-    begin
-      @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
-      I18n.load_path.clear
-      I18n.backend = I18n::Backend::Simple.new
-      I18n.backend.store_translations("en",
-        errors: { messages: { confirmation: "doesn't match %{attribute}" } },
-        activemodel: { attributes: { topic: { title: "Test Title" } } })
+    @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
+    I18n.load_path.clear
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend.store_translations("en",
+      errors: { messages: { confirmation: "doesn't match %{attribute}" } },
+      activemodel: { attributes: { topic: { title: "Test Title" } } })
 
-      Topic.validates_confirmation_of(:title)
+    Topic.validates_confirmation_of(:title)
 
-      t = Topic.new("title" => "We should be confirmed", "title_confirmation" => "")
-      assert_predicate t, :invalid?
-      assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
-    ensure
-      I18n.load_path.replace @old_load_path
-      I18n.backend = @old_backend
-      I18n.backend.reload!
-    end
+    t = Topic.new("title" => "We should be confirmed", "title_confirmation" => "")
+    assert_predicate t, :invalid?
+    assert_equal ["doesn't match Test Title"], t.errors[:title_confirmation]
+  ensure
+    I18n.load_path.replace @old_load_path
+    I18n.backend = @old_backend
+    I18n.backend.reload!
   end
 
   test "does not override confirmation reader if present" do

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -9,11 +9,9 @@ def run_without_aborting(*tasks)
   errors = []
 
   tasks.each do |task|
-    begin
-      Rake::Task[task].invoke
-    rescue Exception
-      errors << task
-    end
+    Rake::Task[task].invoke
+  rescue Exception
+    errors << task
   end
 
   abort "Errors running #{errors.join(', ')}" if errors.any?

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -45,16 +45,14 @@ module ActiveRecord
       def execute_callstack_for_multiparameter_attributes(callstack)
         errors = []
         callstack.each do |name, values_with_empty_parameters|
-          begin
-            if values_with_empty_parameters.each_value.all?(&:nil?)
-              values = nil
-            else
-              values = values_with_empty_parameters
-            end
-            send("#{name}=", values)
-          rescue => ex
-            errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+          if values_with_empty_parameters.each_value.all?(&:nil?)
+            values = nil
+          else
+            values = values_with_empty_parameters
           end
+          send("#{name}=", values)
+        rescue => ex
+          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
         end
         unless errors.empty?
           error_descriptions = errors.map(&:message).join(",")

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -631,13 +631,11 @@ module ActiveRecord
             statement_name:    statement_name,
             connection_id:     object_id,
             connection:        self) do
-            begin
-              @lock.synchronize do
-                yield
-              end
-            rescue => e
-              raise translate_exception_class(e, sql, binds)
+            @lock.synchronize do
+              yield
             end
+          rescue => e
+            raise translate_exception_class(e, sql, binds)
           end
         end
 

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -124,15 +124,13 @@ module ActiveRecord
       end
 
       def build_db_config_from_string(env_name, spec_name, config)
-        begin
-          url = config
-          uri = URI.parse(url)
-          if uri.try(:scheme)
-            ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url)
-          end
-        rescue URI::InvalidURIError
-          ActiveRecord::DatabaseConfigurations::HashConfig.new(env_name, spec_name, config)
+        url = config
+        uri = URI.parse(url)
+        if uri.try(:scheme)
+          ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url)
         end
+      rescue URI::InvalidURIError
+        ActiveRecord::DatabaseConfigurations::HashConfig.new(env_name, spec_name, config)
       end
 
       def build_db_config_from_hash(env_name, spec_name, config)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -519,11 +519,9 @@ module ActiveRecord
       def instantiate_fixtures(object, fixture_set, load_instances = true)
         return unless load_instances
         fixture_set.each do |fixture_name, fixture|
-          begin
-            object.instance_variable_set "@#{fixture_name}", fixture.find
-          rescue FixtureClassNotFound
-            nil
-          end
+          object.instance_variable_set "@#{fixture_name}", fixture.find
+        rescue FixtureClassNotFound
+          nil
         end
       end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -191,11 +191,9 @@ db_namespace = namespace :db do
 
   # desc "Retrieves the collation for the current environment's database"
   task collation: :load_config do
-    begin
-      puts ActiveRecord::Tasks::DatabaseTasks.collation_current
-    rescue NoMethodError
-      $stderr.puts "Sorry, your database adapter is not supported yet. Feel free to submit a patch."
-    end
+    puts ActiveRecord::Tasks::DatabaseTasks.collation_current
+  rescue NoMethodError
+    $stderr.puts "Sorry, your database adapter is not supported yet. Feel free to submit a patch."
   end
 
   desc "Retrieves the current schema version number"
@@ -361,17 +359,15 @@ db_namespace = namespace :db do
 
     # desc "Recreate the test database from an existent schema.rb file"
     task load_schema: %w(db:test:purge) do
-      begin
-        should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
-        ActiveRecord::Schema.verbose = false
-        ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
-          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, :ruby, filename, "test")
-        end
-      ensure
-        if should_reconnect
-          ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.default_hash(ActiveRecord::Tasks::DatabaseTasks.env))
-        end
+      should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
+      ActiveRecord::Schema.verbose = false
+      ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
+        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, :ruby, filename, "test")
+      end
+    ensure
+      if should_reconnect
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.default_hash(ActiveRecord::Tasks::DatabaseTasks.env))
       end
     end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -132,19 +132,17 @@ module ActiveRecord
       end
 
       def test_not_specifying_database_name_for_cross_database_selects
-        begin
-          assert_nothing_raised do
-            ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"].except(:database))
+        assert_nothing_raised do
+          ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"].except(:database))
 
-            config = ARTest.connection_config
-            ActiveRecord::Base.connection.execute(
-              "SELECT #{config['arunit']['database']}.pirates.*, #{config['arunit2']['database']}.courses.* " \
-              "FROM #{config['arunit']['database']}.pirates, #{config['arunit2']['database']}.courses"
-            )
-          end
-        ensure
-          ActiveRecord::Base.establish_connection :arunit
+          config = ARTest.connection_config
+          ActiveRecord::Base.connection.execute(
+            "SELECT #{config['arunit']['database']}.pirates.*, #{config['arunit2']['database']}.courses.* " \
+            "FROM #{config['arunit']['database']}.pirates, #{config['arunit2']['database']}.courses"
+          )
         end
+      ensure
+        ActiveRecord::Base.establish_connection :arunit
       end
     end
 

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -130,29 +130,25 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
 
   def test_add_timestamps
     with_real_execute do
-      begin
-        ActiveRecord::Base.connection.create_table :delete_me
-        ActiveRecord::Base.connection.add_timestamps :delete_me, null: true
-        assert column_present?("delete_me", "updated_at", "datetime")
-        assert column_present?("delete_me", "created_at", "datetime")
-      ensure
-        ActiveRecord::Base.connection.drop_table :delete_me rescue nil
-      end
+      ActiveRecord::Base.connection.create_table :delete_me
+      ActiveRecord::Base.connection.add_timestamps :delete_me, null: true
+      assert column_present?("delete_me", "updated_at", "datetime")
+      assert column_present?("delete_me", "created_at", "datetime")
+    ensure
+      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
     end
   end
 
   def test_remove_timestamps
     with_real_execute do
-      begin
-        ActiveRecord::Base.connection.create_table :delete_me do |t|
-          t.timestamps null: true
-        end
-        ActiveRecord::Base.connection.remove_timestamps :delete_me, null: true
-        assert_not column_present?("delete_me", "updated_at", "datetime")
-        assert_not column_present?("delete_me", "created_at", "datetime")
-      ensure
-        ActiveRecord::Base.connection.drop_table :delete_me rescue nil
+      ActiveRecord::Base.connection.create_table :delete_me do |t|
+        t.timestamps null: true
       end
+      ActiveRecord::Base.connection.remove_timestamps :delete_me, null: true
+      assert_not column_present?("delete_me", "updated_at", "datetime")
+      assert_not column_present?("delete_me", "created_at", "datetime")
+    ensure
+      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -71,17 +71,15 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "assigning 'infinity' on a datetime column with TZ aware attributes" do
-    begin
-      in_time_zone "Pacific Time (US & Canada)" do
-        record = PostgresqlInfinity.create!(datetime: "infinity")
-        assert_equal Float::INFINITY, record.datetime
-        assert_equal record.datetime, record.reload.datetime
-      end
-    ensure
-      # setting time_zone_aware_attributes causes the types to change.
-      # There is no way to do this automatically since it can be set on a superclass
-      PostgresqlInfinity.reset_column_information
+    in_time_zone "Pacific Time (US & Canada)" do
+      record = PostgresqlInfinity.create!(datetime: "infinity")
+      assert_equal Float::INFINITY, record.datetime
+      assert_equal record.datetime, record.reload.datetime
     end
+  ensure
+    # setting time_zone_aware_attributes causes the types to change.
+    # There is no way to do this automatically since it can be set on a superclass
+    PostgresqlInfinity.reset_column_information
   end
 
   test "where clause with infinite range on a datetime column" do

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -108,23 +108,19 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_create_schema
-    begin
-      @connection.create_schema "test_schema3"
-      assert @connection.schema_names.include? "test_schema3"
-    ensure
-      @connection.drop_schema "test_schema3"
-    end
+    @connection.create_schema "test_schema3"
+    assert @connection.schema_names.include? "test_schema3"
+  ensure
+    @connection.drop_schema "test_schema3"
   end
 
   def test_raise_create_schema_with_existing_schema
-    begin
+    @connection.create_schema "test_schema3"
+    assert_raises(ActiveRecord::StatementInvalid) do
       @connection.create_schema "test_schema3"
-      assert_raises(ActiveRecord::StatementInvalid) do
-        @connection.create_schema "test_schema3"
-      end
-    ensure
-      @connection.drop_schema "test_schema3"
     end
+  ensure
+    @connection.drop_schema "test_schema3"
   end
 
   def test_drop_schema

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -8,17 +8,15 @@ module ActiveRecord
     class SQLite3CreateFolder < ActiveRecord::SQLite3TestCase
       def test_sqlite_creates_directory
         Dir.mktmpdir do |dir|
-          begin
-            dir = Pathname.new(dir)
-            @conn = Base.sqlite3_connection database: dir.join("db/foo.sqlite3"),
-                                 adapter: "sqlite3",
-                                 timeout: 100
+          dir = Pathname.new(dir)
+          @conn = Base.sqlite3_connection database: dir.join("db/foo.sqlite3"),
+                               adapter: "sqlite3",
+                               timeout: 100
 
-            assert Dir.exist? dir.join("db")
-            assert File.exist? dir.join("db/foo.sqlite3")
-          ensure
-            @conn.disconnect! if @conn
-          end
+          assert Dir.exist? dir.join("db")
+          assert File.exist? dir.join("db/foo.sqlite3")
+        ensure
+          @conn.disconnect! if @conn
         end
       end
     end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -1007,16 +1007,14 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_and_belongs_to_many_while_partial_writes_false
-    begin
-      original_partial_writes = ActiveRecord::Base.partial_writes
-      ActiveRecord::Base.partial_writes = false
-      developer = Developer.new(name: "Mehmet Emin İNAÇ")
-      developer.projects << Project.new(name: "Bounty")
+    original_partial_writes = ActiveRecord::Base.partial_writes
+    ActiveRecord::Base.partial_writes = false
+    developer = Developer.new(name: "Mehmet Emin İNAÇ")
+    developer.projects << Project.new(name: "Bounty")
 
-      assert developer.save
-    ensure
-      ActiveRecord::Base.partial_writes = original_partial_writes
-    end
+    assert developer.save
+  ensure
+    ActiveRecord::Base.partial_writes = original_partial_writes
   end
 
   def test_has_and_belongs_to_many_with_belongs_to

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -25,20 +25,18 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   test "belongs_to associations can be optional by default" do
-    begin
-      original_value = ActiveRecord::Base.belongs_to_required_by_default
-      ActiveRecord::Base.belongs_to_required_by_default = false
+    original_value = ActiveRecord::Base.belongs_to_required_by_default
+    ActiveRecord::Base.belongs_to_required_by_default = false
 
-      model = subclass_of(Child) do
-        belongs_to :parent, inverse_of: false,
-          class_name: "RequiredAssociationsTest::Parent"
-      end
-
-      assert model.new.save
-      assert model.new(parent: Parent.new).save
-    ensure
-      ActiveRecord::Base.belongs_to_required_by_default = original_value
+    model = subclass_of(Child) do
+      belongs_to :parent, inverse_of: false,
+        class_name: "RequiredAssociationsTest::Parent"
     end
+
+    assert model.new.save
+    assert model.new(parent: Parent.new).save
+  ensure
+    ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
   test "required belongs_to associations have presence validated" do
@@ -56,24 +54,22 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   test "belongs_to associations can be required by default" do
-    begin
-      original_value = ActiveRecord::Base.belongs_to_required_by_default
-      ActiveRecord::Base.belongs_to_required_by_default = true
+    original_value = ActiveRecord::Base.belongs_to_required_by_default
+    ActiveRecord::Base.belongs_to_required_by_default = true
 
-      model = subclass_of(Child) do
-        belongs_to :parent, inverse_of: false,
-          class_name: "RequiredAssociationsTest::Parent"
-      end
-
-      record = model.new
-      assert_not record.save
-      assert_equal ["Parent must exist"], record.errors.full_messages
-
-      record.parent = Parent.new
-      assert record.save
-    ensure
-      ActiveRecord::Base.belongs_to_required_by_default = original_value
+    model = subclass_of(Child) do
+      belongs_to :parent, inverse_of: false,
+        class_name: "RequiredAssociationsTest::Parent"
     end
+
+    record = model.new
+    assert_not record.save
+    assert_equal ["Parent must exist"], record.errors.full_messages
+
+    record.parent = Parent.new
+    assert record.save
+  ensure
+    ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
   test "has_one associations are not required by default" do

--- a/activerecord/test/cases/errors_test.rb
+++ b/activerecord/test/cases/errors_test.rb
@@ -8,11 +8,9 @@ class ErrorsTest < ActiveRecord::TestCase
     error_klasses = ObjectSpace.each_object(Class).select { |klass| klass < base }
 
     (error_klasses - [ActiveRecord::AmbiguousSourceReflectionForThroughAssociation]).each do |error_klass|
-      begin
-        error_klass.new.inspect
-      rescue ArgumentError
-        raise "Instance of #{error_klass} can't be initialized with no arguments"
-      end
+      error_klass.new.inspect
+    rescue ArgumentError
+      raise "Instance of #{error_klass} can't be initialized with no arguments"
     end
   end
 end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -90,15 +90,13 @@ class FilterAttributesTest < ActiveRecord::TestCase
   end
 
   test "filter_attributes should handle [FILTERED] value properly" do
-    begin
-      User.filter_attributes = ["auth"]
-      user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
+    User.filter_attributes = ["auth"]
+    user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
 
-      assert_includes user.inspect, "auth_token: [FILTERED]"
-      assert_includes user.inspect, 'token: "[FILTERED]"'
-    ensure
-      User.remove_instance_variable(:@filter_attributes)
-    end
+    assert_includes user.inspect, "auth_token: [FILTERED]"
+    assert_includes user.inspect, 'token: "[FILTERED]"'
+  ensure
+    User.remove_instance_variable(:@filter_attributes)
   end
 
   test "filter_attributes on pretty_print" do
@@ -121,16 +119,14 @@ class FilterAttributesTest < ActiveRecord::TestCase
   end
 
   test "filter_attributes on pretty_print should handle [FILTERED] value properly" do
-    begin
-      User.filter_attributes = ["auth"]
-      user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
-      actual = "".dup
-      PP.pp(user, StringIO.new(actual))
+    User.filter_attributes = ["auth"]
+    user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
 
-      assert_includes actual, "auth_token: [FILTERED]"
-      assert_includes actual, 'token: "[FILTERED]"'
-    ensure
-      User.remove_instance_variable(:@filter_attributes)
-    end
+    assert_includes actual, "auth_token: [FILTERED]"
+    assert_includes actual, 'token: "[FILTERED]"'
+  ensure
+    User.remove_instance_variable(:@filter_attributes)
   end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -73,14 +73,12 @@ class FixturesTest < ActiveRecord::TestCase
 
   if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
     def test_bulk_insert
-      begin
-        subscriber = InsertQuerySubscriber.new
-        subscription = ActiveSupport::Notifications.subscribe("sql.active_record", subscriber)
-        create_fixtures("bulbs")
-        assert_equal 1, subscriber.events.size, "It takes one INSERT query to insert two fixtures"
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscription)
-      end
+      subscriber = InsertQuerySubscriber.new
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record", subscriber)
+      create_fixtures("bulbs")
+      assert_equal 1, subscriber.events.size, "It takes one INSERT query to insert two fixtures"
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription)
     end
 
     def test_bulk_insert_multiple_table_with_a_multi_statement_query

--- a/activerecord/test/cases/habtm_destroy_order_test.rb
+++ b/activerecord/test/cases/habtm_destroy_order_test.rb
@@ -30,23 +30,21 @@ class HabtmDestroyOrderTest < ActiveRecord::TestCase
 
   test "not destroying a student with lessons leaves student<=>lesson association intact" do
     # test a normal before_destroy doesn't destroy the habtm joins
-    begin
-      sicp = Lesson.new(name: "SICP")
-      ben = Student.new(name: "Ben Bitdiddle")
-      # add a before destroy to student
-      Student.class_eval do
-        before_destroy do
-          raise ActiveRecord::Rollback unless lessons.empty?
-        end
+    sicp = Lesson.new(name: "SICP")
+    ben = Student.new(name: "Ben Bitdiddle")
+    # add a before destroy to student
+    Student.class_eval do
+      before_destroy do
+        raise ActiveRecord::Rollback unless lessons.empty?
       end
-      ben.lessons << sicp
-      ben.save!
-      ben.destroy
-      assert_not_empty ben.reload.lessons
-    ensure
-      # get rid of it so Student is still like it was
-      Student.reset_callbacks(:destroy)
     end
+    ben.lessons << sicp
+    ben.save!
+    ben.destroy
+    assert_not_empty ben.reload.lessons
+  ensure
+    # get rid of it so Student is still like it was
+    Student.reset_callbacks(:destroy)
   end
 
   test "not destroying a lesson with students leaves student<=>lesson association intact" do

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -152,25 +152,23 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         test "foreign key methods respect pluralize_table_names" do
-          begin
-            original_pluralize_table_names = ActiveRecord::Base.pluralize_table_names
-            ActiveRecord::Base.pluralize_table_names = false
-            @connection.create_table :testing
-            @connection.change_table :testing_parents do |t|
-              t.references :testing, foreign_key: true
-            end
-
-            fk = @connection.foreign_keys("testing_parents").first
-            assert_equal "testing_parents", fk.from_table
-            assert_equal "testing", fk.to_table
-
-            assert_difference "@connection.foreign_keys('testing_parents').size", -1 do
-              @connection.remove_reference :testing_parents, :testing, foreign_key: true
-            end
-          ensure
-            ActiveRecord::Base.pluralize_table_names = original_pluralize_table_names
-            @connection.drop_table "testing", if_exists: true
+          original_pluralize_table_names = ActiveRecord::Base.pluralize_table_names
+          ActiveRecord::Base.pluralize_table_names = false
+          @connection.create_table :testing
+          @connection.change_table :testing_parents do |t|
+            t.references :testing, foreign_key: true
           end
+
+          fk = @connection.foreign_keys("testing_parents").first
+          assert_equal "testing_parents", fk.from_table
+          assert_equal "testing", fk.to_table
+
+          assert_difference "@connection.foreign_keys('testing_parents').size", -1 do
+            @connection.remove_reference :testing_parents, :testing, foreign_key: true
+          end
+        ensure
+          ActiveRecord::Base.pluralize_table_names = original_pluralize_table_names
+          @connection.drop_table "testing", if_exists: true
         end
 
         class CreateDogsMigration < ActiveRecord::Migration::Current

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -576,29 +576,25 @@ class MigrationTest < ActiveRecord::TestCase
       # table name is 29 chars, the standard sequence name will
       # be 33 chars and should be shortened
       assert_nothing_raised do
-        begin
-          Person.connection.create_table :table_with_name_thats_just_ok do |t|
-            t.column :foo, :string, null: false
-          end
-        ensure
-          Person.connection.drop_table :table_with_name_thats_just_ok rescue nil
+        Person.connection.create_table :table_with_name_thats_just_ok do |t|
+          t.column :foo, :string, null: false
         end
+      ensure
+        Person.connection.drop_table :table_with_name_thats_just_ok rescue nil
       end
 
       # should be all good w/ a custom sequence name
       assert_nothing_raised do
-        begin
-          Person.connection.create_table :table_with_name_thats_just_ok,
-            sequence_name: "suitably_short_seq" do |t|
-            t.column :foo, :string, null: false
-          end
-
-          Person.connection.execute("select suitably_short_seq.nextval from dual")
-
-        ensure
-          Person.connection.drop_table :table_with_name_thats_just_ok,
-            sequence_name: "suitably_short_seq" rescue nil
+        Person.connection.create_table :table_with_name_thats_just_ok,
+          sequence_name: "suitably_short_seq" do |t|
+          t.column :foo, :string, null: false
         end
+
+        Person.connection.execute("select suitably_short_seq.nextval from dual")
+
+      ensure
+        Person.connection.drop_table :table_with_name_thats_just_ok,
+          sequence_name: "suitably_short_seq" rescue nil
       end
 
       # confirm the custom sequence got dropped
@@ -742,15 +738,13 @@ class MigrationTest < ActiveRecord::TestCase
       test_terminated = Concurrent::CountDownLatch.new
 
       other_process = Thread.new do
-        begin
-          conn = ActiveRecord::Base.connection_pool.checkout
-          conn.get_advisory_lock(lock_id)
-          thread_lock.count_down
-          test_terminated.wait # hold the lock open until we tested everything
-        ensure
-          conn.release_advisory_lock(lock_id)
-          ActiveRecord::Base.connection_pool.checkin(conn)
-        end
+        conn = ActiveRecord::Base.connection_pool.checkout
+        conn.get_advisory_lock(lock_id)
+        thread_lock.count_down
+        test_terminated.wait # hold the lock open until we tested everything
+      ensure
+        conn.release_advisory_lock(lock_id)
+        ActiveRecord::Base.connection_pool.checkin(conn)
       end
 
       thread_lock.wait # wait until the 'other process' has the lock

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -106,14 +106,12 @@ class MultipleDbTest < ActiveRecord::TestCase
     end
 
     def test_associations_should_work_when_model_has_no_connection
-      begin
-        ActiveRecord::Base.remove_connection
-        assert_nothing_raised do
-          College.first.courses.first
-        end
-      ensure
-        ActiveRecord::Base.establish_connection :arunit
+      ActiveRecord::Base.remove_connection
+      assert_nothing_raised do
+        College.first.courses.first
       end
+    ensure
+      ActiveRecord::Base.establish_connection :arunit
     end
   end
 end

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -25,14 +25,12 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     @timed_out = 0
     threads.times do
       Thread.new do
-        begin
-          conn = ActiveRecord::Base.connection_pool.checkout
-          sleep 0.1
-          ActiveRecord::Base.connection_pool.checkin conn
-          @connection_count += 1
-        rescue ActiveRecord::ConnectionTimeoutError
-          @timed_out += 1
-        end
+        conn = ActiveRecord::Base.connection_pool.checkout
+        sleep 0.1
+        ActiveRecord::Base.connection_pool.checkin conn
+        @connection_count += 1
+      rescue ActiveRecord::ConnectionTimeoutError
+        @timed_out += 1
       end.join
     end
   end
@@ -42,14 +40,12 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     @connection_count = 0
     @timed_out = 0
     loops.times do
-      begin
-        conn = ActiveRecord::Base.connection_pool.checkout
-        ActiveRecord::Base.connection_pool.checkin conn
-        @connection_count += 1
-        ActiveRecord::Base.connection.data_sources
-      rescue ActiveRecord::ConnectionTimeoutError
-        @timed_out += 1
-      end
+      conn = ActiveRecord::Base.connection_pool.checkout
+      ActiveRecord::Base.connection_pool.checkin conn
+      @connection_count += 1
+      ActiveRecord::Base.connection.data_sources
+    rescue ActiveRecord::ConnectionTimeoutError
+      @timed_out += 1
     end
   end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -73,76 +73,74 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_query_cache_across_threads
     with_temporary_connection_pool do
-      begin
-        if in_memory_db?
-          # Separate connections to an in-memory database create an entirely new database,
-          # with an empty schema etc, so we just stub out this schema on the fly.
-          ActiveRecord::Base.connection_pool.with_connection do |connection|
-            connection.create_table :tasks do |t|
-              t.datetime :starting
-              t.datetime :ending
-            end
+      if in_memory_db?
+        # Separate connections to an in-memory database create an entirely new database,
+        # with an empty schema etc, so we just stub out this schema on the fly.
+        ActiveRecord::Base.connection_pool.with_connection do |connection|
+          connection.create_table :tasks do |t|
+            t.datetime :starting
+            t.datetime :ending
           end
-          ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_path, ["tasks"], {}, ActiveRecord::Base)
         end
-
-        ActiveRecord::Base.connection_pool.connections.each do |conn|
-          assert_cache :off, conn
-        end
-
-        assert_not_predicate ActiveRecord::Base.connection, :nil?
-        assert_cache :off
-
-        middleware {
-          assert_cache :clean
-
-          Task.find 1
-          assert_cache :dirty
-
-          thread_1_connection = ActiveRecord::Base.connection
-          ActiveRecord::Base.clear_active_connections!
-          assert_cache :off, thread_1_connection
-
-          started = Concurrent::Event.new
-          checked = Concurrent::Event.new
-
-          thread_2_connection = nil
-          thread = Thread.new {
-            thread_2_connection = ActiveRecord::Base.connection
-
-            assert_equal thread_2_connection, thread_1_connection
-            assert_cache :off
-
-            middleware {
-              assert_cache :clean
-
-              Task.find 1
-              assert_cache :dirty
-
-              started.set
-              checked.wait
-
-              ActiveRecord::Base.clear_active_connections!
-            }.call({})
-          }
-
-          started.wait
-
-          thread_1_connection = ActiveRecord::Base.connection
-          assert_not_equal thread_1_connection, thread_2_connection
-          assert_cache :dirty, thread_2_connection
-          checked.set
-          thread.join
-
-          assert_cache :off, thread_2_connection
-        }.call({})
-
-        ActiveRecord::Base.connection_pool.connections.each do |conn|
-          assert_cache :off, conn
-        end
-      ensure
-        ActiveRecord::Base.connection_pool.disconnect!
+        ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_path, ["tasks"], {}, ActiveRecord::Base)
       end
+
+      ActiveRecord::Base.connection_pool.connections.each do |conn|
+        assert_cache :off, conn
+      end
+
+      assert_not_predicate ActiveRecord::Base.connection, :nil?
+      assert_cache :off
+
+      middleware {
+        assert_cache :clean
+
+        Task.find 1
+        assert_cache :dirty
+
+        thread_1_connection = ActiveRecord::Base.connection
+        ActiveRecord::Base.clear_active_connections!
+        assert_cache :off, thread_1_connection
+
+        started = Concurrent::Event.new
+        checked = Concurrent::Event.new
+
+        thread_2_connection = nil
+        thread = Thread.new {
+          thread_2_connection = ActiveRecord::Base.connection
+
+          assert_equal thread_2_connection, thread_1_connection
+          assert_cache :off
+
+          middleware {
+            assert_cache :clean
+
+            Task.find 1
+            assert_cache :dirty
+
+            started.set
+            checked.wait
+
+            ActiveRecord::Base.clear_active_connections!
+          }.call({})
+        }
+
+        started.wait
+
+        thread_1_connection = ActiveRecord::Base.connection
+        assert_not_equal thread_1_connection, thread_2_connection
+        assert_cache :dirty, thread_2_connection
+        checked.set
+        thread.join
+
+        assert_cache :off, thread_2_connection
+      }.call({})
+
+      ActiveRecord::Base.connection_pool.connections.each do |conn|
+        assert_cache :off, conn
+      end
+    ensure
+      ActiveRecord::Base.connection_pool.disconnect!
     end
   end
 
@@ -369,12 +367,10 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert_not_predicate Task, :connected?
 
       Task.cache do
-        begin
-          assert_queries(1) { Task.find(1); Task.find(1) }
-        ensure
-          ActiveRecord::Base.connection_handler.remove_connection(Task.connection_specification_name)
-          Task.connection_specification_name = spec_name
-        end
+        assert_queries(1) { Task.find(1); Task.find(1) }
+      ensure
+        ActiveRecord::Base.connection_handler.remove_connection(Task.connection_specification_name)
+        Task.connection_specification_name = spec_name
       end
     end
   end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -198,11 +198,9 @@ class UpdateAllTest < ActiveRecord::TestCase
     def test_update_all_doesnt_ignore_order
       assert_equal authors(:david).id + 1, authors(:mary).id # make sure there is going to be a duplicate PK error
       test_update_with_order_succeeds = lambda do |order|
-        begin
-          Author.order(order).update_all("id = id + 1")
-        rescue ActiveRecord::ActiveRecordError
-          false
-        end
+        Author.order(order).update_all("id = id + 1")
+      rescue ActiveRecord::ActiveRecordError
+        false
       end
 
       if test_update_with_order_succeeds.call("id DESC")

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -51,12 +51,10 @@ module ActiveStorage
 
     def delete(key)
       instrument :delete, key: key do
-        begin
-          blobs.delete_blob(container, key)
-        rescue Azure::Core::Http::HTTPError => e
-          raise unless e.type == "BlobNotFound"
-          # Ignore files already deleted
-        end
+        blobs.delete_blob(container, key)
+      rescue Azure::Core::Http::HTTPError => e
+        raise unless e.type == "BlobNotFound"
+        # Ignore files already deleted
       end
     end
 

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -29,35 +29,29 @@ module ActiveStorage
         end
       else
         instrument :download, key: key do
-          begin
-            File.binread path_for(key)
-          rescue Errno::ENOENT
-            raise ActiveStorage::FileNotFoundError
-          end
-        end
-      end
-    end
-
-    def download_chunk(key, range)
-      instrument :download_chunk, key: key, range: range do
-        begin
-          File.open(path_for(key), "rb") do |file|
-            file.seek range.begin
-            file.read range.size
-          end
+          File.binread path_for(key)
         rescue Errno::ENOENT
           raise ActiveStorage::FileNotFoundError
         end
       end
     end
 
+    def download_chunk(key, range)
+      instrument :download_chunk, key: key, range: range do
+        File.open(path_for(key), "rb") do |file|
+          file.seek range.begin
+          file.read range.size
+        end
+      rescue Errno::ENOENT
+        raise ActiveStorage::FileNotFoundError
+      end
+    end
+
     def delete(key)
       instrument :delete, key: key do
-        begin
-          File.delete path_for(key)
-        rescue Errno::ENOENT
-          # Ignore files already deleted
-        end
+        File.delete path_for(key)
+      rescue Errno::ENOENT
+        # Ignore files already deleted
       end
     end
 

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -18,11 +18,9 @@ module ActiveStorage
 
     def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
-        begin
-          object_for(key).put(upload_options.merge(body: io, content_md5: checksum))
-        rescue Aws::S3::Errors::BadDigest
-          raise ActiveStorage::IntegrityError
-        end
+        object_for(key).put(upload_options.merge(body: io, content_md5: checksum))
+      rescue Aws::S3::Errors::BadDigest
+        raise ActiveStorage::IntegrityError
       end
     end
 
@@ -33,22 +31,18 @@ module ActiveStorage
         end
       else
         instrument :download, key: key do
-          begin
-            object_for(key).get.body.string.force_encoding(Encoding::BINARY)
-          rescue Aws::S3::Errors::NoSuchKey
-            raise ActiveStorage::FileNotFoundError
-          end
+          object_for(key).get.body.string.force_encoding(Encoding::BINARY)
+        rescue Aws::S3::Errors::NoSuchKey
+          raise ActiveStorage::FileNotFoundError
         end
       end
     end
 
     def download_chunk(key, range)
       instrument :download_chunk, key: key, range: range do
-        begin
-          object_for(key).get(range: "bytes=#{range.begin}-#{range.exclude_end? ? range.end - 1 : range.end}").body.read.force_encoding(Encoding::BINARY)
-        rescue Aws::S3::Errors::NoSuchKey
-          raise ActiveStorage::FileNotFoundError
-        end
+        object_for(key).get(range: "bytes=#{range.begin}-#{range.exclude_end? ? range.end - 1 : range.end}").body.read.force_encoding(Encoding::BINARY)
+      rescue Aws::S3::Errors::NoSuchKey
+        raise ActiveStorage::FileNotFoundError
       end
     end
 

--- a/activestorage/test/dummy/bin/yarn
+++ b/activestorage/test/dummy/bin/yarn
@@ -3,11 +3,9 @@
 
 VENDOR_PATH = File.expand_path("..", __dir__)
 Dir.chdir(VENDOR_PATH) do
-  begin
-    exec "yarnpkg #{ARGV.join(" ")}"
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg #{ARGV.join(" ")}"
+rescue Errno::ENOENT
+  $stderr.puts "Yarn executable was not detected in the system."
+  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -26,16 +26,14 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "monochrome with default variant_processor" do
-    begin
-      ActiveStorage.variant_processor = nil
+    ActiveStorage.variant_processor = nil
 
-      blob = create_file_blob(filename: "racecar.jpg")
-      variant = blob.variant(monochrome: true).processed
-      image = read_image(variant)
-      assert_match(/Gray/, image.colorspace)
-    ensure
-      ActiveStorage.variant_processor = :mini_magick
-    end
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(monochrome: true).processed
+    image = read_image(variant)
+    assert_match(/Gray/, image.colorspace)
+  ensure
+    ActiveStorage.variant_processor = :mini_magick
   end
 
   test "disabled variation of JPEG blob" do
@@ -66,45 +64,41 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "disabled variation using :combine_options" do
-    begin
-      ActiveStorage.variant_processor = nil
-      blob = create_file_blob(filename: "racecar.jpg")
-      variant = ActiveSupport::Deprecation.silence do
-        blob.variant(combine_options: {
-          crop: "100x100+0+0",
-          monochrome: false
-        }).processed
-      end
-      assert_match(/racecar\.jpg/, variant.service_url)
-
-      image = read_image(variant)
-      assert_equal 100, image.width
-      assert_equal 100, image.height
-      assert_match(/RGB/, image.colorspace)
-    ensure
-      ActiveStorage.variant_processor = :mini_magick
+    ActiveStorage.variant_processor = nil
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = ActiveSupport::Deprecation.silence do
+      blob.variant(combine_options: {
+        crop: "100x100+0+0",
+        monochrome: false
+      }).processed
     end
+    assert_match(/racecar\.jpg/, variant.service_url)
+
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 100, image.height
+    assert_match(/RGB/, image.colorspace)
+  ensure
+    ActiveStorage.variant_processor = :mini_magick
   end
 
   test "center-weighted crop of JPEG blob using :combine_options" do
-    begin
-      ActiveStorage.variant_processor = nil
-      blob = create_file_blob(filename: "racecar.jpg")
-      variant = ActiveSupport::Deprecation.silence do
-        blob.variant(combine_options: {
-          gravity: "center",
-          resize: "100x100^",
-          crop: "100x100+0+0",
-        }).processed
-      end
-      assert_match(/racecar\.jpg/, variant.service_url)
-
-      image = read_image(variant)
-      assert_equal 100, image.width
-      assert_equal 100, image.height
-    ensure
-      ActiveStorage.variant_processor = :mini_magick
+    ActiveStorage.variant_processor = nil
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = ActiveSupport::Deprecation.silence do
+      blob.variant(combine_options: {
+        gravity: "center",
+        resize: "100x100^",
+        crop: "100x100+0+0",
+      }).processed
     end
+    assert_match(/racecar\.jpg/, variant.service_url)
+
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 100, image.height
+  ensure
+    ActiveStorage.variant_processor = :mini_magick
   end
 
   test "center-weighted crop of JPEG blob using :resize_to_fill" do
@@ -160,18 +154,16 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "works for vips processor" do
-    begin
-      ActiveStorage.variant_processor = :vips
-      blob = create_file_blob(filename: "racecar.jpg")
-      variant = blob.variant(thumbnail_image: 100).processed
+    ActiveStorage.variant_processor = :vips
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(thumbnail_image: 100).processed
 
-      image = read_image(variant)
-      assert_equal 100, image.width
-      assert_equal 67, image.height
-    rescue LoadError
-      # libvips not installed
-    ensure
-      ActiveStorage.variant_processor = :mini_magick
-    end
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  rescue LoadError
+    # libvips not installed
+  ensure
+    ActiveStorage.variant_processor = :mini_magick
   end
 end

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -18,20 +18,18 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
 
     test "uploading a tempfile" do
-      begin
-        key  = SecureRandom.base58(24)
-        data = "Something else entirely!"
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
 
-        Tempfile.open do |file|
-          file.write(data)
-          file.rewind
-          @service.upload(key, file)
-        end
-
-        assert_equal data, @service.download(key)
-      ensure
-        @service.delete(key)
+      Tempfile.open do |file|
+        file.write(data)
+        file.rewind
+        @service.upload(key, file)
       end
+
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete(key)
     end
   end
 else

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -10,74 +10,66 @@ if SERVICE_CONFIGURATIONS[:gcs]
     include ActiveStorage::Service::SharedServiceTests
 
     test "direct upload" do
-      begin
-        key      = SecureRandom.base58(24)
-        data     = "Something else entirely!"
-        checksum = Digest::MD5.base64digest(data)
-        url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+      url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
-        uri = URI.parse url
-        request = Net::HTTP::Put.new uri.request_uri
-        request.body = data
-        request.add_field "Content-Type", ""
-        request.add_field "Content-MD5", checksum
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-          http.request request
-        end
-
-        assert_equal data, @service.download(key)
-      ensure
-        @service.delete key
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      request.add_field "Content-Type", ""
+      request.add_field "Content-MD5", checksum
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
       end
+
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete key
     end
 
     test "upload with content_type and content_disposition" do
-      begin
-        key      = SecureRandom.base58(24)
-        data     = "Something else entirely!"
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
 
-        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
 
-        url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
-        response = Net::HTTP.get_response(URI(url))
-        assert_equal "text/plain", response.content_type
-        assert_match(/attachment;.*test.txt/, response["Content-Disposition"])
-      ensure
-        @service.delete key
-      end
+      url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "text/plain", response.content_type
+      assert_match(/attachment;.*test.txt/, response["Content-Disposition"])
+    ensure
+      @service.delete key
     end
 
     test "upload with content_type" do
-      begin
-        key      = SecureRandom.base58(24)
-        data     = "Something else entirely!"
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
 
-        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")
 
-        url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
-        response = Net::HTTP.get_response(URI(url))
-        assert_equal "text/plain", response.content_type
-        assert_match(/inline;.*test.html/, response["Content-Disposition"])
-      ensure
-        @service.delete key
-      end
+      url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "text/plain", response.content_type
+      assert_match(/inline;.*test.html/, response["Content-Disposition"])
+    ensure
+      @service.delete key
     end
 
     test "update metadata" do
-      begin
-        key      = SecureRandom.base58(24)
-        data     = "Something else entirely!"
-        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html")
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html")
 
-        @service.update_metadata(key, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
-        url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+      @service.update_metadata(key, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
 
-        response = Net::HTTP.get_response(URI(url))
-        assert_equal "text/plain", response.content_type
-        assert_match(/inline;.*test.txt/, response["Content-Disposition"])
-      ensure
-        @service.delete key
-      end
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "text/plain", response.content_type
+      assert_match(/inline;.*test.txt/, response["Content-Disposition"])
+    ensure
+      @service.delete key
     end
 
     test "signed URL generation" do

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -18,22 +18,20 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "uploading to all services" do
-    begin
-      key      = SecureRandom.base58(24)
-      data     = "Something else entirely!"
-      io       = StringIO.new(data)
-      checksum = Digest::MD5.base64digest(data)
+    key      = SecureRandom.base58(24)
+    data     = "Something else entirely!"
+    io       = StringIO.new(data)
+    checksum = Digest::MD5.base64digest(data)
 
-      @service.upload key, io.tap(&:read), checksum: checksum
-      assert_predicate io, :eof?
+    @service.upload key, io.tap(&:read), checksum: checksum
+    assert_predicate io, :eof?
 
-      assert_equal data, @service.primary.download(key)
-      @service.mirrors.each do |mirror|
-        assert_equal data, mirror.download(key)
-      end
-    ensure
-      @service.delete key
+    assert_equal data, @service.primary.download(key)
+    @service.mirrors.each do |mirror|
+      assert_equal data, mirror.download(key)
     end
+  ensure
+    @service.delete key
   end
 
   test "downloading from primary service" do

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -11,25 +11,23 @@ if SERVICE_CONFIGURATIONS[:s3]
     include ActiveStorage::Service::SharedServiceTests
 
     test "direct upload" do
-      begin
-        key      = SecureRandom.base58(24)
-        data     = "Something else entirely!"
-        checksum = Digest::MD5.base64digest(data)
-        url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+      url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
-        uri = URI.parse url
-        request = Net::HTTP::Put.new uri.request_uri
-        request.body = data
-        request.add_field "Content-Type", "text/plain"
-        request.add_field "Content-MD5", checksum
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-          http.request request
-        end
-
-        assert_equal data, @service.download(key)
-      ensure
-        @service.delete key
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      request.add_field "Content-Type", "text/plain"
+      request.add_field "Content-MD5", checksum
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
       end
+
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete key
     end
 
     test "upload a zero byte file" do

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -20,48 +20,42 @@ module ActiveStorage::Service::SharedServiceTests
     end
 
     test "uploading with integrity" do
-      begin
-        key  = SecureRandom.base58(24)
-        data = "Something else entirely!"
-        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data))
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data))
 
-        assert_equal data, @service.download(key)
-      ensure
-        @service.delete key
-      end
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete key
     end
 
     test "uploading without integrity" do
-      begin
-        key  = SecureRandom.base58(24)
-        data = "Something else entirely!"
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
 
-        assert_raises(ActiveStorage::IntegrityError) do
-          @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest("bad data"))
-        end
-
-        assert_not @service.exist?(key)
-      ensure
-        @service.delete key
+      assert_raises(ActiveStorage::IntegrityError) do
+        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest("bad data"))
       end
+
+      assert_not @service.exist?(key)
+    ensure
+      @service.delete key
     end
 
     test "uploading with integrity and multiple keys" do
-      begin
-        key  = SecureRandom.base58(24)
-        data = "Something else entirely!"
-        @service.upload(
-          key,
-          StringIO.new(data),
-          checksum: Digest::MD5.base64digest(data),
-          filename: "racecar.jpg",
-          content_type: "image/jpg"
-        )
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
+      @service.upload(
+        key,
+        StringIO.new(data),
+        checksum: Digest::MD5.base64digest(data),
+        filename: "racecar.jpg",
+        content_type: "image/jpg"
+      )
 
-        assert_equal data, @service.download(key)
-      ensure
-        @service.delete key
-      end
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete key
     end
 
     test "downloading" do
@@ -129,20 +123,18 @@ module ActiveStorage::Service::SharedServiceTests
     end
 
     test "deleting by prefix" do
-      begin
-        @service.upload("a/a/a", StringIO.new(FIXTURE_DATA))
-        @service.upload("a/a/b", StringIO.new(FIXTURE_DATA))
-        @service.upload("a/b/a", StringIO.new(FIXTURE_DATA))
+      @service.upload("a/a/a", StringIO.new(FIXTURE_DATA))
+      @service.upload("a/a/b", StringIO.new(FIXTURE_DATA))
+      @service.upload("a/b/a", StringIO.new(FIXTURE_DATA))
 
-        @service.delete_prefixed("a/a/")
-        assert_not @service.exist?("a/a/a")
-        assert_not @service.exist?("a/a/b")
-        assert @service.exist?("a/b/a")
-      ensure
-        @service.delete("a/a/a")
-        @service.delete("a/a/b")
-        @service.delete("a/b/a")
-      end
+      @service.delete_prefixed("a/a/")
+      assert_not @service.exist?("a/a/a")
+      assert_not @service.exist?("a/a/b")
+      assert @service.exist?("a/b/a")
+    ensure
+      @service.delete("a/a/a")
+      @service.delete("a/a/b")
+      @service.delete("a/b/a")
     end
   end
 end

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -108,12 +108,10 @@ module ActiveSupport
         def lock_file(file_name, &block)
           if File.exist?(file_name)
             File.open(file_name, "r+") do |f|
-              begin
-                f.flock File::LOCK_EX
-                yield
-              ensure
-                f.flock File::LOCK_UN
-              end
+              f.flock File::LOCK_EX
+              yield
+            ensure
+              f.flock File::LOCK_UN
             end
           else
             yield

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -57,11 +57,9 @@ module ActiveSupport
         # usage of attr_* macros for private attributes, but adds a lot of noise
         # to our test suite. Thus, we lazy load it and disable warnings locally.
         silence_warnings do
-          begin
-            require "listen"
-          rescue LoadError => e
-            raise LoadError, "Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile", e.backtrace
-          end
+          require "listen"
+        rescue LoadError => e
+          raise LoadError, "Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile", e.backtrace
         end
       end
       boot!

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -50,11 +50,9 @@ module ActiveSupport
     def self.reload!
       executor.wrap do
         new.tap do |instance|
-          begin
-            instance.run!
-          ensure
-            instance.complete!
-          end
+          instance.run!
+        ensure
+          instance.complete!
         end
       end
       prepare!

--- a/activesupport/test/cache/behaviors/connection_pool_behavior.rb
+++ b/activesupport/test/cache/behaviors/connection_pool_behavior.rb
@@ -7,24 +7,22 @@ module ConnectionPoolBehavior
     threads = []
 
     emulating_latency do
-      begin
-        cache = ActiveSupport::Cache.lookup_store(store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
-        cache.clear
+      cache = ActiveSupport::Cache.lookup_store(store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
+      cache.clear
 
-        assert_raises Timeout::Error do
-          # One of the three threads will fail in 1 second because our pool size
-          # is only two.
-          3.times do
-            threads << Thread.new do
-              cache.read("latency")
-            end
+      assert_raises Timeout::Error do
+        # One of the three threads will fail in 1 second because our pool size
+        # is only two.
+        3.times do
+          threads << Thread.new do
+            cache.read("latency")
           end
-
-          threads.each(&:join)
         end
-      ensure
-        threads.each(&:kill)
+
+        threads.each(&:join)
       end
+    ensure
+      threads.each(&:kill)
     end
   ensure
     Thread.report_on_exception = original_report_on_exception
@@ -34,24 +32,22 @@ module ConnectionPoolBehavior
     threads = []
 
     emulating_latency do
-      begin
-        cache = ActiveSupport::Cache.lookup_store(store, store_options)
-        cache.clear
+      cache = ActiveSupport::Cache.lookup_store(store, store_options)
+      cache.clear
 
-        assert_nothing_raised do
-          # Default connection pool size is 5, assuming 10 will make sure that
-          # the connection pool isn't used at all.
-          10.times do
-            threads << Thread.new do
-              cache.read("latency")
-            end
+      assert_nothing_raised do
+        # Default connection pool size is 5, assuming 10 will make sure that
+        # the connection pool isn't used at all.
+        10.times do
+          threads << Thread.new do
+            cache.read("latency")
           end
-
-          threads.each(&:join)
         end
-      ensure
-        threads.each(&:kill)
+
+        threads.each(&:join)
       end
+    ensure
+      threads.each(&:kill)
     end
   end
 

--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -13,10 +13,9 @@ class TestLoadError < ActiveSupport::TestCase
   end
 
   def test_path
-    begin load "nor/this/one.rb"
-    rescue LoadError => e
-      assert_equal "nor/this/one.rb", e.path
-    end
+    load "nor/this/one.rb"
+   rescue LoadError => e
+     assert_equal "nor/this/one.rb", e.path
   end
 
   def test_is_missing_with_nil_path

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -21,20 +21,18 @@ class TestJSONEncoding < ActiveSupport::TestCase
 
   JSONTest::EncodingTestCases.constants.each do |class_tests|
     define_method("test_#{class_tests[0..-6].underscore}") do
-      begin
-        prev = ActiveSupport.use_standard_json_time_format
+      prev = ActiveSupport.use_standard_json_time_format
 
-        standard_class_tests = /Standard/.match?(class_tests)
+      standard_class_tests = /Standard/.match?(class_tests)
 
-        ActiveSupport.escape_html_entities_in_json  = !standard_class_tests
-        ActiveSupport.use_standard_json_time_format = standard_class_tests
-        JSONTest::EncodingTestCases.const_get(class_tests).each do |pair|
-          assert_equal pair.last, sorted_json(ActiveSupport::JSON.encode(pair.first))
-        end
-      ensure
-        ActiveSupport.escape_html_entities_in_json  = false
-        ActiveSupport.use_standard_json_time_format = prev
+      ActiveSupport.escape_html_entities_in_json  = !standard_class_tests
+      ActiveSupport.use_standard_json_time_format = standard_class_tests
+      JSONTest::EncodingTestCases.const_get(class_tests).each do |pair|
+        assert_equal pair.last, sorted_json(ActiveSupport::JSON.encode(pair.first))
       end
+    ensure
+      ActiveSupport.escape_html_entities_in_json  = false
+      ActiveSupport.use_standard_json_time_format = prev
     end
   end
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -11,16 +11,14 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel
     Time.stub(:now, Time.now) do
-      begin
-        expected_time = Time.now + 1.day
-        travel 1.day
+      expected_time = Time.now + 1.day
+      travel 1.day
 
-        assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
-        assert_equal expected_time.to_date, Date.today
-        assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
-      ensure
-        travel_back
-      end
+      assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
+      assert_equal expected_time.to_date, Date.today
+      assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
+    ensure
+      travel_back
     end
   end
 
@@ -42,16 +40,14 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to
     Time.stub(:now, Time.now) do
-      begin
-        expected_time = Time.new(2004, 11, 24, 01, 04, 44)
-        travel_to expected_time
+      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      travel_to expected_time
 
-        assert_equal expected_time, Time.now
-        assert_equal Date.new(2004, 11, 24), Date.today
-        assert_equal expected_time.to_datetime, DateTime.now
-      ensure
-        travel_back
-      end
+      assert_equal expected_time, Time.now
+      assert_equal Date.new(2004, 11, 24), Date.today
+      assert_equal expected_time.to_datetime, DateTime.now
+    ensure
+      travel_back
     end
   end
 
@@ -73,21 +69,19 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_back
     Time.stub(:now, Time.now) do
-      begin
-        expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
 
-        travel_to expected_time
-        assert_equal expected_time, Time.now
-        assert_equal Date.new(2004, 11, 24), Date.today
-        assert_equal expected_time.to_datetime, DateTime.now
-        travel_back
+      travel_to expected_time
+      assert_equal expected_time, Time.now
+      assert_equal Date.new(2004, 11, 24), Date.today
+      assert_equal expected_time.to_datetime, DateTime.now
+      travel_back
 
-        assert_not_equal expected_time, Time.now
-        assert_not_equal Date.new(2004, 11, 24), Date.today
-        assert_not_equal expected_time.to_datetime, DateTime.now
-      ensure
-        travel_back
-      end
+      assert_not_equal expected_time, Time.now
+      assert_not_equal Date.new(2004, 11, 24), Date.today
+      assert_not_equal expected_time.to_datetime, DateTime.now
+    ensure
+      travel_back
     end
   end
 
@@ -122,20 +116,18 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to_with_subsequent_calls
     Time.stub(:now, Time.now) do
-      begin
-        initial_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
-        subsequent_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
-        assert_nothing_raised do
-          travel_to initial_expected_time
-          travel_to subsequent_expected_time
+      initial_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      subsequent_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
+      assert_nothing_raised do
+        travel_to initial_expected_time
+        travel_to subsequent_expected_time
 
-          assert_equal subsequent_expected_time, Time.now
+        assert_equal subsequent_expected_time, Time.now
 
-          travel_back
-        end
-      ensure
         travel_back
       end
+    ensure
+      travel_back
     end
   end
 

--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -13,8 +13,6 @@ require "rails"
   rails/test_unit/railtie
   sprockets/railtie
 ).each do |railtie|
-  begin
-    require railtie
-  rescue LoadError
-  end
+  require railtie
+rescue LoadError
 end

--- a/railties/lib/rails/command/behavior.rb
+++ b/railties/lib/rails/command/behavior.rb
@@ -56,12 +56,10 @@ module Rails
           def lookup!
             $LOAD_PATH.each do |base|
               Dir[File.join(base, *file_lookup_paths)].each do |path|
-                begin
-                  path = path.sub("#{base}/", "")
-                  require path
-                rescue Exception
-                  # No problem
-                end
+                path = path.sub("#{base}/", "")
+                require path
+              rescue Exception
+                # No problem
               end
             end
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1493,14 +1493,12 @@ module ApplicationTests
     end
 
     test "config.session_store with :active_record_store with activerecord-session_store gem" do
-      begin
-        make_basic_app do |application|
-          ActionDispatch::Session::ActiveRecordStore = Class.new(ActionDispatch::Session::CookieStore)
-          application.config.session_store :active_record_store
-        end
-      ensure
-        ActionDispatch::Session.send :remove_const, :ActiveRecordStore
+      make_basic_app do |application|
+        ActionDispatch::Session::ActiveRecordStore = Class.new(ActionDispatch::Session::CookieStore)
+        application.config.session_store :active_record_store
       end
+    ensure
+      ActionDispatch::Session.send :remove_const, :ActiveRecordStore
     end
 
     test "config.session_store with :active_record_store without activerecord-session_store gem" do

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -230,35 +230,31 @@ module ApplicationTests
     end
 
     test "active record establish_connection uses Rails.env if DATABASE_URL is not set" do
-      begin
-        require "#{app_path}/config/environment"
-        orig_database_url = ENV.delete("DATABASE_URL")
-        orig_rails_env, Rails.env = Rails.env, "development"
-        ActiveRecord::Base.establish_connection
-        assert ActiveRecord::Base.connection
-        assert_match(/#{ActiveRecord::Base.configurations[Rails.env]['database']}/, ActiveRecord::Base.connection_config[:database])
-      ensure
-        ActiveRecord::Base.remove_connection
-        ENV["DATABASE_URL"] = orig_database_url if orig_database_url
-        Rails.env = orig_rails_env if orig_rails_env
-      end
+      require "#{app_path}/config/environment"
+      orig_database_url = ENV.delete("DATABASE_URL")
+      orig_rails_env, Rails.env = Rails.env, "development"
+      ActiveRecord::Base.establish_connection
+      assert ActiveRecord::Base.connection
+      assert_match(/#{ActiveRecord::Base.configurations[Rails.env]['database']}/, ActiveRecord::Base.connection_config[:database])
+    ensure
+      ActiveRecord::Base.remove_connection
+      ENV["DATABASE_URL"] = orig_database_url if orig_database_url
+      Rails.env = orig_rails_env if orig_rails_env
     end
 
     test "active record establish_connection uses DATABASE_URL even if Rails.env is set" do
-      begin
-        require "#{app_path}/config/environment"
-        orig_database_url = ENV.delete("DATABASE_URL")
-        orig_rails_env, Rails.env = Rails.env, "development"
-        database_url_db_name = "db/database_url_db.sqlite3"
-        ENV["DATABASE_URL"] = "sqlite3:#{database_url_db_name}"
-        ActiveRecord::Base.establish_connection
-        assert ActiveRecord::Base.connection
-        assert_match(/#{database_url_db_name}/, ActiveRecord::Base.connection_config[:database])
-      ensure
-        ActiveRecord::Base.remove_connection
-        ENV["DATABASE_URL"] = orig_database_url if orig_database_url
-        Rails.env = orig_rails_env if orig_rails_env
-      end
+      require "#{app_path}/config/environment"
+      orig_database_url = ENV.delete("DATABASE_URL")
+      orig_rails_env, Rails.env = Rails.env, "development"
+      database_url_db_name = "db/database_url_db.sqlite3"
+      ENV["DATABASE_URL"] = "sqlite3:#{database_url_db_name}"
+      ActiveRecord::Base.establish_connection
+      assert ActiveRecord::Base.connection
+      assert_match(/#{database_url_db_name}/, ActiveRecord::Base.connection_config[:database])
+    ensure
+      ActiveRecord::Base.remove_connection
+      ENV["DATABASE_URL"] = orig_database_url if orig_database_url
+      Rails.env = orig_rails_env if orig_rails_env
     end
 
     test "connections checked out during initialization are returned to the pool" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -321,13 +321,12 @@ module ApplicationTests
       end
 
       test "db:setup loads schema and seeds database" do
-        begin
-          @old_rails_env = ENV["RAILS_ENV"]
-          @old_rack_env = ENV["RACK_ENV"]
-          ENV.delete "RAILS_ENV"
-          ENV.delete "RACK_ENV"
+        @old_rails_env = ENV["RAILS_ENV"]
+        @old_rack_env = ENV["RACK_ENV"]
+        ENV.delete "RAILS_ENV"
+        ENV.delete "RACK_ENV"
 
-          app_file "db/schema.rb", <<-RUBY
+        app_file "db/schema.rb", <<-RUBY
             ActiveRecord::Schema.define(version: "1") do
               create_table :users do |t|
                 t.string :name
@@ -335,16 +334,15 @@ module ApplicationTests
             end
           RUBY
 
-          app_file "db/seeds.rb", <<-RUBY
-            puts ActiveRecord::Base.connection_config[:database]
-          RUBY
+        app_file "db/seeds.rb", <<-RUBY
+          puts ActiveRecord::Base.connection_config[:database]
+        RUBY
 
-          database_path = rails("db:setup")
-          assert_equal "development.sqlite3", File.basename(database_path.strip)
-        ensure
-          ENV["RAILS_ENV"] = @old_rails_env
-          ENV["RACK_ENV"] = @old_rack_env
-        end
+        database_path = rails("db:setup")
+        assert_equal "development.sqlite3", File.basename(database_path.strip)
+      ensure
+        ENV["RAILS_ENV"] = @old_rails_env
+        ENV["RACK_ENV"] = @old_rack_env
       end
 
       test "db:setup sets ar_internal_metadata" do

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -308,11 +308,9 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     def capture_abort
       @aborted = false
       @output = capture(:stderr) do
-        begin
-          yield
-        rescue SystemExit
-          @aborted = true
-        end
+        yield
+      rescue SystemExit
+        @aborted = true
       end
     end
 

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -161,19 +161,18 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
   end
 
   test "rails routes with expanded option" do
-    begin
-      previous_console_winsize = IO.console.winsize
-      IO.console.winsize = [0, 27]
+    previous_console_winsize = IO.console.winsize
+    IO.console.winsize = [0, 27]
 
-      app_file "config/routes.rb", <<-RUBY
+    app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get '/cart', to: 'cart#show'
         end
       RUBY
 
-      output = run_routes_command(["--expanded"])
+    output = run_routes_command(["--expanded"])
 
-      assert_equal <<~MESSAGE, output
+    assert_equal <<~MESSAGE, output
         --[ Route 1 ]--------------
         Prefix            | cart
         Verb              | GET
@@ -205,9 +204,8 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
         URI               | /rails/active_storage/direct_uploads(.:format)
         Controller#Action | active_storage/direct_uploads#create
       MESSAGE
-    ensure
-      IO.console.winsize = previous_console_winsize
-    end
+  ensure
+    IO.console.winsize = previous_console_winsize
   end
 
   private

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -30,12 +30,10 @@ class HelperGeneratorTest < Rails::Generators::TestCase
     require "#{destination_root}/app/helpers/products_helper"
 
     assert_nothing_raised do
-      begin
-        run_generator ["admin::products"]
-      ensure
-        # cleanup
-        Object.send(:remove_const, :ProductsHelper)
-      end
+      run_generator ["admin::products"]
+    ensure
+      # cleanup
+      Object.send(:remove_const, :ProductsHelper)
     end
   end
 

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -25,12 +25,10 @@ module RailtiesTest
     end
 
     test "Railtie provides railtie_name" do
-      begin
-        class ::FooBarBaz < Rails::Railtie ; end
-        assert_equal "foo_bar_baz", FooBarBaz.railtie_name
-      ensure
-        Object.send(:remove_const, :"FooBarBaz")
-      end
+      class ::FooBarBaz < Rails::Railtie ; end
+      assert_equal "foo_bar_baz", FooBarBaz.railtie_name
+    ensure
+      Object.send(:remove_const, :"FooBarBaz")
     end
 
     test "railtie_name can be set manually" do
@@ -203,14 +201,12 @@ module RailtiesTest
     end
 
     test "we can change our environment if we want to" do
-      begin
-        original_env = Rails.env
-        Rails.env = "foo"
-        assert_equal("foo", Rails.env)
-      ensure
-        Rails.env = original_env
-        assert_equal(original_env, Rails.env)
-      end
+      original_env = Rails.env
+      Rails.env = "foo"
+      assert_equal("foo", Rails.env)
+    ensure
+      Rails.env = original_env
+      assert_equal(original_env, Rails.env)
     end
   end
 end

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -35,15 +35,13 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "reading with ENV variable" do
     run_secrets_generator do
-      begin
-        old_key = ENV["RAILS_MASTER_KEY"]
-        ENV["RAILS_MASTER_KEY"] = IO.binread("config/secrets.yml.key").strip
-        FileUtils.rm("config/secrets.yml.key")
+      old_key = ENV["RAILS_MASTER_KEY"]
+      ENV["RAILS_MASTER_KEY"] = IO.binread("config/secrets.yml.key").strip
+      FileUtils.rm("config/secrets.yml.key")
 
-        assert_match "# production:\n#   external_api_key:", Rails::Secrets.read
-      ensure
-        ENV["RAILS_MASTER_KEY"] = old_key
-      end
+      assert_match "# production:\n#   external_api_key:", Rails::Secrets.read
+    ensure
+      ENV["RAILS_MASTER_KEY"] = old_key
     end
   end
 


### PR DESCRIPTION
Currently we sometimes find a redundant begin block in code review
(e.g. https://github.com/rails/rails/pull/33604#discussion_r209784205).

I'd like to enable `Style/RedundantBegin` cop to avoid that, since
rescue/else/ensure are allowed inside do/end blocks in Ruby 2.5
(https://bugs.ruby-lang.org/issues/12906), so we'd probably meets with
that situation than before.