### PR TITLE
Fallback to `rubygems` 2.7.8 when failed to install 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "travis_retry gem update --system"
+  - "travis_retry gem update --system || travis_retry gem update --system 2.7.8"
   - "travis_retry gem install bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
`rubygems-update` only supports Ruby >= 2.3.0. So it cannot install in
Ruby 2.2, fall back to the old version failed to install.

Ref: https://travis-ci.org/rails/rails/jobs/471729316#L749-L754
