### PR TITLE
Deliver parameterized mail with correct DeliveryJob

### DIFF
--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -139,8 +139,25 @@ module ActionMailer
           if processed?
             super
           else
-            args = @mailer_class.name, @action.to_s, delivery_method.to_s, @params, *@args
-            ActionMailer::Parameterized::DeliveryJob.set(options).perform_later(*args)
+            job  = delivery_job_class
+            args = arguments_for(job, delivery_method)
+            job.set(options).perform_later(*args)
+          end
+        end
+
+        def delivery_job_class
+          if @mailer_class.delivery_job <= MailDeliveryJob
+            @mailer_class.delivery_job
+          else
+            Parameterized::DeliveryJob
+          end
+        end
+
+        def arguments_for(delivery_job, delivery_method)
+          if delivery_job <= DeliveryJob
+            [@mailer_class.name, @action.to_s, delivery_method.to_s, params: @params, args: @args]
+          else
+            [@mailer_class.name, @action.to_s, delivery_method.to_s, @params, *@args]
           end
         end
     end

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -53,4 +53,30 @@ class ParameterizedTest < ActiveSupport::TestCase
       invitation = mailer.method(:anything)
     end
   end
+
+  test "should enqueue a parameterized request with the correct delivery job" do
+    args = [
+      "ParamsMailer",
+      "invitation",
+      "deliver_now",
+      params: { inviter: "david@basecamp.com", invitee: "jason@basecamp.com" },
+      args: [],
+    ]
+
+    with_delivery_job DummyDeliveryJob do
+      assert_performed_with(job: DummyDeliveryJob, args: args) do
+        @mail.deliver_later
+      end
+    end
+  end
+
+  private
+
+    def with_delivery_job(job)
+      old_delivery_job = ParamsMailer.delivery_job
+      ParamsMailer.delivery_job = job
+      yield
+    ensure
+      ParamsMailer.delivery_job = old_delivery_job
+    end
 end


### PR DESCRIPTION
### Summary
When using a custom delivery job in combination with a parameterized mail it did not use the specified custom mailer job but always Parameterized::DeliveryJob.

### Other Information

This is already fixed in master. This is basically just a cherry-pick of @gmcgibbon work into 5-2-stable. However, the original work also contained some more code so cherry-picking did not work so I added @gmcgibbon as co-author of the commit to give him the proper credit, I hope this is fine.

cc @sikachu