### PR TITLE
Finish rename of database_operations to database_resolver_context

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -29,7 +29,7 @@
     ```
     config.active_record.database_selector = { delay: 2.seconds }
     config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    config.active_record.database_operations = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
     ```
 
     To change the database selection strategy, pass a custom class to the
@@ -38,7 +38,7 @@
     ```
     config.active_record.database_selector = { delay: 10.seconds }
     config.active_record.database_resolver = MyResolver
-    config.active_record.database_operations = MyResolver::MyCookies
+    config.active_record.database_resolver_context = MyResolver::MyCookies
     ```
 
     *Eileen M. Uchitelle*

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -91,7 +91,7 @@ module ActiveRecord
     initializer "active_record.database_selector" do
       if options = config.active_record.delete(:database_selector)
         resolver = config.active_record.delete(:database_resolver)
-        operations = config.active_record.delete(:database_operations)
+        operations = config.active_record.delete(:database_resolver_context)
         config.app_middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, operations, options
       end
     end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -107,9 +107,10 @@ Rails.application.configure do
   # The `database_resolver` class is used by the middleware to determine which
   # database is appropriate to use based on the time delay.
   #
-  # The `database_operations` class is used by the middleware to set timestamps
-  # for the last write to the primary. The resolver uses the operations class
-  # timestamps to determine how long to wait before reading from the replica.
+  # The `database_resolver_context` class is used by the middleware to set
+  # timestamps for the last write to the primary. The resolver uses the context
+  # class timestamps to determine how long to wait before reading from the
+  # replica.
   #
   # By default Rails will store a last write timestamp in the session. The
   # DatabaseSelector middleware is designed as such you can define your own
@@ -117,5 +118,5 @@ Rails.application.configure do
   # these configuration options.
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_operations = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end


### PR DESCRIPTION
I missed these in #35182 😳, this finishes the rename of `config.active_record.database_operations` to `database_resolver_context`.

I also updated the message from the previous config's introduction in the CHANGELOG, which I hope is okay since a release hasn't been cut with that config yet.

cc @eileencodes 