### PR TITLE
Clarify `delegate_missing_to` [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -243,7 +243,7 @@ class Module
   #     end
   #
   #     def person
-  #       @event.detail.person || @event.creator
+  #       detail.person || creator
   #     end
   #
   #     private


### PR DESCRIPTION
Since #34864 removed explicit receiver to clarify the
purpose of `delegate_missing_to`, I think it will be
better to do the same a few lines above to easier figure
out that `delegate_missing_to` defines `method_missing`,
`respond_to_missing?` when comparing these examples.
