### PR TITLE
Add option ActiveStorage.browser_no_cache

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs_controller.rb
@@ -8,7 +8,7 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
   def show
-    unless Rails.env.test? && ActiveStorage.disable_cache_for_tests
+    unless ActiveStorage.browser_no_cache
       expires_in ActiveStorage.service_urls_expire_in
     end
     redirect_to @blob.service_url(disposition: params[:disposition])

--- a/activestorage/app/controllers/active_storage/blobs_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs_controller.rb
@@ -8,7 +8,9 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
   def show
-    expires_in ActiveStorage.service_urls_expire_in
+    unless Rails.env.test? && ActiveStorage.disable_cache_for_tests
+      expires_in ActiveStorage.service_urls_expire_in
+    end
     redirect_to @blob.service_url(disposition: params[:disposition])
   end
 end

--- a/activestorage/app/controllers/active_storage/representations_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations_controller.rb
@@ -8,7 +8,7 @@ class ActiveStorage::RepresentationsController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
   def show
-    unless Rails.env.test? && ActiveStorage.disable_cache_for_tests
+    unless ActiveStorage.browser_no_cache
       expires_in ActiveStorage.service_urls_expire_in
     end
     redirect_to @blob.representation(params[:variation_key]).processed.service_url(disposition: params[:disposition])

--- a/activestorage/app/controllers/active_storage/representations_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations_controller.rb
@@ -8,7 +8,9 @@ class ActiveStorage::RepresentationsController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
   def show
-    expires_in ActiveStorage.service_urls_expire_in
+    unless Rails.env.test? && ActiveStorage.disable_cache_for_tests
+      expires_in ActiveStorage.service_urls_expire_in
+    end
     redirect_to @blob.representation(params[:variation_key]).processed.service_url(disposition: params[:disposition])
   end
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -52,6 +52,7 @@ module ActiveStorage
   mattr_accessor :content_types_allowed_inline, default: []
   mattr_accessor :binary_content_type, default: "application/octet-stream"
   mattr_accessor :service_urls_expire_in, default: 5.minutes
+  mattr_accessor :disable_cache_for_tests, default: false
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
 
   module Transformers

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -52,7 +52,7 @@ module ActiveStorage
   mattr_accessor :content_types_allowed_inline, default: []
   mattr_accessor :binary_content_type, default: "application/octet-stream"
   mattr_accessor :service_urls_expire_in, default: 5.minutes
-  mattr_accessor :disable_cache_for_tests, default: false
+  mattr_accessor :browser_no_cache, default: false
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
 
   module Transformers

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -71,6 +71,7 @@ module ActiveStorage
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []
         ActiveStorage.service_urls_expire_in = app.config.active_storage.service_urls_expire_in || 5.minutes
+        ActiveStorage.disable_cache_for_tests = app.config.active_storage.disable_cache_for_tests || false
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
       end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -71,7 +71,7 @@ module ActiveStorage
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []
         ActiveStorage.service_urls_expire_in = app.config.active_storage.service_urls_expire_in || 5.minutes
-        ActiveStorage.disable_cache_for_tests = app.config.active_storage.disable_cache_for_tests || false
+        ActiveStorage.browser_no_cache = app.config.active_storage.browser_no_cache || false
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
       end

--- a/activestorage/test/controllers/blobs_controller_test.rb
+++ b/activestorage/test/controllers/blobs_controller_test.rb
@@ -21,6 +21,24 @@ class ActiveStorage::BlobsControllerTest < ActionDispatch::IntegrationTest
   end
 end
 
+class ActiveStorage::BlobsControllerNoCacheTest < ActionDispatch::IntegrationTest
+  setup do
+    ActiveStorage.disable_cache_for_tests = true
+    @blob = create_file_blob filename: "racecar.jpg"
+  end
+
+  teardown do
+    ActiveStorage.disable_cache_for_tests = false
+  end
+
+  test "disable_cache_for_tests disables browser caching" do
+    get rails_blob_url(@blob)
+
+    assert_redirected_to(/racecar\.jpg/)
+    assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+end
+
 if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].present?
   class ActiveStorage::S3BlobsControllerTest < ActionDispatch::IntegrationTest
     setup do

--- a/activestorage/test/controllers/blobs_controller_test.rb
+++ b/activestorage/test/controllers/blobs_controller_test.rb
@@ -23,15 +23,15 @@ end
 
 class ActiveStorage::BlobsControllerNoCacheTest < ActionDispatch::IntegrationTest
   setup do
-    ActiveStorage.disable_cache_for_tests = true
+    ActiveStorage.browser_no_cache = true
     @blob = create_file_blob filename: "racecar.jpg"
   end
 
   teardown do
-    ActiveStorage.disable_cache_for_tests = false
+    ActiveStorage.browser_no_cache = false
   end
 
-  test "disable_cache_for_tests disables browser caching" do
+  test "browser_no_cache disables browser caching" do
     get rails_blob_url(@blob)
 
     assert_redirected_to(/racecar\.jpg/)


### PR DESCRIPTION
Fixing bug #34989 : in feature testing, when attachments records are created with the same id, the browser cache get populated with urls that may become invalid between tests.

Add option ActiveStorage.disable_cache_for_tests. Default to false.

When set to true, and only in test environment, BlobsController and RepresentationsController do not set browser cache for the redirect. As a result the redirect for blobs is sent to the browser with "Cache-Control" header set to "no-cache"
