### PR TITLE
Add `Hash#deep_reverse_merge` and `Hash#deep_reverse_merge!`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Hash#deep_reverse_merge` and `Hash#deep_reverse_merge!`
+
+    *Alex Ghiculescu*
+
 *   Fix `String#safe_constantize` throwing a `LoadError` for incorrectly cased constant references.
 
     *Keenan Brock*

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/hash/conversions"
 require "active_support/core_ext/hash/deep_merge"
+require "active_support/core_ext/hash/deep_reverse_merge"
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/keys"

--- a/activesupport/lib/active_support/core_ext/hash/deep_reverse_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_reverse_merge.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Hash
+  # Deep merges the caller into +other_hash+. For example,
+  #
+  #   options = options.deep_reverse_merge(size: 25, coords: { x: 2, y: -1 })
+  #
+  # is equivalent to
+  #
+  #   options = { size: 25, coords: { x: 2, y: -1 } }.deep_merge(options)
+  #
+  # This is particularly useful for initializing an options hash
+  # with default values.
+  def deep_reverse_merge(other_hash)
+    other_hash.deep_merge(self)
+  end
+
+  # Same as +deep_reverse_merge+, but modifies +self+.
+  def deep_reverse_merge!(other_hash)
+    replace(deep_reverse_merge(other_hash))
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -310,6 +310,17 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, merged
   end
 
+  def test_deep_reverse_merge
+    defaults = {a: "a", b: "b", c: { c1: "c1", c2: "c2", c3: { d1: "d1" } }}.freeze
+    options = { a: 1, c: { c1: 2, c3: { d2: "d2" } } }
+    expected = { a: 1, b: "b", c: { c1: 2, c2: "c2", c3: { d1: "d1", d2: "d2" } } }.freeze
+
+    assert_equal expected, options.deep_reverse_merge(defaults)
+
+    options.deep_reverse_merge!(defaults)
+    assert_equal expected, options
+  end
+
   def test_slice_inplace
     original = { a: "x", b: "y", c: 10 }
     expected_return = { c: 10 }


### PR DESCRIPTION
`Hash#deep_reverse_merge` combines the logic from `Hash#deep_merge` and `Hash#reverse_merge`. This is useful when configuring libraries that use nested hashes.
