### PR TITLE
Alias case nodes

### DIFF
--- a/activerecord/lib/arel/nodes/case.rb
+++ b/activerecord/lib/arel/nodes/case.rb
@@ -3,6 +3,8 @@
 module Arel # :nodoc: all
   module Nodes
     class Case < Arel::Nodes::Node
+      include Arel::AliasPredication
+
       attr_accessor :case, :conditions, :default
 
       def initialize(expression = nil, default = nil)

--- a/activerecord/test/cases/arel/nodes/case_test.rb
+++ b/activerecord/test/cases/arel/nodes/case_test.rb
@@ -80,6 +80,16 @@ module Arel
             assert_equal 2, array.uniq.size
           end
         end
+
+        describe "#as" do
+          it "allows aliasing" do
+            node = Case.new "foo"
+            as = node.as("bar")
+
+            assert_equal node, as.left
+            assert_kind_of Arel::Nodes::SqlLiteral, as.right
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When `Arel` was merged into `ActiveRecord` we lost the ability to alias case nodes. This adds it back.