### PR TITLE
Add ActiveRecord::Base.destroy_later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
     activemodel (6.0.0.beta3)
       activesupport (= 6.0.0.beta3)
     activerecord (6.0.0.beta3)
+      activejob (= 6.0.0.beta3)
       activemodel (= 6.0.0.beta3)
       activesupport (= 6.0.0.beta3)
     activestorage (6.0.0.beta3)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `ActiveRecord::Base.destroy_later` for automatically destroying records
+    after a specified amount of time.
+
+    ```ruby
+    class Export < ApplicationRecord
+      # Destroy all exports 30 days after creation
+      destroy_later after: 30.days
+
+      # Destroy exports 30 days after completing them
+      destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }
+
+      # Destroy exports 30 days after completing them, ensuring they're still completed at destroy time
+      destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }, ensuring: :completed?
+    end
+    ```
+
+    *DHH*, *George Claghorn*
+
 *   Don't call commit/rollback callbacks despite a record isn't saved.
 
     Fixes #29747.

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
+  s.add_dependency "activejob",     version
 end

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -26,6 +26,7 @@
 require "active_support"
 require "active_support/rails"
 require "active_model"
+require "active_job"
 require "arel"
 require "yaml"
 
@@ -74,6 +75,8 @@ module ActiveRecord
   autoload :Validations
   autoload :SecureToken
   autoload :DatabaseSelector, "active_record/middleware/database_selector"
+  autoload :DestroyLater
+  autoload :DestroyJob
 
   eager_autoload do
     autoload :ActiveRecordError, "active_record/errors"

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -322,6 +322,7 @@ module ActiveRecord #:nodoc:
     include Store
     include SecureToken
     include Suppressor
+    include DestroyLater
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -26,6 +26,12 @@ module ActiveRecord
       mattr_accessor :verbose_query_logs, instance_writer: false, default: false
 
       ##
+      # :singleton-method:
+      #
+      # Specifies the names of the queues used by background jobs.
+      mattr_accessor :queues, instance_accessor: false, default: {}
+
+      ##
       # Contains the database configuration - as is typically stored in config/database.yml -
       # as an ActiveRecord::DatabaseConfigurations object.
       #

--- a/activerecord/lib/active_record/destroy_job.rb
+++ b/activerecord/lib/active_record/destroy_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class DestroyJob < ActiveJob::Base
+    queue_as { ActiveRecord::Base.queues[:destroy] }
+
+    discard_on ActiveJob::DeserializationError
+
+    def perform(record, ensuring: nil)
+      record.destroy! if eligible?(record, ensuring)
+    end
+
+    private
+      def eligible?(record, ensuring)
+        ensuring.nil? || record.public_send(ensuring)
+      end
+  end
+end

--- a/activerecord/lib/active_record/destroy_later.rb
+++ b/activerecord/lib/active_record/destroy_later.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # Automatically destroy records after a specified amount of time.
+  #
+  #   class Export < ApplicationRecord
+  #     # Destroy all exports 30 days after creation
+  #     destroy_later after: 30.days
+  #
+  #     # Destroy exports 30 days after completing them
+  #     destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }
+  #   end
+  #
+  # +destroy_later+ adds an +after_commit+ callback that schedules an ActiveRecord::DestroyJob. In the example above,
+  # we use +completed_previously_changed?+ to check whether the record's +completed+ flag was changed in the preceding
+  # save. (+completed_changed?+ wouldn't work because any prior changes to the record have been saved at the time the
+  # condition is evaluated.)
+  #
+  # Optionally pass the name of an instance method in +ensuring:+. If the given method returns false at the
+  # scheduled destroy time, the record will not be destroyed.
+  #
+  #   # Destroy exports 30 days after completing them, ensuring they're still marked as completed at destroy time
+  #   class Export < ApplicationRecord
+  #     destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }, ensuring: :completed?
+  #   end
+  module DestroyLater
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def destroy_later(after:, if: nil, ensuring: nil)
+        after_commit -> { destroy_later after: after, ensuring: ensuring },
+          on: binding.local_variable_get(:if) ? %i[ create update ] : :create, if: binding.local_variable_get(:if)
+      end
+    end
+
+    def destroy_later(after:, ensuring: nil)
+      ActiveRecord::DestroyJob.set(wait: after).perform_later(self, ensuring: ensuring)
+    end
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -3,6 +3,7 @@
 require "active_record"
 require "rails"
 require "active_model/railtie"
+require "active_job/railtie"
 
 # For now, action_controller must always be present with
 # Rails, so let's make sure that it gets required before
@@ -30,6 +31,8 @@ module ActiveRecord
 
     config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
     config.active_record.sqlite3.represent_boolean_as_integer = nil
+
+    config.active_record.queues = ActiveSupport::InheritableOptions.new(destroy: :active_record_destroy)
 
     config.eager_load_namespaces << ActiveRecord
 

--- a/activerecord/test/cases/destroy_later_test.rb
+++ b/activerecord/test/cases/destroy_later_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+require "models/book"
+require "models/pirate"
+require "models/parrot"
+
+class DestroyLaterTest < ActiveRecord::TestCase
+  include ActiveJob::TestHelper
+
+  fixtures :books, :pirates
+
+  test "creating a pirate enqueues it for unconditional destruction 10 days later" do
+    freeze_time
+
+    pirate = Pirate.create!(catchphrase: "Arr, matey!")
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ pirate, ensuring: nil ], at: 10.days.from_now
+
+    travel 10.days
+
+    assert_difference -> { Pirate.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "updating a pirate does not enqueue it for destruction" do
+    assert_no_enqueued_jobs only: ActiveRecord::DestroyJob do
+      pirates(:redbeard).update! catchphrase: "Shiver me timbers!"
+    end
+  end
+
+  test "updating a pirate does not prevent its scheduled destruction" do
+    freeze_time
+
+    pirate = Pirate.create!(catchphrase: "Arr, matey!")
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ pirate, ensuring: nil ], at: 10.days.from_now
+
+    travel 2.days
+
+    pirate.update! catchphrase: "Shiver me timbers!"
+
+    travel 8.days
+
+    assert_difference -> { Pirate.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "publishing a book enqueues it for destruction 30 days later" do
+    freeze_time
+
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ books(:rfr), ensuring: :published? ], at: 30.days.from_now do
+      books(:rfr).published!
+    end
+
+    travel 30.days
+
+    assert_difference -> { Book.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "creating a published book enqueues it for destruction 30 days later" do
+    freeze_time
+
+    book = Book.create!(name: "Getting Real", status: :published)
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ book, ensuring: :published? ], at: 30.days.from_now
+
+    travel 30.days
+
+    assert_difference -> { Book.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "unpublishing a book prevents its scheduled destruction" do
+    freeze_time
+
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ books(:rfr), ensuring: :published? ], at: 30.days.from_now do
+      books(:rfr).published!
+    end
+
+    travel 10.days
+
+    assert_no_enqueued_jobs do
+      books(:rfr).proposed!
+    end
+
+    travel 20.days
+
+    assert_no_difference -> { Book.count } do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "writing a book does not enqueue it for destruction" do
+    assert_no_enqueued_jobs do
+      books(:rfr).written!
+    end
+  end
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -203,4 +203,12 @@ module InTimeZone
     end
 end
 
+require "global_id"
+GlobalID.app = "ActiveRecordExampleApp"
+ActiveRecord::Base.include GlobalID::Identification
+
+require "active_job"
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = ActiveSupport::Logger.new(nil)
+
 require_relative "../../../tools/test_common"

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -19,6 +19,8 @@ class Book < ActiveRecord::Base
   enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
 
+  destroy_later after: 30.days, if: -> { status_previously_changed? && published? }, ensuring: :published?
+
   def published!
     super
     "do publish work..."

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -53,6 +53,8 @@ class Pirate < ActiveRecord::Base
 
   validates_presence_of :catchphrase
 
+  destroy_later after: 10.days
+
   def ship_log
     @ship_log ||= []
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -381,6 +381,8 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
+* `config.active_record.queues.destroy` allows specifying the Active Job queue to use for destroy jobs. It defaults to `:active_record_destroy`.
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
Generalize Action Mailbox's incineration feature, as proposed by @dhh in rails/actionmailbox#16. Permit automatically destroying records after a specified amount of time:

```ruby
class Export < ApplicationRecord
  # Destroy all exports 30 days after creation
  destroy_later after: 30.days

  # Destroy exports 30 days after completing them
  destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }

  # Destroy exports 30 days after completing them.
  # Ensure they're still completed at destroy time.
  destroy_later after: 30.days,
    if: -> { status_previously_changed? && completed? }, ensuring: :completed?
end
```

The implementation as it stands now is not final. I expect to find a way to avoid the hard dependency on Active Job—it will only be required to use `destroy_later`.