### PR TITLE
No need to handle if FrozenError is available

### DIFF
--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -27,7 +27,7 @@ class AggregationsTest < ActiveRecord::TestCase
 
   def test_immutable_value_objects
     customers(:david).balance = Money.new(100)
-    assert_raise(frozen_error_class) { customers(:david).balance.instance_eval { @amount = 20 } }
+    assert_raise(FrozenError) { customers(:david).balance.instance_eval { @amount = 20 } }
   end
 
   def test_inferred_mapping

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -43,8 +43,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_assigning_belongs_to_on_destroyed_object
     client = Client.create!(name: "Client")
     client.destroy!
-    assert_raise(frozen_error_class) { client.firm = nil }
-    assert_raise(frozen_error_class) { client.firm = Firm.new(name: "Firm") }
+    assert_raise(FrozenError) { client.firm = nil }
+    assert_raise(FrozenError) { client.firm = Firm.new(name: "Firm") }
   end
 
   def test_eager_loading_wont_mutate_owner_record

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -314,7 +314,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    assert_raises frozen_error_class do
+    assert_raises FrozenError do
       ActiveRecord::Base.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -79,10 +79,6 @@ module ActiveRecord
       model.reset_column_information
       model.column_names.include?(column_name.to_s)
     end
-
-    def frozen_error_class
-      Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
-    end
   end
 
   class PostgreSQLTestCase < TestCase

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -587,7 +587,7 @@ class TransactionTest < ActiveRecord::TestCase
   def test_rollback_when_saving_a_frozen_record
     topic = Topic.new(title: "test")
     topic.freeze
-    e = assert_raise(frozen_error_class) { topic.save }
+    e = assert_raise(FrozenError) { topic.save }
     # Not good enough, but we can't do much
     # about it since there is no specific error
     # for frozen objects.

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -39,8 +39,4 @@ class ActiveSupport::TestCase
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)
     end
-
-    def frozen_error_class
-      Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
-    end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -395,7 +395,7 @@ class HashExtTest < ActiveSupport::TestCase
     original.freeze
     assert_nothing_raised { original.except(:a) }
 
-    assert_raise(frozen_error_class) { original.except!(:a) }
+    assert_raise(FrozenError) { original.except!(:a) }
   end
 
   def test_except_does_not_delete_values_in_original

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -255,7 +255,7 @@ module ApplicationTests
 
     test "can't change middleware after it's built" do
       boot!
-      assert_raise frozen_error_class do
+      assert_raise FrozenError do
         app.config.middleware.use Rack::Config
       end
     end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -462,10 +462,6 @@ class ActiveSupport::TestCase
   include TestHelpers::Generation
   include ActiveSupport::Testing::Stream
   include ActiveSupport::Testing::MethodCallAssertions
-
-  def frozen_error_class
-    Object.const_defined?(:FrozenError) ? FrozenError : RuntimeError
-  end
 end
 
 # Create a scope and build a fixture rails app


### PR DESCRIPTION
### Summary

Rails 6 requires Ruby 2.5, which introduces `FrozenError` https://docs.ruby-lang.org/en/2.5.0/NEWS.html

Related to #31520
