### PR TITLE
Corrected spelling of ActionCable::Connection::TestCase

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1775,7 +1775,7 @@ test "connects with cookies" do
 end
 ```
 
-See the API documentation for [`AcionCable::Connection::TestCase`](http://api.rubyonrails.org/classes/ActionCable/Connection/TestCase.html) for more information.
+See the API documentation for [`ActionCable::Connection::TestCase`](http://api.rubyonrails.org/classes/ActionCable/Connection/TestCase.html) for more information.
 
 ### Channel Test Case
 


### PR DESCRIPTION
ActionCable was spelled AcionCable in the link to TestCase towards the bottom of the doc.  Pretty straightforward.