### PR TITLE
activerecord: Fix where nil condition on composed_of attribute

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -90,16 +90,17 @@ module ActiveRecord
             queries.reduce(&:or)
           elsif table.aggregated_with?(key)
             mapping = table.reflect_on_aggregation(key).mapping
-            if mapping.length == 1
+            values = value.nil? ? [nil] : Array.wrap(value)
+            if mapping.length == 1 || values.empty?
               column_name, aggr_attr = mapping.first
-              values = Array.wrap(value).map do |object|
+              values = values.map do |object|
                 object.respond_to?(aggr_attr) ? object.public_send(aggr_attr) : object
               end
               build(table.arel_attribute(column_name), values)
             else
-              queries = Array.wrap(value).map do |object|
+              queries = values.map do |object|
                 mapping.map do |field_attr, aggregate_attr|
-                  build(table.arel_attribute(field_attr), object.send(aggregate_attr))
+                  build(table.arel_attribute(field_attr), object.try!(aggregate_attr))
                 end.reduce(&:and)
               end
               queries.reduce(&:or)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1003,6 +1003,24 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal customers(:david), found_customer
   end
 
+  def test_hash_condition_find_nil_with_aggregate_having_one_mapping
+    assert_nil customers(:zaphod).gps_location
+    found_customer = Customer.where(gps_location: nil, name: customers(:zaphod).name).first
+    assert_equal customers(:zaphod), found_customer
+  end
+
+  def test_hash_condition_find_nil_with_aggregate_having_multiple_mappings
+    customers(:david).update(address: nil)
+    assert_nil customers(:david).address_street
+    assert_nil customers(:david).address_city
+    found_customer = Customer.where(address: nil, name: customers(:david).name).first
+    assert_equal customers(:david), found_customer
+  end
+
+  def test_hash_condition_find_empty_array_with_aggregate_having_multiple_mappings
+    assert_nil Customer.where(address: []).first
+  end
+
   def test_condition_utc_time_interpolation_with_default_timezone_local
     with_env_tz "America/New_York" do
       with_timezone_config default: :local do


### PR DESCRIPTION
### Problem

Using a where condition on a composed_of attribute with a `nil` value doesn't work as expected.

If the composed_of attribute has a single mapping, then a condition like `where(gps_location: nil)` will end up with `WHERE 1=0` in the SQL query, so it never matches any row.  This is because the value gets turned into an array using `Array.wrap(value)` where `Array.wrap(nil)` returns `[]`, making the example query effectively `where(gps_location: [])`.

If the composed_of attribute has multiple mappings, then it results in a `Arel::Visitors::UnsupportedVisitError: Unsupported argument type: NilClass. Construct an Arel node instead.` being raised because of the same mis-use of `Array.wrap`.  It builds separate conditions for an empty array of values , then tries to `OR` an empty array of them (`[].reduce(&:or)`), which results in `nil`, which isn't a valid Arel node.

### Solution

Replace `Array.wrap(value)` with `value.nil? ? [nil] : Array.wrap(value)` and use `try!` to avoid calling the aggregate attribute method on `nil`.

This issue also shows that empty values were being handled in the multiple mappings path, so I re-used the single values path to handle that by changing the condition to `if mapping.length == 1 || values.empty?`.  If that is too implicit, I could add a separate `if values.empty?` branch that just does `build(table.arel_attribute(column_name), values)`, which would have the same effect.