### PR TITLE
Always save ActiveStorage::Blob before uploading to service

### DIFF
--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -28,7 +28,7 @@ end
 class ActiveSupport::TestCase
   private
     def create_file_blob(filename:, content_type:, metadata: nil)
-      ActiveStorage::Blob.create_after_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
+      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
     end
 end
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Replace `Blob.create_after_upload!` with `Blob.create_and_upload!` and deprecate the former.
+
+    `create_after_upload!` has been removed since it could lead to data
+    curruption by uploading to a key on the storage service which happened to
+    be already taken. Creating the record would then correctly raise a
+    database uniqueness exception but the stored object would already have
+    overwritten another. `create_and_upload!` swaps the order of operations
+    so that the key gets reserved up-front or the uniqueness error gets raised,
+    before the upload to a key takes place.
+
+    *Julik Tarkhanov*
+
 *   Set content disposition in direct upload using `filename` and `disposition` parameters to `ActiveStorage::Service#headers_for_direct_upload`.
 
     *Peter Zhu*

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -5,8 +5,9 @@ require "active_storage/downloader"
 # A blob is a record that contains the metadata about a file and a key for where that file resides on the service.
 # Blobs can be created in two ways:
 #
-# 1. Subsequent to the file being uploaded server-side to the service via <tt>create_after_upload!</tt>.
-# 2. Ahead of the file being directly uploaded client-side to the service via <tt>create_before_direct_upload!</tt>.
+# 1. Ahead of the file being uploaded server-side to the service, via <tt>create_and_upload!</tt>. A rewindable
+#    <tt>io</tt> with the file contents must be available at the server for this operation.
+# 2. Ahead of the file being directly uploaded client-side to the service, via <tt>create_before_direct_upload!</tt>.
 #
 # The first option doesn't require any client-side JavaScript integration, and can be used by any other back-end
 # service that deals with files. The second option is faster, since you're not using your own server as a staging
@@ -49,9 +50,8 @@ class ActiveStorage::Blob < ActiveRecord::Base
       find ActiveStorage.verifier.verify(id, purpose: :blob_id)
     end
 
-    # Returns a new, unsaved blob instance after the +io+ has been uploaded to the service.
-    # When providing a content type, pass <tt>identify: false</tt> to bypass automatic content type inference.
-    def build_after_upload(io:, filename:, content_type: nil, metadata: nil, identify: true, record: nil)
+    def build_after_upload(io:, filename:, content_type: nil, metadata: nil, identify: true, record: nil) #:nodoc:
+      ActiveSupport::Deprecation.warn("ActiveStorage::Blob.build_after_upload is deprecated and will be removed in Rails 6.2")
       new(filename: filename, content_type: content_type, metadata: metadata).tap do |blob|
         blob.upload(io, identify: identify)
       end
@@ -63,12 +63,24 @@ class ActiveStorage::Blob < ActiveRecord::Base
       end
     end
 
-    # Returns a saved blob instance after the +io+ has been uploaded to the service. Note, the blob is first built,
-    # then the +io+ is uploaded, then the blob is saved. This is done this way to avoid uploading (which may take
-    # time), while having an open database transaction.
-    # When providing a content type, pass <tt>identify: false</tt> to bypass automatic content type inference.
-    def create_after_upload!(io:, filename:, content_type: nil, metadata: nil, identify: true, record: nil)
-      build_after_upload(io: io, filename: filename, content_type: content_type, metadata: metadata, identify: identify).tap(&:save!)
+    def create_after_unfurling!(io:, filename:, content_type: nil, metadata: nil, identify: true, record: nil) #:nodoc:
+      build_after_unfurling(io: io, filename: filename, content_type: content_type, metadata: metadata, identify: identify).tap(&:save!)
+    end
+
+    # Creates a new blob instance and then uploads the contents of
+    # the given <tt>io</tt> to the service. The blob instance is going to
+    # be saved before the upload begins to prevent the upload clobbering another due to key collisions.
+    # When providing a content type, pass <tt>identify: false</tt> to bypass
+    # automatic content type inference.
+    def create_and_upload!(io:, filename:, content_type: nil, metadata: nil, identify: true, record: nil)
+      create_after_unfurling!(io: io, filename: filename, content_type: content_type, metadata: metadata, identify: identify).tap do |blob|
+        blob.upload_without_unfurling(io)
+      end
+    end
+
+    def create_after_upload!(**arguments_for_create_and_upload) #:nodoc:
+      ActiveSupport::Deprecation.warn("ActiveStorage::Blob.create_after_upload! has been renamed to create_and_upload!. The old name will be removed in Rails 6.2")
+      create_and_upload!(**arguments_for_create_and_upload)
     end
 
     # Returns a saved blob _without_ uploading a file to the service. This blob will point to a key where there is
@@ -165,8 +177,10 @@ class ActiveStorage::Blob < ActiveRecord::Base
   # and store that in +byte_size+ on the blob record. The content type is automatically extracted from the +io+ unless
   # you specify a +content_type+ and pass +identify+ as false.
   #
-  # Normally, you do not have to call this method directly at all. Use the factory class methods of +build_after_upload+
-  # and +create_after_upload!+.
+  # Normally, you do not have to call this method directly at all.
+  # Use the +create_and_upload!+ class method instead. If you do use
+  # this method directly, make sure you are using it on a persisted Blob as otherwise
+  # another blob's data might get overwrittein on the service.
   def upload(io, identify: true)
     unfurl io, identify: identify
     upload_without_unfurling io

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -39,6 +39,14 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "Some other, even more funky file", readback
   end
 
+  test "build_after_upload uploads to service but does not save the Blob" do
+    data = "A potentially overwriting file"
+    blob = ActiveStorage::Blob.build_after_upload(io: StringIO.new(data), filename: 'funky.bin')
+    refute blob.persisted?
+    readback = blob.download
+    assert_equal "A potentially overwriting file", readback
+  end
+
   test "create_and_upload sets byte size and checksum" do
     data = "Hello world!"
     blob = create_blob data: data

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -18,7 +18,28 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
-  test "create after upload sets byte size and checksum" do
+  test "create_and_upload does not permit a conflicting blob key to overwrite an existing object" do
+    data = "First file"
+    first_blob = create_blob data: data
+    assert_raise ActiveRecord::RecordNotUnique do
+      ActiveStorage::Blob.stub :generate_unique_secure_token, first_blob.key do
+        data = "This would overwrite"
+        create_blob data: data
+      end
+    end
+    readback = first_blob.download
+    assert_equal "First file", readback
+  end
+
+  test "create_after_upload! has the same effect as create_and_upload!" do
+    data = "Some other, even more funky file"
+    blob = ActiveStorage::Blob.create_after_upload!(io: StringIO.new(data), filename: 'funky.bin')
+    assert blob.persisted?
+    readback = blob.download
+    assert_equal "Some other, even more funky file", readback
+  end
+
+  test "create_and_upload sets byte size and checksum" do
     data = "Hello world!"
     blob = create_blob data: data
 
@@ -27,31 +48,31 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal Digest::MD5.base64digest(data), blob.checksum
   end
 
-  test "create after upload extracts content type from data" do
+  test "create_and_upload extracts content type from data" do
     blob = create_file_blob content_type: "application/octet-stream"
     assert_equal "image/jpeg", blob.content_type
   end
 
-  test "create after upload extracts content type from filename" do
+  test "create_and_upload extracts content type from filename" do
     blob = create_blob content_type: "application/octet-stream"
     assert_equal "text/plain", blob.content_type
   end
 
-  test "create after upload extracts content_type from io when no content_type given and identify: false" do
+  test "create_and_upload extracts content_type from io when no content_type given and identify: false" do
     blob = create_blob content_type: nil, identify: false
     assert_equal "text/plain", blob.content_type
   end
 
-  test "create after upload uses content_type when identify: false" do
+  test "create_and_upload uses content_type when identify: false" do
     blob = create_blob data: "Article,dates,analysis\n1, 2, 3", filename: "table.csv", content_type: "text/csv", identify: false
     assert_equal "text/csv", blob.content_type
   end
 
-  test "create after upload generates a 28-character base36 key" do
+  test "create_and_upload generates a 28-character base36 key" do
     assert_match(/^[a-z0-9]{28}$/, create_blob.key)
   end
 
-  test "create after upload accepts a record for overrides" do
+  test "create_and_upload accepts a record for overrides" do
     assert_nothing_raised do
       create_blob(record: User.new)
     end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -33,7 +33,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "create_after_upload! has the same effect as create_and_upload!" do
     data = "Some other, even more funky file"
-    blob = ActiveStorage::Blob.create_after_upload!(io: StringIO.new(data), filename: 'funky.bin')
+    blob = ActiveStorage::Blob.create_after_upload!(io: StringIO.new(data), filename: "funky.bin")
     assert blob.persisted?
     readback = blob.download
     assert_equal "Some other, even more funky file", readback
@@ -41,8 +41,8 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "build_after_upload uploads to service but does not save the Blob" do
     data = "A potentially overwriting file"
-    blob = ActiveStorage::Blob.build_after_upload(io: StringIO.new(data), filename: 'funky.bin')
-    refute blob.persisted?
+    blob = ActiveStorage::Blob.build_after_upload(io: StringIO.new(data), filename: "funky.bin")
+    assert_not blob.persisted?
     readback = blob.download
     assert_equal "A potentially overwriting file", readback
   end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -52,11 +52,11 @@ class ActiveSupport::TestCase
 
   private
     def create_blob(data: "Hello world!", filename: "hello.txt", content_type: "text/plain", identify: true, record: nil)
-      ActiveStorage::Blob.create_after_upload! io: StringIO.new(data), filename: filename, content_type: content_type, identify: identify, record: record
+      ActiveStorage::Blob.create_and_upload! io: StringIO.new(data), filename: filename, content_type: content_type, identify: identify, record: record
     end
 
     def create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg", metadata: nil, record: nil)
-      ActiveStorage::Blob.create_after_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata, record: record
+      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata, record: record
     end
 
     def create_blob_before_direct_upload(filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain", record: nil)


### PR DESCRIPTION
### Summary

Closes #34805 

This PR will be contentious as there is an assumption made that it is possible, with a sufficiently random `key`, to permit the user to upload to the storage without reserving that key first. I believe the assumption is flawed because it makes the following situation possible:

* User A uploads a PDF of an important legal document (I'm exaggerating, on purpose)
* 4 months pass
* User B edits his comment on something totally unrelated and ponders adding a NSFW picture as an attachment to that comment. Because the user A is unlucky, the picture gets issued the same `key` as the legal document user A has already uploaded.
* The text editing control user B is using preemptively uploads the file under the `key` so that saving the comment is fast once the user is done writing. It does receive an error from the ActiveStorage endpoint and tries again. The legal document of the user A is at this point overwritten, and at this stage has been irrecoverably lost. The legal document has been replaced with the NSFW picture.

So I believe, however unlikely (the value spread for the `key` is very very large indeed) this introduces a possibility of a very sneaky data corruption, which would overwrite data uploaded by the users of the application. This is exacerbated by the fact that when you generate a pre-signed URL to an external service the service will most likely not verify the checksum for you. This means that a person meaning to download the legal document of User A is going to receive the NSFW picture from User B, without any warning.

I know the solution proposed here was probably not the one desired (not holding a DB transaction during upload is a valid requirement) but I believe having risks of silent user data clobbering is worse. 

There are a few ways to solve this problem:

* Only use storage backends which support "upload here or error if already taken". Off the top of my head only Redis supports this with SETNX, and then again you need to hold the entire set in memory in Redis for this to work. S3 will happily overwrite on any PUT (it will also overwrite your checksum value)
* Pre-reserve keys using a deterministic sequence number obtained from the database. I tried this and it causes deadlocks on MySQL and is hard to do if your database does not have native cheap sequences. PostgreSQL does but most other databases do not.
* And the last option: insert the row into the database before allowing the upload to take place, so that the database observes the constraint and refuses if the key is taken.

I think part of the reason for this is the method naming for `generate_unique_secret_token`, because despite it is name it offers no actual guarantees of uniqueness - and it does recommend adding a database constraint on top. The problem here is rather we deliberately allow a state change on an external service which cannot be rolled back before allowing this index to fire.

I've left the test failing for now because they make assumptions about how `build...` is supposed to work in this case. I do believe that these assumptions should be changed to prevent user data corruption, but would like to poll first.

If the concern is holding a DB transaction open maybe the scope of this transaction should somehow be reduced to key reservation only, I just don't know if ActiveRecord has this facility or not.

_Empirical evidence_ - I work for a company that does lots of file uploads, and I did see wrong things happen, more than once. Some of those wrong things did involve probabilities and preemptive key generation.

