### PR TITLE
Module.delegate rdoc update to clarify :to parameter [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -19,7 +19,7 @@ class Module
   # public methods as your own.
   #
   # ==== Options
-  # * <tt>:to</tt> - Specifies the target object
+  # * <tt>:to</tt> - Specifies the target object name as a symbol or string
   # * <tt>:prefix</tt> - Prefixes the new method with the target name or a custom prefix
   # * <tt>:allow_nil</tt> - If set to true, prevents a +Module::DelegationError+
   #   from being raised


### PR DESCRIPTION
### Summary

Update the rdoc comment for `Module.delegate` to clarify that the `:to` parameter must be the _name_ of the target object, not the object itself.