### PR TITLE
Allow using Action Mailbox on MySQL 5.5

### DIFF
--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -5,8 +5,11 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
 
-      t.datetime :created_at, precision: 6, null: false
-      t.datetime :updated_at, precision: 6, null: false
+      if supports_datetime_with_precision?
+        t.timestamps precision: 6
+      else
+        t.timestamps
+      end
 
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end

--- a/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
@@ -5,8 +5,11 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
 
-      t.datetime :created_at, precision: 6, null: false
-      t.datetime :updated_at, precision: 6, null: false
+      if supports_datetime_with_precision?
+        t.timestamps precision: 6
+      else
+        t.timestamps
+      end
 
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end

--- a/actionmailbox/test/dummy/db/schema.rb
+++ b/actionmailbox/test/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 


### PR DESCRIPTION
Active Record still support MySQL 5.5 which doesn't support datetime
with precision.

https://github.com/rails/rails/blob/9e34df00039d63b5672315419e76f06f80ef3dc4/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L99-L101

So we should check `supports_datetime_with_precision?` on the
connection.