### PR TITLE
Update test schema.rb to reflect the recent changes

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -28,8 +28,7 @@ module Rails
       end
 
       def create_inbound_email(mail)
-        ActionMailbox::InboundEmail.create! raw_email: \
-          { io: StringIO.new(mail.to_s), filename: "inbound.eml", content_type: "message/rfc822" }
+        ActionMailbox::InboundEmail.create_and_extract_message_id!(mail.to_s)
       end
   end
 end

--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -8,7 +8,7 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.datetime :created_at, precision: 6, null: false
       t.datetime :updated_at, precision: 6, null: false
 
-      t.index [ :message_id, :message_checksum ], unique: true
+      t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
 end

--- a/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailroom_tables.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailroom_tables.rb
@@ -5,10 +5,10 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
 
-      t.datetime :created_at, precision: 6
-      t.datetime :updated_at, precision: 6
+      t.datetime :created_at, precision: 6, null: false
+      t.datetime :updated_at, precision: 6, null: false
 
-      t.index [ :message_id, :message_checksum ], unique: true
+      t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
 end

--- a/actionmailbox/test/dummy/db/schema.rb
+++ b/actionmailbox/test/dummy/db/schema.rb
@@ -14,10 +14,10 @@ ActiveRecord::Schema.define(version: 2018_02_12_164506) do
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
-    t.string "message_id"
-    t.string "message_checksum"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.string "message_id", null: false
+    t.string "message_checksum", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["message_id", "message_checksum"], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
   end
 


### PR DESCRIPTION
Test suite's schema.rb is currently stale. This will fix that.

Also, updates the conductor inbounds controller to use `create_and_extract_message_id!` for creating an `InboundEmail`. This makes sure the new `InboundEmail` always has `message_id` and `message_checksum` columns set.