### PR TITLE
Numericality validation skips some checks when a proc or a method call return nil

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,14 +1,33 @@
+*   Numericality validation should skip `:greater_than`, `:greater_than_or_equal_to`, `:less_than`,
+    `:less_than_or_equal_to` checks when a proc or a method call return nil instead of throwing
+    `ArgumentError: comparison of Integer with nil failed`.
+
+    Example:
+
+    ```
+    class ProductFilter
+      include ActiveModel::Validations
+
+      validates :min_price, numericality: { allow_nil: true }
+      validates :max_price, numericality: { allow_nil: true, greater_than: :min_price }
+    end
+
+    ProductFilter.new(max_price: 100).valid? # => true
+    ```
+
+    *Dmitry Tsepelev*
+
 *   Raise FrozenError when trying to write attributes that aren't backed by the database on an object that is frozen:
 
         class Animal
           include ActiveModel::Attributes  
           attribute :age 
         end
-        
+
         animal = Animal.new
         animal.freeze 
         animal.age = 25 # => FrozenError, "can't modify a frozen Animal"
-          
+
 *   Add *_previously_was attribute methods when dirty tracking. Example:
 
         pirate.update(catchphrase: "Ahoy!")

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -233,6 +233,31 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Topic.remove_method :max_approved
   end
 
+  def test_validates_numericality_with_symbol_and_nil_value
+    Topic.define_method(:max_approved) { nil }
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: :max_approved
+
+    valid!([4])
+  ensure
+    Topic.remove_method :max_approved
+  end
+
+  def test_validates_numericality_equal_to_with_symbol_and_nil_value
+    Topic.define_method(:max_approved) { nil }
+    Topic.validates_numericality_of :approved, allow_nil: true, equal_to: :max_approved
+
+    invalid!([4, 5])
+    valid!([nil])
+  ensure
+    Topic.remove_method :max_approved
+  end
+
+  def test_validates_numericality_with_proc_and_nil_value
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: ->(_) { nil }
+
+    valid!([4])
+  end
+
   def test_validates_numericality_with_numeric_message
     Topic.validates_numericality_of :approved, less_than: 4, message: "smaller than %{count}"
     topic = Topic.new("title" => "numeric test", "approved" => 10)


### PR DESCRIPTION
Numericality validation should skip `:greater_than`, `:greater_than_or_equal_to`, `:equal_to`,
`:less_than`, `:less_than_or_equal_to` checks when a proc or a method call return nil instead
of throwing `ArgumentError: comparison of Integer with nil failed`.

In my opinion, it would be more helpful to skip these checks, because in this case user won't have to write a complex proc to handle the case when the value it's compared to is nil.

In other words, now we can write:

```ruby
class ProductFilter
  include ActiveModel::Validations

  validates :min_price, numericality: { allow_nil: true }
  validates :max_price, numericality: { allow_nil: true, greater_than: :min_price }
end

ProductFilter.new(max_price: 100).valid? # => true
```

instead of something like:

```ruby
class ProductFilter
  include ActiveModel::Validations

  validates :min_price, numericality: { allow_nil: true }
  validates :max_price, numericality: { allow_nil: true, greater_than: ->(filter) { filter.min_price.to_i } }
end

ProductFilter.new(max_price: 100).valid? # => true
```