### PR TITLE
Duration#coerce should always return a Scalar

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -214,8 +214,11 @@ module ActiveSupport
     end
 
     def coerce(other) #:nodoc:
-      if Scalar === other
+      case other
+      when Scalar
         [other, self]
+      when Duration
+        [Scalar.new(other.value), self]
       else
         [Scalar.new(other), self]
       end


### PR DESCRIPTION
This speeds up Range.new(x, y).step(Duration).each { ... }

Fixes #34888

A few things about this PR:

1. I'm not sure if it's completely the right fix.  It seems like `coerce` should *always* return a scalar object, but I'm not super familiar with this code.
2. It's still not as fast as Ruby 2.5.

Here is a benchmark:

```ruby
require 'active_support/all'
require 'benchmark/ips'

hr = ActiveSupport::Duration.hours(1)

Benchmark.ips do |x|
  x.report("step enum")    { (1...72000).step(hr).each { |_| } }
  x.report("step no enum") { (1...72000).step(hr) { |_| } }
end
```

On Ruby 2.5:

```
$ ruby -v -Iactivesupport/lib test.rb
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]
Warming up --------------------------------------
           step enum    45.600k i/100ms
        step no enum    71.395k i/100ms
Calculating -------------------------------------
           step enum    593.116k (±13.8%) i/s -      2.918M in   5.039765s
        step no enum    845.040k (± 7.1%) i/s -      4.212M in   5.016175s
```

On Ruby 2.6 (before this PR):

```
$ be ruby -Iactivesupport/lib ../test.rb 
Warming up --------------------------------------
           step enum     1.000  i/100ms
        step no enum    72.725k i/100ms
Calculating -------------------------------------
           step enum      0.193  (± 0.0%) i/s -      1.000  in   5.170499s
        step no enum    931.121k (±10.0%) i/s -      4.654M in   5.068382s
```

On Ruby 2.6 (after this PR):

```
$ be ruby -Iactivesupport/lib ../test.rb 
Warming up --------------------------------------
           step enum     2.609k i/100ms
        step no enum    76.393k i/100ms
Calculating -------------------------------------
           step enum     26.740k (± 7.9%) i/s -    135.668k in   5.113837s
        step no enum    934.370k (± 5.2%) i/s -      4.660M in   5.004186s
```

As can be seen from the benchmarks, this patch makes the benchmark on Ruby 2.6 many times faster.  However, it's still slower than Ruby 2.5.  The new enumerator type returned by `each` in Ruby 2.6 seems to do more work than Ruby 2.5.  I'll investigate, but we may just have to live with this speed regression.