### PR TITLE
Declare Trix as peer dependency of Action Text's npm package

### DIFF
--- a/actiontext/app/javascript/actiontext/index.js
+++ b/actiontext/app/javascript/actiontext/index.js
@@ -1,4 +1,3 @@
-import * as Trix from "trix"
 import { AttachmentUpload } from "./attachment_upload"
 
 addEventListener("trix-attachment-add", event => {

--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -1,3 +1,13 @@
+require "pathname"
+require "json"
+
+APPLICATION_PACK_PATH = Pathname.new("app/javascript/packs/application.js")
+JS_PACKAGE_PATH = Pathname.new("#{__dir__}/../../package.json")
+
+JS_PACKAGE = JSON.load(JS_PACKAGE_PATH)
+JS_DEPENDENCIES = JS_PACKAGE["peerDependencies"].dup.merge \
+  JS_PACKAGE["name"] => "^#{JS_PACKAGE["version"]}"
+
 say "Copying actiontext.scss to app/assets/stylesheets"
 copy_file "#{__dir__}/actiontext.scss", "app/assets/stylesheets/actiontext.scss"
 
@@ -8,14 +18,15 @@ say "Copying blob rendering partial to app/views/active_storage/blobs/_blob.html
 copy_file "#{__dir__}/../../app/views/active_storage/blobs/_blob.html.erb",
   "app/views/active_storage/blobs/_blob.html.erb"
 
-say "Installing JavaScript dependency"
-run "yarn add @rails/actiontext"
+say "Installing JavaScript dependencies"
+run "yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
 
-APPLICATION_PACK_PATH = "app/javascript/packs/application.js"
-
-if File.exist?(APPLICATION_PACK_PATH) && File.read(APPLICATION_PACK_PATH) !~ /import "@rails\/actiontext"/
-  say "Adding import to default JavaScript pack"
-  append_to_file APPLICATION_PACK_PATH, <<-EOS
-import "@rails/actiontext"
-EOS
+if APPLICATION_PACK_PATH.exist?
+  JS_DEPENDENCIES.keys.each do |name|
+    line = %[require("#{name}")]
+    unless APPLICATION_PACK_PATH.read.include? line
+      say "Adding #{name} to #{APPLICATION_PACK_PATH}"
+      append_to_file APPLICATION_PACK_PATH, "#{line}\n"
+    end
+  end
 end

--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -21,7 +21,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "trix": "^1.0.0",
     "@rails/activestorage": "^6.0.0-alpha"
+  },
+  "peerDependencies": {
+    "trix": "^1.0.0"
   }
 }


### PR DESCRIPTION
1. Change [`trix`](https://www.npmjs.com/package/trix) from a dependency to a [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/) since Trix isn't used directly by [`@rails/actiontext`](https://www.npmjs.com/package/@rails/actiontext)
1. Tidy up the `action_text:install` task to install both `@rails/actiontext` and `trix` using the versions specified in `package.json`