### PR TITLE
Describe how to silence the deprecation warning about empty I18n fall…

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -97,7 +97,8 @@ module I18n
           If you desire the default locale to be included in the defaults, please
           explicitly configure it with `config.i18n.fallbacks.defaults =
           [I18n.default_locale]` or `config.i18n.fallbacks = [I18n.default_locale,
-          {...}]`
+          {...}]`. If you want to opt-in to the new behavior, use
+          `config.i18n.fallbacks.defaults = [nil, {...}]`.
         MSG
         args.unshift I18n.default_locale
       end


### PR DESCRIPTION
…backs

The existing code already skips the deprecation warning if the first element of the fallbacks array is `nil` (which is otherwise ignored). In my opinion this also fits well semantically (i.e. setting the default locale to `nil`), and it doesn't require introducing yet another config option.