### PR TITLE
Add missing `require "tmpdir"` in ActiveSupport::EncryptedFile

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "tmpdir"
 require "active_support/message_encryptor"
 
 module ActiveSupport
@@ -67,7 +68,7 @@ module ActiveSupport
 
         write(updated_contents) if updated_contents != contents
       ensure
-        FileUtils.rm(tmp_path) if tmp_path.exist?
+        FileUtils.rm(tmp_path) if tmp_path&.exist?
       end
 
 


### PR DESCRIPTION
### Summary

`Dir.tmpdir` require `tmpdir` to be loaded. We do not require it explicitly.

I've been caught in the situation when it might be not loaded in the app (https://travis-ci.org/palkan/anyway_config/jobs/489168942).

That also leads to the exception in the `ensure` block, thus making debugging not so simple 🙂 Fixed that one too.

