### PR TITLE
ActiveModel typo fixes.

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -32,7 +32,7 @@ module ActiveModel
           value = options[key]
 
           unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY || value.is_a?(Symbol) || value.is_a?(Proc)
-            raise ArgumentError, ":#{key} must be a nonnegative Integer, Infinity, Symbol, or Proc"
+            raise ArgumentError, ":#{key} must be a non-negative Integer, Infinity, Symbol, or Proc"
           end
         end
       end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -281,7 +281,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_predicate topic, :invalid?
   end
 
-  def test_validates_numericalty_with_object_acting_as_numeric
+  def test_validates_numericality_with_object_acting_as_numeric
     klass = Class.new do
       def to_f
         123.54


### PR DESCRIPTION
This PR includes:
1. numericalty typo fix.
2. Renamed variable `microsec` to `microsecond` and `microsec_part` to `microsecond_part`.
3. changed `nonnegative` to `non-negative`