### PR TITLE
Add `--skip-action-mailbox` option to `rails new`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -44,6 +44,9 @@ module Rails
                                            default: false,
                                            desc: "Skip Action Mailer files"
 
+        class_option :skip_action_mailbox, type: :boolean, default: false,
+                                           desc: "Skip Action Mailbox files"
+
         class_option :skip_active_record,  type: :boolean, aliases: "-O", default: false,
                                            desc: "Skip Active Record files"
 
@@ -231,7 +234,7 @@ module Rails
       end
 
       def skip_action_mailbox? # :doc:
-        options[:skip_active_record]
+        options[:skip_action_mailbox] || options[:skip_active_record]
       end
 
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -435,6 +435,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "#{app_root}/config/storage.yml"
   end
 
+  def test_generator_when_skip_action_mailbox_is_given
+    run_generator [destination_root, "--skip-action-mailbox"]
+    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
+  end
+
+  def test_generator_skips_action_mailbox_when_skip_active_record_is_given
+    run_generator [destination_root, "--skip-active-record"]
+    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
+  end
+
   def test_app_update_does_not_change_config_target_version
     run_generator
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -127,6 +127,7 @@ module SharedGeneratorTests
       "--skip-active-record",
       "--skip-active-storage",
       "--skip-action-mailer",
+      "--skip-action-mailbox",
       "--skip-action-cable",
       "--skip-sprockets"
     ]
@@ -138,6 +139,9 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']active_storage\/engine["']/
     assert_file "#{application_path}/config/application.rb", /^require\s+["']action_controller\/railtie["']/
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']action_mailer\/railtie["']/
+    unless generator_class.name == "Rails::Generators::PluginGenerator"
+      assert_file "#{application_path}/config/application.rb", /^# require\s+["']action_mailbox\/engine["']/
+    end
     assert_file "#{application_path}/config/application.rb", /^require\s+["']action_view\/railtie["']/
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']action_cable\/engine["']/
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']sprockets\/railtie["']/


### PR DESCRIPTION
Currently, we do not generate Action Mailbox files, but It would be great to have `skip-action-mailbox` option for flexibility, and consistency.
Related to https://github.com/rails/rails/commit/ddaf06779aa51d5d1ca462c21c53f2ed169a0d2f
/cc @georgeclaghorn 