### PR TITLE
Relax sqlite3 version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.3.6"
+  gem "sqlite3", "~> 1.3", ">= 1.3.6"
 
   group :db do
     gem "pg", ">= 0.18.0"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -9,7 +9,7 @@ require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
 require "active_record/connection_adapters/sqlite3/schema_statements"
 
-gem "sqlite3", "~> 1.3.6"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"
 require "sqlite3"
 
 module ActiveRecord


### PR DESCRIPTION
sqlite3 v1.4 has been released just now. Since we don't specify `sqlite3` gem version by default in Gemfile, it'll break adapter loading. 

Should we backport it into 5.x branches? There [are no significant changes](https://github.com/sparklemotion/sqlite3-ruby/blob/master/CHANGELOG.rdoc#140) since 1.3.13

cc @tenderlove 