### PR TITLE
Fix database configurations building when DATABASE_URL present

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -157,7 +157,7 @@ module ActiveRecord
             configs
           else
             configs.map do |config|
-              ActiveRecord::DatabaseConfigurations::UrlConfig.new(env, config.spec_name, url, config.config)
+              ActiveRecord::DatabaseConfigurations::UrlConfig.new(config.env_name, config.spec_name, url, config.config)
             end
           end
         else

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -72,6 +72,16 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_resolver_with_database_uri_and_multiple_envs
+        ENV["DATABASE_URL"] = "postgres://localhost"
+        ENV["RAILS_ENV"] = "test"
+
+        config   = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
+        actual   = resolve_spec(:test, config)
+        expected = { "adapter" => "postgresql", "database" => "foo_test", "host" => "localhost", "name" => "test" }
+        assert_equal expected, actual
+      end
+
       def test_resolver_with_database_uri_and_unknown_symbol_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }


### PR DESCRIPTION
### Summary

**Rails Version**: 6.0.0.beta1

Having the following `database.yml`:

```yml
default: &default
  adapter: postgresql
  encoding: unicode
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

development:
  <<: *default
  database: project_development

test:
  <<: *default
  database: project_test

production:
  <<: *default
  database: project_production
```

I got the following exceptions running tests (after calling `maintain_test_schema!`):

```
PG::ConnectionBad:
#   FATAL:  database "project_development" does not exist
#   /bundle/gems/pg-1.1.4/lib/pg.rb:56:in `initialize'
```

After some investigation I found that DB configurations all had `"test"` as `env_name`.
And specifically for `test` env:

```
[6] pry(main)> resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
=> #<ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver:0x000055b27e697590
 @configurations=
  #<ActiveRecord::DatabaseConfigurations:0x000055b27e5febb0
   @configurations=
    [#<ActiveRecord::DatabaseConfigurations::UrlConfig:0x000055b27bec2830
      @config=
       {"adapter"=>"postgresql",
        "encoding"=>"unicode",
        "pool"=>5,
        "database"=>"project_development",
        "username"=>"postgres",
        "password"=>"postgres",
[7] pry(main)> resolver.resolve(:test, :test)
=> {"adapter"=>"postgresql",
 "encoding"=>"unicode",
 "pool"=>5,
 "database"=>"project_development",
 "username"=>"postgres",
 "password"=>"postgres",
 "port"=>5432,
 "host"=>"postgres",
 "name"=>"test"}
```

This is a regression comparing to 5.2.

**NOTE:** For those struggling with this problem: it could be fixed by adding `url`

```yml
default: &default
  url: <%= ENV['DATABASE_URL'] %>
```