### PR TITLE
MySQL 8.0.14 adds `ER_FK_INCOMPATIBLE_COLUMNS`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -627,6 +627,7 @@ module ActiveRecord
         ER_LOCK_WAIT_TIMEOUT    = 1205
         ER_QUERY_INTERRUPTED    = 1317
         ER_QUERY_TIMEOUT        = 3024
+        ER_FK_INCOMPATIBLE_COLUMNS = 3780
 
         def translate_exception(exception, message:, sql:, binds:)
           case error_number(exception)
@@ -634,7 +635,7 @@ module ActiveRecord
             RecordNotUnique.new(message, sql: sql, binds: binds)
           when ER_NO_REFERENCED_ROW, ER_ROW_IS_REFERENCED, ER_ROW_IS_REFERENCED_2, ER_NO_REFERENCED_ROW_2
             InvalidForeignKey.new(message, sql: sql, binds: binds)
-          when ER_CANNOT_ADD_FOREIGN
+          when ER_CANNOT_ADD_FOREIGN, ER_FK_INCOMPATIBLE_COLUMNS
             mismatched_foreign_key(message, sql: sql, binds: binds)
           when ER_CANNOT_CREATE_TABLE
             if message.include?("errno: 150")


### PR DESCRIPTION
### Summary

This pull request addresses this failure with MySQL 8.0.14.

```ruby
$ ARCONN=mysql2 bundle exec ruby -w -Itest test/cases/adapters/mysql2/mysql2_adapter_test.rb -n test_errors_for_bigint_fks_on_integer_pk_table
Using mysql2
Run options: -n test_errors_for_bigint_fks_on_integer_pk_table --seed 54672

# Running:

F

Failure:
Mysql2AdapterTest#test_errors_for_bigint_fks_on_integer_pk_table [test/cases/adapters/mysql2/mysql2_adapter_test.rb:62]:
[ActiveRecord::MismatchedForeignKey] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"Mysql2::Error: Referencing column 'old_car_id' and referenced column 'id' in foreign key constraint 'fk_rails_9f49f34f36' are incompatible.">
---Backtrace---
/home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `_query'
/home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `block in query'
/home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `handle_interrupt'
/home/yahonda/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `query'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:181:in `block (2 levels) in execute'
/home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/home/yahonda/git/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/home/yahonda/git/rails/activesupport/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:180:in `block in execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:641:in `block (2 levels) in log'
/home/yahonda/.rbenv/versions/2.6.0/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:640:in `block in log'
/home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:631:in `log'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:179:in `execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:39:in `execute'
/home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:977:in `add_foreign_key'
test/cases/adapters/mysql2/mysql2_adapter_test.rb:64:in `block in test_errors_for_bigint_fks_on_integer_pk_table'
---------------


rails test test/cases/adapters/mysql2/mysql2_adapter_test.rb:59



Finished in 0.028579s, 34.9906 runs/s, 34.9906 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

### Other Information

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-14.html
> Error messages relating to creating and dropping foreign keys
> were improved to be more specific and informative. (Bug #28526309, Bug #92087)

https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html

> Error number: 3780; Symbol: ER_FK_INCOMPATIBLE_COLUMNS; SQLSTATE: HY000
> Message: Referencing column '%s' and referenced column '%s' in foreign key constraint '%s' are incompatible.
> ER_FK_INCOMPATIBLE_COLUMNS was added in 8.0.14.
