### PR TITLE
Improve Errors#fill_message rendering without i18n config

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -411,10 +411,9 @@ module ActiveModel
     # * <tt>errors.format</tt>
     def full_message(attribute, message)
       return message if attribute == :base
-      attribute = attribute.to_s
+      attribute = attribute.to_s.remove(/\[\d\]/)
 
       if self.class.i18n_full_message && @base.class.respond_to?(:i18n_scope)
-        attribute = attribute.remove(/\[\d\]/)
         parts = attribute.split(".")
         attribute_name = parts.pop
         namespace = parts.join("/") unless parts.empty?

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -142,8 +142,8 @@ class I18nValidationTest < ActiveModel::TestCase
       errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
 
     person = Person.new
-    assert_equal "Contacts[0]/addresses[0] street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
-    assert_equal "Contacts[0]/addresses[0] country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+    assert_equal "Contacts/addresses street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Contacts/addresses country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
   end
 
   def test_errors_full_messages_with_i18n_attribute_name_without_i18n_config
@@ -154,8 +154,8 @@ class I18nValidationTest < ActiveModel::TestCase
     })
 
     person = Person.new
-    assert_equal "Contacts[0]/addresses[0] street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
-    assert_equal "Country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
+    assert_equal "Contacts/addresses street cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].street', "cannot be blank")
+    assert_equal "Contacts/addresses country cannot be blank", person.errors.full_message(:'contacts[0]/addresses[0].country', "cannot be blank")
   end
 
   # ActiveModel::Validations


### PR DESCRIPTION
This is a followup to https://github.com/rails/rails/pull/33615

The removal of array indexes being done only for i18n situation makes for fairly inconsistent results as you can see in the two tests I modified.

@Larochelle in your initial patch the `.remove(/\[\d\]/)` was also before the `if`, but then you moved it inside for https://github.com/rails/rails/pull/33615, is there something I'm missing?

@rafaelfranca @Edouard-chin @Larochelle 
