### PR TITLE
Bring in all of aws-sdk-sns if using Amazon ingress

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/amazon/inbound_emails_controller.rb
@@ -37,7 +37,7 @@ module ActionMailbox
 
     def self.prepare
       self.verifier ||= begin
-        require "aws-sdk-sns/message_verifier"
+        require "aws-sdk-sns"
         Aws::SNS::MessageVerifier.new
       end
     end


### PR DESCRIPTION
Requiring _just_ the `Aws::SNS::MessageVerifier` does not work as this class references other classes in the AWS SDK.

eg MessageVerifier uses the AWS `Json` class [here](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-sns/lib/aws-sdk-sns/message_verifier.rb#L61) which is [in the sdk core](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/json.rb)

I tried to require in _just_ the classes required but gave up at up when I got to 10 requires lines and think the most elegant solution is to bring in the entire SNS SDK in one line.   Since we aren't initializing any code from it except the MessageVerifier I don't think there are any negatives to this approach (happy to be corrected!)

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


