### PR TITLE
Permit sending Active Storage purge and analysis jobs to separate queues

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Replace `config.active_storage.queue` with two options that indicate which
+    queues analysis and purge jobs should use, respectively:
+
+    * `config.active_storage.queues.analysis`
+    * `config.active_storage.queues.purge`
+
+    `config.active_storage.queue` is preferred over the new options when it's
+    set, but it is deprecated and will be removed in Rails 6.1.
+
+    *George Claghorn*
+
 *   Permit generating variants of TIFF images.
 
     *Luciano Sousa*

--- a/activestorage/app/jobs/active_storage/analyze_job.rb
+++ b/activestorage/app/jobs/active_storage/analyze_job.rb
@@ -2,6 +2,8 @@
 
 # Provides asynchronous analysis of ActiveStorage::Blob records via ActiveStorage::Blob#analyze_later.
 class ActiveStorage::AnalyzeJob < ActiveStorage::BaseJob
+  queue_as { ActiveStorage.queues[:analysis] }
+
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
 
   def perform(blob)

--- a/activestorage/app/jobs/active_storage/base_job.rb
+++ b/activestorage/app/jobs/active_storage/base_job.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ActiveStorage::BaseJob < ActiveJob::Base
-  queue_as { ActiveStorage.queue }
 end

--- a/activestorage/app/jobs/active_storage/purge_job.rb
+++ b/activestorage/app/jobs/active_storage/purge_job.rb
@@ -2,6 +2,8 @@
 
 # Provides asynchronous purging of ActiveStorage::Blob records via ActiveStorage::Blob#purge_later.
 class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
+  queue_as { ActiveStorage.queues[:purge] }
+
   discard_on ActiveRecord::RecordNotFound
   retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :exponentially_longer
 

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -42,7 +42,7 @@ module ActiveStorage
 
   mattr_accessor :logger
   mattr_accessor :verifier
-  mattr_accessor :queue
+  mattr_accessor :queues, default: {}
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers, default: []
   mattr_accessor :variant_processor, default: :mini_magick

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -843,10 +843,16 @@ normal Rails server.
 * `config.active_storage.content_types_to_serve_as_binary` accepts an array of strings indicating the content types that Active Storage will always serve as an attachment, rather than inline. The default is `%w(text/html
 text/javascript image/svg+xml application/postscript application/x-shockwave-flash text/xml application/xml application/xhtml+xml)`.
 
-* `config.active_storage.queue` can be used to set the name of the Active Job queue used to perform jobs like analyzing the content of a blob or purging a blog.
+* `config.active_storage.queues.analysis` accepts a symbol indicating the Active Job queue to use for analysis jobs. When this option is `nil`, analysis jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
+
+   ```ruby
+   config.active_storage.queues.analysis = :low_priority
+   ```
+
+* `config.active_storage.queues.purge` accepts a symbol indicating the Active Job queue to use for purge jobs. When this option is `nil`, purge jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
 
   ```ruby
-  config.active_storage.queue = :low_priority
+  config.active_storage.queues.purge = :low_priority
   ```
 
 * `config.active_storage.logger` can be used to set the logger used by Active Storage. Accepts a logger conforming to the interface of Log4r or the default Ruby Logger class.
@@ -869,6 +875,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
   ```
 
   The default is `/rails/active_storage`
+
 
 ### Configuring a Database
 


### PR DESCRIPTION
Replace `config.active_storage.queue` with `config.active_storage.queues.analysis` and `config.active_storage.queues.purge`. Prefer `config.active_storage.queue` when it’s set, emitting a deprecation warning.

Match Action Mailbox, which similarly allows configuring each of its two jobs to use different queues.