### PR TITLE
Fallback to `bundler` 1.7.3 when failed to install 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system || travis_retry gem update --system 2.7.8"
-  - "travis_retry gem install bundler"
+  - "travis_retry gem install bundler || travis_retry gem install bundler -v 1.17.3"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
   - "[[ -z $encrypted_0fb9444d0374_key && -z $encrypted_0fb9444d0374_iv ]] || openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in activestorage/test/service/configurations.yml.enc -out activestorage/test/service/configurations.yml -d"


### PR DESCRIPTION
`bundler` 2.0 only supports Ruby >= 2.3.0. So fall back to the old
version when failed to install.

Ref: https://travis-ci.org/rails/rails/jobs/474466077#L1149-L1151