### PR TITLE
Add multi parameter attributes to ActiveModel.

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -40,8 +40,16 @@ module ActiveModel
     private
 
       def _assign_attributes(attributes)
+        multi_parameter_attributes = {}
         attributes.each do |k, v|
-          _assign_attribute(k, v)
+          if k.include?("(")
+            multi_parameter_attributes[k] = attributes.delete(k)
+          else
+            _assign_attribute(k, v)
+          end
+        end
+        unless multi_parameter_attributes.empty?
+          assign_multiparameter_attributes(multi_parameter_attributes)
         end
       end
 
@@ -52,6 +60,58 @@ module ActiveModel
         else
           raise UnknownAttributeError.new(self, k)
         end
+      end
+
+      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
+      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
+      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
+      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
+      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
+      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
+      def assign_multiparameter_attributes(pairs)
+        execute_callstack_for_multiparameter_attributes(
+          extract_callstack_for_multiparameter_attributes(pairs)
+        )
+      end
+
+      def execute_callstack_for_multiparameter_attributes(callstack)
+        errors = []
+        callstack.each do |name, values_with_empty_parameters|
+          if values_with_empty_parameters.each_value.all?(&:nil?)
+            values = nil
+          else
+            values = values_with_empty_parameters
+          end
+          send("#{name}=", values)
+        rescue => ex
+          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+        end
+        unless errors.empty?
+          error_descriptions = errors.map(&:message).join(",")
+          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
+        end
+      end
+
+      def extract_callstack_for_multiparameter_attributes(pairs)
+        attributes = {}
+
+        pairs.each do |(multiparameter_name, value)|
+          attribute_name = multiparameter_name.split("(").first
+          attributes[attribute_name] ||= {}
+
+          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
+        end
+
+        attributes
+      end
+
+      def type_cast_attribute_value(multiparameter_name, value)
+        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
+      end
+
+      def find_parameter_position(multiparameter_name)
+        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
       end
   end
 end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -593,4 +593,29 @@ module ActiveModel
       super("unknown attribute '#{attribute}' for #{@record.class}.")
     end
   end
+
+  # Raised when an error occurred while doing a mass assignment to an attribute through the
+  # {ActiveModel#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  # The exception has an +attribute+ property that is the name of the offending attribute.
+  class AttributeAssignmentError < NoMethodError
+    attr_reader :exception, :attribute
+
+    def initialize(message = nil, exception = nil, attribute = nil)
+      super(message)
+      @exception = exception
+      @attribute = attribute
+    end
+  end
+
+  # Raised when there are multiple errors while doing a mass assignment through the
+  # ActiveModel#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
+  # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
+  # objects, each corresponding to the error while assigning to an attribute.
+  class MultiparameterAssignmentErrors < NoMethodError
+    attr_reader :errors
+
+    def initialize(errors = nil)
+      @errors = errors
+    end
+  end
 end

--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -4,6 +4,7 @@ module ActiveModel
   module Type
     class Date < Value # :nodoc:
       include Helpers::Timezone
+      include Helpers::TimeValue
       include Helpers::AcceptsMultiparameterTime.new
 
       def type

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -93,5 +93,35 @@ module ActiveModel
 
       assert_equal attributes, new_attributes
     end
+
+    test "multi parameter dates assignment" do
+      valid_dates = [[2007, 11, 30], [1993, 2, 28], [2008, 2, 29]]
+
+      invalid_dates = [[2007, 11, 31], [1993, 2, 29], [2007, 2, 29]]
+
+      valid_dates.each do |date_src|
+        model = ModelForAttributesTest.new(
+          "date_field(1i)" => date_src[0].to_s,
+          "date_field(2i)" => date_src[1].to_s,
+          "date_field(3i)" => date_src[2].to_s
+        )
+        assert_equal(model.date_field, Date.new(*date_src))
+      end
+
+      invalid_dates.each do |date_src|
+        assert_nothing_raised do
+          model = ModelForAttributesTest.new(
+            "date_field(1i)" => date_src[0].to_s,
+            "date_field(2i)" => date_src[1].to_s,
+            "date_field(3i)" => date_src[2].to_s
+          )
+          assert_equal(
+            model.date_field,
+            Time.local(*date_src).to_date,
+            "The date should be modified according to the behavior of the Time object"
+          )
+        end
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -9,77 +9,21 @@ module ActiveRecord
     private
 
       def _assign_attributes(attributes)
-        multi_parameter_attributes  = {}
         nested_parameter_attributes = {}
 
         attributes.each do |k, v|
-          if k.include?("(")
-            multi_parameter_attributes[k] = attributes.delete(k)
-          elsif v.is_a?(Hash)
+          if v.is_a?(Hash)
             nested_parameter_attributes[k] = attributes.delete(k)
           end
         end
         super(attributes)
 
         assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
-        assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
       end
 
       # Assign any deferred nested attributes after the base attributes have been set.
       def assign_nested_parameter_attributes(pairs)
         pairs.each { |k, v| _assign_attribute(k, v) }
-      end
-
-      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
-      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
-      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
-      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
-      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
-      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
-      def assign_multiparameter_attributes(pairs)
-        execute_callstack_for_multiparameter_attributes(
-          extract_callstack_for_multiparameter_attributes(pairs)
-        )
-      end
-
-      def execute_callstack_for_multiparameter_attributes(callstack)
-        errors = []
-        callstack.each do |name, values_with_empty_parameters|
-          if values_with_empty_parameters.each_value.all?(&:nil?)
-            values = nil
-          else
-            values = values_with_empty_parameters
-          end
-          send("#{name}=", values)
-        rescue => ex
-          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
-        end
-        unless errors.empty?
-          error_descriptions = errors.map(&:message).join(",")
-          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
-        end
-      end
-
-      def extract_callstack_for_multiparameter_attributes(pairs)
-        attributes = {}
-
-        pairs.each do |(multiparameter_name, value)|
-          attribute_name = multiparameter_name.split("(").first
-          attributes[attribute_name] ||= {}
-
-          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
-          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
-        end
-
-        attributes
-      end
-
-      def type_cast_attribute_value(multiparameter_name, value)
-        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
-      end
-
-      def find_parameter_position(multiparameter_name)
-        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
       end
   end
 end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -262,27 +262,13 @@ module ActiveRecord
   # Raised when an error occurred while doing a mass assignment to an attribute through the
   # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
   # The exception has an +attribute+ property that is the name of the offending attribute.
-  class AttributeAssignmentError < ActiveRecordError
-    attr_reader :exception, :attribute
-
-    def initialize(message = nil, exception = nil, attribute = nil)
-      super(message)
-      @exception = exception
-      @attribute = attribute
-    end
-  end
+  AttributeAssignmentError = ActiveModel::AttributeAssignmentError
 
   # Raised when there are multiple errors while doing a mass assignment through the
   # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
   # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
   # objects, each corresponding to the error while assigning to an attribute.
-  class MultiparameterAssignmentErrors < ActiveRecordError
-    attr_reader :errors
-
-    def initialize(errors = nil)
-      @errors = errors
-    end
-  end
+  MultiparameterAssignmentErrors = ActiveModel::MultiparameterAssignmentErrors
 
   # Raised when a primary key is needed, but not specified in the schema or model.
   class UnknownPrimaryKey < ActiveRecordError


### PR DESCRIPTION
### Summary
Add multi parameter attributes to ActiveModel.

Multi parameter dates were raising `ActiveModel::UnknownAttributeError`
for ActiveModel instances. (Rails 5.2.2 and 6.0.0.beta1)

Example
```
  class Example
    include ActiveModel::Model
    include ActiveModel::Attributes
    attribute :date_field, :datetime
  end
```

Expected
```
  Example.new(
    "date_field(3i)"=>"1",
    "date_field(2i)"=>"3",
    "date_field(1i)"=>"2019"
  ).date_field
  #=> 2019-03-01 00:00:00 UTC
```

Actual
```
  Example.new(
    "date_field(3i)"=>"1",
    "date_field(2i)"=>"3",
    "date_field(1i)"=>"2019"
  )
  #=> ActiveModel::UnknownAttributeError: unknown attribute 'date_field(3i)'
```

This commit moves the multi parameter attribute support from
ActiveRecord::AttributeAssignment to ActiveModel::AttributeAssignment.
ActiveRecord::AttributeAssignment now inherits this behaviour from
ActiveModel::AttributeAssignment.

We also now need to include `ActiveModel::Type::Helpers::TimeValue` helper in
ActiveModel::Type::Date. As `default_timezone` is now called on dates by
`ActiveModel::Type::Helpers::AcceptsMultiparameterTime` (already included in
ActiveModel) we need to provide a default_timezone. We can get this behaviour
from `ActiveModel::Type::Helpers::TimeValue` and as dates don't `acts_like?`
time we don't acquire any time specific behaviour.


### Other Information
Here's the backtrace I was getting
```
irb(main):010:0> begin; Example.new("date_field(3i)"=>"1", "date_field(2i)"=>"3", "date_
field(1i)"=>"2019"); rescue => e; pp e.message; pp e.backtrace; end
"unknown attribute 'date_field(3i)' for Example."
["/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attribute_assignment.rb:53:in `_assign_attribute'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attribute_assignment.rb:44:in `block in _assign_attributes'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attribute_assignment.rb:43:in `each'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attribute_assignment.rb:43:in `_assign_attributes'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attribute_assignment.rb:35:in `assign_attributes'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/model.rb:81:in `initialize'",
 "/Users/richardlynch/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activemodel-5.2.2/lib/active_model/attributes.rb:66:in `initialize'",
 "(irb):10:in `new'",
```
Hope this is useful 👍 