### PR TITLE
Add note about view contexts to ActionController::Helpers.helpers

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -73,6 +73,11 @@ module ActionController
       end
 
       # Provides a proxy to access helper methods from outside the view.
+      #
+      # Note that the proxy is rendered under a different view context.
+      # This may cause incorrect behaviour with capture methods. Consider
+      # using {helper}[rdoc-ref:AbstractController::Helpers::ClassMethods#helper]
+      # instead when using +capture+.
       def helpers
         @helper_proxy ||= begin
           proxy = ActionView::Base.new


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/34729.

Adds clarification that `helper_method` defined methods that call view helpers don't share the same view context with ones defined with `helper`, or through a helper module.