### PR TITLE
Tighten up the AV::Base constructor

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -75,7 +75,7 @@ module ActionController
       # Provides a proxy to access helper methods from outside the view.
       def helpers
         @helper_proxy ||= begin
-          proxy = ActionView::Base.new
+          proxy = ActionView::Base.empty
           proxy.config = config.inheritable_copy
           proxy.extend(_helpers)
         end

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -10,7 +10,9 @@ module ActionDispatch
     RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
 
     def initialize(assigns)
-      super([RESCUES_TEMPLATE_PATH], assigns)
+      paths = [RESCUES_TEMPLATE_PATH]
+      renderer = ActionView::Renderer.new ActionView::LookupContext.new(paths)
+      super(renderer, assigns)
     end
 
     def debug_params(params)

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -26,7 +26,7 @@ module ActionView
             view = Class.new(ActionView::Base) {
               include action_view_erb_handler_context._routes.url_helpers
               class_eval("define_method(:_template) { |local_assigns, output_buffer| #{src} }", @filename || "(erubi)", 0)
-            }.new(action_view_erb_handler_context)
+            }.with_context(action_view_erb_handler_context)
             view.run(:_template, {}, ActionView::OutputBuffer.new)
           end
 

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -48,7 +48,7 @@ module RenderERBUtils
     @view ||= begin
       path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
       view_paths = ActionView::PathSet.new([path])
-      ActionView::Base.new(view_paths)
+      ActionView::Base.with_view_paths(view_paths)
     end
   end
 
@@ -61,7 +61,7 @@ module RenderERBUtils
       ActionView::Template::Handlers::ERB,
       {})
 
-    template.render(ActionView::Base.new, {}).strip
+    template.render(ActionView::Base.empty, {}).strip
   end
 end
 

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -77,7 +77,7 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def test_template_appends_view_path_correctly
-    @controller.instance_variable_set :@template, ActionView::Base.new(TestController.view_paths, {}, @controller)
+    @controller.instance_variable_set :@template, ActionView::Base.with_view_paths(TestController.view_paths, {}, @controller)
     class_view_paths = TestController.view_paths
 
     @controller.append_view_path "foo"
@@ -89,7 +89,7 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def test_template_prepends_view_path_correctly
-    @controller.instance_variable_set :@template, ActionView::Base.new(TestController.view_paths, {}, @controller)
+    @controller.instance_variable_set :@template, ActionView::Base.with_view_paths(TestController.view_paths, {}, @controller)
     class_view_paths = TestController.view_paths
 
     @controller.prepend_view_path "baz"

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -19,7 +19,7 @@ class MultifetchCacheTest < ActiveRecordTestCase
       def combined_fragment_cache_key(key)
         [ :views, key ]
       end
-    end.new(view_paths, {})
+    end.with_view_paths(view_paths, {})
   end
 
   def test_only_preloading_for_records_that_miss_the_cache

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -5,7 +5,7 @@ require "abstract_unit"
 class CaptureHelperTest < ActionView::TestCase
   def setup
     super
-    @av = ActionView::Base.new
+    @av = ActionView::Base.empty
     @view_flow = ActionView::OutputFlow.new
   end
 

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -72,13 +72,13 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
     def render_with_cache(*args)
       view_paths = ActionController::Base.view_paths
-      ActionView::Base.new(view_paths, {}).render(*args)
+      ActionView::Base.with_view_paths(view_paths, {}).render(*args)
     end
 
     def render_without_cache(*args)
       path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
       view_paths = ActionView::PathSet.new([path])
-      ActionView::Base.new(view_paths, {}).render(*args)
+      ActionView::Base.with_view_paths(view_paths, {}).render(*args)
     end
 
     def modify_template(template, content)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -15,7 +15,7 @@ module RenderTestCases
       def combined_fragment_cache_key(key)
         [ :views, key ]
       end
-    end.new(paths, @assigns)
+    end.with_view_paths(paths, @assigns)
 
     @controller_view = TestController.new.view_context
 

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -9,7 +9,7 @@ class SetupFiberedBase < ActiveSupport::TestCase
   def setup
     view_paths = ActionController::Base.view_paths
     @assigns = { secret: "in the sauce", name: nil }
-    @view = ActionView::Base.new(view_paths, @assigns)
+    @view = ActionView::Base.with_view_paths(view_paths, @assigns)
     @controller_view = TestController.new.view_context
   end
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -52,7 +52,7 @@ module ActionView
     end
 
     test "retrieve non existing config values" do
-      assert_nil ActionView::Base.new.config.something_odd
+      assert_nil ActionView::Base.empty.config.something_odd
     end
 
     test "works without testing a helper module" do

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -36,7 +36,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
         }
       }
     )
-    @view = ::ActionView::Base.new(ActionController::Base.view_paths, {})
+    @view = ::ActionView::Base.with_view_paths(ActionController::Base.view_paths, {})
   end
 
   teardown do

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -150,8 +150,8 @@ module RailsGuides
         puts "Generating #{guide} as #{output_file}"
         layout = @kindle ? "kindle/layout" : "layout"
 
-        view = ActionView::Base.new(
-          @source_dir,
+        view = ActionView::Base.with_view_paths(
+          [@source_dir],
           edge:     @edge,
           version:  @version,
           mobi:     "kindle/#{mobi}",


### PR DESCRIPTION
The AV::Base constructor was too complicated, and this commit tightens
up the parameters it will take.  At runtime, AV::Base is most commonly
constructed here:

  https://github.com/rails/rails/blob/94d54fa4ab641a0ddeb173409cb41cc5becc02a9/actionview/lib/action_view/rendering.rb#L72-L74

This provides an AV::Renderer instance, a hash of assignments, and a
controller instance.  Since this is the common case for construction, we
should remove logic from the constructor that handles other cases.  This
commit introduces special constructors for those other cases.
Interestingly, most code paths that construct AV::Base "strangely" are
tests.