### PR TITLE
Test actiontext on Rails 6.0

### DIFF
--- a/actionmailbox/test/dummy/db/migrate/20180212164506_create_active_storage_tables.active_storage.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180212164506_create_active_storage_tables.active_storage.rb
@@ -21,6 +21,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.datetime :created_at, null: false
 
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 end

--- a/actiontext/test/dummy/config/application.rb
+++ b/actiontext/test/dummy/config/application.rb
@@ -8,7 +8,7 @@ require "action_text"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/actiontext/test/dummy/db/migrate/20180208205311_create_messages.rb
+++ b/actiontext/test/dummy/db/migrate/20180208205311_create_messages.rb
@@ -1,4 +1,4 @@
-class CreateMessages < ActiveRecord::Migration[5.2]
+class CreateMessages < ActiveRecord::Migration[6.0]
   def change
     create_table :messages do |t|
       t.string :subject

--- a/actiontext/test/dummy/db/migrate/20180212164506_create_active_storage_tables.rb
+++ b/actiontext/test/dummy/db/migrate/20180212164506_create_active_storage_tables.rb
@@ -21,6 +21,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.datetime :created_at, null: false
 
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 end

--- a/actiontext/test/dummy/db/migrate/20181003185713_create_people.rb
+++ b/actiontext/test/dummy/db/migrate/20181003185713_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration[5.2]
+class CreatePeople < ActiveRecord::Migration[6.0]
   def change
     create_table :people do |t|
       t.string :name

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -12,7 +12,6 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
-        '<input name="utf8" type="hidden" value="&#x2713;" />' \
         '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -27,7 +26,6 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
-        '<input name="utf8" type="hidden" value="&#x2713;" />' \
         '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="custom-class" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -42,7 +40,6 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
-        '<input name="utf8" type="hidden" value="&#x2713;" />' \
         '<input type="hidden" name="message[not_an_attribute]" id="message_not_an_attribute_trix_input_message" />' \
         '<trix-editor id="message_not_an_attribute" input="message_not_an_attribute_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -57,7 +54,6 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
-        '<input name="utf8" type="hidden" value="&#x2713;" />' \
         '<input type="hidden" name="message[content]" id="trix_input_1" />' \
         '<trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
         "</trix-editor>" \


### PR DESCRIPTION
- config.load_defaults 6.0 in the dummy app and
  fix the test since by default rails 6.0 configured
  does not generate "utf8" hidden input, see #32125
- Use `ActiveRecord::Migration[6.0]` in the dummy app
  since actiontext will be since Rails 6.0
- Fix `CreateActiveStorageTables` migration in the dummy app(and for actionmailbox's dummy app).
  Add `t.foreign_key :active_storage_blobs, column: :blob_id`
  It was added in 2ae3a29508e.
<strike>- `rails/actiontext$ yarn install`</strike>
\cc @georgeclaghorn 