### PR TITLE
 Remove mention about `Test::Unit::TestCase` [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -276,9 +276,6 @@ module ActionController
   #      after calling +post+. If the various assert methods are not sufficient, then you
   #      may use this object to inspect the HTTP response in detail.
   #
-  # (Earlier versions of \Rails required each functional test to subclass
-  # Test::Unit::TestCase and define @controller, @request, @response in +setup+.)
-  #
   # == Controller is automatically inferred
   #
   # ActionController::TestCase will automatically infer the controller under test


### PR DESCRIPTION
We've switched from `Test::Unit::TestCase` to `ActiveSupport::TestCase`
since Rails 2.3.
See https://edgeguides.rubyonrails.org/2_3_release_notes.html#other-railties-changes