### PR TITLE
Seed database with inline ActiveJob job adapter

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Seed database with inline ActiveJob job adapter.
+
+    *Gannon McGibbon*
+
 *   Add `rails db:system:change` command for changing databases.
 
     ```

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -548,7 +548,7 @@ module Rails
     # Blog::Engine.load_seed
     def load_seed
       seed_file = paths["db/seeds.rb"].existent.first
-      load(seed_file) if seed_file
+      with_inline_jobs { load(seed_file) } if seed_file
     end
 
     # Add configured load paths to Ruby's load path, and remove duplicate entries.
@@ -655,6 +655,18 @@ module Rails
       def load_config_initializer(initializer) # :doc:
         ActiveSupport::Notifications.instrument("load_config_initializer.railties", initializer: initializer) do
           load(initializer)
+        end
+      end
+
+      def with_inline_jobs
+        queue_adapter = config.active_job.queue_adapter
+        ActiveSupport.on_load(:active_job) do
+          self.queue_adapter = :inline
+        end
+        yield
+      ensure
+        ActiveSupport.on_load(:active_job) do
+          self.queue_adapter = queue_adapter
         end
       end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -879,6 +879,18 @@ YAML
       assert Bukkits::Engine.config.bukkits_seeds_loaded
     end
 
+    test "jobs are ran inline while loading seeds" do
+      app_file "db/seeds.rb", <<-RUBY
+        Rails.application.config.seed_queue_adapter = ActiveJob::Base.queue_adapter
+      RUBY
+
+      boot_rails
+      Rails.application.load_seed
+
+      assert_instance_of ActiveJob::QueueAdapters::InlineAdapter, Rails.application.config.seed_queue_adapter
+      assert_instance_of ActiveJob::QueueAdapters::AsyncAdapter, ActiveJob::Base.queue_adapter
+    end
+
     test "skips nonexistent seed data" do
       FileUtils.rm "#{app_path}/db/seeds.rb"
       boot_rails


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/34939.

It appears that `ActiveStorage` enqueues `ActiveStorage::AnalyzeJob`s when attaching a file. This prompts `ActiveJob` to enqueue jobs (via the async queue adapter by default in development) and can cause problems for one-off scripts such as database seeding.

This may also be a symptom of a bigger problem with `ActiveStorage`'s queueing assumptions, or maybe the async job adapter. For now, I think temporarily setting the queue adapter to inline for all seeding in all environments is reasonable.
