### PR TITLE
Address test_belongs_to_does_not_use_order_by failure

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -63,7 +63,8 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::SQLCounter.clear_log
     Client.find(3).firm
   ensure
-    assert ActiveRecord::SQLCounter.log_all.all? { |sql| /order by/i !~ sql }, "ORDER BY was used in the query"
+    sql_log = ActiveRecord::SQLCounter.log
+    assert sql_log.all? { |sql| /order by/i !~ sql }, "ORDER BY was used in the query: #{sql_log}"
   end
 
   def test_belongs_to_with_primary_key

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -37,8 +37,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::SQLCounter.clear_log
     companies(:first_firm).account
   ensure
-    log_all = ActiveRecord::SQLCounter.log_all
-    assert log_all.all? { |sql| /order by/i !~ sql }, "ORDER BY was used in the query: #{log_all}"
+    sql_log = ActiveRecord::SQLCounter.log
+    assert sql_log.all? { |sql| /order by/i !~ sql }, "ORDER BY was used in the query: #{sql_log}"
   end
 
   def test_has_one_cache_nils


### PR DESCRIPTION


### Summary

This pull request addresses `test_belongs_to_does_not_use_order_by` failure due to checking order by for metadata query.

```ruby
irb(#<BelongsToAssociationsTest:0x000055a210688d48>):006:0> ActiveRecord::SQLCounter.log_all[1]
=> "SELECT a.attname, format_type(a.atttypid, a.atttypmod),\n       pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,\n       c.collname, col_description(a.attrelid, a.attnum) AS comment\n  FROM pg_attribute a\n  LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum\n  LEFT JOIN pg_type t ON a.atttypid = t.oid\n  LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation\n WHERE a.attrelid = '\"companies\"'::regclass\n   AND a.attnum > 0 AND NOT a.attisdropped\n ORDER BY a.attnum\n"
```

Fixes #35098

### Steps to reproduce

```ruby
$ cd activerecord
$ ARCONN=postgresql bin/test "test/cases/inheritance_test.rb" "test/cases/arel/insert_manager_test.rb" "test/cases/arel/collectors/substitute_bind_collector_test.rb" "test/cases/arel/collectors/composite_test.rb" "test/cases/arel/collectors/bind_test.rb" "test/cases/arel/collectors/sql_string_test.rb" "test/cases/arel/attributes/attribute_test.rb" "test/cases/arel/attributes/math_test.rb" "test/cases/arel/visitors/dispatch_contamination_test.rb" "test/cases/arel/visitors/mysql_test.rb" "test/cases/arel/visitors/oracle_test.rb" "test/cases/arel/visitors/ibm_db_test.rb" "test/cases/arel/visitors/postgres_test.rb" "test/cases/arel/visitors/informix_test.rb" "test/cases/arel/visitors/oracle12_test.rb" "test/cases/arel/visitors/to_sql_test.rb" "test/cases/arel/visitors/sqlite_test.rb" "test/cases/arel/visitors/mssql_test.rb" "test/cases/arel/visitors/depth_first_test.rb" "test/cases/arel/visitors/dot_test.rb" "test/cases/arel/crud_test.rb" "test/cases/arel/table_test.rb" "test/cases/arel/delete_manager_test.rb" "test/cases/arel/nodes/bin_test.rb" "test/cases/arel/nodes/false_test.rb" "test/cases/arel/nodes/named_function_test.rb" "test/cases/arel/nodes/insert_statement_test.rb" "test/cases/arel/nodes/update_statement_test.rb" "test/cases/arel/nodes/equality_test.rb" "test/cases/arel/nodes/not_test.rb" "test/cases/arel/nodes/grouping_test.rb" "test/cases/arel/nodes/true_test.rb" "test/cases/arel/nodes/select_core_test.rb" "test/cases/arel/nodes/descending_test.rb" "test/cases/arel/nodes/over_test.rb" "test/cases/arel/nodes/unary_operation_test.rb" "test/cases/arel/nodes/distinct_test.rb" "test/cases/arel/nodes/ascending_test.rb" "test/cases/arel/nodes/node_test.rb" "test/cases/arel/nodes/as_test.rb" "test/cases/arel/nodes/delete_statement_test.rb" "test/cases/arel/nodes/binary_test.rb" "test/cases/arel/nodes/bind_param_test.rb" "test/cases/arel/nodes/extract_test.rb" "test/cases/arel/nodes/sum_test.rb" "test/cases/arel/nodes/or_test.rb" "test/cases/arel/nodes/infix_operation_test.rb" "test/cases/arel/nodes/count_test.rb" "test/cases/arel/nodes/table_alias_test.rb" "test/cases/arel/nodes/window_test.rb" "test/cases/arel/nodes/sql_literal_test.rb" "test/cases/arel/nodes/case_test.rb" "test/cases/arel/nodes/casted_test.rb" "test/cases/arel/nodes/and_test.rb" "test/cases/arel/nodes/select_statement_test.rb" "test/cases/arel/select_manager_test.rb" "test/cases/arel/attributes_test.rb" "test/cases/arel/nodes_test.rb" "test/cases/arel/update_manager_test.rb" "test/cases/arel/factory_methods_test.rb" "test/cases/column_alias_test.rb" "test/cases/tasks/postgresql_rake_test.rb" "test/cases/tasks/database_tasks_test.rb" "test/cases/tasks/mysql_rake_test.rb" "test/cases/tasks/sqlite_rake_test.rb" "test/cases/autosave_association_test.rb" "test/cases/primary_keys_test.rb" "test/cases/defaults_test.rb" "test/cases/habtm_destroy_order_test.rb" "test/cases/touch_later_test.rb" "test/cases/connection_adapters/type_lookup_test.rb" "test/cases/connection_adapters/connection_handlers_multi_db_test.rb" "test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb" "test/cases/connection_adapters/schema_cache_test.rb" "test/cases/connection_adapters/connection_handler_test.rb" "test/cases/connection_adapters/mysql_type_lookup_test.rb" "test/cases/connection_adapters/connection_specification_test.rb" "test/cases/connection_adapters/adapter_leasing_test.rb" "test/cases/multiple_db_test.rb" "test/cases/relation_test.rb" "test/cases/unsafe_raw_sql_test.rb" "test/cases/view_test.rb" "test/cases/reaper_test.rb" "test/cases/explain_subscriber_test.rb" "test/cases/multiparameter_attributes_test.rb" "test/cases/dup_test.rb" "test/cases/reserved_word_test.rb" "test/cases/i18n_test.rb" "test/cases/comment_test.rb" "test/cases/fixtures_test.rb" "test/cases/fixture_set/file_test.rb" "test/cases/connection_pool_test.rb" "test/cases/secure_token_test.rb" "test/cases/transactions_test.rb" "test/cases/core_test.rb" "test/cases/legacy_configurations_test.rb" "test/cases/schema_loading_test.rb" "test/cases/log_subscriber_test.rb" "test/cases/pooled_connections_test.rb" "test/cases/validations/association_validation_test.rb" "test/cases/validations/uniqueness_validation_test.rb" "test/cases/validations/i18n_generate_message_validation_test.rb" "test/cases/validations/length_validation_test.rb" "test/cases/validations/absence_validation_test.rb" "test/cases/validations/presence_validation_test.rb" "test/cases/validations/i18n_validation_test.rb" "test/cases/nested_attributes_test.rb" "test/cases/custom_locking_test.rb" "test/cases/numeric_data_test.rb" "test/cases/attribute_methods_test.rb" "test/cases/forbidden_attributes_protection_test.rb" "test/cases/migration_test.rb" "test/cases/transaction_isolation_test.rb" "test/cases/attribute_decorators_test.rb" "test/cases/cache_key_test.rb" "test/cases/sanitize_test.rb" "test/cases/bind_parameter_test.rb" "test/cases/null_relation_test.rb" "test/cases/unconnected_test.rb" "test/cases/column_definition_test.rb" "test/cases/modules_test.rb" "test/cases/serialization_test.rb" "test/cases/reload_models_test.rb" "test/cases/finder_test.rb" "test/cases/suppressor_test.rb" "test/cases/json_attribute_test.rb" "test/cases/explain_test.rb" "test/cases/mixin_test.rb" "test/cases/boolean_test.rb" "test/cases/test_fixtures_test.rb" "test/cases/relation/delete_all_test.rb" "test/cases/relation/update_all_test.rb" "test/cases/relation/where_chain_test.rb" "test/cases/relation/where_test.rb" "test/cases/relation/predicate_builder_test.rb" "test/cases/relation/merging_test.rb" "test/cases/relation/record_fetch_warning_test.rb" "test/cases/relation/delegation_test.rb" "test/cases/relation/mutation_test.rb" "test/cases/relation/where_clause_test.rb" "test/cases/relation/or_test.rb" "test/cases/relation/select_test.rb" "test/cases/query_cache_test.rb" "test/cases/filter_attributes_test.rb" "test/cases/schema_dumper_test.rb" "test/cases/dirty_test.rb" "test/cases/clone_test.rb" "test/cases/scoping/relation_scoping_test.rb" "test/cases/scoping/named_scoping_test.rb" "test/cases/scoping/default_scoping_test.rb" "test/cases/callbacks_test.rb" "test/cases/connection_management_test.rb" "test/cases/coders/json_test.rb" "test/cases/coders/yaml_column_test.rb" "test/cases/binary_test.rb" "test/cases/transaction_callbacks_test.rb" "test/cases/hot_compatibility_test.rb" "test/cases/time_precision_test.rb" "test/cases/type/integer_test.rb" "test/cases/type/unsigned_integer_test.rb" "test/cases/type/string_test.rb" "test/cases/type/date_time_test.rb" "test/cases/type/type_map_test.rb" "test/cases/type/time_test.rb" "test/cases/type/adapter_specific_registry_test.rb" "test/cases/persistence_test.rb" "test/cases/yaml_serialization_test.rb" "test/cases/date_time_test.rb" "test/cases/invalid_connection_test.rb" "test/cases/nested_attributes_with_callbacks_test.rb" "test/cases/locking_test.rb" "test/cases/associations_test.rb" "test/cases/counter_cache_test.rb" "test/cases/connection_specification/resolver_test.rb" "test/cases/readonly_test.rb" "test/cases/quoting_test.rb" "test/cases/reflection_test.rb" "test/cases/migrator_test.rb" "test/cases/batches_test.rb" "test/cases/serialized_attribute_test.rb" "test/cases/timestamp_test.rb" "test/cases/instrumentation_test.rb" "test/cases/result_test.rb" "test/cases/disconnected_test.rb" "test/cases/attribute_methods/read_test.rb" "test/cases/aggregations_test.rb" "test/cases/json_serialization_test.rb" "test/cases/statement_invalid_test.rb" "test/cases/finder_respond_to_test.rb" "test/cases/relations_test.rb" "test/cases/errors_test.rb" "test/cases/store_test.rb" "test/cases/base_test.rb" "test/cases/integration_test.rb" "test/cases/types_test.rb" "test/cases/attributes_test.rb" "test/cases/date_test.rb" "test/cases/type_test.rb" "test/cases/date_time_precision_test.rb" "test/cases/adapter_test.rb" "test/cases/database_statements_test.rb" "test/cases/associations/eager_load_includes_full_sti_class_test.rb" "test/cases/associations/eager_singularization_test.rb" "test/cases/associations/eager_load_nested_include_test.rb" "test/cases/associations/has_many_associations_test.rb" "test/cases/associations/extension_test.rb" "test/cases/associations/has_one_through_associations_test.rb" "test/cases/associations/left_outer_join_association_test.rb" "test/cases/associations/join_model_test.rb" "test/cases/associations/cascaded_eager_loading_test.rb" "test/cases/associations/required_test.rb" "test/cases/associations/nested_through_associations_test.rb" "test/cases/associations/has_many_through_associations_test.rb" "test/cases/associations/has_one_associations_test.rb" "test/cases/associations/callbacks_test.rb" "test/cases/associations/inverse_associations_test.rb" "test/cases/associations/eager_test.rb" "test/cases/associations/bidirectional_destroy_dependencies_test.rb" "test/cases/associations/belongs_to_associations_test.rb" "test/cases/associations/inner_join_association_test.rb" "test/cases/associations/has_and_belongs_to_many_associations_test.rb" "test/cases/calculations_test.rb" "test/cases/invertible_migration_test.rb" "test/cases/statement_cache_test.rb" "test/cases/ar_schema_test.rb" "test/cases/enum_test.rb" "test/cases/collection_cache_key_test.rb" "test/cases/validations_test.rb" "test/cases/migration/references_index_test.rb" "test/cases/migration/column_positioning_test.rb" "test/cases/migration/rename_table_test.rb" "test/cases/migration/foreign_key_test.rb" "test/cases/migration/change_schema_test.rb" "test/cases/migration/create_join_table_test.rb" "test/cases/migration/change_table_test.rb" "test/cases/migration/references_foreign_key_test.rb" "test/cases/migration/pending_migrations_test.rb" "test/cases/migration/column_attributes_test.rb" "test/cases/migration/logger_test.rb" "test/cases/migration/compatibility_test.rb" "test/cases/migration/columns_test.rb" "test/cases/migration/index_test.rb" "test/cases/migration/command_recorder_test.rb" "test/cases/migration/references_statements_test.rb" "test/cases/adapters/postgresql/money_test.rb" "test/cases/adapters/postgresql/foreign_table_test.rb" "test/cases/adapters/postgresql/integer_test.rb" "test/cases/adapters/postgresql/infinity_test.rb" "test/cases/adapters/postgresql/partitions_test.rb" "test/cases/adapters/postgresql/schema_authorization_test.rb" "test/cases/adapters/postgresql/type_lookup_test.rb" "test/cases/adapters/postgresql/numbers_test.rb" "test/cases/adapters/postgresql/schema_test.rb" "test/cases/adapters/postgresql/rename_table_test.rb" "test/cases/adapters/postgresql/citext_test.rb" "test/cases/adapters/postgresql/serial_test.rb" "test/cases/adapters/postgresql/datatype_test.rb" "test/cases/adapters/postgresql/case_insensitive_test.rb" "test/cases/adapters/postgresql/domain_test.rb" "test/cases/adapters/postgresql/ltree_test.rb" "test/cases/adapters/postgresql/active_schema_test.rb" "test/cases/adapters/postgresql/change_schema_test.rb" "test/cases/adapters/postgresql/connection_test.rb" "test/cases/adapters/postgresql/transaction_test.rb" "test/cases/adapters/postgresql/collation_test.rb" "test/cases/adapters/postgresql/utils_test.rb" "test/cases/adapters/postgresql/uuid_test.rb" "test/cases/adapters/postgresql/prepared_statements_disabled_test.rb" "test/cases/adapters/postgresql/composite_test.rb" "test/cases/adapters/postgresql/explain_test.rb" "test/cases/adapters/postgresql/hstore_test.rb" "test/cases/adapters/postgresql/geometric_test.rb" "test/cases/adapters/postgresql/statement_pool_test.rb" "test/cases/adapters/postgresql/create_unlogged_tables_test.rb" "test/cases/adapters/postgresql/json_test.rb" "test/cases/adapters/postgresql/network_test.rb" "test/cases/adapters/postgresql/quoting_test.rb" "test/cases/adapters/postgresql/xml_test.rb" "test/cases/adapters/postgresql/timestamp_test.rb" "test/cases/adapters/postgresql/referential_integrity_test.rb" "test/cases/adapters/postgresql/range_test.rb" "test/cases/adapters/postgresql/array_test.rb" "test/cases/adapters/postgresql/full_text_test.rb" "test/cases/adapters/postgresql/bit_string_test.rb" "test/cases/adapters/postgresql/date_test.rb" "test/cases/adapters/postgresql/cidr_test.rb" "test/cases/adapters/postgresql/postgresql_adapter_test.rb" "test/cases/adapters/postgresql/bytea_test.rb" "test/cases/adapters/postgresql/extension_migration_test.rb" "test/cases/adapters/postgresql/enum_test.rb" --seed 31342 -n "/^(?:ModulesTest#(?:test_find_account_and_include_company|test_module_table_name_prefix_with_global_prefix)|EagerLoadPolyAssocsTest#(?:test_include_query)|BelongsToAssociationsTest#(?:test_belongs_to_does_not_use_order_by))$/"
```

### Actual behavior
```ruby
Using postgresql
Run options: --seed 31342 -n "/^(?:ModulesTest#(?:test_find_account_and_include_company|test_module_table_name_prefix_with_global_prefix)|EagerLoadPolyAssocsTest#(?:test_include_query)|BelongsToAssociationsTest#(?:test_belongs_to_does_not_use_order_by))$/"

# Running:

...F

Failure:
BelongsToAssociationsTest#test_belongs_to_does_not_use_order_by [/home/yahonda/git/rails/activerecord/test/cases/associations/belongs_to_associations_test.rb:66]:
ORDER BY was used in the query


bin/test test/cases/associations/belongs_to_associations_test.rb:62



Finished in 1.373576s, 2.9121 runs/s, 151.4296 assertions/s.
4 runs, 208 assertions, 1 failures, 0 errors, 0 skips
$
```
