### PR TITLE
Allow using combine the Cache-Control `public` and `no-cache` headers

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -197,10 +197,12 @@ module ActionDispatch
           if control.empty?
             # Let middleware handle default behavior
           elsif control[:no_cache]
-            self._cache_control = NO_CACHE
-            if control[:extras]
-              self._cache_control = _cache_control + ", #{control[:extras].join(', ')}"
-            end
+            options = []
+            options << PUBLIC if control[:public]
+            options << NO_CACHE
+            options.concat(control[:extras]) if control[:extras]
+
+            self._cache_control = options.join(", ")
           else
             extras = control[:extras]
             max_age = control[:max_age]

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -183,6 +183,11 @@ class TestController < ActionController::Base
     render action: "hello_world"
   end
 
+  def conditional_hello_without_expires_and_public_header
+    response.headers["Cache-Control"] = "public, no-cache"
+    render action: "hello_world"
+  end
+
   def conditional_hello_with_bangs
     render action: "hello_world"
   end
@@ -416,6 +421,11 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_no_expires_now_with_conflicting_cache_control_headers
     get :conditional_hello_without_expires_and_confliciting_cache_control_headers
     assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+
+  def test_no_expires_now_with_public
+    get :conditional_hello_without_expires_and_public_header
+    assert_equal "public, no-cache", @response.headers["Cache-Control"]
   end
 
   def test_date_header_when_expires_in


### PR DESCRIPTION
Since #30367, if `no-cache` includes Cache-Control headers, special keys like `public`, `must-revalidate` are ignored.
But in my understanding, `public` still need in case of want to cache authenticated pages.
The authenticated pages to be cacheable, but still authenticated for every user, need to specify the `Cache-Control: public, no-cache`.

For keys other than `public`, I did not know the case where it was necessary to use it in combination with `no-cache`, so I fixed that can be used only for `public`.

Ref: https://www.mnot.net/cache_docs/#CACHE-CONTROL

Fixes #34780.