### PR TITLE
Add Worker Pool section to Action Cable configuration docs

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -671,6 +671,21 @@ To configure the URL, add a call to `action_cable_meta_tag` in your HTML layout
 HEAD. This uses a URL or path typically set via `config.action_cable.url` in the
 environment configuration files.
 
+### Worker Pool Configuration
+
+The worker pool is used to run connection callbacks and channel actions in
+isolation from the server's main thread. Action Cable allows the application
+to configure the number of simultaneously processed threads in the worker pool.
+
+```ruby
+config.action_cable.worker_pool_size = 4
+```
+
+Also, note that your server must provide at least the same number of database
+connections as you have workers. The default worker pool size is set to 4, so
+that means you have to make at least 4 database connections available.
+ You can change that in `config/database.yml` through the `pool` attribute.
+
 ### Other Configurations
 
 The other common option to configure is the log tags applied to the
@@ -687,11 +702,6 @@ config.action_cable.log_tags = [
 
 For a full list of all configuration options, see the
 `ActionCable::Server::Configuration` class.
-
-Also, note that your server must provide at least the same number of database
-connections as you have workers. The default worker pool size is set to 4, so
-that means you have to make at least that available. You can change that in
-`config/database.yml` through the `pool` attribute.
 
 ## Running Standalone Cable Servers
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -798,6 +798,9 @@ main application.
 You can set this as nil to not mount Action Cable as part of your
 normal Rails server.
 
+You can find more detailed configuration options in the
+[Action Cable Overview](action_cable_overview.html#configuration).
+
 
 ### Configuring Active Storage
 


### PR DESCRIPTION
Unfortunately, the current state of docs about Worker Pool size is confusing. This configuration option is essential for any production usage, it's slightly covered in the Action Cable Overview but it's impossible to understand its importance and real usage without digging into the code. 

The proposed changes are trying to eliminate the confusion.