### PR TITLE
Use consistent hash syntax for routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -74,8 +74,8 @@ module ActionDispatch
   # For routes that don't fit the <tt>resources</tt> mold, you can use the HTTP helper
   # methods <tt>get</tt>, <tt>post</tt>, <tt>patch</tt>, <tt>put</tt> and <tt>delete</tt>.
   #
-  #   get 'post/:id' => 'posts#show'
-  #   post 'post/:id' => 'posts#create_comment'
+  #   get 'post/:id', to: 'posts#show'
+  #   post 'post/:id', to: 'posts#create_comment'
   #
   # Now, if you POST to <tt>/posts/:id</tt>, it will route to the <tt>create_comment</tt> action. A GET on the same
   # URL will route to the <tt>show</tt> action.
@@ -83,7 +83,7 @@ module ActionDispatch
   # If your route needs to respond to more than one HTTP method (or all methods) then using the
   # <tt>:via</tt> option on <tt>match</tt> is preferable.
   #
-  #   match 'post/:id' => 'posts#show', via: [:get, :post]
+  #   match 'post/:id', to: 'posts#show', via: [:get, :post]
   #
   # == Named routes
   #
@@ -94,7 +94,7 @@ module ActionDispatch
   # Example:
   #
   #   # In config/routes.rb
-  #   get '/login' => 'accounts#login', as: 'login'
+  #   get '/login', to: 'accounts#login', as: 'login'
   #
   #   # With render, redirect_to, tests, etc.
   #   redirect_to login_url
@@ -120,9 +120,9 @@ module ActionDispatch
   #
   #   # In config/routes.rb
   #   controller :blog do
-  #     get 'blog/show'     => :list
-  #     get 'blog/delete'   => :delete
-  #     get 'blog/edit'     => :edit
+  #     get 'blog/show',    to: :list
+  #     get 'blog/delete',  to: :delete
+  #     get 'blog/edit',    to: :edit
   #   end
   #
   #   # provides named routes for show, delete, and edit
@@ -132,7 +132,7 @@ module ActionDispatch
   #
   # Routes can generate pretty URLs. For example:
   #
-  #   get '/articles/:year/:month/:day' => 'articles#find_by_id', constraints: {
+  #   get '/articles/:year/:month/:day', to: 'articles#find_by_id', constraints: {
   #     year:       /\d{4}/,
   #     month:      /\d{1,2}/,
   #     day:        /\d{1,2}/
@@ -147,7 +147,7 @@ module ActionDispatch
   # You can specify a regular expression to define a format for a parameter.
   #
   #   controller 'geocode' do
-  #     get 'geocode/:postalcode' => :show, constraints: {
+  #     get 'geocode/:postalcode', to: :show, constraints: {
   #       postalcode: /\d{5}(-\d{4})?/
   #     }
   #   end
@@ -156,13 +156,13 @@ module ActionDispatch
   # expression modifiers:
   #
   #   controller 'geocode' do
-  #     get 'geocode/:postalcode' => :show, constraints: {
+  #     get 'geocode/:postalcode', to: :show, constraints: {
   #       postalcode: /hx\d\d\s\d[a-z]{2}/i
   #     }
   #   end
   #
   #   controller 'geocode' do
-  #     get 'geocode/:postalcode' => :show, constraints: {
+  #     get 'geocode/:postalcode', to: :show, constraints: {
   #       postalcode: /# Postalcode format
   #          \d{5} #Prefix
   #          (-\d{4})? #Suffix
@@ -178,13 +178,13 @@ module ActionDispatch
   #
   # You can redirect any path to another path using the redirect helper in your router:
   #
-  #   get "/stories" => redirect("/posts")
+  #   get "/stories", to: redirect("/posts")
   #
   # == Unicode character routes
   #
   # You can specify unicode character routes in your router:
   #
-  #   get "こんにちは" => "welcome#index"
+  #   get "こんにちは", to: "welcome#index"
   #
   # == Routing to Rack Applications
   #
@@ -192,7 +192,7 @@ module ActionDispatch
   # index action in the PostsController, you can specify any Rack application
   # as the endpoint for a matcher:
   #
-  #   get "/application.js" => Sprockets
+  #   get "/application.js", to: Sprockets
   #
   # == Reloading routes
   #

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -260,7 +260,7 @@ In each of these cases, the named routes remain the same as if you did not use `
 | PATCH/PUT | /admin/articles/:id      | articles#update      | article_path(:id)      |
 | DELETE    | /admin/articles/:id      | articles#destroy     | article_path(:id)      |
 
-TIP: _If you need to use a different controller namespace inside a `namespace` block you can specify an absolute controller path, e.g: `get '/foo' => '/foo#index'`._
+TIP: _If you need to use a different controller namespace inside a `namespace` block you can specify an absolute controller path, e.g: `get '/foo', to: '/foo#index'`._
 
 ### Nested Resources
 


### PR DESCRIPTION
### Summary

Rails supports two ways of defining non-resourceful routes:

```
get 'post/:id' => 'posts#show' 
get 'post/:id', to: 'posts#show' 
```

The Rails generators and most of the documentation use Ruby 1.9 hash syntax, but the documentation has some examples which use strings as keys. This results in situations where a single hash contains a mix of two different styles.

By suggesting the `to:` version in the docs, we can help developers to avoid this inconsistency.