### PR TITLE
Specify sqlite gem version explicitly in bug report templates

### DIFF
--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "5.2.0"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "5.2.0"
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 require "active_record"


### PR DESCRIPTION
Follow up for  #35154 

For version-dependent bug report templates, we still require specific sqlite3 version. 🤷‍♂️ 