### PR TITLE
 Prohibit sneaky custom params from being drawn (Fix #30467)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Raise an `ArgumentError` if a resource custom param contains a colon (`:`).
+
+    After this change it's not possible anymore to configure routes like this:
+
+    ```
+    routes.draw do
+      resources :users, param: 'name/:sneaky'
+    end
+    ```
+
+    Fixes #30467.
+
+    *Josua Schmid*
+
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   No changes.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1141,6 +1141,10 @@ module ActionDispatch
           attr_reader :controller, :path, :param
 
           def initialize(entities, api_only, shallow, options = {})
+            if options[:param].to_s.include?(":")
+              raise ArgumentError, ":param option can't contain colons"
+            end
+
             @name       = entities.to_s
             @path       = (options[:path] || @name).to_s
             @controller = (options[:controller] || @name).to_s

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3338,6 +3338,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "0c0c0b68-d24b-11e1-a861-001ff3fffe6f", @request.params[:download]
   end
 
+  def test_colon_containing_custom_param
+    ex = assert_raises(ArgumentError) {
+      draw do
+        resources :profiles, param: "username/:is_admin"
+      end
+    }
+
+    assert_match(/:param option can't contain colon/, ex.message)
+  end
+
   def test_action_from_path_is_not_frozen
     draw do
       get "search" => "search"


### PR DESCRIPTION
### Summary

This PR fixes https://github.com/rails/rails/issues/30467 by raising an `ArgumentError` if a resource custom param contains a colon (`:`).

After this change it's not possible anymore to configure routes like this:

    routes.draw do
      resources :users, param: 'name/:sneaky'
    end

See the regression test here: https://github.com/rails/rails/pull/35236/commits/8e3573a25cc6870f97a1c32416a2d60d5b890e39