### PR TITLE
Fix Ruby 2.6 `warning: mismatched indentations at 'rescue' with 'def' at 15`.

### DIFF
--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -14,8 +14,8 @@ class TestLoadError < ActiveSupport::TestCase
 
   def test_path
     load "nor/this/one.rb"
-   rescue LoadError => e
-     assert_equal "nor/this/one.rb", e.path
+  rescue LoadError => e
+    assert_equal "nor/this/one.rb", e.path
   end
 
   def test_is_missing_with_nil_path


### PR DESCRIPTION
See https://travis-ci.org/rails/rails/jobs/470890129#L2361