### PR TITLE
Filter out authenticity token by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :authenticity_token]


### PR DESCRIPTION
The authenticity token gets logged by default, it's stored in the session so there is a chance an attacker could take advantage of this. I think it is safer to exclude it by default.