### PR TITLE
Send Active Storage analysis and purge jobs to dedicated queues by default

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -906,6 +906,8 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.action_view.default_enforce_utf8`: `false`
 - `config.action_dispatch.use_cookies_with_metadata`: `true`
 - `config.active_job.return_false_on_aborted_enqueue`: `true`
+- `config.active_storage.queues.analysis`: `:active_storage_analysis`
+- `config.active_storage.queues.purge`: `:active_storage_purge`
 
 ### Configuring a Database
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Send Active Storage analysis and purge jobs to dedicated queues by default.
+
+    Analysis jobs now use the `:active_storage_analysis` queue, and purge jobs
+    now use the `:active_storage_purge` queue. This matches Action Mailbox,
+    which sends its jobs to dedicated queues by default.
+
+    *George Claghorn*
+
 *   Add `rails test:mailboxes`.
 
     *George Claghorn*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -133,6 +133,11 @@ module Rails
           if respond_to?(:active_job)
             active_job.return_false_on_aborted_enqueue = true
           end
+
+          if respond_to?(:active_storage)
+            active_storage.queues.analysis = :active_storage_analysis
+            active_storage.queues.purge    = :active_storage_purge
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -6,7 +6,7 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-# Don't force requests from old versions of IE to be UTF-8 encoded
+# Don't force requests from old versions of IE to be UTF-8 encoded.
 # Rails.application.config.action_view.default_enforce_utf8 = false
 
 # Embed purpose and expiry metadata inside signed and encrypted
@@ -16,5 +16,9 @@
 # It's best enabled when your entire app is migrated and stable on 6.0.
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
-# Return false instead of self when #enqueue method was aborted from the callback
+# Return false instead of self when enqueuing is aborted from a callback.
 Rails.application.config.active_job.return_false_on_aborted_enqueue = true
+
+# Send Active Storage analysis and purge jobs to dedicated queues.
+# Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
+# Rails.application.config.active_storage.queues.purge    = :active_storage_purge

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2226,6 +2226,34 @@ module ApplicationTests
       assert_equal true, ActiveJob::Base.return_false_on_aborted_enqueue
     end
 
+    test "ActiveStorage.queues[:analysis] is :active_storage_analysis by default" do
+      app "development"
+
+      assert_equal :active_storage_analysis, ActiveStorage.queues[:analysis]
+    end
+
+    test "ActiveStorage.queues[:analysis] is nil without Rails 6 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_nil ActiveStorage.queues[:analysis]
+    end
+
+    test "ActiveStorage.queues[:purge] is :active_storage_purge by default" do
+      app "development"
+
+      assert_equal :active_storage_purge, ActiveStorage.queues[:purge]
+    end
+
+    test "ActiveStorage.queues[:purge] is nil without Rails 6 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_nil ActiveStorage.queues[:purge]
+    end
+
     test "ActiveRecord::Base.filter_attributes should equal to filter_parameters" do
       app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
         Rails.application.config.filter_parameters += [ :password, :credit_card_number ]


### PR DESCRIPTION
Match Action Mailbox, which sets a default queue for each of its two jobs.