### PR TITLE
Set sqlite3 gem version explicitly in generated Gemfile

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -15,6 +15,7 @@ module Rails
         case database
         when "mysql"          then ["mysql2", [">= 0.4.4"]]
         when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
+        when "sqlite3"        then ["sqlite3", ["~> 1.3", ">= 1.3.6"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -526,7 +526,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcsqlite3-adapter"
     else
-      assert_gem "sqlite3"
+      assert_gem "sqlite3", "'~> 1.3', '>= 1.3.6'"
     end
   end
 


### PR DESCRIPTION
`sqlite3` gem was the last one within popular db drivers which version was not fixed in generated Gemfile. This change will prevent issues like #35161 in the future.

Previous changes  #35154 #35157