### PR TITLE
Fix empty custom model callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -97,7 +97,7 @@ module ActiveSupport
     def run_callbacks(kind)
       callbacks = __callbacks[kind.to_sym]
 
-      if callbacks.empty?
+      if callbacks.blank?
         yield if block_given?
       else
         env = Filters::Environment.new(self, false, nil)


### PR DESCRIPTION
In case you're creating custom callbacks in your ActiveRecord with conditions app will raise if conditions are not met:

```
NoMethodError: undefined method `empty?' for nil:NilClass
from /.../active_support/callbacks.rb:97:in `run_callbacks'
```

Example:

```
class User < ApplicationRecord
  define_model_callbacks :custom_test
  
  after_custom_test :custom_callback, if: -> { false }

  def custom_test
    run_callbacks :custom_test do
      puts 'testing'
    end
  end
end

User.new.test # => NoMethodError: undefined method `empty?' for nil:NilClass
```
