### PR TITLE
Allow deprecated non-symbol access to nested `config_for` hashes

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix non-symbol access to nested hashes returned from `Rails::Application.config_for`
+    being broken by allowing non-symbol access with a deprecation notice.
+
+    *Ufuk Kayserilioglu*
+
 *   Fix deeply nested namespace command printing.
 
     *Gannon McGibbon*

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1782,12 +1782,12 @@ module ApplicationTests
 
       actual = Rails.application.config.my_custom_config
 
-      assert_equal actual, foo: 0, bar: { baz: 1 }
-      assert_equal actual.keys, [ :foo, :bar ]
-      assert_equal actual.values, [ 0, baz: 1]
-      assert_equal actual.to_h, foo: 0, bar: { baz: 1 }
-      assert_equal actual[:foo], 0
-      assert_equal actual[:bar], baz: 1
+      assert_equal({ foo: 0, bar: { baz: 1 } }, actual)
+      assert_equal([ :foo, :bar ], actual.keys)
+      assert_equal([ 0, baz: 1], actual.values)
+      assert_equal({ foo: 0, bar: { baz: 1 } }, actual.to_h)
+      assert_equal(0, actual[:foo])
+      assert_equal({ baz: 1 }, actual[:bar])
     end
 
     test "config_for generates deprecation notice when nested hash methods are called with non-symbols" do


### PR DESCRIPTION
### Summary

A change to `config_for` in https://github.com/rails/rails/pull/33815 and https://github.com/rails/rails/pull/33882 has altered the behaviour of the returned object in a breaking manner. 

Before that change, nested hashes returned from `config_for` could be accessed using non-symbol keys. After the change, all keys are recursively symbolized so non-symbol access fails to read the expected values.

This is a breaking change for any app that might be relying on the nested hashes returned from `config_for` calls, and thus should be deprecated before being removed from the codebase.

### Solution

This PR introduces a temporary `NonSymbolAccessDeprecatedHash` class that recursively wraps any nested hashes inside the `OrderedOptions` object returned from `config_for` and issues a deprecation notice when a non-symbol based access is performed.

This way, any apps that are still relying on the ability to access these nested hashes using non-symbol keys will be able to observe the deprecation notices and have time to implement fixes before non-symbol access is removed for good.

### Other Information

Note that the top-level access to the `OrderedOptions` object returned from `config_for` has indifferent access semantics due to the nature of how `OrderedOptions` works. This functionality is the same for `Rails.config` and `secrets`, so is not changed nor is any deprecation notice issued.

The deprecation is only for nested keys below the top-level, since that is the functionality that is potentially broken.