### PR TITLE
Add reasoning for `I18n.with_locale`

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -139,9 +139,11 @@ Note that appending directly to `I18n.load_paths` instead of to the application'
 
 ### Managing the Locale across Requests
 
-The default locale is used for all translations unless `I18n.locale` is explicitly set.
-
 A localized application will likely need to provide support for multiple locales. To accomplish this, the locale should be set at the beginning of each request so that all strings are translated using the desired locale during the lifetime of that request.
+
+The default locale is used for all translations unless `I18n.locale=` or `I18n.with_locale` is used.
+
+`I18n.locale` can leak into subsequent requests served by the same thread/process if it is not consistently set in every controller. For example executing `I18n.locale = :es` in one POST requests will have effects for all later requests to controllers that don't set the locale, but only in that particular thread/process. For that reason, instead of `I18n.locale =` you can use `I18n.with_locale` which does not have this leak issue.
 
 The locale can be set in an `around_action` in the `ApplicationController`:
 


### PR DESCRIPTION
[ci skip]

### Summary
Some explanation why `I18n.locale = :es` is not a good practice.

### Other Information

If someone set locale based on parametar
```
if params[:locale].present?
  I18n.locale = params[:locale].to_sym
end
```
Than it could be that localization is set only in thread that serve this request, and it is not cleared at the end, so future requests can be in default locale or in newly locale (depending on which thread is serving it) 
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
