### PR TITLE
Fix app boot file for Ruby 2.4 so it tells you to install Ruby 2.5

### DIFF
--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/RedundantBegin
+
 require "rails"
 
 %w(
@@ -13,6 +15,8 @@ require "rails"
   rails/test_unit/railtie
   sprockets/railtie
 ).each do |railtie|
-  require railtie
-rescue LoadError
+  begin
+    require railtie
+  rescue LoadError
+  end
 end


### PR DESCRIPTION
I have a test app that was on Ruby 2.4. When I pulled Rails master the
app no longer would boot because of this change and I saw the following
error:

```
SyntaxError:
/Users/eileencodes/open_source/real_rails/railties/lib/rails/all.rb:18:
syntax error, unexpected keyword_rescue, expecting keyword_end
rescue LoadError
      ^
```

Ruby 2.4 doesn't support removing redundant begins so the real issue is
that this app is on Ruby 2.4 and not on Ruby 2.5. But it's super
confusing for a user to understand the reason the app is failing to boot
is because we need Ruby 2.5.

I added this redundant begin back because we need to give a clearer
error message.

Followup to https://github.com/rails/rails/pull/34764, cc/ @kamipo 