### PR TITLE
Add more Ruby `2.6.0` and `head` on CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,23 @@ matrix:
         - "GEM=activerecord:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.3
+    - rvm: 2.6.0
+      env:
+        - "GEM=activerecord:mysql2 MYSQL=mariadb"
+      addons:
+        mariadb: 10.3
+    - rvm: ruby-head
+      env:
+        - "GEM=activerecord:mysql2 MYSQL=mariadb"
+      addons:
+        mariadb: 10.3
     - rvm: 2.5.3
+      env:
+        - "GEM=activerecord:sqlite3_mem"
+    - rvm: 2.6.0
+      env:
+        - "GEM=activerecord:sqlite3_mem"
+    - rvm: ruby-head
       env:
         - "GEM=activerecord:sqlite3_mem"
     - rvm: 2.5.3


### PR DESCRIPTION
This PR adds a few builds on CI with Ruby `2.6.0` and `head` versions.