### PR TITLE
Fix `relation.create` to avoid leaking scope to initialization block and callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `relation.create` to avoid leaking scope to initialization block and callbacks.
+
+    Fixes #9894, #17577.
+
+    *Ryuta Kamizono*
+
 *   Chaining named scope is no longer leaking to class level querying methods.
 
     Fixes #14003.

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1535,7 +1535,7 @@ class BasicsTest < ActiveRecord::TestCase
     Bird.create!(name: "Bluejay")
 
     ActiveRecord::Base.connection.while_preventing_writes do
-      assert_queries(2) { Bird.where(name: "Bluejay").explain }
+      assert_nothing_raised { Bird.where(name: "Bluejay").explain }
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1167,7 +1167,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_first_or_create_with_block
-    parrot = Bird.where(color: "green").first_or_create { |bird| bird.name = "parrot" }
+    canary = Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_create do |bird|
+      bird.name = "parrot"
+      assert_equal canary, Bird.find_by!(name: "canary")
+    end
+    assert_equal 1, parrot.total_count
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
     assert_equal "green", parrot.color
@@ -1209,7 +1214,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_first_or_create_bang_with_valid_block
-    parrot = Bird.where(color: "green").first_or_create! { |bird| bird.name = "parrot" }
+    canary = Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_create! do |bird|
+      bird.name = "parrot"
+      assert_equal canary, Bird.find_by!(name: "canary")
+    end
+    assert_equal 1, parrot.total_count
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
     assert_equal "green", parrot.color
@@ -1259,7 +1269,12 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_first_or_initialize_with_block
-    parrot = Bird.where(color: "green").first_or_initialize { |bird| bird.name = "parrot" }
+    canary = Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_initialize do |bird|
+      bird.name = "parrot"
+      assert_equal canary, Bird.find_by!(name: "canary")
+    end
+    assert_equal 1, parrot.total_count
     assert_kind_of Bird, parrot
     assert_not_predicate parrot, :persisted?
     assert_predicate parrot, :valid?

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -16,4 +16,9 @@ class Bird < ActiveRecord::Base
   def cancel_save_callback_method
     throw(:abort)
   end
+
+  attr_accessor :total_count
+  after_initialize do
+    self.total_count = Bird.count
+  end
 end


### PR DESCRIPTION
`relation.create` populates scope attributes to new record by `scoping`,
it is necessary to assign the scope attributes to the record and to find
STI subclass from the scope attributes.

But the effect of `scoping` is class global, it was caused undesired
behavior that pollute all class level querying methods in initialization
block and callbacks (`after_initialize`, `before_validation`,
`before_save`, etc), which are user provided code.

To avoid the leaking scope issue, restore the original current scope
before initialization block and callbacks are invoked.

Fixes #9894.
Fixes #17577.
Closes #31526.