### PR TITLE
Fix a bug in generated scaffold_controller for plugins and Add tests for it

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -158,7 +158,7 @@ module Rails
 
         def singular_route_name # :doc:
           if options[:model_name]
-            (controller_class_path + [ singular_table_name ]) * '_'
+            (controller_class_path + [ singular_table_name ]) * "_"
           else
             singular_table_name
           end
@@ -166,7 +166,7 @@ module Rails
 
         def plural_route_name # :doc:
           if options[:model_name]
-            (controller_class_path + [ plural_table_name ]) * '_'
+            (controller_class_path + [ plural_table_name ]) * "_"
           else
             plural_table_name
           end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -150,7 +150,7 @@ module Rails
         def model_resource_name(prefix: "") # :doc:
           resource_name = "#{prefix}#{singular_table_name}"
           if options[:model_name]
-            "[#{controller_class_path.map { |name| ":" + name }.join(", ")}, #{resource_name}]"
+            "[#{(controller_class_path.map { |name| ":" + name }.to_a << resource_name) * ', '}]"
           else
             resource_name
           end
@@ -158,7 +158,7 @@ module Rails
 
         def singular_route_name # :doc:
           if options[:model_name]
-            "#{controller_class_path.join('_')}_#{singular_table_name}"
+            (controller_class_path + [ singular_table_name ]) * '_'
           else
             singular_table_name
           end
@@ -166,7 +166,7 @@ module Rails
 
         def plural_route_name # :doc:
           if options[:model_name]
-            "#{controller_class_path.join('_')}_#{plural_table_name}"
+            (controller_class_path + [ plural_table_name ]) * '_'
           else
             plural_table_name
           end

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -168,6 +168,26 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, "users", :plural_route_name
   end
 
+  def test_scaffold_redirect_resource_name_with_model_name_option
+    g = generator ["User"], model_name: "User"
+    assert_name g, "[@user]", :redirect_resource_name
+  end
+
+  def test_scaffold_model_resource_name_with_model_name_option
+    g = generator ["User"], model_name: "User"
+    assert_name g, "[user]",  :model_resource_name
+  end
+
+  def test_scaffold_singular_route_name_with_model_name_option
+    g = generator ["User"], model_name: "User"
+    assert_name g, "user",  :singular_route_name
+  end
+
+  def test_scaffold_plural_route_name_with_model_name_option
+    g = generator ["User"], model_name: "User"
+    assert_name g, "users", :plural_route_name
+  end
+
   private
 
     def assert_name(generator, value, method)


### PR DESCRIPTION
### Summary
I generated a scaffold controller in a plugin:
```
$ rails plugin new my-plugin --full
$ rails generate scaffold_controller blog --model-name=Post
```
And I got this buggy result:
```
# app/controllers/blogs_controller.rb
27     redirect_to [, @post], notice: 'Post was successfully created.'
36     redirect_to [, @post], notice: 'Post was successfully updated.'
```
```
# test/controllers/blogs_controller_test.rb
require 'test_helper'

class BlogsControllerTest < ActionDispatch::IntegrationTest
  setup do
    @post = posts(:one)
  end 

  test "should get index" do
    get _posts_url
    assert_response :success
  end 

  test "should get new" do
    get new__post_url
    assert_response :success
  end 

  test "should create post" do
    assert_difference('Post.count') do
      post _posts_url, params: { post: {  } } 
    end 

    assert_redirected_to post_url(Post.last)
  end 

  test "should show post" do
    get _post_url(@post)
    assert_response :success
  end 

  test "should get edit" do
    get edit__post_url(@post)
    assert_response :success
  end 

  test "should update post" do
    patch _post_url(@post), params: { post: {  } }
    assert_redirected_to post_url(@post)
  end

  test "should destroy post" do
    assert_difference('Post.count', -1) do
      delete _post_url(@post)
    end

    assert_redirected_to _posts_url
  end
end
```
I mean to fix this bug with my changes in this pull request.
Now I get these results:
```
# app/controllers/blogs_controller.rb
27     redirect_to [@post], notice: 'Post was successfully created.'
36     redirect_to [@post], notice: 'Post was successfully updated.'
```
```
# test/controllers/blogs_controller_test.rb
equire 'test_helper'

class BlogsControllerTest < ActionDispatch::IntegrationTest
  setup do
    @post = posts(:one)
  end 

  test "should get index" do
    get posts_url
    assert_response :success
  end 

  test "should get new" do
    get new_post_url
    assert_response :success
  end 

  test "should create post" do
    assert_difference('Post.count') do
      post posts_url, params: { post: {  } } 
    end 

    assert_redirected_to post_url(Post.last)
  end 

  test "should show post" do
    get post_url(@post)
    assert_response :success
  end 

  test "should get edit" do
    get edit_post_url(@post)
    assert_response :success
  end 

  test "should update post" do
    patch post_url(@post), params: { post: {  } } 
    assert_redirected_to post_url(@post)
  end

  test "should destroy post" do
       assert_difference('Post.count', -1) do
       delete post_url(@post)
    end

    assert_redirected_to posts_url
  end
end
```
This pull request is based on https://github.com/rails/rails/pull/34857
y-yagi and eileencodes advised me to add tests and change the target branch to master.
So I added four tests to prove the bugs before my solutions.