### PR TITLE
Fix syntax error on Action Text application.js installation boilerplate

### DIFF
--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -26,7 +26,7 @@ if APPLICATION_PACK_PATH.exist?
     line = %[require("#{name}")]
     unless APPLICATION_PACK_PATH.read.include? line
       say "Adding #{name} to #{APPLICATION_PACK_PATH}"
-      append_to_file APPLICATION_PACK_PATH, "#{line}\n"
+      append_to_file APPLICATION_PACK_PATH, "\n#{line}"
     end
   end
 end


### PR DESCRIPTION
### Summary

Action Text installation appends `require("trix")` to the application.js file. The problem is that there isn't a line break in the beginning of the installation output, leading to syntax errors, e.g.:

```
import './application.scss'require("trix")
```

This commit moves the line break from the end to the beginning of the output, fixing it to:

```
import './application.scss'
require("trix")
```
