### PR TITLE
Switch from sass-rails to sassc-rails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -326,7 +326,7 @@ module Rails
       def assets_gemfile_entry
         return [] if options[:skip_sprockets]
 
-        GemfileEntry.version("sass-rails", "~> 5.0", "Use SCSS for stylesheets")
+        GemfileEntry.version("sassc-rails", "~> 2.1", "Use SCSS for stylesheets")
       end
 
       def webpacker_gemfile_entry

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -40,7 +40,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "Gemfile" do |content|
-      assert_no_match(/gem 'sass-rails'/, content)
+      assert_no_match(/gem 'sassc-rails'/, content)
       assert_no_match(/gem 'web-console'/, content)
       assert_no_match(/gem 'capybara'/, content)
       assert_no_match(/gem 'selenium-webdriver'/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -579,7 +579,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_has_assets_gems
     run_generator
 
-    assert_gem "sass-rails"
+    assert_gem "sassc-rails"
   end
 
   def test_action_cable_redis_gems

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -321,7 +321,7 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']sprockets\/railtie["']/
 
     assert_file "Gemfile" do |content|
-      assert_no_match(/sass-rails/, content)
+      assert_no_match(/sassc-rails/, content)
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|


### PR DESCRIPTION
Ruby Sass will be deprecated on March 2019 so we are switching to use the SassC gem based on the LibSass C library.

sassc-rails is a drop in alternative to sass-rails.

This closes #32896