### PR TITLE
Pass the view around instead of using an ivar

### DIFF
--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -43,14 +43,14 @@ module ActionView
     # For streaming, instead of rendering a given a template, we return a Body
     # object that responds to each. This object is initialized with a block
     # that knows how to render the template.
-    def render_template(template, layout_name = nil, locals = {}) #:nodoc:
+    def render_template(view, template, layout_name = nil, locals = {}) #:nodoc:
       return [super] unless layout_name && template.supports_streaming?
 
       locals ||= {}
       layout   = layout_name && find_layout(layout_name, locals.keys, [formats.first])
 
       Body.new do |buffer|
-        delayed_render(buffer, template, layout, @view, locals)
+        delayed_render(buffer, template, layout, view, locals)
       end
     end
 


### PR DESCRIPTION
If we pass the view instance around it's easier to understand the flow
control.
