### PR TITLE
Reset column info on original Topic in serialized attr test

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -22,7 +22,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialize_does_not_eagerly_load_columns
-    Topic.reset_column_information
+    reset_column_information_of(Topic)
     assert_no_queries do
       Topic.serialize(:content)
     end
@@ -377,7 +377,8 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     topic.update group: "1"
 
     model.serialize :group, JSON
-    model.reset_column_information
+
+    reset_column_information_of(model)
 
     # This isn't strictly necessary for the test, but a little bit of
     # knowledge of internals allows us to make failures far more likely.
@@ -397,4 +398,12 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     # raw string ("1"), or raise an exception.
     assert_equal [1] * threads.size, threads.map(&:value)
   end
+
+  private
+
+    def reset_column_information_of(topic_class)
+      topic_class.reset_column_information
+      # reset original topic to undefine attribute methods
+      ::Topic.reset_column_information
+    end
 end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/34738.

### Summary

Calls `.reset_column_information` on `::Topic` in ActiveRecord's serialized attribute test so that attribute methods are safely undefined for all topics.

Seeing how `Topic.reset_column_information` [calls `undefine_attribute_methods`](https://github.com/rails/rails/blob/b03d493cf61f37abe7dc0539aee1985b6a9eea63/activerecord/lib/active_record/model_schema.rb#L451) on itself and all subclasses, I assume this is another hiccup I caused in  https://github.com/rails/rails/pull/34560 by duping `Topic`. 