### PR TITLE
ActiveStorage: Don’t include an undefined X-CSRF-Token header when creating a blob record

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   It doesn’t include an `X-CSRF-Token` header if a meta tag is not found on
+    the page. It previously included one with a value of `undefined`.
+
+    *Cameron Bothner*
+
 *   Fix `ArgumentError` when uploading to amazon s3
 
     *Hiroki Sanpei*

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -560,7 +560,10 @@
       this.xhr.setRequestHeader("Content-Type", "application/json");
       this.xhr.setRequestHeader("Accept", "application/json");
       this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-      this.xhr.setRequestHeader("X-CSRF-Token", getMetaValue("csrf-token"));
+      var csrfToken = getMetaValue("csrf-token");
+      if (csrfToken != undefined) {
+        this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
+      }
       this.xhr.addEventListener("load", function(event) {
         return _this.requestDidLoad(event);
       });

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -17,7 +17,12 @@ export class BlobRecord {
     this.xhr.setRequestHeader("Content-Type", "application/json")
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
-    this.xhr.setRequestHeader("X-CSRF-Token", getMetaValue("csrf-token"))
+
+    const csrfToken = getMetaValue("csrf-token")
+    if (csrfToken != undefined) {
+      this.xhr.setRequestHeader("X-CSRF-Token", csrfToken)
+    }
+
     this.xhr.addEventListener("load", event => this.requestDidLoad(event))
     this.xhr.addEventListener("error", event => this.requestDidError(event))
   }


### PR DESCRIPTION
### Summary

If there is not a `csrf-token` meta tag in the document, the blob record XHR includes an `X-CSRF-Token` header set to the string `"undefined"`. Instead, it should not be included in the absence of a meta tag.

### Other Information

This came up in a library using ActiveStorage in a React context: https://github.com/cbothner/react-activestorage-provider/pull/10#issuecomment-432447633. Since it's not possible to remove a header from an XHR (and the only way to change it is by appending) it's not possible for an API only application to provide a CSRF token that was acquired in a different way. If we omit the header when there's no meta tag on the page, users can set the header in a callback to `direct-upload:before-blob-request`.

r? @georgeclaghorn 
