### PR TITLE
Fix attribute typo in ActionCable connection test request

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -42,8 +42,6 @@ module ActionCable
 
     class TestRequest < ActionDispatch::TestRequest
       attr_accessor :session, :cookie_jar
-
-      attr_writer :cookie_jar
     end
 
     module TestConnection


### PR DESCRIPTION
It causes a buzzy warning during ActionCable test running