### PR TITLE
No need to take timezone into consideration when comparing time (past?, future?)

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -341,4 +341,14 @@ class Time
   def next_year(years = 1)
     advance(years: years)
   end
+
+  # Returns true if the time is in the past.
+  def past?
+    self < self.class.now
+  end
+
+  # Returns true if the time is in the future.
+  def future?
+    self > self.class.now
+  end
 end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -688,7 +688,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_past_with_time_current_as_time_local
     with_env_tz "US/Eastern" do
-      Time.stub(:current, Time.local(2005, 2, 10, 15, 30, 45)) do
+      Time.stub(:now, Time.local(2005, 2, 10, 15, 30, 45)) do
         assert_equal true,  Time.local(2005, 2, 10, 15, 30, 44).past?
         assert_equal false,  Time.local(2005, 2, 10, 15, 30, 45).past?
         assert_equal false,  Time.local(2005, 2, 10, 15, 30, 46).past?
@@ -702,7 +702,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   def test_past_with_time_current_as_time_with_zone
     with_env_tz "US/Eastern" do
       twz = Time.utc(2005, 2, 10, 15, 30, 45).in_time_zone("Central Time (US & Canada)")
-      Time.stub(:current, twz) do
+      Time.stub(:now, twz) do
         assert_equal true,  Time.local(2005, 2, 10, 10, 30, 44).past?
         assert_equal false,  Time.local(2005, 2, 10, 10, 30, 45).past?
         assert_equal false,  Time.local(2005, 2, 10, 10, 30, 46).past?
@@ -715,7 +715,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_future_with_time_current_as_time_local
     with_env_tz "US/Eastern" do
-      Time.stub(:current, Time.local(2005, 2, 10, 15, 30, 45)) do
+      Time.stub(:now, Time.local(2005, 2, 10, 15, 30, 45)) do
         assert_equal false,  Time.local(2005, 2, 10, 15, 30, 44).future?
         assert_equal false,  Time.local(2005, 2, 10, 15, 30, 45).future?
         assert_equal true,  Time.local(2005, 2, 10, 15, 30, 46).future?
@@ -729,7 +729,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   def test_future_with_time_current_as_time_with_zone
     with_env_tz "US/Eastern" do
       twz = Time.utc(2005, 2, 10, 15, 30, 45).in_time_zone("Central Time (US & Canada)")
-      Time.stub(:current, twz) do
+      Time.stub(:now, twz) do
         assert_equal false,  Time.local(2005, 2, 10, 10, 30, 44).future?
         assert_equal false,  Time.local(2005, 2, 10, 10, 30, 45).future?
         assert_equal true,  Time.local(2005, 2, 10, 10, 30, 46).future?

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -253,7 +253,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_past_with_time_current_as_time_local
     with_env_tz "US/Eastern" do
-      Time.stub(:current, Time.local(2005, 2, 10, 15, 30, 45)) do
+      Time.stub(:now, Time.local(2005, 2, 10, 15, 30, 45)) do
         assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 44)).past?
         assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45)).past?
         assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 46)).past?
@@ -263,7 +263,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_past_with_time_current_as_time_with_zone
     twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45))
-    Time.stub(:current, twz) do
+    Time.stub(:now, twz) do
       assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 44)).past?
       assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45)).past?
       assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 46)).past?
@@ -272,7 +272,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_future_with_time_current_as_time_local
     with_env_tz "US/Eastern" do
-      Time.stub(:current, Time.local(2005, 2, 10, 15, 30, 45)) do
+      Time.stub(:now, Time.local(2005, 2, 10, 15, 30, 45)) do
         assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 44)).future?
         assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45)).future?
         assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 46)).future?
@@ -282,7 +282,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_future_with_time_current_as_time_with_zone
     twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45))
-    Time.stub(:current, twz) do
+    Time.stub(:now, twz) do
       assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 44)).future?
       assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 45)).future?
       assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.local(2005, 2, 10, 15, 30, 46)).future?


### PR DESCRIPTION
### Summary

When comparing two times, it doesn't matter which timezone they are in.
```rb
time = Time.current
# => Mon, 21 Jan 2019 19:10:34 UTC +00:00

time.in_time_zone(8) == time
# => true
```

In current implementation `Time.current.past?` equals to `Time.current.utc < Time.current`

https://github.com/rails/rails/blob/bfa12d7a02ce0e84fcd2b83f2ce6fee1386757e3/activesupport/lib/active_support/time_with_zone.rb#L170-L172
https://github.com/rails/rails/blob/40da1c430bc2d8d5cd9a9349993fbdf62e68529f/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb#L44-L46

But calling `Time.current` is **275 times slower** than calling `Time.now` (See the benchmark below).
I think it can be replaced by `Time.now` safely and make the method call faster.

### Other Information


#### Benchmark of Time.now and Time.current

Script:
```rb
require 'benchmark/ips'

time = Time.current
Benchmark.ips do |x|
  x.report("time < Time.now")      { time < Time.now }
  x.report("time < Time.current")  { time < Time.current }
  x.compare!
end
```

Tested on Rails 5.2.1, MacOs 10.13, Intel i5-5257U 2.7Ghz.

```
Warming up --------------------------------------
     time < Time.now    98.567k i/100ms
 time < Time.current   483.000  i/100ms
Calculating -------------------------------------
     time < Time.now      1.178M (±16.9%) i/s -      5.717M in   5.032405s
 time < Time.current      4.287k (±15.0%) i/s -     21.252k in   5.085127s

Comparison:
     time < Time.now:  1178256.8 i/s
 time < Time.current:     4286.9 i/s - 274.85x  slower
```

Tested on Rails 5.2.1, Windows 10 (Debian for WSL), Intel i7-8750H 2.2Ghz.

```
Warming up --------------------------------------
     time < Time.now    46.864k i/100ms
 time < Time.current     6.211k i/100ms
Calculating -------------------------------------
     time < Time.now    838.052k (± 2.3%) i/s -      4.218M in   5.035600s
 time < Time.current     66.657k (± 3.1%) i/s -    335.394k in   5.036861s

Comparison:
     time < Time.now:   838051.7 i/s
 time < Time.current:    66656.8 i/s - 12.57x  slower
```

