### PR TITLE
Allow touch updates to bypass optimistic locking

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,11 @@
-*   Set polymorphic type column to NULL on `dependent: :nullify` strategy. 
-    
+*   Allow `#touch` updates to bypass optimistic locking.
+
+    *Gannon McGibbon*
+
+*   Set polymorphic type column to NULL on `dependent: :nullify` strategy.
+
     On polymorphic associations both the foreign key and the foreign type columns will be set to NULL.
-    
+
     *Laerti Papa*
 
 *   Allow `ActionController::Params` as argument of `ActiveRecord::Base#exists?`.

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -71,9 +71,7 @@ module ActiveRecord
         end
 
         def _touch_row(attribute_names, time)
-          super
-        ensure
-          clear_attribute_change(self.class.locking_column) if locking_enabled?
+          without_locking { super }
         end
 
         def _update_row(attribute_names, attempted_action = "update")
@@ -120,6 +118,14 @@ module ActiveRecord
           end
 
           affected_rows
+        end
+
+        def without_locking
+          old_lock_optimistically = self.class.lock_optimistically
+          self.class.lock_optimistically = false
+          yield
+        ensure
+          self.class.lock_optimistically = old_lock_optimistically
         end
 
         module ClassMethods

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -176,21 +176,22 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal 42, p1.lock_version
   end
 
-  def test_touch_existing_lock
+  def test_touch_existing_lock_should_not_raise
     p1 = Person.find(1)
     assert_equal 0, p1.lock_version
 
     p1.touch
-    assert_equal 1, p1.lock_version
-    assert_not p1.changed?, "Changes should have been cleared"
+
+    assert_equal 0, p1.lock_version
+    assert_not p1.changed?, "Lock should not have been changed"
   end
 
-  def test_touch_stale_object
+  def test_touch_stale_object_should_not_raise
     person = Person.create!(first_name: "Mehmet Emin")
     stale_person = Person.find(person.id)
     person.update_attribute(:gender, "M")
 
-    assert_raises(ActiveRecord::StaleObjectError) do
+    assert_nothing_raised do
       stale_person.touch
     end
   end
@@ -295,16 +296,16 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     t1.touch
 
-    assert_equal 1, t1.lock_version
+    assert_equal 0, t1.lock_version
   end
 
-  def test_touch_stale_object_with_lock_without_default
+  def test_touch_does_not_raise_stale_object_with_lock_without_default
     t1 = LockWithoutDefault.create!(title: "title1")
     stale_object = LockWithoutDefault.find(t1.id)
 
     t1.update!(title: "title2")
 
-    assert_raises(ActiveRecord::StaleObjectError) do
+    assert_nothing_raised do
       stale_object.touch
     end
   end
@@ -463,7 +464,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, car.reload.wheels_count
-    assert_equal 2, car.lock_version
+    assert_equal 1, car.lock_version
     assert_operator previously_updated_at, :<, car.updated_at
     assert_operator previously_wheels_owned_at, :<, car.wheels_owned_at
 
@@ -474,7 +475,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     end
 
     assert_equal 0, car.reload.wheels_count
-    assert_equal 3, car.lock_version
+    assert_equal 2, car.lock_version
     assert_operator previously_updated_at, :<, car.updated_at
     assert_operator previously_wheels_owned_at, :<, car.wheels_owned_at
   end


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/34768.

Allows `touch` updates to bypass optimistic locking. Also removes the `ensure` attribute cleanup in the optimistic override of `_touch_row` because its not needed in this approach.

This may be a bad idea, but I can't think of a scenario where raising `StaleObjectError` on `touch` is necessary. That said, we have fairly thorough test coverage for touching in our lock tests, so I may be missing something.