### PR TITLE
Allow user to skip migrations

### DIFF
--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -454,6 +454,24 @@ module ApplicationTests
           assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
         end
       end
+
+      test "running migrations with skip flag" do
+        app_file "db/migrate/01_one_migration.rb", <<-MIGRATION
+          class OneMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        app_file "db/migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+            skip!
+          end
+        MIGRATION
+
+        rails "db:migrate"
+
+        output = rails("db:version")
+        assert_match(/Current version: 1/, output)
+      end
     end
   end
 end


### PR DESCRIPTION
I've been working recently on some projects where the release cycles are based on [Feature flags](https://en.wikipedia.org/wiki/Feature_toggle) and I was looking for a way to skip some migrations on certain environments but from what I see there is nothing in the documentation (I didn't find how to do it 😅 ).

The idea is to allow the users to skip migrations for specific environments or conditions (like feature flags)

```ruby
class AddRolesToUsers < ActiveRecord::Migration[6.0]
  skip! if Rails.env.production? || Rails.env.integration?

  def change
    ...
  end
end
```

```ruby
class AddRolesToUsers < ActiveRecord::Migration[6.0]
  skip! unless $feature_enabled?(:role_system)

  def change
    ...
  end
end
```

