### PR TITLE
`bundle update --bundler`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,4 +587,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.17.2
+   2.0.0


### PR DESCRIPTION
Use Bundler 2.0 on localhost as well.

Related to #34849, https://bundler.io/blog/2019/01/03/announcing-bundler-2.html.

/cc @y-yagi