### PR TITLE
Hint at advanced options for foreign_key

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -680,9 +680,10 @@ module ActiveRecord
       end
       alias :remove_belongs_to :remove_references
 
-      # Adds a foreign key.
+      # Adds a foreign key to the table using a supplied table name.
       #
       #  t.foreign_key(:authors)
+      #  t.foreign_key(:authors, column: :author_id, primary_key: "id")
       #
       # See {connection.add_foreign_key}[rdoc-ref:SchemaStatements#add_foreign_key]
       def foreign_key(*args)


### PR DESCRIPTION
We sometimes display simple examples of additional parameters that can be
supplied to table-wise methods like these and I found it particularly difficult
to figure out which options `t.foreign_key` accepts without drilling very deep
into the specific SchemaStatements docs.

Since it's relatively common to create foreign keys with custom column names or
primary keys, it seems like this should help quite a few people.

I don't love the new description: 
> Adds a foreign key from the receiver to the supplied table name.

But I think it's a bit less ambiguous about what the first parameter is supposed to point to (since the first parameter to `add_foreign_key` is implied as `t` (the receiver) here.