### PR TITLE
Make Notifications::Fanout faster after changing subscriptions

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -24,10 +24,11 @@ module ActiveSupport
         synchronize do
           if String === pattern
             @string_subscribers[pattern] << subscriber
+            @listeners_for.delete(pattern)
           else
             @other_subscribers << subscriber
+            @listeners_for.clear
           end
-          @listeners_for.clear
         end
         subscriber
       end
@@ -37,16 +38,17 @@ module ActiveSupport
           case subscriber_or_name
           when String
             @string_subscribers[subscriber_or_name].clear
+            @listeners_for.delete(subscriber_or_name)
           else
             pattern = subscriber_or_name.try(:pattern)
             if String === pattern
               @string_subscribers[pattern].delete(subscriber_or_name)
+              @listeners_for.delete(pattern)
             else
               @other_subscribers.delete(subscriber_or_name)
+              @listeners_for.clear
             end
           end
-
-          @listeners_for.clear
         end
       end
 


### PR DESCRIPTION
This PR aims to reduce the performance impact of adding/removing subscribers to `ActiveSupport::Notifications`.

[The docs say:](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#module-ActiveSupport::Notifications-label-Temporary+Subscriptions)

> WARNING: The instrumentation framework is designed for long-running subscribers, use this feature sparingly because it wipes some internal caches and that has a negative impact on performance.

Unfortunately not everyone heeds that advice 😅. If nothing else I suspect this is pretty common to do in tests.

---

The first commit hashes any subscribers with a string pattern by their pattern, which allows a fast lookup of all matching string patterns in `listeners_for`. This avoids testing equality against all N patterns. Regex patterns are still stored in a single array and each need to be checked.

I wrote a benchmark to test having 500 String pattern listeners, and sending an event of each type.

``` ruby
require 'benchmark/ips'
require 'active_support/all'

notifier = ActiveSupport::Notifications::Fanout.new

patterns = 0.upto(500).map { |n| "pattern#{n}" }
patterns.each do |name|
  notifier.subscribe(name) { |*| }
end

Benchmark.ips do |x|
  x.report("cached") do |x|
    patterns.each do |name|
      notifier.publish(name)
    end
  end

  x.report("uncached") do |x|
    # subscribe and unsubscribe to clear cache
    subscriber = notifier.subscribe {}
    notifier.unsubscribe(subscriber)

    patterns.each do |name|
      notifier.publish(name)
    end
  end
end
```

**Before**
```
              cached      1.527M (±11.1%) i/s -      7.493M in   4.994136s
            uncached    267.741  (± 3.7%) i/s -      1.340k in   5.014361s
```

**After**
```
              cached      1.539M (±11.6%) i/s -      7.534M in   4.994576s
            uncached    259.025k (±11.8%) i/s -      1.260M in   4.997521s
```

In this case it's in the order of ~1000x faster.

---

The second commit avoids clearing the full cache when adding/removing a subscriber with a String pattern, since we need only clear the one key in the cache that will affect.

cc @tenderlove @eileencodes 