### PR TITLE
Allow extra client configuration options - azure storage

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::AzureStorageService < Service
     attr_reader :client, :blobs, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key:, container:)
-      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key)
+    def initialize(storage_account_name:, storage_access_key:, container:, **extra_client_options)
+      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **extra_client_options)
       @signer = Azure::Storage::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
       @blobs = client.blob_client
       @container = container

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::AzureStorageService < Service
     attr_reader :client, :blobs, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key:, container:, **extra_client_options)
-      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **extra_client_options)
+    def initialize(storage_account_name:, storage_access_key:, container:, **options)
+      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **options)
       @signer = Azure::Storage::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
       @blobs = client.blob_client
       @container = container


### PR DESCRIPTION
### Summary

Allows extra client configuration options to be specified for the azure storage service in active support.

### Other Information

When developing with azure, we often want to run a local storage emulator - maybe using microsoft's emulator or even the open source 'azurite'.  However, unlike in the S3 service - there is no way to pass extra options in the storage.yml file.

This change allows any extra options accepted by the azure-storage gem (such as storage_blob_host and use_path_style_uri which are useful for this setup) to also be accepted by active storage and passed on to the underlying azure-storage client

See my blog post for more details http://www.garytaylor.blog/index.php/2019/01/30/rails-active-storage-and-azure-beyond-config/
