### PR TITLE
Make ActiveStorage::Blob keys lowercase

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Use base36 (all lowercase) for all new Blob keys keys to prevent
+*   Use base36 (all lowercase) for all new Blob keys to prevent
     collisions and undefined behavior with case-insensitive filesystems and
     database indices.
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use base36 (all lowercase) for all new Blob keys keys to prevent
+    collisions and undefined behavior with case-insensitive filesystems and
+    database indices.
+
+    *Julik Tarkhanov*
+
 *   It doesn’t include an `X-CSRF-Token` header if a meta tag is not found on
     the page. It previously included one with a value of `undefined`.
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -79,6 +79,15 @@ class ActiveStorage::Blob < ActiveRecord::Base
     def create_before_direct_upload!(filename:, byte_size:, checksum:, content_type: nil, metadata: nil)
       create! filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, metadata: metadata
     end
+
+    # To prevent problems with case-insensitive filesystems, especially in combination
+    # with databases which treat indices as case-sensitive, all blob keys generated are going
+    # to only contain the base-36 character alphabet and will therefore be lowercase. To maintain
+    # the same or higher amount of entropy as in the base-58 encoding used by `has_secure_token`
+    # the number of bytes used is increased to 28 from the standard 24
+    def generate_unique_secure_token
+      SecureRandom.base58(28).downcase
+    end
   end
 
   # Returns a signed ID for this blob that's suitable for reference on the client-side without fear of tampering.
@@ -88,8 +97,9 @@ class ActiveStorage::Blob < ActiveRecord::Base
   end
 
   # Returns the key pointing to the file on the service that's associated with this blob. The key is in the
-  # standard secure-token format from Rails. So it'll look like: XTAPjJCJiuDrLk3TmwyJGpUo. This key is not intended
-  # to be revealed directly to the user. Always refer to blobs using the signed_id or a verified form of the key.
+  # standard secure-token format from Rails. So it'll look like: xtapjjcjiudrlk3tmwyjgpuobabd.
+  # This key is not intended to be revealed directly to the user.
+  # Always refer to blobs using the signed_id or a verified form of the key.
   def key
     # We can't wait until the record is first saved to have a key for it
     self[:key] ||= self.class.generate_unique_secure_token

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -86,7 +86,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # the same or higher amount of entropy as in the base-58 encoding used by `has_secure_token`
     # the number of bytes used is increased to 28 from the standard 24
     def generate_unique_secure_token
-      SecureRandom.base36_lowercase(28)
+      SecureRandom.base36(28)
     end
   end
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -16,6 +16,8 @@ require "active_storage/downloader"
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
+  BASE36_ALPHABET = ('a'..'z').to_a + ('0'..'9').to_a
+
   require_dependency "active_storage/blob/analyzable"
   require_dependency "active_storage/blob/identifiable"
   require_dependency "active_storage/blob/representable"
@@ -86,7 +88,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # the same or higher amount of entropy as in the base-58 encoding used by `has_secure_token`
     # the number of bytes used is increased to 28 from the standard 24
     def generate_unique_secure_token
-      SecureRandom.base58(28).downcase
+      28.times.map { BASE36_ALPHABET[SecureRandom.random_number(BASE36_ALPHABET.length)] }.join
     end
   end
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -16,8 +16,6 @@ require "active_storage/downloader"
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
-  BASE36_ALPHABET = ("a".."z").to_a + ("0".."9").to_a
-
   require_dependency "active_storage/blob/analyzable"
   require_dependency "active_storage/blob/identifiable"
   require_dependency "active_storage/blob/representable"

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -98,8 +98,8 @@ class ActiveStorage::Blob < ActiveRecord::Base
     ActiveStorage.verifier.generate(id, purpose: :blob_id)
   end
 
-  # Returns the key pointing to the file on the service that's associated with this blob. The key is in the
-  # standard secure-token format from Rails. So it'll look like: xtapjjcjiudrlk3tmwyjgpuobabd.
+  # Returns the key pointing to the file on the service that's associated with this blob. The key is the
+  # secure-token format from Rails in lower case. So it'll look like: xtapjjcjiudrlk3tmwyjgpuobabd.
   # This key is not intended to be revealed directly to the user.
   # Always refer to blobs using the signed_id or a verified form of the key.
   def key

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -88,7 +88,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # the same or higher amount of entropy as in the base-58 encoding used by `has_secure_token`
     # the number of bytes used is increased to 28 from the standard 24
     def generate_unique_secure_token
-      28.times.map { BASE36_ALPHABET[SecureRandom.random_number(BASE36_ALPHABET.length)] }.join
+      SecureRandom.base36_lowercase(28)
     end
   end
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -16,7 +16,7 @@ require "active_storage/downloader"
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
-  BASE36_ALPHABET = ('a'..'z').to_a + ('0'..'9').to_a
+  BASE36_ALPHABET = ("a".."z").to_a + ("0".."9").to_a
 
   require_dependency "active_storage/blob/analyzable"
   require_dependency "active_storage/blob/identifiable"

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -47,6 +47,16 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "text/csv", blob.content_type
   end
 
+  test "create after upload only assigns lowercase keys with 28 bytes of data" do
+    blobs = 20.times.map do
+      create_blob data: Random.new.bytes(20), filename: "rand.bin", content_type: "binary/octet-stream", identify: false
+    end
+    keys = blobs.map(&:key)
+    keys.each do |key|
+      assert_match /^[a-z0-9]{28}$/, key
+    end
+  end
+
   test "image?" do
     blob = create_file_blob filename: "racecar.jpg"
     assert_predicate blob, :image?

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -47,14 +47,8 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "text/csv", blob.content_type
   end
 
-  test "create after upload only assigns lowercase keys with 28 bytes of data" do
-    blobs = 20.times.map do
-      create_blob data: Random.new.bytes(20), filename: "rand.bin", content_type: "binary/octet-stream", identify: false
-    end
-    keys = blobs.map(&:key)
-    keys.each do |key|
-      assert_match /^[a-z0-9]{28}$/, key
-    end
+  test "create after upload generates a 28-character base36 key" do
+    assert_match(/^[a-z0-9]{28}$/, create_blob.key)
   end
 
   test "image?" do

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -150,7 +150,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "service_url doesn't grow in length despite long variant options" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(font: "a" * 10_000).processed
-    assert_operator variant.service_url.length, :<, 729
+    assert_operator variant.service_url.length, :<, 730
   end
 
   test "works for vips processor" do

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -150,7 +150,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "service_url doesn't grow in length despite long variant options" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(font: "a" * 10_000).processed
-    assert_operator variant.service_url.length, :<, 726
+    assert_operator variant.service_url.length, :<, 729
   end
 
   test "works for vips processor" do

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -4,6 +4,8 @@ require "securerandom"
 
 module SecureRandom
   BASE58_ALPHABET = ("0".."9").to_a + ("A".."Z").to_a + ("a".."z").to_a - ["0", "O", "I", "l"]
+  BASE36_ALPHABET = ("0".."9").to_a + ("a".."z").to_a
+
   # SecureRandom.base58 generates a random base58 string.
   #
   # The argument _n_ specifies the length, of the random string to be generated.
@@ -20,6 +22,26 @@ module SecureRandom
       idx = byte % 64
       idx = SecureRandom.random_number(58) if idx >= 58
       BASE58_ALPHABET[idx]
+    end.join
+  end
+
+  # SecureRandom.base36 generates a random base36 string in lowercase.
+  #
+  # The argument _n_ specifies the length, of the random string to be generated.
+  #
+  # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
+  # This method can be used over +base58+ if a deterministic case key is necessary.
+  #
+  # The result may contain alphanumeric characters in lowercase
+  #
+  #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
+  #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
+  #
+  def self.base36_lowercase(n = 16)
+    SecureRandom.random_bytes(n).unpack("C*").map do |byte|
+      idx = byte % 64
+      idx = SecureRandom.random_number(36) if idx >= 36
+      BASE36_ALPHABET[idx]
     end.join
   end
 end

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -8,15 +8,14 @@ module SecureRandom
 
   # SecureRandom.base58 generates a random base58 string.
   #
-  # The argument _n_ specifies the length, of the random string to be generated.
+  # The argument _n_ specifies the length of the random string to be generated.
   #
   # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
   #
-  # The result may contain alphanumeric characters except 0, O, I and l
+  # The result may contain alphanumeric characters except 0, O, I and l.
   #
   #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
   #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
-  #
   def self.base58(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|
       idx = byte % 64
@@ -27,17 +26,16 @@ module SecureRandom
 
   # SecureRandom.base36 generates a random base36 string in lowercase.
   #
-  # The argument _n_ specifies the length, of the random string to be generated.
+  # The argument _n_ specifies the length of the random string to be generated.
   #
   # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
   # This method can be used over +base58+ if a deterministic case key is necessary.
   #
-  # The result may contain alphanumeric characters in lowercase
+  # The result will contain alphanumeric characters in lowercase.
   #
   #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
   #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
-  #
-  def self.base36_lowercase(n = 16)
+  def self.base36(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|
       idx = byte % 64
       idx = SecureRandom.random_number(36) if idx >= 36

--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -21,23 +21,22 @@ class SecureRandomTest < ActiveSupport::TestCase
   end
 
   def test_base36_lowercase
-    s1 = SecureRandom.base36_lowercase
-    s2 = SecureRandom.base36_lowercase
+    s1 = SecureRandom.base36
+    s2 = SecureRandom.base36
 
     assert_not_equal s1, s2
     assert_equal 16, s1.length
-    assert_match /^[a-z0-9]+$/, s1
-    assert_match /^[a-z0-9]+$/, s2
+    assert_match(/^[a-z0-9]+$/, s1)
+    assert_match(/^[a-z0-9]+$/, s2)
   end
 
   def test_base36_with_length
-    s1 = SecureRandom.base36_lowercase(24)
-    s2 = SecureRandom.base36_lowercase(24)
+    s1 = SecureRandom.base36(24)
+    s2 = SecureRandom.base36(24)
 
     assert_not_equal s1, s2
     assert_equal 24, s1.length
-    assert_match /^[a-z0-9]+$/, s1
-    assert_match /^[a-z0-9]+$/, s2
+    assert_match(/^[a-z0-9]+$/, s1)
+    assert_match(/^[a-z0-9]+$/, s2)
   end
-
 end

--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -19,4 +19,25 @@ class SecureRandomTest < ActiveSupport::TestCase
     assert_not_equal s1, s2
     assert_equal 24, s1.length
   end
+
+  def test_base36_lowercase
+    s1 = SecureRandom.base36_lowercase
+    s2 = SecureRandom.base36_lowercase
+
+    assert_not_equal s1, s2
+    assert_equal 16, s1.length
+    assert_match /^[a-z0-9]+$/, s1
+    assert_match /^[a-z0-9]+$/, s2
+  end
+
+  def test_base36_with_length
+    s1 = SecureRandom.base36_lowercase(24)
+    s2 = SecureRandom.base36_lowercase(24)
+
+    assert_not_equal s1, s2
+    assert_equal 24, s1.length
+    assert_match /^[a-z0-9]+$/, s1
+    assert_match /^[a-z0-9]+$/, s2
+  end
+
 end


### PR DESCRIPTION
### Summary

When used with case-insensitive filesystems ActiveStorage blobs might cause non-portable Disk storage directories to be created, and the UNIQUE index that gets configured on the `active_storage_blobs` table is database-dependent in terms of case-sensitivity. If the database index is case-sensitive, but the underlying filesystem is not, blobs might be overwritten and the available key space for uploaded blobs shrinks drastically. This does happen on macOS filesystems already.

This patch changes the ActiveStorage key generation from mixed-case base-58 to lowercase base-36, and increases the key size from 24 bytes to 28. When using base58 there are `58**24` possible key values, and to have the same or more possible keys with base36 we need to have `36**28`, increasing the storage requirement for the key by 4 bytes. Since the database migrations for the blobs table are not CHAR()-size-restricted (and the fix worked for me both on SQLite and MySQL) I believe this is a reasonable compromise.

Note that this will not alter the storage keys that have already been generated, their treatment wills tay unchanged. Neither will it correct the storage directory structures that were created using mixed-case keys on macOS since you need to "rekey" the stored objects if you want the storage directory to be portable to a case-sensitive filesystem.

Closes #34804 , addresses the underlying issue in #33864 for freshly-generated uploaded blobs. Unfortunately it cannot be excluded that for some people some blobs already did get overwritten if SQLite was used in combination with a case-insensitive filesystem and the Disk storage service. Neither does this change existing blob keys.

This change does have an implication that for existing S3 buckets and for other services that potentially use "naive partitioning" (first N  bytes of the given object store key) partition usage is going to become less "fair". However, AWS recently dropped the recommendation on manual key distribution for the key prefix (https://www.infoq.com/news/2018/10/amazon-s3-performance-increase) as it seems they have adopted hashing for the keys the user provides, so this would not be a problem for buckets that get created.

The advantages of using a lowercase-only key:

* Less potential issues with collation-sensitive database indices
* Removes issues with potentially case-insensitive blob stores
* Makes it easier to download blobs from a remote store to a case-insensitive filesystem for debugging