### PR TITLE
Zeitwerk integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,9 @@ gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
 
 # for railties app_generator_test
-gem "bootsnap", ">= 1.1.0", require: false
+gem "bootsnap", ">= 1.4.0", require: false
+
+gem "zeitwerk", ">= 1.0.0" if RUBY_ENGINE == "ruby"
 
 # Active Job
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,9 +166,9 @@ GEM
       childprocess
       faraday
       selenium-webdriver
-    bootsnap (1.3.2)
+    bootsnap (1.4.0)
       msgpack (~> 1.0)
-    bootsnap (1.3.2-java)
+    bootsnap (1.4.0-java)
       msgpack (~> 1.0)
     builder (3.2.3)
     bunny (2.13.0)
@@ -324,10 +324,10 @@ GEM
     minitest-server (1.0.5)
       minitest (~> 5.0)
     mono_logger (1.1.0)
-    msgpack (1.2.4)
-    msgpack (1.2.4-java)
-    msgpack (1.2.4-x64-mingw32)
-    msgpack (1.2.4-x86-mingw32)
+    msgpack (1.2.6)
+    msgpack (1.2.6-java)
+    msgpack (1.2.6-x64-mingw32)
+    msgpack (1.2.6-x86-mingw32)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustache (1.1.0)
@@ -516,6 +516,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zeitwerk (1.0.0)
 
 PLATFORMS
   java
@@ -535,7 +536,7 @@ DEPENDENCIES
   benchmark-ips
   blade
   blade-sauce_labs_plugin
-  bootsnap (>= 1.1.0)
+  bootsnap (>= 1.4.0)
   byebug
   capybara (>= 2.15)
   chromedriver-helper
@@ -588,6 +589,7 @@ DEPENDENCIES
   webmock
   webpacker (>= 4.0.0.rc.3)
   websocket-client-simple!
+  zeitwerk (>= 1.0.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -59,6 +59,14 @@ module ActionMailer
       end
     end
 
+    initializer "action_mailer.set_autoload_paths" do |app|
+      options = app.config.action_mailer
+
+      if options.show_previews && options.preview_path
+        ActiveSupport::Dependencies.autoload_paths << options.preview_path
+      end
+    end
+
     initializer "action_mailer.compile_config_methods" do
       ActiveSupport.on_load(:action_mailer) do
         config.compile_methods! if config.respond_to?(:compile_methods!)
@@ -76,12 +84,8 @@ module ActionMailer
 
       if options.show_previews
         app.routes.prepend do
-          get "/rails/mailers"         => "rails/mailers#index", internal: true
-          get "/rails/mailers/*path"   => "rails/mailers#preview", internal: true
-        end
-
-        if options.preview_path
-          ActiveSupport::Dependencies.autoload_paths << options.preview_path
+          get "/rails/mailers"       => "rails/mailers#index", internal: true
+          get "/rails/mailers/*path" => "rails/mailers#preview", internal: true
         end
       end
     end

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveSupport
   module Dependencies
     module ZeitwerkIntegration # :nodoc: all

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -1,0 +1,71 @@
+module ActiveSupport
+  module Dependencies
+    module ZeitwerkIntegration # :nodoc: all
+      module Decorations
+        def clear
+          Dependencies.unload_interlock do
+            Rails.autoloader.reload
+          end
+        end
+
+        def constantize(cpath)
+          Inflector.constantize(cpath)
+        end
+
+        def safe_constantize(cpath)
+          Inflector.safe_constantize(cpath)
+        end
+
+        def autoloaded_constants
+          Rails.autoloaders.flat_map do |autoloader|
+            autoloader.loaded.to_a
+          end
+        end
+
+        def autoloaded?(object)
+          cpath = object.is_a?(Module) ? object.name : object.to_s
+          Rails.autoloaders.any? { |autoloader| autoloader.loaded?(cpath) }
+        end
+      end
+
+      class << self
+        def take_over
+          setup_autoloaders
+          freeze_autoload_paths
+          decorate_dependencies
+        end
+
+        private
+
+          def setup_autoloaders
+            Dependencies.autoload_paths.each do |autoload_path|
+              if File.directory?(autoload_path)
+                if autoload_once?(autoload_path)
+                  Rails.once_autoloader.push_dir(autoload_path)
+                else
+                  Rails.autoloader.push_dir(autoload_path)
+                end
+              end
+            end
+
+            Rails.autoloaders.each(&:setup)
+          end
+
+          def autoload_once?(autoload_path)
+            Dependencies.autoload_once_paths.include?(autoload_path) ||
+            Gem.path.any? { |gem_path| autoload_path.to_s.start_with?(gem_path) }
+          end
+
+          def freeze_autoload_paths
+            Dependencies.autoload_paths.freeze
+            Dependencies.autoload_once_paths.freeze
+          end
+
+          def decorate_dependencies
+            Dependencies.singleton_class.prepend(Decorations)
+            Object.class_eval { alias_method :require_dependency, :require }
+          end
+      end
+    end
+  end
+end

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -110,5 +110,25 @@ module Rails
     def public_path
       application && Pathname.new(application.paths["public"].first)
     end
+
+    def autoloader
+      if configuration.autoloader == :zeitwerk
+        @autoloader ||= Zeitwerk::Loader.new
+      end
+    end
+
+    def once_autoloader
+      if configuration.autoloader == :zeitwerk
+        @once_autoloader ||= Zeitwerk::Loader.new
+      end
+    end
+
+    def autoloaders
+      if configuration.autoloader == :zeitwerk
+        [autoloader, once_autoloader]
+      else
+        []
+      end
+    end
   end
 end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -21,6 +21,13 @@ module Rails
         end
       end
 
+      initializer :let_zeitwerk_take_over do
+        if config.autoloader == :zeitwerk
+          require "active_support/dependencies/zeitwerk_integration"
+          ActiveSupport::Dependencies::ZeitwerkIntegration.take_over
+        end
+      end
+
       initializer :add_builtin_route do |app|
         if Rails.env.development?
           app.routes.prepend do
@@ -66,6 +73,7 @@ module Rails
       initializer :eager_load! do
         if config.eager_load
           ActiveSupport.run_load_hooks(:before_eager_load, self)
+          Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
           config.eager_load_namespaces.each(&:eager_load!)
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -28,7 +28,7 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 
 <% if depend_on_bootsnap? -%>
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
+gem 'bootsnap', '>= 1.4.0', require: false
 
 <%- end -%>
 <%- if options.api? -%>
@@ -36,7 +36,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # gem 'rack-cors'
 
 <%- end -%>
-<% if RUBY_ENGINE == 'ruby' -%>
+<% if RUBY_ENGINE == "ruby" -%>
+gem "zeitwerk", ">= 1.0.0"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1157,6 +1157,27 @@ module ApplicationTests
       end
     end
 
+    test "autoloader & autoloader=" do
+      app "development"
+
+      config = Rails.application.config
+      assert_instance_of Zeitwerk::Loader, Rails.autoloader
+      assert_instance_of Zeitwerk::Loader, Rails.once_autoloader
+      assert_equal [Rails.autoloader, Rails.once_autoloader], Rails.autoloaders
+
+      config.autoloader = :classic
+      assert_nil Rails.autoloader
+      assert_nil Rails.once_autoloader
+      assert_empty Rails.autoloaders
+
+      config.autoloader = :zeitwerk
+      assert_instance_of Zeitwerk::Loader, Rails.autoloader
+      assert_instance_of Zeitwerk::Loader, Rails.once_autoloader
+      assert_equal [Rails.autoloader, Rails.once_autoloader], Rails.autoloaders
+
+      assert_raises(ArgumentError) { config.autoloader = :unknown }
+    end
+
     test "config.action_view.cache_template_loading with cache_classes default" do
       add_to_config "config.cache_classes = true"
 

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -85,6 +85,7 @@ module ApplicationTests
     end
 
     test "mailer previews are loaded from a custom preview_path" do
+      app_dir "lib/mailer_previews"
       add_to_config "config.action_mailer.preview_path = '#{app_path}/lib/mailer_previews'"
 
       mailer "notifier", <<-RUBY
@@ -254,6 +255,7 @@ module ApplicationTests
     end
 
     test "mailer previews are reloaded from a custom preview_path" do
+      app_dir "lib/mailer_previews"
       add_to_config "config.action_mailer.preview_path = '#{app_path}/lib/mailer_previews'"
 
       app("development")
@@ -818,6 +820,7 @@ module ApplicationTests
       def build_app
         super
         app_file "config/routes.rb", "Rails.application.routes.draw do; end"
+        app_dir "test/mailers/previews"
       end
 
       def mailer(name, contents)

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -100,30 +100,6 @@ module ApplicationTests
       assert_nothing_raised { AppTemplate::Application.new }
     end
 
-    def test_initializers_run_on_different_applications_go_to_the_same_class
-      application1 = AppTemplate::Application.new
-      run_count = 0
-
-      AppTemplate::Application.initializer :init0 do
-        run_count += 1
-      end
-
-      application1.initializer :init1 do
-        run_count += 1
-      end
-
-      AppTemplate::Application.new.initializer :init2 do
-        run_count += 1
-      end
-
-      assert_equal 0, run_count, "Without loading the initializers, the count should be 0"
-
-      # Set config.eager_load to false so that an eager_load warning doesn't pop up
-      AppTemplate::Application.create { config.eager_load = false }.initialize!
-
-      assert_equal 3, run_count, "There should have been three initializers that incremented the count"
-    end
-
     def test_consoles_run_on_different_applications_go_to_the_same_class
       run_count = 0
       AppTemplate::Application.console { run_count += 1 }

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -145,8 +145,8 @@ module ApplicationTests
       # loading a specific fixture
       rails "db:fixtures:load", "FIXTURES=products"
 
-      assert_equal 2, ::AppTemplate::Application::Product.count
-      assert_equal 0, ::AppTemplate::Application::User.count
+      assert_equal 2, Product.count
+      assert_equal 0, User.count
     end
 
     def test_loading_only_yml_fixtures

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "active_support/dependencies/zeitwerk_integration"
+
+class ZeitwerkIntegrationTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def setup
+    build_app
+  end
+
+  def boot(env = "development")
+    app(env)
+  end
+
+  def teardown
+    teardown_app
+  end
+
+  def deps
+    ActiveSupport::Dependencies
+  end
+
+  def decorated?
+    deps.singleton_class < deps::ZeitwerkIntegration::Decorations
+  end
+
+  test "ActiveSupport::Dependencies is decorated by default" do
+    boot
+
+    assert decorated?
+    assert_instance_of Zeitwerk::Loader, Rails.autoloader
+    assert_instance_of Zeitwerk::Loader, Rails.once_autoloader
+    assert_equal [Rails.autoloader, Rails.once_autoloader], Rails.autoloaders
+  end
+
+  test "ActiveSupport::Dependencies is not decorated in classic mode" do
+    add_to_config 'config.autoloader = :classic'
+    boot
+
+    assert_not decorated?
+    assert_nil Rails.autoloader
+    assert_nil Rails.once_autoloader
+    assert_empty Rails.autoloaders
+  end
+
+  test "constantize returns the value stored in the constant" do
+    app_file "app/models/admin/user.rb", "class Admin::User; end"
+    boot
+
+    assert_same Admin::User, deps.constantize("Admin::User")
+  end
+
+  test "constantize raises if the constant is unknown" do
+    boot
+
+    assert_raises(NameError) { deps.constantize("Admin") }
+  end
+
+  test "safe_constantize returns the value stored in the constant" do
+    app_file "app/models/admin/user.rb", "class Admin::User; end"
+    boot
+
+    assert_same Admin::User, deps.safe_constantize("Admin::User")
+  end
+
+  test "safe_constantize returns nil for unknown constants" do
+    boot
+
+    assert_nil deps.safe_constantize("Admin")
+  end
+
+  test "autoloaded_constants returns autoloaded constant paths" do
+    app_file "app/models/admin/user.rb", "class Admin::User; end"
+    app_file "app/models/post.rb", "class Post; end"
+    boot
+
+    assert Admin::User
+    assert_equal ["Admin", "Admin::User"], deps.autoloaded_constants
+  end
+
+  test "autoloaded? says if a constant has been autoloaded" do
+    app_file "app/models/user.rb", "class User; end"
+    app_file "app/models/post.rb", "class Post; end"
+    boot
+
+    assert Post
+    assert deps.autoloaded?("Post")
+    assert deps.autoloaded?(Post)
+    assert_not deps.autoloaded?("User")
+  end
+
+  test "eager loading loads the application code" do
+    $zeitwerk_integration_test_user = false
+    $zeitwerk_integration_test_post = false
+
+    app_file "app/models/user.rb", "class User; end; $zeitwerk_integration_test_user = true"
+    app_file "app/models/post.rb", "class Post; end; $zeitwerk_integration_test_post = true"
+    boot("production")
+
+    assert $zeitwerk_integration_test_user
+    assert $zeitwerk_integration_test_post
+  end
+
+  test "eager loading loads anything managed by Zeitwerk" do
+    $zeitwerk_integration_test_user  = false
+    app_file "app/models/user.rb", "class User; end; $zeitwerk_integration_test_user = true"
+
+    $zeitwerk_integration_test_extras = false
+    app_dir "extras"
+    app_file "extras/webhook_hacks.rb", "WebhookHacks = 1; $zeitwerk_integration_test_extras = true"
+
+    require "zeitwerk"
+    autoloader = Zeitwerk::Loader.new
+    autoloader.push_dir("#{app_path}/extras")
+    autoloader.setup
+
+    boot("production")
+
+    assert $zeitwerk_integration_test_user
+    assert $zeitwerk_integration_test_extras
+  end
+
+  test "autoload paths that are below Gem.path go to the once autoloader" do
+    app_dir "extras"
+    add_to_config 'config.autoload_paths << "#{Rails.root}/extras"'
+
+    # Mocks Gem.path to include the extras directory.
+    Gem.singleton_class.prepend(
+      Module.new do
+        def path
+          super + ["#{Rails.root}/extras"]
+        end
+      end
+    )
+    boot
+
+    refute_includes Rails.autoloader.dirs, "#{app_path}/extras"
+    assert_includes Rails.once_autoloader.dirs, "#{app_path}/extras"
+  end
+
+  test "clear reloads the main autoloader, and does not reload the once one" do
+    boot
+
+    $zeitwerk_integration_reload_test = []
+
+    autoloader = Rails.autoloader
+    def autoloader.reload
+      $zeitwerk_integration_reload_test << :autoloader
+      super
+    end
+
+    once_autoloader = Rails.once_autoloader
+    def once_autoloader.reload
+      $zeitwerk_integration_reload_test << :once_autoloader
+      super
+    end
+
+    ActiveSupport::Dependencies.clear
+
+    assert_equal %i(autoloader), $zeitwerk_integration_reload_test
+  end
+end

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -36,7 +36,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
   end
 
   test "ActiveSupport::Dependencies is not decorated in classic mode" do
-    add_to_config 'config.autoloader = :classic'
+    add_to_config "config.autoloader = :classic"
     boot
 
     assert_not decorated?
@@ -104,7 +104,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
   end
 
   test "eager loading loads anything managed by Zeitwerk" do
-    $zeitwerk_integration_test_user  = false
+    $zeitwerk_integration_test_user = false
     app_file "app/models/user.rb", "class User; end; $zeitwerk_integration_test_user = true"
 
     $zeitwerk_integration_test_extras = false
@@ -136,7 +136,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     )
     boot
 
-    refute_includes Rails.autoloader.dirs, "#{app_path}/extras"
+    assert_not_includes Rails.autoloader.dirs, "#{app_path}/extras"
     assert_includes Rails.once_autoloader.dirs, "#{app_path}/extras"
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -660,6 +660,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "jbuilder"
   end
 
+  def test_inclusion_of_zeitwerk
+    run_generator
+    if RUBY_ENGINE == "ruby"
+      assert_gem "zeitwerk"
+    else
+      assert_no_gem "zeitwerk"
+    end
+  end
+
   def test_inclusion_of_a_debugger
     run_generator
     if defined?(JRUBY_VERSION) || RUBY_ENGINE == "rbx"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -421,6 +421,10 @@ module TestHelpers
       file_name
     end
 
+    def app_dir(path)
+      FileUtils.mkdir_p("#{app_path}/#{path}")
+    end
+
     def remove_file(path)
       FileUtils.rm_rf "#{app_path}/#{path}"
     end
@@ -487,7 +491,11 @@ Module.new do
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.
   contents = File.read("#{app_template_path}/config/application.rb")
-  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
+  if RUBY_ENGINE == "ruby"
+    contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker zeitwerk).each { |r| require r }")
+  else
+    contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
+  end
   File.write("#{app_template_path}/config/application.rb", contents)
 
   require "rails"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -704,25 +704,27 @@ YAML
       RUBY
 
       @plugin.write "app/controllers/bukkits/foo_controller.rb", <<-RUBY
-        class Bukkits::FooController < ActionController::Base
-          def index
-            render inline: "<%= help_the_engine %>"
-          end
+        module Bukkits
+          class FooController < ActionController::Base
+            def index
+              render inline: "<%= help_the_engine %>"
+            end
 
-          def show
-            render plain: foo_path
-          end
+            def show
+              render plain: foo_path
+            end
 
-          def from_app
-            render inline: "<%= (self.respond_to?(:bar_path) || self.respond_to?(:something)) %>"
-          end
+            def from_app
+              render inline: "<%= (self.respond_to?(:bar_path) || self.respond_to?(:something)) %>"
+            end
 
-          def routes_helpers_in_view
-            render inline: "<%= foo_path %>, <%= main_app.bar_path %>"
-          end
+            def routes_helpers_in_view
+              render inline: "<%= foo_path %>, <%= main_app.bar_path %>"
+            end
 
-          def polymorphic_path_without_namespace
-            render plain: polymorphic_path(Post.new)
+            def polymorphic_path_without_namespace
+              render plain: polymorphic_path(Post.new)
+            end
           end
         end
       RUBY


### PR DESCRIPTION
## Introduction

This patch integrates [Zeitwerk](https://github.com/fxn/zeitwerk) and makes it the default autoloader for Rails 6 applications.

* You can now robustly use constant paths in class and module definitions:

  ```ruby
  # Matches Ruby semantics now.
  class Admin::UsersController < ApplicationController
    # ...
  end
  ```

* All known use cases of `require_dependency` have been eliminated.

* There is a [centralized solution](https://github.com/fxn/zeitwerk#preloading) to orderly preload STI hierarchies.

* Edge cases in which the autoloaded constant depended on execution order are gone.

* Autoloading is thread-safe in general, not just for the currently supported use cases with explicit locks like web requests. For example, you can now write multi-threaded scripts to be run by `bin/rails runner` and they will autoload just fine.

## Principles behind the integration

The classic autoloader has been there since [the beginning](https://github.com/rails/rails/blob/v1.0.0/activesupport/lib/active_support/dependencies.rb), and while it has [no public interface](https://api.rubyonrails.org/classes/ActiveSupport/Dependencies.html) except for locking mechanisms, extra care has been taken:

* The implementation of `ActiveSupport::Dependencies` and its test suite are untouched.

* Easy way to opt-out: just throw `config.autoloader = :classic` into `config/application.rb`. It has to go after `config.load_defaults 6.0` if you have that line.

* Integration has been clearly delineated so that falling back to the classic autoloader is safe.

* It is a key observation that `Kernel#autoload` is invoked by the constant resolution algorithm as classes and modules are checked. In particular, it takes precedence over `const_missing` and thus we can leave `const_missing` there to have a cleaner patch, it won't do anything anyway for autoloadable constants.

* Seamless take over in new apps from an end-user point of view.

I envision a gradual evolution of this feature, Rails 6 is just a first step.

## Patch overview

* There is a new config attribute `config.autoloader` that can be `:classic` or `:zeitwerk`. This is `:zeitwerk` for new apps on CRuby, and `:classic` for apps loading the defaults of previous versions or run by other interpreters.

* If Zeitwerk is enabled, there are two globally accessible autoloaders: `Rails.autoloader`, and `Rails.once_autoloader`. The former is the main one. The latter, in addition to not win a Pulitzer for naming, is responsible for `autoload_once_paths`, and importantly also for autoload paths that come from gems. Both autoloaders autoload, but only `Rails.autoloader` is invoked by Rails to reload, so if you have engines like Action Storage or Devise installed as gems, they won't be reloaded anymore.

* In particular, if you throw `Rails.autoloader.logger = method(:puts)` to `config/application.rb` you'll see Zeitwerk doing its thing.

* Selected private API is emulated, but it is _not_ the goal of the integration to fully replicate the private API. If there is code that depends on the inner workings excessively, I prefer that people switch to `:classic` until it gets updated, to clutter the integration to support any imaginable abuse of the private API. This autoloading is an inflection point and it is our opportunity to start afresh.

* Furthermore, the private API called downwards from `const_missing` should not be called anymore because, as explained above, `Kernel#autoload` runs first. There might be some edge case around autoloading errors, not worth it, keep it simple.

* People should not write `require_dependency` anymore, and upgrades should delete the calls. If you detect a use case for it please tell us.

* Eager loading calls `Zeitwerk.eager_load_all`. Therefore, it will eager load not only the Rails application, but also all gems managed by Zeitwerk.

* Engines can technically use Zeitwerk by clearing their autoload paths, but better don't and leave the choice to the parent application.

* Autoload paths are frozen in the finisher. The public API for them is `config.autoload_paths`, but if existing code is pushing to `ActiveSupport::Dependencies.autoload_paths`, it has to do so before the finisher. Action Mailer has been updated to do that.

* Applications using `bootsnap` have to upgrade to 1.4.0.

## Backwards incompatibility

In `:classic` mode there is no change. If Zeitwerk is enabled:

* For files below the standard `concerns` directories (like `app/models/concerns`), `Concerns` cannot be a namespace. That is, `app/models/concerns/geolocatable.rb` is expected to define `Geolocatable`, not `Concerns::Geolocatable`.

* A file should define only one constant in its namespace (but can define inner ones). So, if `app/models/foo.rb` defines `Foo` and also `Bar`, `Bar` won't be reloaded cleanly. You can have inner constants, so `Foo` may define an auxiliary internal class `Foo::Woo`.

* A file that defines a class or module that acts as a namespace, needs to define the class or module using the `class` and `module` keywords. For example, if you have `app/models/hotel.rb` defining the `Hotel` class, and `app/models/hotel/pricing.rb` defining a mixin for hotels, the `Hotel` class must be defined with `class`, you cannot do `Hotel = Class.new { ... }` or `Hotel = Struct.new { ... }` or anything like that. Those idioms are fine in classes and modules that do not act as namespaces.

* Once the application has booted, autoload paths are frozen.

* Autoload paths that do not exist on boot are ignored.

## Future work

I believe the patch is in good shape for a beta. For final, I'll work on documentation. In particular, the [Autoloading and Reloading Constants](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html) needs a complete revision.

There are some `if RUBY_ENGINE == "ruby"` and `config.autoloader == :zeitwerk` here and there, I'll try to encapsulate them somehow.
