### PR TITLE
Update Sneakers to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,8 +171,8 @@ GEM
     bootsnap (1.3.2-java)
       msgpack (~> 1.0)
     builder (3.2.3)
-    bunny (2.9.2)
-      amq-protocol (~> 2.3.0)
+    bunny (2.13.0)
+      amq-protocol (~> 2.3, >= 2.3.0)
     byebug (10.0.2)
     capybara (3.10.1)
       addressable
@@ -191,7 +191,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     cookiejar (0.3.3)
     crack (0.4.3)
@@ -336,6 +336,7 @@ GEM
     mysql2 (0.5.2-x64-mingw32)
     mysql2 (0.5.2-x86-mingw32)
     nio4r (2.3.1)
+    nio4r (2.3.1-java)
     nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
     nokogiri (1.9.1-java)
@@ -453,9 +454,10 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.4)
       tilt (~> 2.0)
-    sneakers (2.7.0)
-      bunny (~> 2.9.2)
+    sneakers (2.11.0)
+      bunny (~> 2.12)
       concurrent-ruby (~> 1.0)
+      rake
       serverengine (~> 2.0.5)
       thor
     sprockets (3.7.2)
@@ -508,6 +510,8 @@ GEM
       railties (>= 4.2)
     websocket (1.2.8)
     websocket-driver (0.7.0)
+      websocket-extensions (>= 0.1.0)
+    websocket-driver (0.7.0-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     xpath (3.2.0)


### PR DESCRIPTION
Sneakers 2.11.0 has a more recent Bunny dependency which squashes some
Ruby 2.6 warnings tickled by ActiveJob tests.