### PR TITLE
Correct JavaScript guide example

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -475,7 +475,7 @@ respond to your Ajax request. You then have a corresponding
 code that will be sent and executed on the client side.
 
 ```erb
-$("<%= escape_javascript(render @user) %>").appendTo("#users");
+$("#users").appendTo("<%= raw escape_javascript(render @user) %>");
 ```
 
 Turbolinks


### PR DESCRIPTION
### Summary

Corrects a small error in the documentation regarding usage of JavaScript in Rails 😄

1. Swaps the `#users` jQuery selector to correct position.
2. Prevents ERB from escaping the HTML using the `raw` helper.