### PR TITLE
Action Cable: move channel_name to Channel.broadcasting_for

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Add `Channel::Base#broadcast_to`.
+
+    You can now call `broadcast_to` within a channel action, which equals to
+    the `self.class.broadcast_to`.
+
+    *Vladimir Dementyev*
+
+*   Make `Channel::Base.broadcasting_for` a public API.
+
+    You can use `.broadcasting_for` to generate a unique stream identifier within
+    a channel for the specified target (e.g. Active Record model):
+
+    ```ruby
+    ChatChannel.broadcasting_for(model) # => "chat:<model.to_gid_param>"
+    ```
+
+    *Vladimir Dementyev*
+
+
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
 *   Merge [`action-cable-testing`](https://github.com/palkan/action-cable-testing) to Rails.

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -7,7 +7,7 @@ module ActionCable
     module Broadcasting
       extend ActiveSupport::Concern
 
-      delegate :broadcasting_for, to: :class
+      delegate :broadcasting_for, :broadcast_to, to: :class
 
       module ClassMethods
         # Broadcast a hash to a unique broadcasting for this <tt>model</tt> in this channel.

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -12,17 +12,22 @@ module ActionCable
       module ClassMethods
         # Broadcast a hash to a unique broadcasting for this <tt>model</tt> in this channel.
         def broadcast_to(model, message)
-          ActionCable.server.broadcast(broadcasting_for([ channel_name, model ]), message)
+          ActionCable.server.broadcast(broadcasting_for(model), message)
         end
 
-        def broadcasting_for(model) #:nodoc:
+        # Returns a unique broadcasting identifier for this <tt>model</tt> in this channel.
+        def broadcasting_for(model)
+          serialize_broadcasting([ channel_name, model ])
+        end
+
+        def serialize_broadcasting(object) #:nodoc:
           case
-          when model.is_a?(Array)
-            model.map { |m| broadcasting_for(m) }.join(":")
-          when model.respond_to?(:to_gid_param)
-            model.to_gid_param
+          when object.is_a?(Array)
+            object.map { |m| serialize_broadcasting(m) }.join(":")
+          when object.respond_to?(:to_gid_param)
+            object.to_gid_param
           else
-            model.to_param
+            object.to_param
           end
         end
       end

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -15,7 +15,12 @@ module ActionCable
           ActionCable.server.broadcast(broadcasting_for(model), message)
         end
 
-        # Returns a unique broadcasting identifier for this <tt>model</tt> in this channel.
+        # Returns a unique broadcasting identifier for this <tt>model</tt> in this channel:
+        #
+        #    CommentsChannel.broadcasting_for("all") # => "comments:all"
+        #
+        # You can pass any object as a target (e.g. Active Record model), and it
+        # would be serialized into a string under the hood.
         def broadcasting_for(model)
           serialize_broadcasting([ channel_name, model ])
         end

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -99,7 +99,7 @@ module ActionCable
       # Pass <tt>coder: ActiveSupport::JSON</tt> to decode messages as JSON before passing to the callback.
       # Defaults to <tt>coder: nil</tt> which does no decoding, passes raw messages.
       def stream_for(model, callback = nil, coder: nil, &block)
-        stream_from(broadcasting_for([ channel_name, model ]), callback || block, coder: coder)
+        stream_from(broadcasting_for(model), callback || block, coder: coder)
       end
 
       # Unsubscribes all streams associated with this channel from the pubsub queue.

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -143,7 +143,7 @@ module ActionCable
     # You need to set up your connection manually to provide values for the identifiers.
     # To do this just use:
     #
-    #   stub_connection(user: users[:john])
+    #   stub_connection(user: users(:john))
     #
     # == Testing broadcasting
     #
@@ -157,9 +157,9 @@ module ActionCable
     #  end
     #
     #  def test_speak
-    #    subscribe room_id: rooms[:chat].id
+    #    subscribe room_id: rooms(:chat).id
     #
-    #    assert_broadcasts_on(rooms[:chat], text: "Hello, Rails!") do
+    #    assert_broadcasts_on(rooms(:chat), text: "Hello, Rails!") do
     #      perform :speak, message: "Hello, Rails!"
     #    end
     #  end

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -300,9 +300,7 @@ module ActionCable
           def broadcasting_for(stream_or_object)
             return stream_or_object if stream_or_object.is_a?(String)
 
-            self.class.channel_class.broadcasting_for(
-              [self.class.channel_class.channel_name, stream_or_object]
-            )
+            self.class.channel_class.broadcasting_for(stream_or_object)
           end
       end
 

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -26,14 +26,23 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
   end
 
   test "broadcasting_for with an object" do
-    assert_equal "Room#1-Campfire", ChatChannel.broadcasting_for(Room.new(1))
+    assert_equal(
+      "action_cable:channel:broadcasting_test:chat:Room#1-Campfire",
+      ChatChannel.broadcasting_for(Room.new(1))
+    )
   end
 
   test "broadcasting_for with an array" do
-    assert_equal "Room#1-Campfire:Room#2-Campfire", ChatChannel.broadcasting_for([ Room.new(1), Room.new(2) ])
+    assert_equal(
+      "action_cable:channel:broadcasting_test:chat:Room#1-Campfire:Room#2-Campfire",
+      ChatChannel.broadcasting_for([ Room.new(1), Room.new(2) ])
+    )
   end
 
   test "broadcasting_for with a string" do
-    assert_equal "hello", ChatChannel.broadcasting_for("hello")
+    assert_equal(
+      "action_cable:channel:broadcasting_test:chat:hello",
+      ChatChannel.broadcasting_for("hello")
+    )
   end
 end

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -180,7 +180,7 @@ class BroadcastsTestChannel < ActionCable::Channel::Base
   def broadcast_to_user(data)
     user = User.new user_id
 
-    self.class.broadcast_to user, text: data["message"]
+    broadcast_to user, text: data["message"]
   end
 end
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1806,11 +1806,11 @@ require "test_helper"
 
 class WebNotificationsChannelTest < ActionCable::Channel::TestCase
   test "subscribes and stream for user" do
-    stub_connection current_user: users[:john]
+    stub_connection current_user: users(:john)
 
     subscribe
 
-    assert_has_stream_for users[:john]
+    assert_has_stream_for users(:john)
   end
 end
 ```
@@ -1855,7 +1855,7 @@ class ChatRelayJobTest < ActiveJob::TestCase
   include ActionCable::TestHelper
 
   test "broadcast message to room" do
-    room = rooms[:all]
+    room = rooms(:all)
 
     assert_broadcast_on(ChatChannel.broadcasting_for(room), text: "Hi!") do
       ChatRelayJob.perform_now(room, "Hi!")

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1837,6 +1837,33 @@ class ProductTest < ActionCable::TestCase
 end
 ```
 
+If you want to test the broadcasting made with `Channel.broadcast_to`, you shoud use
+`Channel.broadcasting_for` to generate an underlying stream name:
+
+```ruby
+# app/jobs/chat_relay_job.rb
+class ChatRelayJob < ApplicationJob
+  def perform_later(room, message)
+    ChatChannel.broadcast_to room, text: message
+  end
+end
+
+# test/jobs/chat_relay_job_test.rb
+require 'test_helper'
+
+class ChatRelayJobTest < ActiveJob::TestCase
+  include ActionCable::TestHelper
+
+  test "broadcast message to room" do
+    room = rooms[:all]
+
+    assert_broadcast_on(ChatChannel.broadcasting_for(room), text: "Hi!") do
+      ChatRelayJob.perform_now(room, "Hi!")
+    end
+  end
+end
+```
+
 Additional Testing Resources
 ----------------------------
 


### PR DESCRIPTION
### Summary

That main purpose of this PR is to make the following example _testable_:

```ruby
class ChatRelayJob < ApplicationJob
  def perform_later(room, msg)
    ChatChannel.broadcast_to room, message: msg
  end
end
```

To test this functionality we need to know the underlying stream name
(to use `assert_broadcasts`), which relies on `channel_name`.

We had to use the following code:

```ruby
assert_broadcasts(ChatChannel.broadcasting_for([ChatChannel.channel_name, room]), 1) do
  ChatRelayJob.perform_now
end
```

The problem with this approach is that we use _internal_ API: we shouldn't care about `channel_name` prefix in our code (and how should developers know that it's even used?).

With this commit we could re-write the test as following:

```ruby
 assert_broadcasts(ChatChannel.broadcasting_for(room), 1) do
   ChatRelayJob.perform_now
 end
```

IMO, this refactoring also makes the `broadcasting_for` method much easier to use _internally_, since we should't think about adding a `channel_name` every time we use it (like we did in `channel/streams`).

This PR also adds `Channel#broadcast_to` (we had `#steam_for` but hadn't a shorter syntax for broadcasting for some reason).

**NOTE:** in [`action-cable-testing`](https://github.com/palkan/action-cable-testing) we handled this differently: by adding `channel: ...` option to assertions; but that was a temporary hack since we couldn't change the Rails API.
