### PR TITLE
Fail in action text installer if yarn is not detected

### DIFF
--- a/actiontext/lib/tasks/actiontext.rake
+++ b/actiontext/lib/tasks/actiontext.rake
@@ -10,6 +10,7 @@ namespace :action_text do
   task :run_installer do
     installer_template = File.expand_path("../templates/installer.rb", __dir__)
     system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{installer_template}"
+    abort unless $?.success?
   end
 
   task :copy_migrations do

--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -12,7 +12,7 @@ JS_DEPENDENCIES = JS_PACKAGE["peerDependencies"].dup.merge \
 
 say "Installing JavaScript dependencies"
 run "bin/yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}",
-    abort_on_failure: true
+    abort_on_failure: true, capture: true
 
 say "Copying actiontext.scss to app/assets/stylesheets"
 copy_file "#{__dir__}/actiontext.scss", "app/assets/stylesheets/actiontext.scss"

--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -10,6 +10,9 @@ JS_PACKAGE = JSON.load(JS_PACKAGE_PATH)
 JS_DEPENDENCIES = JS_PACKAGE["peerDependencies"].dup.merge \
   JS_PACKAGE["name"] => "^#{JS_PACKAGE["version"]}"
 
+say "Installing JavaScript dependencies"
+run "bin/yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
+
 say "Copying actiontext.scss to app/assets/stylesheets"
 copy_file "#{__dir__}/actiontext.scss", "app/assets/stylesheets/actiontext.scss"
 
@@ -19,16 +22,6 @@ copy_file "#{__dir__}/fixtures.yml", "test/fixtures/action_text/rich_texts.yml"
 say "Copying blob rendering partial to app/views/active_storage/blobs/_blob.html.erb"
 copy_file "#{__dir__}/../../app/views/active_storage/blobs/_blob.html.erb",
   "app/views/active_storage/blobs/_blob.html.erb"
-
-say "Installing JavaScript dependencies"
-
-begin
-  exec "yarnpkg add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
-rescue Errno::ENOENT
-  $stderr.puts "Yarn executable was not detected in the system."
-  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-  exit 1
-end
 
 if APPLICATION_PACK_PATH.exist?
   JS_DEPENDENCIES.keys.each do |name|

--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -11,7 +11,8 @@ JS_DEPENDENCIES = JS_PACKAGE["peerDependencies"].dup.merge \
   JS_PACKAGE["name"] => "^#{JS_PACKAGE["version"]}"
 
 say "Installing JavaScript dependencies"
-run "bin/yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
+run "bin/yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}",
+    abort_on_failure: true
 
 say "Copying actiontext.scss to app/assets/stylesheets"
 copy_file "#{__dir__}/actiontext.scss", "app/assets/stylesheets/actiontext.scss"

--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 require "json"
 
@@ -19,7 +21,14 @@ copy_file "#{__dir__}/../../app/views/active_storage/blobs/_blob.html.erb",
   "app/views/active_storage/blobs/_blob.html.erb"
 
 say "Installing JavaScript dependencies"
-run "yarn add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
+
+begin
+  exec "yarnpkg add #{JS_DEPENDENCIES.map { |name, version| "#{name}@#{version}" }.join(" ")}"
+rescue Errno::ENOENT
+  $stderr.puts "Yarn executable was not detected in the system."
+  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
+end
 
 if APPLICATION_PACK_PATH.exist?
   JS_DEPENDENCIES.keys.each do |name|


### PR DESCRIPTION
### Summary

Fixes #35003

This PR prevents the action text installer to succeed if yarn is not installed. The implementation was based on the bin entry for yarn that is generated for new apps, but aimed to address applications that are being upgraded (i.e.: that don't necessarily have the bin/yarn file).