### PR TITLE
activerecord: Fix statement cache for strictly cast attributes

### DIFF
--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         if defined?(@_unboundable)
           @_unboundable
         else
-          value_for_database
+          value_for_database unless value_before_type_cast.is_a?(StatementCache::Substitute)
           @_unboundable = nil
         end
       rescue ::RangeError

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "models/book"
 require "models/liquid"
 require "models/molecule"
+require "models/numeric_data"
 require "models/electron"
 
 module ActiveRecord
@@ -72,6 +73,11 @@ module ActiveRecord
 
       liquids = cache.execute([], Book.connection)
       assert_equal "salty", liquids[0].name
+    end
+
+    def test_statement_cache_with_strictly_cast_attribute
+      row = NumericData.create(temperature: 1.5)
+      assert_equal row, NumericData.find_by(temperature: 1.5)
     end
 
     def test_statement_cache_values_differ


### PR DESCRIPTION
### Problem

When building the statement for the statement cache (e.g. for `find` or `find_by`) Active Record is passing `ActiveRecord::StatementCache::Substitute` objects into the attribute type's `cast` method.  The return value for these cast calls isn't very important, but it is relying on it not raising an exception when this happens.  For instance, ActiveModel::Type::Float#cast_value will raise an exception when it tries to call `to_f` on this `ActiveRecord::StatementCache::Substitute` object.  This can also be a problem for custom attribute types.

The included regression test shows the problem without the corresponding fix in this PR, because `NumericData.find_by(temperature: 1.5)` causes the following exception to be raised

```
ActiveRecord::StatementCacheTest#test_statement_cache_with_strictly_cast_attribute:
NoMethodError: undefined method `to_f' for #<ActiveRecord::StatementCache::Substitute:0x00007fcc8a2bc948>
Did you mean?  to_s
    /Users/dylansmith/src/rails/activemodel/lib/active_model/type/float.rb:31:in `cast_value'
    /Users/dylansmith/src/rails/activemodel/lib/active_model/type/value.rb:38:in `cast'
    /Users/dylansmith/src/rails/activemodel/lib/active_model/type/helpers/numeric.rb:15:in `cast'
    /Users/dylansmith/src/rails/activemodel/lib/active_model/attribute.rb:55:in `value_for_database'
    /Users/dylansmith/src/rails/activerecord/lib/active_record/relation/query_attribute.rb:13:in `value_for_database'
    /Users/dylansmith/src/rails/activerecord/lib/active_record/relation/query_attribute.rb:35:in `unboundable?'
    /Users/dylansmith/src/rails/activerecord/lib/arel/nodes/bind_param.rb:32:in `unboundable?'
    /Users/dylansmith/src/rails/activerecord/lib/arel/visitors/to_sql.rb:820:in `unboundable?'
    /Users/dylansmith/src/rails/activerecord/lib/arel/visitors/to_sql.rb:632:in `visit_Arel_Nodes_Equality'
```
...

### Solution

The Active Model attribute type shouldn't have to deal with these `ActiveRecord::StatementCache::Substitute` objects, so I changed ActiveRecord::Relation::QueryAttribute#value_for_database to not call `super` if it gets one of these objects.  This class was already special casing these objects, since it already had a type check for them in its `nil?` method.