### PR TITLE
Add `null: false` to `created_at` and `updated_at` columns in Action Mailbox table

### DIFF
--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -4,8 +4,8 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.integer :status, default: 0, null: false
       t.string  :message_id
 
-      t.datetime :created_at, precision: 6
-      t.datetime :updated_at, precision: 6
+      t.datetime :created_at, precision: 6, null: false
+      t.datetime :updated_at, precision: 6, null: false
     end
   end
 end


### PR DESCRIPTION
### Summary
`created_at` and `updated_at` columns in Action Mailbox table aren't intended nullable.