### PR TITLE
Fix deeply nested namespace command printing

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix deeply nested namespace command printing.
+
+    *Gannon McGibbon*
+
+
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
 *   Remove deprecated `after_bundle` helper inside plugins templates.

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -115,7 +115,7 @@ module Rails
         # For a Rails::Command::TestCommand placed in <tt>rails/command/test_command.rb</tt>
         # would return <tt>rails/test</tt>.
         def default_command_root
-          path = File.expand_path(File.join("../commands", command_root_namespace), __dir__)
+          path = File.expand_path(relative_command_path, __dir__)
           path if File.exist?(path)
         end
 
@@ -135,12 +135,20 @@ module Rails
           end
 
           def command_root_namespace
-            (namespace.split(":") - %w( rails )).first
+            (namespace.split(":") - %w(rails)).join(":")
+          end
+
+          def relative_command_path
+            File.join("../commands", *command_root_namespace.split(":"))
           end
 
           def namespaced_commands
             commands.keys.map do |key|
-              key == command_root_namespace ? key : "#{command_root_namespace}:#{key}"
+              if command_root_namespace.match?(/(\A|\:)#{key}\z/)
+                command_root_namespace
+              else
+                "#{command_root_namespace}:#{key}"
+              end
             end
           end
       end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -4,10 +4,12 @@ require "abstract_unit"
 require "rails/command"
 require "rails/commands/generate/generate_command"
 require "rails/commands/secrets/secrets_command"
+require "rails/commands/db/system/change/change_command"
 
 class Rails::Command::BaseTest < ActiveSupport::TestCase
   test "printing commands" do
     assert_equal %w(generate), Rails::Command::GenerateCommand.printing_commands
     assert_equal %w(secrets:setup secrets:edit secrets:show), Rails::Command::SecretsCommand.printing_commands
+    assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands
   end
 end


### PR DESCRIPTION
### Summary

Deeply nested commands currently don't get printed properly. See https://github.com/rails/rails/pull/34832#issuecomment-456070659. This should fix that by allowing `Rails::Command::Base#command_root_namespace` to include nested namespace segments, and not just the first one.

I tried making it so `command_root_namespace` excluded the `command_name` as well, but that didn't play nicely with method-based command definition (eg. `SecretsCommand`). The regex I use in `namespaced_commands` is probably not the best approach, any feedback here would be appreciated.