### PR TITLE
Bugfix has_many association #size when ids reader is cached and assoc…

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -348,7 +348,6 @@ module ActiveRecord
               add_to_target(record) do
                 result = insert_record(record, true, raise) {
                   @_was_loaded = loaded?
-                  @association_ids = nil
                 }
               end
               raise ActiveRecord::Rollback unless result
@@ -385,6 +384,7 @@ module ActiveRecord
 
           delete_records(existing_records, method) if existing_records.any?
           @target -= records
+          @association_ids = nil
 
           records.each { |record| callback(:after_remove, record) }
         end
@@ -425,7 +425,6 @@ module ActiveRecord
               unless owner.new_record?
                 result &&= insert_record(record, true, raise) {
                   @_was_loaded = loaded?
-                  @association_ids = nil
                 }
               end
             end
@@ -448,6 +447,7 @@ module ActiveRecord
           if index
             target[index] = record
           elsif @_was_loaded || !loaded?
+            @association_ids = nil
             target << record
           end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2003,6 +2003,21 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate company.clients, :loaded?
   end
 
+  def test_ids_reader_cache_not_used_for_size_when_association_is_dirty
+    firm = Firm.create!(name: "Startup")
+    assert_equal 0, firm.client_ids.size
+    firm.clients.build
+    assert_equal 1, firm.clients.size
+  end
+
+  def test_ids_reader_cache_should_be_cleared_when_collection_is_deleted
+    firm = companies(:first_firm)
+    assert_equal [2, 3, 11], firm.client_ids
+    client = firm.clients.first
+    firm.clients.delete(client)
+    assert_equal [3, 11], firm.client_ids
+  end
+
   def test_zero_counter_cache_usage_on_unloaded_association
     car = Car.create!(name: "My AppliCar")
     assert_no_queries do


### PR DESCRIPTION
…iation is changed

This is the regression fix after 19c80718afea8cf8f56ee68fcfbe325d54c02906.
The `target.empty?` condition was removed  -https://github.com/rails/rails/commit/19c80718afea8cf8f56ee68fcfbe325d54c02906#diff-20f545c453ee24942b6f7ae565e9e369L215
which introduced the bug:

``` ruby
company.client_ids.size # => 3
company.clients.build
company.clients.size # => 4
```

I am not sure why it was removed as no existing test fails when I put it back.

cc @kamipo 
