### PR TITLE
Add Channel tests to `rails stats`

### DIFF
--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -20,6 +20,7 @@ STATS_DIRECTORIES = [
   %w(Model\ tests       test/models),
   %w(Mailer\ tests      test/mailers),
   %w(Mailbox\ tests     test/mailboxes),
+  %w(Channel\ tests     test/channels),
   %w(Job\ tests         test/jobs),
   %w(Integration\ tests test/integration),
   %w(System\ tests      test/system),

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -118,7 +118,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 29     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 32     Test LOC: 0     Code to Test Ratio: 1:0.0",
         rails("stats")
     end
 


### PR DESCRIPTION
Rails generates `test/channels`(#34933) and
even allows `rails test:channels` (#34947).
`rails stats` has been providing info about `app/channels`,
it makes sense to add `test/channels` as well.

(I've changed the test to address the failure https://travis-ci.org/rails/rails/jobs/482332741#L4925 since Rails generates `test/channels` with some code)
