### PR TITLE
Fix incorrectly matching unanchored paths

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -119,7 +119,7 @@ module ActionDispatch
 
         class UnanchoredRegexp < AnchoredRegexp # :nodoc:
           def accept(node)
-            %r{\A#{visit node}\b}
+            %r{\A#{visit node}(?:\b|\Z)}
           end
         end
 

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -119,7 +119,7 @@ module ActionDispatch
 
         class UnanchoredRegexp < AnchoredRegexp # :nodoc:
           def accept(node)
-            %r{\A#{visit node}}
+            %r{\A#{visit node}\b}
           end
         end
 

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -80,6 +80,12 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
     assert_equal "/shorthand -- /omg", response.body
   end
 
+  def test_mounting_does_not_match_similar_paths
+    get "/shorthandomg"
+    assert_not_equal "/shorthand -- /omg", response.body
+    assert_equal " -- /shorthandomg", response.body
+  end
+
   def test_mounting_works_with_via
     get "/getfake"
     assert_equal "OK", response.body

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -34,17 +34,17 @@ module ActionDispatch
         end
 
         {
-          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?},
-          "/:controller/foo"             => %r{\A/(#{x})/foo},
-          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)},
-          "/:controller"                 => %r{\A/(#{x})},
-          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?},
-          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml},
-          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)},
-          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?},
-          "/:controller/*foo"            => %r{\A/(#{x})/(.+)},
-          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar},
-          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))},
+          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?\b},
+          "/:controller/foo"             => %r{\A/(#{x})/foo\b},
+          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)\b},
+          "/:controller"                 => %r{\A/(#{x})\b},
+          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?\b},
+          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml\b},
+          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)\b},
+          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?\b},
+          "/:controller/*foo"            => %r{\A/(#{x})/(.+)\b},
+          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar\b},
+          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))\b},
         }.each do |path, expected|
           define_method(:"test_to_non_anchored_regexp_#{Regexp.escape(path)}") do
             path = Pattern.build(

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -34,17 +34,17 @@ module ActionDispatch
         end
 
         {
-          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?\b},
-          "/:controller/foo"             => %r{\A/(#{x})/foo\b},
-          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)\b},
-          "/:controller"                 => %r{\A/(#{x})\b},
-          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?\b},
-          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml\b},
-          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)\b},
-          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?\b},
-          "/:controller/*foo"            => %r{\A/(#{x})/(.+)\b},
-          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar\b},
-          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))\b},
+          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?(?:\b|\Z)},
+          "/:controller/foo"             => %r{\A/(#{x})/foo(?:\b|\Z)},
+          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)(?:\b|\Z)},
+          "/:controller"                 => %r{\A/(#{x})(?:\b|\Z)},
+          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?(?:\b|\Z)},
+          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml(?:\b|\Z)},
+          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)(?:\b|\Z)},
+          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?(?:\b|\Z)},
+          "/:controller/*foo"            => %r{\A/(#{x})/(.+)(?:\b|\Z)},
+          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar(?:\b|\Z)},
+          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))(?:\b|\Z)},
         }.each do |path, expected|
           define_method(:"test_to_non_anchored_regexp_#{Regexp.escape(path)}") do
             path = Pattern.build(


### PR DESCRIPTION
### Summary

There is a bug that incorrectly matches routes of mounted applications (e.g. sprockets-rails) with a shorthand path (e.g. `/assets`).

The queries to http://localhost:3000/assets/foo.png and to http://localhost:3000/assetsfoo.png are equivalent currently.

`The ActionDispatch::Journey::Path::Pattern::UnanchoredRegexp` generates regex that allows the route matcher to consider `/assets/foo.png` and `/assetsfoo.png` as same paths.

This PR fixes the issue by adding a word boundary to the generated regex.

### Other Information
Way to reproduce the bug:
1. Run commands
```shell
$ rails new test-app
$ cd test-app
$ touch app/assets/images/foo.png
$ ./bin/rails server
```
2. Accessing http://localhost:3000/assetsfoo.png returns 200 with the correct image file