### PR TITLE
Set the ActiveJob adapter to :test for the test environment

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -51,4 +51,9 @@ Rails.application.configure do
 
   # Prevent expensive template finalization at end of test suite runs.
   config.action_view.finalize_compiled_template_methods = false
+
+  # Don't automatically run jobs created in test cases. The :test adapter lets
+  # you inspect the job queue and perform enqueued jobs in a predictable way -
+  # see ActiveJob::TestHelper for details
+  config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
### Summary

Change new Rails applications to use the ActiveJob `:test` queue adapter in the test environment. Right now the test adapter is used for test cases that inherit from ActiveJob::TestCase, but other test cases (models, controllers) currently use the default `:async` adapter.

The current behavior is surprising to me: if a model or controller test generates a job, that job will be performed immediately and concurrently with test execution in a different thread, with no visibility into success, failure, or side-effects generated by the job (i.e. database writes). With this change, if a test case does want enqueued jobs to execute, it can use `perform_enqueued_jobs` to run them on the main test thread in a deterministic manner.

Using the `:test` adapter in the test environment (in a documented and overridable way) is consistent with other Rails defaults like the ActiveStorage test service and the ActionMailer test delivery method.