### PR TITLE
include the content type when uploading to S3

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -16,9 +16,9 @@ module ActiveStorage
       @upload_options = upload
     end
 
-    def upload(key, io, checksum: nil, **)
+    def upload(key, io, checksum: nil, content_type: nil, **)
       instrument :upload, key: key, checksum: checksum do
-        object_for(key).put(upload_options.merge(body: io, content_md5: checksum))
+        object_for(key).put(upload_options.merge(body: io, content_md5: checksum, content_type: content_type))
       rescue Aws::S3::Errors::BadDigest
         raise ActiveStorage::IntegrityError
       end

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -59,6 +59,24 @@ if SERVICE_CONFIGURATIONS[:s3]
         service.delete key
       end
     end
+
+    test "upload with content type" do
+      key          = SecureRandom.base58(24)
+      data         = "Something else entirely!"
+      content_type = "text/plain"
+
+      @service.upload(
+        key,
+        StringIO.new(data),
+        checksum: Digest::MD5.base64digest(data),
+        filename: "cool_data.txt",
+        content_type: content_type
+      )
+
+      assert_equal content_type, @service.bucket.object(key).content_type
+    ensure
+      @service.delete key
+    end
   end
 else
   puts "Skipping S3 Service tests because no S3 configuration was supplied"


### PR DESCRIPTION
### Summary

Content Type is provided by many callers of `.upload`, but the S3 service was discarding this information. This change makes it included so that it gets set on the S3 object's metadata.

### Other Information

Our company happens to use ActiveStorage with S3 in a slightly non-standard way, which brought this issue to our attention. We use ActiveStorage to manage all of the attach/detach/upload/download and so on, but instead of generating signed private URLS, we serve up public URLs to a CloudFront distribution backed by the same S3 bucket. For our use-case in particular, it would be good to have Content-Type included with the objects in S3 so that caches and browsers behave properly when they access the content.