### PR TITLE
Adding enque time tracking and logging

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -101,7 +101,7 @@ module ActiveJob
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
         "timezone"   => Time.zone.try(:name),
-        "enqueued_at" => Time.now.utc.to_s
+        "enqueued_at" => Time.now.utc.iso8601
       }
     end
 

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -101,7 +101,7 @@ module ActiveJob
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
         "timezone"   => Time.zone.try(:name),
-        "enqueued_at" => Time.now
+        "enqueued_at" => Time.now.utc
       }
     end
 
@@ -145,7 +145,7 @@ module ActiveJob
     end
 
     def enqueded_for
-      Time.now - enqueued_at
+      Time.now.utc - enqueued_at
     end
 
     private

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -41,7 +41,7 @@ module ActiveJob
     attr_accessor :timezone
 
     # Track when a job was enqueded
-    attr_accessor :enqueded_at
+    attr_accessor :enqueued_at
 
     # These methods will be included into any Active Job object, adding
     # helpers for de/serialization and creation of job instances.
@@ -101,7 +101,7 @@ module ActiveJob
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
         "timezone"   => Time.zone.try(:name),
-        "enqueded_at"=> Time.now
+        "enqueued_at" => Time.now
       }
     end
 
@@ -141,11 +141,11 @@ module ActiveJob
       self.exception_executions = job_data["exception_executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone.try(:name)
-      self.enqueded_at          = job_data["enqueded_at"]
+      self.enqueued_at          = job_data["enqueued_at"]
     end
 
     def enqueded_for
-      Time.now - enqueded_at
+      Time.now - enqueued_at
     end
 
     private

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -40,6 +40,9 @@ module ActiveJob
     # Timezone to be used during the job.
     attr_accessor :timezone
 
+    # Track when a job was enqueded
+    attr_accessor :enqueded_at
+
     # These methods will be included into any Active Job object, adding
     # helpers for de/serialization and creation of job instances.
     module ClassMethods
@@ -97,7 +100,8 @@ module ActiveJob
         "executions" => executions,
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
-        "timezone"   => Time.zone.try(:name)
+        "timezone"   => Time.zone.try(:name),
+        "enqueded_at"=> Time.now
       }
     end
 
@@ -137,6 +141,11 @@ module ActiveJob
       self.exception_executions = job_data["exception_executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone.try(:name)
+      self.enqueded_at          = job_data["enqueded_at"]
+    end
+
+    def enqueded_for
+      Time.now - enqueded_at
     end
 
     private

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -101,7 +101,7 @@ module ActiveJob
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
         "timezone"   => Time.zone.try(:name),
-        "enqueued_at" => Time.now.utc
+        "enqueued_at" => Time.now.utc.to_s
       }
     end
 
@@ -142,10 +142,6 @@ module ActiveJob
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone.try(:name)
       self.enqueued_at          = job_data["enqueued_at"]
-    end
-
-    def enqueded_for
-      Time.now.utc - enqueued_at
     end
 
     private

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -68,12 +68,9 @@ module ActiveJob
         end
 
         def perform_start(event)
-          job = event.payload[:job]
           info do
-            "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + args_info(job)
-          end
-          info do
-            "#{job.class.name} (Job ID: #{job.job_id}) waited in the queue for #{job.enqueded_for}ms"
+            job = event.payload[:job]
+            "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + args_info(job) + "added to queue at #{job.enqueued_at}"
           end
         end
 

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -70,7 +70,7 @@ module ActiveJob
         def perform_start(event)
           info do
             job = event.payload[:job]
-            "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + args_info(job) + "added to queue at #{job.enqueued_at}"
+            "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + args_info(job) + "enqueued at #{job.enqueued_at}"
           end
         end
 

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -68,9 +68,12 @@ module ActiveJob
         end
 
         def perform_start(event)
+          job = event.payload[:job]
           info do
-            job = event.payload[:job]
             "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + args_info(job)
+          end
+          info do
+            "#{job.class.name} (Job ID: #{job.job_id}) waited in the queue for #{job.enqueded_for}ms"
           end
         end
 

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -62,9 +62,9 @@ class JobSerializationTest < ActiveSupport::TestCase
     end
   end
 
-  test "serialize stores the enqueded_at time" do
+  test "serialize stores the enqueued_at time" do
     job = HelloJob.new
-    type = job.serialize["enqueded_at"].class
+    type = job.serialize["enqueued_at"].class
     assert_equal Time, type
   end
 end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -61,4 +61,10 @@ class JobSerializationTest < ActiveSupport::TestCase
       assert_equal "Hawaii", job.serialize["timezone"]
     end
   end
+
+  test "serialize stores the enqueded_at time" do
+    job = HelloJob.new
+    type = job.serialize["enqueded_at"].class
+    assert_equal Time, type
+  end
 end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -63,8 +63,13 @@ class JobSerializationTest < ActiveSupport::TestCase
   end
 
   test "serialize stores the enqueued_at time" do
-    job = HelloJob.new
-    type = job.serialize["enqueued_at"].class
+    h1 = HelloJob.new
+    type = h1.serialize["enqueued_at"].class
+    assert_equal String, type
+
+    h2 = HelloJob.deserialize(h1.serialize)
+    # We should be able to parse a timestamp
+    type = Time.parse(h2.enqueued_at).class
     assert_equal Time, type
   end
 end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -116,7 +116,7 @@ class LoggingTest < ActiveSupport::TestCase
       LoggingJob.perform_later "Dummy"
       assert_match(/Performing LoggingJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
 
-      assert_match(/added to queue at /, @logger.messages)
+      assert_match(/enqueued at /, @logger.messages)
       assert_match(/Dummy, here is it: Dummy/, @logger.messages)
       assert_match(/Performed LoggingJob \(Job ID: .*?\) from .*? in .*ms/, @logger.messages)
     end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -116,7 +116,7 @@ class LoggingTest < ActiveSupport::TestCase
       LoggingJob.perform_later "Dummy"
       assert_match(/Performing LoggingJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
 
-      assert_match(/LoggingJob \(Job ID: .*?\) waited in the queue for /, @logger.messages)
+      assert_match(/added to queue at /, @logger.messages)
       assert_match(/Dummy, here is it: Dummy/, @logger.messages)
       assert_match(/Performed LoggingJob \(Job ID: .*?\) from .*? in .*ms/, @logger.messages)
     end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -115,6 +115,8 @@ class LoggingTest < ActiveSupport::TestCase
     perform_enqueued_jobs do
       LoggingJob.perform_later "Dummy"
       assert_match(/Performing LoggingJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
+
+      assert_match(/LoggingJob \(Job ID: .*?\) waited in the queue for /, @logger.messages)
       assert_match(/Dummy, here is it: Dummy/, @logger.messages)
       assert_match(/Performed LoggingJob \(Job ID: .*?\) from .*? in .*ms/, @logger.messages)
     end


### PR DESCRIPTION
Motivation:
  - Currently we have 2 separate monkey patches in place for tracking
  enqueued time for 2 separate workers. It seems that activejob could be
  a source of truth for how long an item has been enqueued so that we can
  easily use it for consistent monitoring across workers/apps to ensure
  that jobs are running at an acceptable speed.

Changes:
  - Add an enqueued at attribute and serialization tooling.
  - Add a method to get how long a job has been enqueued for.
  - Add a logging item to show how long a job was enqueued prior to the
  perform method firing.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
