### PR TITLE
Made `String#singularize` and `String#pluralize` respect I18n locale

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Made `String#singularize` and `String#pluralize` respect the current locale
+
+    `String#singularize` and `String#pluralize` now use the current I18n locale,
+    if one has been set. If there is no locale set, it defaults to English (which
+    was the old behaviour, regardless of the current locale).
+
 *   Allow Range#=== and Range#cover? on Range
 
     `Range#cover?` can now accept a range argument like `Range#include?` and

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -17,7 +17,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be pluralized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to the current I18n locale.
   # You must define your own inflection rules for languages other than English.
   #
   #   'post'.pluralize             # => "posts"
@@ -30,8 +30,8 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
-  def pluralize(count = nil, locale = :en)
-    locale = count if count.is_a?(Symbol)
+  def pluralize(count = nil, locale = nil)
+    locale = count.is_a?(Symbol) ? count : (locale || I18n.locale || :en)
     if count == 1
       dup
     else
@@ -43,7 +43,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be singularized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to the current I18n locale.
   # You must define your own inflection rules for languages other than English.
   #
   #   'posts'.singularize            # => "post"
@@ -53,7 +53,8 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = :en)
+  def singularize(locale = nil)
+    locale = locale || I18n.locale || :en
     ActiveSupport::Inflector.singularize(self, locale)
   end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -72,9 +72,53 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_not_same name.pluralize(1), name
   end
 
+  test "pluralize uses specific I18n locale if locale is specified" do
+    begin
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.plural(/z$/, "ces") }
+      assert_equal("peces", "pez".pluralize(:"es-test"))
+      assert_equal("pez", "pez".pluralize(1, :"es-test"))
+      assert_equal("peces", "pez".pluralize(2, :"es-test"))
+    ensure
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.clear }
+    end
+  end
+
+  test "pluralize uses current I18n locale if locale is not specified" do
+    begin
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.plural(/z$/, "ces") }
+      I18n.with_locale(:"es-test") do
+        assert_equal("peces", "pez".pluralize)
+        assert_equal("pez", "pez".pluralize(1))
+        assert_equal("peces", "pez".pluralize(2))
+      end
+    ensure
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.clear }
+    end
+  end
+
   def test_singularize
     SingularToPlural.each do |singular, plural|
       assert_equal(singular, plural.singularize)
+    end
+  end
+
+  test "singularize uses current I18n locale if locale is specified" do
+    begin
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.singular(/ces$/, "z") }
+      assert_equal("pez", "peces".singularize(:"es-test"))
+    ensure
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.clear }
+    end
+  end
+
+  test "singularize uses current I18n locale if locale is not specified" do
+    begin
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.singular(/ces$/, "z") }
+      I18n.with_locale(:"es-test") do
+        assert_equal("pez", "peces".singularize)
+      end
+    ensure
+      ActiveSupport::Inflector.inflections(:"es-test") { |i| i.clear }
     end
   end
 


### PR DESCRIPTION
### Summary

On master, `String#singularize` and `String#pluralize` always default to using English inflections, regardless of the current I18n locale. The only way to use non-English inflections is to specify the I18n locale every time `singularize` or `pluralize` is called (ie. `'ley'.pluralize(:es)`).

I've changed those two methods to default to the current I18n locale, and if one is not set it then it will fall back to English (which is the old behaviour). On non-English rails apps, this will change the behaviour of `singularize` and `pluralize`, such that it will no longer apply English inflection rules, and will instead apply any inflection rules defined for the current locale (or none if none have been set).

This makes `String#singularize` and `String#pluralize` behave consistently with `TextHelper#singularize` and `TextHelper#pluralize`, which already use the I18n locale (without having to specify it explicitly).