### PR TITLE
Don't add `RAILS_ENV` in generate action

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -222,6 +222,7 @@ module Rails
         log :generate, what
 
         options = args.extract_options!
+        options[:without_rails_env] = true
         argument = args.flat_map(&:to_s).join(" ")
 
         execute_command :rails, "generate #{what} #{argument}", options
@@ -284,14 +285,15 @@ module Rails
         # based on the executor parameter provided.
         def execute_command(executor, command, options = {}) # :doc:
           log executor, command
-          env  = options[:env] || ENV["RAILS_ENV"] || "development"
+          env = options[:env] || ENV["RAILS_ENV"] || "development"
+          rails_env = " RAILS_ENV=#{env}" unless options[:without_rails_env]
           sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
           config = { verbose: false }
 
           config[:capture] = options[:capture] if options[:capture]
           config[:abort_on_failure] = options[:abort_on_failure] if options[:abort_on_failure]
 
-          in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", config) }
+          in_root { run("#{sudo}#{extify(executor)} #{command}#{rails_env}", config) }
         end
 
         # Add an extension to the given name based on the platform.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -320,6 +320,12 @@ class ActionsTest < Rails::Generators::TestCase
     assert_no_file "app/models/my_model.rb"
   end
 
+  def test_generate_should_run_command_without_env
+    assert_called_with(generator, :run, ["rails generate model MyModel name:string", verbose: false]) do
+      action :generate, "model", "MyModel", "name:string"
+    end
+  end
+
   def test_rake_should_run_rake_command_with_default_env
     assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do


### PR DESCRIPTION
In the case of generator, `RAILS_ENV` is interpreted as an argument as it　is. Avoid this because it will result unintended by the user.

Fixes #34979.

---

By the way, I think that this is a problem that does not occur if env is specified before the command. 
I did not understand why env was last specified(it seems that was due to the first commit d57b19380eaad8bda63743107f085e72935343b9), so this time I leave it as it is.
