### PR TITLE
activerecord: Use a simpler query condition for aggregates with one mapping

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -93,7 +93,7 @@ module ActiveRecord
             if mapping.length == 1
               column_name, aggr_attr = mapping.first
               values = Array.wrap(value).map do |object|
-                object.respond_to?(aggr_attr) ? object.send(aggr_attr) : object
+                object.respond_to?(aggr_attr) ? object.public_send(aggr_attr) : object
               end
               build(table.arel_attribute(column_name), values)
             else

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -91,12 +91,11 @@ module ActiveRecord
           elsif table.aggregated_with?(key)
             mapping = table.reflect_on_aggregation(key).mapping
             if mapping.length == 1
-              mapping.first.yield_self do |field_attr, aggregate_attr|
-                values = Array.wrap(value).map do |object|
-                  object.respond_to?(aggregate_attr) ? object.send(aggregate_attr) : object
-                end
-                build(table.arel_attribute(field_attr), values)
+              column_name, aggr_attr = mapping.first
+              values = Array.wrap(value).map do |object|
+                object.respond_to?(aggr_attr) ? object.send(aggr_attr) : object
               end
+              build(table.arel_attribute(column_name), values)
             else
               queries = Array.wrap(value).map do |object|
                 mapping.map do |field_attr, aggregate_attr|

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -947,6 +947,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_kind_of Money, zaphod_balance
     found_customers = Customer.where(balance: [david_balance, zaphod_balance])
     assert_equal [customers(:david), customers(:zaphod)], found_customers.sort_by(&:id)
+    assert_equal Customer.where(balance: [david_balance.amount, zaphod_balance.amount]).to_sql, found_customers.to_sql
   end
 
   def test_hash_condition_find_with_aggregate_attribute_having_same_name_as_field_and_key_value_being_aggregate


### PR DESCRIPTION
## Problem

When using an aggregate with one mapping, e.g.

```ruby
class Customer < ActiveRecord::Base
  composed_of :balance, class_name: "Money", mapping: %w(balance amount)
end
```

The SQL query from `Customer.where(balance: (1..50).map { |amount| Money.new(amount) })` would be something like

```sql
SELECT "customers".* FROM "customers" WHERE ((((((((((((((((((((((((((((((((((((((((((((((((("customers"."balance" = 1 OR "customers"."balance" = 2) OR "customers"."balance" = 3) OR "customers"."balance" = 4) OR "customers"."balance" = 5) OR "customers"."balance" = 6) OR "customers"."balance" = 7) OR "customers"."balance" = 8) OR "customers"."balance" = 9) OR "customers"."balance" = 10) OR "customers"."balance" = 11) OR "customers"."balance" = 12) OR "customers"."balance" = 13) OR "customers"."balance" = 14) OR "customers"."balance" = 15) OR "customers"."balance" = 16) OR "customers"."balance" = 17) OR "customers"."balance" = 18) OR "customers"."balance" = 19) OR "customers"."balance" = 20) OR "customers"."balance" = 21) OR "customers"."balance" = 22) OR "customers"."balance" = 23) OR "customers"."balance" = 24) OR "customers"."balance" = 25) OR "customers"."balance" = 26) OR "customers"."balance" = 27) OR "customers"."balance" = 28) OR "customers"."balance" = 29) OR "customers"."balance" = 30) OR "customers"."balance" = 31) OR "customers"."balance" = 32) OR "customers"."balance" = 33) OR "customers"."balance" = 34) OR "customers"."balance" = 35) OR "customers"."balance" = 36) OR "customers"."balance" = 37) OR "customers"."balance" = 38) OR "customers"."balance" = 39) OR "customers"."balance" = 40) OR "customers"."balance" = 41) OR "customers"."balance" = 42) OR "customers"."balance" = 43) OR "customers"."balance" = 44) OR "customers"."balance" = 45) OR "customers"."balance" = 46) OR "customers"."balance" = 47) OR "customers"."balance" = 48) OR "customers"."balance" = 49) OR "customers"."balance" = 50)
```

instead of the simpler query that we would get from not using `composed_of` (i.e. querying using `Customer.where(balance: (1..50))`)

```sql
SELECT "customers".* FROM "customers" WHERE "customers"."balance" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50)
```

https://stackoverflow.com/questions/782915/mysql-or-vs-in-performance shows this could have a performance impact, at least in older versions of mysql.  Mostly I just want to avoid a database regression by using `composed_of` to introduce an abstraction.

## Solution

The code already had a special case for a single mapping, so I just separated this code path more to avoid building multiple conditions joined with OR.