### PR TITLE
Use `flunk` instead of `yield` to ensure that the block is not called

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -332,7 +332,7 @@ module ActiveRecord
       def test_calling_connected_to_on_a_non_existent_handler_raises
         error = assert_raises ArgumentError do
           ActiveRecord::Base.connected_to(role: :reading) do
-            yield
+            flunk "should not call this block"
           end
         end
 


### PR DESCRIPTION
It should make the test more readable since `flunk` emphasizes better
than `yield` that the block shouldn't be called.

Also, it improves error message:
```
(snip)
should not call this block
(snip)
```

```
(snip)
[ArgumentError] exception expected, not Class: <LocalJumpError>
Message: <"no block given (yield)">
---Backtrace---
(snip)
```

Related to #34753