### PR TITLE
Wrap Mysql count of deleted rows in lock block to avoid conflict in test

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -61,7 +61,9 @@ module ActiveRecord
 
         def exec_delete(sql, name = nil, binds = [])
           if without_prepared_statement?(binds)
-            execute_and_free(sql, name) { @connection.affected_rows }
+            @lock.synchronize do
+              execute_and_free(sql, name) { @connection.affected_rows }
+            end
           else
             exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }
           end

--- a/activerecord/test/cases/adapters/mysql2/count_deleted_rows_with_lock_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/count_deleted_rows_with_lock_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "models/author"
+require "models/bulb"
+
+module ActiveRecord
+  class CountDeletedRowsWithLockTest < ActiveRecord::Mysql2TestCase
+    test "delete and create in different threads synchronize correctly" do
+      Bulb.unscoped.delete_all
+      Bulb.create!(name: "Jimmy", color: "blue")
+
+      delete_thread = Thread.new do
+        Bulb.unscoped.delete_all
+      end
+
+      create_thread = Thread.new do
+        Author.create!(name: "Tommy")
+      end
+
+      delete_thread.join
+      create_thread.join
+
+      assert_equal 1, delete_thread.value
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This PR is my attempt to fix my discovered issue #34798. My logic here is that the connection is still needed to count the number of deleted rows in

https://github.com/rails/rails/blob/96dee0e7e5a8dd6ce42999b13d0bd0623073e229/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb#L45

So I wrap the function `execute_and_free` in the block of `@block.synchronize` so that no other threads can use the connection until it finishes counting the deleted rows.
