### PR TITLE
Avoid ReferenceError exceptions if ActionCable is used in a web worker

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -49,7 +49,7 @@
         this.startedAt = now();
         delete this.stoppedAt;
         this.startPolling();
-        document.addEventListener("visibilitychange", this.visibilityDidChange);
+        addEventListener("visibilitychange", this.visibilityDidChange);
         logger.log("ConnectionMonitor started. pollInterval = " + this.getPollInterval() + " ms");
       }
     };
@@ -57,7 +57,7 @@
       if (this.isRunning()) {
         this.stoppedAt = now();
         this.stopPolling();
-        document.removeEventListener("visibilitychange", this.visibilityDidChange);
+        removeEventListener("visibilitychange", this.visibilityDidChange);
         logger.log("ConnectionMonitor stopped");
       }
     };

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -3,8 +3,8 @@
 })(this, function(exports) {
   "use strict";
   var adapters = {
-    logger: window.console,
-    WebSocket: window.WebSocket
+    logger: self.console,
+    WebSocket: self.WebSocket
   };
   var logger = {
     log: function log() {

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,4 @@
 export default {
-  logger: window.console,
-  WebSocket: window.WebSocket
+  logger: self.console,
+  WebSocket: self.WebSocket
 }

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -21,7 +21,7 @@ class ConnectionMonitor {
       this.startedAt = now()
       delete this.stoppedAt
       this.startPolling()
-      document.addEventListener("visibilitychange", this.visibilityDidChange)
+      addEventListener("visibilitychange", this.visibilityDidChange)
       logger.log(`ConnectionMonitor started. pollInterval = ${this.getPollInterval()} ms`)
     }
   }
@@ -30,7 +30,7 @@ class ConnectionMonitor {
     if (this.isRunning()) {
       this.stoppedAt = now()
       this.stopPolling()
-      document.removeEventListener("visibilitychange", this.visibilityDidChange)
+      removeEventListener("visibilitychange", this.visibilityDidChange)
       logger.log("ConnectionMonitor stopped")
     }
   }

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -6,14 +6,14 @@ const {module, test} = QUnit
 module("ActionCable", () => {
   module("Adapters", () => {
     module("WebSocket", () => {
-      test("default is window.WebSocket", assert => {
-        assert.equal(ActionCable.adapters.WebSocket, window.WebSocket)
+      test("default is self.WebSocket", assert => {
+        assert.equal(ActionCable.adapters.WebSocket, self.WebSocket)
       })
     })
 
     module("logger", () => {
-      test("default is window.console", assert => {
-        assert.equal(ActionCable.adapters.logger, window.console)
+      test("default is self.console", assert => {
+        assert.equal(ActionCable.adapters.logger, self.console)
       })
     })
   })


### PR DESCRIPTION
### Summary

Before this change, it was not possible to use ActionCable in a web worker because it would throw an error when trying to access `window` or `document`, which are not available in the [`WorkerGlobalScope`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope).

It may be desirable to offload WebSocket interaction to a worker to free up the main thread for other activity. But even in applications where the main thread can handle WebSocket interaction and other tasks just fine, there's still a benefit to running ActionCable in a worker: If it is common for your users to have multiple tabs of your application open at once, you can take advantage of the [`SharedWorker`](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) API to reduce load on your servers. With a `SharedWorker`, multiple tabs can share a single WebSocket connection, meaning you can drastically reduce the number of active connections (if users commonly have 2 tabs open, this can cut the number of connections in half - if they have more than 2, it's even more significant).

Fortunately, it's not too difficult to address the issues that prevent the current version of ActionCable from running in a worker. To support the worker context in addition to the window context, it's recommended to use [`self`](https://developer.mozilla.org/en-US/docs/Web/API/Window/self) instead of `window` . So that's what the first change in this PR does. To avoid the `document` `ReferenceError`, I've removed the explicit `document` receiver from the `addEventListener` and `removeEventListener` calls. The `visibilitychange` event won't ever get triggered in a worker, so adding the listener is effectively a no-op there. But this listener is not critical for ActionCable to function properly; it's more of a "nice to have", so ActionCable is still fully functional even without that event handler getting invoked. With those two changes, ActionCable can run in a worker.

### Other Information

To provide a working example, I've created the [`cable-in-web-worker` branch](https://github.com/rmacklin/anycable_demo/tree/cable-in-web-worker) in my fork of @palkan's anycable_demo repository. In that branch I extracted the ActionCable interaction to a shared worker using the changes from this PR.