### PR TITLE
Bugfix association loading behavior when counter cache is zero

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -210,7 +210,8 @@ module ActiveRecord
       # This method is abstract in the sense that it relies on
       # +count_records+, which is a method descendants have to provide.
       def size
-        if !find_target? || loaded?
+        if !find_target?
+          loaded! unless loaded?
           target.size
         elsif @association_ids
           @association_ids.size
@@ -233,7 +234,7 @@ module ActiveRecord
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        if loaded? || @association_ids
+        if loaded? || @association_ids || reflection.has_cached_counter?
           size.zero?
         else
           target.empty? && !scope.exists?

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1223,12 +1223,15 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_has_many_without_counter_cache_option
     # Ship has a conventionally named `treasures_count` column, but the counter_cache
     # option is not given on the association.
-    ship = Ship.create(name: "Countless", treasures_count: 10)
+    ship = Ship.create!(name: "Countless", treasures_count: 10)
 
     assert_not_predicate Ship.reflect_on_association(:treasures), :has_cached_counter?
 
     # Count should come from sql count() of treasures rather than treasures_count attribute
-    assert_equal ship.treasures.size, 0
+    assert_queries(1) do
+      assert_equal ship.treasures.size, 0
+      assert_predicate ship.treasures, :loaded?
+    end
 
     assert_no_difference lambda { ship.reload.treasures_count }, "treasures_count should not be changed" do
       ship.treasures.create(name: "Gold")
@@ -1349,6 +1352,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     post = posts(:welcome)
     assert_no_queries do
       assert_not_empty post.comments
+      assert_equal 2, post.comments.size
+      assert_not_predicate post.comments, :loaded?
+    end
+    post = posts(:misc_by_bob)
+    assert_no_queries do
+      assert_empty post.comments
+      assert_predicate post.comments, :loaded?
+    end
+  end
+
+  def test_empty_association_loading_with_counter_cache
+    post = posts(:misc_by_bob)
+    assert_no_queries do
+      assert_empty post.comments.to_a
     end
   end
 
@@ -1969,9 +1986,22 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate company.clients, :loaded?
   end
 
-  def test_counter_cache_on_unloaded_association
-    car = Car.create(name: "My AppliCar")
-    assert_equal car.engines.size, 0
+  def test_zero_counter_cache_usage_on_unloaded_association
+    car = Car.create!(name: "My AppliCar")
+    assert_no_queries do
+      assert_equal car.engines.size, 0
+      assert_predicate car.engines, :loaded?
+    end
+  end
+
+  def test_counter_cache_on_new_record_unloaded_association
+    car = Car.new(name: "My AppliCar")
+    # Ensure no schema queries inside assertion
+    Engine.primary_key
+    assert_no_queries do
+      assert_equal car.engines.size, 0
+      assert_predicate car.engines, :loaded?
+    end
   end
 
   def test_get_ids_ignores_include_option


### PR DESCRIPTION
Suppose we have a `has_many` association with a counter cache.
In this case, when counter cache is zero, it is often used to avoid certain SQL queries.

Example:

``` ruby
Reward.belogns_to :coupon, counter_cache: true
coupon = Coupon.create!
coupon.rewards_count # => 0 - required

coupon.rewards.size # => 0 no query
coupon.rewards.to_a # => [] no query
```

However, this behavior doesn't happen consistently. If we change the method call order the number of SQL queries is different:

``` ruby
coupon.rewards.to_a # => [] with query
coupon.rewards.size # => [] no query
```

It happens because `#size` makes use of the counter cache and assumes the association is loaded when it is zero. I think that this behavior should be consistent with direct association loading.

A lot of additional tests were added to ensure no regression occur.

cc @kamipo 