### PR TITLE
Enable `Lint/UselessAssignment` cop to avoid unused variable warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -191,6 +191,9 @@ Lint/StringConversionInInterpolation:
 Lint/UriEscapeUnescape:
   Enabled: true
 
+Lint/UselessAssignment:
+  Enabled: true
+
 Lint/DeprecatedClassMethods:
   Enabled: true
 

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -888,7 +888,7 @@ class ControllerWithSymbolAsFilter < PostsController
       yield
 
       # Do stuff...
-      wtf += 1
+      wtf + 1
     end
 end
 

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -14,7 +14,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
     end
 
     def dump_params_keys(hash = params)
-      hash.keys.sort.inject(+"") do |s, k|
+      hash.keys.sort.each_with_object(+"") do |k, s|
         value = hash[k]
 
         if value.is_a?(Hash) || value.is_a?(ActionController::Parameters)

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -14,7 +14,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
     end
 
     def dump_params_keys(hash = params)
-      hash.keys.sort.inject("") do |s, k|
+      hash.keys.sort.inject(+"") do |s, k|
         value = hash[k]
 
         if value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
@@ -23,8 +23,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
           value = ""
         end
 
-        s += ", " unless s.empty?
-        s += "#{k}#{value}"
+        s << ", " unless s.empty?
+        s << "#{k}#{value}"
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         def create_database(name, options = {})
           options = { encoding: "utf8" }.merge!(options.symbolize_keys)
 
-          option_string = options.inject(+"") do |memo, (key, value)|
+          option_string = options.each_with_object(+"") do |(key, value), memo|
             memo << case key
                     when :owner
                       " OWNER = \"#{value}\""

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -22,8 +22,8 @@ module ActiveRecord
         def create_database(name, options = {})
           options = { encoding: "utf8" }.merge!(options.symbolize_keys)
 
-          option_string = options.inject("") do |memo, (key, value)|
-            memo += case key
+          option_string = options.inject(+"") do |memo, (key, value)|
+            memo << case key
                     when :owner
                       " OWNER = \"#{value}\""
                     when :template

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       def touch_attributes_with_time(*names, time: nil)
         attribute_names = timestamp_attributes_for_update_in_model
         attribute_names |= names.map(&:to_s)
-        attribute_names.index_with(time ||= current_time_from_proper_timezone)
+        attribute_names.index_with(time || current_time_from_proper_timezone)
       end
 
       private

--- a/activerecord/lib/arel/visitors/informix.rb
+++ b/activerecord/lib/arel/visitors/informix.rb
@@ -15,8 +15,9 @@ module Arel # :nodoc: all
             collector << "ORDER BY "
             collector = inject_join o.orders, collector, ", "
           end
-          collector = maybe_visit o.lock, collector
+          maybe_visit o.lock, collector
         end
+
         def visit_Arel_Nodes_SelectCore(o, collector)
           collector = inject_join o.projections, collector, ", "
           if o.source && !o.source.empty?

--- a/activerecord/lib/arel/visitors/oracle12.rb
+++ b/activerecord/lib/arel/visitors/oracle12.rb
@@ -18,8 +18,8 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)
-          maybe_visit o.offset, collector
-          maybe_visit o.limit, collector
+          collector = maybe_visit o.offset, collector
+          collector = maybe_visit o.limit, collector
           maybe_visit o.lock, collector
         end
 

--- a/activerecord/lib/arel/visitors/oracle12.rb
+++ b/activerecord/lib/arel/visitors/oracle12.rb
@@ -18,9 +18,9 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)
-          collector = maybe_visit o.offset, collector
-          collector = maybe_visit o.limit, collector
-          collector = maybe_visit o.lock, collector
+          maybe_visit o.offset, collector
+          maybe_visit o.limit, collector
+          maybe_visit o.lock, collector
         end
 
         def visit_Arel_Nodes_Limit(o, collector)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -213,9 +213,9 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)
-          collector = maybe_visit o.limit, collector
-          collector = maybe_visit o.offset, collector
-          collector = maybe_visit o.lock, collector
+          maybe_visit o.limit, collector
+          maybe_visit o.offset, collector
+          maybe_visit o.lock, collector
         end
 
         def visit_Arel_Nodes_SelectCore(o, collector)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -208,13 +208,11 @@ module Arel # :nodoc: all
           end
 
           visit_Arel_Nodes_SelectOptions(o, collector)
-
-          collector
         end
 
         def visit_Arel_Nodes_SelectOptions(o, collector)
-          maybe_visit o.limit, collector
-          maybe_visit o.offset, collector
+          collector = maybe_visit o.limit, collector
+          collector = maybe_visit o.offset, collector
           maybe_visit o.lock, collector
         end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -430,7 +430,7 @@ class EachTest < ActiveRecord::TestCase
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
 
-        relation = [not_a_post] * relation.count
+        [not_a_post] * relation.count
       end
     end
   end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -144,7 +144,7 @@ class CounterCacheTest < ActiveRecord::TestCase
 
   test "update other counters on parent destroy" do
     david, joanna = dog_lovers(:david, :joanna)
-    joanna = joanna # squelch a warning
+    _ = joanna # squelch a warning
 
     assert_difference "joanna.reload.dogs_count", -1 do
       david.destroy

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -240,7 +240,7 @@ class InheritanceTest < ActiveRecord::TestCase
     cabbage = vegetable.becomes!(Cabbage)
     assert_equal "Cabbage", cabbage.custom_type
 
-    vegetable = cabbage.becomes!(Vegetable)
+    cabbage.becomes!(Vegetable)
     assert_nil cabbage.custom_type
   end
 
@@ -654,7 +654,7 @@ class InheritanceAttributeMappingTest < ActiveRecord::TestCase
 
     assert_equal ["omg_inheritance_attribute_mapping_test/company"], ActiveRecord::Base.connection.select_values("SELECT sponsorable_type FROM sponsors")
 
-    sponsor = Sponsor.first
+    sponsor = Sponsor.find(sponsor.id)
     assert_equal startup, sponsor.sponsorable
   end
 end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -104,7 +104,7 @@ class AssertionsTest < ActiveSupport::TestCase
   def test_expression_is_evaluated_in_the_appropriate_scope
     silence_warnings do
       local_scope = "foo"
-      local_scope = local_scope  # to suppress unused variable warning
+      _ = local_scope  # to suppress unused variable warning
       assert_difference("local_scope; @object.num") { @object.increment }
     end
   end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -63,9 +63,9 @@ module RailsGuides
       end
 
       def mobi
-        mobi  = "ruby_on_rails_guides_#{@version || @edge[0, 7]}"
-        mobi += ".#{@language}" if @language
-        mobi += ".mobi"
+        mobi = +"ruby_on_rails_guides_#{@version || @edge[0, 7]}"
+        mobi << ".#{@language}" if @language
+        mobi << ".mobi"
       end
 
       def initialize_dirs

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -95,8 +95,8 @@ class CodeStatistics #:nodoc:
     end
 
     def print_line(name, statistics)
-      m_over_c   = (statistics.methods / statistics.classes) rescue m_over_c = 0
-      loc_over_m = (statistics.code_lines / statistics.methods) - 2 rescue loc_over_m = 0
+      m_over_c   = (statistics.methods / statistics.classes) rescue 0
+      loc_over_m = (statistics.code_lines / statistics.methods) - 2 rescue 0
 
       print "| #{name.ljust(20)} "
       HEADERS.each_key do |k|

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -351,7 +351,7 @@ task default: :test
         modules.reverse.inject(unwrapped_code) do |content, mod|
           str = +"module #{mod}\n"
           str << content.lines.map { |line| "  #{line}" }.join
-          str << content.present? ? "\nend" : "end"
+          str << (content.present? ? "\nend" : "end")
         end
       end
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -349,9 +349,9 @@ task default: :test
       def wrap_in_modules(unwrapped_code)
         unwrapped_code = "#{unwrapped_code}".strip.gsub(/\s$\n/, "")
         modules.reverse.inject(unwrapped_code) do |content, mod|
-          str = "module #{mod}\n"
-          str += content.lines.map { |line| "  #{line}" }.join
-          str += content.present? ? "\nend" : "end"
+          str = +"module #{mod}\n"
+          str << content.lines.map { |line| "  #{line}" }.join
+          str << content.present? ? "\nend" : "end"
         end
       end
 


### PR DESCRIPTION
Since we've addressed the warning "assigned but unused variable"
frequently.

370537de05092aeea552146b42042833212a1acc
3040446cece8e7a6d9e29219e636e13f180a1e03
5ed618e192e9788094bd92c51255dda1c4fd0eae
76ebafe594fc23abc3764acc7a3758ca473799e5

And also, I've found the unused args in c1b14ad which raises no warnings
by the cop, it shows the value of the cop.