### PR TITLE
Retain selections with `includes` and `joins`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Retain explicit selections on the base model after applying `includes` and `joins`.
+
+    Resolves #34889.
+
+    *Patrick Rebsch*
+
 *   Allow attributes to be fetched from Arel node groupings.
 
     *Jeff Emminger*, *Gannon McGibbon*

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -2,10 +2,11 @@
 
 require "cases/helper"
 require "models/post"
+require "models/comment"
 
 module ActiveRecord
   class SelectTest < ActiveRecord::TestCase
-    fixtures :posts
+    fixtures :posts, :comments
 
     def test_select_with_nil_argument
       expected = Post.select(:title).to_sql
@@ -22,6 +23,21 @@ module ActiveRecord
       actual   = PostWithDefaultSelect.reselect(:title).to_sql
 
       assert_equal expected, actual
+    end
+
+    def test_aliased_select_using_as_with_joins_and_includes
+      posts = Post.select("posts.id AS field_alias").joins(:comments).includes(:comments)
+      assert_includes posts.first.attributes, "field_alias"
+    end
+
+    def test_aliased_select_not_using_as_with_joins_and_includes
+      posts = Post.select("posts.id field_alias").joins(:comments).includes(:comments)
+      assert_includes posts.first.attributes, "field_alias"
+    end
+
+    def test_star_select_with_joins_and_includes
+      posts = Post.select("posts.*").joins(:comments).includes(:comments)
+      assert_not_includes posts.first.attributes, "posts.*"
     end
   end
 end


### PR DESCRIPTION
### Summary

Resolves #34889.

Applying `includes` and `joins` to a relation that selected additional database fields would cause those additional fields not to be included in the results even though they were queried from the database:

```ruby
posts = Post.select('1 as other').includes(:comments).joins(:comments)

posts.to_sql.include?('1 as other')       #=> true
posts.first.attributes.include?('other')  #=> false
```

This PR includes these additionally selected fields in the instantiated results.

One difference in behavior is that normally the presence of a `select` on the relation would limit the selected fields to only those provided, but in this case it doesn't affect the default inclusion of all fields of the base model and just adds those provided fields to the result.