### PR TITLE
Allow skipping incineration of processed emails

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 *   Allow skipping incineration of processed emails.
 
-    This can be done by setting `config.action_mailbox.skip_incineration` to `true`.
+    This can be done by setting `config.action_mailbox.incinerate` to `false`.
 
     *Pratik Naik*
 

--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,10 +1,10 @@
-## Rails 6.0.0.beta1 (January 18, 2019) ##
-
 *   Allow skipping incineration of processed emails.
 
     This can be done by setting `config.action_mailbox.incinerate` to `false`.
 
     *Pratik Naik*
+
+## Rails 6.0.0.beta1 (January 18, 2019) ##
 
 *   Added to Rails.
 

--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
+*   Allow skipping incineration of processed emails.
+
+    This can be done by setting `config.action_mailbox.skip_incineration` to `true`.
+
+    *Pratik Naik*
+
 *   Added to Rails.
 
     *DHH*

--- a/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
+++ b/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
@@ -7,8 +7,8 @@ module ActionMailbox
   # Since this incineration is set for the future, it'll automatically ignore any <tt>InboundEmail</tt>s
   # that have already been deleted and discard itself if so.
   #
-  # You can disable incinerating processed emails by setting +config.action_mailbox.skip_incineration+ or
-  # +ActionMailbox.skip_incineration+ to +true+.
+  # You can disable incinerating processed emails by setting +config.action_mailbox.incinerate+ or
+  # +ActionMailbox.incinerate+ to +false+.
   class IncinerationJob < ActiveJob::Base
     queue_as { ActionMailbox.queues[:incineration] }
 

--- a/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
+++ b/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
@@ -6,6 +6,9 @@ module ActionMailbox
   #
   # Since this incineration is set for the future, it'll automatically ignore any <tt>InboundEmail</tt>s
   # that have already been deleted and discard itself if so.
+  #
+  # You can disable incinerating processed emails by setting +config.action_mailbox.skip_incineration+ or
+  # +ActionMailbox.skip_incineration+ to +true+.
   class IncinerationJob < ActiveJob::Base
     queue_as { ActionMailbox.queues[:incineration] }
 

--- a/actionmailbox/app/models/action_mailbox/inbound_email/incineratable.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/incineratable.rb
@@ -7,7 +7,7 @@ module ActionMailbox::InboundEmail::Incineratable
   extend ActiveSupport::Concern
 
   included do
-    after_update_commit :incinerate_later, if: -> { !ActionMailbox.skip_incineration && status_previously_changed? && processed? }
+    after_update_commit :incinerate_later, if: -> { ActionMailbox.incinerate && status_previously_changed? && processed? }
   end
 
   def incinerate_later

--- a/actionmailbox/app/models/action_mailbox/inbound_email/incineratable.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/incineratable.rb
@@ -7,7 +7,7 @@ module ActionMailbox::InboundEmail::Incineratable
   extend ActiveSupport::Concern
 
   included do
-    after_update_commit :incinerate_later, if: -> { status_previously_changed? && processed? }
+    after_update_commit :incinerate_later, if: -> { !ActionMailbox.skip_incineration && status_previously_changed? && processed? }
   end
 
   def incinerate_later

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -11,6 +11,7 @@ module ActionMailbox
 
   mattr_accessor :ingress
   mattr_accessor :logger
+  mattr_accessor :skip_incineration, default: false
   mattr_accessor :incinerate_after, default: 30.days
   mattr_accessor :queues, default: {}
 end

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -11,7 +11,7 @@ module ActionMailbox
 
   mattr_accessor :ingress
   mattr_accessor :logger
-  mattr_accessor :skip_incineration, default: false
+  mattr_accessor :incinerate, default: true
   mattr_accessor :incinerate_after, default: 30.days
   mattr_accessor :queues, default: {}
 end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -14,6 +14,7 @@ module ActionMailbox
     config.eager_load_namespaces << ActionMailbox
 
     config.action_mailbox = ActiveSupport::OrderedOptions.new
+    config.action_mailbox.incinerate = true
     config.action_mailbox.incinerate_after = 30.days
 
     config.action_mailbox.queues = ActiveSupport::InheritableOptions.new \
@@ -22,6 +23,7 @@ module ActionMailbox
     initializer "action_mailbox.config" do
       config.after_initialize do |app|
         ActionMailbox.logger = app.config.action_mailbox.logger || Rails.logger
+        ActionMailbox.incinerate = app.config.action_mailbox.incinerate.nil? ? true : app.config.action_mailbox.incinerate
         ActionMailbox.incinerate_after = app.config.action_mailbox.incinerate_after || 30.days
         ActionMailbox.queues = app.config.action_mailbox.queues || {}
       end

--- a/actionmailbox/test/unit/inbound_email/incineration_test.rb
+++ b/actionmailbox/test/unit/inbound_email/incineration_test.rb
@@ -44,4 +44,14 @@ class ActionMailbox::InboundEmail::IncinerationTest < ActiveSupport::TestCase
       perform_enqueued_jobs only: ActionMailbox::IncinerationJob
     end
   end
+
+  test "skipping incineration" do
+    original, ActionMailbox.skip_incineration = ActionMailbox.skip_incineration, true
+
+    assert_no_enqueued_jobs only: ActionMailbox::IncinerationJob do
+      create_inbound_email_from_fixture("welcome.eml").delivered!
+    end
+  ensure
+    ActionMailbox.skip_incineration = original
+  end
 end

--- a/actionmailbox/test/unit/inbound_email/incineration_test.rb
+++ b/actionmailbox/test/unit/inbound_email/incineration_test.rb
@@ -46,12 +46,12 @@ class ActionMailbox::InboundEmail::IncinerationTest < ActiveSupport::TestCase
   end
 
   test "skipping incineration" do
-    original, ActionMailbox.skip_incineration = ActionMailbox.skip_incineration, true
+    original, ActionMailbox.incinerate = ActionMailbox.incinerate, false
 
     assert_no_enqueued_jobs only: ActionMailbox::IncinerationJob do
       create_inbound_email_from_fixture("welcome.eml").delivered!
     end
   ensure
-    ActionMailbox.skip_incineration = original
+    ActionMailbox.incinerate = original
   end
 end


### PR DESCRIPTION
### Summary

Allow skipping incineration of processed emails. This would be useful when applications wants to keep the original email around and manage its incineration.