### PR TITLE
add `rails credentials:encrypt` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `rails credentials:encrypt` command to support create credentials
+    from a cleartext YAML file.
+
+    It reads `config/credentials.yml` by default, if `--environment` given
+    it will reads `config/credentials/:environment.yml`.
+
+    You can specify other YAML file by using `--file`,
+    e.g: `rails credentials:encrypt --file config/secret.yml`.
+
+    If `credentials.yml.enc` already exists, you have to give `--force` to
+    replace it.
+
+    If `master.key` doesn't exist, it will generate one.
+
+    The cleartext YAML file will be deleted unless you give `--keep-cleartext`
+
+    *Jiang Jun*
+
 *   Add benchmark method that can be called from anywhere.
 
     This method is used as a quick way to measure & log the speed of some code.
@@ -9,6 +27,13 @@
         end
 
     *Simon Perepelitsa*
+
+*   Only execute route reloads once on boot for development environment
+
+## Rails 6.1.0.rc1 (November 02, 2020) ##
+
+    *Louis Cloutier*
+>>>>>>> beec2a3e26... add `rails credentials:encrypt` that helps for encrypt a cleartext YAML as credentials
 
 *   Removed manifest.js and application.css in app/assets
     folder when --skip-sprockets option passed as flag to rails.

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -71,6 +71,42 @@ module Rails
         say credentials.content_path.read
       end
 
+      option :force, type: :boolean,
+             desc: "Overwrite encrypted file if already existed"
+      option :file, type: :string,
+             desc: "Specify a YAML file that you want to be encrypted as credentials"
+      option :keep_cleartext, type: :boolean,
+             desc: "Don't delete the cleartext YAML file after encrypted"
+
+      def encrypt
+        require_application_and_environment!
+
+        file_path = options[:file] || cleartext_content_path
+        unless File.exist? file_path
+          say "Couldn't find #{file_path}."
+          exit
+        end
+        content = File.read file_path
+
+        if File.exist?(content_path) && !options[:force]
+          say "Encrypted file already existed: #{content_path}. Use --force to replace it."
+          exit
+        end
+
+        encrypted = credentials
+
+        ensure_encryption_key_has_been_added if credentials.key.nil?
+        ensure_credentials_have_been_added
+
+        encrypted.write content
+
+        say "File encrypted and saved."
+
+        unless options[:keep_cleartext]
+          File.delete file_path
+        end
+      end
+
       private
         def credentials
           Rails.application.encrypted(content_path, key_path: key_path)
@@ -101,6 +137,10 @@ module Rails
           else
             "File '#{content_path}' does not exist. Use `bin/rails credentials:edit` to change that."
           end
+        end
+
+        def cleartext_content_path
+          @cleartext_content_path ||= options[:environment] ? "config/credentials/#{options[:environment]}.yml" : "config/credentials.yml"
         end
 
         def content_path


### PR DESCRIPTION
### Summary

Open source apps usually given some config templates (e.g `database.yml.example`)
to help deployer to configure the app.

But credentials isn't easy to do that, because we can't bundle `master.key` into repo and `credentials.yml.enc` isn't readable.

This PR provides a new command `rails credentials:encrypt`
that can encrypt `credentials.yml` into `credentials.yml.enc`
(also generate a new `master.key` if not have yet').

So now we can bundle a credentials template into repo like old way does.