### PR TITLE
Add `#before` and `#after` methods to date and time classes.

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -110,6 +110,16 @@ module DateAndTime
       advance(years: years)
     end
 
+    # Returns a new date/time before <tt>date_or_time</tt>.
+    def before(date_or_time)
+      since(-date_or_time)
+    end
+
+    # Returns a new date/time after <tt>date_or_time</tt>.
+    def after(date_or_time)
+      since(date_or_time)
+    end
+
     # Returns a new date/time at the start of the month.
     #
     #   today = Date.today # => Thu, 18 Jun 2015

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -110,7 +110,7 @@ class DateTime
   # instance time. Do not use this method in combination with x.months, use
   # months_since instead!
   def since(seconds)
-    self + Rational(seconds, 86400)
+    self + Rational(seconds.to_f, 86400)
   end
   alias :in :since
 

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -385,16 +385,28 @@ module DateAndTimeBehavior
     assert_predicate date_time_init(2015, 1, 5, 15, 15, 10), :on_weekday?
   end
 
-  def test_before
+  def test_before_comparison
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 5, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 6, 12, 0, 0))
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
-  def test_after
+  def test_after_comparison
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 5, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 6, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
+  def test_before_calculation
+    assert_equal date_time_init(2018, 3, 5, 12, 0, 0).in_time_zone, date_time_init(2018, 3, 6, 12, 0, 0).before(1.day)
+    assert_equal date_time_init(2018, 3, 5, 12, 0, 0).in_time_zone, date_time_init(2018, 4, 6, 12, 0, 0).before(32.day)
+    assert_equal date_time_init(2018, 4, 7, 12, 0, 0).in_time_zone, date_time_init(2018, 4, 6, 12, 0, 0).before(-1.day)
+  end
+
+  def test_after_calculation
+    assert_equal date_time_init(2018, 3, 6, 12, 0, 0).in_time_zone, date_time_init(2018, 3, 5, 12, 0, 0).after(1.day)
+    assert_equal date_time_init(2018, 4, 6, 12, 0, 0).in_time_zone, date_time_init(2018, 3, 5, 12, 0, 0).after(32.day)
+    assert_equal date_time_init(2018, 4, 6, 12, 0, 0).in_time_zone, date_time_init(2018, 4, 7, 12, 0, 0).after(-1.day)
   end
 
   def with_bw_default(bw = :monday)


### PR DESCRIPTION
`#ago` method isn't good syntax for human readability so takes some time to remember.
If use `#before`,  it improves readability like,

```ruby
time.before 1.day
```

better than

```ruby
time.ago 1.day
```

And it's also good to have a correspondence to `#before?` and `#after?`
Related to #32185, #32398

After merged, it could be used with `#before`, `#before?` and `#after`, `#after?` methods for calculation and comparison. That is good interface for us.