### PR TITLE
Typo fixes in action cable.

### DIFF
--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -81,7 +81,7 @@ module ActionCable
 
     # Asserts that the specified message has been sent to the stream.
     #
-    #   def test_assert_transmited_message
+    #   def test_assert_transmitted_message
     #     ActionCable.server.broadcast 'messages', text: 'hello'
     #     assert_broadcast_on('messages', text: 'hello')
     #   end

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -140,7 +140,7 @@ class ClientTest < ActionCable::TestCase
           end
         end
 
-        ws.on(:close) do |event|
+        ws.on(:close) do |_|
           closed.set
         end
       end

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -74,7 +74,7 @@ class TransmissionsTest < ActionCable::TestCase
   end
 end
 
-class TransmitedDataTest < ActionCable::TestCase
+class TransmittedDataTest < ActionCable::TestCase
   include ActionCable::TestHelper
 
   def test_assert_broadcast_on


### PR DESCRIPTION
### Summary
1. Replaced unused variables with `_`.
2. Used `%w(..)` instead of `[...]`.
3. Typo fixes
