### PR TITLE
Add `normalize` to `ActiveSupport::Duration`

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -661,6 +661,16 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal 660, (d1 + 60).to_i
   end
 
+  def test_normalize
+    assert_equal_parts(110.seconds, 1.minutes + 50.seconds)
+    assert_equal_parts(3665.seconds, 1.hour + 1.minutes + 5.seconds)
+    assert_equal_parts(3665.seconds, 61.minutes + 5.seconds, :minutes)
+    assert_equal_parts((2.minutes + 2.seconds) * 60, 2.hours + 2.minutes)
+    assert_equal_parts((2.minutes + 2.seconds) * 60, 122.minutes, :minutes)
+    assert_equal_parts(24.days + 65.seconds, 3.weeks + 3.days + 1.minute + 5.seconds)
+    assert_equal_parts(24.days + 60.seconds, 576.hours + 1.minute, :hours)
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?
@@ -668,5 +678,10 @@ class DurationTest < ActiveSupport::TestCase
       else
         "America/New_York"
       end
+    end
+
+    def assert_equal_parts(d1, d2, max_part = :years)
+      assert_equal(d1, d2)
+      assert_equal(d1.normalize(max_part).parts, d2.normalize(max_part).parts)
     end
 end


### PR DESCRIPTION
While mostly used to modify Date and Time objects, Duration is really useful in itself to hold time periods and operate with them.

However, I noticed that after several operations, the resulting Duration, although correct, could look really weird, because of the way parts are combined.

Like in this example:

```ruby
irb(main):015:0> durations = [40, 80, 140, 250].map { |d| ActiveSupport::Duration.build(d) }
=> [40.0 seconds, 1 minute and 20.0 seconds, 2 minutes and 20.0 seconds, 4 minutes and 10.0 seconds]
irb(main):016:0> total_duration = durations.sum
=> 7 minutes and 90.0 seconds
```

The result is valid, but most of us would expect `8 minutes and 30.0 seconds`.

So this PR adds the method `ActiveSupport::Duration#normalize` that does just that.

```ruby
irb(main):017:0> total_duration.normalize
=> 8 minutes and 30.0 seconds
```

Both durations have the same value and are equal, but the second one has a more desirable parts composition, that is useful if you need to show the duration to the user.

In some cases, you might want to put a upper limit on the time units used. For instance, when adding up the durations of a list of phone calls, it might make more sense to say `25 hours, 15 minutes and 10 seconds` than `1 day, 1 hour, 15 minutes and 10 seconds`.  Or someone could even prefer `1515 minutes and 10 seconds`, as billing usually comes in minutes.

In these situations, you can pass an additional argument to `normalize` with the maximum time part that you want the resulting duration to have.

```ruby
irb(main):018:0> d = 1.day + 1.hour + 15.minutes + 10.seconds
=> 1 day, 1 hour, 15 minutes, and 10 seconds
irb(main):019:0> d.normalize
=> 1 day, 1 hour, 15 minutes, and 10.0 seconds
irb(main):020:0> d.normalize(:hours)
=> 25 hours, 15 minutes, and 10.0 seconds
irb(main):021:0> d.normalize(:minutes)
=> 1515 minutes and 10.0 seconds
```

Finally, as part of the implementation, but also useful IMHO, I added the same optional argument to `ActiveSupport::Duration#build`.

```ruby
irb(main):022:0> d = ActiveSupport::Duration.build(4565)
=> 1 hour, 16 minutes, and 5.0 seconds
irb(main):023:0> d = ActiveSupport::Duration.build(4565, :minutes)
=> 76 minutes and 5.0 seconds
```

And that's it! This is my first contribution to Rails, BTW, so hope you like it!!!
