### PR TITLE
Clarify that some configuration still needs to happen in config/appli…

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -32,10 +32,13 @@ module <%= app_const_base %>
     config.load_defaults Rails::VERSION::STRING.to_f
 <%- end -%>
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
 <%- if options.api? -%>
 
     # Only loads a smaller set of middleware suitable for API only apps.


### PR DESCRIPTION
…cation.rb [ci skip]

### Summary

This adds a note into `config/application.rb` that explains that `config.time_zone` and `config.autoload_paths` need to be configured in that file, not in an initializer.

### Other Information

The problem that the above options don't work in `config/initializers` was reported in bug report https://github.com/rails/rails/issues/24748, which was closed by https://github.com/rails/rails/pull/31572. That PR only clarified that the initializers are loaded after the framework and gems, but left the recommendation "Application configuration can go into files in config/initializers", which wrongly makes it sound that this works for all configuration options.

I'm only mentioning `time_zone` and `autoload_paths`, as these seem to be the most frequently used ones affected; feel free to suggest others.