### PR TITLE
params[:article] does not return an ActionController::Parameters

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -638,6 +638,15 @@ this situation, the only parameters that matter are the ones from the form.
 
 TIP: Ensure you have a firm grasp of the `params` method, as you'll use it fairly regularly. Let's consider an example URL: **http://www.example.com/?username=dhh&email=dhh@email.com**. In this URL, `params[:username]` would equal "dhh" and `params[:email]` would equal "dhh@email.com".
 
+To view the full `ActionController::Parameters` object, change the `create`
+action to this:
+
+```ruby
+def create
+  render plain: params.inspect
+end
+```
+
 If you re-submit the form one more time, you'll see something that looks like the following:
 
 ```ruby


### PR DESCRIPTION
### Summary

Mistake in getting started page - `params` itself is the Parameters object - to inspect it, you must not index into it
