### PR TITLE
`select(...).joins(...)` populates `attributes` with aliased columns

### DIFF
--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -2,14 +2,20 @@
 
 require "cases/helper"
 require "models/post"
+require "models/comment"
 
 module ActiveRecord
   class SelectTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :comments
 
     def test_select_with_nil_argument
       expected = Post.select(:title).to_sql
       assert_equal expected, Post.select(nil).select(:title).to_sql
+    end
+
+    def test_select_with_joins_populates_attributes_with_aliased_column
+      relation = Post.all.select("posts.id as post_id").joins(:comments).includes(:comments)
+      assert relation.first.attributes["post_id"].present?
     end
   end
 end


### PR DESCRIPTION
Fixes #34889 - `select(...).joins(...)` combo should populate `@attributes` with aliased columns;

For example;

```ruby
relation = Post.all.select("posts.id as post_id").joins(:comments).includes(:comments)
relation.first.attributes # => {...., :post_id => 1}
```


- [x] Add a test, basically just enough code to fail
- [ ] Make it pass

