### PR TITLE
Fix case when we want a UrlConfig but the URL is nil

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -134,9 +134,11 @@ module ActiveRecord
       end
 
       def build_db_config_from_hash(env_name, spec_name, config)
-        if url = config["url"]
+        if config.has_key?("url")
+          url = config["url"]
           config_without_url = config.dup
           config_without_url.delete "url"
+
           ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url, config_without_url)
         elsif config["database"] || (config.size == 1 && config.values.all? { |v| v.is_a? String })
           ActiveRecord::DatabaseConfigurations::HashConfig.new(env_name, spec_name, config)

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -56,12 +56,17 @@ module ActiveRecord
       end
 
       private
-        def build_config(original_config, url)
-          if /^jdbc:/.match?(url)
-            hash = { "url" => url }
+
+        def build_url_hash(url)
+          if url.nil? || /^jdbc:/.match?(url)
+            { "url" => url }
           else
-            hash = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
+            ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
           end
+        end
+
+        def build_config(original_config, url)
+          hash = build_url_hash(url)
 
           if original_config[env_name]
             original_config[env_name].merge(hash)

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -46,6 +46,14 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_resolver_with_nil_database_url_and_current_env
+        ENV["RAILS_ENV"] = "foo"
+        config = { "foo" => { "adapter" => "postgres", "url" => ENV["DATABASE_URL"] } }
+        actual   = resolve_spec(:foo, config)
+        expected = { "adapter" => "postgres", "url" => nil, "name" => "foo" }
+        assert_equal expected, actual
+      end
+
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rack_env
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         ENV["RACK_ENV"]     = "foo"


### PR DESCRIPTION
Previously if the `url` key in a config hash was nil we'd ignore the
configuration as invalid. This can happen when you're relying on a
`DATABASE_URL` in the env and that is not set in the environment.

```
production:
  <<: *default
  url: ENV['DATABASE_URL']
```

This PR fixes that case by checking if there is a `url` key in the
config instead of checking if the `url` is not nil in the config.

In addition to changing the conditional we then need to build a url hash
to merge with the original hash in the `UrlConfig` object.

Fixes #35091

cc/ @gmcgibbon @msdundar this should fix the issue you opened.