### PR TITLE
Clarify benefit of `delegate_missing_to`

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -266,7 +266,7 @@ class Module
   #     end
   #
   #     def person
-  #       @event.detail.person || @event.creator
+  #       detail.person || creator
   #     end
   #   end
   #


### PR DESCRIPTION
### Summary

Removing the explicit receiver clarifies the purpose of `delegate_missing_to`.