### PR TITLE
`ActionView::Helpers::FormOptionsHelper#select` should mark option for `nil` as selected

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   `ActionView::Helpers::FormOptionsHelper#select` should mark option for `nil` as selected.
+
+    ```ruby
+    @post = Post.new
+    @post.category = nil
+
+    # Before
+    select("post", "category", none: nil, programming: 1, economics: 2)
+    # =>
+    # <select name="post[category]" id="post_category">
+    #   <option value="">none</option>
+    #  <option value="1">programming</option>
+    #  <option value="2">economics</option>
+    # </select>
+
+    # After
+    select("post", "category", none: nil, programming: 1, economics: 2)
+    # =>
+    # <select name="post[category]" id="post_category">
+    #   <option selected="selected" value="">none</option>
+    #  <option value="1">programming</option>
+    #  <option value="2">economics</option>
+    # </select>
+    ```
+
+    *bogdanvlviv*
+
 *   Log lines for partial renders and started template renders are now
     emitted at the `DEBUG` level instead of `INFO`.
 

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -15,7 +15,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value },
+            selected: @options.fetch(:selected) { value.to_s },
             disabled: @options[:disabled]
           }
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -826,6 +826,24 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_nil_as_selected_value
+    @post = Post.new
+    @post.category = nil
+    assert_dom_equal(
+      "<select name=\"post[category]\" id=\"post_category\"><option selected=\"selected\" value=\"\">none</option>\n<option value=\"1\">programming</option>\n<option value=\"2\">economics</option></select>",
+      select("post", "category", none: nil, programming: 1, economics: 2)
+    )
+  end
+
+  def test_select_with_nil_and_selected_option_as_nil
+    @post = Post.new
+    @post.category = nil
+    assert_dom_equal(
+      "<select name=\"post[category]\" id=\"post_category\"><option value=\"\">none</option>\n<option value=\"1\">programming</option>\n<option value=\"2\">economics</option></select>",
+      select("post", "category", { none: nil, programming: 1, economics: 2 }, { selected: nil })
+    )
+  end
+
   def test_required_select
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required"><option value=""></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),


### PR DESCRIPTION
```ruby
@post = Post.new
@post.category = nil

# Before
select("post", "category", none: nil, programming: 1, economics: 2)
# =>
# <select name="post[category]" id="post_category">
#   <option value="">none</option>
#  <option value="1">programming</option>
#  <option value="2">economics</option>
# </select>

# After
select("post", "category", none: nil, programming: 1, economics: 2)
# =>
# <select name="post[category]" id="post_category">
#   <option selected="selected" value="">none</option>
#  <option value="1">programming</option>
#  <option value="2">economics</option>
# </select>
```

To get the same result without these changes we can set `:selected` as `@post.category.to_s`:
```ruby
select("post", "category", {none: nil, programming: 1, economics: 2}, {selected: @post.category.to_s})
```

Currently, I think that `select` with these changes will behave in a more expected way in this case with `nil`.
Please, let me know what do you think about it?