### PR TITLE
Ensure radio/checkbox DOM IDs with float values are unique

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure unique DOM IDs for collection inputs with float values.
+    Fixes #34974
+
+    *Mark Edmondson*
+
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
 *   Remove deprecated `image_alt` helper.

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -138,7 +138,7 @@ module ActionView
           end
 
           def sanitized_value(value)
-            value.to_s.gsub(/\s/, "_").gsub(/[^-[[:word:]]]/, "").mb_chars.downcase.to_s
+            value.to_s.gsub(/[\s\.]/, "_").gsub(/[^-[[:word:]]]/, "").mb_chars.downcase.to_s
           end
 
           def select_content_tag(option_tags, options, html_options)

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -48,8 +48,16 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection radio should sanitize collection values for labels correctly" do
     with_collection_radio_buttons :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
-    assert_select "label[for=user_name_099]", "$0.99"
-    assert_select "label[for=user_name_199]", "$1.99"
+    assert_select "label[for=user_name_0_99]", "$0.99"
+    assert_select "label[for=user_name_1_99]", "$1.99"
+  end
+
+  test "collection radio correctly builds unique DOM IDs for float values" do
+    with_collection_radio_buttons :user, :name, [1.0, 10], :to_s, :to_s
+    assert_select "label[for=user_name_1_0]", "1.0"
+    assert_select "label[for=user_name_10]", "10"
+    assert_select 'input#user_name_1_0[type=radio][value="1.0"]'
+    assert_select 'input#user_name_10[type=radio][value="10"]'
   end
 
   test "collection radio accepts checked item" do
@@ -302,8 +310,16 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check box should sanitize collection values for labels correctly" do
     with_collection_check_boxes :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
-    assert_select "label[for=user_name_099]", "$0.99"
-    assert_select "label[for=user_name_199]", "$1.99"
+    assert_select "label[for=user_name_0_99]", "$0.99"
+    assert_select "label[for=user_name_1_99]", "$1.99"
+  end
+
+  test "collection check boxes correctly builds unique DOM IDs for float values" do
+    with_collection_check_boxes :user, :name, [1.0, 10], :to_s, :to_s
+    assert_select "label[for=user_name_1_0]", "1.0"
+    assert_select "label[for=user_name_10]", "10"
+    assert_select 'input#user_name_1_0[type=checkbox][value="1.0"]'
+    assert_select 'input#user_name_10[type=checkbox][value="10"]'
   end
 
   test "collection check boxes generates labels for non-English values correctly" do


### PR DESCRIPTION
### Summary
Updates the DOM ID sanitizer for form input values so as to not cause potential duplicate values when using float values on a collection.

For example:
```ruby
collection_check_boxes :user, :name, [1.0, 10], :to_s, :to_s
```

Returns:
```html
<input type="hidden" name="user[name][]" value="" />
<input type="checkbox" value="1.0" name="user[name][]" id="user_name_10" />
<label for="user_name_10">1.0</label>
<input type="checkbox" value="10" name="user[name][]" id="user_name_10" />
<label for="user_name_10">10</label>
```

With this change:
```html
<input type="hidden" name="user[name][]" value="" />
<input type="checkbox" value="1.0" name="user[name][]" id="user_name_1_0" />
<label for="user_name_1_0">1.0</label>
<input type="checkbox" value="10" name="user[name][]" id="user_name_10" />
<label for="user_name_10">10</label>
```

Fixes #34974

