### PR TITLE
Use latest Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ bundler_args: --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"
-  - "travis_retry gem install bundler -v '2.0.0.pre.2'"
+  - "travis_retry gem install bundler"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"
   - "[[ $GEM != 'actioncable:integration' ]] || yarn install"
   - "[[ $GEM != 'actionview:ujs' ]] || nvm install node"


### PR DESCRIPTION
Don't need to specify the version because Bundler 2.0 released.
Ref: https://bundler.io/blog/2019/01/03/announcing-bundler-2.html
