### PR TITLE
Rescue ParseError in ActionController::ParamsWrapper#process_action

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -253,10 +253,9 @@ module ActionController
         # This will display the wrapped hash in the log file.
         request.filtered_parameters.merge! wrapped_filtered_hash
       end
-    ensure
-      # NOTE: Rescues all exceptions so they
-      # may be caught in ActionController::Rescue.
-      return super
+      super
+    rescue ActionDispatch::Http::Parameters::ParseError
+      super
     end
 
     private


### PR DESCRIPTION
Closes #34811 
### Summary

Refactored the `ensure return super` part of ActionController::ParamsWrapper#process_action by using an explicit rescue for parameter parsing errors.

r? @rafaelfranca @gmcgibbon 