### PR TITLE
Revert "Merge pull request #35211 from y-yagi/fix_broken_association_test"

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -488,22 +488,6 @@ Module.new do
   Dir.chdir(app_template_path) { `yarn add webpack@4.17.1 --tilde` }
   Dir.chdir(app_template_path) { `yarn add webpack-cli` }
 
-  # FIXME: Temporary fix for webpack + ajv@6.9.0 compatible issue.
-  #        See https://github.com/epoberezkin/ajv/issues/941
-  Dir.chdir(app_template_path) do
-    package = File.read("package.json")
-    resolutions = <<~EOS
-      ,
-        "resolutions": {
-          "ajv": "6.8.1"
-        }
-      }
-    EOS
-    if package =~ /\n}\n\z/
-      File.open("package.json", "w") { |f| f.puts $` + resolutions + $' }
-    end
-  end
-
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.
   contents = File.read("#{app_template_path}/config/application.rb")


### PR DESCRIPTION
This reverts commit 38f9e41f2c4b64377ffb036c53873dbfb51546cf, reversing
changes made to 5e493c3b839f10d639f5cce1f1b9ff9292702821.

Reason: The ajv@6.9.1 was released that fixes issue.

I want to check this fix in CI...
