### PR TITLE
Refactor options for database selector middleware

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -35,13 +35,14 @@ module ActiveRecord
     #   config.active_record.database_resolver = MyResolver
     #   config.active_record.database_operations = MyResolver::MySession
     class DatabaseSelector
-      def initialize(app, resolver_klass = Resolver, operations_klass = Resolver::Session)
+      def initialize(app, resolver_klass = Resolver, operations_klass = Resolver::Session, options = {})
         @app = app
         @resolver_klass = resolver_klass
         @operations_klass = operations_klass
+        @options = options
       end
 
-      attr_reader :resolver_klass, :operations_klass
+      attr_reader :resolver_klass, :operations_klass, :options
 
       # Middleware that determines which database connection to use in a multiple
       # database application.
@@ -57,7 +58,7 @@ module ActiveRecord
 
         def select_database(request, &blk)
           operations = operations_klass.build(request)
-          database_resolver = resolver_klass.call(operations)
+          database_resolver = resolver_klass.call(operations, options)
 
           if reading_request?(request)
             database_resolver.read(&blk)

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -89,10 +89,10 @@ module ActiveRecord
     end
 
     initializer "active_record.database_selector" do
-      if config.active_record.database_selector
+      if options = config.active_record.delete(:database_selector)
         resolver = config.active_record.delete(:database_resolver)
         operations = config.active_record.delete(:database_operations)
-        config.app_middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, operations
+        config.app_middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, operations, options
       end
     end
 

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -95,6 +95,54 @@ module ActiveRecord
       assert @session_store[:last_write]
     end
 
+    def test_read_from_primary_with_options
+      resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session, delay: 5.seconds)
+
+      # Session should start empty
+      assert_nil @session_store[:last_write]
+
+      called = false
+      resolver.write do
+        assert ActiveRecord::Base.connected_to?(role: :writing)
+        called = true
+      end
+      assert called
+
+      # and be populated by the last write time
+      assert @session_store[:last_write]
+
+      read = false
+      resolver.read do
+        assert ActiveRecord::Base.connected_to?(role: :writing)
+        read = true
+      end
+      assert read
+    end
+
+    def test_read_from_replica_with_no_delay
+      resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session, delay: 0.seconds)
+
+      # Session should start empty
+      assert_nil @session_store[:last_write]
+
+      called = false
+      resolver.write do
+        assert ActiveRecord::Base.connected_to?(role: :writing)
+        called = true
+      end
+      assert called
+
+      # and be populated by the last write time
+      assert @session_store[:last_write]
+
+      read = false
+      resolver.read do
+        assert ActiveRecord::Base.connected_to?(role: :reading)
+        read = true
+      end
+      assert read
+    end
+
     def test_the_middleware_chooses_writing_role_with_POST_request
       middleware = ActiveRecord::Middleware::DatabaseSelector.new(lambda { |env|
         assert ActiveRecord::Base.connected_to?(role: :writing)


### PR DESCRIPTION
Right now we only have one option that's supported, the delay. However I
can see us supporting other options in the future.

This PR refactors the options to get passed into the resolver so whether
you're using middleware or using the config options you can pass options
to the resolver. This will also make it easy to add new options in the
future.

cc/ @tenderlove @jhawthorn