### PR TITLE
Active Record lazy preloading

### DIFF
--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -6,7 +6,7 @@ require "active_record/railties/collection_cache_association_loading"
 ActionView::PartialRenderer.prepend(ActiveRecord::Railties::CollectionCacheAssociationLoading)
 
 class MultifetchCacheTest < ActiveRecordTestCase
-  fixtures :topics, :replies
+  fixtures :topics, :replies, :developers
 
   def setup
     view_paths = ActionController::Base.view_paths
@@ -25,11 +25,29 @@ class MultifetchCacheTest < ActiveRecordTestCase
   def test_only_preloading_for_records_that_miss_the_cache
     @view.render partial: "test/partial", collection: [topics(:rails)], cached: true
 
-    @topics = Topic.preload(:replies)
+    @topics = Topic.includes_immediately(:replies)
 
     @view.render partial: "test/partial", collection: @topics, cached: true
 
     assert_not @topics.detect { |topic| topic.id == topics(:rails).id }.replies.loaded?
     assert     @topics.detect { |topic| topic.id != topics(:rails).id }.replies.loaded?
+  end
+
+  def test_only_lazy_loading_for_records_that_miss_the_cache
+    @view.render partial: "test/partial", collection: [developers(:poor_jamis)], cached: true
+
+    @developers = Developer.preload(:replies)
+
+    @view.render partial: "test/partial", collection: @developers, cached: true
+
+    assert @developers.size >= 3
+    assert_not @developers.detect { |developer| developer.id == developers(:poor_jamis).id }.replies.loaded?
+    assert_not @developers.detect { |developer| developer.id != developers(:poor_jamis).id }.replies.loaded?
+
+    @developers.detect { |developer| developer.id != developers(:poor_jamis).id }.replies.to_a
+    @developers.each do |developer|
+      next if developer.id == developers(:poor_jamis).id
+      assert developer.replies.loaded?
+    end
   end
 end

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -216,6 +216,7 @@ module ActiveRecord
       autoload :HasOneThroughAssociation
 
       autoload :Preloader
+      autoload :LazyPreloader
       autoload :JoinDependency
       autoload :AssociationScope
       autoload :AliasTracker

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -137,7 +137,7 @@ module ActiveRecord
               end
 
               reflection.all_includes do
-                scope.includes! item.includes_values
+                scope.includes_immediately! item.includes_values
               end
 
               scope.unscope!(*item.unscope_values)

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -137,7 +137,7 @@ module ActiveRecord
               end
 
               reflection.all_includes do
-                scope.includes_immediately! item.includes_values
+                scope.includes! item.includes_values
               end
 
               scope.unscope!(*item.unscope_values)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       def ids_reader
         if loaded?
           target.pluck(reflection.association_primary_key)
-        elsif !target.empty?
+        elsif !target.empty? || lazy_preloadable?
           load_target.pluck(reflection.association_primary_key)
         else
           @association_ids ||= scope.pluck(reflection.association_primary_key)
@@ -214,7 +214,7 @@ module ActiveRecord
           target.size
         elsif @association_ids
           @association_ids.size
-        elsif !association_scope.group_values.empty?
+        elsif !association_scope.group_values.empty? || lazy_preloadable?
           load_target.size
         elsif !association_scope.distinct_value && !target.empty?
           unsaved_records = target.select(&:new_record?)
@@ -233,7 +233,7 @@ module ActiveRecord
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        if loaded? || @association_ids
+        if loaded? || lazy_preloadable? || @association_ids
           size.zero?
         else
           target.empty? && !scope.exists?
@@ -271,6 +271,8 @@ module ActiveRecord
       end
 
       def load_target
+        lazy_preload
+
         if find_target?
           @target = merge_target_lists(find_target, target)
         end
@@ -298,6 +300,7 @@ module ActiveRecord
 
       def find_from_target?
         loaded? ||
+          lazy_preloadable? ||
           owner.new_record? ||
           target.any? { |record| record.new_record? || record.changed? }
       end

--- a/activerecord/lib/active_record/associations/lazy_preloader.rb
+++ b/activerecord/lib/active_record/associations/lazy_preloader.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Associations
+    class LazyPreloader
+      # Implements the details of lazy eager loading of Active Record associations.
+      #
+      # Suppose that you have the following two Active Record models:
+      #
+      #   class Author < ActiveRecord::Base
+      #     # columns: name, age
+      #     has_many :books
+      #   end
+      #
+      #   class Book < ActiveRecord::Base
+      #     # columns: title, sales, author_id
+      #   end
+      #
+      # When you load an author with all associated books Active Record will make
+      # only one query:
+      #
+      #   authors = Author.lazy_preload(:books).where(name: ['bell hooks', 'Homer']).to_a
+      #
+      #   => SELECT `authors`.* FROM `authors` WHERE `name` IN ('bell hooks', 'Homer')
+      #
+      # Then you probably will want to retrieve books while iterating authors
+      #
+      #   authors.each { |author| read author.books }
+      #
+      # And only after books method invocation second query will be executed
+      # to load all books for authors in the collection:
+      #
+      # => SELECT `books`.* FROM `books` WHERE `author_id` IN (2, 5)
+      #
+      require "weakref"
+
+      class Registry
+        def self.store(record, instance)
+          record.instance_variable_set :@_lazy_preloader, instance
+        end
+
+        def self.fetch(record)
+          if record.instance_variable_defined? :@_lazy_preloader
+            yield record.instance_variable_get :@_lazy_preloader
+          end
+        end
+      end
+
+      def initialize(records, preloader, associations)
+        @records = weak_references records
+        @preloader = preloader
+        @associations = associations
+      end
+
+      # Maps weak references to real objects
+      def records
+        @records.values.map(&:__getobj__)
+      end
+
+      # Determines whether lazy loading of the given association is needed
+      def should_load?(association)
+        associations_to_load.include? association
+      end
+
+      # Preloads the given association and plans to lazily preload nested associations
+      def preload(association)
+        return unless should_load? association
+        associations_to_load.delete association
+        @preloader.preload records, association
+        @preloader.lazy_preload loaded_records(association), associations_to_load_next(association)
+      end
+
+      private
+
+        def weak_references(records)
+          records.index_by(&:object_id).transform_values! do |record|
+            ::ObjectSpace.define_finalizer record, record_finalizer
+            ::WeakRef.new record
+          end
+        end
+
+        def record_finalizer
+          -> object_id { @records.delete object_id }
+        end
+
+        def loaded_records(association)
+          records.flat_map { |record| record.association(association).target }
+        end
+
+        def associations_to_load
+          @associations_to_load ||= @associations
+            .flatten
+            .map { |association| association.is_a?(::Hash) ? association.keys : association }
+            .flatten
+        end
+
+        def associations_to_load_next(association)
+          @associations.flatten.each_with_object([]) do |current, result|
+            if current.is_a?(::Hash) && current.key?(association)
+              result << current[association]
+            end
+          end
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -101,11 +101,11 @@ module ActiveRecord
         end
       end
 
-      def lazy_preload(records, associations, polymorphic_parent = false)
+      def lazy_preload(records, associations, **opts)
         records = Array.wrap(records).compact
 
         unless records.empty?
-          LazyPreloader.preload(records, self, associations, polymorphic_parent)
+          LazyPreloader.preload(records, self, associations, opts)
         end
       end
 

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -65,9 +65,9 @@ module ActiveRecord
               values = reflection_scope.values
 
               if includes = values[:includes]
-                scope.includes!(source_reflection.name => includes)
+                scope.includes_immediately!(source_reflection.name => includes)
               else
-                scope.includes!(source_reflection.name)
+                scope.includes_immediately!(source_reflection.name)
               end
 
               if values[:references] && !values[:references].empty?

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           reflection.chain.drop(1).each do |reflection|
             relation = reflection.klass.scope_for_association
             scope.merge!(
-              relation.except(:select, :create_with, :includes, :preload, :joins, :eager_load)
+              relation.except(:select, :create_with, :includes, :includes_immediately, :preload, :joins, :eager_load)
             )
           end
           scope

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     delegate :destroy_all, :delete_all, :update_all, to: :all
     delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_joins, :left_outer_joins, :or,
-             :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,
+             :where, :rewhere, :preload, :eager_load, :includes, :includes_immediately, :from, :lock, :readonly, :extending,
              :having, :create_with, :distinct, :references, :none, :unscope, :merge, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :pick, :ids, to: :all

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -616,7 +616,7 @@ module ActiveRecord
       return if preload.empty? && (includes_immediately_values.empty? || eager_loading?)
 
       preloader = build_preloader
-      preloader.preload records, includes_immediately_values unless eager_loading?
+      preloader.preload(records, includes_immediately_values) unless eager_loading?
       ExplainRegistry.collect? ? preloader.preload(records, preload) : preloader.lazy_preload(records, preload)
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -617,7 +617,9 @@ module ActiveRecord
 
       preloader = build_preloader
       preloader.preload(records, includes_immediately_values) unless eager_loading?
-      ExplainRegistry.collect? ? preloader.preload(records, preload) : preloader.lazy_preload(records, preload)
+
+      loaded_associations = eager_loading? ? (eager_load_values | includes_values) : includes_immediately_values
+      ExplainRegistry.collect? ? preloader.preload(records, preload) : preloader.lazy_preload(records, preload, loaded_associations: loaded_associations)
     end
 
     protected

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -379,7 +379,7 @@ module ActiveRecord
 
       def apply_join_dependency(eager_loading: group_values.empty?)
         join_dependency = construct_join_dependency(eager_load_values + includes_values)
-        relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
+        relation = except(:includes, :includes_immediately, :eager_load, :preload).joins!(join_dependency)
 
         if eager_loading && !using_limitable_reflections?(join_dependency.reflections)
           if has_limit_or_offset?

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -56,7 +56,7 @@ module ActiveRecord
 
       NORMAL_VALUES = Relation::VALUE_METHODS -
                       Relation::CLAUSE_METHODS -
-                      [:includes, :preload, :joins, :left_outer_joins, :order, :reverse_order, :lock, :create_with, :reordering] # :nodoc:
+                      [:includes, :includes_immediately, :preload, :joins, :left_outer_joins, :order, :reverse_order, :lock, :create_with, :reordering] # :nodoc:
 
       def normal_values
         NORMAL_VALUES
@@ -91,11 +91,12 @@ module ActiveRecord
       private
 
         def merge_preloads
-          return if other.preload_values.empty? && other.includes_values.empty?
+          return if other.preload_values.empty? && other.includes_values.empty? && other.includes_immediately_values.empty?
 
           if other.klass == relation.klass
             relation.preload!(*other.preload_values) unless other.preload_values.empty?
             relation.includes!(other.includes_values) unless other.includes_values.empty?
+            relation.includes_immediately!(other.includes_immediately_values) unless other.includes_immediately_values.empty?
           else
             reflection = relation.klass.reflect_on_all_associations.find do |r|
               r.class_name == other.klass.name
@@ -107,6 +108,10 @@ module ActiveRecord
 
             unless other.includes_values.empty?
               relation.includes! reflection.name => other.includes_values
+            end
+
+            unless other.includes_immediately_values.empty?
+              relation.includes_immediately! reflection.name => other.includes_immediately_values
             end
           end
         end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -124,6 +124,21 @@ module ActiveRecord
       self
     end
 
+    # Works exactly like +includes+ method, but preloads associations
+    # right after main ActiveRecord::Relation execution
+    def includes_immediately(*args)
+      check_if_method_has_arguments!(:includes_immediately, args)
+      spawn.includes_immediately!(*args)
+    end
+
+    def includes_immediately!(*args) # :nodoc:
+      args.reject!(&:blank?)
+      args.flatten!
+
+      self.includes! args
+      self.includes_immediately_values |= args
+    end
+
     # Forces eager loading by performing a LEFT OUTER JOIN on +args+:
     #
     #   User.eager_load(:posts)
@@ -140,10 +155,8 @@ module ActiveRecord
       self
     end
 
-    # Allows preloading of +args+, in the same way that #includes does:
-    #
-    #   User.preload(:posts)
-    #   # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" IN (1, 2, 3)
+    # Allows preloading of +args+, in the same way that #includes does,
+    # but does not allow to reference table.
     def preload(*args)
       check_if_method_has_arguments!(:preload, args)
       spawn.preload!(*args)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -137,6 +137,7 @@ module ActiveRecord
 
       self.includes! args
       self.includes_immediately_values |= args
+      self
     end
 
     # Forces eager loading by performing a LEFT OUTER JOIN on +args+:

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -263,19 +263,37 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_eager_loading_with_primary_key
     Firm.create("name" => "Apple")
     Client.create("name" => "Citibank", :firm_name => "Apple")
-    citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key).first
-    assert_not_predicate citibank_result.association(:firm_with_primary_key), :loaded?
-    citibank_result.firm_with_primary_key
+    citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes_immediately: :firm_with_primary_key).first
     assert_predicate citibank_result.association(:firm_with_primary_key), :loaded?
+  end
+
+  def test_lazy_loading_with_primary_key
+    Firm.create("name" => "Apple")
+    Client.create("name" => "Citibank", :firm_name => "Apple")
+    Client.create("name" => "Citibank", :firm_name => "Apple")
+    citibank_results = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key).to_a
+    assert_not_predicate citibank_results[0].association(:firm_with_primary_key), :loaded?
+    citibank_results[0].firm_with_primary_key
+    assert_predicate citibank_results[0].association(:firm_with_primary_key), :loaded?
+    assert_predicate citibank_results[1].association(:firm_with_primary_key), :loaded?
   end
 
   def test_eager_loading_with_primary_key_as_symbol
     Firm.create("name" => "Apple")
     Client.create("name" => "Citibank", :firm_name => "Apple")
-    citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key_symbols).first
-    assert_not_predicate citibank_result.association(:firm_with_primary_key_symbols), :loaded?
-    citibank_result.firm_with_primary_key_symbols
+    citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes_immediately: :firm_with_primary_key_symbols).first
     assert_predicate citibank_result.association(:firm_with_primary_key_symbols), :loaded?
+  end
+
+  def test_lazy_loading_with_primary_key_as_symbol
+    Firm.create("name" => "Apple")
+    Client.create("name" => "Citibank", :firm_name => "Apple")
+    Client.create("name" => "Citibank", :firm_name => "Apple")
+    citibank_results = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key_symbols).to_a
+    assert_not_predicate citibank_results[0].association(:firm_with_primary_key_symbols), :loaded?
+    citibank_results[0].firm_with_primary_key_symbols
+    assert_predicate citibank_results[0].association(:firm_with_primary_key_symbols), :loaded?
+    assert_predicate citibank_results[1].association(:firm_with_primary_key_symbols), :loaded?
   end
 
   def test_creating_the_belonging_object

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -264,6 +264,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Firm.create("name" => "Apple")
     Client.create("name" => "Citibank", :firm_name => "Apple")
     citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key).first
+    assert_not_predicate citibank_result.association(:firm_with_primary_key), :loaded?
+    citibank_result.firm_with_primary_key
     assert_predicate citibank_result.association(:firm_with_primary_key), :loaded?
   end
 
@@ -271,6 +273,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Firm.create("name" => "Apple")
     Client.create("name" => "Citibank", :firm_name => "Apple")
     citibank_result = Client.all.merge!(where: { name: "Citibank" }, includes: :firm_with_primary_key_symbols).first
+    assert_not_predicate citibank_result.association(:firm_with_primary_key_symbols), :loaded?
+    citibank_result.firm_with_primary_key_symbols
     assert_predicate citibank_result.association(:firm_with_primary_key_symbols), :loaded?
   end
 

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -74,7 +74,8 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     authors = Author.joins(:special_posts).includes([:posts, :categorizations])
 
     assert_nothing_raised { authors.count }
-    assert_queries(3) { authors.to_a }
+    assert_queries(1) { authors.to_a }
+    assert_queries(2) { authors.each { |a| a.posts.first }.each { |a| a.categorizations.first } }
   end
 
   def test_eager_association_loading_with_cascaded_two_levels_with_two_has_many_associations
@@ -110,7 +111,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
   def test_eager_association_loading_with_has_many_sti
     topics = Topic.all.merge!(includes: :replies, order: "topics.id").to_a
     first, second, = topics(:first).replies.size, topics(:second).replies.size
-    assert_no_queries do
+    assert_queries(2) do
       assert_equal first, topics[0].replies.size
       assert_equal second, topics[1].replies.size
     end
@@ -131,6 +132,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     replies = Reply.all.merge!(includes: :topic, order: "topics.id").to_a
     assert_includes replies, topics(:second)
     assert_not_includes replies, topics(:first)
+    assert_queries(1) { replies.each &:topic }
     assert_equal topics(:first), assert_no_queries { replies.first.topic }
   end
 
@@ -155,6 +157,11 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
   def test_eager_association_loading_where_first_level_returns_nil
     authors = Author.all.merge!(includes: { post_about_thinking: :comments }, order: "authors.id DESC").to_a
     assert_equal [authors(:bob), authors(:mary), authors(:david)], authors
+
+    assert_queries(2) do
+      authors.each { |author| author.try(:post_about_thinking).try(:comments).try(:first) }
+    end
+
     assert_no_queries do
       authors[2].post_about_thinking.comments.first
     end
@@ -172,12 +179,12 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_many_through
     source = Vertex.all.merge!(includes: { sinks: { sinks: { sinks: :sinks } } }, order: "vertices.id").first
-    assert_equal vertices(:vertex_4), assert_no_queries { source.sinks.first.sinks.first.sinks.first }
+    assert_equal vertices(:vertex_4), assert_queries(6) { source.sinks.first.sinks.first.sinks.first }
   end
 
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_and_belongs_to_many
     sink = Vertex.all.merge!(includes: { sources: { sources: { sources: :sources } } }, order: "vertices.id DESC").first
-    assert_equal vertices(:vertex_1), assert_no_queries { sink.sources.first.sources.first.sources.first.sources.first }
+    assert_equal vertices(:vertex_1), assert_queries(8) { sink.sources.first.sources.first.sources.first.sources.first }
   end
 
   def test_eager_association_loading_with_cascaded_interdependent_one_level_and_two_levels

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -9,60 +9,68 @@ require "models/category"
 require "models/categorization"
 require "models/tagging"
 
-module Remembered
-  extend ActiveSupport::Concern
-
-  included do
-    after_create :remember
-  private
-    def remember; self.class.remembered << self; end
-  end
-
-  module ClassMethods
-    def remembered; @@remembered ||= []; end
-    def sample; @@remembered.sample; end
-  end
-end
-
-class ShapeExpression < ActiveRecord::Base
-  belongs_to :shape, polymorphic: true
-  belongs_to :paint, polymorphic: true
-end
-
-class Circle < ActiveRecord::Base
-  has_many :shape_expressions, as: :shape
-  include Remembered
-end
-class Square < ActiveRecord::Base
-  has_many :shape_expressions, as: :shape
-  include Remembered
-end
-class Triangle < ActiveRecord::Base
-  has_many :shape_expressions, as: :shape
-  include Remembered
-end
-class PaintColor < ActiveRecord::Base
-  has_many   :shape_expressions, as: :paint
-  belongs_to :non_poly, foreign_key: "non_poly_one_id", class_name: "NonPolyOne"
-  include Remembered
-end
-class PaintTexture < ActiveRecord::Base
-  has_many   :shape_expressions, as: :paint
-  belongs_to :non_poly, foreign_key: "non_poly_two_id", class_name: "NonPolyTwo"
-  include Remembered
-end
-class NonPolyOne < ActiveRecord::Base
-  has_many :paint_colors
-  include Remembered
-end
-class NonPolyTwo < ActiveRecord::Base
-  has_many :paint_textures
-  include Remembered
-end
-
 class EagerLoadPolyAssocsTest < ActiveRecord::TestCase
-  NUM_SIMPLE_OBJS = 50
-  NUM_SHAPE_EXPRESSIONS = 100
+  module Remembered
+    extend ActiveSupport::Concern
+
+    included do
+      after_create :remember
+      private
+        def remember; self.class.remembered << self; end
+    end
+
+    class_methods do
+      def remembered; @remembered ||= []; end
+      def forget_all; @remembered = nil; end
+      def sample; @remembered.sample; end
+    end
+  end
+
+  class ShapeExpression < ActiveRecord::Base
+    belongs_to :shape, polymorphic: true
+    belongs_to :paint, polymorphic: true
+    include Remembered
+  end
+
+  class Circle < ActiveRecord::Base
+    has_many :shape_expressions, as: :shape
+    include Remembered
+  end
+
+  class Square < ActiveRecord::Base
+    has_many :shape_expressions, as: :shape
+    include Remembered
+  end
+
+  class Triangle < ActiveRecord::Base
+    has_many :shape_expressions, as: :shape
+    include Remembered
+  end
+
+  class PaintColor < ActiveRecord::Base
+    has_many   :shape_expressions, as: :paint
+    belongs_to :non_poly, foreign_key: "non_poly_one_id", class_name: "NonPolyOne"
+    include Remembered
+  end
+
+  class PaintTexture < ActiveRecord::Base
+    has_many   :shape_expressions, as: :paint
+    belongs_to :non_poly, foreign_key: "non_poly_two_id", class_name: "NonPolyTwo"
+    include Remembered
+  end
+
+  class NonPolyOne < ActiveRecord::Base
+    has_many :paint_colors
+    include Remembered
+  end
+
+  class NonPolyTwo < ActiveRecord::Base
+    has_many :paint_textures
+    include Remembered
+  end
+
+  NUM_SIMPLE_OBJS = 3
+  NUM_SHAPE_EXPRESSIONS = 6
 
   def setup
     generate_test_object_graphs
@@ -70,32 +78,46 @@ class EagerLoadPolyAssocsTest < ActiveRecord::TestCase
 
   teardown do
     [Circle, Square, Triangle, PaintColor, PaintTexture,
-     ShapeExpression, NonPolyOne, NonPolyTwo].each(&:delete_all)
+     ShapeExpression, NonPolyOne, NonPolyTwo]
+      .each(&:delete_all)
+      .each(&:forget_all)
   end
 
   def generate_test_object_graphs
     1.upto(NUM_SIMPLE_OBJS) do
-      [Circle, Square, Triangle, NonPolyOne, NonPolyTwo].map(&:create!)
+      [Circle, Square, Triangle, NonPolyOne, NonPolyTwo].each(&:create!)
     end
     1.upto(NUM_SIMPLE_OBJS) do
       PaintColor.create!(non_poly_one_id: NonPolyOne.sample.id)
       PaintTexture.create!(non_poly_two_id: NonPolyTwo.sample.id)
     end
-    1.upto(NUM_SHAPE_EXPRESSIONS) do
-      shape_type = [Circle, Square, Triangle].sample
-      paint_type = [PaintColor, PaintTexture].sample
-      ShapeExpression.create!(shape_type: shape_type.to_s, shape_id: shape_type.sample.id,
-                              paint_type: paint_type.to_s, paint_id: paint_type.sample.id)
+    1.upto(NUM_SHAPE_EXPRESSIONS / 3) do
+      ShapeExpression.create!(shape: Circle.sample, paint: PaintColor.sample)
+      ShapeExpression.create!(shape: Square.sample, paint: PaintTexture.sample)
+      ShapeExpression.create!(shape: Triangle.sample, paint: PaintTexture.sample)
     end
   end
 
-  def test_include_query
-    res = ShapeExpression.all.merge!(includes: [ :shape, { paint: :non_poly } ]).to_a
+  def test_preload_query
+    subject :preload
+  end
+
+  def test_includes_query
+    subject :includes
+  end
+
+  def subject(eager_type)
+    res = ShapeExpression.all.merge!(eager_type => [ { shape: :shape_expressions }, { paint: :non_poly } ])
+
+    assert_queries(1) { res.records }
     assert_equal NUM_SHAPE_EXPRESSIONS, res.size
-    assert_no_queries do
+
+    # 3 tables for shapes; 2 tables for paints; 2 tables for polys
+    # 3 queries for shape_expressions because there is no sti
+    assert_queries(10) do
       res.each do |se|
-        assert_not_nil se.paint.non_poly, "this is the association that was loading incorrectly before the change"
-        assert_not_nil se.shape, "just making sure other associations still work"
+        assert_not_empty se.shape.shape_expressions, "collection nested associations are loaded on demand"
+        assert_not_nil se.paint.non_poly, "nested associations are loaded on demand"
       end
     end
   end
@@ -114,6 +136,14 @@ class EagerLoadNestedIncludeWithMissingDataTest < ActiveRecord::TestCase
     @first_post.destroy
     @first_comment.destroy
     @first_categorization.destroy
+  end
+
+  def test_missing_data_in_a_nested_preload_should_not_cause_errors_when_constructing_objects
+    assert_nothing_raised do
+      # @davey_mcdave doesn't have any author_favorites
+      preload = { posts: :comments, categorizations: :category, author_favorites: :favorite_author }
+      Author.all.merge!(preload: preload, where: { authors: { name: @davey_mcdave.name } }).to_a
+    end
   end
 
   def test_missing_data_in_a_nested_include_should_not_cause_errors_when_constructing_objects

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1967,7 +1967,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
 
     assert_no_queries do
-      sponsors.each(&:sponsorable).each{ |s| s.respond_to?(:post) && s.post }
+      sponsors.each(&:sponsorable).each { |s| s.respond_to?(:post) && s.post }
     end
 
     assert_queries(2) do

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -140,8 +140,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assertions = ->(firm) {
       assert_equal companies(:first_firm), firm
 
-      assert_predicate firm.association(:readonly_account), :loaded?
-      assert_predicate firm.association(:accounts), :loaded?
+      assert_not_predicate firm.association(:readonly_account), :loaded?
+      assert_not_predicate firm.association(:accounts), :loaded?
 
       assert_equal accounts(:signals37), firm.readonly_account
       assert_equal [accounts(:signals37)], firm.accounts
@@ -194,35 +194,35 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_duplicate_middle_objects
     comments = Comment.all.merge!(where: "post_id = 1", includes: [post: :author]).to_a
-    assert_no_queries do
+    assert_queries(2) do
       comments.each { |comment| comment.post.author.name }
     end
   end
 
   def test_preloading_has_many_in_multiple_queries_with_more_ids_than_database_can_handle
     assert_called(Comment.connection, :in_clause_length, returns: 5) do
-      posts = Post.all.merge!(includes: :comments).to_a
+      posts = Post.all.merge!(includes: :comments).each { |post| post.comments.first }
       assert_equal 11, posts.size
     end
   end
 
   def test_preloading_has_many_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     assert_called(Comment.connection, :in_clause_length, returns: nil) do
-      posts = Post.all.merge!(includes: :comments).to_a
+      posts = Post.all.merge!(includes: :comments).each { |post| post.comments.first }
       assert_equal 11, posts.size
     end
   end
 
   def test_preloading_habtm_in_multiple_queries_with_more_ids_than_database_can_handle
     assert_called(Comment.connection, :in_clause_length, times: 2, returns: 5) do
-      posts = Post.all.merge!(includes: :categories).to_a
+      posts = Post.all.merge!(includes: :categories).each { |post| post.categories.first }
       assert_equal 11, posts.size
     end
   end
 
   def test_preloading_habtm_in_one_queries_when_database_has_no_limit_on_ids_it_can_handle
     assert_called(Comment.connection, :in_clause_length, times: 2, returns: nil) do
-      posts = Post.all.merge!(includes: :categories).to_a
+      posts = Post.all.merge!(includes: :categories).each { |post| post.categories.first }
       assert_equal 11, posts.size
     end
   end
@@ -231,7 +231,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_called(Comment.connection, :in_clause_length, returns: nil) do
       post = posts(:welcome)
       assert_queries(2) do
-        Post.includes(:comments).where(id: post.id).to_a
+        Post.includes(:comments).where(id: post.id).each { |post| post.comments.first }
       end
     end
   end
@@ -240,7 +240,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_called(Comment.connection, :in_clause_length, returns: 1) do
       post1, post2 = posts(:welcome), posts(:thinking)
       assert_queries(3) do
-        Post.includes(:comments).where(id: [post1.id, post2.id]).to_a
+        Post.includes(:comments).where(id: [post1.id, post2.id]).each { |post| post.comments.first }
       end
     end
   end
@@ -249,7 +249,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_called(Comment.connection, :in_clause_length, returns: 3) do
       post = posts(:welcome)
       assert_queries(2) do
-        Post.includes(:comments).where(id: post.id).to_a
+        Post.includes(:comments).where(id: post.id).each { |post| post.comments.first }
       end
     end
   end
@@ -286,16 +286,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
     first_category = Category.create! name: "First!", posts: [post]
     second_category = Category.create! name: "Second!", posts: [post]
 
-    categories = Category.where(id: [first_category.id, second_category.id]).includes(posts: :special_comments)
+    categories = Category.where(id: [first_category.id, second_category.id]).includes(posts: :special_comments).to_a
+    assert_queries(2) { categories.first.posts.first.special_comments.first }
     assert_equal categories.map { |category| category.posts.first.special_comments.loaded? }, [true, true]
   end
 
   def test_finding_with_includes_on_has_many_association_with_same_include_includes_only_once
     author_id = authors(:david).id
-    author = assert_queries(3) { Author.all.merge!(includes: { posts_with_comments: :comments }).find(author_id) } # find the author, then find the posts, then find the comments
-    author.posts_with_comments.each do |post_with_comments|
-      assert_equal post_with_comments.comments.length, post_with_comments.comments.count
-      assert_nil post_with_comments.comments.to_a.uniq!
+    author = assert_queries(1) { Author.all.merge!(includes: { posts_with_comments: :comments }).find(author_id) } # find the author, then find the posts, then find the comments
+    assert_queries(2) do
+      author.posts_with_comments.each do |post_with_comments|
+        assert_equal post_with_comments.comments.length, post_with_comments.comments.count
+        assert_nil post_with_comments.comments.to_a.uniq!
+      end
     end
   end
 
@@ -303,8 +306,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     author = authors(:david)
     post = author.post_about_thinking_with_last_comment
     last_comment = post.last_comment
-    author = assert_queries(3) { Author.all.merge!(includes: { post_about_thinking_with_last_comment: :last_comment }).find(author.id) } # find the author, then find the posts, then find the comments
-    assert_no_queries do
+    author = assert_queries(1) { Author.all.merge!(includes: { post_about_thinking_with_last_comment: :last_comment }).find(author.id) } # find the author, then find the posts, then find the comments
+    assert_queries(2) do
       assert_equal post, author.post_about_thinking_with_last_comment
       assert_equal last_comment, author.post_about_thinking_with_last_comment.last_comment
     end
@@ -314,8 +317,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     post = posts(:welcome)
     author = post.author
     author_address = author.author_address
-    post = assert_queries(3) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) } # find the post, then find the author, then find the address
-    assert_no_queries do
+    post = assert_queries(1) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) } # find the post, then find the author, then find the address
+    assert_queries(2) do
       assert_equal author, post.author_with_address
       assert_equal author_address, post.author_with_address.author_address
     end
@@ -517,32 +520,37 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_association_loading_with_belongs_to_inferred_foreign_key_from_association_name
-    author_favorite = AuthorFavorite.all.merge!(includes: :favorite_author).first
-    assert_equal authors(:mary), assert_no_queries { author_favorite.favorite_author }
+    author_favorite = nil
+    assert_queries(1) { author_favorite = AuthorFavorite.all.merge!(includes: :favorite_author).first }
+    assert_equal authors(:mary), assert_queries(1) { author_favorite.favorite_author }
   end
 
   def test_eager_load_belongs_to_quotes_table_and_column_names
     job = Job.includes(:ideal_reference).find jobs(:unicyclist).id
     references(:michael_unicyclist)
-    assert_no_queries { assert_equal references(:michael_unicyclist), job.ideal_reference }
+    assert_queries(1) { assert_equal references(:michael_unicyclist), job.ideal_reference }
   end
 
   def test_eager_load_has_one_quotes_table_and_column_names
-    michael = Person.all.merge!(includes: :favourite_reference).find(people(:michael).id)
+    michael = nil
+    people(:michael)
+    assert_queries(1) do
+      michael = Person.all.merge!(includes: :favourite_reference).find(people(:michael).id)
+    end
     references(:michael_unicyclist)
-    assert_no_queries { assert_equal references(:michael_unicyclist), michael.favourite_reference }
+    assert_queries(1) { assert_equal references(:michael_unicyclist), michael.favourite_reference }
   end
 
   def test_eager_load_has_many_quotes_table_and_column_names
     michael = Person.all.merge!(includes: :references).find(people(:michael).id)
     references(:michael_magician, :michael_unicyclist)
-    assert_no_queries { assert_equal references(:michael_magician, :michael_unicyclist), michael.references.sort_by(&:id) }
+    assert_queries(1) { assert_equal references(:michael_magician, :michael_unicyclist), michael.references.sort_by(&:id) }
   end
 
   def test_eager_load_has_many_through_quotes_table_and_column_names
     michael = Person.all.merge!(includes: :jobs).find(people(:michael).id)
     jobs(:magician, :unicyclist)
-    assert_no_queries { assert_equal jobs(:unicyclist, :magician), michael.jobs.sort_by(&:id) }
+    assert_queries(2) { assert_equal jobs(:unicyclist, :magician), michael.jobs.sort_by(&:id) }
   end
 
   def test_eager_load_has_many_with_string_keys
@@ -585,8 +593,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     posts_with_author = people(:michael).posts.merge(includes: :author, order: "posts.id").to_a
     posts_with_comments_and_author = people(:michael).posts.merge(includes: [ :comments, :author ], order: "posts.id").to_a
     assert_equal 2, posts_with_comments.inject(0) { |sum, post| sum + post.comments.size }
-    assert_equal authors(:david), assert_no_queries { posts_with_author.first.author }
-    assert_equal authors(:david), assert_no_queries { posts_with_comments_and_author.first.author }
+    assert_equal authors(:david), assert_queries(1) { posts_with_author.first.author }
+    assert_equal authors(:david), assert_queries(1) { posts_with_comments_and_author.first.author }
   end
 
   def test_eager_with_has_many_through_a_belongs_to_association
@@ -595,7 +603,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     author.author_favorites.create(favorite_author_id: 1)
     author.author_favorites.create(favorite_author_id: 2)
     posts_with_author_favorites = author.posts.merge(includes: :author_favorites).to_a
-    assert_no_queries { posts_with_author_favorites.first.author_favorites.first.author_id }
+    assert_queries(1) { posts_with_author_favorites.first.author_favorites.first.author_id }
   end
 
   def test_eager_with_has_many_through_an_sti_join_model
@@ -605,7 +613,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_preloading_has_many_through_with_implicit_source
     authors = Author.includes(:very_special_comments).to_a
-    assert_no_queries do
+    assert_queries(1) do
       special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size] }
       assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors
     end
@@ -831,22 +839,22 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_with_invalid_association_reference
     e = assert_raise(ActiveRecord::AssociationNotFoundError) {
-      Post.all.merge!(includes: :monkeys).find(6)
+      Post.all.merge!(includes: :monkeys).find(6).tap &:monkeys
     }
     assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
 
     e = assert_raise(ActiveRecord::AssociationNotFoundError) {
-      Post.all.merge!(includes: [ :monkeys ]).find(6)
+      Post.all.merge!(includes: [ :monkeys ]).find(6).tap &:monkeys
     }
     assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
 
     e = assert_raise(ActiveRecord::AssociationNotFoundError) {
-      Post.all.merge!(includes: [ "monkeys" ]).find(6)
+      Post.all.merge!(includes: [ "monkeys" ]).find(6).tap &:monkeys
     }
     assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
 
     e = assert_raise(ActiveRecord::AssociationNotFoundError) {
-      Post.all.merge!(includes: [ :monkeys, :elephants ]).find(6)
+      Post.all.merge!(includes: [ :monkeys, :elephants ]).find(6).tap &:monkeys
     }
     assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
   end
@@ -1057,7 +1065,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_with_floating_point_numbers
     assert_queries(2) do
       # Before changes, the floating point numbers will be interpreted as table names and will cause this to run in one query
-      Comment.all.merge!(where: "123.456 = 123.456", includes: :post).to_a
+      Comment.all.merge!(where: "123.456 = 123.456", includes: :post).each &:post
     end
   end
 
@@ -1068,7 +1076,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_preconfigured_includes_with_has_one
     comment = posts(:sti_comments).very_special_comment_with_post
-    assert_no_queries { assert_equal posts(:sti_comments), comment.post }
+    assert_queries(1) { assert_equal posts(:sti_comments), comment.post }
   end
 
   def test_eager_association_with_scope_with_joins
@@ -1096,9 +1104,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_preconfigured_includes_with_has_many_and_habtm
-    posts = authors(:david).posts_with_comments_and_categories
+    posts = assert_queries(1) { authors(:david).posts_with_comments_and_categories }
     one = posts.detect { |p| p.id == 1 }
-    assert_no_queries do
+    assert_queries(2) do
       assert_equal 5, posts.size
       assert_equal 2, one.comments.size
       assert_equal 2, one.categories.size
@@ -1147,7 +1155,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_load_with_sti_sharing_association
     assert_queries(2) do # should not do 1 query per subclass
-      Comment.includes(:post).to_a
+      Comment.includes(:post).each &:post
     end
   end
 
@@ -1166,26 +1174,28 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_order_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(joins: :comments, includes: :author, order: "comments.id DESC").to_a
     end
-    assert_equal posts(:eager_other), posts[1]
-    assert_equal authors(:mary), assert_no_queries { posts[1].author }
+    assert_queries(1) do
+      assert_equal posts(:eager_other), posts[1]
+      assert_equal authors(:mary), assert_no_queries { posts[1].author }
+    end
   end
 
   def test_eager_loading_with_conditions_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: [:comments], where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
-    assert_equal authors(:david), assert_no_queries { posts[0].author }
+    assert_equal authors(:david), assert_queries(1) { posts[0].author }
 
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(includes: :author, joins: { taggings: :tag }, where: "tags.name = 'General'", order: "posts.id").to_a
     end
     assert_equal posts(:welcome, :thinking), posts
 
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(includes: :author, joins: { taggings: { tag: :taggings } }, where: "taggings_tags.super_tag_id=2", order: "posts.id").to_a
     end
     assert_equal posts(:welcome, :thinking), posts
@@ -1204,29 +1214,29 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_conditions_on_string_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: "INNER JOIN comments on comments.post_id = posts.id", where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
-    assert_equal authors(:david), assert_no_queries { posts[0].author }
+    assert_equal authors(:david), assert_queries(1) { posts[0].author }
 
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: ["INNER JOIN comments on comments.post_id = posts.id"], where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
-    assert_equal authors(:david), assert_no_queries { posts[0].author }
+    assert_equal authors(:david), assert_queries(1) { posts[0].author }
   end
 
   def test_eager_loading_with_select_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries(1) do
       Post.all.merge!(select: "posts.*, authors.name as author_name", includes: :comments, joins: :author, order: "posts.id").to_a
     end
     assert_equal "David", posts[0].author_name
-    assert_equal posts(:welcome).comments, assert_no_queries { posts[0].comments }
+    assert_equal posts(:welcome).comments, assert_queries(1) { posts[0].comments }
   end
 
   def test_eager_loading_with_conditions_on_join_model_preloads
-    authors = assert_queries(2) do
+    authors = assert_queries(1) do
       Author.all.merge!(includes: :author_address, joins: :comments, where: "posts.title like 'Welcome%'").to_a
     end
     assert_equal authors(:david), authors[0]
@@ -1236,8 +1246,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preload_belongs_to_uses_exclusive_scope
     people = Person.males.merge(includes: :primary_contact).to_a
     assert_not_equal people.length, 0
-    people.each do |person|
-      assert_no_queries { assert_not_nil person.primary_contact }
+    people.each_with_index do |person, index|
+      assert_queries(index.zero? ? 1 : 0) { assert_not_nil person.primary_contact }
       assert_equal Person.find(person.id).primary_contact, person.primary_contact
     end
   end
@@ -1252,7 +1262,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preload_has_many_using_primary_key
     expected = Firm.first.clients_using_primary_key.to_a
     firm = Firm.includes(:clients_using_primary_key).first
-    assert_no_queries do
+    assert_queries(1) do
       assert_equal expected, firm.clients_using_primary_key
     end
   end
@@ -1273,7 +1283,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preload_has_one_using_primary_key
     expected = accounts(:signals37)
     firm = Firm.all.merge!(includes: :account_using_primary_key, order: "companies.id").first
-    assert_no_queries do
+    assert_queries(1) do
       assert_equal expected, firm.account_using_primary_key
     end
   end
@@ -1289,24 +1299,24 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preloading_empty_belongs_to
     c = Client.create!(name: "Foo", client_of: Company.maximum(:id) + 1)
 
-    client = assert_queries(2) { Client.preload(:firm).find(c.id) }
-    assert_no_queries { assert_nil client.firm }
+    client = assert_queries(1) { Client.preload(:firm).find(c.id) }
+    assert_queries(1) { assert_nil client.firm }
     assert_equal c.client_of, client.client_of
   end
 
   def test_preloading_empty_belongs_to_polymorphic
     t = Tagging.create!(taggable_type: "Post", taggable_id: Post.maximum(:id) + 1, tag: tags(:general))
 
-    tagging = assert_queries(2) { Tagging.preload(:taggable).find(t.id) }
-    assert_no_queries { assert_nil tagging.taggable }
+    tagging = assert_queries(1) { Tagging.preload(:taggable).find(t.id) }
+    assert_queries(1) { assert_nil tagging.taggable }
     assert_equal t.taggable_id, tagging.taggable_id
   end
 
   def test_preloading_through_empty_belongs_to
     c = Client.create!(name: "Foo", client_of: Company.maximum(:id) + 1)
 
-    client = assert_queries(2) { Client.preload(:accounts).find(c.id) }
-    assert_no_queries { assert client.accounts.empty? }
+    client = assert_queries(1) { Client.preload(:accounts).find(c.id) }
+    assert_queries(1) { assert client.accounts.empty? }
   end
 
   def test_preloading_has_many_through_with_distinct
@@ -1337,10 +1347,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     groucho = members(:groucho)
 
-    sponsor = assert_queries(2) {
+    sponsor = assert_queries(1) {
       Sponsor.includes(:thing).where(id: sponsor.id).first
     }
-    assert_no_queries { assert_equal groucho, sponsor.thing }
+    assert_queries(1) { assert_equal groucho, sponsor.thing }
   end
 
   def test_joins_with_includes_should_preload_via_joins
@@ -1401,21 +1411,32 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "deep preload" do
-    post = Post.preload(author: :posts, comments: :post).first
+    post = nil
 
-    assert_predicate post.author.association(:posts), :loaded?
-    assert_predicate post.comments.first.association(:post), :loaded?
+    assert_queries(1) do
+      post = Post.preload(author: :posts, comments: :post).first
+    end
+
+    assert_not_predicate post.author.association(:posts), :loaded?
+    assert_not_predicate post.comments.first.association(:post), :loaded?
+
+    assert_queries(4) do
+      post.tap { |post| post.author.posts.first }.tap { |post| post.comments.first.post }
+      assert_predicate post.author.association(:posts), :loaded?
+      assert_predicate post.comments.first.association(:post), :loaded?
+    end
   end
 
   test "preloading does not cache has many association subset when preloaded with a through association" do
-    author = Author.includes(:comments_with_order_and_conditions, :posts).first
-    assert_no_queries { assert_equal 2, author.comments_with_order_and_conditions.size }
-    assert_no_queries { assert_equal 5, author.posts.size, "should not cache a subset of the association" }
+    author = nil
+    assert_queries(1) { author = Author.includes(:comments_with_order_and_conditions, :posts).first }
+    assert_queries(1) { assert_equal 2, author.comments_with_order_and_conditions.size }
+    assert_queries(1) { assert_equal 5, author.posts.size, "should not cache a subset of the association" }
   end
 
   test "preloading a through association twice does not reset it" do
     members = Member.includes(current_membership: :club).includes(:club).to_a
-    assert_no_queries {
+    assert_queries(2) {
       assert_equal 3, members.map(&:current_membership).map(&:club).size
     }
   end
@@ -1439,7 +1460,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   test "preloading the same association twice works" do
     Member.create!
     members = Member.preload(:current_membership).includes(current_membership: :club).all.to_a
-    assert_no_queries {
+    assert_queries(2) {
       members_with_membership = members.select(&:current_membership)
       assert_equal 3, members_with_membership.map(&:current_membership).map(&:club).size
     }
@@ -1456,10 +1477,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preloading associations with string joins and order references" do
-    author = assert_queries(2) {
+    author = assert_queries(1) {
       Author.includes(:posts).joins("LEFT JOIN posts ON posts.author_id = authors.id").order("posts.title DESC").first
     }
-    assert_no_queries {
+    assert_queries(1) {
       assert_equal 5, author.posts.size
     }
   end
@@ -1481,26 +1502,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
   test "preloading and eager loading of instance dependent associations is not supported" do
     message = "association scope 'posts_with_signature' is"
     error = assert_raises(ArgumentError) do
-      Author.includes(:posts_with_signature).to_a
+      Author.includes(:posts_with_signature).each &:posts_with_signature
     end
     assert_match message, error.message
 
     error = assert_raises(ArgumentError) do
-      Author.preload(:posts_with_signature).to_a
+      Author.preload(:posts_with_signature).each &:posts_with_signature
     end
     assert_match message, error.message
 
     error = assert_raises(ArgumentError) do
-      Author.eager_load(:posts_with_signature).to_a
+      Author.eager_load(:posts_with_signature).each &:posts_with_signature
     end
     assert_match message, error.message
-  end
-
-  test "preload with invalid argument" do
-    exception = assert_raises(ArgumentError) do
-      Author.preload(10).to_a
-    end
-    assert_equal("10 was not recognized for preload", exception.message)
   end
 
   test "associations with extensions are not instance dependent" do
@@ -1511,7 +1525,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   test "including associations with extensions and an instance dependent scope is not supported" do
     e = assert_raises(ArgumentError) do
-      Author.includes(:posts_with_extension_and_instance).to_a
+      Author.includes(:posts_with_extension_and_instance).each &:posts_with_extension_and_instance
     end
     assert_match(/Preloading instance dependent scopes is not supported/, e.message)
   end
@@ -1591,22 +1605,22 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   test "preloading through a polymorphic association doesn't require the association to exist" do
     sponsors = []
-    assert_queries 5 do
+    assert_queries 1 do
       sponsors = Sponsor.where(sponsorable_id: 1).preload(sponsorable: [:post, :membership]).to_a
     end
-    # check the preload worked
-    assert_queries 0 do
+    # check the lazy preloading works
+    assert_queries 4 do
       sponsors.map(&:sponsorable).map { |s| s.respond_to?(:posts) ? s.post.author : s.membership }
     end
   end
 
   test "preloading a regular association through a polymorphic association doesn't require the association to exist on all types" do
     sponsors = []
-    assert_queries 6 do
+    assert_queries 1 do
       sponsors = Sponsor.where(sponsorable_id: 1).preload(sponsorable: [{ post: :first_comment }, :membership]).to_a
     end
-    # check the preload worked
-    assert_queries 0 do
+    # check the lazy preloading works
+    assert_queries 5 do
       sponsors.map(&:sponsorable).map { |s| s.respond_to?(:posts) ? s.post.author : s.membership }
     end
   end
@@ -1614,7 +1628,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
   test "preloading a regular association with a typo through a polymorphic association still raises" do
     # this test contains an intentional typo of first -> fist
     assert_raises(ActiveRecord::AssociationNotFoundError) do
-      Sponsor.where(sponsorable_id: 1).preload(sponsorable: [{ post: :fist_comment }, :membership]).to_a
+      Sponsor.where(sponsorable_id: 1)
+        .preload(sponsorable: [{ post: :fist_comment }, :membership])
+        .each { |sponsor| sponsor.sponsorable.post.fist_comment }
     end
   end
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -986,6 +986,25 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     # Nested HATBM
     first_project = Developer.first.projects.first
     preloaded_first_project =
+      Developer.includes_immediately(projects: :salaried_developers).
+        first.
+        projects.
+        detect { |p| p.id == first_project.id }
+
+    assert preloaded_first_project.salaried_developers.loaded?, true
+    assert_equal first_project.salaried_developers.size, preloaded_first_project.salaried_developers.size
+  end
+
+  def test_lazy_loaded_associations_size
+    assert_equal Project.first.salaried_developers.size,
+      Project.preload(:salaried_developers).first.salaried_developers.size
+
+    assert_equal Project.includes(:salaried_developers).references(:salaried_developers).first.salaried_developers.size,
+      Project.preload(:salaried_developers).first.salaried_developers.size
+
+    # Nested HATBM
+    first_project = Developer.first.projects.first
+    preloaded_first_project =
       Developer.preload(projects: :salaried_developers).
         first.
         projects.

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -991,8 +991,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
         projects.
         detect { |p| p.id == first_project.id }
 
-    assert preloaded_first_project.salaried_developers.loaded?, true
+    assert_not_predicate preloaded_first_project.salaried_developers, :loaded?
     assert_equal first_project.salaried_developers.size, preloaded_first_project.salaried_developers.size
+    assert_predicate preloaded_first_project.salaried_developers, :loaded?
   end
 
   def test_has_and_belongs_to_many_is_useable_with_belongs_to_required_by_default

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -44,6 +44,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { assert_nil firm.account }
 
     firms = Firm.includes(:account).to_a
+    assert_queries(1) { firms.each(&:account) }
     assert_no_queries { firms.each(&:account) }
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -45,6 +45,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     firms = Firm.includes(:account).to_a
     assert_queries(1) { firms.each(&:account) }
+
+    firms = Firm.includes_immediately(:account).to_a
     assert_no_queries { firms.each(&:account) }
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -137,19 +137,19 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_eager_loading
-    members = assert_queries(3) do # base table, through table, clubs table
+    members = assert_queries(1) do # base table, through table, clubs table
       Member.all.merge!(includes: :club, where: ["name = ?", "Groucho Marx"]).to_a
     end
     assert_equal 1, members.size
-    assert_not_nil assert_no_queries { members[0].club }
+    assert_not_nil assert_queries(2) { members[0].club }
   end
 
   def test_has_one_through_eager_loading_through_polymorphic
-    members = assert_queries(3) do # base table, through table, clubs table
+    members = assert_queries(1) do # base table, through table, clubs table
       Member.all.merge!(includes: :sponsor_club, where: ["name = ?", "Groucho Marx"]).to_a
     end
     assert_equal 1, members.size
-    assert_not_nil assert_no_queries { members[0].sponsor_club }
+    assert_not_empty assert_queries(2) { members.map(&:sponsor_club).compact }
   end
 
   def test_has_one_through_with_conditions_eager_loading
@@ -171,7 +171,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   def test_eager_has_one_through_polymorphic_with_source_type
     clubs = Club.all.merge!(includes: :sponsored_member, where: ["name = ?", "Moustache and Eyebrow Fancier Club"]).to_a
     # Only the eyebrow fanciers club has a sponsored_member
-    assert_not_nil assert_no_queries { clubs[0].sponsored_member }
+    assert_not_nil assert_queries(2) { clubs[0].sponsored_member }
   end
 
   def test_has_one_through_nonpreload_eagerloading
@@ -262,12 +262,12 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     @member_detail = MemberDetail.new
     @member.member_detail = @member_detail
     @member.organization = @organization
-    @member_details = assert_queries(3) do
+    @member_details = assert_queries(1) do
       MemberDetail.all.merge!(includes: :member_type).to_a
     end
     @new_detail = @member_details[0]
-    assert_predicate @new_detail.send(:association, :member_type), :loaded?
-    assert_no_queries { @new_detail.member_type }
+    assert_not_predicate @new_detail.send(:association, :member_type), :loaded?
+    assert_queries(2) { @new_detail.member_type }
   end
 
   def test_save_of_record_with_loaded_has_one_through

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -62,10 +62,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_many_through_source_reflection_preload
-    authors = assert_queries(5) { Author.includes(:tags).to_a }
+    authors = assert_queries(1) { Author.includes(:tags).to_a }
     general = tags(:general)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [general, general], authors.first.tags
     end
   end
@@ -91,8 +91,8 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_many_through_with_has_many_source_reflection_preload
     luke, david = subscribers(:first), subscribers(:second)
-    authors = assert_queries(4) { Author.includes(:subscribers).to_a }
-    assert_no_queries do
+    authors = assert_queries(1) { Author.includes(:subscribers).to_a }
+    assert_queries(3) do
       assert_equal [luke, david, david], authors.first.subscribers.sort_by(&:nick)
     end
   end
@@ -113,9 +113,9 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_with_has_one_through_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:nested_member_types).to_a }
+    members = assert_queries(1) { Member.includes(:nested_member_types).to_a }
     founding = member_types(:founding)
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [founding], members.first.nested_member_types
     end
   end
@@ -135,9 +135,9 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:nested_sponsors).to_a }
+    members = assert_queries(1) { Member.includes(:nested_sponsors).to_a }
     mustache = sponsors(:moustache_club_sponsor_for_groucho)
-    assert_no_queries do
+    assert_queries(3, ignore_none: false) do
       assert_equal [mustache], members.first.nested_sponsors
     end
   end
@@ -161,10 +161,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_one_with_has_many_through_source_reflection_preload
     ActiveRecord::Base.connection.table_alias_length  # preheat cache
-    members = assert_queries(4) { Member.includes(:organization_member_details).to_a.sort_by(&:id) }
+    members = assert_queries(1) { Member.includes(:organization_member_details).to_a.sort_by(&:id) }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [groucho_details, other_details], members.first.organization_member_details.sort_by(&:id)
     end
   end
@@ -191,12 +191,12 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_many_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:organization_member_details_2).to_a.sort_by(&:id) }
+    members = assert_queries(1) { Member.includes(:organization_member_details_2).to_a.sort_by(&:id) }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
     # postgresql test if randomly executed then executes "SHOW max_identifier_length". Hence
     # the need to ignore certain predefined sqls that deal with system calls.
-    assert_no_queries do
+    assert_queries(3, ignore_none: false) do
       assert_equal [groucho_details, other_details], members.first.organization_member_details_2.sort_by(&:id)
     end
   end
@@ -222,10 +222,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_and_belongs_to_many_source_reflection_preload
-    authors = assert_queries(4) { Author.includes(:post_categories).to_a.sort_by(&:id) }
+    authors = assert_queries(1) { Author.includes(:post_categories).to_a.sort_by(&:id) }
     general, cooking = categories(:general), categories(:cooking)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [general, cooking], authors[2].post_categories.sort_by(&:id)
     end
   end
@@ -251,10 +251,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_and_belongs_to_many_with_has_many_source_reflection_preload
     Category.includes(:post_comments).to_a # preheat cache
-    categories = assert_queries(4) { Category.includes(:post_comments).to_a.sort_by(&:id) }
+    categories = assert_queries(1) { Category.includes(:post_comments).to_a.sort_by(&:id) }
     greetings, more = comments(:greetings), comments(:more_greetings)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [greetings, more], categories[1].post_comments.sort_by(&:id)
     end
   end
@@ -279,10 +279,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_many_through_habtm_source_reflection_preload
-    authors = assert_queries(6) { Author.includes(:category_post_comments).to_a.sort_by(&:id) }
+    authors = assert_queries(1) { Author.includes(:category_post_comments).to_a.sort_by(&:id) }
     greetings, more = comments(:greetings), comments(:more_greetings)
 
-    assert_no_queries do
+    assert_queries(5) do
       assert_equal [greetings, more], authors[2].category_post_comments.sort_by(&:id)
     end
   end
@@ -305,10 +305,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_through_with_belongs_to_source_reflection_preload
-    authors = assert_queries(5) { Author.includes(:tagging_tags).to_a }
+    authors = assert_queries(1) { Author.includes(:tagging_tags).to_a }
     general = tags(:general)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [general, general], authors.first.tagging_tags
     end
   end
@@ -331,10 +331,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_belongs_to_with_has_many_through_source_reflection_preload
-    categorizations = assert_queries(4) { Categorization.includes(:post_taggings).to_a.sort_by(&:id) }
+    categorizations = assert_queries(1) { Categorization.includes(:post_taggings).to_a.sort_by(&:id) }
     welcome_general, thinking_general = taggings(:welcome_general), taggings(:thinking_general)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [welcome_general, thinking_general], categorizations.first.post_taggings.sort_by(&:id)
     end
   end
@@ -354,10 +354,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_has_one_with_has_one_through_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:nested_member_type).to_a.sort_by(&:id) }
+    members = assert_queries(1) { Member.includes(:nested_member_type).to_a.sort_by(&:id) }
     founding = member_types(:founding)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal founding, members.first.nested_member_type
     end
   end
@@ -388,10 +388,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_has_one_through_with_belongs_to_source_reflection_preload
-    members = assert_queries(4) { Member.includes(:club_category).to_a.sort_by(&:id) }
+    members = assert_queries(1) { Member.includes(:club_category).to_a.sort_by(&:id) }
     general = categories(:general)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal general, members.first.club_category
     end
   end
@@ -519,10 +519,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_nested_has_many_through_with_conditions_on_through_associations_preload
     assert_empty Author.where("tags.id" => 100).joins(:misc_post_first_blue_tags)
 
-    authors = assert_queries(3) { Author.includes(:misc_post_first_blue_tags).to_a.sort_by(&:id) }
+    authors = assert_queries(1) { Author.includes(:misc_post_first_blue_tags).to_a.sort_by(&:id) }
     blue = tags(:blue)
 
-    assert_no_queries do
+    assert_queries(2) do
       assert_equal [blue], authors[2].misc_post_first_blue_tags
     end
   end
@@ -540,10 +540,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nested_has_many_through_with_conditions_on_source_associations_preload
-    authors = assert_queries(4) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
+    authors = assert_queries(1) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
     blue = tags(:blue)
 
-    assert_no_queries do
+    assert_queries(3) do
       assert_equal [blue], authors[2].misc_post_first_blue_tags_2
     end
   end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -462,18 +462,22 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_eager_load_belongs_to_something_inherited
     account = Account.all.merge!(includes: :firm).find(1)
+    assert_not account.association(:firm).loaded?, "association was eager loaded prematurely"
+    account.firm
     assert account.association(:firm).loaded?, "association was not eager loaded"
   end
 
   def test_alt_eager_loading
     cabbage = RedCabbage.all.merge!(includes: :seller).find(4)
+    assert_not cabbage.association(:seller).loaded?, "association was eager loaded prematurely"
+    cabbage.seller
     assert cabbage.association(:seller).loaded?, "association was not eager loaded"
   end
 
   def test_eager_load_belongs_to_primary_key_quoting
     con = Account.connection
-    bind_param = Arel::Nodes::BindParam.new(nil)
-    assert_sql(/#{con.quote_table_name('companies')}\.#{con.quote_column_name('id')} = (?:#{Regexp.quote(bind_param.to_sql)}|1)/) do
+    bind_param = Arel::Nodes::BindParam.new(1)
+    assert_sql(/#{con.quote_table_name('accounts')}\.#{con.quote_column_name('id')} = (?:#{Regexp.quote(bind_param.to_sql)}|1)/) do
       Account.all.merge!(includes: :firm).find(1)
     end
   end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -388,9 +388,9 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_alt_inheritance_condition
-    assert_equal 4, Vegetable.count
+    assert_equal 5, Vegetable.count
     assert_equal 1, Cucumber.count
-    assert_equal 3, Cabbage.count
+    assert_equal 4, Cabbage.count
   end
 
   def test_finding_incorrect_type_data
@@ -461,17 +461,27 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_eager_load_belongs_to_something_inherited
-    account = Account.all.merge!(includes: :firm).find(1)
-    assert_not account.association(:firm).loaded?, "association was eager loaded prematurely"
-    account.firm
+    account = Account.all.merge!(includes_immediately: :firm).find(1)
     assert account.association(:firm).loaded?, "association was not eager loaded"
   end
 
+  def test_lazy_load_belongs_to_something_inherited
+    accounts = Account.all.merge!(includes: :firm).order(:id).to_a
+    assert_not accounts[0].association(:firm).loaded?, "association was eager loaded prematurely"
+    accounts[1].firm
+    assert accounts[0].association(:firm).loaded?, "association was not eager loaded"
+  end
+
   def test_alt_eager_loading
-    cabbage = RedCabbage.all.merge!(includes: :seller).find(4)
-    assert_not cabbage.association(:seller).loaded?, "association was eager loaded prematurely"
-    cabbage.seller
+    cabbage = RedCabbage.all.merge!(includes_immediately: :seller).find(4)
     assert cabbage.association(:seller).loaded?, "association was not eager loaded"
+  end
+
+  def test_alt_lazy_loading
+    cabbages = RedCabbage.all.merge!(includes: :seller).to_a
+    assert_not cabbages[0].association(:seller).loaded?, "association was eager loaded prematurely"
+    cabbages[1].seller
+    assert cabbages[0].association(:seller).loaded?, "association was not eager loaded"
   end
 
   def test_eager_load_belongs_to_primary_key_quoting

--- a/activerecord/test/cases/modules_test.rb
+++ b/activerecord/test/cases/modules_test.rb
@@ -79,8 +79,8 @@ class ModulesTest < ActiveRecord::TestCase
       clients << MyApplication::Business::Client.includes(firm: :account).find(3)
     end
 
-    clients.each do |client|
-      assert_no_queries do
+    assert_queries(2) do
+      clients.each do |client|
         assert_not_nil(client.firm.account)
       end
     end

--- a/activerecord/test/fixtures/author_favorites.yml
+++ b/activerecord/test/fixtures/author_favorites.yml
@@ -2,3 +2,8 @@ david_mary:
   id: 1
   author_id: 1
   favorite_author_id: 2
+
+susan_david:
+  id: 2
+  author_id: 3
+  favorite_author_id: 1

--- a/activerecord/test/fixtures/references.yml
+++ b/activerecord/test/fixtures/references.yml
@@ -15,3 +15,9 @@ david_unicyclist:
   person_id: 2
   job_id: 1
   favourite: false
+
+susan_favourite_unicyclist:
+  id: 4
+  person_id: 3
+  job_id: 3
+  favourite: true

--- a/activerecord/test/fixtures/vegetables.yml
+++ b/activerecord/test/fixtures/vegetables.yml
@@ -13,8 +13,14 @@ second_cabbage:
   custom_type: Cabbage
   name: 'his cabbage'
 
-red_cabbage:
+first_red_cabbage:
   id: 4
+  custom_type: RedCabbage
+  name: 'red cabbage'
+  seller_id: 3
+
+second_red_cabbage:
+  id: 5
   custom_type: RedCabbage
   name: 'red cabbage'
   seller_id: 3

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -6,12 +6,15 @@ class Author < ActiveRecord::Base
   has_one :post
   has_many :very_special_comments, through: :posts
   has_many :posts_with_comments, -> { includes(:comments) }, class_name: "Post"
+  has_many :posts_with_immediate_comments, -> { includes_immediately(:comments) }, class_name: "Post"
   has_many :popular_grouped_posts, -> { includes(:comments).group("type").having("SUM(comments_count) > 1").select("type") }, class_name: "Post"
   has_many :posts_with_comments_sorted_by_comment_id, -> { includes(:comments).order("comments.id") }, class_name: "Post"
   has_many :posts_sorted_by_id, -> { order(:id) }, class_name: "Post"
   has_many :posts_sorted_by_id_limited, -> { order("posts.id").limit(1) }, class_name: "Post"
   has_many :posts_with_categories, -> { includes(:categories) }, class_name: "Post"
+  has_many :posts_with_immediate_categories, -> { includes_immediately(:categories) }, class_name: "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, class_name: "Post"
+  has_many :posts_with_immediate_comments_and_categories, -> { includes_immediately(:comments, :categories).order("posts.id") }, class_name: "Post"
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"
   has_one  :post_about_thinking, -> { where("posts.title like '%thinking%'") }, class_name: "Post"
   has_one  :post_about_thinking_with_last_comment, -> { where("posts.title like '%thinking%'").includes(:last_comment) }, class_name: "Post"

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -19,6 +19,9 @@ class Car < ActiveRecord::Base
   scope :incl_tyres, -> { includes(:tyres) }
   scope :incl_engines, -> { includes(:engines) }
 
+  scope :incl_immediate_tyres, -> { includes_immediately(:tyres) }
+  scope :incl_immediate_engines, -> { includes_immediately(:engines) }
+
   scope :order_using_new_style,  -> { order("name asc") }
 
   attribute :wheels_owned_at, :datetime, default: -> { Time.now }

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -227,10 +227,47 @@ class EagerDeveloperWithDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
-  default_scope { includes(:projects) }
+  default_scope { includes_immediately(:projects) }
 end
 
 class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
+  self.table_name = "developers"
+  has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
+
+  def self.default_scope
+    includes_immediately(:projects)
+  end
+end
+
+class EagerDeveloperWithLambdaDefaultScope < ActiveRecord::Base
+  self.table_name = "developers"
+  has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
+
+  default_scope lambda { includes_immediately(:projects) }
+end
+
+class EagerDeveloperWithBlockDefaultScope < ActiveRecord::Base
+  self.table_name = "developers"
+  has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
+
+  default_scope { includes_immediately(:projects) }
+end
+
+class EagerDeveloperWithCallableDefaultScope < ActiveRecord::Base
+  self.table_name = "developers"
+  has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
+
+  default_scope OpenStruct.new(call: includes_immediately(:projects))
+end
+
+class LazyDeveloperWithDefaultScope < ActiveRecord::Base
+  self.table_name = "developers"
+  has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
+
+  default_scope { includes(:projects) }
+end
+
+class LazyDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
@@ -239,26 +276,27 @@ class EagerDeveloperWithClassMethodDefaultScope < ActiveRecord::Base
   end
 end
 
-class EagerDeveloperWithLambdaDefaultScope < ActiveRecord::Base
+class LazyDeveloperWithLambdaDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
   default_scope lambda { includes(:projects) }
 end
 
-class EagerDeveloperWithBlockDefaultScope < ActiveRecord::Base
+class LazyDeveloperWithBlockDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
   default_scope { includes(:projects) }
 end
 
-class EagerDeveloperWithCallableDefaultScope < ActiveRecord::Base
+class LazyDeveloperWithCallableDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
   default_scope OpenStruct.new(call: includes(:projects))
 end
+
 
 class ThreadsafeDeveloper < ActiveRecord::Base
   self.table_name = "developers"

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -30,6 +30,7 @@ class Post < ActiveRecord::Base
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id
 
   belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id
+  belongs_to :author_with_immediate_posts, -> { includes_immediately(:posts) }, class_name: "Author", foreign_key: :author_id
   belongs_to :author_with_address, -> { includes(:author_address) }, class_name: "Author", foreign_key: :author_id
 
   def first_comment
@@ -44,6 +45,9 @@ class Post < ActiveRecord::Base
 
   scope :with_comments, -> { preload(:comments) }
   scope :with_tags, -> { preload(:taggings) }
+
+  scope :with_immediate_comments, -> { includes_immediately(:comments) }
+  scope :with_immediate_tags, -> { includes_immediately(:taggings) }
 
   scope :tagged_with, ->(id) { joins(:taggings).where(taggings: { tag_id: id }) }
   scope :tagged_with_comment, ->(comment) { joins(:taggings).where(taggings: { comment: comment }) }
@@ -85,6 +89,7 @@ class Post < ActiveRecord::Base
 
   has_one  :very_special_comment
   has_one  :very_special_comment_with_post, -> { includes(:post) }, class_name: "VerySpecialComment"
+  has_one  :very_special_comment_with_immediate_post, -> { includes_immediately(:post) }, class_name: "VerySpecialComment"
   has_one :very_special_comment_with_post_with_joins, -> { joins(:post).order("posts.id") }, class_name: "VerySpecialComment"
   has_many :special_comments
   has_many :nonexistent_comments, -> { where "comments.id < 0" }, class_name: "Comment"
@@ -247,6 +252,14 @@ class PostWithIncludesDefaultScope < ActiveRecord::Base
   has_many :readers, foreign_key: "post_id"
 
   default_scope { includes(:readers) }
+end
+
+class PostWithIncludesImmediatelyDefaultScope < ActiveRecord::Base
+  self.table_name = "posts"
+
+  has_many :readers, foreign_key: "post_id"
+
+  default_scope { includes_immediately(:readers) }
 end
 
 class SpecialPostWithDefaultScope < ActiveRecord::Base

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -34,7 +34,7 @@ class Post < ActiveRecord::Base
   belongs_to :author_with_address, -> { includes(:author_address) }, class_name: "Author", foreign_key: :author_id
 
   def first_comment
-    super.body
+    super&.body
   end
   has_one :first_comment, -> { order("id ASC") }, class_name: "Comment"
   has_one :last_comment, -> { order("id desc") }, class_name: "Comment"


### PR DESCRIPTION
### Summary

Continuation of https://github.com/rails/rails/pull/33527. Looking at https://github.com/rails/rails/pull/33527 it seems like original author is inactive. 

I think this feature should be part of Rails 6.0 so I'll like to take this feature forward.
   
I've fixed & improved majority of existing test cases and added few more. 

### Original Summary

Suppose that you have the following two Active Record models:
```
class Author < ActiveRecord::Base
  # columns: name, age
  has_many :books
end

class Book < ActiveRecord::Base
  # columns: title, sales, author_id
end
```
When you load an author with all associated books Active Record will make
only one query:
```
authors = Author.lazy_preload(:books).where(name: ['bell hooks', 'Homer']).to_a
=> SELECT `authors`.* FROM `authors` WHERE `name` IN ('bell hooks', 'Homer')
```
Then you probably will want to retrieve books while iterating authors
```
authors.each { |author| read author.books }
```
And only after books method invocation second query will be executed
to load all books for authors in the collection:

```
=> SELECT `books`.* FROM `books` WHERE `author_id` IN (2, 5)
```
This also works for nested association preloading, what can be useful for writing e.g. graphql apis.

### Other Information
@matthewd suggested in https://github.com/rails/rails/pull/33527 to make this behavior default.