### PR TITLE
Capture parsing errors only for ActionController::ParamsWrapper#process_actions

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -241,22 +241,8 @@ module ActionController
     # Performs parameters wrapping upon the request. Called automatically
     # by the metal call stack.
     def process_action(*args)
-      if _wrapper_enabled?
-        wrapped_hash = _wrap_parameters request.request_parameters
-        wrapped_keys = request.request_parameters.keys
-        wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
-
-        # This will make the wrapped hash accessible from controller and view.
-        request.parameters.merge! wrapped_hash
-        request.request_parameters.merge! wrapped_hash
-
-        # This will display the wrapped hash in the log file.
-        request.filtered_parameters.merge! wrapped_filtered_hash
-      end
-    ensure
-      # NOTE: Rescues all exceptions so they
-      # may be caught in ActionController::Rescue.
-      return super
+      _perform_parameter_wrapping if _wrapper_enabled?
+      super
     end
 
     private
@@ -291,6 +277,21 @@ module ActionController
 
         ref = request.content_mime_type.ref
         _wrapper_formats.include?(ref) && _wrapper_key && !request.parameters.key?(_wrapper_key)
+      end
+
+      def _perform_parameter_wrapping
+        wrapped_hash = _wrap_parameters request.request_parameters
+        wrapped_keys = request.request_parameters.keys
+        wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
+
+        # This will make the wrapped hash accessible from controller and view.
+        request.parameters.merge! wrapped_hash
+        request.request_parameters.merge! wrapped_hash
+
+        # This will display the wrapped hash in the log file.
+        request.filtered_parameters.merge! wrapped_filtered_hash
+      rescue ActionDispatch::Http::Parameters::ParseError
+        # swallow parse error exception
       end
   end
 end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/34811.

Refactored `ActionController::ParamsWrapper#process_actions` to capture parsing errors.

cc/ @gmcgibbon 