### PR TITLE
Fix DatabaseSelector test that fails sometimes

### DIFF
--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -11,6 +11,10 @@ module ActiveRecord
       @session = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session.new(@session_store)
     end
 
+    teardown do
+      ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+    end
+
     def test_empty_session
       assert_equal Time.at(0), @session.last_write_timestamp
     end


### PR DESCRIPTION
On CI we've seen a few test failures when the DatabaseSelectorTest runs
before the ConnectionHandlersMultiDbTest. This is because it's creating
2 handlers but not properly tearing them down.

Example failure:

```
Failure:
ActiveRecord::ConnectionAdapters::ConnectionHandlersMultiDbTest#test_connects_to_with_single_configuration
[/rails/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb:241]:
Expected: 1
  Actual: 2
```

cc/ @matthewd for bringing this to my attention.