### PR TITLE
Document the ActionCable JS changes in the upgrade guide and release notes

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -92,6 +92,22 @@ Please refer to the [Changelog][action-cable] for detailed changes.
 
 ### Notable changes
 
+*   The ActionCable javascript package has been converted from CoffeeScript
+    to ES2015, and we now publish the source code in the npm distribution.
+
+    This allows ActionCable users to depend on the javascript source code
+    rather than the compiled code, which can produce smaller javascript bundles.
+
+    This change includes some breaking changes to optional parts of the
+    ActionCable javascript API:
+
+    - Configuration of the WebSocket adapter and logger adapter have been moved
+      from properties of `ActionCable` to properties of `ActionCable.adapters`.
+
+    - The `ActionCable.startDebugging()` and `ActionCable.stopDebugging()`
+      methods have been removed and replaced with the property
+      `ActionCable.logger.enabled`.
+
 Action Pack
 -----------
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -97,6 +97,42 @@ If you require your cookies to be read by 5.2 and older, or you are still valida
 to allow you to rollback set
 `Rails.application.config.action_dispatch.use_cookies_with_metadata` to `false`.
 
+### ActionCable javascript API Changes
+
+The ActionCable javascript package has been converted from CoffeeScript
+to ES2015, and we now publish the source code in the npm distribution.
+
+This change includes some breaking changes to optional parts of the
+ActionCable javascript API:
+
+- Configuration of the WebSocket adapter and logger adapter have been moved
+  from properties of `ActionCable` to properties of `ActionCable.adapters`.
+  If you are currently configuring these adapters you will need to make
+  these changes when upgrading:
+
+  ```diff
+  -    ActionCable.WebSocket = MyWebSocket
+  +    ActionCable.adapters.WebSocket = MyWebSocket
+  ```
+  ```diff
+  -    ActionCable.logger = myLogger
+  +    ActionCable.adapters.logger = myLogger
+  ```
+
+- The `ActionCable.startDebugging()` and `ActionCable.stopDebugging()`
+  methods have been removed and replaced with the property
+  `ActionCable.logger.enabled`. If you are currently using these methods you
+  will need to make these changes when upgrading:
+
+  ```diff
+  -    ActionCable.startDebugging()
+  +    ActionCable.logger.enabled = true
+  ```
+  ```diff
+  -    ActionCable.stopDebugging()
+  +    ActionCable.logger.enabled = false
+  ```
+
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------
 


### PR DESCRIPTION
### Summary

@palkan pointed out that it'd be helpful to call out the changes to the ActionCable javascript API not only in the ActionCable [changelog](https://github.com/rails/rails/commit/aa1ba9cb244b1e03d36aaa941ae4e91c6713b77e#diff-b8f5c211bba9b53d2faec429bda265e5), but also in the rails guides.

In this PR I've documented the relevant changes in both the Upgrading Ruby on Rails guide and the 
6.0 Release Notes.