### PR TITLE
[ActiveStorage] Allow `variant` method to be called by `TIFF` images

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Permit generating variants of TIFF images.
+
+    *Luciano Sousa*
+
 *   Use base36 (all lowercase) for all new Blob keys to prevent
     collisions and undefined behavior with case-insensitive filesystems and
     database indices.

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -27,6 +27,7 @@ module ActiveStorage
       image/jpg
       image/jpeg
       image/pjpeg
+      image/tiff
       image/vnd.adobe.photoshop
       image/vnd.microsoft.icon
     )
@@ -49,6 +50,7 @@ module ActiveStorage
       image/gif
       image/jpg
       image/jpeg
+      image/tiff
       image/vnd.adobe.photoshop
       image/vnd.microsoft.icon
       application/pdf

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -133,6 +133,17 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_equal 20, image.height
   end
 
+  test "resized variation of TIFF blob" do
+    blob = create_file_blob(filename: "racecar.tif")
+    variant = blob.variant(resize: "50x50").processed
+    assert_match(/racecar\.png/, variant.service_url)
+
+    image = read_image(variant)
+    assert_equal "PNG", image.type
+    assert_equal 50, image.width
+    assert_equal 33, image.height
+  end
+
   test "optimized variation of GIF blob" do
     blob = create_file_blob(filename: "image.gif", content_type: "image/gif")
 


### PR DESCRIPTION
### Summary
Allow a new image extension(`tiff`) to call the `variant` method and generate custom images

### Other Information
Fixes #34698 
`TIFF` images are supported by IE and Safari browsers, but not by Chrome or Firefox
