### PR TITLE
Fix safe_constantize to not raise a LoadError.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `String#safe_constantize` throwing a `LoadError` for incorrectly cased constant references.
+
+    *Keenan Brock*
+
 *   Preserve key order passed to `ActiveSupport::CacheStore#fetch_multi`.
 
     `fetch_multi(*names)` now returns its results in the same order as the `*names` requested, rather than returning cache hits followed by cache misses.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -328,6 +328,8 @@ module ActiveSupport
         e.name.to_s == camel_cased_word.to_s)
     rescue ArgumentError => e
       raise unless /not missing constant #{const_regexp(camel_cased_word)}!$/.match?(e.message)
+    rescue LoadError => e
+      raise unless /Unable to autoload constant #{const_regexp(camel_cased_word)}/.match?(e.message)
     end
 
     # Returns the suffix that should be added to a number to denote the position

--- a/activesupport/test/autoloading_fixtures/raises_load_error.rb
+++ b/activesupport/test/autoloading_fixtures/raises_load_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# raises a load error typical of the dynamic code that manually raises load errors
+raise LoadError, "required gem not present kind of error"

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -112,6 +112,16 @@ module ConstantizeTestCases
     assert_nil yield("A::Object::B")
     assert_nil yield("A::Object::Object::Object::B")
 
+    with_autoloading_fixtures do
+      assert_nil yield("Em")
+    end
+
+    assert_raises(LoadError) do
+      with_autoloading_fixtures do
+        yield("RaisesLoadError")
+      end
+    end
+
     assert_raises(NameError) do
       with_autoloading_fixtures do
         yield("RaisesNameError")


### PR DESCRIPTION
### Summary

There was an issues when using `safe_constantize` on a string that has the wrong case.

File `em.rb` defines `EM`.
`"Em".safe_constantize` causes a little confusion with the autoloader.
The autoloader finds file "em.rb", expecting it to define `Em`, but `Em` is not defined.
The autoloader raises a `LoadError`, which is good, but `safe_constantize` is defined to return `nil` when a class is not found.

### Before

```ruby
"Em".safe_constantize
LoadError: Unable to autoload constant Em, expected rails/activesupport/test/autoloading_fixtures/em.rb to define it
```

### After

```ruby
"Em".safe_constantize
# => nil
```
