### PR TITLE
Cached collections only work if there is one template

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -308,6 +308,9 @@ module ActionView
         template = find_partial(@path, @template_keys)
         @variable ||= template.variable
       else
+        if options[:cached]
+          raise NotImplementedError, "render caching requires a template. Please specify a partial when rendering"
+        end
         template = nil
       end
 
@@ -337,9 +340,14 @@ module ActionView
             spacer = find_template(@options[:spacer_template], @locals.keys).render(view, @locals)
           end
 
-          cache_collection_render(payload, view, template) do
-            template ? collection_with_template(view, template) : collection_without_template(view)
-          end.join(spacer).html_safe
+          collection_body = if template
+            cache_collection_render(payload, view, template) do
+              collection_with_template(view, template)
+            end
+          else
+            collection_without_template(view)
+          end
+          collection_body.join(spacer).html_safe
         end
       end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -752,6 +752,17 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
       @view.render(partial: "test/cached_customer", collection: [customer], cached: true)
   end
 
+  test "collection caching does not work on multi-partials" do
+    a = Object.new
+    b = Object.new
+    def a.to_partial_path; "test/partial_iteration_1"; end
+    def b.to_partial_path; "test/partial_iteration_2"; end
+
+    assert_raises(NotImplementedError) do
+      @controller_view.render(partial: [a, b], cached: true)
+    end
+  end
+
   private
     def cache_key(*names, virtual_path)
       digest = ActionView::Digestor.digest name: virtual_path, finder: @view.lookup_context, dependencies: []


### PR DESCRIPTION
I don't know this is the right fix necessarily.

When rendering a collection, each object in the collection can respond to `to_partial_path`.  The template renderer will render the partial returned by that method.  However, each object in the collection could return a different template.  That means there isn't *one* template associated with the collection.  Our collection template cache code depends on the collection using just one template.  If you try to set `cached: true` on a collection that doesn't have just one template associated with it, it will raise an exception.

The patch in this PR fixes the exception, but doesn't actually cache the templates.  Obviously, this use case isn't supported today, and it seems like nobody has noticed.

1. I'm not sure how or if we should support caching collections like this
2. If we decide not to support this, should it raise an exception?