### PR TITLE
Remove unused code

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -28,7 +28,6 @@ module AbstractController
         self.fragment_cache_keys = []
 
         if respond_to?(:helper_method)
-          helper_method :fragment_cache_key
           helper_method :combined_fragment_cache_key
         end
       end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -12,16 +12,8 @@ class Topic < ActiveRecord::Base
 
   scope :scope_with_lambda, lambda { all }
 
-  scope :by_private_lifo, -> { where(author_name: private_lifo) }
   scope :by_lifo, -> { where(author_name: "lifo") }
   scope :replied, -> { where "replies_count > 0" }
-
-  class << self
-    private
-      def private_lifo
-        "lifo"
-      end
-  end
 
   scope "approved_as_string", -> { where(approved: true) }
   scope :anonymous_extension, -> { } do


### PR DESCRIPTION
- Remove `fragment_cache_key` helper declaration.
  It was removed in e70d3df7c9b05c129b0fdcca57f66eca316c5cfc

- Remove `by_private_lifo`.
  It is unused since a7becf147afc85c354e5cfa519911a948d25fc4d
