### PR TITLE
Fix partial caching ignore repeated items issue

### DIFF
--- a/actionview/test/fixtures/test/_cached_set.erb
+++ b/actionview/test/fixtures/test/_cached_set.erb
@@ -1,0 +1,1 @@
+<%= cached_set.first %> | <%= cached_set.second %> | <%= cached_set.third %> | <%= cached_set.fourth %> | <%= cached_set.fifth %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -811,6 +811,28 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
     end
   end
 
+  test "collection caching with repeated collection" do
+    sets = [
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 4],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 4],
+        [1, 2, 3, 4, 6]
+    ]
+
+    result = @view.render(partial: "test/cached_set", collection: sets, cached: true)
+
+    splited_result = result.split("\n")
+    assert_equal 5, splited_result.count
+    assert_equal [
+      "1 | 2 | 3 | 4 | 5",
+      "1 | 2 | 3 | 4 | 4",
+      "1 | 2 | 3 | 4 | 5",
+      "1 | 2 | 3 | 4 | 4",
+      "1 | 2 | 3 | 4 | 6"
+    ], splited_result
+  end
+
   private
     def cache_key(*names, virtual_path)
       digest = ActionView::Digestor.digest name: virtual_path, format: :html, finder: @view.lookup_context, dependencies: []


### PR DESCRIPTION
### Summary
This is for #35114 
Partial caching doesn't return the right collection when some of the items are repeated.

Let's say we have this template:

```erb
<%= cached_set.first %> | <%= cached_set.second %> | <%= cached_set.third %> | <%= cached_set.fourth %> | <%= cached_set.fifth %>
```

And a `cached_set` collection:

```ruby
[1,2,3,4,5],
[1,2,3,4,4],
[1,2,3,4,5],
[1,2,3,4,4],
[1,2,3,4,6]
```

On current master, the rendered result will be
```
      "1 | 2 | 3 | 4 | 5",
      "1 | 2 | 3 | 4 | 4",
      "1 | 2 | 3 | 4 | 6"
```

The duplicated items are ignored.

This is because we only use hash to maintain the result. So when the key are the same, the result would be skipped.