### PR TITLE
Respect Rails.env when running `rails yarn:install`

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -6,8 +6,7 @@ namespace :yarn do
     # Install only production deps when for not usual envs.
     valid_node_envs = %w[test development production]
     node_env = ENV.fetch("NODE_ENV") do
-      rails_env = ENV["RAILS_ENV"]
-      valid_node_envs.include?(rails_env) ? rails_env : "production"
+      valid_node_envs.include?(Rails.env) ? Rails.env : "production"
     end
     system({ "NODE_ENV" => node_env }, "#{Rails.root}/bin/yarn install --no-progress --frozen-lockfile")
   end


### PR DESCRIPTION
When no environment variables are set the expectation is that we are in development.

Related to #32699.