### PR TITLE
Bug 30846 AR/PG Disable referential integrity for all tables in all schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -8,6 +8,7 @@ module ActiveRecord
           original_exception = nil
 
           begin
+            execute('reset role')
             transaction(requires_new: true) do
               execute(tables_with_schema_all.collect { |name| "ALTER TABLE #{name} DISABLE TRIGGER ALL" }.join(";"))
             end
@@ -33,6 +34,10 @@ Rails needs superuser privileges to disable referential integrity.
           begin
             transaction(requires_new: true) do
               execute(tables_with_schema_all.collect { |name| "ALTER TABLE #{name} ENABLE TRIGGER ALL" }.join(";"))
+            end
+            r = Rails.configuration.test_role
+            if r.present?
+              execute("set role #{r}")
             end
           rescue ActiveRecord::ActiveRecordError
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
           begin
             transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+              execute(tables_with_schema_all.collect { |name| "ALTER TABLE #{name} DISABLE TRIGGER ALL" }.join(";"))
             end
           rescue ActiveRecord::ActiveRecordError => e
             original_exception = e
@@ -32,7 +32,7 @@ Rails needs superuser privileges to disable referential integrity.
 
           begin
             transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+              execute(tables_with_schema_all.collect { |name| "ALTER TABLE #{name} ENABLE TRIGGER ALL" }.join(";"))
             end
           rescue ActiveRecord::ActiveRecordError
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -299,7 +299,12 @@ module ActiveRecord
               end
             end
 
+            execute('reset role')
             query_value("SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})", "SCHEMA")
+            r = Rails.configuration.test_role
+            if r.present?
+              execute("set role #{r}")
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

This PR addresses issue #30846 . Referential integrity disabling is incomplete when several PostgreSQL schemas contain tables with the same name. Currently one has to use *schema_search_path* in `config/database.yml` just for fixtures to load alright. However it doesn't help much as `#data_sources_sql` and `#tables` won't return full names along with schema.

This PR will disable referential integrity in **all** user tables while maintaining default `#data_sources_sql` behavior otherwise. This way there is no need to mess with *schema_search_path*.

It introduces new optional parameter *all = false* to `#data_sources_sql` and a new method `#tables_with_schema_all` in PG specific *schema_statement.rb* and uses that from PG specific *referential_integrity.rb*.