### PR TITLE
Clean up ActionCable JS a bit more after the CoffeeScript conversion

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -191,7 +191,7 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive() && this.webSocket) {
+      if (this.isActive()) {
         return this.webSocket.close();
       }
     };

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -191,8 +191,8 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive()) {
-        return this.webSocket ? this.webSocket.close() : undefined;
+      if (this.isActive() && this.webSocket) {
+        return this.webSocket.close();
       }
     };
     Connection.prototype.reopen = function reopen() {
@@ -211,7 +211,9 @@
       }
     };
     Connection.prototype.getProtocol = function getProtocol() {
-      return this.webSocket ? this.webSocket.protocol : undefined;
+      if (this.webSocket) {
+        return this.webSocket.protocol;
+      }
     };
     Connection.prototype.isOpen = function isOpen() {
       return this.isState("open");
@@ -458,7 +460,9 @@
   }
   function getConfig(name) {
     var element = document.head.querySelector("meta[name='action-cable-" + name + "']");
-    return element ? element.getAttribute("content") : undefined;
+    if (element) {
+      return element.getAttribute("content");
+    }
   }
   function createWebSocketURL(url) {
     if (url && !/^wss?:/i.test(url)) {

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -452,11 +452,8 @@
     };
     return Consumer;
   }();
-  function createConsumer(url) {
-    if (url == null) {
-      var urlConfig = getConfig("url");
-      url = urlConfig ? urlConfig : INTERNAL.default_mount_path;
-    }
+  function createConsumer() {
+    var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getConfig("url") || INTERNAL.default_mount_path;
     return new Consumer(createWebSocketURL(url));
   }
   function getConfig(name) {

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -44,7 +44,7 @@ class Connection {
 
   close({allowReconnect} = {allowReconnect: true}) {
     if (!allowReconnect) { this.monitor.stop() }
-    if (this.isActive() && this.webSocket) {
+    if (this.isActive()) {
       return this.webSocket.close()
     }
   }

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -44,7 +44,9 @@ class Connection {
 
   close({allowReconnect} = {allowReconnect: true}) {
     if (!allowReconnect) { this.monitor.stop() }
-    if (this.isActive()) { return (this.webSocket ? this.webSocket.close() : undefined) }
+    if (this.isActive() && this.webSocket) {
+      return this.webSocket.close()
+    }
   }
 
   reopen() {
@@ -65,7 +67,9 @@ class Connection {
   }
 
   getProtocol() {
-    return (this.webSocket ? this.webSocket.protocol : undefined)
+    if (this.webSocket) {
+      return this.webSocket.protocol
+    }
   }
 
   isOpen() {

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -24,7 +24,9 @@ export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_
 
 export function getConfig(name) {
   const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
-  return (element ? element.getAttribute("content") : undefined)
+  if (element) {
+    return element.getAttribute("content")
+  }
 }
 
 export function createWebSocketURL(url) {

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -18,11 +18,7 @@ export {
   logger,
 }
 
-export function createConsumer(url) {
-  if (url == null) {
-    const urlConfig = getConfig("url")
-    url = (urlConfig ? urlConfig : INTERNAL.default_mount_path)
-  }
+export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
   return new Consumer(createWebSocketURL(url))
 }
 


### PR DESCRIPTION
### Summary

In #34177 we converted the ActionCable JS package from CoffeeScript to ES2015. The conversion was largely automated by [decaffeinate](https://github.com/decaffeinate/decaffeinate), and then looked over manually to make it more idiomatic. Looking again after some time away, I found a few more non-idiomatic artifacts from the CoffeeScript conversion that could be simplified, and I've addressed them in this PR:

- Simplify `ActionCable.createConsumer` by using default argument

- Simplify `ActionCable.getConfig`, `Connection#getProtocol`, and `Connection#close` by relying on the implicit `undefined` return value (instead of explicitly `return`ing `undefined`)

- Simplify `this.isActive() && this.webSocket` into `this.isActive()` in `Connection#close`. We can do this because `isActive()` can only return `true` if `this.webSocket` is truthy. (We can't have an active connection without having instantiated a WebSocket. This is confirmed in the code: `Connection#isActive` calls `Connection#isState` which calls `Connection#getState`, which checks if `this.webSocket` is truthy and returns `null` otherwise.)