### PR TITLE
Fix typo: inherts -> inherits [ci skip]

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       # determine which database the request should use.
       #
       # To change the behavior of the Resolver class in your application,
-      # create a custom resolver class that inherts from
+      # create a custom resolver class that inherits from
       # DatabaseSelector::Resolver and implements the methods that need to
       # be changed.
       #


### PR DESCRIPTION
While reading the documentation for #35073 found a typo. 
`inherts` -> `inherits`