### PR TITLE
Improve behavior of DateTime.change for minutes and seconds.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
+*   Add `minute` and `second` parameters to DateTime.change, in addition to existing `min` and `sec`.
+
+    *Ivan Tumanov*
 
 *   Remove deprecated `Module#reachable?` method.
 

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -49,6 +49,9 @@ class DateTime
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => DateTime.new(1981, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
   def change(options)
+    options[:min] = options[:minute]  if options[:minute]
+    options[:sec] = options[:second]  if options[:second]
+    
     if new_nsec = options[:nsec]
       raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
       new_fraction = Rational(new_nsec, 1000000000)

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -82,11 +82,16 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Date.new(2005, 2, 21), Date.new(2005, 2, 21).to_date
   end
 
-  def test_change
+  def test_change_of_date
     assert_equal Date.new(2005, 2, 21), Date.new(2005, 2, 11).change(day: 21)
     assert_equal Date.new(2007, 5, 11), Date.new(2005, 2, 11).change(year: 2007, month: 5)
     assert_equal Date.new(2006, 2, 22), Date.new(2005, 2, 22).change(year: 2006)
     assert_equal Date.new(2005, 6, 22), Date.new(2005, 2, 22).change(month: 6)
+  end
+
+  def test_change_of_time
+    assert_equal DateTime.new(2005, 6, 22, 3, 12, 9), DateTime.new(2005, 6, 22, 0, 0, 0).change(hour: 3, min: 12, sec: 9)
+    assert_equal DateTime.new(2005, 6, 22, 0, 23, 8), DateTime.new(2005, 6, 22, 0, 0, 0).change(minute: 23, second: 8)
   end
 
   def test_sunday


### PR DESCRIPTION
### Summary

Improved behavior of DateTime.change function.

Before this patch:
```
date = DateTime.new(2018, 12, 11, 10, 9, 8)
# => Tue, 11 Dec 2018 10:09:08 +0000
date.change(year: 2018)
# => Tue, 11 Dec 2018 10:09:08 +0000
date.change(year: 2018, month: 10)
# => Thu, 11 Oct 2018 10:09:08 +0000
date.change(year: 2018, month: 10, hour: 5)
# => Thu, 11 Oct 2018 05:00:00 +0000
date.change(year: 2018, month: 10, hour: 5, minute: 4)
# => Thu, 11 Oct 2018 05:00:00 +0000
date.change(year: 2018, month: 10, hour: 5, minute: 4, second: 2)
# => Thu, 11 Oct 2018 05:00:00 +0000
```

Have you noticed an unexpected behavior in this method for 'minute' and 'second'? It does not work, and does not show an error message about invalid parameters. 

The only way to use this method is to write  'min' instead of 'minute' and 'sec' instead of 'second':
```
date.change(year: 2018, month: 10, hour: 5, min: 4, sec: 2)
# => Thu, 11 Oct 2018 05:04:02 +0000
```

I think this behavior should be changed to one of following:
1. Allow to pass both variants (min or minute)
2. Raise an error if user tries to use 'minute' or 'second' as arguments.

I have included #1 variant in this pull request. So, it will be possible to use date.change like you expect it to. Without breaking any backward compatibility.

```
date = DateTime.new(2018, 12, 11, 10, 9, 8)
date.change(minute: 2, second: 3)
# => Tue, 11 Dec 2018 10:02:03 +0000
date.change(min: 2, sec: 3)
# => Tue, 11 Dec 2018 10:02:03 +0000
```

### Other Information

Tests added too.