### PR TITLE
Fix reset of the source association when through association is loaded

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -116,7 +116,7 @@ module ActiveRecord
           def build_scope
             scope = klass.scope_for_association
 
-            if reflection.type
+            if reflection.type && !reflection.through_reflection?
               scope.where!(reflection.type => model.polymorphic_name)
             end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2080,10 +2080,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_associations_order_should_be_priority_over_throughs_order
-    david = authors(:david)
+    original = authors(:david)
     expected = [12, 10, 9, 8, 7, 6, 5, 3, 2, 1]
-    assert_equal expected, david.comments_desc.map(&:id)
-    assert_equal expected, Author.includes(:comments_desc).find(david.id).comments_desc.map(&:id)
+    assert_equal expected, original.comments_desc.map(&:id)
+    preloaded = Author.includes(:comments_desc).find(original.id)
+    assert_equal expected, preloaded.comments_desc.map(&:id)
+    assert_equal original.posts_sorted_by_id.first.comments.map(&:id), preloaded.posts_sorted_by_id.first.comments.map(&:id)
   end
 
   def test_dynamic_find_should_respect_association_order_for_through

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -610,6 +610,12 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal hotel, Hotel.joins(:cake_designers, :drink_designers).take
   end
 
+  def test_has_many_through_reset_source_reflection_after_loading_is_complete
+    preloaded = Category.preload(:ordered_post_comments).find(1, 2).last
+    original = Category.find(2)
+    assert_equal original.ordered_post_comments.ids, preloaded.ordered_post_comments.ids
+  end
+
   private
 
     def assert_includes_and_joins_equal(query, expected, association)

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -26,6 +26,7 @@ class Category < ActiveRecord::Base
   has_many :categorizations
   has_many :special_categorizations
   has_many :post_comments, through: :posts, source: :comments
+  has_many :ordered_post_comments, -> { order(id: :desc) }, through: :posts, source: :comments
 
   has_many :authors, through: :categorizations
   has_many :authors_with_select, -> { select "authors.*, categorizations.post_id" }, through: :categorizations, source: :author


### PR DESCRIPTION
The special case happens when through association has a custom scope
that is applied to the source association when loading.
In this case, the source association would need to be reset after
main association is loaded. See tests.

After this patch, the source association reset code will consistently relay on the scope passed to the preloader as being a reason for extra SQL conditions and reset to be done. 