### PR TITLE
use correct resize syntax

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -434,7 +434,7 @@ original blob into the specified format and redirect to its new service
 location.
 
 ```erb
-<%= image_tag user.avatar.variant(resize_to_fit: [100, 100]) %>
+<%= image_tag user.avatar.variant(resize: "100x100") %>
 ```
 
 To switch to the Vips processor, you would add the following to


### PR DESCRIPTION
Found a bug in the ActiveStorage documentation, using resize_to_fit: with the default minimagick gem as specified in the doco returns a mogrify error as ImageMagicks resize method has the following syntax 
image.resize "100x100" 

which uses the ImageMagick syntax for geometric resizing. 
widthxheight | Maximum values of height and width given, aspect ratio preserved.

The documentation should contain the following for a successful resize
variant(resize: "100x100")

Mogrify error
`mogrify -resize-to-fit [100, 100] /var/folders/mini_magick.png` failed with error: mogrify: unrecognized option `-resize-to-fit' @ error/mogrify.c/MogrifyImageCommand/5932.

Relevant Guides below
https://www.rubydoc.info/github/minimagick/minimagick -> Under the usages section
https://www.imagemagick.org/script/command-line-processing.php#geometry
