### PR TITLE
Use 6.0 version of `ActiveRecord::Migration` for Action Mailbox

### DIFF
--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -1,4 +1,4 @@
-class CreateActionMailboxTables < ActiveRecord::Migration[5.2]
+class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_mailbox_inbound_emails do |t|
       t.integer :status, default: 0, null: false

--- a/actionmailbox/test/dummy/config/application.rb
+++ b/actionmailbox/test/dummy/config/application.rb
@@ -7,7 +7,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailroom_tables.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailroom_tables.rb
@@ -1,4 +1,4 @@
-class CreateActionMailboxTables < ActiveRecord::Migration[5.2]
+class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_mailbox_inbound_emails do |t|
       t.integer :status, default: 0, null: false

--- a/activestorage/test/dummy/config/application.rb
+++ b/activestorage/test/dummy/config/application.rb
@@ -15,7 +15,7 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     config.active_storage.service = :local
   end


### PR DESCRIPTION
- Use 6.0 version of `ActiveRecord::Migration` for Action Mailbox
  Since Action Mailbox will be introduced in Rails 6.0,
  it makes more sense to generate migration of that version.
  Also, I changed its test dummy app to use default 6.0 configs.

- Use 6.0 default configs in Active Storage test dummy app

/cc @georgeclaghorn 