### PR TITLE
Improve naming in DatabaseSelector

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       private
 
         def select_database(request, &blk)
-          operations = operations_klass.build(request)
+          operations = operations_klass.call(request)
           database_resolver = resolver_klass.call(operations, options)
 
           if reading_request?(request)

--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -12,8 +12,8 @@ module ActiveRecord
     #
     # The resolver class defines when the application should switch (i.e. read
     # from the primary if a write occurred less than 2 seconds ago) and an
-    # operations class that sets a value that helps the resolver class decide
-    # when to switch.
+    # resolver context class that sets a value that helps the resolver class
+    # decide when to switch.
     #
     # Rails default middleware uses the request's session to set a timestamp
     # that informs the application when to read from a primary or read from a
@@ -24,7 +24,7 @@ module ActiveRecord
     #
     #   config.active_record.database_selector = { delay: 2.seconds }
     #   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    #   config.active_record.database_operations = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
     #
     # New applications will include these lines commented out in the production.rb.
     #
@@ -33,16 +33,16 @@ module ActiveRecord
     #
     #   config.active_record.database_selector = { delay: 2.seconds }
     #   config.active_record.database_resolver = MyResolver
-    #   config.active_record.database_operations = MyResolver::MySession
+    #   config.active_record.database_resolver_context = MyResolver::MySession
     class DatabaseSelector
-      def initialize(app, resolver_klass = Resolver, operations_klass = Resolver::Session, options = {})
+      def initialize(app, resolver_klass = Resolver, context_klass = Resolver::Session, options = {})
         @app = app
         @resolver_klass = resolver_klass
-        @operations_klass = operations_klass
+        @context_klass = context_klass
         @options = options
       end
 
-      attr_reader :resolver_klass, :operations_klass, :options
+      attr_reader :resolver_klass, :context_klass, :options
 
       # Middleware that determines which database connection to use in a multiple
       # database application.
@@ -57,13 +57,13 @@ module ActiveRecord
       private
 
         def select_database(request, &blk)
-          operations = operations_klass.call(request)
-          database_resolver = resolver_klass.call(operations, options)
+          context = context_klass.call(request)
+          resolver = resolver_klass.call(context, options)
 
           if reading_request?(request)
-            database_resolver.read(&blk)
+            resolver.read(&blk)
           else
-            database_resolver.write(&blk)
+            resolver.write(&blk)
           end
         end
 

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -18,18 +18,18 @@ module ActiveRecord
       class Resolver # :nodoc:
         SEND_TO_REPLICA_DELAY = 2.seconds
 
-        def self.call(operations, options = {})
-          new(operations, options)
+        def self.call(context, options = {})
+          new(context, options)
         end
 
-        def initialize(operations, options = {})
-          @operations = operations
+        def initialize(context, options = {})
+          @context = context
           @options = options
           @delay = @options && @options[:delay] ? @options[:delay] : SEND_TO_REPLICA_DELAY
           @instrumenter = ActiveSupport::Notifications.instrumenter
         end
 
-        attr_reader :operations, :delay, :instrumenter
+        attr_reader :context, :delay, :instrumenter
 
         def read(&blk)
           if read_from_primary?
@@ -68,7 +68,7 @@ module ActiveRecord
               instrumenter.instrument("database_selector.active_record.wrote_to_primary") do
                 yield
               ensure
-                operations.update_last_write_timestamp
+                context.update_last_write_timestamp
               end
             end
           end
@@ -82,7 +82,7 @@ module ActiveRecord
           end
 
           def time_since_last_write_ok?
-            Time.now - operations.last_write_timestamp >= send_to_replica_delay
+            Time.now - context.last_write_timestamp >= send_to_replica_delay
           end
       end
     end

--- a/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         # The last_write is used to determine whether it's safe to read
         # from the replica or the request needs to be sent to the primary.
         class Session # :nodoc:
-          def self.build(request)
+          def self.call(request)
             new(request.session)
           end
 


### PR DESCRIPTION
This makes two naming changes to improve the API of the new database selector.

1. Rename the `resolver` ivar/attribute of `DatabaseSelector::Resolver` to `operations`

"Operations" is what we call that object/class elsewhere (in `DatabaseSelector` and in the config).

2. Rename `Session.build` to `Session.call`

This better matches `DatabaseSelector::Resolver`, which is built with `.call`, and also means we can configure a proc as the operations.

For example this could be useful to swap between different operations classes for different types of requests (which I think is a pretty common use case):

``` ruby
config.active_record.database_operations = ->(request) do
  if request.path.start_with?("/api/")
    MyCustomApiOperations.call(request)
  else
    ActiveRecord::Middleware::DatabaseSelector::Session.call(request)
  end
end
```

cc @eileencodes @tenderlove 