### PR TITLE
Fix NameError : Make debug exceptions works in an environment where ActiveStorage is not loaded.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make debug exceptions works in an environment where ActiveStorage is not loaded.
+
+    *Tomoyuki Kurosawa*
+
 *   `ActionDispatch::SystemTestCase.driven_by` can now be called with a block
     to define specific browser capabilities.
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -10,7 +10,7 @@
 <div id="container">
   <h2>
     <%= h @exception.message %>
-    <% if @exception.message.match? %r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}} %>
+    <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
       <br />To resolve this issue run: rails active_storage:install
     <% end %>
   </h2>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <%= @exception.message %>
-<% if @exception.message.match? %r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}} %>
+<% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
 To resolve this issue run: rails active_storage:install
 <% end %>
 


### PR DESCRIPTION
Make debug exceptions works in an environment where ActiveStorage is not loaded.

Error occurred before change:

```
Error:
NameError: uninitialized constant ActionView::CompiledTemplates::ActiveStorage
```



