### PR TITLE
Support endless ranges in where

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for endless ranges introduces in Ruby 2.6.
+
+    *Greg Navis*
+
 *   Deprecate passing `migrations_paths` to `connection.assume_migrated_upto_version`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -36,14 +36,14 @@ module Arel # :nodoc: all
 
     def between(other)
       if infinity?(other.begin)
-        if infinity?(other.end)
+        if other.end.nil? || infinity?(other.end)
           not_in([])
         elsif other.exclude_end?
           lt(other.end)
         else
           lteq(other.end)
         end
-      elsif infinity?(other.end)
+      elsif other.end.nil? || infinity?(other.end)
         gteq(other.begin)
       elsif other.exclude_end?
         gteq(other.begin).and(lt(other.end))

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -639,6 +639,18 @@ module Arel
           )
         end
 
+        if Gem::Version.new("2.6.0") <= Gem::Version.new(RUBY_VERSION)
+          it "can be constructed with a range implicitly ending at Infinity" do
+            attribute = Attribute.new nil, nil
+            node = attribute.between(eval("0..")) # Use eval for compatibility with Ruby < 2.6 parser
+
+            node.must_equal Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            )
+          end
+        end
+
         it "can be constructed with a quoted range ending at Infinity" do
           attribute = Attribute.new nil, nil
           node = attribute.between(quoted_range(0, ::Float::INFINITY, false))


### PR DESCRIPTION
### Summary

This commit adds support for endless ranges, e.g. `(1..)`, that were added in Ruby 2.6. They're functionally equivalent to explicitly specifying `Float::INFINITY` as the end of the range.

Specifically:

```ruby
relation.where(column: 1..Float::INFINITY)
```

is equivalent to

```ruby
relation.where(column: (1..))
```

### Other Information

Only the end of a range can be omitted. Trying `(..1)` results in a syntax error so there's no need to add support for implicit `-Float::INFINITY`.

### Alternative Implementation

We could modify `other` at the beginning of `between` and replace `nil` with `Float::INFINITY` (or even support `-Float::INFINITY`) so that there'd be no changes to conditions in `if` statements below + we would be able to support `nil..1` (equivalent to `-Float::INFINITY..1`).

Please let me know if you find this preferable and I'll update the PR.