### PR TITLE
Move compiled ERB to an AV::Base subclass

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -9,11 +9,6 @@ module ActionDispatch
   class DebugView < ActionView::Base # :nodoc:
     RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
 
-    module CompiledTemplates
-    end
-
-    include CompiledTemplates
-
     def initialize(assigns)
       paths = [RESCUES_TEMPLATE_PATH]
       renderer = ActionView::Renderer.new ActionView::LookupContext.new(paths)
@@ -21,7 +16,7 @@ module ActionDispatch
     end
 
     def compiled_method_container
-      CompiledTemplates
+      self.class
     end
 
     def debug_params(params)

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -9,10 +9,19 @@ module ActionDispatch
   class DebugView < ActionView::Base # :nodoc:
     RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
 
+    module CompiledTemplates
+    end
+
+    include CompiledTemplates
+
     def initialize(assigns)
       paths = [RESCUES_TEMPLATE_PATH]
       renderer = ActionView::Renderer.new ActionView::LookupContext.new(paths)
       super(renderer, assigns)
+    end
+
+    def compiled_method_container
+      CompiledTemplates
     end
 
     def debug_params(params)

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   ActionView::Template.finalize_compiled_template_methods is deprecated with
+    no replacement.
+
+*   config.action_view.finalize_compiled_template_methods is deprecated with
+    no replacement.
+
 *   Ensure unique DOM IDs for collection inputs with float values.
     Fixes #34974
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,8 +1,12 @@
 *   ActionView::Template.finalize_compiled_template_methods is deprecated with
     no replacement.
 
+    *tenderlove*
+
 *   config.action_view.finalize_compiled_template_methods is deprecated with
     no replacement.
+
+    *tenderlove*
 
 *   Ensure unique DOM IDs for collection inputs with float values.
     Fixes #34974

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -35,7 +35,6 @@ module ActionView
   eager_autoload do
     autoload :Base
     autoload :Context
-    autoload :CompiledTemplates, "action_view/context"
     autoload :Digestor
     autoload :Helpers
     autoload :LookupContext

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -185,8 +185,13 @@ module ActionView #:nodoc:
         template_container = Module.new
         Class.new(self) {
           include template_container
-          define_method(:compiled_method_container) { template_container }
+          define_method(:compiled_method_container)           { template_container }
+          define_singleton_method(:compiled_method_container) { template_container }
         }
+      end
+
+      def changed?(other) # :nodoc:
+        compiled_method_container != other.compiled_method_container
       end
     end
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -268,7 +268,11 @@ module ActionView #:nodoc:
     end
 
     def compiled_method_container
-      raise NotImplementedError
+      raise NotImplementedError, <<~msg
+        Subclasses of ActionView::Base must implement `compiled_method_container`
+        or use the class method `with_empty_template_cache` for constructing
+        an ActionView::Base subclass thata has an empty cache.
+      msg
     end
 
     ActiveSupport.run_load_hooks(:action_view, self)

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -182,11 +182,12 @@ module ActionView #:nodoc:
       end
 
       def with_empty_template_cache # :nodoc:
-        template_container = Module.new
-        Class.new(self) {
-          include template_container
-          define_method(:compiled_method_container)           { template_container }
-          define_singleton_method(:compiled_method_container) { template_container }
+        subclass = Class.new(self) {
+          # We can't implement these as self.class because subclasses will
+          # share the same template cache as superclasses, so "changed?" won't work
+          # correctly.
+          define_method(:compiled_method_container)           { subclass }
+          define_singleton_method(:compiled_method_container) { subclass }
         }
       end
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -271,7 +271,7 @@ module ActionView #:nodoc:
       raise NotImplementedError, <<~msg
         Subclasses of ActionView::Base must implement `compiled_method_container`
         or use the class method `with_empty_template_cache` for constructing
-        an ActionView::Base subclass thata has an empty cache.
+        an ActionView::Base subclass that has an empty cache.
       msg
     end
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -11,10 +11,6 @@ require "action_view/template"
 require "action_view/lookup_context"
 
 module ActionView #:nodoc:
-  module CompiledTemplates #:nodoc:
-    # holds compiled template code
-  end
-
   # = Action View Base
   #
   # Action View templates can be written in several ways.
@@ -146,8 +142,6 @@ module ActionView #:nodoc:
   class Base
     include Helpers, ::ERB::Util, Context
 
-    include CompiledTemplates
-
     # Specify the proc used to decorate input tags that refer to attributes with errors.
     cattr_accessor :field_error_proc, default: Proc.new { |html_tag, instance| "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe }
 
@@ -185,6 +179,14 @@ module ActionView #:nodoc:
 
       def xss_safe? #:nodoc:
         true
+      end
+
+      def with_empty_template_cache # :nodoc:
+        template_container = Module.new
+        Class.new(self) {
+          include template_container
+          define_method(:compiled_method_container) { template_container }
+        }
       end
     end
 
@@ -260,7 +262,7 @@ module ActionView #:nodoc:
     end
 
     def compiled_method_container
-      CompiledTemplates
+      raise NotImplementedError
     end
 
     ActiveSupport.run_load_hooks(:action_view, self)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -68,11 +68,16 @@ module ActionView
       end
 
       def self.clear
+        @view_context_class = nil
         @details_keys.clear
       end
 
       def self.digest_caches
         @details_keys.values
+      end
+
+      def self.view_context_class(klass)
+        @view_context_class ||= klass.with_empty_template_cache
       end
     end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -6,10 +6,13 @@ require "rails"
 module ActionView
   # = Action View Railtie
   class Railtie < Rails::Engine # :nodoc:
+    NULL_OPTION = Object.new
+
     config.action_view = ActiveSupport::OrderedOptions.new
     config.action_view.embed_authenticity_token_in_remote_forms = nil
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
+    config.action_view.finalize_compiled_template_methods = NULL_OPTION
 
     config.eager_load_namespaces << ActionView
 
@@ -41,6 +44,16 @@ module ActionView
         default_enforce_utf8 = app.config.action_view.delete(:default_enforce_utf8)
         unless default_enforce_utf8.nil?
           ActionView::Helpers::FormTagHelper.default_enforce_utf8 = default_enforce_utf8
+        end
+      end
+    end
+
+    initializer "action_view.finalize_compiled_template_methods" do |app|
+      ActiveSupport.on_load(:action_view) do
+        option = app.config.action_view.delete(:finalize_compiled_template_methods)
+
+        if option != NULL_OPTION
+          ActiveSupport::Deprecation.warn "action_view.finalize_compiled_template_methods is deprecated and has no effect"
         end
       end
     end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -10,7 +10,6 @@ module ActionView
     config.action_view.embed_authenticity_token_in_remote_forms = nil
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
-    config.action_view.finalize_compiled_template_methods = true
 
     config.eager_load_namespaces << ActionView
 
@@ -43,13 +42,6 @@ module ActionView
         unless default_enforce_utf8.nil?
           ActionView::Helpers::FormTagHelper.default_enforce_utf8 = default_enforce_utf8
         end
-      end
-    end
-
-    initializer "action_view.finalize_compiled_template_methods" do |app|
-      ActiveSupport.on_load(:action_view) do
-        ActionView::Template.finalize_compiled_template_methods =
-          app.config.action_view.delete(:finalize_compiled_template_methods)
       end
     end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -36,21 +36,12 @@ module ActionView
 
     module ClassMethods
       def view_context_class
-        @view_context_class ||= begin
-          supports_path = supports_path?
-          routes  = respond_to?(:_routes)  && _routes
-          helpers = respond_to?(:_helpers) && _helpers
+        klass = ActionView::LookupContext::DetailsKey.view_context_class(ActionView::Base)
 
-          Class.new(ActionView::Base) do
-            if routes
-              include routes.url_helpers(supports_path)
-              include routes.mounted_helpers
-            end
+        @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
 
-            if helpers
-              include helpers
-            end
-          end
+        if klass.changed?(@view_context_class)
+          @view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
         end
       end
     end

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -35,14 +35,35 @@ module ActionView
     end
 
     module ClassMethods
+      def _routes
+      end
+
+      def _helpers
+      end
+
+      def build_av_class(klass, supports_path, routes, helpers)
+        Class.new(klass) do
+          if routes
+            include routes.url_helpers(supports_path)
+            include routes.mounted_helpers
+          end
+
+          if helpers
+            include helpers
+          end
+        end
+      end
+
       def view_context_class
         klass = ActionView::LookupContext::DetailsKey.view_context_class(ActionView::Base)
 
-        @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
+        @view_context_class ||= build_av_class(klass, supports_path?, _routes, _helpers)
 
         if klass.changed?(@view_context_class)
-          @view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
+          @view_context_class = build_av_class(klass, supports_path?, _routes, _helpers)
         end
+
+        @view_context_class
       end
     end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -41,7 +41,7 @@ module ActionView
       def _helpers
       end
 
-      def build_av_class(klass, supports_path, routes, helpers)
+      def build_view_context_class(klass, supports_path, routes, helpers)
         Class.new(klass) do
           if routes
             include routes.url_helpers(supports_path)
@@ -57,10 +57,10 @@ module ActionView
       def view_context_class
         klass = ActionView::LookupContext::DetailsKey.view_context_class(ActionView::Base)
 
-        @view_context_class ||= build_av_class(klass, supports_path?, _routes, _helpers)
+        @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
 
         if klass.changed?(@view_context_class)
-          @view_context_class = build_av_class(klass, supports_path?, _routes, _helpers)
+          @view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
         end
 
         @view_context_class

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/kernel/singleton_class"
+require "active_support/deprecation"
 require "thread"
 require "delegate"
 
@@ -9,6 +10,14 @@ module ActionView
   # = Action View Template
   class Template
     extend ActiveSupport::Autoload
+
+    def self.finalize_compiled_template_methods
+      ActiveSupport::Deprecation.warn "ActionView::Template.finalize_compiled_template_methods is deprecated and has no effect"
+    end
+
+    def self.finalize_compiled_template_methods=(_)
+      ActiveSupport::Deprecation.warn "ActionView::Template.finalize_compiled_template_methods= is deprecated and has no effect"
+    end
 
     # === Encodings in ActionView::Template
     #

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -10,8 +10,6 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
-    mattr_accessor :finalize_compiled_template_methods, default: true
-
     # === Encodings in ActionView::Template
     #
     # ActionView::Template is one of a few sources of potential
@@ -117,16 +115,6 @@ module ActionView
     attr_accessor :locals, :formats, :variants, :virtual_path
 
     attr_reader :source, :identifier, :handler, :original_encoding, :updated_at
-
-    # This finalizer is needed (and exactly with a proc inside another proc)
-    # otherwise templates leak in development.
-    Finalizer = proc do |method_name, mod| # :nodoc:
-      proc do
-        mod.module_eval do
-          remove_possible_method method_name
-        end
-      end
-    end
 
     attr_reader :variable
 
@@ -337,9 +325,6 @@ module ActionView
         end
 
         mod.module_eval(source, identifier, 0)
-        if finalize_compiled_template_methods
-          ObjectSpace.define_finalizer(self, Finalizer[method_name, mod])
-        end
       end
 
       def handle_render_error(view, e)

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -48,7 +48,8 @@ module RenderERBUtils
     @view ||= begin
       path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
       view_paths = ActionView::PathSet.new([path])
-      ActionView::Base.with_view_paths(view_paths)
+      view = ActionView::Base.with_empty_template_cache
+      view.with_view_paths(view_paths)
     end
   end
 
@@ -61,7 +62,8 @@ module RenderERBUtils
       ActionView::Template.handler_for_extension(:erb),
       {})
 
-    template.render(ActionView::Base.empty, {}).strip
+    view = ActionView::Base.with_empty_template_cache
+    template.render(view.empty, {}).strip
   end
 end
 

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -10,8 +10,10 @@ class MultifetchCacheTest < ActiveRecordTestCase
 
   def setup
     view_paths = ActionController::Base.view_paths
+    view_paths.each(&:clear_cache)
+    ActionView::LookupContext.fallbacks.each(&:clear_cache)
 
-    @view = Class.new(ActionView::Base) do
+    @view = Class.new(ActionView::Base.with_empty_template_cache) do
       def view_cache_dependencies
         []
       end

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -3,7 +3,18 @@
 require "abstract_unit"
 
 class CompiledTemplatesTest < ActiveSupport::TestCase
-  teardown do
+  attr_reader :view_class
+
+  def setup
+    super
+    view_paths     = ActionController::Base.view_paths
+    view_paths.each(&:clear_cache)
+    ActionView::LookupContext.fallbacks.each(&:clear_cache)
+    @view_class = ActionView::Base.with_empty_template_cache
+  end
+
+  def teardown
+    super
     ActionView::LookupContext::DetailsKey.clear
   end
 
@@ -72,13 +83,13 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
     def render_with_cache(*args)
       view_paths = ActionController::Base.view_paths
-      ActionView::Base.with_view_paths(view_paths, {}).render(*args)
+      view_class.with_view_paths(view_paths, {}).render(*args)
     end
 
     def render_without_cache(*args)
       path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
       view_paths = ActionView::PathSet.new([path])
-      ActionView::Base.with_view_paths(view_paths, {}).render(*args)
+      view_class.with_view_paths(view_paths, {}).render(*args)
     end
 
     def modify_template(template, content)

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -7,7 +7,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
   def setup
     super
-    view_paths     = ActionController::Base.view_paths
+    view_paths = ActionController::Base.view_paths
     view_paths.each(&:clear_cache)
     ActionView::LookupContext.fallbacks.each(&:clear_cache)
     @view_class = ActionView::Base.with_empty_template_cache

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -11,7 +11,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   def setup
     super
 
-    view_paths     = ActionController::Base.view_paths
+    view_paths = ActionController::Base.view_paths
     view_paths.each(&:clear_cache)
     ActionView::LookupContext.fallbacks.each(&:clear_cache)
 

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -12,9 +12,12 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     super
 
     view_paths     = ActionController::Base.view_paths
+    view_paths.each(&:clear_cache)
+    ActionView::LookupContext.fallbacks.each(&:clear_cache)
+
     lookup_context = ActionView::LookupContext.new(view_paths, {}, ["test"])
     renderer       = ActionView::Renderer.new(lookup_context)
-    @view          = ActionView::Base.new(renderer, {})
+    @view          = ActionView::Base.with_empty_template_cache.new(renderer, {})
 
     ActionView::LogSubscriber.attach_to :action_view
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -19,15 +19,8 @@ module RenderTestCases
     end.with_view_paths(paths, @assigns)
 
     controller = TestController.new
-    view = @view
 
-    @controller_view = Class.new(controller.view_context_class) do
-      include view.compiled_method_container
-
-      define_method(:compiled_method_container) do
-        view.compiled_method_container
-      end
-    end.new(controller.view_renderer, controller.view_assigns, controller)
+    @controller_view = controller.view_context_class.with_empty_template_cache.new(controller.view_renderer, controller.view_assigns, controller)
 
     # Reload and register danish language for testing
     I18n.backend.store_translations "da", {}

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -8,8 +8,11 @@ end
 class SetupFiberedBase < ActiveSupport::TestCase
   def setup
     view_paths = ActionController::Base.view_paths
+    view_paths.each(&:clear_cache)
+    ActionView::LookupContext.fallbacks.each(&:clear_cache)
+
     @assigns = { secret: "in the sauce", name: nil }
-    @view = ActionView::Base.with_view_paths(view_paths, @assigns)
+    @view = ActionView::Base.with_empty_template_cache.with_view_paths(view_paths, @assigns)
     @controller_view = TestController.new.view_context
   end
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -20,6 +20,7 @@ class TestERBTemplate < ActiveSupport::TestCase
 
   class Context < ActionView::Base
     def initialize
+      super
       @output_buffer = "original"
       @virtual_path = nil
     end
@@ -63,7 +64,8 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def setup
-    @context = Context.new
+    @context = Context.with_empty_template_cache.new
+    super
   end
 
   def test_basic_template

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -19,7 +19,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   class Context < ActionView::Base
-    def initialize
+    def initialize(*)
       super
       @output_buffer = "original"
       @virtual_path = nil
@@ -64,7 +64,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def setup
-    @context = Context.with_empty_template_cache.new
+    @context = Context.with_empty_template_cache.empty
     super
   end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -36,7 +36,10 @@ class TranslationHelperTest < ActiveSupport::TestCase
         }
       }
     )
-    @view = ::ActionView::Base.with_view_paths(ActionController::Base.view_paths, {})
+    view_paths     = ActionController::Base.view_paths
+    view_paths.each(&:clear_cache)
+    ActionView::LookupContext.fallbacks.each(&:clear_cache)
+    @view = ::ActionView::Base.with_empty_template_cache.with_view_paths(view_paths, {})
   end
 
   teardown do

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -36,7 +36,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
         }
       }
     )
-    view_paths     = ActionController::Base.view_paths
+    view_paths = ActionController::Base.view_paths
     view_paths.each(&:clear_cache)
     ActionView::LookupContext.fallbacks.each(&:clear_cache)
     @view = ::ActionView::Base.with_empty_template_cache.with_view_paths(view_paths, {})

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -590,13 +590,6 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.default_enforce_utf8` determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8. This defaults to `false`.
 
-* `config.action_view.finalize_compiled_template_methods` determines
-  whether the methods on `ActionView::CompiledTemplates` that templates
-  compile themselves to are removed when template instances are
-  destroyed by the garbage collector. This helps prevent memory leaks in
-  development mode, but for large test suites, disabling this option in
-  the test environment can improve performance. This defaults to `true`.
-
 
 ### Configuring Action Mailbox
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -48,7 +48,4 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-
-  # Prevent expensive template finalization at end of test suite runs.
-  config.action_view.finalize_compiled_template_methods = false
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2092,6 +2092,27 @@ module ApplicationTests
       assert_equal true, ActionView::Helpers::FormTagHelper.default_enforce_utf8
     end
 
+    test "ActionView::Template.finalize_compiled_template_methods is true by default" do
+      app "test"
+      assert_deprecated do
+        ActionView::Template.finalize_compiled_template_methods
+      end
+    end
+
+    test "ActionView::Template.finalize_compiled_template_methods can be configured via config.action_view.finalize_compiled_template_methods" do
+      app_file "config/environments/test.rb", <<-RUBY
+      Rails.application.configure do
+        config.action_view.finalize_compiled_template_methods = false
+      end
+      RUBY
+
+      app "test"
+
+      assert_deprecated do
+        ActionView::Template.finalize_compiled_template_methods
+      end
+    end
+
     test "ActiveJob::Base.return_false_on_aborted_enqueue is true by default" do
       app "development"
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2092,23 +2092,6 @@ module ApplicationTests
       assert_equal true, ActionView::Helpers::FormTagHelper.default_enforce_utf8
     end
 
-    test "ActionView::Template.finalize_compiled_template_methods is true by default" do
-      app "test"
-      assert_equal true, ActionView::Template.finalize_compiled_template_methods
-    end
-
-    test "ActionView::Template.finalize_compiled_template_methods can be configured via config.action_view.finalize_compiled_template_methods" do
-      app_file "config/environments/test.rb", <<-RUBY
-      Rails.application.configure do
-        config.action_view.finalize_compiled_template_methods = false
-      end
-      RUBY
-
-      app "test"
-
-      assert_equal false, ActionView::Template.finalize_compiled_template_methods
-    end
-
     test "ActiveJob::Base.return_false_on_aborted_enqueue is true by default" do
       app "development"
 


### PR DESCRIPTION
This is part one for https://github.com/rails/rails/issues/35032

This PR moves methods generated from ERB to a subclass of `AV::Base`.  I was able to verify that the `AV::Base` subclass is thrown away every time `DetailsKey` gets cleared, so I also removed the finalizer from the Template object as we don't need to remove methods anymore.

The good news is that the number of available methods seen from an ERB file is now constant:

<img width="398" alt="untitled 2019-01-23 16-00-57" src="https://user-images.githubusercontent.com/3124/51645226-18fe9080-1f28-11e9-808f-cd00080cac84.png">

The bad news is that we are still leaking memory:

<img width="421" alt="untitled 2019-01-23 16-01-41" src="https://user-images.githubusercontent.com/3124/51645241-329fd800-1f28-11e9-943f-9905bf3b6405.png">

This patch doesn't fix the unbounded growth of [this cache](https://github.com/rails/rails/blob/52af51c08a48ea7c6e0df09e2470a66a3141087d/actionview/lib/action_view/template/resolver.rb#L73), so it isn't surprising that we still leak.  The good news is that the leak is slower, before this patch we leak about 137 objects per request, after we leak about 111 objects per request.

I think the next step is to move [this cache](https://github.com/rails/rails/blob/52af51c08a48ea7c6e0df09e2470a66a3141087d/actionview/lib/action_view/template/resolver.rb#L73) on to the `DetailsKey` cache, so they both get cleared at the same time.

After that, we need to give `DetailsKey` a better name.