### PR TITLE
Ensure that AR::Relation#exists? allows only permitted params

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,10 +1,10 @@
-*   Set polymorphic type column to NULL on `dependent: :nullify` strategy. 
-    
+*   Set polymorphic type column to NULL on `dependent: :nullify` strategy.
+
     On polymorphic associations both the foreign key and the foreign type columns will be set to NULL.
-    
+
     *Laerti Papa*
 
-*   Allow `ActionController::Params` as argument of `ActiveRecord::Base#exists?`.
+*   Allow permitted instance of `ActionController::Parameters` as argument of `ActiveRecord::Relation#exists?`.
 
     *Gannon McGibbon*
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -226,11 +226,15 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_with_strong_parameters
-    assert_equal false, Subscriber.exists?(Parameters.new(nick: "foo"))
+    assert_equal false, Subscriber.exists?(Parameters.new(nick: "foo").permit!)
 
     Subscriber.create!(nick: "foo")
 
-    assert_equal true, Subscriber.exists?(Parameters.new(nick: "foo"))
+    assert_equal true, Subscriber.exists?(Parameters.new(nick: "foo").permit!)
+
+    assert_raises(ActiveModel::ForbiddenAttributesError) do
+      Subscriber.exists?(Parameters.new(nick: "foo"))
+    end
   end
 
   def test_exists_passing_active_record_object_is_not_permitted

--- a/activerecord/test/support/stubs/strong_parameters.rb
+++ b/activerecord/test/support/stubs/strong_parameters.rb
@@ -3,10 +3,16 @@
 class Parameters
   def initialize(parameters = {})
     @parameters = parameters.with_indifferent_access
+    @permitted = false
   end
 
   def permitted?
-    true
+    @permitted
+  end
+
+  def permit!
+    @permitted = true
+    self
   end
 
   def to_h


### PR DESCRIPTION
Clarify changelog entry
Related to #34891
