### PR TITLE
Improve execution time of railties' test 

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -504,6 +504,8 @@ Module.new do
   require "action_view"
   require "active_storage"
   require "action_cable"
+  require "action_mailbox"
+  require "action_text"
   require "sprockets"
 
   require "action_view/helpers"


### PR DESCRIPTION
This PR includes the following improvement. 

* Excludes unnecessary install tasks in engine test. Since `action_text:install` contains the execution of yarn, it slows.
* Added that the preload of the newly added component was insufficient. 
