### PR TITLE
Make average compatible across ruby versions

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -401,7 +401,7 @@ module ActiveRecord
         case operation
         when "count"   then value.to_i
         when "sum"     then type.deserialize(value || 0)
-        when "average" then value.respond_to?(:to_d) ? value.to_d : value
+        when "average" then value&.respond_to?(:to_d) ? value.to_d : value
         else type.deserialize(value)
         end
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -57,12 +57,8 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 3, value
   end
 
-  def test_should_return_nil_to_d_as_average
-    if nil.respond_to?(:to_d)
-      assert_equal BigDecimal(0), NumericData.average(:bank_balance)
-    else
-      assert_nil NumericData.average(:bank_balance)
-    end
+  def test_should_return_nil_as_average
+    assert_nil NumericData.average(:bank_balance)
   end
 
   def test_should_get_maximum_of_field


### PR DESCRIPTION
### Summary

Since Ruby 2.6.0 `NilClass#to_d` is returning `BigDecimal` 0.0. This breaks `average` compatibility with prior Ruby versions. This patch makes `average` return `nil` in all Ruby versions when there are no rows.

### Other Information

Reverts #34601
Fixes #34850

r? @rafaelfranca 