### PR TITLE
Call `IO#rewind` after uploading to disk

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -20,6 +20,7 @@ module ActiveStorage
         IO.copy_stream(io, make_path_for(key))
         ensure_integrity_of(key, checksum) if checksum
       end
+      io.rewind
     end
 
     def download(key, &block)


### PR DESCRIPTION
`#upload` is called with `io` attribute from outside the class, but the
position of the pointer changes by `IO.copy_stream`. This method has
side effect which may occurs unexpected errors.