### PR TITLE
Add a link to where "inquiry" is defined in ActiveSupport docs

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1201,6 +1201,8 @@ The `inquiry` method converts a string into a `StringInquirer` object making equ
 "active".inquiry.inactive?       # => false
 ```
 
+NOTE: Defined in `active_support/core_ext/string/inquiry.rb`.
+
 ### `starts_with?` and `ends_with?`
 
 Active Support defines 3rd person aliases of `String#start_with?` and `String#end_with?`:


### PR DESCRIPTION
The docs don't include a link to where this method is defined. I tested the link I put in as follows:

```
2.2.0 :001 > "production".inquiry.production?
NoMethodError: undefined method `inquiry' for "production":String
2.2.0 :002 > require 'active_support'; require 'active_support/core_ext/string/inquiry'
 => true 
2.2.0 :003 > "production".inquiry.production?
 => true 
2.2.0 :004 > 
```