### PR TITLE
Allow route redirects pointing to a path only

### DIFF
--- a/actionpack/test/dispatch/routing/match_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/match_redirect_test.rb
@@ -26,15 +26,23 @@ class MatchRedirectIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   Routes.draw do
-    match "/redirect/*path", via: [:get], to: redirect(path: "/works/%{path}", only_path: true)
+    match "/option_redirect_full_uri/*path", via: [:get], to: redirect(path: "/works/%{path}")
+    match "/option_redirect_path_only/*path", via: [:get], to: redirect(path: "/works/%{path}", only_path: true)
+    match "/path_redirect/*path", via: [:get], to: redirect("/works/%{path}")
 
     namespace :works, path: "works" do
       resources :users, only: [:index]
     end
   end
 
-  test "redirection" do
-    get "/redirect/users"
+  test "OptionRedirect full URI redirection" do
+    get "/option_redirect_full_uri/users"
+    assert_response :redirect
+    assert_equal "http://www.example.com/works/users", response.headers["Location"]
+  end
+
+  test "OptionRedirect path only redirection" do
+    get "/option_redirect_path_only/users"
     assert_response :redirect
     assert_equal "/works/users", response.headers["Location"]
   end

--- a/actionpack/test/dispatch/routing/match_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/match_redirect_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class MatchRedirectIntegrationTest < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new
+  APP = build_app Routes
+
+  include Routes.url_helpers
+
+  def _routes
+    Routes
+  end
+
+  def app
+    APP
+  end
+
+  module Works
+    class UsersController < ActionController::Base
+      include Routes.url_helpers
+      def index
+        render plain: foo_path
+      end
+    end
+  end
+
+  Routes.draw do
+    match "/redirect/*path", via: [:get], to: redirect(path: "/works/%{path}", only_path: true)
+
+    namespace :works, path: "works" do
+      resources :users, only: [:index]
+    end
+  end
+
+  test "redirection" do
+    get "/redirect/users"
+    assert_response :redirect
+    assert_equal "/works/users", response.headers["Location"]
+  end
+end

--- a/actionpack/test/dispatch/routing/match_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/match_redirect_test.rb
@@ -28,7 +28,7 @@ class MatchRedirectIntegrationTest < ActionDispatch::IntegrationTest
   Routes.draw do
     match "/option_redirect_full_uri/*path", via: [:get], to: redirect(path: "/works/%{path}")
     match "/option_redirect_path_only/*path", via: [:get], to: redirect(path: "/works/%{path}", only_path: true)
-    match "/path_redirect/*path", via: [:get], to: redirect("/works/%{path}")
+    match "/string_redirect/*path", via: [:get], to: redirect("/works/%{path}")
 
     namespace :works, path: "works" do
       resources :users, only: [:index]
@@ -45,5 +45,11 @@ class MatchRedirectIntegrationTest < ActionDispatch::IntegrationTest
     get "/option_redirect_path_only/users"
     assert_response :redirect
     assert_equal "/works/users", response.headers["Location"]
+  end
+
+  test "String redirection" do
+    get "/string_redirect/users"
+    assert_response :redirect
+    assert_equal "http://www.example.com/works/users", response.headers["Location"]
   end
 end


### PR DESCRIPTION
### Summary

Previously redirects always included scheme, host and port as well.  Some proxies require that those not be present in the Location header.
Related: https://github.com/ManageIQ/topological_inventory-api/pull/105

cc @tenderlove It looks like you were here quite a while ago