### PR TITLE
Support before_reset callback in CurrentAttributes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,12 @@
+*   Add `before_reset` callback to `CurrentAttributes` and define `after_reset` as an alias of `resets` for symmetry.
+
+    *Rosa Gutierrez*
+
 *   Add `ActiveSupport::HashWithIndifferentAccess#assoc`.
 
     `assoc` can now be called with either a string or a symbol.
 
     *Stefan Schüßler*
-
 
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -119,10 +119,16 @@ module ActiveSupport
         end
       end
 
+      # Calls this block before #reset is called on the instance. Used for resetting external collaborators that depend on current values.
+      def before_reset(&block)
+        set_callback :reset, :before, &block
+      end
+
       # Calls this block after #reset is called on the instance. Used for resetting external collaborators, like Time.zone.
       def resets(&block)
         set_callback :reset, :after, &block
       end
+      alias_method :after_reset, :resets
 
       delegate :set, :reset, to: :instance
 


### PR DESCRIPTION
### Summary

This PR adds a `before_reset` callback in `CurrentAttributes`. The existing `resets` callback runs after `reset` has been called on the instance, which means we can't use it to do work that depends on the instance values, only to reset global independent collaborators like `Time.zone`. 

----

I think this might need something added to the `CHANGELOG`, I'll add it if you think this `before_reset` is useful and can be added to Rails. 