### PR TITLE
Activejob typo fixes.

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -67,7 +67,7 @@ module ActiveJob
           false
         else
           ActiveSupport::Deprecation.warn(
-            "Rails 6.0 will return false when the enqueing is aborted. Make sure your code doesn't depend on it" \
+            "Rails 6.0 will return false when the enqueuing is aborted. Make sure your code doesn't depend on it" \
             " returning the instance of the job and set `config.active_job.return_false_on_aborted_enqueue = true`" \
             " to remove the deprecations."
           )

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -1688,7 +1688,7 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
-  def test_assert_performed_with_without_bllock_with_global_id_args
+  def test_assert_performed_with_without_block_with_global_id_args
     ricardo = Person.new(9)
     HelloJob.perform_later(ricardo)
     perform_enqueued_jobs


### PR DESCRIPTION
1. `enqueing` to `enqueuing`
1. `_bllock_with` to `_block_with` 