### PR TITLE
Support testing of non-ActionDispatch-routed apps.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -335,7 +335,7 @@ module ActionDispatch
         klass = APP_SESSIONS[app] ||= Class.new(Integration::Session) {
           # If the app is a Rails app, make url_helpers available on the session.
           # This makes app.url_for and app.foo_path available in the console.
-          if app.respond_to?(:routes)
+          if app.respond_to?(:routes) && app.routes.is_a?(ActionDispatch::Routing::RouteSet)
             include app.routes.url_helpers
             include app.routes.mounted_helpers
           end

--- a/actionpack/test/dispatch/routing/non_dispatch_routed_app_test.rb
+++ b/actionpack/test/dispatch/routing/non_dispatch_routed_app_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module ActionDispatch
+  module Routing
+    class NonDispatchRoutedAppTest < ActionDispatch::IntegrationTest
+      # For example, Grape::API
+      class SimpleApp
+        def self.call(env)
+          [ 200, { "Content-Type" => "text/plain" }, [] ]
+        end
+
+        def self.routes
+          []
+        end
+      end
+
+      setup { @app = SimpleApp }
+
+      test "does not except" do
+        get "/foo"
+        assert_response :success
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

The [Grape API framework](https://github.com/ruby-grape/grape) regularly writes tests like [spec/grape/api_spec.rb](https://github.com/ruby-grape/grape/blob/master/spec/grape/api_spec.rb).

When attempting to write a test in a Rails environment similar to the following:
```
describe Grape::Api, type: :request do
  let(:app) {
    Class.new(Grape::API) do
      get 'test' do
        { foo: 'bar' }
      end
    end
  }

  it '200s' do
    get 'test'
  end
end
```

The following exception is thrown:

```
NoMethodError: undefined method `url_helpers' for #<Array:0x00007fb4e4bc4c88>
--
0: .../lib/action_dispatch/testing/integration.rb:330:in `block in create_session'
1: .../lib/action_dispatch/testing/integration.rb:326:in `initialize'
2: .../lib/action_dispatch/testing/integration.rb:326:in `new'
3: .../lib/action_dispatch/testing/integration.rb:326:in `create_session'
4: .../lib/action_dispatch/testing/integration.rb:316:in `integration_session'
5: .../lib/action_dispatch/testing/integration.rb:348:in `block (2 levels) in <module:Runner>'
```

This change explicitly ensures that `app.routes` is an `ActionDispatch::Routing::RouteSet` instance and enables writing tests with a non-ActionDispatch-routed app (like Grape::API) in a Rails environment.