### PR TITLE
Add missing entries to guides' changelog file [ci skip]

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
+*   Add "Action Text Overview" Guide.
+
+    *DHH*
+
+*   Add "Action Mailbox Basics" Guide.
+
+    *DHH*
+
 *   New section _Troubleshooting_ in the _Autoloading and Reloading Constants_ guide.
 
     *Xavier Noria*


### PR DESCRIPTION
We added "Action Mailbox Basics", "Action Text Overview" guides(#34812, #34878)
I think it makes to mention about it in the changelog file. (Similar to 7200ec92f8)
Note that entries retain original author since
I just moved content from readme files to the guides.
