### PR TITLE
Add ActionCable channel/connection load hooks

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `:action_cable_connection` and `:action_cable_channel` load hooks.
+
+    You can use them to extend `ActionCable::Connection::Base` and `ActionCable::Channel::Base`
+    functionality:
+
+    ```ruby
+    ActiveSupport.on_load(:action_cable_channel) do
+      # do something in the context of ActionCable::Channel::Base
+    end
+    ```
+
+    *Vladimir Dementyev*
+
 *   Add `Channel::Base#broadcast_to`.
 
     You can now call `broadcast_to` within a channel action, which equals to

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -307,3 +307,5 @@ module ActionCable
     end
   end
 end
+
+ActiveSupport.run_load_hooks(:action_cable_channel, ActionCable::Channel::Base)

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -260,3 +260,5 @@ module ActionCable
     end
   end
 end
+
+ActiveSupport.run_load_hooks(:action_cable_connection, ActionCable::Connection::Base)

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1497,6 +1497,8 @@ To hook into the initialization process of one of the following classes use the 
 | Class                             | Available Hooks                      |
 | --------------------------------- | ------------------------------------ |
 | `ActionCable`                     | `action_cable`                       |
+| `ActionCable::Channel::Base`      | `action_cable_channel`               |
+| `ActionCable::Connection::Base`   | `action_cable_connection`            |
 | `ActionController::API`           | `action_controller_api`              |
 | `ActionController::API`           | `action_controller`                  |
 | `ActionController::Base`          | `action_controller_base`             |


### PR DESCRIPTION
### Summary

This PR adds `:action_cable_connection` and `:action_cable_channel` load hooks.

You can use them to extend `ActionCable::Connection::Base` and `ActionCable::Channel::Base` functionality:

```ruby
ActiveSupport.on_load(:action_cable_channel) do
  # do something in the context of ActionCable::Channel::Base
end
```