### PR TITLE
Fix year value when casting a multiparameter time hash

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   Fix year value when casting a multiparameter time hash
+
+    When assigning a hash to a time attribute that's missing a year component
+    (e.g. a `time_select` with `:ignore_date` set to `true`) then the year
+    defaults to 1970 instead of the expected 2000. This results in the attribute
+    changing as a result of the save.
+
+    Before:
+    ```
+    event = Event.new(start_time: { 4 => 20, 5 => 30 })
+    event.start_time # => 1970-01-01 20:30:00 UTC
+    event.save
+    event.reload
+    event.start_time # => 2000-01-01 20:30:00 UTC
+    ```
+
+    After:
+    ```
+    event = Event.new(start_time: { 4 => 20, 5 => 30 })
+    event.start_time # => 2000-01-01 20:30:00 UTC
+    event.save
+    event.reload
+    event.start_time # => 2000-01-01 20:30:00 UTC
+    ```
+
+    *Andrew White*
+
+
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
 *   Add `ActiveModel::Errors#of_kind?`.

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class Time < Value # :nodoc:
       include Helpers::TimeValue
       include Helpers::AcceptsMultiparameterTime.new(
-        defaults: { 1 => 1970, 2 => 1, 3 => 1, 4 => 0, 5 => 0 }
+        defaults: { 1 => 2000, 2 => 1, 3 => 1, 4 => 0, 5 => 0 }
       )
 
       def type

--- a/activemodel/test/cases/type/time_test.rb
+++ b/activemodel/test/cases/type/time_test.rb
@@ -16,6 +16,7 @@ module ActiveModel
 
         assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast("2015-06-13T19:45:54+03:00")
         assert_equal ::Time.utc(1999, 12, 31, 21,  7,  8), type.cast("06:07:08+09:00")
+        assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast(4 => 16, 5 => 45, 6 => 54)
       end
 
       def test_user_input_in_time_zone

--- a/activerecord/test/cases/type/time_test.rb
+++ b/activerecord/test/cases/type/time_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+
+module ActiveRecord
+  module Type
+    class TimeTest < ActiveRecord::TestCase
+      def test_default_year_is_correct
+        expected_time = ::Time.utc(2000, 1, 1, 10, 30, 0)
+        topic = Topic.new(bonus_time: { 4 => 10, 5 => 30 })
+
+        assert_equal expected_time, topic.bonus_time
+
+        topic.save!
+        topic.reload
+
+        assert_equal expected_time, topic.bonus_time
+      end
+    end
+  end
+end


### PR DESCRIPTION
When assigning a hash to a time attribute that's missing a year component (e.g. a `time_select` with `:ignore_date` set to `true`) then the year defaults to 1970 instead of the expected 2000. This results in the attribute changing as a result of the save.

Before:

``` ruby
event = Event.new(start_time: { 4 => 20, 5 => 30 })
event.start_time # => 1970-01-01 20:00:00 UTC
event.save
event.reload
event.start_time # => 2000-01-01 20:00:00 UTC
```

After:
``` ruby
event = Event.new(start_time: { 4 => 20, 5 => 30 })
event.start_time # => 2000-01-01 20:00:00 UTC
event.save
event.reload
event.start_time # => 2000-01-01 20:00:00 UTC
```