### PR TITLE
Switch queue_classic back to origin repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :job do
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
-  gem "queue_classic", github: "rafaelfranca/queue_classic", branch: "update-pg", require: false, platforms: :ruby
+  gem "queue_classic", github: "QueueClassic/queue_classic", require: false, platforms: :ruby
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/QueueClassic/queue_classic.git
+  revision: 4cdc9b8e804badf7dea7078dd81092972d292c14
+  specs:
+    queue_classic (3.2.0.RC1)
+      pg (>= 0.17, < 2.0)
+
+GIT
   remote: https://github.com/matthewd/websocket-client-simple.git
   revision: e161305f1a466b9398d86df3b1731b03362da91b
   branch: close-race
@@ -6,14 +13,6 @@ GIT
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
-
-GIT
-  remote: https://github.com/rafaelfranca/queue_classic.git
-  revision: dee64b361355d56700ad7aa3b151bf653a617526
-  branch: update-pg
-  specs:
-    queue_classic (3.2.0.RC1)
-      pg (>= 0.17, < 2.0)
 
 PATH
   remote: .


### PR DESCRIPTION
It has been moved to the a fork as part of https://github.com/rails/rails/pull/31671 .
That was since to that time a required PR was not yet merged.
Now the queue_classic master branch is compatible to recent pg versions,
so that there's no need to keep using a fork.
