### PR TITLE
Remove duplicate ruby version specification

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "'#{RUBY_VERSION}'" -%>
+ruby File.read(File.join(__dir__, '.ruby-version'))
 
 <% unless gemfile_entries.first.comment -%>
 


### PR DESCRIPTION
### Summary

Avoid duplicated ruby version specification by reading it directly from the `.ruby-version` file, already present in the project.