### PR TITLE
Close all connections explicitly before ActionCable server stops

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Close all connections explicitly before ActionCable server stops
+
+    Each connection will receive `server_stop` reason with an instruction to
+    to try to reconnect again.
+
+    *Sergey Ponomarev*
+
 *   Allow passing custom configuration to `ActionCable::Server::Base`.
 
     You can now create a standalone Action Cable server with a custom configuration

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -144,7 +144,8 @@
     disconnect_reasons: {
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
-      server_restart: "server_restart"
+      server_restart: "server_restart",
+      server_stop: "server_stop"
     },
     default_mount_path: "/cable",
     protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -41,7 +41,8 @@ module ActionCable
     disconnect_reasons: {
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
-      server_restart: "server_restart"
+      server_restart: "server_restart",
+      server_stop: "server_stop"
     },
     default_mount_path: "/cable",
     protocols: ["actioncable-v1-json", "actioncable-unsupported"].freeze
@@ -49,7 +50,9 @@ module ActionCable
 
   # Singleton instance of the server
   module_function def server
-    @server ||= ActionCable::Server::Base.new
+    @server ||= ActionCable::Server::Base.new.tap do |server|
+      at_exit { server.shutdown }
+    end
   end
 
   autoload :Server

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -39,9 +39,7 @@ module ActionCable
       end
 
       def restart
-        connections.each do |connection|
-          connection.close(reason: ActionCable::INTERNAL[:disconnect_reasons][:server_restart])
-        end
+        close_all_connections(ActionCable::INTERNAL[:disconnect_reasons][:server_restart])
 
         @mutex.synchronize do
           # Shutdown the worker pool
@@ -52,6 +50,10 @@ module ActionCable
           @pubsub.shutdown if @pubsub
           @pubsub = nil
         end
+      end
+
+      def shutdown
+        close_all_connections(ActionCable::INTERNAL[:disconnect_reasons][:server_stop])
       end
 
       # Gateway to RemoteConnections. See that class for details.

--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -19,6 +19,12 @@ module ActionCable
         connections.delete connection
       end
 
+      def close_all_connections(reason)
+        connections.each do |connection|
+          connection.close(reason: reason)
+        end
+      end
+
       # WebSocket connection implementations differ on when they'll mark a connection as stale. We basically never want a connection to go stale, as you
       # then can't rely on being able to communicate with the connection. To solve this, a 3 second heartbeat runs on all connections. If the beat fails, we automatically
       # disconnect.

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -35,4 +35,13 @@ class BaseTest < ActionCable::TestCase
       @server.restart
     end
   end
+
+  test "#shutdown closes all open connections" do
+    conn = FakeConnection.new
+    @server.add_connection(conn)
+
+    assert_called(conn, :close) do
+      @server.shutdown
+    end
+  end
 end


### PR DESCRIPTION
On ActionCable process stopping, each connection will receive `server_stop` reason with an instruction to try to reconnect again (default behavior). `Connection#disconnect` and each subscribed channels `Channel#unsubscribed` will be invoked before the server stops.

It can be useful for these purposes: 

- Free resources gracefully which were acquired in `Connection#connect` or `Channel#subscribe`
- Notify other clients on disconnect in case of a multi-phased restart or rescale of ActionCable processes cluster
- Keep external state consistent if you rely on connection's connect/disconnect or channel's subscribe/unsubscribed actions. Related feature request #35103.

Additional idea is to introduce some ActiveSupport before/after hooks on server shutdown for better end-user customization.

Looking forward to seeing your thoughts. 
 






