### PR TITLE
[BUG] Don't restrict to Bundler 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system 2.6.13"
-  - "travis_retry gem install bundler -v '<2'"
+  - "travis_retry gem install bundler"
 before_script:
   - bundle update
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ PATH
       activemodel (= 4.2.11)
       activerecord (= 4.2.11)
       activesupport (= 4.2.11)
-      bundler (>= 1.3.0, < 2.0)
+      bundler (>= 1.3.0)
       railties (= 4.2.11)
       sprockets-rails
     railties (4.2.11)
@@ -302,4 +302,4 @@ DEPENDENCIES
   w3c_validators
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activejob',     version
   s.add_dependency 'railties',      version
 
-  s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'
+  s.add_dependency 'bundler',         '>= 1.3.0'
   s.add_dependency 'sprockets-rails'
 end


### PR DESCRIPTION
### Summary

A bunch of downstream builds are breaking in rails/webpacker because Rails 4.2 unnecessarily restricts the bundler version.

https://travis-ci.org/rails/webpacker/builds/476824252?utm_source=github_status&utm_medium=notification
https://travis-ci.org/rails/webpacker/builds/477670329?utm_source=github_status&utm_medium=notification

AFAIC there's no reason Rails 4.2 shouldn't be able to run with Bundler 2.x.
