### PR TITLE
Fix the `config_for` to always return a NonSymbolAccessDeprecatedHash:

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `Rails.application.config_for` returning a HWIA when Hash were
+    inside Array.
+
+    *Edouard Chin*
+
 *   Fix non-symbol access to nested hashes returned from `Rails::Application.config_for`
     being broken by allowing non-symbol access with a deprecation notice.
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1787,6 +1787,28 @@ module ApplicationTests
       end
     end
 
+    test "config_for loads nested custom configuration inside array from yaml with deprecated non-symbol access" do
+      app_file "config/custom.yml", <<-RUBY
+      development:
+        foo:
+          bar:
+          - baz: 1
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      config = Rails.application.config.my_custom_config
+      assert_instance_of Rails::Application::NonSymbolAccessDeprecatedHash, config[:foo][:bar].first
+
+      assert_deprecated do
+        assert_equal 1, config[:foo][:bar].first["baz"]
+      end
+    end
+
     test "config_for makes all hash methods available" do
       app_file "config/custom.yml", <<-RUBY
       development:


### PR DESCRIPTION
Fix the `config_for` to always return a NonSymbolAccessDeprecatedHash:

- If you have hashes inside array, the hashes were getting initialized
  as regular HWIA wereas we want them to be
  NonSymbolAccessDeprecatedHash in order to trigger a deprecation
  warning when keys are accessed with string.

  This patch fixes that by overwriting the `[]=` to to the same
  as what HWIA does (with the difference that we don't call
  `convert_key` to not trigger a deprecation when setting value).

  I also took the liberty to extract `hash.nested_under_indifferent_access`,
  into a separate method to allow subclasses to return whatever
  they want.
  Inheriting HWIA is not common, but I think it's useful for cases
  like this one where we want to preprocess reading and writing values
  in the hash (for deprecation purposes or other reasons).

cc/ @gmcgibbon 
