### PR TITLE
Guides: Fix parent class of model test example

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1723,6 +1723,8 @@ within a model:
 require 'test_helper'
 
 class ProductTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test 'billing job scheduling' do
     assert_enqueued_with(job: BillingJob) do
       product.charge(account)

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1722,7 +1722,7 @@ within a model:
 ```ruby
 require 'test_helper'
 
-class ProductTest < ActiveJob::TestCase
+class ProductTest < ActiveSupport::TestCase
   test 'billing job scheduling' do
     assert_enqueued_with(job: BillingJob) do
       product.charge(account)


### PR DESCRIPTION
### Summary

The testing guide example for asserting whether a job was enqueued outside of an `ActiveJob::TestCase` mistakenly showed a model test class inheriting from `ActiveJob::TestCase` instead of `ActiveSupport::TestCase`. 

[ci skip]