### PR TITLE
Add new frameworks to `tasks/release.rb`

### DIFF
--- a/actionmailbox/Rakefile
+++ b/actionmailbox/Rakefile
@@ -4,6 +4,8 @@ require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+task :package
+
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"

--- a/actiontext/Rakefile
+++ b/actiontext/Rakefile
@@ -4,6 +4,8 @@ require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+task :package
+
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
-FRAMEWORKS = %w( activesupport activemodel activerecord actionview actionpack activejob actionmailer actioncable activestorage railties )
+FRAMEWORKS = %w(
+  activejob
+  activemodel
+  activerecord
+  activestorage
+  activesupport
+  actioncable
+  actionmailbox
+  actionmailer
+  actionpack
+  actiontext
+  actionview
+  railties
+)
 FRAMEWORK_NAMES = Hash.new { |h, k| k.split(/(?<=active|action)/).map(&:capitalize).join(" ") }
 
 root    = File.expand_path("..", __dir__)


### PR DESCRIPTION
The Frameworks collection declared in the `release.rb` is missing actiontext and actionmailbox, this means they are skipped when running any tasks that iterated through this collection

changes include

Breaking up frameworks declaration into multiple lines and put them in order. This should make adding to the list easier and if you need to scan it, they will be in order you would expect

Add `package` task to both actiontext and actionmailbox

