### PR TITLE
Tune stack usage in ToSQL visitor for Arel::Nodes::And (and other nodes using inject_join)

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -804,14 +804,20 @@ module Arel # :nodoc: all
         end
 
         def inject_join(list, collector, join_str)
+          i = 0
           len = list.length - 1
-          list.each_with_index.inject(collector) { |c, (x, i)|
-            if i == len
-              visit x, c
-            else
-              visit(x, c) << join_str
-            end
-          }
+
+          for x in list do
+            collector = if i == len
+                          visit(x, collector)
+                        else
+                          visit(x, collector) << join_str
+                        end
+
+            i += 1
+          end
+
+          collector
         end
 
         def boundable?(value)


### PR DESCRIPTION
### Summary

Replacing the `#inject` call in `#inject_join` with a `for` loop removes 5 out of 7 stack frames associated with the call to `#visit_Arel_Nodes_And`. This increases the complexity of queries that Arel is able to construct by delaying a `SystemStackError`.

Before these changes the stack looked like this:

1. `Arel::Visitors::ToSql#visit_Arel_Nodes_And`
2. `Arel::Visitors::ToSql#inject_join`
3. `Arel::Visitors::ToSql#inject`
4. `Arel::Visitors::ToSql#each`
5. `Arel::Visitors::ToSql#each_with_index`
6. `Arel::Visitors::ToSql#each`
7. (block in `Arel::Visitors::ToSql#inject_join`)
8. (call `#visit` for each child and `#join_str` for all children but the last)

After these changes, it looks like this (*EDIT: this was speculative, see comments below*):

1. `Arel::Visitors::ToSql#visit_Arel_Nodes_And`
2. `Arel::Visitors::ToSql#inject_join`
3. (call `#visit` for each child and `#join_str` for all children but the last)

All the existing tests pass when I run `rake test:sqlite3`.