### PR TITLE
Improve the type map inizitalizer records processing time

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -17,20 +17,23 @@ module ActiveRecord
           end
 
           def run(records)
-            nodes = records.reject { |row| @store.key? row["oid"].to_i }
-            mapped = nodes.extract! { |row| @store.key? row["typname"] }
-            ranges = nodes.extract! { |row| row["typtype"] == "r" }
-            enums = nodes.extract! { |row| row["typtype"] == "e" }
-            domains = nodes.extract! { |row| row["typtype"] == "d" }
-            arrays = nodes.extract! { |row| row["typinput"] == "array_in" }
-            composites = nodes.extract! { |row| row["typelem"].to_i != 0 }
-
-            mapped.each     { |row| register_mapped_type(row)    }
-            enums.each      { |row| register_enum_type(row)      }
-            domains.each    { |row| register_domain_type(row)    }
-            arrays.each     { |row| register_array_type(row)     }
-            ranges.each     { |row| register_range_type(row)     }
-            composites.each { |row| register_composite_type(row) }
+            records.each do |row|
+              if @store.key? row["oid"].to_i
+                continue
+              elsif @store.key? row["typname"]
+                register_mapped_type(row)
+              elsif row["typtype"] == "r"
+                register_range_type(row)
+              elsif row["typtype"] == "e"
+                register_enum_type(row)
+              elsif row["typtype"] == "d"
+                register_domain_type(row)
+              elsif row["typinput"] == "array_in"
+                register_array_type(row)
+              elsif row["typelem"].to_i != 0
+                register_composite_type(row)
+              end
+            end
           end
 
           def query_conditions_for_initial_load


### PR DESCRIPTION
### Summary

Now the code iterates multiple times in two ways without need:

- First, it goes through the records object multiple times doing
partitions. In case we have hundreds of thousands of records (like in
the benchmark I've left below) that means that we have to go
through all of them multiple times doing it very slowly. That depends on
the distribution of course but in PG if you have a huge number of tables
the majority of the data are going to be `array_in` or composite
elements
- Second, once we have processed the records, we iterate over all of them
again to register every record.

It's tested in rails 4.2.10 / ruby 2.2. (our production environment) but the code is the same in Rails 6.0 AFAIK

### Other Information

Related to #19578

Here are the benchmarks where you can see a slight improvement for
hundreds of records (the normal case) but if you have a huge number of
types you improve a lot the performance

```
-- Current method benchmark
Records count: 207
  0.000000   0.010000   0.010000 (  0.002049)
  0.000000   0.000000   0.000000 (  0.002214)
  0.000000   0.000000   0.000000 (  0.001979)
  0.010000   0.000000   0.010000 (  0.002516)
  0.000000   0.000000   0.000000 (  0.002142)
Records count: 142191
  2.050000   0.180000   2.230000 (  2.224884)
  2.090000   0.090000   2.180000 (  2.176774)
  2.050000   0.080000   2.130000 (  2.124951)
  2.140000   0.100000   2.240000 (  2.249662)
  2.040000   0.100000   2.140000 (  2.157886)
```
```
-- Suggested method benchmark
Records count: 207
  0.010000   0.000000   0.010000 (  0.001821)
  0.010000   0.000000   0.010000 (  0.001999)
  0.000000   0.000000   0.000000 (  0.001983)
  0.000000   0.000000   0.000000 (  0.001906)
  0.000000   0.000000   0.000000 (  0.001829)
Records count: 142191
  1.050000   0.000000   1.050000 (  1.056097)
  1.040000   0.000000   1.040000 (  1.034397)
  1.020000   0.010000   1.030000 (  1.018424)
  1.100000   0.000000   1.100000 (  1.103647)
  1.030000   0.000000   1.030000 (  1.032034)
```

I've also checked the object's allocation and they remain practically the same:

#### Current method objects allocation

```
                                                                              sourcefile                                                                                sourceline                             class                             count
----------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------  -----------------------------------------------------------  -----
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          39  String                                                       3270399
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          39  Hash                                                         142191
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          39  Array                                                            1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  Proc                                                            49
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  RubyVM::Env                                                     49
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          45  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          44  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          43  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          42  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          41  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          40  Array                                                            3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    30  Proc                                                            11
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    30  RubyVM::Env                                                     11
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          99  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Vector        2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/integer.rb                                                      8  Range                                                            3
/ruby/2.2.0/gems/state_machines-0.5.0/lib/state_machines/assertions.rb                                                     15  Array                                                            9
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/value.rb                                                        9  Array                                                           18
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  Array                                                            6
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer       3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  Hash                                                             6
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                        19  Array                                                           22
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    19  Array                                                           40
/ruby/2.2.0/gems/thread_safe-0.3.6/lib/thread_safe/non_concurrent_cache_backend.rb                                         16  String                                                          10
/ruby/2.2.0/gems/thread_safe-0.3.6/lib/thread_safe/non_concurrent_cache_backend.rb                                          8  Hash                                                            20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                     9  ThreadSafe::Cache                                               20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  Proc                                                            20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  RubyVM::Env                                                     20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  Array                                                           40
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  Array                                                           20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          98  Array                                                            2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb         119  Proc                                                           112
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb         119  RubyVM::Env                                                    112
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          90  Array                                                            8
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/value.rb                                                        8  Hash                                                             2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    60  ActiveRecord::Type::Value                                        1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  ActiveRecord::Type::String                                       3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql_adapter.rb                          487  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime      1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql_adapter.rb                          487  Hash                                                             1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          74  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum          1
```

#### Suggested method objects allocation

```
                                                                              sourcefile                                                                                sourceline                             class                             count
----------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------  -----------------------------------------------------------  -----
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          19  String                                                       3270399
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          19  Hash                                                         142191
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    30  Proc                                                            11
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    30  RubyVM::Env                                                     11
/ruby/2.2.0/gems/state_machines-0.5.0/lib/state_machines/assertions.rb                                                     15  Array                                                           10
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/value.rb                                                        9  Array                                                           20
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql_adapter.rb                          487  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime      1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql_adapter.rb                          487  Hash                                                             1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    19  Array                                                           48
/ruby/2.2.0/gems/thread_safe-0.3.6/lib/thread_safe/non_concurrent_cache_backend.rb                                         16  String                                                          12
/ruby/2.2.0/gems/thread_safe-0.3.6/lib/thread_safe/non_concurrent_cache_backend.rb                                          8  Hash                                                            24
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                     9  ThreadSafe::Cache                                               24
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  Proc                                                            24
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  RubyVM::Env                                                     24
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/type_map.rb                                                    14  Array                                                           48
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  Array                                                           24
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                        19  Array                                                           30
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  Proc                                                            49
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/hash_lookup_type_map.rb                                         5  RubyVM::Env                                                     49
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          99  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Vector        2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/integer.rb                                                      8  Range                                                            5
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  Array                                                           10
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer       5
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  Hash                                                             8
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          98  Array                                                            2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb         119  Proc                                                           122
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb         119  RubyVM::Env                                                    122
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          90  Array                                                            8
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb                            441  ActiveRecord::Type::String                                       3
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/type/value.rb                                                        8  Hash                                                             1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          74  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum          1
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb          79  ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array         2
/ruby/2.2.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb         120  Array                                                            4

```