### PR TITLE
Update terminal-to-html inline images url in ScreenshotHelper documentation

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         # * [+inline+]              Display the screenshot in the terminal using the
         #                           iTerm image protocol (https://iterm2.com/documentation-images.html).
         # * [+artifact+]            Display the screenshot in the terminal, using the terminal
-        #                           artifact format (https://buildkite.github.io/terminal/inline-images/).
+        #                           artifact format (https://buildkite.github.io/terminal-to-html/inline-images/).
         def take_screenshot
           save_image
           puts display_image


### PR DESCRIPTION
### Summary

Was reading through the documentation for the `ScreenshotHelper` class. Noticed that the terminal artifact format reference URL (https://buildkite.github.io/terminal/inline-images/) is out of date and leads to a 404 page. Updated it to the new URL https://buildkite.github.io/terminal-to-html/inline-images/
