### PR TITLE
Fix `ActiveModel::Errors#added?`

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -328,20 +328,24 @@ module ActiveModel
     #   person.errors.added? :name, :blank           # => true
     #   person.errors.added? :name, "can't be blank" # => true
     #
-    # If the error message requires an option, then it returns +true+ with
-    # the correct option, or +false+ with an incorrect or missing option.
+    # If the error message requires options, then it returns +true+ with
+    # the correct options, or +false+ with incorrect options.
     #
     #  person.errors.add :name, :too_long, { count: 25 }
+    #  person.errors.added? :name, :too_long                                # => true
     #  person.errors.added? :name, :too_long, count: 25                     # => true
     #  person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
     #  person.errors.added? :name, :too_long, count: 24                     # => false
-    #  person.errors.added? :name, :too_long                                # => false
     #  person.errors.added? :name, "is too long"                            # => false
     def added?(attribute, message = :invalid, options = {})
       message = message.call if message.respond_to?(:call)
 
       if message.is_a? Symbol
-        details[attribute.to_sym].include? normalize_detail(message, options)
+        if options.blank?
+          details[attribute.to_sym].map { |e| e[:error] }.include? message
+        else
+          details[attribute.to_sym].include? normalize_detail(message, options)
+        end
       else
         self[attribute].include? message
       end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -228,13 +228,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not person.errors.added?(:name)
   end
 
-  test "added? returns false when checking for an error with an incorrect or missing option" do
+  test "added? returns false when checking for an error with incorrect options" do
     person = Person.new
-    person.errors.add :name, :too_long, count: 25
+    person.errors.add :name, :too_long, count: 25, actual_count: 42
 
-    assert person.errors.added? :name, :too_long, count: 25
+    assert person.errors.added? :name, :too_long
+    assert person.errors.added? :name, :too_long, count: 25, actual_count: 42
+    assert person.errors.added? :name, "is too long (maximum is 25 characters)"
+    assert_not person.errors.added? :name, :too_long, count: 25
+    assert_not person.errors.added? :name, :too_long, count: 24, actual_count: 42
     assert_not person.errors.added? :name, :too_long, count: 24
-    assert_not person.errors.added? :name, :too_long
     assert_not person.errors.added? :name, "is too long"
   end
 


### PR DESCRIPTION
`#added?` without options shouldn't try to match by options

See https://github.com/rails/rails/issues/34813#issuecomment-450375840

I know that we are working on https://github.com/rails/rails/pull/32313 that should introduce model for an error object(instead of using Hash), but there is two reasons why we should merge this to master: Improved test that describes `added?` method behavior better and also we should backport it to `5-2-stable` since we made regression in 5.2.2 ad739f59aa0fd81850010cedf992b81b24da9ff1.

Closes #34813
