### PR TITLE
Fix partial renderer assuming `locals` responds to `symbolize_keys`

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -363,7 +363,7 @@ module ActionView
         @options = options
         @block   = block
 
-        @locals  = options[:locals] ? options[:locals].symbolize_keys : {}
+        @locals  = options[:locals] || {}
         @details = extract_details(options)
 
         prepend_formats(options[:formats])

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -485,10 +485,6 @@ class TestController < ActionController::Base
     render partial: "customer", locals: { customer: Customer.new("david") }
   end
 
-  def partial_with_string_locals
-    render partial: "customer", locals: { "customer" => Customer.new("david") }
-  end
-
   def partial_with_form_builder
     render partial: ActionView::Helpers::FormBuilder.new(:post, nil, view_context, {})
   end
@@ -691,7 +687,6 @@ class RenderTest < ActionController::TestCase
     get :partial_with_locals, to: "test#partial_with_locals"
     get :partial_with_nested_object, to: "test#partial_with_nested_object"
     get :partial_with_nested_object_shorthand, to: "test#partial_with_nested_object_shorthand"
-    get :partial_with_string_locals, to: "test#partial_with_string_locals"
     get :partials_list, to: "test#partials_list"
     get :render_action_hello_world, to: "test#render_action_hello_world"
     get :render_action_hello_world_as_string, to: "test#render_action_hello_world_as_string"
@@ -1289,11 +1284,6 @@ class RenderTest < ActionController::TestCase
 
   def test_partial_with_locals
     get :partial_with_locals
-    assert_equal "Hello: david", @response.body
-  end
-
-  def test_partial_with_string_locals
-    get :partial_with_string_locals
     assert_equal "Hello: david", @response.body
   end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -485,6 +485,10 @@ class TestController < ActionController::Base
     render partial: "customer", locals: { customer: Customer.new("david") }
   end
 
+  def partial_with_hashlike_locals
+    render partial: "customer", locals: ActionController::Parameters.new(customer: Customer.new("david"))
+  end
+
   def partial_with_form_builder
     render partial: ActionView::Helpers::FormBuilder.new(:post, nil, view_context, {})
   end
@@ -687,6 +691,7 @@ class RenderTest < ActionController::TestCase
     get :partial_with_locals, to: "test#partial_with_locals"
     get :partial_with_nested_object, to: "test#partial_with_nested_object"
     get :partial_with_nested_object_shorthand, to: "test#partial_with_nested_object_shorthand"
+    get :partial_with_hashlike_locals, to: "test#partial_with_hashlike_locals"
     get :partials_list, to: "test#partials_list"
     get :render_action_hello_world, to: "test#render_action_hello_world"
     get :render_action_hello_world_as_string, to: "test#render_action_hello_world_as_string"
@@ -1284,6 +1289,11 @@ class RenderTest < ActionController::TestCase
 
   def test_partial_with_locals
     get :partial_with_locals
+    assert_equal "Hello: david", @response.body
+  end
+
+  def test_partial_with_hashlike_locals
+    get :partial_with_hashlike_locals
     assert_equal "Hello: david", @response.body
   end
 


### PR DESCRIPTION
### Summary

Since https://github.com/rails/rails/pull/30647 was merged, partial renderer does not play well with anything that is passed to `locals` which does not respond to `symbolize_keys`.

Before the PR, the `locals` option value was passed along untouched, or was substituted with an emtpy hash if it wasn't supplied. The PR added an operation to symbolize keys of the passed object which ends up making an assumption that the option value will always be a Hash.

There are legitimate cases, however, where a Hash-like object could be supplied instead, like an `ActionController::Parameters` instance, which does not respond to `symbolize_keys`.

This PR reverts the changes made in the previous PR to restore the use of symbols as the only supported method of passing in values.

An extra test is included that explicitly checks the case where a Hash-like object is supplied as the `locals` option.