### PR TITLE
Allow intercepting exceptions that are raised in ActionCable command

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActionCable::Connection::Base` now allows intercepting unhandled exceptions
+    with `rescue_from` before they are logged, which is useful for error reporting
+    tools and other integrations.
+
+    *Justin Talbott*
+
 *   Add `ActionCable::Channel#stream_or_reject_for` to stream if record is present, otherwise reject the connection
 
     *Atul Bhosale*

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_dispatch"
+require "active_support/rescuable"
 
 module ActionCable
   module Connection
@@ -46,6 +47,7 @@ module ActionCable
       include Identification
       include InternalChannel
       include Authorization
+      include ActiveSupport::Rescuable
 
       attr_reader :server, :env, :subscriptions, :logger, :worker_pool, :protocol
       delegate :event_loop, :pubsub, to: :server

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -21,6 +21,7 @@ module ActionCable
           logger.error "Received unrecognized command in #{data.inspect}"
         end
       rescue Exception => e
+        @connection.rescue_with_handler(e)
         logger.error "Could not execute command from (#{data.inspect}) [#{e.class} - #{e.message}]: #{e.backtrace.first(5).join(" | ")}"
       end
 

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -3,11 +3,24 @@
 require "test_helper"
 
 class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
+  class ChatChannelError < Exception; end
+
   class Connection < ActionCable::Connection::Base
-    attr_reader :websocket
+    attr_reader :websocket, :exceptions
+
+    rescue_from ChatChannelError, with: :error_handler
+
+    def initialize(*)
+      super
+      @exceptions = []
+    end
 
     def send_async(method, *args)
       send method, *args
+    end
+
+    def error_handler(e)
+      @exceptions << e
     end
   end
 
@@ -21,6 +34,10 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
 
     def speak(data)
       @lines << data
+    end
+
+    def throw_exception(_data)
+      raise ChatChannelError.new("Uh Oh")
     end
   end
 
@@ -82,6 +99,19 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       @subscriptions.execute_command "command" => "message", "identifier" => @chat_identifier, "data" => ActiveSupport::JSON.encode(data)
 
       assert_equal [ data ], channel.lines
+    end
+  end
+
+  test "accessing exceptions thrown during command execution" do
+    run_in_eventmachine do
+      setup_connection
+      subscribe_to_chat_channel
+
+      data = { "content" => "Hello World!", "action" => "throw_exception" }
+      @subscriptions.execute_command "command" => "message", "identifier" => @chat_identifier, "data" => ActiveSupport::JSON.encode(data)
+
+      exception = @connection.exceptions.first
+      assert_kind_of ChatChannelError, exception
     end
   end
 


### PR DESCRIPTION
### Summary

Exceptions raised during command execution on an ActionCable Channel
are logged and suppressed, which does not allow for any sort of error
handling or reporting (via external services such as Bugsnag or Honeybadger).
This adds a simple hook to intercept the rescued exception on the ActionCable Connection.

### Other Information

I had thought that maybe the default implementation of `on_command_execution_exception` should be the current logging behavior, but I opted for it being a no op. I'm happy to change it if that is preferable.

This is my first Rails PR so please let me know if there are any conventions that I should change about this patch.
