### PR TITLE
Make the lookup context more "read-only"

### DIFF
--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -8,11 +8,13 @@ module ActionView #:nodoc:
   # useful for testing extensions that have no way of knowing what the file
   # system will look like at runtime.
   class FixtureResolver < PathResolver
-    attr_reader :hash
-
     def initialize(hash = {}, pattern = nil)
       super(pattern)
       @hash = hash
+    end
+
+    def data
+      @hash
     end
 
     def to_s

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -5,8 +5,12 @@ require "abstract_controller/rendering"
 
 class LookupContextTest < ActiveSupport::TestCase
   def setup
-    @lookup_context = ActionView::LookupContext.new(FIXTURE_LOAD_PATH, {})
+    @lookup_context = build_lookup_context(FIXTURE_LOAD_PATH, {})
     ActionView::LookupContext::DetailsKey.clear
+  end
+
+  def build_lookup_context(paths, details)
+    ActionView::LookupContext.new(paths, details)
   end
 
   def teardown
@@ -156,7 +160,7 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 
   test "gives the key forward to the resolver, so it can be used as cache key" do
-    @lookup_context.view_paths = ActionView::FixtureResolver.new("test/_foo.erb" => "Foo")
+    @lookup_context = build_lookup_context(ActionView::FixtureResolver.new("test/_foo.erb" => "Foo"), {})
     template = @lookup_context.find("foo", %w(test), true)
     assert_equal "Foo", template.source
 
@@ -185,7 +189,7 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 
   test "can disable the cache on demand" do
-    @lookup_context.view_paths = ActionView::FixtureResolver.new("test/_foo.erb" => "Foo")
+    @lookup_context = build_lookup_context(ActionView::FixtureResolver.new("test/_foo.erb" => "Foo"), {})
     old_template = @lookup_context.find("foo", %w(test), true)
 
     template = @lookup_context.find("foo", %w(test), true)

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -162,7 +162,7 @@ class LookupContextTest < ActiveSupport::TestCase
 
     # Now we are going to change the template, but it won't change the returned template
     # since we will hit the cache.
-    @lookup_context.view_paths.first.hash["test/_foo.erb"] = "Bar"
+    @lookup_context.view_paths.first.data["test/_foo.erb"] = "Bar"
     template = @lookup_context.find("foo", %w(test), true)
     assert_equal "Foo", template.source
 
@@ -221,12 +221,12 @@ class LookupContextWithFalseCaching < ActiveSupport::TestCase
 
       # Now we are going to change the template, but it won't change the returned template
       # since the timestamp is the same.
-      @resolver.hash["test/_foo.erb"][0] = "Bar"
+      @resolver.data["test/_foo.erb"][0] = "Bar"
       template = @lookup_context.find("foo", %w(test), true)
       assert_equal "Foo", template.source
 
       # Now update the timestamp.
-      @resolver.hash["test/_foo.erb"][1] = Time.now.utc
+      @resolver.data["test/_foo.erb"][1] = Time.now.utc
       template = @lookup_context.find("foo", %w(test), true)
       assert_equal "Bar", template.source
     end
@@ -237,7 +237,7 @@ class LookupContextWithFalseCaching < ActiveSupport::TestCase
       template = @lookup_context.find("foo", %w(test), true)
       assert_equal "Foo", template.source
 
-      @resolver.hash.clear
+      @resolver.data.clear
       assert_raise ActionView::MissingTemplate do
         @lookup_context.find("foo", %w(test), true)
       end
@@ -246,12 +246,12 @@ class LookupContextWithFalseCaching < ActiveSupport::TestCase
 
   test "if no template was cached in the first lookup, retrieval should work in the second call" do
     ActionView::Resolver.stub(:caching?, false) do
-      @resolver.hash.clear
+      @resolver.data.clear
       assert_raise ActionView::MissingTemplate do
         @lookup_context.find("foo", %w(test), true)
       end
 
-      @resolver.hash["test/_foo.erb"] = ["Foo", Time.utc(2000)]
+      @resolver.data["test/_foo.erb"] = ["Foo", Time.utc(2000)]
       template = @lookup_context.find("foo", %w(test), true)
       assert_equal "Foo", template.source
     end


### PR DESCRIPTION
I am trying to curb mutations so that we can more easily cache and understand relationships between objects in Action View.  This PR eliminates a `view_paths` setter on the lookup context.  I think this is safe to remove because view_paths should be set on the controller, and we still maintain that API.