### PR TITLE
Reuse AR::Association#find_target method

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -179,6 +179,23 @@ module ActiveRecord
       end
 
       private
+
+        def find_target
+          scope = self.scope
+          return scope.to_a if skip_statement_cache?(scope)
+
+          conn = klass.connection
+          sc = reflection.association_scope_cache(conn, owner) do |params|
+            as = AssociationScope.create { params.bind }
+            target_scope.merge!(as.scope(self))
+          end
+
+          binds = AssociationScope.get_bind_values(owner, reflection.chain)
+          sc.execute(binds, conn) do |record|
+            set_inverse_instance(record)
+          end
+        end
+
         # The scope for this association.
         #
         # Note that the association_scope is merged into the target_scope only when the

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -26,7 +26,9 @@ module ActiveRecord
         chain = get_chain(reflection, association, scope.alias_tracker)
 
         scope.extending! reflection.extensions
-        add_constraints(scope, owner, chain)
+        scope = add_constraints(scope, owner, chain)
+        scope.limit!(1) unless reflection.collection?
+        scope
       end
 
       def self.get_bind_values(owner, chain)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -303,21 +303,6 @@ module ActiveRecord
       end
 
       private
-        def find_target
-          scope = self.scope
-          return scope.to_a if skip_statement_cache?(scope)
-
-          conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do |params|
-            as = AssociationScope.create { params.bind }
-            target_scope.merge!(as.scope(self))
-          end
-
-          binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, conn) do |record|
-            set_inverse_instance(record)
-          end
-        end
 
         # We have some records loaded from the database (persisted) and some that are
         # in-memory (memory). The same record may be represented in the persisted array

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -36,19 +36,7 @@ module ActiveRecord
         end
 
         def find_target
-          scope = self.scope
-          return scope.take if skip_statement_cache?(scope)
-
-          conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do |params|
-            as = AssociationScope.create { params.bind }
-            target_scope.merge!(as.scope(self)).limit(1)
-          end
-
-          binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, conn) do |record|
-            set_inverse_instance record
-          end.first
+          super.first
         rescue ::RangeError
           nil
         end


### PR DESCRIPTION
After the failed attempt to reuse code https://github.com/rails/rails/pull/34538 the regression was added https://github.com/rails/rails/commit/ba4e68f577efc76f351d30a2914e29942b97830e

This patch incorporates the regression by extending a more low level methods inside `AssociationScope` which is the only place the `limit(1)` can be shared across all usages.

cc @eileencodes 

r? @kamipo 

