### PR TITLE
Add i18n capabilities to ActiveSupport::Inflector#titleize

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   `ActiveSupport::Inflector#titleize` now supports translations through I18n.
+
+        # locale/fr.rb
+
+        {
+          fr: {
+            string: {
+              format: {
+                titleize: lambda do |_key, word:, keep_id_suffix: false, **_options|
+                  ActiveSupport::Inflector.humanize(
+                    ActiveSupport::Inflector.underscore(word),
+                    keep_id_suffix: keep_id_suffix
+                  ).capitalize
+                end
+              }
+            }
+          }
+        }
+
+
+    *Christian Blais*
+
 *   If the same block is `included` multiple times for a Concern, an exception is no longer raised.
 
     *Mark J. Titorenko*, *Vlad Bokov*

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -172,9 +172,7 @@ module ActiveSupport
     #   titleize('raiders_of_the_lost_ark')                      # => "Raiders Of The Lost Ark"
     #   titleize('string_ending_with_id', keep_id_suffix: true)  # => "String Ending With Id"
     def titleize(word, keep_id_suffix: false)
-      humanize(underscore(word), keep_id_suffix: keep_id_suffix).gsub(/\b(?<!\w['’`])[a-z]/) do |match|
-        match.capitalize
-      end
+      I18n.translate("string.format.titleize", word: word, keep_id_suffix: keep_id_suffix)
     end
 
     # Creates the name of a table like Rails does for models to table names.

--- a/activesupport/lib/active_support/locale/en.rb
+++ b/activesupport/lib/active_support/locale/en.rb
@@ -26,6 +26,16 @@
           "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
         end
       }
+    },
+    string: {
+      format: {
+        titleize: lambda do |_key, word:, keep_id_suffix: false, **_options|
+          ActiveSupport::Inflector.humanize(
+            ActiveSupport::Inflector.underscore(word),
+            keep_id_suffix: keep_id_suffix
+          ).gsub(/\b(?<!\w['’`])[a-z]/, &:capitalize)
+        end
+      }
     }
   }
 }


### PR DESCRIPTION
Similar to what https://github.com/rails/rails/pull/32168 did to `ordinal` and `ordinalized`, this PR adds I18n capabilities to `titleize`.

### Summary

`titleize` currently capitalizes all the words of a string, which unfortunately doesn't work in all languages. Taking "raiders of the lost ark" as an example, what would become "Raiders Of The Lost Ark" in English should instead become "Raiders of the lost ark" in French. Other languages might very well treat this differently too. This PR moves the logic to an I18n rule, where each language will be able to define their own rule.

I was afraid `titleize` could be used for some internal mechanics, but [the method definition clearly state otherwise](https://github.com/rails/rails/blob/260b273106168ba7a122c76c79a3b7f4a3209559/activesupport/lib/active_support/inflector/methods.rb#L159-L161). Given that information, this should be a safe change.

### Other Information

This is a noop. The English rule acts exactly the same as it used too, and no other languages are provided by default.
