### PR TITLE
Revert "Chaining named scope is no longer leaking to class level querying methods"

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,12 +4,6 @@
 
     *Ryuta Kamizono*
 
-*   Chaining named scope is no longer leaking to class level querying methods.
-
-    Fixes #14003.
-
-    *Ryuta Kamizono*
-
 *   Allow applications to automatically switch connections.
 
     Adds a middleware and configuration options that can be used in your

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -321,12 +321,12 @@ module ActiveRecord
     # Please check unscoped if you want to remove all previous scopes (including
     # the default_scope) during the execution of a block.
     def scoping
-      @delegate_to_klass && klass.current_scope(true) ? yield : _scoping(self) { yield }
+      @delegate_to_klass ? yield : _scoping(self) { yield }
     end
 
     def _exec_scope(*args, &block) # :nodoc:
       @delegate_to_klass = true
-      _scoping(nil) { instance_exec(*args, &block) || self }
+      instance_exec(*args, &block) || self
     ensure
       @delegate_to_klass = false
     end

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -8,7 +8,7 @@ module ActiveRecord
   module SpawnMethods
     # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
-      @delegate_to_klass && klass.current_scope(true) ? klass.all : clone
+      @delegate_to_klass ? klass.all : clone
     end
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -447,9 +447,8 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal [posts(:sti_comments)], Post.with_special_comments.with_post(4).to_a.uniq
   end
 
-  def test_chaining_doesnt_leak_conditions_to_another_scopes
-    expected = Topic.where(approved: false).where(id: Topic.children.select(:parent_id))
-    assert_equal expected.to_a, Topic.rejected.has_children.to_a
+  def test_class_method_in_scope
+    assert_equal [topics(:second)], topics(:first).approved_replies.ordered
   end
 
   def test_nested_scoping

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -7,6 +7,8 @@ class Reply < Topic
   belongs_to :topic_with_primary_key, class_name: "Topic", primary_key: "title", foreign_key: "parent_title", counter_cache: "replies_count", touch: true
   has_many :replies, class_name: "SillyReply", dependent: :destroy, foreign_key: "parent_id"
   has_many :silly_unique_replies, dependent: :destroy, foreign_key: "parent_id"
+
+  scope :ordered, -> { Reply.order(:id) }
 end
 
 class SillyReply < Topic

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -10,9 +10,6 @@ class Topic < ActiveRecord::Base
   scope :approved, -> { where(approved: true) }
   scope :rejected, -> { where(approved: false) }
 
-  scope :children, -> { where.not(parent_id: nil) }
-  scope :has_children, -> { where(id: Topic.children.select(:parent_id)) }
-
   scope :scope_with_lambda, lambda { all }
 
   scope :by_lifo, -> { where(author_name: "lifo") }


### PR DESCRIPTION
This reverts #32380, since this may cause that silently leaking
information when people upgrade the app.

We need deprecation first before making this.