### PR TITLE
Add `config.credentials.content_path` and `config.credentials.key_path` to the guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -135,6 +135,10 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 
 * `config.reload_classes_only_on_change` enables or disables reloading of classes only when tracked files change. By default tracks everything on autoload paths and is set to `true`. If `config.cache_classes` is `true`, this option is ignored.
 
+* `config.credentials.content_path` configures lookup path for encrypted credentials.
+
+* `config.credentials.key_path` configures lookup path for encryption key.
+
 * `secret_key_base` is used for specifying a key which allows sessions for the application to be verified against a known secure key to prevent tampering. Applications get a random generated key in test and development environments, other environments should set one in `config/credentials.yml.enc`.
 
 * `config.public_file_server.enabled` configures Rails to serve static files from the public directory. This option defaults to `true`, but in the production environment it is set to `false` because the server software (e.g. NGINX or Apache) used to run the application should serve static files instead. If you are running or testing your app in production mode using WEBrick (it is not recommended to use WEBrick in production) set the option to `true.` Otherwise, you won't be able to use page caching and request for files that exist under the public directory.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -6,14 +6,15 @@
         gsub  Gemfile
     ```
 
-    The change command copies a template `config/database.yml` with the target database adapter into your app, and replaces your database gem with the target database gem.
+    The change command copies a template `config/database.yml` with
+    the target database adapter into your app, and replaces your database gem
+    with the target database gem.
 
     *Gannon McGibbon*
 
 *   Add `rails test:channels`.
 
     *bogdanvlviv*
-
 
 *   Use original `bundler` environment variables during the process of generating a new rails project.
 
@@ -141,7 +142,7 @@
     The encryption key can be in `ENV["RAILS_MASTER_KEY"]` or `config/credentials/production.key`.
 
     Environment credentials overrides can be edited with `rails credentials:edit --environment production`.
-    If no override is setup for the passed environment, it will be created.
+    If no override is set up for the passed environment, it will be created.
 
     Additionally, the default lookup paths can be overwritten with these configs:
 

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -42,7 +42,7 @@ from leaking.
 === Environment Specific Credentials
 
 The `credentials` command supports passing an `--environment` option to create an
-environment specific override. That override will takes precedence over the
+environment specific override. That override will take precedence over the
 global `config/credentials.yml.enc` file when running in that environment. So:
 
    rails credentials:edit --environment development
@@ -54,5 +54,5 @@ doesn't exist.
 The encryption key can also be put in `ENV["RAILS_MASTER_KEY"]`, which takes
 precedence over the file encryption key.
 
-In addition to that, the default credentials lookup paths can be overriden through
+In addition to that, the default credentials lookup paths can be overridden through
 `config.credentials.content_path` and `config.credentials.key_path`.


### PR DESCRIPTION
- Fix some typos




@kaspth Should `rails credentials(:edit/:show)` respect `config.credentials.content_path` and `config.credentials.key_path`? Example:
```ruby
test "edit command respects `config.credentials.content_path` and `config.credentials.key_path`" do
  add_to_config("config.credentials.content_path = config.root.join('config/new_credentials.yml.enc')")
  add_to_config("config.credentials.key_path = config.root.join('config/new_master.key')")
   
  assert_match(/access_key_id: 123/, run_edit_command(environment: "production"))
  Dir.chdir(app_path) do
    assert File.exist?("config/new_master.key")
    assert File.exist?("config/new_credentials.yml.enc")
   end
end
```
Edited: I just found 68479d09ba6bbd583055672eb70518c1586ae534, so I think it shouldn't since we can edit/show `config/new_credentials.yml.enc` file  by using: 
```bash
rails encrypted:edit config/new_credentials.yml.enc --key config/new_master.key`.
```