### PR TITLE
Fix "Action Cable Overview" guide [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -165,12 +165,12 @@ you're interested in having.
 A consumer becomes a subscriber by creating a subscription to a given channel:
 
 ```js
-// app/javascript/cable/subscriptions/chat_channel.js
+// app/javascript/channels/chat_channel.js
 import consumer from "./consumer"
 
 consumer.subscriptions.create({ channel: "ChatChannel", room: "Best Room" })
 
-// app/javascript/cable/subscriptions/appearance_channel.js
+// app/javascript/channels/appearance_channel.js
 import consumer from "./consumer"
 
 consumer.subscriptions.create({ channel: "AppearanceChannel" })
@@ -183,7 +183,7 @@ A consumer can act as a subscriber to a given channel any number of times. For
 example, a consumer could subscribe to multiple chat rooms at the same time:
 
 ```js
-// app/javascript/cable/subscriptions/chat_channel.js
+// app/javascript/channels/chat_channel.js
 import consumer from "./consumer"
 
 consumer.subscriptions.create({ channel: "ChatChannel", room: "1st Room" })
@@ -261,7 +261,7 @@ connection is called a subscription. Incoming messages are then routed to
 these channel subscriptions based on an identifier sent by the cable consumer.
 
 ```js
-// app/javascript/cable/subscriptions/chat_channel.js
+// app/javascript/channels/chat_channel.js
 // Assumes you've already requested the right to send web notifications
 import consumer from "./consumer"
 
@@ -305,7 +305,7 @@ An object passed as the first argument to `subscriptions.create` becomes the
 params hash in the cable channel. The keyword `channel` is required:
 
 ```js
-// app/javascript/cable/subscriptions/chat_channel.js
+// app/javascript/channels/chat_channel.js
 import consumer from "./consumer"
 
 consumer.subscriptions.create({ channel: "ChatChannel", room: "Best Room" }, {
@@ -359,7 +359,7 @@ end
 ```
 
 ```js
-// app/javascript/cable/subscriptions/chat_channel.js
+// app/javascript/channels/chat_channel.js
 import consumer from "./consumer"
 
 const chatChannel = consumer.subscriptions.create({ channel: "ChatChannel", room: "Best Room" }, {
@@ -419,7 +419,7 @@ appear/disappear API could be backed by Redis, a database, or whatever else.
 Create the client-side appearance channel subscription:
 
 ```js
-// app/javascript/cable/subscriptions/appearance_channel.js
+// app/javascript/channels/appearance_channel.js
 import consumer from "./consumer"
 
 consumer.subscriptions.create("AppearanceChannel", {
@@ -534,7 +534,7 @@ end
 Create the client-side web notifications channel subscription:
 
 ```js
-// app/javascript/cable/subscriptions/web_notifications_channel.js
+// app/javascript/channels/web_notifications_channel.js
 // Client-side which assumes you've already requested
 // the right to send web notifications.
 import consumer from "./consumer"


### PR DESCRIPTION
Fix path to channel files.

`rails generate channel Chat` generates `app/javascript/channels/chat_channel.js`.
See also,
railties/lib/rails/generators/rails/app/templates/app/javascript/packs/application.js.tt,
actioncable/lib/rails/generators/channel/templates/javascript/index.js.tt
by default `application.js` imports "channels", where
`app/javascript/channels/index.js` loads all the channels within
this directory and all subdirectories.

Follow up #34709
Related to #33079
