### PR TITLE
Cookie doesn't expire anymore unless a flag is set:

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -488,13 +488,8 @@ module ActionDispatch
         end
 
         def cookie_metadata(name, options)
-          if request.use_cookies_with_metadata
-            metadata = expiry_options(options)
-            metadata[:purpose] = "cookie.#{name}"
-
-            metadata
-          else
-            {}
+          expiry_options(options).tap do |metadata|
+            metadata[:purpose] = "cookie.#{name}" if request.use_cookies_with_metadata
           end
         end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1193,11 +1193,7 @@ class CookiesTest < ActionController::TestCase
     get :encrypted_discount_and_user_id_cookie
 
     travel 2.hours
-    assert_equal 50, cookies.encrypted[:user_id]
-
-    cookies[:discount_percentage] = cookies[:user_id]
-    assert_not_equal 10, cookies.encrypted[:discount_percentage]
-    assert_equal 50, cookies.encrypted[:discount_percentage]
+    assert_nil cookies.signed[:user_id]
   end
 
   def test_switch_off_metadata_for_signed_cookies_if_config_is_false
@@ -1206,11 +1202,8 @@ class CookiesTest < ActionController::TestCase
     get :signed_discount_and_user_id_cookie
 
     travel 2.hours
-    assert_equal 50, cookies.signed[:user_id]
 
-    cookies[:discount_percentage] = cookies[:user_id]
-    assert_not_equal 10, cookies.signed[:discount_percentage]
-    assert_equal 50, cookies.signed[:discount_percentage]
+    assert_nil cookies.signed[:user_id]
   end
 
   def test_read_rails_5_2_stable_encrypted_cookies_if_config_is_false


### PR DESCRIPTION
Cookie doesn't expire anymore unless a flag is set:

- There is a regression in 6.0 introduced by #32937 where cookie
  doesn't expire anymore unless the new `use_cookies_with_metadata`
  configuration is set to `true`.

  This causes issue for app migration from 5.2 to 6.0 because the
  `use_cookies_with_metadata` flag can't be set to true until all
  servers are running on 6.0.

  Here is a small reproduction script that you can run in the console

  ```ruby
  ActionDispatch::Cookies

  request = ActionDispatch::Request.empty
  request.env["action_dispatch.key_generator"] = ActiveSupport::KeyGenerator.new('1234567890')
  request.env["action_dispatch.signed_cookie_salt"] = 'signed cookie'
  request.env["action_dispatch.cookies_rotations"] = ActiveSupport::Messages::RotationConfiguration.new
  request.env["action_dispatch.use_authenticated_cookie_encryption"] = true
  signed_cookie = request.cookie_jar.signed
  signed_cookie[:foobar] = { value: '123', expires: 1.day.ago }
  p signed_cookie[:foobar] # nil on 5.2, '123' on 6.0
  ```

