### PR TITLE
Fix error raised when handler doesn't exist

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1006,7 +1006,16 @@ module ActiveRecord
       # for (not necessarily the current class).
       def retrieve_connection(spec_name) #:nodoc:
         pool = retrieve_connection_pool(spec_name)
-        raise ConnectionNotEstablished, "No connection pool with '#{spec_name}' found." unless pool
+
+        unless pool
+          # multiple database application
+          if ActiveRecord::Base.connection_handler != ActiveRecord::Base.default_connection_handler
+            raise ConnectionNotEstablished, "No connection pool with '#{spec_name}' found for the '#{ActiveRecord::Base.current_role}' role."
+          else
+            raise ConnectionNotEstablished, "No connection pool with '#{spec_name}' found."
+          end
+        end
+
         pool.connection
       end
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -158,10 +158,6 @@ module ActiveRecord
     end
 
     def with_handler(handler_key, &blk) # :nodoc:
-      unless ActiveRecord::Base.connection_handlers.keys.include?(handler_key)
-        raise ArgumentError, "The #{handler_key} role does not exist. Add it by establishing a connection with `connects_to` or use an existing role (#{ActiveRecord::Base.connection_handlers.keys.join(", ")})."
-      end
-
       handler = lookup_connection_handler(handler_key)
       swap_connection_handler(handler, &blk)
     end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -336,13 +336,13 @@ module ActiveRecord
       end
 
       def test_calling_connected_to_on_a_non_existent_handler_raises
-        error = assert_raises ArgumentError do
+        error = assert_raises ActiveRecord::ConnectionNotEstablished do
           ActiveRecord::Base.connected_to(role: :reading) do
-            yield
+            Person.first
           end
         end
 
-        assert_equal "The reading role does not exist. Add it by establishing a connection with `connects_to` or use an existing role (writing).", error.message
+        assert_equal "No connection pool with 'primary' found for the 'reading' role.", error.message
       end
     end
   end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -29,6 +29,14 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
     end
   end
 
+  def test_error_message_when_connection_not_established
+    error = assert_raise(ActiveRecord::ConnectionNotEstablished) do
+      TestRecord.find(1)
+    end
+
+    assert_equal "No connection pool with 'primary' found.", error.message
+  end
+
   def test_underlying_adapter_no_longer_active
     assert_not @underlying.active?, "Removed adapter should no longer be active"
   end


### PR DESCRIPTION
While working on another feature for multiple databases (auto-switching)
I observed that in development the first request won't autoload the
application record connection for the primary database and may not yet
know about the replica connection.

In my test application this caused the application to thrown an error if
I tried to send the first request to the replica before the replica was
connected. This wouldn't be an issue in production because the
application is preloaded.

In order to fix this I decided to leave the original error message and
delete the new error message. I updated the original error message to
include the `role` to make it a bit clearer that the connection isn't
established for that particular role.

The error now reads:

```
No connection pool with 'primary' found for the 'reading' role.
```

cc/ @tenderlove @rafaelfranca @matthewd 