### PR TITLE
Document that `format.any` can match all formats

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -124,6 +124,14 @@ module ActionController #:nodoc:
     #
     #   render json: @people
     #
+    # +any+ can also be used with no arguments, in which case it will be used for any format requested by
+    # the user:
+    #
+    #   respond_to do |format|
+    #     format.html
+    #     format.any { redirect_to support_path }
+    #   end
+    #
     # Formats can have different variants.
     #
     # The request variant is a specialization of the request format, like <tt>:tablet</tt>,


### PR DESCRIPTION
### Summary

I had to dig around the code to discover this, since I had a use case for the behavior.