### PR TITLE
Fix usage documentation in VideoAnalyzer

### DIFF
--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -11,7 +11,7 @@ module ActiveStorage
   #
   # Example:
   #
-  #   ActiveStorage::VideoAnalyzer.new(blob).metadata
+  #   ActiveStorage::Analyzer::VideoAnalyzer.new(blob).metadata
   #   # => { width: 640.0, height: 480.0, duration: 5.0, angle: 0, display_aspect_ratio: [4, 3] }
   #
   # When a video's angle is 90 or 270 degrees, its width and height are automatically swapped for convenience.


### PR DESCRIPTION
### Summary

The code snippet within the usage documentation comment used the wrong object namespace for the ActiveStorage::Analyzer::VideoAnalyzer