### PR TITLE
Allow `truncate` for SQLite3 adapter and add `rails db:seed:replant`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,5 @@
-*   Add `rails db:seed:replant` that truncates database tables and loads the seeds.
+*   Add `rails db:seed:replant` that truncates tables of each database
+    for current environment and loads the seeds.
 
     *bogdanvlviv*, *DHH*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Base.connection.truncate` for SQLite3 adapter.
+
+    *bogdanvlviv*
+
 *   Add `reselect` method. This is a short-hand for `unscope(:select).select(fields)`.
 
     Fixes #27340.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `rails db:seed:replant` that truncates database tables and loads the seeds.
+
+    *bogdanvlviv*, *DHH*
+
 *   Add `ActiveRecord::Base.connection.truncate` for SQLite3 adapter.
 
     *bogdanvlviv*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -154,6 +154,10 @@ module ActiveRecord
         @statements.clear
       end
 
+      def truncate(table_name, name = nil)
+        execute "DELETE FROM #{quote_table_name(table_name)}", name
+      end
+
       def supports_index_sort_order?
         true
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -62,15 +62,7 @@ db_namespace = namespace :db do
 
   # desc "Truncates database tables for current environment"
   task truncate_tables: [:load_config, :check_protected_environments] do
-    table_names = ActiveRecord::Base.connection.tables
-    internal_table_names = [
-      ActiveRecord::Base.schema_migrations_table_name,
-      ActiveRecord::Base.internal_metadata_table_name
-    ]
-
-    table_names.without(*internal_table_names).each do |table_name|
-      ActiveRecord::Base.connection.truncate(table_name)
-    end
+    ActiveRecord::Tasks::DatabaseTasks.truncate_tables
   end
 
   namespace :purge do

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -60,15 +60,15 @@ db_namespace = namespace :db do
     ActiveRecord::Tasks::DatabaseTasks.drop_current
   end
 
-  # desc "Truncates database tables for current environment"
-  task truncate_tables: [:load_config, :check_protected_environments] do
-    ActiveRecord::Tasks::DatabaseTasks.truncate_tables
-  end
-
   namespace :purge do
     task all: [:load_config, :check_protected_environments] do
       ActiveRecord::Tasks::DatabaseTasks.purge_all
     end
+  end
+
+  # desc "Truncates tables of each database for current environment"
+  task truncate_all: [:load_config, :check_protected_environments] do
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
   # desc "Empty the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:purge:all to purge all databases in the config). Without RAILS_ENV it defaults to purging the development and test databases."
@@ -229,8 +229,8 @@ db_namespace = namespace :db do
   end
 
   namespace :seed do
-    desc "Truncates database tables and loads the seeds"
-    task replant: [:load_config, :truncate_tables, :seed]
+    desc "Truncates tables of each database for current environment and loads the seeds"
+    task replant: [:load_config, :truncate_all, :seed]
   end
 
   namespace :fixtures do

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -189,8 +189,10 @@ module ActiveRecord
           ActiveRecord::Base.internal_metadata_table_name
         ]
 
-        table_names.without(*internal_table_names).each do |table_name|
-          ActiveRecord::Base.connection.truncate(table_name)
+        ActiveRecord::Base.connection.disable_referential_integrity do
+          table_names.without(*internal_table_names).each do |table_name|
+            ActiveRecord::Base.connection.truncate(table_name)
+          end
         end
       end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -182,6 +182,18 @@ module ActiveRecord
         }
       end
 
+      def truncate_tables
+        table_names = ActiveRecord::Base.connection.tables
+        internal_table_names = [
+          ActiveRecord::Base.schema_migrations_table_name,
+          ActiveRecord::Base.internal_metadata_table_name
+        ]
+
+        table_names.without(*internal_table_names).each do |table_name|
+          ActiveRecord::Base.connection.truncate(table_name)
+        end
+      end
+
       def migrate
         check_target_version
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -183,21 +183,21 @@ module ActiveRecord
       end
 
       def truncate_tables(configuration)
-        ActiveRecord::Base.establish_connection(configuration)
-        table_names = ActiveRecord::Base.connection.tables
-        internal_table_names = [
-          ActiveRecord::Base.schema_migrations_table_name,
-          ActiveRecord::Base.internal_metadata_table_name
-        ]
+        ActiveRecord::Base.connected_to(database: { truncation: configuration }) do
+          table_names = ActiveRecord::Base.connection.tables
+          internal_table_names = [
+            ActiveRecord::Base.schema_migrations_table_name,
+            ActiveRecord::Base.internal_metadata_table_name
+          ]
 
-        class_for_adapter(configuration["adapter"]).new(configuration).truncate_tables(*table_names.without(*internal_table_names))
+          class_for_adapter(configuration["adapter"]).new(configuration).truncate_tables(*table_names.without(*internal_table_names))
+        end
       end
 
       def truncate_all(environment = env)
         ActiveRecord::Base.configurations.configs_for(env_name: environment).each do |db_config|
           truncate_tables db_config.config
         end
-        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def migrate

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -31,6 +31,16 @@ module ActiveRecord
         connection.recreate_database configuration["database"], creation_options
       end
 
+      def truncate_tables(*table_names)
+        return if table_names.empty?
+
+        ActiveRecord::Base.connection.disable_referential_integrity do
+          table_names.each do |table_name|
+            ActiveRecord::Base.connection.truncate(table_name)
+          end
+        end
+      end
+
       def charset
         connection.charset
       end

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -48,6 +48,18 @@ module ActiveRecord
         create true
       end
 
+      def truncate_tables(*table_names)
+        return if table_names.empty?
+
+        ActiveRecord::Base.connection.disable_referential_integrity do
+          quoted_table_names = table_names.map do |table_name|
+            ActiveRecord::Base.connection.quote_table_name(table_name)
+          end
+
+          ActiveRecord::Base.connection.execute "TRUNCATE TABLE #{quoted_table_names.join(", ")}"
+        end
+      end
+
       def structure_dump(filename, extra_flags)
         set_psql_env
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -33,6 +33,16 @@ module ActiveRecord
         create
       end
 
+      def truncate_tables(*table_names)
+        return if table_names.empty?
+
+        ActiveRecord::Base.connection.disable_referential_integrity do
+          table_names.each do |table_name|
+            ActiveRecord::Base.connection.truncate(table_name)
+          end
+        end
+      end
+
       def charset
         connection.encoding
       end

--- a/activerecord/test/cases/adapters/sqlite3/connection_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/connection_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class SQLite3ConnectionTest < ActiveRecord::SQLite3TestCase
+  fixtures :comments
+
+  def test_truncate
+    rows = ActiveRecord::Base.connection.exec_query("select count(*) from comments")
+    count = rows.first.values.first
+    assert_operator count, :>, 0
+
+    ActiveRecord::Base.connection.truncate("comments")
+    rows = ActiveRecord::Base.connection.exec_query("select count(*) from comments")
+    count = rows.first.values.first
+    assert_equal 0, count
+  end
+end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -946,6 +946,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksTruncateTablesTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
     fixtures :authors, :author_addresses
 
     def test_truncate_tables

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_record/tasks/database_tasks"
+require "models/author"
 
 module ActiveRecord
   module DatabaseTasksSetupper
@@ -941,6 +942,20 @@ module ActiveRecord
       end
     ensure
       ActiveRecord::Base.configurations = old_configurations
+    end
+  end
+
+  class DatabaseTasksTruncateTablesTest < ActiveRecord::TestCase
+    fixtures :authors, :author_addresses
+
+    def test_truncate_tables
+      assert_operator Author.count, :>, 0
+      assert_operator AuthorAddress.count, :>, 0
+
+      ActiveRecord::Tasks::DatabaseTasks.truncate_tables
+
+      assert_equal 0, Author.count
+      assert_equal 0, AuthorAddress.count
     end
   end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -983,7 +983,7 @@ module ActiveRecord
     end
 
     def test_truncate_all_databases_for_environment
-      with_stubbed_configurations_establish_connection do
+      with_stubbed_configurations do
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
@@ -1000,7 +1000,7 @@ module ActiveRecord
     end
 
     def test_truncate_all_databases_with_url_for_environment
-      with_stubbed_configurations_establish_connection do
+      with_stubbed_configurations do
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
@@ -1017,7 +1017,7 @@ module ActiveRecord
     end
 
     def test_truncate_all_development_databases_when_env_was_no_specified
-      with_stubbed_configurations_establish_connection do
+      with_stubbed_configurations do
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
@@ -1037,7 +1037,7 @@ module ActiveRecord
       old_env = ENV["RAILS_ENV"]
       ENV["RAILS_ENV"] = "development"
 
-      with_stubbed_configurations_establish_connection do
+      with_stubbed_configurations do
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
@@ -1055,28 +1055,12 @@ module ActiveRecord
       ENV["RAILS_ENV"] = old_env
     end
 
-    def test_establishes_connection_for_the_given_environments_config
-      ActiveRecord::Tasks::DatabaseTasks.stub(:truncate_tables, nil) do
-        assert_called_with(
-          ActiveRecord::Base,
-          :establish_connection,
-          [:development]
-        ) do
-          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
-            ActiveSupport::StringInquirer.new("development")
-          )
-        end
-      end
-    end
-
     private
-      def with_stubbed_configurations_establish_connection
+      def with_stubbed_configurations
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
 
-        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
-          yield
-        end
+        yield
       ensure
         ActiveRecord::Base.configurations = old_configurations
       end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -945,20 +945,141 @@ module ActiveRecord
     end
   end
 
-  class DatabaseTasksTruncateTablesTest < ActiveRecord::TestCase
-    self.use_transactional_tests = false
+  unless in_memory_db?
+    class DatabaseTasksTruncateAllTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
 
-    fixtures :authors, :author_addresses
+      fixtures :authors, :author_addresses
 
-    def test_truncate_tables
-      assert_operator Author.count, :>, 0
-      assert_operator AuthorAddress.count, :>, 0
+      def test_truncate_tables
+        assert_operator Author.count, :>, 0
+        assert_operator AuthorAddress.count, :>, 0
 
-      ActiveRecord::Tasks::DatabaseTasks.truncate_tables
+        old_configurations = ActiveRecord::Base.configurations
+        configurations = { development: ActiveRecord::Base.configurations["arunit"] }
+        ActiveRecord::Base.configurations = configurations
 
-      assert_equal 0, Author.count
-      assert_equal 0, AuthorAddress.count
+        ActiveRecord::Tasks::DatabaseTasks.stub(:root, nil) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("development")
+          )
+        end
+
+        assert_equal 0, Author.count
+        assert_equal 0, AuthorAddress.count
+      ensure
+        ActiveRecord::Base.configurations = old_configurations
+      end
     end
+  end
+
+  class DatabaseTasksTruncateAllWithMultipleDatabasesTest < ActiveRecord::TestCase
+    def setup
+      @configurations = {
+        "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
+        "test" => { "primary" => { "database" => "test-db" }, "secondary" => { "database" => "secondary-test-db" } },
+        "production" => { "primary" => { "url" => "abstract://prod-db-host/prod-db" }, "secondary" => { "url" => "abstract://secondary-prod-db-host/secondary-prod-db" } }
+      }
+    end
+
+    def test_truncate_all_databases_for_environment
+      with_stubbed_configurations_establish_connection do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :truncate_tables,
+          [
+            ["database" => "test-db"],
+            ["database" => "secondary-test-db"]
+          ]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("test")
+          )
+        end
+      end
+    end
+
+    def test_truncate_all_databases_with_url_for_environment
+      with_stubbed_configurations_establish_connection do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :truncate_tables,
+          [
+            ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"],
+            ["adapter" => "abstract", "database" => "secondary-prod-db", "host" => "secondary-prod-db-host"]
+          ]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("production")
+          )
+        end
+      end
+    end
+
+    def test_truncate_all_development_databases_when_env_was_no_specified
+      with_stubbed_configurations_establish_connection do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :truncate_tables,
+          [
+            ["database" => "dev-db"],
+            ["database" => "secondary-dev-db"]
+          ]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("development")
+          )
+        end
+      end
+    end
+
+    def test_truncate_all_development_databases_when_env_is_development
+      old_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "development"
+
+      with_stubbed_configurations_establish_connection do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :truncate_tables,
+          [
+            ["database" => "dev-db"],
+            ["database" => "secondary-dev-db"]
+          ]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("development")
+          )
+        end
+      end
+    ensure
+      ENV["RAILS_ENV"] = old_env
+    end
+
+    def test_establishes_connection_for_the_given_environments_config
+      ActiveRecord::Tasks::DatabaseTasks.stub(:truncate_tables, nil) do
+        assert_called_with(
+          ActiveRecord::Base,
+          :establish_connection,
+          [:development]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.truncate_all(
+            ActiveSupport::StringInquirer.new("development")
+          )
+        end
+      end
+    end
+
+    private
+      def with_stubbed_configurations_establish_connection
+        old_configurations = ActiveRecord::Base.configurations
+        ActiveRecord::Base.configurations = @configurations
+
+        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
+          yield
+        end
+      ensure
+        ActiveRecord::Base.configurations = old_configurations
+      end
   end
 
   class DatabaseTasksCharsetTest < ActiveRecord::TestCase

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -140,7 +140,7 @@ module ApplicationTests
         end
       end
 
-      test "db:truncate_tables truncates all not internal tables" do
+      test "db:truncate_all truncates all not internal tables" do
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           rails "db:migrate"
@@ -150,7 +150,7 @@ module ApplicationTests
           schema_migrations = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
           internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
 
-          rails "db:truncate_tables"
+          rails "db:truncate_all"
 
           assert_equal(
             schema_migrations,
@@ -164,7 +164,7 @@ module ApplicationTests
         end
       end
 
-      test "db:truncate_tables does not truncate any tables when environment is protected" do
+      test "db:truncate_all does not truncate any tables when environment is protected" do
         with_rails_env "production" do
           Dir.chdir(app_path) do
             rails "generate", "model", "book", "title:string"
@@ -176,7 +176,7 @@ module ApplicationTests
             internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
             books = ActiveRecord::Base.connection.execute("SELECT * from \"books\"")
 
-            output = rails("db:truncate_tables", allow_failure: true)
+            output = rails("db:truncate_all", allow_failure: true)
             assert_match(/ActiveRecord::ProtectedEnvironmentError/, output)
 
             assert_equal(

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require "isolation/abstract_unit"
+require "env_helpers"
 
 module ApplicationTests
   module RakeTests
     class RakeDbsTest < ActiveSupport::TestCase
-      include ActiveSupport::Testing::Isolation
+      include ActiveSupport::Testing::Isolation, EnvHelpers
 
       def setup
         build_app
@@ -135,6 +136,59 @@ module ApplicationTests
             output = rails("db:drop", allow_failure: true)
             assert_match(/Couldn't drop/, output)
             assert_equal 1, $?.exitstatus
+          end
+        end
+      end
+
+      test "db:truncate_tables truncates all not internal tables" do
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          rails "db:migrate"
+          require "#{app_path}/config/environment"
+          Book.create!(title: "Remote")
+          assert_equal 1, Book.count
+          schema_migrations = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+          internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+
+          rails "db:truncate_tables"
+
+          assert_equal(
+            schema_migrations,
+            ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+          )
+          assert_equal(
+            internal_metadata,
+            ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+          )
+          assert_equal 0, Book.count
+        end
+      end
+
+      test "db:truncate_tables does not truncate any tables when environment is protected" do
+        with_rails_env "production" do
+          Dir.chdir(app_path) do
+            rails "generate", "model", "book", "title:string"
+            rails "db:migrate"
+            require "#{app_path}/config/environment"
+            Book.create!(title: "Remote")
+            assert_equal 1, Book.count
+            schema_migrations = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+            internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+            books = ActiveRecord::Base.connection.execute("SELECT * from \"books\"")
+
+            output = rails("db:truncate_tables", allow_failure: true)
+            assert_match(/ActiveRecord::ProtectedEnvironmentError/, output)
+
+            assert_equal(
+              schema_migrations,
+              ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+            )
+            assert_equal(
+              internal_metadata,
+              ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+            )
+            assert_equal 1, Book.count
+            assert_equal(books, ActiveRecord::Base.connection.execute("SELECT * from \"books\""))
           end
         end
       end
@@ -386,6 +440,72 @@ module ApplicationTests
         rails "db:test:prepare"
 
         assert_equal "test", test_environment.call
+      end
+
+      test "db:seed:replant truncates all not internal tables and loads the seeds" do
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          rails "db:migrate"
+          require "#{app_path}/config/environment"
+          Book.create!(title: "Remote")
+          assert_equal 1, Book.count
+          schema_migrations = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+          internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+
+          app_file "db/seeds.rb", <<-RUBY
+            Book.create!(title: "Rework")
+            Book.create!(title: "Ruby Under a Microscope")
+          RUBY
+
+          rails "db:seed:replant"
+
+          assert_equal(
+            schema_migrations,
+            ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+          )
+          assert_equal(
+            internal_metadata,
+            ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+          )
+          assert_equal 2, Book.count
+          assert_not_predicate Book.where(title: "Remote"), :exists?
+          assert_predicate Book.where(title: "Rework"), :exists?
+          assert_predicate Book.where(title: "Ruby Under a Microscope"), :exists?
+        end
+      end
+
+      test "db:seed:replant does not truncate any tables and does not load the seeds when environment is protected" do
+        with_rails_env "production" do
+          Dir.chdir(app_path) do
+            rails "generate", "model", "book", "title:string"
+            rails "db:migrate"
+            require "#{app_path}/config/environment"
+            Book.create!(title: "Remote")
+            assert_equal 1, Book.count
+            schema_migrations = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+            internal_metadata = ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+            books = ActiveRecord::Base.connection.execute("SELECT * from \"books\"")
+
+            app_file "db/seeds.rb", <<-RUBY
+              Book.create!(title: "Rework")
+            RUBY
+
+            output = rails("db:seed:replant", allow_failure: true)
+            assert_match(/ActiveRecord::ProtectedEnvironmentError/, output)
+
+            assert_equal(
+              schema_migrations,
+              ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.schema_migrations_table_name}\"")
+            )
+            assert_equal(
+              internal_metadata,
+              ActiveRecord::Base.connection.execute("SELECT * from \"#{ActiveRecord::Base.internal_metadata_table_name}\"")
+            )
+            assert_equal 1, Book.count
+            assert_equal(books, ActiveRecord::Base.connection.execute("SELECT * from \"books\""))
+            assert_not_predicate Book.where(title: "Rework"), :exists?
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- Add `ActiveRecord::Base.connection.truncate` for SQLite3 adapter.
    SQLite doesn't support `TRUNCATE TABLE`, but SQLite3 adapter can support
    `ActiveRecord::Base.connection.truncate` by using `DELETE FROM`.
    `DELETE` without `WHERE` uses "The Truncate Optimization",
    see https://www.sqlite.org/lang_delete.html.

- Add `rails db:seed:replant` that truncates tables of each database for current environment and loads the seeds.
  Closes #34765
