### PR TITLE
Add info about `config.action_mailer.delivery_job` to the guide [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -721,6 +721,8 @@ There are a number of settings available on `config.action_mailer`:
 
 * `config.action_mailer.perform_caching` specifies whether the mailer templates should perform fragment caching or not. By default this is `false` in all environments.
 
+* `config.action_mailer.delivery_job` specifies delivery job for mail. Defaults to `ActionMailer::DeliveryJob`.
+
 
 ### Configuring Active Support
 
@@ -905,6 +907,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 - `config.action_view.default_enforce_utf8`: `false`
 - `config.action_dispatch.use_cookies_with_metadata`: `true`
+- `config.action_mailer.delivery_job`: `"ActionMailer::MailDeliveryJob"`
 - `config.active_job.return_false_on_aborted_enqueue`: `true`
 - `config.active_storage.queues.analysis`: `:active_storage_analysis`
 - `config.active_storage.queues.purge`: `:active_storage_purge`

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -25,8 +25,8 @@
 
 # Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
 #
-# The default delivery job (ActionMailer::DeliveryJob), will be removed in Rails 6.1.
-# This setting is not backwards compatible with earlier Rails versions.
+# The default delivery jobs (ActionMailer::Parameterized::DeliveryJob, ActionMailer::DeliveryJob),
+# will be removed in Rails 6.1. This setting is not backwards compatible with earlier Rails versions.
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.


### PR DESCRIPTION
Also, add mention to `new_framework_defaults_6_0.rb` that
`ActionMailer::Parameterized::DeliveryJob` is default for parameterized mail and will be removed.

Related to #34692
