### PR TITLE
Fixed a bug where the debug view does not show the error page properly

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -31,14 +31,26 @@ module ActionDispatch
       "ActionController::MissingExactTemplate" => "missing_exact_template",
     )
 
+    cattr_accessor :wrapper_exceptions, default: [
+      "ActionView::Template::Error"
+    ]
+
     attr_reader :backtrace_cleaner, :exception, :wrapped_causes, :line_number, :file
 
     def initialize(backtrace_cleaner, exception)
       @backtrace_cleaner = backtrace_cleaner
-      @exception = original_exception(exception)
+      @exception = exception
       @wrapped_causes = wrapped_causes_for(exception, backtrace_cleaner)
 
       expand_backtrace if exception.is_a?(SyntaxError) || exception.cause.is_a?(SyntaxError)
+    end
+
+    def unwrapped_exception
+      if wrapper_exceptions.include?(exception.class.to_s)
+        exception.cause
+      else
+        exception
+      end
     end
 
     def rescue_template
@@ -46,7 +58,7 @@ module ActionDispatch
     end
 
     def status_code
-      self.class.status_code_for_exception(@exception.class.name)
+      self.class.status_code_for_exception(unwrapped_exception.class.name)
     end
 
     def application_trace
@@ -120,14 +132,6 @@ module ActionDispatch
 
       def backtrace
         Array(@exception.backtrace)
-      end
-
-      def original_exception(exception)
-        if @@rescue_responses.has_key?(exception.cause.class.name)
-          exception.cause
-        else
-          exception
-        end
       end
 
       def causes_for(exception)

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -45,7 +45,7 @@ module ActionDispatch
         backtrace_cleaner = request.get_header "action_dispatch.backtrace_cleaner"
         wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
         status  = wrapper.status_code
-        request.set_header "action_dispatch.exception", wrapper.exception
+        request.set_header "action_dispatch.exception", wrapper.unwrapped_exception
         request.set_header "action_dispatch.original_path", request.path_info
         request.path_info = "/#{status}"
         response = @exceptions_app.call(request.env)


### PR DESCRIPTION
fixes #33414
cc @SzNagyMisu

There are two cases where the debug view does not show the error details properly:

 * When the cause is mapped to an HTTP status code the last exception is unexpectedly unwrapped
 * When the last error is thrown from a view template the debug view is not using the `lib/action_dispatch/middleware/templates/rescues/template_error.html.erb` to generate the view

Both the cases could be fixed by not unwrapping the exception. The only case where the exception should be unwrapped is when the last error is an `ActionView::Template::Error` object. In this case the HTTP status code is determined based on the cause.

There are actually more wrapper exceptions that are intentionally thrown from within Rails. However, there is a consistent pattern of setting the original message and original backtrace to the wrapper exception, implemented at:

 * [`ActionController::BadRequest`](https://github.com/rails/rails/blob/5f7d5995a65d97f2592213889672e9c4799556ec/actionpack/lib/action_controller/metal/exceptions.rb#L9-L10)
 * [`ActionDispatch::Session::SessionRestoreError`](https://github.com/rails/rails/blob/5f7d5995a65d97f2592213889672e9c4799556ec/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L13-L16)
 * [`ActiveJob::DeserializationError`](https://github.com/rails/rails/blob/5f7d5995a65d97f2592213889672e9c4799556ec/activejob/lib/active_job/arguments.rb#L11-L12)
 * [`ActiveRecord`](https://github.com/rails/rails/blob/5f7d5995a65d97f2592213889672e9c4799556ec/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L620-L628)

So the debug view will not lose the information about what went wrong eariler.

(I might have missed a few more, please let me know if there's something missing)

## Case 1: When the cause is in `rescue_responses`

Given that you have the following in your controller:

```ruby
def create
  @book = Book.new(book_params)
  ...
rescue ActionController::ParameterMissing
  method_that_has_typo
end
```

Then this PR fixes the left to look like the right:

<img width="2163" alt="fixed-case-1" src="https://user-images.githubusercontent.com/386234/51716387-913d8280-200a-11e9-9748-30dc3bd58997.png">

## Case 1: When an error is thrown from a view

Given that you have:

```erb
<%
  raise ActiveRecord::RecordNotFound
%>
```

Then this PR fixes the left to look like the right:

<img width="2169" alt="fixed-case-2" src="https://user-images.githubusercontent.com/386234/51717637-9a7d1e00-200f-11e9-8002-6b76e4a1bcf4.png">
