### PR TITLE
Ruby 2.7 warning: creating a Proc without a block

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -944,9 +944,9 @@ module ActionMailer
         assignable.each { |k, v| message[k] = v }
       end
 
-      def collect_responses(headers)
+      def collect_responses(headers, &block)
         if block_given?
-          collect_responses_from_block(headers, &Proc.new)
+          collect_responses_from_block(headers, &block)
         elsif headers[:body]
           collect_responses_from_text(headers)
         else

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -26,10 +26,10 @@ module ActionController
       end
     end
 
-    def build(action, app = Proc.new)
+    def build(action, app = nil, &block)
       action = action.to_s
 
-      middlewares.reverse.inject(app) do |a, middleware|
+      middlewares.reverse.inject(app || block) do |a, middleware|
         middleware.valid?(action) ? middleware.build(a) : a
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -97,8 +97,8 @@ module ActionDispatch
       middlewares.push(build_middleware(klass, args, block))
     end
 
-    def build(app = Proc.new)
-      middlewares.freeze.reverse.inject(app) { |a, e| e.build(a) }
+    def build(app = nil, &block)
+      middlewares.freeze.reverse.inject(app || block) { |a, e| e.build(a) }
     end
 
     private

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -739,7 +739,7 @@ module ActionView
       #   def labelled_form_with(**options, &block)
       #     form_with(**options.merge(builder: LabellingFormBuilder), &block)
       #   end
-      def form_with(model: nil, scope: nil, url: nil, format: nil, **options)
+      def form_with(model: nil, scope: nil, url: nil, format: nil, **options, &block)
         options[:allow_method_names_outside_object] = true
         options[:skip_default_ids] = !form_with_generates_ids
 
@@ -752,7 +752,7 @@ module ActionView
 
         if block_given?
           builder = instantiate_builder(scope, model, options)
-          output  = capture(builder, &Proc.new)
+          output  = capture(builder, &block)
           options[:multipart] ||= builder.multipart?
 
           html_options = html_options_for_form_with(url, model, options)

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -20,10 +20,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
       }
     end
 
-    def self.define_extensions(model, name)
+    def self.define_extensions(model, name, &block)
       if block_given?
         extension_module_name = "#{model.name.demodulize}#{name.to_s.camelize}AssociationExtension"
-        extension = Module.new(&Proc.new)
+        extension = Module.new(&block)
         model.module_parent.const_set(extension_module_name, extension)
       end
     end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -86,8 +86,8 @@ module ActiveRecord
           #       # Should return a scope, you can call 'super' here etc.
           #     end
           #   end
-          def default_scope(scope = nil) # :doc:
-            scope = Proc.new if block_given?
+          def default_scope(scope = nil, &block) # :doc:
+            scope = block if block_given?
 
             if scope.is_a?(Relation) || !scope.respond_to?(:call)
               raise ArgumentError,

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -113,8 +113,8 @@ module ActiveRecord
       end
     end
 
-    def self.create(connection, block = Proc.new)
-      relation = block.call Params.new
+    def self.create(connection, callable = nil, &block)
+      relation = (callable || block).call Params.new
       query_builder, binds = connection.cacheable_query(self, relation.arel)
       bind_map = BindMap.new(binds)
       new(query_builder, bind_map, relation.klass)

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -20,8 +20,8 @@ module ActiveSupport
         super
       end
 
-      def subscribe(pattern = nil, block = Proc.new)
-        subscriber = Subscribers.new pattern, block
+      def subscribe(pattern = nil, callable = nil, &block)
+        subscriber = Subscribers.new(pattern, callable || block)
         synchronize do
           if String === pattern
             @string_subscribers[pattern] << subscriber

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -530,9 +530,9 @@ module Rails
 
     # Defines the routes for this engine. If a block is given to
     # routes, it is appended to the engine.
-    def routes
+    def routes(&block)
       @routes ||= ActionDispatch::Routing::RouteSet.new_with_config(config)
-      @routes.append(&Proc.new) if block_given?
+      @routes.append(&block) if block_given?
       @routes
     end
 


### PR DESCRIPTION
As of https://github.com/ruby/ruby/commit/9f1fb0a17feb calls to
`Proc.new` without giving a block tickles:

```
warning: tried to create Proc object without a block
```

We have a few such calls in Rails. This commit fixes the easier instances.

See:
https://travis-ci.org/rails/rails/jobs/487205819#L1161-L1190
https://travis-ci.org/rails/rails/jobs/487205821#L1154-1159
https://travis-ci.org/rails/rails/jobs/487205821#L1160-L1169
https://travis-ci.org/rails/rails/jobs/487205821#L1189

Two additional instances remain to be fixed.

The first, in [`ActionView#form_with`](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/form_helper.rb#L755) may require changing a method signature that is already long and ends with a double splat, as well as many internal calls.

The second, in [`ActiveSupport::Fanout#subscribe'](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/notifications/fanout.rb#L21) just leaves me baffled :( It's a very popular method in the test suite, gets tickled over 10_000 times when I run the Rails tests.