### PR TITLE
Disable pager when loading structure for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -108,6 +108,7 @@ module ActiveRecord
           ENV["PGPORT"]     = configuration["port"].to_s     if configuration["port"]
           ENV["PGPASSWORD"] = configuration["password"].to_s if configuration["password"]
           ENV["PGUSER"]     = configuration["username"].to_s if configuration["username"]
+          ENV["PSQL_PAGER"] = ""
         end
 
         def run_cmd(cmd, args, action)

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -526,6 +526,23 @@ if current_adapter?(:PostgreSQLAdapter)
         end
       end
 
+      def test_structure_load_disables_pager
+        previous_env, ENV["PSQL_PAGER"] = ENV["PSQL_PAGER"], nil
+
+        filename = "awesome-file.sql"
+        assert_called(
+          Kernel,
+          :system,
+          returns: true
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+
+        assert_equal "", ENV["PSQL_PAGER"]
+      ensure
+        ENV["PSQL_PAGER"] = previous_env
+      end
+
       private
         def with_structure_load_flags(flags)
           old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags


### PR DESCRIPTION
### Summary

tl;dr In PostgreSQL 9.6.8+ (and similarly patched versions of 10 as well as 11), the `rake db:test:load_structure` task can cause a blocking interactive shell command.

The [fix to CVE-2018-1058](https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058:_Protect_Your_Search_Path) (among other things) changes pg_dump to emit:
   SELECT pg_catalog.set_config('search_path', '', false);
into the structure.sql file. In certain environments (e.g., docker) this
triggers the pager when psql is used to restore the database structure.
Since the pager results in the rake task containing a blocking
interactive shell command, we need to make sure psql never uses a pager
when running rake tasks for PostgreSQL.