### PR TITLE
Actionpack typo fixes.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -82,7 +82,7 @@
 *   Apply mapping to symbols returned from dynamic CSP sources
 
     Previously if a dynamic source returned a symbol such as :self it
-    would be converted to a string implicity, e.g:
+    would be converted to a string implicitly, e.g:
 
         policy.default_src -> { :self }
 
@@ -135,7 +135,7 @@
 
     *Assain Jaleel*
 
-*   Raises `ActionController::RespondToMismatchError` with confliciting `respond_to` invocations.
+*   Raises `ActionController::RespondToMismatchError` with conflicting `respond_to` invocations.
 
     `respond_to` can match multiple types and lead to undefined behavior when
     multiple invocations are made and the types do not match:

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -8,7 +8,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
   class Boomer
     attr_accessor :closed
 
-    def initialize(detailed  = false)
+    def initialize(detailed = false)
       @detailed = detailed
       @closed = false
     end

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -284,7 +284,7 @@ module ActionDispatch
 
       def test_generate_missing_keys_no_matches_different_format_keys
         get "/:controller/:action/:name", to: "foo#bar"
-        primarty_parameters = {
+        primary_parameters = {
           id: 1,
           controller: "tasks",
           action: "show",
@@ -297,9 +297,9 @@ module ActionDispatch
         missing_parameters = {
           missing_key => "task_1"
         }
-        request_parameters = primarty_parameters.merge(redirection_parameters).merge(missing_parameters)
+        request_parameters = primary_parameters.merge(redirection_parameters).merge(missing_parameters)
 
-        message = "No route matches #{Hash[request_parameters.sort_by { |k, v|k.to_s }].inspect}, missing required keys: #{[missing_key.to_sym].inspect}"
+        message = "No route matches #{Hash[request_parameters.sort_by { |k, _|k.to_s }].inspect}, missing required keys: #{[missing_key.to_sym].inspect}"
 
         error = assert_raises(ActionController::UrlGenerationError) do
           @formatter.generate(


### PR DESCRIPTION
1. Replaced unused variables by `_`.
2. Typo fixes.
