### PR TITLE
Fix that adding attachments lose a body

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,7 @@ module Rails
       def new_mail
         Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
           params[:mail][:attachments].to_a.each do |attachment|
-            mail.attachments[attachment.original_filename] = { filename: attachment.path, content_type: attachment.content_type }
+            mail.add_file(filename: attachment.path, content: attachment.read)
           end
         end
       end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -12,6 +12,25 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
             to: "Replies <replies@example.com>",
             bcc: "",
             in_reply_to: "<4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>",
+            subject: "Create",
+            body: "New Mail"
+          }
+        }
+      end
+
+      assert_equal "New Mail", ActionMailbox::InboundEmail.last.mail.decoded
+    end
+  end
+
+  test "create inbound email with attachments" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_emails_path, params: {
+          mail: {
+            from: "Jason Fried <jason@37signals.com>",
+            to: "Replies <replies@example.com>",
+            bcc: "",
+            in_reply_to: "<4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>",
             subject: "Discussion: Let's debate these attachments",
             body: "Let's talk about these images:",
             attachments: [fixture_file_upload("files/avatar1.jpeg"), fixture_file_upload("files/avatar2.jpeg")]
@@ -19,7 +38,9 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
         }
       end
 
-      assert_equal 2, ActionMailbox::InboundEmail.last.mail.attachments.size
+      mail = ActionMailbox::InboundEmail.last.mail
+      assert_equal 2, mail.attachments.size
+      assert_equal "Let's talk about these images:", mail.text_part.decoded
     end
   end
 


### PR DESCRIPTION
Fixed the following.

1. Visit `/rails/conductor/action_mailbox/inbound_emails/new`
2. Fill `Body` and `Attachments`
3. New incoming email does not contain `Body`
