### PR TITLE
PostgreSQL: Use native timestamp decoders of pg-1.1

### DIFF
--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -51,7 +51,7 @@ module ActiveRecord
     end
 
     test "cache_version is the same when it comes from the DB or from the user" do
-      skip("Mysql2 does not return a string value for updated_at") if current_adapter?(:Mysql2Adapter)
+      skip("Mysql2 and PostgreSQL don't return a string value for updated_at") if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
 
       record = CacheMeWithVersion.create
       record_from_db = CacheMeWithVersion.find(record.id)
@@ -63,7 +63,7 @@ module ActiveRecord
     end
 
     test "cache_version does not truncate zeros when timestamp ends in zeros" do
-      skip("Mysql2 does not return a string value for updated_at") if current_adapter?(:Mysql2Adapter)
+      skip("Mysql2 and PostgreSQL don't return a string value for updated_at") if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
 
       travel_to Time.now.beginning_of_day do
         record = CacheMeWithVersion.create
@@ -84,7 +84,7 @@ module ActiveRecord
     end
 
     test "cache_version does NOT call updated_at when value is from the database" do
-      skip("Mysql2 does not return a string value for updated_at") if current_adapter?(:Mysql2Adapter)
+      skip("Mysql2 and PostgreSQL don't return a string value for updated_at") if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
 
       record = CacheMeWithVersion.create
       record_from_db = CacheMeWithVersion.find(record.id)


### PR DESCRIPTION
### Summary

This improves performance of timestamp conversion and avoids additional string allocations. Compatibility to older pg versions is preserved.

### Other Information

It improves query times by more than [50%](https://gist.github.com/larskanis/7755170c6b880e61931a524603b7d336) if many time columns are involved. 

I didn't find a reliable trigger to change the timezone handling (local vs. utc). Therefore I added a check before each query, which I think is sub-optimal. Maybe someone has a better idea. Nevertheless the speed improvement outperforms this timezone update check by far.
