### PR TITLE
Cleanup the whitelisting references after #33145

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -14,7 +14,7 @@
 *   Introduce ActionDispatch::HostAuthorization
 
     This is a new middleware that guards against DNS rebinding attacks by
-    white-listing the allowed hosts a request can be made to.
+    explicitly permitting the hosts a request can be made to.
 
     Each host is checked with the case operator (`#===`) to support `RegExp`,
     `Proc`, `IPAddr` and custom objects as host allowances.

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -3,8 +3,8 @@
 require "action_dispatch/http/request"
 
 module ActionDispatch
-  # This middleware guards from DNS rebinding attacks by white-listing the
-  # hosts a request can be sent to.
+  # This middleware guards from DNS rebinding attacks by explicitly permitting
+  # the hosts a request can be sent to.
   #
   # When a request comes to an unauthorized host, the +response_app+
   # application will be executed and rendered. If no +response_app+ is given, a

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -15,7 +15,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_match "Blocked host: www.example.com", response.body
   end
 
-  test "passes all requests to if the whitelist is empty" do
+  test "allows all requests if hosts is empty" do
     @app = ActionDispatch::HostAuthorization.new(App, nil)
 
     get "/"
@@ -24,7 +24,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Success", body
   end
 
-  test "passes requests to allowed host" do
+  test "hosts can be a single element array" do
     @app = ActionDispatch::HostAuthorization.new(App, %w(www.example.com))
 
     get "/"
@@ -33,7 +33,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Success", body
   end
 
-  test "the whitelist could be a single element" do
+  test "hosts can be a string" do
     @app = ActionDispatch::HostAuthorization.new(App, "www.example.com")
 
     get "/"

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -374,7 +374,7 @@ controller modules by default:
 - `ActionController::Renderers::All`: Support for `render :json` and friends.
 - `ActionController::ConditionalGet`: Support for `stale?`.
 - `ActionController::BasicImplicitRender`: Makes sure to return an empty response, if there isn't an explicit one.
-- `ActionController::StrongParameters`: Support for parameters white-listing in combination with Active Model mass assignment.
+- `ActionController::StrongParameters`: Support for parameters filtering in combination with Active Model mass assignment.
 - `ActionController::DataStreaming`: Support for `send_file` and `send_data`.
 - `AbstractController::Callbacks`: Support for `before_action` and
   similar helpers.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -75,7 +75,7 @@
 
     In other environments `Rails.application.config.hosts` is empty and no
     `Host` header checks will be done. If you want to guard against header
-    attacks on production, you have to manually whitelist the allowed hosts
+    attacks on production, you have to manually permit the allowed hosts
     with:
 
         Rails.application.config.hosts << "product.com"
@@ -88,7 +88,7 @@
         # `beta1.product.com`.
         Rails.application.config.hosts << /.*\.product\.com/
 
-    A special case is supported that allows you to whitelist all sub-domains:
+    A special case is supported that allows you to permit all sub-domains:
 
         # Allow requests from subdomains like `www.product.com` and
         # `beta1.product.com`.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2289,7 +2289,7 @@ module ApplicationTests
       MESSAGE
     end
 
-    test "the host whitelist includes .localhost in development" do
+    test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"
     end


### PR DESCRIPTION
During the development of #33145, I have named a few concepts in the
code as `whitelisted`. We decided to stay away from the term and I
adjusted most of the code afterward, but here are the cases I forgot to
change.

I also found a case in the API guide that we could have cleaned up as
well.