### PR TITLE
[WIP] Remove virtual path mutations

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -45,6 +45,7 @@ module ActionView
     autoload :Rendering
     autoload :RoutingUrlFor
     autoload :Template
+    autoload :FileTemplate
     autoload :ViewPaths
 
     autoload_under "renderer" do

--- a/actionview/lib/action_view/file_template.rb
+++ b/actionview/lib/action_view/file_template.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "action_view/template"
+
+module ActionView
+  class FileTemplate < Template
+    def initialize(filename, handler, details)
+      @filename = filename
+
+      super(nil, filename, handler, details)
+    end
+
+    def source
+      File.binread @filename
+    end
+
+    def refresh(_)
+      self
+    end
+
+    # Exceptions are marshalled when using the parallel test runner with DRb, so we need
+    # to ensure that references to the template object can be marshalled as well. This means forgoing
+    # the marshalling of the compiler mutex and instantiating that again on unmarshalling.
+    def marshal_dump # :nodoc:
+      [ @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @formats, @variants ]
+    end
+
+    def marshal_load(array) # :nodoc:
+      @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @formats, @variants = *array
+      @compile_mutex = Mutex.new
+    end
+  end
+end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -202,7 +202,9 @@ module ActionView
     # before passing the source on to the template engine, leaving a
     # blank line in its stead.
     def encode!
-      return unless source.encoding == Encoding::BINARY
+      source = self.source
+
+      return source unless source.encoding == Encoding::BINARY
 
       # Look for # encoding: *. If we find one, we'll encode the
       # String in that encoding, otherwise, we'll use the
@@ -290,7 +292,7 @@ module ActionView
       # In general, this means that templates will be UTF-8 inside of Rails,
       # regardless of the original source encoding.
       def compile(mod)
-        encode!
+        source = encode!
         code = @handler.call(self)
 
         # Make sure that the resulting String to be eval'd is in the
@@ -312,7 +314,7 @@ module ActionView
         # handler is valid in the default_internal. This is for handlers
         # that handle encoding but screw up
         unless source.valid_encoding?
-          raise WrongEncodingError.new(@source, Encoding.default_internal)
+          raise WrongEncodingError.new(source, Encoding.default_internal)
         end
 
         mod.module_eval(source, identifier, 0)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -2,7 +2,9 @@
 
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/kernel/singleton_class"
+require "active_support/deprecation"
 require "thread"
+require "delegate"
 
 module ActionView
   # = Action View Template
@@ -279,6 +281,15 @@ module ActionView
         end
       end
 
+      class LegacyTemplate < DelegateClass(Template) # :nodoc:
+        attr_reader :source
+
+        def initialize(template, source)
+          super(template)
+          @source = source
+        end
+      end
+
       # Among other things, this method is responsible for properly setting
       # the encoding of the compiled template.
       #
@@ -293,7 +304,7 @@ module ActionView
       # regardless of the original source encoding.
       def compile(mod)
         source = encode!
-        code = @handler.call(self)
+        code = @handler.call(LegacyTemplate.new(self, source))
 
         # Make sure that the resulting String to be eval'd is in the
         # encoding of the code

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -2,7 +2,6 @@
 
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/kernel/singleton_class"
-require "active_support/deprecation"
 require "thread"
 require "delegate"
 
@@ -304,7 +303,7 @@ module ActionView
       # regardless of the original source encoding.
       def compile(mod)
         source = encode!
-        code = @handler.call(LegacyTemplate.new(self, source))
+        code = @handler.call(self, source)
 
         # Make sure that the resulting String to be eval'd is in the
         # encoding of the code

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -114,9 +114,10 @@ module ActionView
 
     extend Template::Handlers
 
-    attr_accessor :locals, :formats, :variants, :virtual_path
+    attr_accessor :locals, :formats, :variants
 
     attr_reader :source, :identifier, :handler, :original_encoding, :updated_at
+    attr_reader :virtual_path
 
     # This finalizer is needed (and exactly with a proc inside another proc)
     # otherwise templates leak in development.

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module ActionView #:nodoc:
   # = Action View Template Handlers
   class Template #:nodoc:
@@ -14,7 +16,7 @@ module ActionView #:nodoc:
         base.register_template_handler :erb, ERB.new
         base.register_template_handler :html, Html.new
         base.register_template_handler :builder, Builder.new
-        base.register_template_handler :ruby, :source.to_proc
+        base.register_template_handler :ruby, lambda { |_, source| source }
       end
 
       @@template_handlers = {}
@@ -24,11 +26,35 @@ module ActionView #:nodoc:
         @@template_extensions ||= @@template_handlers.keys
       end
 
+      class LegacyHandlerWrapper < SimpleDelegator # :nodoc:
+        def call(view, source)
+          __getobj__.call(ActionView::Template::LegacyTemplate.new(view, source))
+        end
+      end
+
       # Register an object that knows how to handle template files with the given
       # extensions. This can be used to implement new template types.
       # The handler must respond to +:call+, which will be passed the template
       # and should return the rendered template as a String.
       def register_template_handler(*extensions, handler)
+        params = if handler.is_a?(Proc)
+          handler.parameters
+        else
+          handler.method(:call).parameters
+        end
+
+        unless params.find_all { |type, _| type == :req }.length >= 2
+          ActiveSupport::Deprecation.warn <<~eowarn
+          Single arity template handlers are deprecated.  Template handlers must
+          now accept two parameters, the view object and the source for the view object.
+          Change:
+            >> #{handler.class}#call(#{params.map(&:last).join(", ")})
+          To:
+            >> #{handler.class}#call(#{params.map(&:last).join(", ")}, source)
+          eowarn
+          handler = LegacyHandlerWrapper.new(handler)
+        end
+
         raise(ArgumentError, "Extension is required") if extensions.empty?
         extensions.each do |extension|
           @@template_handlers[extension.to_sym] = handler

--- a/actionview/lib/action_view/template/handlers/builder.rb
+++ b/actionview/lib/action_view/template/handlers/builder.rb
@@ -5,11 +5,11 @@ module ActionView
     class Builder
       class_attribute :default_format, default: :xml
 
-      def call(template)
+      def call(template, source)
         require_engine
         "xml = ::Builder::XmlMarkup.new(:indent => 2);" \
           "self.output_buffer = xml.target!;" +
-          template.source +
+          source +
           ";xml.target!;"
       end
 

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -28,8 +28,8 @@ module ActionView
 
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 
-        def self.call(template)
-          new.call(template)
+        def self.call(template, source)
+          new.call(template, source)
         end
 
         def supports_streaming?
@@ -40,17 +40,17 @@ module ActionView
           true
         end
 
-        def call(template)
+        def call(template, source)
           # First, convert to BINARY, so in case the encoding is
           # wrong, we can still find an encoding tag
           # (<%# encoding %>) inside the String using a regular
           # expression
-          template_source = template.source.dup.force_encoding(Encoding::ASCII_8BIT)
+          template_source = source.dup.force_encoding(Encoding::ASCII_8BIT)
 
           erb = template_source.gsub(ENCODING_TAG, "")
           encoding = $2
 
-          erb.force_encoding valid_encoding(template.source.dup, encoding)
+          erb.force_encoding valid_encoding(source.dup, encoding)
 
           # Always make sure we return a String in the default_internal
           erb.encode!

--- a/actionview/lib/action_view/template/handlers/html.rb
+++ b/actionview/lib/action_view/template/handlers/html.rb
@@ -3,7 +3,7 @@
 module ActionView
   module Template::Handlers
     class Html < Raw
-      def call(template)
+      def call(template, source)
         "ActionView::OutputBuffer.new #{super}"
       end
     end

--- a/actionview/lib/action_view/template/handlers/raw.rb
+++ b/actionview/lib/action_view/template/handlers/raw.rb
@@ -3,8 +3,8 @@
 module ActionView
   module Template::Handlers
     class Raw
-      def call(template)
-        "#{template.source.inspect}.html_safe;"
+      def call(template, source)
+        "#{source.inspect}.html_safe;"
       end
     end
   end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -226,9 +226,8 @@ module ActionView
 
         template_paths.map do |template|
           handler, format, variant = extract_handler_and_format_and_variant(template)
-          contents = File.binread(template)
 
-          Template.new(contents, File.expand_path(template), handler,
+          FileTemplate.new(File.expand_path(template), handler,
             virtual_path: path.virtual,
             format: format,
             variant: variant,

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -198,7 +198,9 @@ module ActionView
         t.locals         = locals
         t.formats        = details[:formats]  || [:html] if t.formats.empty?
         t.variants       = details[:variants] || []      if t.variants.empty?
-        t.virtual_path ||= (cached ||= build_path(*path_info))
+        unless t.virtual_path == build_path(*path_info).virtual
+          raise "Virtual path mismatch"
+        end
       end
     end
   end
@@ -421,10 +423,6 @@ module ActionView
   class FallbackFileSystemResolver < FileSystemResolver #:nodoc:
     def self.instances
       [new(""), new("/")]
-    end
-
-    def decorate(*)
-      super.each { |t| t.virtual_path = nil }
     end
   end
 end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -58,7 +58,7 @@ module RenderERBUtils
     template = ActionView::Template.new(
       string.strip,
       "test template",
-      ActionView::Template::Handlers::ERB,
+      ActionView::Template.handler_for_extension(:erb),
       {})
 
     template.render(ActionView::Base.empty, {}).strip

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -70,7 +70,7 @@ class LayoutAutoDiscoveryTest < ActionController::TestCase
   end
 
   def test_third_party_template_library_auto_discovers_layout
-    with_template_handler :mab, lambda { |template| template.source.inspect } do
+    with_template_handler :mab, lambda { |template, source| source.inspect } do
       @controller = ThirdPartyTemplateLibraryController.new
       get :hello
       assert_response :success
@@ -212,7 +212,7 @@ class LayoutSetInResponseTest < ActionController::TestCase
   end
 
   def test_layout_set_when_using_render
-    with_template_handler :mab, lambda { |template| template.source.inspect } do
+    with_template_handler :mab, lambda { |template, source| source.inspect } do
       @controller = SetsLayoutInRenderController.new
       get :hello
       assert_includes @response.body, "layouts/third_party_template_library.mab"

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -17,8 +17,8 @@ class FakeTemplate
   end
 end
 
-Neckbeard = lambda { |template| template.source }
-Bowtie = lambda { |template| template.source }
+Neckbeard = lambda { |template, source| source }
+Bowtie = lambda { |template, source| source }
 
 class DependencyTrackerTest < ActionView::TestCase
   def tracker

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -450,13 +450,22 @@ module RenderTestCases
     assert_equal "Hello, World!", @view.render(inline: "Hello, World!", type: :bar)
   end
 
-  CustomHandler = lambda do |template|
+  CustomHandler = lambda do |template, source|
     "@output_buffer = ''.dup\n" \
-      "@output_buffer << 'source: #{template.source.inspect}'\n"
+      "@output_buffer << 'source: #{source.inspect}'\n"
   end
 
   def test_render_inline_with_render_from_to_proc
-    ActionView::Template.register_template_handler :ruby_handler, :source.to_proc
+    ActionView::Template.register_template_handler :ruby_handler, lambda { |_, source| source }
+    assert_equal "3", @view.render(inline: "(1 + 2).to_s", type: :ruby_handler)
+  ensure
+    ActionView::Template.unregister_template_handler :ruby_handler
+  end
+
+  def test_render_inline_with_render_from_to_proc_deprecated
+    assert_deprecated do
+      ActionView::Template.register_template_handler :ruby_handler, :source.to_proc
+    end
     assert_equal "3", @view.render(inline: "(1 + 2).to_s", type: :ruby_handler)
   ensure
     ActionView::Template.unregister_template_handler :ruby_handler


### PR DESCRIPTION
This is on top of https://github.com/rails/rails/pull/35119

I think we don't need to mutate virtual path on the template objects now that the source is "immutable".  I want to run this through CI to see if the `raise` condition I added hits.  If the build is green, I think we can remove some of this.