### PR TITLE
active storage validation classes added

### DIFF
--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -39,6 +39,7 @@ module ActiveStorage
   autoload :Service
   autoload :Previewer
   autoload :Analyzer
+  autoload :Validations
 
   mattr_accessor :logger
   mattr_accessor :verifier

--- a/activestorage/lib/active_storage/locale/en.yml
+++ b/activestorage/lib/active_storage/locale/en.yml
@@ -1,0 +1,9 @@
+en:
+  errors:
+    # The default format to use in full error messages.
+    format: "%{attribute} %{message}"
+
+    # The values :model, :attribute and :value are always available for interpolation
+    # The value :count is available when applicable. Can be used for pluralization.
+    messages:
+      content_type_invalid: "has an invalid content type"

--- a/activestorage/lib/active_storage/validations/attached_validator.rb
+++ b/activestorage/lib/active_storage/validations/attached_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class AttachedValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        unless record.send(attribute).attached?
+          record.errors.add(attribute, :blank)
+        end
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/validations/content_type_validator.rb
+++ b/activestorage/lib/active_storage/validations/content_type_validator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class ContentTypeValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        files = record.send(attribute)
+
+        return true unless files.attached?
+        return true if types.empty?
+
+        files = Array.wrap(files)
+
+        errors_options = {authorized_types: types_to_human_format}
+        errors_options[:message] = options[:message] if options[:message].present?
+
+        files.each do |file|
+          unless content_type_valid?(file)
+            errors_options[:content_type] = content_type(file)
+
+            record.errors.add(attribute, :content_type_invalid, errors_options)
+            return
+          end
+        end
+      end
+
+      def types
+        Array.wrap(options[:with]) + Array.wrap(options[:in])
+      end
+
+      def types_to_human_format
+        types.join(", ")
+      end
+
+      def content_type(file)
+        file.blob.present? && file.blob.content_type
+      end
+
+      def content_type_valid?(file)
+        file.blob.present? && file.blob.content_type.in?(types)
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/validations/content_type_validator.rb
+++ b/activestorage/lib/active_storage/validations/content_type_validator.rb
@@ -11,7 +11,7 @@ module ActiveStorage
 
         files = Array.wrap(files)
 
-        errors_options = {authorized_types: types_to_human_format}
+        errors_options = { authorized_types: types_to_human_format }
         errors_options[:message] = options[:message] if options[:message].present?
 
         files.each do |file|

--- a/activestorage/lib/active_storage/validations/size_validator.rb
+++ b/activestorage/lib/active_storage/validations/size_validator.rb
@@ -8,7 +8,7 @@ module ActiveStorage
       AVAILABLE_CHECKS = [:less_than, :less_than_or_equal_to, :greater_than, :greater_than_or_equal_to, :between]
 
       def check_validity!
-        unless (AVAILABLE_CHECKS).any? {|argument| options.has_key?(argument)}
+        unless (AVAILABLE_CHECKS).any? { |argument| options.has_key?(argument) }
           raise ArgumentError, "You must pass either :less_than, :greater_than, or :between to the validator"
         end
       end

--- a/activestorage/lib/active_storage/validations/size_validator.rb
+++ b/activestorage/lib/active_storage/validations/size_validator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class SizeValidator < ActiveModel::EachValidator
+      delegate :number_to_human_size, to: ActiveSupport::NumberHelper
+
+      AVAILABLE_CHECKS = [:less_than, :less_than_or_equal_to, :greater_than, :greater_than_or_equal_to, :between]
+
+      def check_validity!
+        unless (AVAILABLE_CHECKS).any? {|argument| options.has_key?(argument)}
+          raise ArgumentError, "You must pass either :less_than, :greater_than, or :between to the validator"
+        end
+      end
+
+      def validate_each(record, attribute, value)
+        files = record.send(attribute)
+        # only attached
+        return true unless files.attached?
+
+        files = Array.wrap(files)
+
+        files.each do |file|
+          if content_size_valid?(file)
+            record.errors.add(attribute, options[:message].presence || "size #{number_to_human_size(file.blob.byte_size)} is not between required range")
+            return
+          end
+        end
+      end
+
+      def content_size_valid?(file)
+        file_size = file.blob.byte_size
+        case
+        when options[:between].present?
+          options[:between].exclude?(file_size)
+        when options[:less_than].present?
+          file_size > options[:less_than]
+        when options[:less_than_or_equal_to].present?
+          file_size >= options[:less_than_or_equal_to]
+        when options[:greater_than].present?
+          file_size < options[:greater_than]
+        when options[:greater_than_or_equal_to].present?
+          file_size <= options[:greater_than_or_equal_to]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary
Alert not completed guidance required
PR with reference #33741 
 ```activestorage/lib/active_storage/validations.rb``` not wriiten to called in ```activestorage/lib/active_storage.rb```
### Other Information

## Usage

For example you have a model like this and you want to add validation.

```ruby
class User < ApplicationRecord
  has_one_attached :avatar
  has_many_attached :photos

  validates :name, presence: true

  validates :avatar, attached: true, content_type: 'image/png'
  validates :photos, attached: true, content_type: ['image/png', 'image/jpg', 'image/jpeg']
end
```

or

```ruby
class Project < ApplicationRecord
  has_one_attached :preview
  has_one_attached :attachment

  validates :title, presence: true

  validates :preview, attached: true, size: { less_than: 100.megabytes , message: 'is not given between size' }
  validates :attachment, attached: true, content_type: { in: 'application/pdf', message: 'is not a PDF' }
end
```

## Internationalization (I18n)

Active Storage Validations use I18n for errors messages. For this add there keys in your translation file :

```yml
en:
  errors:
    messages:
      content_type_invalid: "has an invalid content type"
```


