### PR TITLE
Fix document formatting on Action Text docs [ci skip]

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -4,7 +4,7 @@ module ActionText
   module TagHelper
     cattr_accessor(:id, instance_accessor: false) { 0 }
 
-    # Returns a `trix-editor` tag that instantiates the Trix JavaScript editor as well as a hidden field
+    # Returns a +trix-editor+ tag that instantiates the Trix JavaScript editor as well as a hidden field
     # that Trix will write to on changes, so the content will be sent on form submissions.
     #
     # ==== Options
@@ -50,7 +50,7 @@ module ActionView::Helpers
   end
 
   module FormHelper
-    # Returns a `trix-editor` tag that instantiates the Trix JavaScript editor as well as a hidden field
+    # Returns a +trix-editor+ tag that instantiates the Trix JavaScript editor as well as a hidden field
     # that Trix will write to on changes, so the content will be sent on form submissions.
     #
     # ==== Options

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module ActionText
-  # The RichText record holds the content produced by the Trix editor in a serialized `body` attribute.
+  # The RichText record holds the content produced by the Trix editor in a serialized +body+ attribute.
   # It also holds all the references to the embedded files, which are stored using Active Storage.
   # This record is then associated with the Active Record model the application desires to have
-  # rich text content using the `has_rich_text` class method.
+  # rich text content using the +has_rich_text+ class method.
   class RichText < ActiveRecord::Base
     self.table_name = "action_text_rich_texts"
 


### PR DESCRIPTION
### Summary

Use `+` instead of backquote.

There are some backquotes in Action Text document.
This PR replace them to `+` to amend docs.
