### PR TITLE
Add `rails test:channels` and fix Action Cable templates

### DIFF
--- a/actioncable/lib/rails/generators/test_unit/templates/channel_test.rb.tt
+++ b/actioncable/lib/rails/generators/test_unit/templates/channel_test.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class <%= class_name %>ChannelTest < ActionCable::Channel::TestCase

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1735,14 +1735,14 @@ Testing Action Cable
 --------------------
 
 Since Action Cable is used at different levels inside your application,
-you'll need to test both the channels and connection classes themsleves and that other
+you'll need to test both the channels, connection classes themselves, and that other
 entities broadcast correct messages.
 
 ### Connection Test Case
 
 By default, when you generate new Rails application with Action Cable, a test for the base connection class (`ApplicationCable::Connection`) is generated as well under `test/channels/application_cable` directory.
 
-Connection tests aim to check whether a connection's identifiers gets assigned properly
+Connection tests aim to check whether a connection's identifiers get assigned properly
 or that any improper connection requests are rejected. Here is an example:
 
 ```ruby
@@ -1765,9 +1765,8 @@ end
 
 You can also specify request cookies the same way you do in integration tests:
 
-
 ```ruby
-test "connects with_cookies" do
+test "connects with cookies" do
   cookies.signed[:user_id] = "42"
 
   connect
@@ -1777,7 +1776,6 @@ end
 ```
 
 See the API documentation for [`AcionCable::Connection::TestCase`](http://api.rubyonrails.org/classes/ActionCable/Connection/TestCase.html) for more information.
-
 
 ### Channel Test Case
 
@@ -1823,7 +1821,7 @@ See the API documentation for [`AcionCable::Channel::TestCase`](http://api.rubyo
 
 Action Cable ships with a bunch of custom assertions that can be used to lessen the verbosity of tests. For a full list of available assertions, see the API documentation for [`ActionCable::TestHelper`](http://api.rubyonrails.org/classes/ActionCable/TestHelper.html).
 
-It's a good practice to ensure that the correct message has been broadcasted inside another components (e.g. inside your controllers). This is precisely where
+It's a good practice to ensure that the correct message has been broadcasted inside other components (e.g. inside your controllers). This is precisely where
 the custom assertions provided by Action Cable are pretty useful. For instance,
 within a model:
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `rails test:channels`.
+
+    *bogdanvlviv*
+
 *   Use original `bundler` environment variables during the process of generating a new rails project.
 
     *Marco Costa*

--- a/railties/lib/rails/generators/rails/app/templates/test/channels/application_cable/connection_test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/channels/application_cable/connection_test.rb.tt
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -28,7 +28,7 @@ namespace :test do
   desc "Run tests quickly, but also reset db"
   task db: %w[db:test:prepare test]
 
-  ["models", "helpers", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
+  ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
     task name => "test:prepare" do
       $: << "test"
       Rails::TestUnit::Runner.rake_run(["test/#{name}"])

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -98,6 +98,17 @@ module ApplicationTests
       end
     end
 
+    def test_run_channels
+      create_test_file :channels, "foo_channel"
+      create_test_file :channels, "bar_channel"
+
+      rails("test:channels").tap do |output|
+        assert_match "FooChannelTest", output
+        assert_match "BarChannelTest", output
+        assert_match "2 runs, 2 assertions, 0 failures", output
+      end
+    end
+
     def test_run_controllers
       create_test_file :controllers, "foo_controller"
       create_test_file :controllers, "bar_controller"
@@ -167,11 +178,11 @@ module ApplicationTests
     end
 
     def test_run_all_suites
-      suites = [:models, :helpers, :unit, :controllers, :mailers, :functional, :integration, :jobs, :mailboxes]
+      suites = [:models, :helpers, :unit, :channels, :controllers, :mailers, :functional, :integration, :jobs, :mailboxes]
       suites.each { |suite| create_test_file suite, "foo_#{suite}" }
       run_test_command("") .tap do |output|
         suites.each { |suite| assert_match "Foo#{suite.to_s.camelize}Test", output }
-        assert_match "9 runs, 9 assertions, 0 failures", output
+        assert_match "10 runs, 10 assertions, 0 failures", output
       end
     end
 


### PR DESCRIPTION
- Remove `frozen_string_literal` from Action Cable's template files
  Related to 837f602fa1b3281113dac965a8ef96de3cac8b02.
  Follow up #34933
  Fix the testing guide.

 - Add `rails test:channels`.
   Add this rake task to test channels only.
   We've added `rails test:mailboxes` recently in the same way #34828.


