### PR TITLE
Cache regex in template OptimizedFileSystemResolver

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -325,7 +325,7 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_dynamic_render_with_file
     # This is extremely bad, but should be possible to do.
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
-    response = get :dynamic_render_with_file, params: { id: '../\\../test/abstract_unit.rb' }
+    response = get :dynamic_render_with_file, params: { id: "../../test/abstract_unit.rb" }
     assert_equal File.read(File.expand_path("../../test/abstract_unit.rb", __dir__)),
       response.body
   end
@@ -345,20 +345,20 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_dynamic_render
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
-      get :dynamic_render, params: { id: '../\\../test/abstract_unit.rb' }
+      get :dynamic_render, params: { id: "../../test/abstract_unit.rb" }
     end
   end
 
   def test_permitted_dynamic_render_file_hash
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
-    response = get :dynamic_render_permit, params: { id: { file: '../\\../test/abstract_unit.rb' } }
+    response = get :dynamic_render_permit, params: { id: { file: "../../test/abstract_unit.rb" } }
     assert_equal File.read(File.expand_path("../../test/abstract_unit.rb", __dir__)),
       response.body
   end
 
   def test_dynamic_render_file_hash
     assert_raises ArgumentError do
-      get :dynamic_render, params: { id: { file: '../\\../test/abstract_unit.rb' } }
+      get :dynamic_render, params: { id: { file: "../../test/abstract_unit.rb" } }
     end
   end
 

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -407,7 +407,8 @@ module ActionView
       DETAILS_REGEX_CACHE = Concurrent::Map.new
 
       def regex_for_details(details)
-        DETAILS_REGEX_CACHE[details] ||=
+        details_cache_key = ActionView::LookupContext::DetailsKey.digest_cache(details)
+        DETAILS_REGEX_CACHE[details_cache_key] ||=
           %r{\A#{
             EXTENSIONS.map do |ext, prefix|
               match =

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -367,13 +367,15 @@ module ActionView
     private
 
       def find_template_paths_from_details(path, details)
-        # Instead of checking for every possible path, as our other globs would
-        # do, scan the directory for files with the right prefix.
+        # Instead of checking for every possible path, as our other globs would,
+        # scan the directory for files with the right prefix.
         query = "#{escape_entry(File.join(@path, path))}*"
+        candidates = Dir[query]
+
+        return [] if candidates.empty?
 
         regex = build_regex(path, details)
-
-        Dir[query].uniq.reject do |filename|
+        candidates.uniq.reject do |filename|
           # This regex match does double duty of finding only files which match
           # details (instead of just matching the prefix) and also filtering for
           # case-insensitive file systems.

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -402,7 +402,7 @@ module ActionView
       end
 
       def build_regex(path, details)
-        query = escape_entry(File.join(@path, path))
+        query = Regexp.escape(File.join(@path, path))
         exts = EXTENSIONS.map do |ext, prefix|
           match =
             if ext == :variants && details[ext] == :any


### PR DESCRIPTION
This is a follow up to #33860, which made templates faster by doing more work in ruby to reduce I/O. This PR reduces the amount of work we're doing in ruby. Like the previous PR this will mostly benefit startup time and development mode (where `Resolver.caching` is `false`).

Previously we were building a regex for each call to `#query` (which is called for each `view_path` on each search). Instead, this PR creates a regex for just the details component of the path (which itself is slightly faster), and caches that regex.

A regex used to look like:
```
/\A\/Users\/jhawthorn\/src\/rails\/railties\/lib\/rails\/templates\/rails\/welcome\/index(\.(?<locale>en))?(\.(?<formats>html|text|js|css|ics|csv|vcf|vtt|png|jpeg|gif|bmp|tiff|svg|mpeg|mp3|ogg|m4a|webm|mp4|otf|ttf|woff|woff2|xml|rss|atom|yaml|multipart_form|url_encoded_form|json|pdf|zip|gzip))?(\+(?<variants>))?(\.(?<handlers>raw|erb|html|builder|ruby))?\z/
```

Now looks like:
```
/\A\(\.(?<locale>en))?(\.(?<formats>html|text|js|css|ics|csv|vcf|vtt|png|jpeg|gif|bmp|tiff|svg|mpeg|mp3|ogg|m4a|webm|mp4|otf|ttf|woff|woff2|xml|rss|atom|yaml|multipart_form|url_encoded_form|json|pdf|zip|gzip))?(\+(?<variants>))?(\.(?<handlers>raw|erb|html|builder|ruby))?\z/
```

### Benchmark

The speedup depends a lot on how slow the globs are. Listing directories on my Linux machine is way faster than on my MacBook 🤔. On my MacBook it's still ~1.5x faster 🎉

Benchmark:
```
require "benchmark/ips"
require "action_view"
require "action_pack"
require "action_controller"

class TestController < ActionController::Base
end

ActionView::Resolver.caching = false
TestController.view_paths = [File.expand_path("./railties/lib/rails/templates")]
context = TestController.new.lookup_context

Benchmark.ips do |x|
  x.report("template") do
    context.find_template("rails/welcome/index", [], false, {}, {})
  end
end
```

Before:
```
Warming up --------------------------------------
            template   387.000  i/100ms
Calculating -------------------------------------
            template      3.821k (± 5.0%) i/s -     19.350k in   5.078706s
```

After:
```
Warming up --------------------------------------
            template   586.000  i/100ms
Calculating -------------------------------------
            template      5.717k (± 7.3%) i/s -     28.714k in   5.055056s
```

cc @tenderlove @eileencodes 