### PR TITLE
Improve regexp of `html_safe_translation_key?`

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -138,7 +138,7 @@ module ActionView
         end
 
         def html_safe_translation_key?(key)
-          /(\b|_|\.)html$/.match?(key.to_s)
+          /([_.]|\b)html\z/.match?(key.to_s)
         end
     end
   end


### PR DESCRIPTION

### Summary

- Use `\z` instead of `$`
- Use character class instead of alternation
- Optimize alternation order

### Other Information

`\z` is slower than `$`, but it is better meaning.

Benchmark result is rough, because many other processes run together on my laptop machine.
It seems `([_.]|\b)` is always faster than `(\b|[_.])` and `(\b|_|\.)`.

```
% cat ~/bench.yml
prelude: |
  keys = %w[not_match html foo_html bar.html]
benchmark:
  or_d: |
    keys.each do |key|
      /(\b|_|\.)html$/.match?(key.to_s)
    end
  or_z: |
    keys.each do |key|
      /(\b|_|\.)html\z/.match?(key.to_s)
    end
  char_class_z: |
    keys.each do |key|
      /(\b|[_.])html\z/.match?(key.to_s)
    end
  char_class_d: |
    keys.each do |key|
      /(\b|[_.])html$/.match?(key.to_s)
    end
  char_class_2_z: |
    keys.each do |key|
      /([_.]|\b)html\z/.match?(key.to_s)
    end
  char_class_2_d: |
    keys.each do |key|
      /([_.]|\b)html$/.match?(key.to_s)
    end
% benchmark-driver ~/bench.yml
Warming up --------------------------------------
                or_d     1.529M i/s -      1.625M times in 1.062262s (653.90ns/i)
                or_z     1.539M i/s -      1.602M times in 1.040741s (649.73ns/i)
        char_class_z     1.526M i/s -      1.532M times in 1.003995s (655.51ns/i)
        char_class_d     1.583M i/s -      1.631M times in 1.030430s (631.63ns/i)
      char_class_2_z     1.599M i/s -      1.639M times in 1.025019s (625.33ns/i)
      char_class_2_d     1.662M i/s -      1.754M times in 1.055074s (601.55ns/i)
Calculating -------------------------------------
                or_d     1.612M i/s -      4.588M times in 2.846843s (620.52ns/i)
                or_z     1.510M i/s -      4.617M times in 3.058135s (662.32ns/i)
        char_class_z     1.551M i/s -      4.577M times in 2.951371s (644.88ns/i)
        char_class_d     1.631M i/s -      4.750M times in 2.912536s (613.21ns/i)
      char_class_2_z     1.581M i/s -      4.797M times in 3.033929s (632.41ns/i)
      char_class_2_d     1.693M i/s -      4.987M times in 2.945495s (590.62ns/i)

Comparison:
      char_class_2_d:   1693131.7 i/s 
        char_class_d:   1630754.8 i/s - 1.04x  slower
                or_d:   1611560.2 i/s - 1.05x  slower
      char_class_2_z:   1581264.1 i/s - 1.07x  slower
        char_class_z:   1550673.2 i/s - 1.09x  slower
                or_z:   1509845.1 i/s - 1.12x  slower
% benchmark-driver ~/bench.yml
Warming up --------------------------------------
                or_d     1.534M i/s -      1.538M times in 1.002284s (651.69ns/i)
                or_z     1.495M i/s -      1.529M times in 1.023011s (668.98ns/i)
        char_class_z     1.535M i/s -      1.601M times in 1.043070s (651.49ns/i)
        char_class_d     1.577M i/s -      1.620M times in 1.027315s (634.30ns/i)
      char_class_2_z     1.569M i/s -      1.581M times in 1.007555s (637.46ns/i)
      char_class_2_d     1.645M i/s -      1.738M times in 1.056730s (608.01ns/i)
Calculating -------------------------------------
                or_d     1.578M i/s -      4.603M times in 2.917980s (633.88ns/i)
                or_z     1.549M i/s -      4.484M times in 2.895346s (645.64ns/i)
        char_class_z     1.551M i/s -      4.605M times in 2.968680s (644.69ns/i)
        char_class_d     1.634M i/s -      4.730M times in 2.894710s (612.03ns/i)
      char_class_2_z     1.602M i/s -      4.706M times in 2.937455s (624.17ns/i)
      char_class_2_d     1.648M i/s -      4.934M times in 2.993592s (606.71ns/i)

Comparison:
      char_class_2_d:   1648224.3 i/s 
        char_class_d:   1633896.7 i/s - 1.01x  slower
      char_class_2_z:   1602125.6 i/s - 1.03x  slower
                or_d:   1577594.4 i/s - 1.04x  slower
        char_class_z:   1551127.1 i/s - 1.06x  slower
                or_z:   1548849.8 i/s - 1.06x  slower
```
