### PR TITLE
Bugfix ":verify_authenticity_token has not been defined"

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -147,7 +147,7 @@ module ActionController #:nodoc:
       #
       # See +skip_before_action+ for allowed options.
       def skip_forgery_protection(options = {})
-        skip_before_action :verify_authenticity_token, options
+        skip_before_action :verify_authenticity_token, options if allow_forgery_protection
       end
 
       private


### PR DESCRIPTION
### Summary

Attempt to fix an error in production we receive the following error:

```
Before process_action callback :verify_authenticity_token has not been defined (ArgumentError)
```

The issue happens when we attempt to skip entirely the CSRF protection:

```
class ActiveStorage::BaseController < ActionController::Base

  config_accessor :allow_forgery_protection
  self.allow_forgery_protection = false

end
```

Please let me know if there is a better way to deal with fully remote AJAX calls.

### Other informations

In fact the issue happens also in development if we set `config.eager_load = true` into `development.rb`
