### PR TITLE
Allow space for mysql enum and set keyword.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -579,13 +579,13 @@ module ActiveRecord
           m.alias_type %r(bit)i,           "binary"
 
           m.register_type(%r(enum)i) do |sql_type|
-            limit = sql_type[/^enum\((.+)\)/i, 1]
+            limit = sql_type[/^enum\s*\((.+)\)/i, 1]
               .split(",").map { |enum| enum.strip.length - 2 }.max
             MysqlString.new(limit: limit)
           end
 
           m.register_type(%r(^set)i) do |sql_type|
-            limit = sql_type[/^set\((.+)\)/i, 1]
+            limit = sql_type[/^set\s*\((.+)\)/i, 1]
               .split(",").map { |set| set.strip.length - 1 }.sum - 1
             MysqlString.new(limit: limit)
           end

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -27,8 +27,12 @@ if current_adapter?(:Mysql2Adapter)
         def test_string_types
           assert_lookup_type :string, "enum('one', 'two', 'three')"
           assert_lookup_type :string, "ENUM('one', 'two', 'three')"
+          assert_lookup_type :string, "enum ('one', 'two', 'three')"
+          assert_lookup_type :string, "ENUM ('one', 'two', 'three')"
           assert_lookup_type :string, "set('one', 'two', 'three')"
           assert_lookup_type :string, "SET('one', 'two', 'three')"
+          assert_lookup_type :string, "set ('one', 'two', 'three')"
+          assert_lookup_type :string, "SET ('one', 'two', 'three')"
         end
 
         def test_set_type_with_value_matching_other_type


### PR DESCRIPTION
### Summary
Add `\s*` for regex of type_map mysql enum.

```
-            limit = sql_type[/^enum\((.+)\)/i, 1]
+            limit = sql_type[/^enum\s*\((.+)\)/i, 1]
```

And set keyword.
reference: https://github.com/rails/rails/pull/34896#issuecomment-452177230

```
-            limit = sql_type[/^set\((.+)\)/i, 1]
+            limit = sql_type[/^set\s*\((.+)\)/i, 1]
```

### Other Information
#### Environment

| tools | version |
| --- | --- |
| rails | 5.2.2 |
| ruby | 2.5.0 |
| macOS | maxOS Mojave 10.14.1 |
| mysql | 5.7.22 |

#### Why
I made rails project and add new column of enum type.
But I have this error when `bundle exec rake db:migrate RAILS_ENV=development` .

<details><summary> Error </summary> 

```shell
Caused by:
NoMethodError: undefined method `split' for nil:NilClass
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:591:in `block in initialize_type_map'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/type/type_map.rb:55:in `perform_fetch'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/type/type_map.rb:21:in `block in fetch'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/concurrent-ruby-1.1.4/lib/concurrent/map.rb:193:in `block in fetch_or_store'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/concurrent-ruby-1.1.4/lib/concurrent/map.rb:172:in `fetch'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/concurrent-ruby-1.1.4/lib/concurrent/map.rb:192:in `fetch_or_store'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/type/type_map.rb:20:in `fetch'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/type/type_map.rb:16:in `lookup'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/quoting.rb:151:in `lookup_cast_type'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/quoting.rb:92:in `quote_default_expression'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:19:in `quote_default_expression'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:106:in `add_column_options!'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/mysql/schema_creation.rb:53:in `add_column_options!'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:36:in `visit_ColumnDefinition'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:16:in `accept'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:47:in `block in visit_TableDefinition'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:47:in `map'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:47:in `visit_TableDefinition'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_creation.rb:16:in `accept'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:311:in `create_table'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:871:in `block in method_missing'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:840:in `block in say_with_time'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:840:in `say_with_time'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:860:in `method_missing'
$HOME/develop/library/rails-test-project/rails-test-project/db/migrate/20190108014230_create_items.rb:3:in `change'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:814:in `exec_migration'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:798:in `block (2 levels) in migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:797:in `block in migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:796:in `migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:977:in `migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1292:in `block in execute_migration_in_transaction'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1345:in `ddl_transaction'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `each'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `migrate_without_lock'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `block in migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1363:in `with_advisory_lock'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1036:in `up'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/migration.rb:1011:in `migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.2/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <main>'
$HOME/develop/library/rails-test-project/rails-test-project/vendor/bundle/ruby/2.5.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
$HOME/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
$HOME/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
```
</details>

I confirm my migrate file. It have a space between `ENUM` and `(...)`.

<details><summary>migration script file</summary>


```ruby
class CreateItems < ActiveRecord::Migration[5.2]
  def change
    create_table :items do |t|
      t.column   "my_type", "enum ('hoge', 'fuga')", null: false, default: 'hoge'
      t.timestamps
    end
  end
end
```
</details>

But mysql allow a space between `ENUM` and `(...)`.
So, I tried raw mysql query for CREATE TABLE. And it is created `my_type` enum column.

<details><summary> Raw query </summary>

```mysql
CREATE TABLE `test_enum_table` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `my_type` enum ('hoge','fuga') NOT NULL DEFAULT 'hoge',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
```
</details>

From the above, I decided to make this PR.