### PR TITLE
Don't load app environment when editing credentials

### DIFF
--- a/railties/lib/rails/command/actions.rb
+++ b/railties/lib/rails/command/actions.rb
@@ -11,10 +11,20 @@ module Rails
       end
 
       def require_application_and_environment!
+        require_application!
+        require_environment!
+      end
+
+      def require_application!
         require ENGINE_PATH if defined?(ENGINE_PATH)
 
         if defined?(APP_PATH)
           require APP_PATH
+        end
+      end
+
+      def require_environment!
+        if defined?(APP_PATH)
           Rails.application.require_environment!
         end
       end

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -20,7 +20,7 @@ module Rails
       end
 
       def edit
-        require_application_and_environment!
+        require_application!
 
         ensure_editor_available(command: "bin/rails credentials:edit") || (return)
 
@@ -39,7 +39,7 @@ module Rails
       end
 
       def show
-        require_application_and_environment!
+        require_application!
 
         encrypted = Rails.application.encrypted(content_path, key_path: key_path)
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -63,6 +63,14 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "edit command does not raise when an initializer tries to acces non-existent credentials" do
+    app_file "config/initializers/raise_when_loaded.rb", <<-RUBY
+      Rails.application.credentials.missing_key!
+    RUBY
+
+    assert_match(/access_key_id: 123/, run_edit_command(environment: "qa"))
+  end
+
   test "show credentials" do
     assert_match(/access_key_id: 123/, run_show_command)
   end


### PR DESCRIPTION
### Summary

While evaluating [multi-environment credentials](https://github.com/rails/rails/pull/33521#issuecomment-449735483), I came across a problem trying to create a new environment for my app.

Once you have created your first environment (e.g. `development`) you might start adding configuration in initialisers that tries to access encrypted credentials like so:

```ruby
# config/initializers/sidekiq.rb
Sidekiq::Web.set :session_secret, Rails.application.credentials.secret_key_base!
```

That works fine when running `rails credentials:edit --environment development` 

If you now decide to create a `staging` environment,  doing `rails credentials:edit --environment staging` will fail with something similar to `...ordered_options.rb:49:in 'method_missing': :secret_key_base is blank (KeyError)`

A great many gems that access 3rd party APIs use an initialiser for configuring credentials so the above situation is quite likely to occur.

I worked around the issue by creating a new empty Rails app, running `rails credentials:edit --environment staging` in it, and copying across the generated credential files. 

This PR attempts to fix the issue by not loading the application environment for `rails credentials:*` commands.

I've added a test but I am not sure that it is correct (or sufficient) as I struggled to fully understand the railties test harness. Happy to try another way to test this.