### PR TITLE
Fix API docs of `ActionText::RichText` [ci skip]

### DIFF
--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# The RichText record holds the content produced by the Trix editor in a serialized `body` attribute.
-# It also holds all the references to the embedded files, which are stored using Active Storage.
-# This record is then associated with the Active Record model the application desires to have
-# rich text content using the `has_rich_text` class method.
 module ActionText
+  # The RichText record holds the content produced by the Trix editor in a serialized `body` attribute.
+  # It also holds all the references to the embedded files, which are stored using Active Storage.
+  # This record is then associated with the Active Record model the application desires to have
+  # rich text content using the `has_rich_text` class method.
   class RichText < ActiveRecord::Base
     self.table_name = "action_text_rich_texts"
 


### PR DESCRIPTION
This text should appear on the page
https://api.rubyonrails.org/v6.0/classes/ActionText/RichText.html

Related to 86517942e469193e8624d5078d718785552c1270
/cc @georgeclaghorn 