### PR TITLE
Remove comment from `actiontext/actiontext.gemspec`

### DIFF
--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -2,7 +2,6 @@
 
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
-# Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "actiontext"


### PR DESCRIPTION
This comment was autogenerated, see
`railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt`
Since actiontext is well described in this file, I think we shouldn't
keep this comment. Note that this commit is more like cosmetic change,
so it is OK if we don't merge this.
