### PR TITLE
fix activerecord reaper_test

### DIFF
--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
 
         reaper = ConnectionPool::Reaper.new(fp, 0.0001)
         reaper.run
-        until fp.reaped
+        until fp.flushed
           Thread.pass
         end
         assert fp.reaped


### PR DESCRIPTION
### Summary

Reaper calls `reap` first, and `flush` only after.

This makes the test depend on the threads switching (which produce random failures, e.g. https://travis-ci.org/rails/rails/jobs/474561814)