### PR TITLE
SQLite3: Implement `add_foreign_key` and `remove_foreign_key`

### DIFF
--- a/actionmailbox/test/dummy/db/schema.rb
+++ b/actionmailbox/test/dummy/db/schema.rb
@@ -42,4 +42,5 @@ ActiveRecord::Schema.define(version: 2018_02_12_164506) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -55,4 +55,5 @@ ActiveRecord::Schema.define(version: 2018_10_03_185713) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         end
 
         delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
-          :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys_in_create?, :foreign_key_options,
+          :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys?, :foreign_key_options,
           to: :@conn, private: true
 
         private
@@ -50,7 +50,7 @@ module ActiveRecord
               statements.concat(o.indexes.map { |column_name, options| index_in_create(o.name, column_name, options) })
             end
 
-            if supports_foreign_keys_in_create?
+            if supports_foreign_keys?
               statements.concat(o.foreign_keys.map { |to_table, options| foreign_key_in_create(o.name, to_table, options) })
             end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       alias validated? validate?
 
       def export_name_on_schema_dump?
-        name !~ ActiveRecord::SchemaDumper.fk_ignore_pattern
+        !ActiveRecord::SchemaDumper.fk_ignore_pattern.match?(name) if name
       end
 
       def defined_for?(to_table_ord = nil, to_table: nil, **options)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -335,6 +335,7 @@ module ActiveRecord
       def supports_foreign_keys_in_create?
         supports_foreign_keys?
       end
+      deprecate :supports_foreign_keys_in_create?
 
       # Does this adapter support views?
       def supports_views?

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -121,7 +121,7 @@ module ActiveRecord
         true
       end
 
-      def supports_foreign_keys_in_create?
+      def supports_foreign_keys?
         true
       end
 
@@ -424,9 +424,8 @@ module ActiveRecord
           type.to_sym == :primary_key || options[:primary_key]
         end
 
-        def alter_table(table_name, options = {})
+        def alter_table(table_name, foreign_keys = foreign_keys(table_name), **options)
           altered_table_name = "a#{table_name}"
-          foreign_keys = foreign_keys(table_name)
 
           caller = lambda do |definition|
             rename = options[:rename] || {}

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -348,6 +348,10 @@ module ActiveRecord
       assert_equal "special_db_type", @connection.type_to_sql(:special_db_type)
     end
 
+    def test_supports_foreign_keys_in_create_is_deprecated
+      assert_deprecated { @connection.supports_foreign_keys_in_create? }
+    end
+
     def test_supports_multi_insert_is_deprecated
       assert_deprecated { @connection.supports_multi_insert? }
     end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -462,7 +462,11 @@ module ActiveRecord
         end
 
         def test_create_table_with_force_cascade_drops_dependent_objects
-          skip "MySQL > 5.5 does not drop dependent objects with DROP TABLE CASCADE" if current_adapter?(:Mysql2Adapter)
+          if current_adapter?(:Mysql2Adapter)
+            skip "MySQL > 5.5 does not drop dependent objects with DROP TABLE CASCADE"
+          elsif current_adapter?(:SQLite3Adapter)
+            skip "SQLite3 does not support DROP TABLE CASCADE syntax"
+          end
           # can't re-create table referenced by foreign key
           assert_raises(ActiveRecord::StatementInvalid) do
             @connection.create_table :trains, force: true

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
+if ActiveRecord::Base.connection.supports_foreign_keys?
   module ActiveRecord
     class Migration
       class ReferencesForeignKeyInCreateTest < ActiveRecord::TestCase
@@ -65,9 +65,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
       end
     end
   end
-end
 
-if ActiveRecord::Base.connection.supports_foreign_keys?
   module ActiveRecord
     class Migration
       class ReferencesForeignKeyTest < ActiveRecord::TestCase
@@ -172,12 +170,17 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         class CreateDogsMigration < ActiveRecord::Migration::Current
-          def change
+          def up
             create_table :dog_owners
 
             create_table :dogs do |t|
               t.references :dog_owner, foreign_key: true
             end
+          end
+
+          def down
+            drop_table :dogs, if_exists: true
+            drop_table :dog_owners, if_exists: true
           end
         end
 

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -496,9 +496,6 @@ NOTE: Active Record only supports single column foreign keys. `execute` and
 `structure.sql` are required to use composite foreign keys. See
 [Schema Dumping and You](#schema-dumping-and-you).
 
-NOTE: The SQLite3 adapter doesn't support `add_foreign_key` since SQLite supports
-only [a limited subset of ALTER TABLE](https://www.sqlite.org/lang_altertable.html).
-
 Removing a foreign key is easy as well:
 
 ```ruby


### PR DESCRIPTION
I implemented Foreign key create in `create_table` for SQLite3 at
#24743. This follows #24743 to implement `add_foreign_key` and
`remove_foreign_key`.
Unfortunately SQLite3 has one limitation that
`PRAGMA foreign_key_list(table-name)` doesn't have constraint name.
So we couldn't implement find/remove foreign key by name for now.

Fixes #35207.
Closes #31343.