### PR TITLE
document the possibility of app initializers running before gem initializers

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1239,6 +1239,8 @@ Using Initializer Files
 
 After loading the framework and any gems in your application, Rails turns to loading initializers. An initializer is any Ruby file stored under `config/initializers` in your application. You can use initializers to hold configuration settings that should be made after all of the frameworks and gems are loaded, such as options to configure settings for these parts.
 
+NOTE: There is no guarantee that your initializers will run after all the gem initilizers, so any initialization code that depends on a given gem having been initialized should go into a `config.after_initilize` block.
+
 NOTE: You can use subfolders to organize your initializers if you like, because Rails will look into the whole file hierarchy from the initializers folder on down.
 
 TIP: While Rails supports numbering of initializer file names for load ordering purposes, a better technique is to place any code that need to load in a specific order within the same file. This reduces file name churn, makes dependencies more explicit, and can help surface new concepts within your application.


### PR DESCRIPTION
and suggest a workaround

### Summary

Per #35025, rails provides no guarantee that app initializers will run after gem initializers, which is unfortunate as it makes app initialization non-deterministic and brittle. App init code that depends on a given gem being fully initialized and integrated into rails could suddenly break after inclusion of an unrelated gem (and even it's position in the gem file)

So this possibility should be documented and a workaround suggested.
