### PR TITLE
Do not allow to add column without column name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -229,6 +229,7 @@ module ActiveRecord
           column_types.each do |column_type|
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{column_type}(*names, **options)
+                raise ArgumentError, "missing column name(s) for #{column_type}" if names.empty?
                 names.each { |name| column(name, :#{column_type}, options) }
               end
             RUBY

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -318,6 +318,15 @@ module ActiveRecord
       ensure
         connection.drop_table(:my_table) rescue nil
       end
+
+      def test_add_column_without_column_name
+        e = assert_raise ArgumentError do
+          connection.create_table "my_table", force: true do |t|
+            t.timestamp
+          end
+        end
+        assert e.message.include?("timestamp")
+      end
     end
   end
 end


### PR DESCRIPTION
I applied the following migration.

```ruby
create_table "users" do |t|
  t.string :name
  t.timestamp
end
```

It contains a typo, `timestamp` instead of `timestamps`.
But this is appliable without errors.


Short-hands for TableDefinition#columns is callable without column names.
It do nothing when called without column names.
This change suggests raise ArgumentError in such cases.