### PR TITLE
Use BigDecimal provided methods to convert String to BigDecimal

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -68,11 +68,7 @@ module ActiveSupport
         "float"        => Proc.new { |float|   float.to_f },
         "decimal"      => Proc.new do |number|
           if String === number
-            begin
-              BigDecimal(number)
-            rescue ArgumentError
-              BigDecimal(number.to_f.to_s)
-            end
+            number.to_d
           else
             BigDecimal(number)
           end


### PR DESCRIPTION
`String#to_d` does not raise an exception if an invalid value is specified.
So can remove exception handling.

```
$ bundle exec ruby -v -rbigdecimal -rbigdecimal/util -e 'p "123,003".to_d'
ruby 2.6.0dev (2018-12-21 trunk 66474) [x86_64-linux]
0.123e3
```