### PR TITLE
[WIP] Fix dev environment memory leak

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -101,10 +101,6 @@ module ActionView
         @view_template_cache.clear
       end
 
-      def self.view_template_cache
-        @view_template_cache
-      end
-
       def self.digest_caches
         @digest_cache.values
       end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -76,7 +76,6 @@ module ActionView
 
       alias :eql? :equal?
 
-      @details_keys = Concurrent::Map.new
       @digest_cache = Concurrent::Map.new
       @view_template_cache = SmallCache.new(&KEY_BLOCK)
 
@@ -93,12 +92,11 @@ module ActionView
           details = details.dup
           details[:formats] &= Template::Types.symbols
         end
-        @details_keys[details] ||= Object.new
+        @view_template_cache[details]
       end
 
       def self.clear
         @view_context_class = nil
-        @details_keys.clear
         @digest_cache.clear
         @view_template_cache.clear
       end
@@ -279,6 +277,13 @@ module ActionView
 
       @details = initialize_details({}, details)
       @view_paths = build_view_paths(view_paths)
+    end
+
+    def clear_cache
+      @view_paths.each(&:clear_cache)
+      DetailsKey.clear
+      @details_key = nil
+      @digest_cache = nil
     end
 
     def digest_cache

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -87,6 +87,7 @@ module ActionView
 
     # Returns an object that is able to render templates.
     def view_renderer # :nodoc:
+      # Lifespan: Per controller
       @_view_renderer ||= ActionView::Renderer.new(lookup_context)
     end
 

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -50,15 +50,15 @@ module ActionView
       end
 
       # Cache the templates returned by the block
-      def cache(key, name, prefix, partial, locals)
+      def cache(template_cache, name, prefix, partial, locals)
         if Resolver.caching?
-          key[@resolver][name][prefix][partial][locals] ||= canonical_no_templates(yield)
+          template_cache[@resolver][name][prefix][partial][locals] ||= canonical_no_templates(yield)
         else
           fresh_templates  = yield
-          cached_templates = key[@resolver][name][prefix][partial][locals]
+          cached_templates = template_cache[@resolver][name][prefix][partial][locals]
 
           if templates_have_changed?(cached_templates, fresh_templates)
-            key[@resolver][name][prefix][partial][locals] = canonical_no_templates(fresh_templates)
+            template_cache[@resolver][name][prefix][partial][locals] = canonical_no_templates(fresh_templates)
           else
             cached_templates || NO_TEMPLATES
           end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -53,13 +53,13 @@ module ActionView
       # Cache the templates returned by the block
       def cache(key, name, prefix, partial, locals)
         if Resolver.caching?
-          @data[key][@resolver][name][prefix][partial][locals] ||= canonical_no_templates(yield)
+          key[@resolver][name][prefix][partial][locals] ||= canonical_no_templates(yield)
         else
           fresh_templates  = yield
-          cached_templates = @data[key][@resolver][name][prefix][partial][locals]
+          cached_templates = key[@resolver][name][prefix][partial][locals]
 
           if templates_have_changed?(cached_templates, fresh_templates)
-            @data[key][@resolver][name][prefix][partial][locals] = canonical_no_templates(fresh_templates)
+            key[@resolver][name][prefix][partial][locals] = canonical_no_templates(fresh_templates)
           else
             cached_templates || NO_TEMPLATES
           end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -41,13 +41,12 @@ module ActionView
       NO_TEMPLATES = [].freeze
 
       def initialize(resolver)
-        @data = ActionView::LookupContext::DetailsKey.view_template_cache
         @query_cache = Concurrent::Map.new(initial_capacity: 2)
         @resolver = resolver
       end
 
       def inspect
-        "#<#{self.class.name}:0x#{(object_id << 1).to_s(16)} keys=#{@data.size} queries=#{@query_cache.size}>"
+        "#<#{self.class.name}:0x#{(object_id << 1).to_s(16)} queries=#{@query_cache.size}>"
       end
 
       # Cache the templates returned by the block
@@ -75,25 +74,14 @@ module ActionView
       end
 
       def clear
-        @data.clear
+        ActionView::LookupContext::DetailsKey.clear
         @query_cache.clear
       end
 
       # Get the cache size.  Do not call this
       # method. This method is not guaranteed to be here ever.
       def size # :nodoc:
-        size = 0
-        @data.each_value do |v1|
-          v1.each_value do |v2|
-            v2.each_value do |v3|
-              v3.each_value do |v4|
-                size += v4.size
-              end
-            end
-          end
-        end
-
-        size + @query_cache.size
+        @query_cache.size
       end
 
       private

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -196,7 +196,7 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_equal "Foo", template.source
 
     # Finally, we can expire the cache. And the expected template will be used.
-    @lookup_context.view_paths.first.clear_cache
+    @lookup_context.clear_cache
     template = @lookup_context.find("foo", %w(test), true)
     assert_equal "Bar", template.source
   end

--- a/actionview/test/template/resolver_cache_test.rb
+++ b/actionview/test/template/resolver_cache_test.rb
@@ -4,6 +4,7 @@ require "abstract_unit"
 
 class ResolverCacheTest < ActiveSupport::TestCase
   def test_inspect_shields_cache_internals
+    ActionView::LookupContext::DetailsKey.clear
     assert_match %r(#<ActionView::Resolver:0x[0-9a-f]+ @cache=#<ActionView::Resolver::Cache:0x[0-9a-f]+ keys=0 queries=0>>), ActionView::Resolver.new.inspect
   end
 end

--- a/actionview/test/template/resolver_cache_test.rb
+++ b/actionview/test/template/resolver_cache_test.rb
@@ -5,6 +5,6 @@ require "abstract_unit"
 class ResolverCacheTest < ActiveSupport::TestCase
   def test_inspect_shields_cache_internals
     ActionView::LookupContext::DetailsKey.clear
-    assert_match %r(#<ActionView::Resolver:0x[0-9a-f]+ @cache=#<ActionView::Resolver::Cache:0x[0-9a-f]+ keys=0 queries=0>>), ActionView::Resolver.new.inspect
+    assert_match %r(#<ActionView::Resolver:0x[0-9a-f]+ @cache=#<ActionView::Resolver::Cache:0x[0-9a-f]+ queries=0>>), ActionView::Resolver.new.inspect
   end
 end

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -24,6 +24,10 @@ module ActionView
     DeveloperStruct = Struct.new(:name)
 
     module SharedTests
+      def setup
+        ActionView::LookupContext::DetailsKey.clear
+      end
+
       def self.included(test_case)
         test_case.class_eval do
           test "helpers defined on ActionView::TestCase are available" do


### PR DESCRIPTION
This commit fixes the memory leak in dev.  I'm not super pleased with the commit right now and I want to refactor it some, but I also want to make sure it's public.  Specifically I dislike the part where I added another layer to the cache.  I think I can improve that part.

I think the source of the leak is that the digest cache was combined with the template object cache.  This commit splits the caches, then combines them behind the `DetailsKey` interface.  Resolvers have to ask the details key thing for their cache.  That gave the LookupContext an implicit dependency on `DetailsKey`, which is why I had to change the `fallbacks` method to do a check at runtime (otherwise the circular dependency ruins file loading).

I think separating the caches will fix the tests here: https://github.com/rails/rails/pull/35160

Here's a graph of the heap live slots on master versus this branch:

<img width="490" alt="erb eval 2019-02-07 15-48-58" src="https://user-images.githubusercontent.com/3124/52450461-eb9d0f80-2aef-11e9-9446-263ee5bfb539.png">
