### PR TITLE
Allow arrays in `#attribute_changed?` params

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow multiple values to optional params `from:` and `to:` for `#attribute_changed?`.
+
+    Example:
+
+        person.name = "Bob"
+        person.name_changed?(from: nil, to: ["Bob", "Bill"]) # => true
+        person.name_changed?(from: ["Pete", "Bill"], to: "Bob"]) # => false
+
+    *David Santos Merino*
+
 *   Fix numericality equality validation of `BigDecimal` and `Float`
     by casting to `BigDecimal` on both ends of the validation.
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -70,6 +70,8 @@ module ActiveModel
   #   person.changed?       # => true
   #   person.name_changed?  # => true
   #   person.name_changed?(from: nil, to: "Bob") # => true
+  #   person.name_changed?(from: nil, to: ["Bob", "Bill"]) # => true
+  #   person.name_changed?(from: ["Pete", "Bill"], to: "Bob"]) # => false
   #   person.name_was       # => nil
   #   person.name_change    # => [nil, "Bob"]
   #   person.name = 'Bill'
@@ -174,8 +176,15 @@ module ActiveModel
     # Handles <tt>*_changed?</tt> for +method_missing+.
     def attribute_changed?(attr, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN) # :nodoc:
       !!changes_include?(attr) &&
-        (to == OPTION_NOT_GIVEN || to == _read_attribute(attr)) &&
-        (from == OPTION_NOT_GIVEN || from == changed_attributes[attr])
+        (
+          to == OPTION_NOT_GIVEN ||
+          to == _read_attribute(attr) ||
+          (to.is_a?(Array) && to.include?(_read_attribute(attr)))
+        ) && (
+          from == OPTION_NOT_GIVEN ||
+          from == changed_attributes[attr] ||
+          (from.is_a?(Array) && from.include?(changed_attributes[attr]))
+        )
     end
 
     # Handles <tt>*_was</tt> for +method_missing+.

--- a/activemodel/test/cases/attributes_dirty_test.rb
+++ b/activemodel/test/cases/attributes_dirty_test.rb
@@ -54,6 +54,18 @@ class AttributesDirtyTest < ActiveModel::TestCase
     assert_not @model.name_changed?(from: "Pete")
   end
 
+  test "checking if an attribute has changed from/to a list of values" do
+    @model.name = "Ringo"
+    @model.save
+    @model.name.replace("Pete")
+    assert @model.name_changed?(from: ["Ringo", "Otto"])
+    assert @model.name_changed?(from: ["Ringo", "Otto"], to: "Pete")
+    assert_not @model.name_changed?(from: ["Pete", "Otto"], to: "Ringo")
+    assert_not @model.name_changed?(from: ["David", "Rafael"], to: "Pete")
+    assert @model.name_changed?(from: "Ringo", to: ["David", "Pete"])
+    assert_not @model.name_changed?(from: "Ringo", to: ["David", "Rafael"])
+  end
+
   test "changes accessible through both strings and symbols" do
     @model.name = "David"
     assert_not_nil @model.changes[:name]


### PR DESCRIPTION
### Summary

The existing method `#attribute_changed` now supports to send arrays to `from:` and `to:` optional params.
It will allow checking if a specific attribute has changed `from` a list of values or `to` a list of values.
Now, we'll be able to do something like this:

    person.name = "Bob"
    person.name_changed?(from: nil, to: ["Bob", "Bill"]) # => true
    person.name_changed?(from: ["Pete", "Bill"], to: "Bob"]) # => false

