### PR TITLE
Avoid extra package install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_script:
   # Decodes to e.g. `export VARIABLE=VALUE`
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9YTAzNTM0M2YtZTkyMi00MGIzLWFhM2MtMDZiM2VhNjM1YzQ4")
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXJ1YnlvbnJhaWxz")
+  - "[[ $GEM != 'railties' ]] || (cd actionview && yarn build)"
+  - "[[ $GEM != 'railties' ]] || (cd railties/test/isolation/assets && yarn install)"
 
 script: 'ci/travis.rb'
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
     "actioncable",
     "actiontext",
     "activestorage",
-    "actionview",
-    "tmp/templates/app_template",
-    "railties/test/fixtures/tmp/bukkits/**/test/dummy",
-    "railties/test/fixtures/tmp/bukkits/**/spec/dummy"
+    "actionview"
   ],
   "dependencies": {
     "webpack": "^4.17.1"

--- a/railties/.gitignore
+++ b/railties/.gitignore
@@ -2,4 +2,5 @@
 /test/500.html
 /test/fixtures/tmp/
 /test/initializer/root/log/
+/test/isolation/assets/yarn.lock
 /tmp/

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -38,7 +38,7 @@ namespace :test do
 
     test_patterns = dirs.map { |dir| "test/#{dir}/*_test.rb" }
     test_files = Dir[*test_patterns].select do |file|
-      !file.start_with?("test/fixtures/")
+      !file.start_with?("test/fixtures/") && !file.start_with?("test/isolation/assets/")
     end.sort
 
     if ENV["BUILDKITE_PARALLEL_JOB_COUNT"]

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -472,21 +472,17 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
 
-  Dir.chdir "#{RAILS_FRAMEWORK_ROOT}/actionview" do
-    `yarn build`
-  end
-
-  `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc`
+  `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install`
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
     f.puts "require 'rails/all'"
   end
 
-  Dir.chdir(app_template_path) { `yarn add https://github.com/rails/webpacker.git` } # Use the latest version.
-
-  # Manually install `webpack` as bin symlinks are not created for sub dependencies
-  # in workspaces. See https://github.com/yarnpkg/yarn/issues/4964
-  Dir.chdir(app_template_path) { `yarn add webpack@4.17.1 --tilde` }
-  Dir.chdir(app_template_path) { `yarn add webpack-cli` }
+  assets_path = "#{RAILS_FRAMEWORK_ROOT}/railties/test/isolation/assets"
+  FileUtils.cp("#{assets_path}/package.json", "#{app_template_path}/package.json")
+  FileUtils.cp("#{assets_path}/config/webpacker.yml", "#{app_template_path}/config/webpacker.yml")
+  FileUtils.cp_r("#{assets_path}/config/webpack", "#{app_template_path}/config/webpack")
+  FileUtils.ln_s("#{assets_path}/node_modules", "#{app_template_path}/node_modules")
+  FileUtils.chdir(app_template_path) { `bin/rails webpacker:binstubs` }
 
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.

--- a/railties/test/isolation/assets/config/webpack/development.js
+++ b/railties/test/isolation/assets/config/webpack/development.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+const { environment } = require('@rails/webpacker')
+module.exports = environment.toWebpackConfig()

--- a/railties/test/isolation/assets/config/webpack/production.js
+++ b/railties/test/isolation/assets/config/webpack/production.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+const { environment } = require('@rails/webpacker')
+module.exports = environment.toWebpackConfig()

--- a/railties/test/isolation/assets/config/webpack/test.js
+++ b/railties/test/isolation/assets/config/webpack/test.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+const { environment } = require('@rails/webpacker')
+module.exports = environment.toWebpackConfig()

--- a/railties/test/isolation/assets/config/webpacker.yml
+++ b/railties/test/isolation/assets/config/webpacker.yml
@@ -1,0 +1,8 @@
+default: &default
+  check_yarn_integrity: false
+development:
+  <<: *default
+test:
+  <<: *default
+production:
+  <<: *default

--- a/railties/test/isolation/assets/package.json
+++ b/railties/test/isolation/assets/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dummy",
+  "private": true,
+  "dependencies": {
+    "@rails/ujs": "file:../../../../actionview",
+    "@rails/webpacker": "https://github.com/rails/webpacker.git",
+    "turbolinks": "^5.2.0"
+  }
+}


### PR DESCRIPTION
Some tests are running yarn install during the test.

The directory used for the isolation test is not subject to yarn workspace, and it occurs because the required package is not installed.
In order to avoid this, I fixed all necessary packages to be installed before run test and use a symlink to `node_modules`.

This is a bit complicated, as `yarn install` needs to be run in a specific directory before running the test.
However, running `yarn install` every time run the test is expensive when testing locally and should be avoided.