### PR TITLE
Add `add_global_tags` to ActiveSupport::TaggedLogging.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added `add_global_tags` to `ActiveSupport::TaggedLogging` to allow for
+    multi-tier logging support.
+    
+    *Daniel Orner*
+
 *   If the same block is `included` multiple times for a Concern, an exception is no longer raised.
 
     *Mark J. Titorenko*, *Vlad Bokov*

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -57,6 +57,13 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[A] [B] [C] a\n[A] [B] b\n[A] c\nd\n", @output.string
   end
 
+  test "Add global tags" do
+    @logger.add_global_tags("D")
+    assert_equal %w(A B C), @logger.push_tags("A", ["B", "  ", ["C"]])
+    @logger.info "d"
+    assert_equal "[D] [A] [B] [C] d\n", @output.string
+  end
+
   test "does not strip message content" do
     @logger.info "  Hello"
     assert_equal "  Hello\n", @output.string

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -251,6 +251,18 @@ logger.tagged("BCX", "Jason") { logger.info "Stuff" }                   # Logs "
 logger.tagged("BCX") { logger.tagged("Jason") { logger.info "Stuff" } } # Logs "[BCX] [Jason] Stuff"
 ```
 
+Tags are thread-safe - if you create a new thread, it will start with a clean
+set of tags. You can also add "global" tags, which are synchronized across threads.
+These are useful if you have a multi-tier architecture - you can assign
+each tier a separate logger with its own global tag:
+
+```ruby
+logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+logger.add_global_tags('Messaging')
+logger.info("Stuff")                         # Logs [Messaging] Stuff
+logger.tagged("BCX") { logger.info("Stuff")} # Logs [Messaging] [BCX] Stuff
+```
+
 ### Impact of Logs on Performance
 Logging will always have a small impact on the performance of your Rails app,
         particularly when logging to disk. Additionally, there are a few subtleties:


### PR DESCRIPTION
### Summary

This is to allow for multiple loggers to be created in a multi-tier architecture. For example, if one tier handles messaging, another serialization and another business logic, this allows each tier to have separate loggers that retain the same tag across all threads. Currently tags are thread-safe and
will be blown away whenever a new thread is created.

In my case I'm using TaggedLogging with a custom framework built around [Phobos](https://github.com/klarna/phobos) which is itself a wrapper around RubyKafka. By giving each layer (as well as the application layer) its own permanent tag, I can more easily separate the logs from the different layers.

This is one approach to solving #28156.

### Other Information

Benchmark results are as follows:

```ruby
Benchmark.ips do |x|
  logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
  x.report("standard") do
    logger.tagged('A', 'B') do
      logger.info("Hi mom")
    end
  end

  # patch goes here
  x.report('standard, no globals') do
    logger.tagged('A', 'B') do
      logger.info("Hi mom")
    end
  end

  logger.add_global_tags('Framework')
  x.report('standard, globals') do
    logger.tagged('A', 'B') do
      logger.info("Hi mom")
    end
  end

  x.compare!
```
Results:
```
            standard:    57779.7 i/s
   standard, globals:    57711.4 i/s - same-ish: difference falls within error
standard, no globals:    57679.8 i/s - same-ish: difference falls within error
```

FYI - this is my first Rails PR so please let me know if anything needs to be fixed or changed.