### PR TITLE
Fix error saving Action Text content containing non-blob attachables

### DIFF
--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -15,7 +15,7 @@ module ActionText
     has_many_attached :embeds
 
     before_save do
-      self.embeds = body.attachments.map(&:attachable) if body.present?
+      self.embeds = body.attachables.grep(ActiveStorage::Blob) if body.present?
     end
 
     def to_plain_text

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -35,6 +35,15 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal "racecar.jpg", message.content.embeds.first.filename.to_s
   end
 
+  test "embed extraction only extracts file attachments" do
+    remote_image_html = '<action-text-attachment content-type="image" url="http://example.com/cat.jpg"></action-text-attachment>'
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    content = ActionText::Content.new(remote_image_html).append_attachables(blob)
+    message = Message.create!(subject: "Greetings", content: content)
+    assert_equal [ActionText::Attachables::RemoteImage, ActiveStorage::Blob], message.content.body.attachables.map(&:class)
+    assert_equal [ActiveStorage::Attachment], message.content.embeds.map(&:class)
+  end
+
   test "saving content" do
     message = Message.create!(subject: "Greetings", content: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.content.to_plain_text


### PR DESCRIPTION
Failing test before the `ActionText::RichText` change:

```
Error:
ActionText::ModelTest#test_embed_extraction_only_extracts_file_attachments:
ArgumentError: Could not find or build blob: expected attachable, got #<ActionText::Attachables::RemoteImage:0x00007fb0259fef70 @url="http://example.com/cat.jpg", @content_type="image", @width=nil, @height=nil>
```