### PR TITLE
Fix example of I18n setting in the guide [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -299,7 +299,7 @@ A trivial implementation of using an `Accept-Language` header would be:
 def switch_locale(&action)
   logger.debug "* Accept-Language: #{request.env['HTTP_ACCEPT_LANGUAGE']}"
   locale = extract_locale_from_accept_language_header
-  logger.debug "* Locale set to '#{I18n.locale}'"
+  logger.debug "* Locale set to '#{locale}'"
   I18n.with_locale(locale, &action)
 end
 


### PR DESCRIPTION
Since #34356 logging `locale` value is more correct
