### PR TITLE
Fix typo in ActionCable::Connection::TestCase reference

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1815,7 +1815,7 @@ class WebNotificationsChannelTest < ActionCable::Channel::TestCase
 end
 ```
 
-See the API documentation for [`AcionCable::Channel::TestCase`](http://api.rubyonrails.org/classes/ActionCable/Channel/TestCase.html) for more information.
+See the API documentation for [`ActionCable::Channel::TestCase`](http://api.rubyonrails.org/classes/ActionCable/Channel/TestCase.html) for more information.
 
 ### Custom Assertions And Testing Broadcasts Inside Other Components
 


### PR DESCRIPTION
### Summary
This patch just fixes a small typo in the Rails Testing Guide.