### PR TITLE
Don't rely on the counter_cache to destroy childrens:

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -62,14 +62,6 @@ module ActiveRecord
           [association_scope.limit_value, count].compact.min
         end
 
-        def counter_cache_value
-          reflection.has_cached_counter? ? owner._read_attribute(reflection.counter_cache_column).to_i : nil
-        end
-
-        def find_target?
-          super && !counter_cache_value&.zero?
-        end
-
         def update_counter(difference, reflection = reflection())
           if reflection.has_cached_counter?
             owner.increment!(reflection.counter_cache_column, difference)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1755,6 +1755,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_nil posts.first
   end
 
+  def test_destroy_all_on_desynced_counter_cache_association
+    category = categories(:general)
+    assert_operator category.categorizations.count, :>, 0
+
+    category.categorizations.destroy_all
+    assert_equal 0, category.categorizations.count
+  end
+
   def test_destroy_on_association_clears_scope
     author = Author.create!(name: "Gannon")
     posts = author.posts
@@ -2021,7 +2029,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_zero_counter_cache_usage_on_unloaded_association
     car = Car.create!(name: "My AppliCar")
-    assert_no_queries do
+    assert_no_queries(ignore_none: false) do
       assert_equal car.engines.size, 0
       assert_predicate car.engines, :loaded?
     end


### PR DESCRIPTION
- https://github.com/rails/rails/pull/35127 introduced a new change to
  not make a query when the counter cache value of the parent is 0.

  The implementation was overwriting the `find_target?` method from
  `AR::Associaton`.
  This had the side effect of making `Topic.comments.destroy_all` to
  not destroy anything in some circumstances. You can find a reproduction script 
  in this comment  https://github.com/rails/rails/pull/35127#issuecomment-462876180

  The bug was mainly happening during test because the counter_cache
  value isn't set when fixtures load.

  This PR removes the `find_target?` overwritten method in
  HasManyAssociation and inline the condition inside methods that
  needs it (such as `size` and `load_target` which is used by `to_ary`)

  Even though the root cause of the problem was mainly happening in
  test, I decided to opt-out the `destroy_all` from checking the
  counter cache value has this could cause potential issue if fonr any
  reason the counter cacher get desync.

cc/ @rafaelfranca @byroot 

