### PR TITLE
Fix has_many through association creation

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -612,21 +612,9 @@ module ActiveRecord
 
         # returns either +nil+ or the inverse association name that it finds.
         def automatic_inverse_of
-          return unless can_find_inverse_of_automatically?(self)
+          if can_find_inverse_of_automatically?(self)
+            inverse_name = ActiveSupport::Inflector.underscore(options[:as] || active_record.name.demodulize).to_sym
 
-          inverse_name_candidates =
-            if options[:as]
-              [options[:as]]
-            else
-              active_record_name = active_record.name.demodulize
-              [active_record_name, ActiveSupport::Inflector.pluralize(active_record_name)]
-            end
-
-          inverse_name_candidates.map! do |candidate|
-            ActiveSupport::Inflector.underscore(candidate).to_sym
-          end
-
-          inverse_name_candidates.detect do |inverse_name|
             begin
               reflection = klass._reflect_on_association(inverse_name)
             rescue NameError
@@ -635,7 +623,9 @@ module ActiveRecord
               reflection = false
             end
 
-            valid_inverse_reflection?(reflection)
+            if valid_inverse_reflection?(reflection)
+              return inverse_name
+            end
           end
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -46,6 +46,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
+  def test_has_many_through_create_record
+    assert books(:awdr).subscribers.create!(nick: "bob")
+  end
+
   def test_marshal_dump
     preloaded = Post.includes(:first_blue_tags).first
     assert_equal preloaded, Marshal.load(Marshal.dump(preloaded))

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -20,8 +20,6 @@ require "models/company"
 require "models/project"
 require "models/author"
 require "models/post"
-require "models/department"
-require "models/hotel"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -725,16 +723,6 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_nothing_raised { Face.first.polymorphic_man = Man.first }
     # fails because Interest does have the correct inverse_of
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.polymorphic_man = Interest.first }
-  end
-
-  def test_favors_has_one_associations_for_inverse_of
-    inverse_name = Post.reflect_on_association(:author).inverse_of.name
-    assert_equal :post, inverse_name
-  end
-
-  def test_finds_inverse_of_for_plural_associations
-    inverse_name = Department.reflect_on_association(:hotel).inverse_of.name
-    assert_equal :departments, inverse_name
   end
 end
 

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -3,4 +3,6 @@
 class Subscription < ActiveRecord::Base
   belongs_to :subscriber, counter_cache: :books_count
   belongs_to :book
+
+  validates_presence_of :subscriber_id, :book_id
 end


### PR DESCRIPTION
#33729 affected the behavior of the has_many through record creation.

Since #33729, the intermediate reflection of simple has_many through
association has `inverse_of` to the association, it causes extra through
record creation, the extra through record required valid before the
association record is saved.

https://github.com/rails/rails/blob/23125378673bcc606b274027666a126573e136f8/activerecord/lib/active_record/associations/has_many_through_association.rb#L95-L102

I think that #33729 need to more work to care about has_many through
association, that PR should be reverted to not break existing apps.