### PR TITLE
Make `And` and `Case` into expression nodes

### DIFF
--- a/activerecord/lib/arel/nodes/and.rb
+++ b/activerecord/lib/arel/nodes/and.rb
@@ -2,7 +2,7 @@
 
 module Arel # :nodoc: all
   module Nodes
-    class And < Arel::Nodes::Node
+    class And < Arel::Nodes::NodeExpression
       attr_reader :children
 
       def initialize(children)

--- a/activerecord/lib/arel/nodes/case.rb
+++ b/activerecord/lib/arel/nodes/case.rb
@@ -2,9 +2,7 @@
 
 module Arel # :nodoc: all
   module Nodes
-    class Case < Arel::Nodes::Node
-      include Arel::AliasPredication
-
+    class Case < Arel::Nodes::NodeExpression
       attr_accessor :case, :conditions, :default
 
       def initialize(expression = nil, default = nil)

--- a/activerecord/test/cases/arel/nodes/and_test.rb
+++ b/activerecord/test/cases/arel/nodes/and_test.rb
@@ -16,6 +16,15 @@ module Arel
           assert_equal 2, array.uniq.size
         end
       end
+
+      describe "functions as node expression" do
+        it "allows aliasing" do
+          aliased = And.new(["foo", "bar"]).as("baz")
+
+          assert_kind_of As, aliased
+          assert_kind_of SqlLiteral, aliased.right
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allows aliasing, predications, ordering, and various other functions on `And` and `Case` nodes. This brings them in line with other nodes like `Binary` and `Unary`.

This is following up on #35006.
