### PR TITLE
Update "Development Dependencies Install" guide [ci skip]

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -227,7 +227,6 @@ If you're using another database, check the file `activerecord/test/config.yml` 
 If you installed Yarn, you will need to install the javascript dependencies:
 
 ```bash
-$ cd activestorage
 $ yarn install
 ```
 


### PR DESCRIPTION
Since we use [workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) `yarn install` from the root should install all the javascript dependencies.
