### PR TITLE
Make Ruby on Rails Guides SNS-friendly

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -3,6 +3,7 @@
 require "redcarpet"
 require "nokogiri"
 require "rails_guides/markdown/renderer"
+require "rails-html-sanitizer"
 
 module RailsGuides
   class Markdown
@@ -20,6 +21,7 @@ module RailsGuides
       @raw_body = body
       extract_raw_header_and_body
       generate_header
+      generate_description
       generate_title
       generate_body
       generate_structure
@@ -80,6 +82,11 @@ module RailsGuides
 
       def generate_header
         @header = engine.render(@raw_header).html_safe
+      end
+
+      def generate_description
+        sanitizer = Rails::Html::FullSanitizer.new
+        @description = sanitizer.sanitize(@header).squish
       end
 
       def generate_structure
@@ -165,6 +172,7 @@ module RailsGuides
 
       def render_page
         @view.content_for(:header_section) { @header }
+        @view.content_for(:description) { @description }
         @view.content_for(:page_title) { @title }
         @view.content_for(:index_section) { @index }
         @view.render(layout: @layout, html: @body.html_safe)

--- a/guides/source/index.html.erb
+++ b/guides/source/index.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-Ruby on Rails Guides
-<% end %>
+<% content_for :page_title, "Ruby on Rails Guides" %>
+<% content_for :description, "Ruby on Rails Guides" %>
 
 <% content_for :header_section do %>
 <%= render 'welcome' %>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title><%= yield(:page_title) || 'Ruby on Rails Guides' %></title>
+  <title><%= yield(:page_title) %></title>
   <link rel="stylesheet" type="text/css" href="stylesheets/style.css" data-turbolinks-track="reload">
   <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
   <link rel="stylesheet" type="text/css" href="stylesheets/syntaxhighlighter/shCore.css" data-turbolinks-track="reload">
@@ -14,6 +14,13 @@
   <script src="javascripts/turbolinks.js" data-turbolinks-track="reload"></script>
   <script src="javascripts/guides.js" data-turbolinks-track="reload"></script>
   <script src="javascripts/responsive-tables.js" data-turbolinks-track="reload"></script>
+  <meta property="og:title" content="<%= yield(:page_title) %>" />
+  <meta name="description" content="<%= yield(:description) %>" />
+  <meta property="og:description" content="<%= yield(:description) %>" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:site_name" content="Ruby on Rails Guides" />
+  <meta property="og:image" content="https://avatars.githubusercontent.com/u/4223" />
+  <meta property="og:type" content="website" />
 </head>
 <body class="guide">
   <% if @edge %>


### PR DESCRIPTION
### Summary

[Ruby on Rails Guides](https://guides.rubyonrails.org/) is not SNS-friendly currently. This PR adds [OG meta tags](http://ogp.me/#metadata) to the guides.

![image](https://user-images.githubusercontent.com/803398/50677858-74331680-103f-11e9-94a8-4e13052f90a1.png)

☝️ Twitter Card Preview is unavailable

### Other Information

After this PR is merged, the Twitter Card looks like:

<img width="592" alt="card_validator___twitter_developers" src="https://user-images.githubusercontent.com/803398/50678135-9e390880-1040-11e9-840d-27220ed2525c.png">

#### Related PR

- https://github.com/rails/weblog/pull/88
- https://github.com/rails/weblog/pull/89