### PR TITLE
Let Zeitwerk be a dependency of Active Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,8 +46,6 @@ gem "connection_pool", require: false
 # for railties app_generator_test
 gem "bootsnap", ">= 1.4.0", require: false
 
-gem "zeitwerk", ">= 1.0.0" if RUBY_ENGINE == "ruby"
-
 # Active Job
 group :job do
   gem "resque", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ PATH
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 1.0)
     rails (6.0.0.beta1)
       actioncable (= 6.0.0.beta1)
       actionmailbox (= 6.0.0.beta1)
@@ -276,7 +277,7 @@ GEM
     hiredis (0.6.3-java)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.5.2)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     image_processing (1.7.1)
       mini_magick (~> 4.0)
@@ -589,7 +590,6 @@ DEPENDENCIES
   webmock
   webpacker (>= 4.0.0.rc.3)
   websocket-client-simple!
-  zeitwerk (>= 1.0.0)
 
 BUNDLED WITH
    1.17.3

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |s|
   # NOTE: Please read our dependency guidelines before updating versions:
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
-  s.add_dependency "i18n",       ">= 0.7", "< 2"
-  s.add_dependency "tzinfo",     "~> 1.1"
-  s.add_dependency "minitest",   "~> 5.1"
+  s.add_dependency "i18n",            ">= 0.7", "< 2"
+  s.add_dependency "tzinfo",          "~> 1.1"
+  s.add_dependency "minitest",        "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+  s.add_dependency "zeitwerk",        "~> 1.0"
 end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -271,7 +271,11 @@ module Rails
       end
 
       def autoloader=(autoloader)
-        if %i(classic zeitwerk).include?(autoloader)
+        case autoloader
+        when :classic
+          @autoloader = autoloader
+        when :zeitwerk
+          require "zeitwerk"
           @autoloader = autoloader
         else
           raise ArgumentError, "config.autoloader may be :classic or :zeitwerk, got #{autoloader.inspect} instead"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -36,9 +36,7 @@ gem 'bootsnap', '>= 1.4.0', require: false
 # gem 'rack-cors'
 
 <%- end -%>
-<% if RUBY_ENGINE == "ruby" -%>
-gem "zeitwerk", ">= 1.0.0"
-
+<% if RUBY_ENGINE == 'ruby' -%>
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -660,15 +660,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "jbuilder"
   end
 
-  def test_inclusion_of_zeitwerk
-    run_generator
-    if RUBY_ENGINE == "ruby"
-      assert_gem "zeitwerk"
-    else
-      assert_no_gem "zeitwerk"
-    end
-  end
-
   def test_inclusion_of_a_debugger
     run_generator
     if defined?(JRUBY_VERSION) || RUBY_ENGINE == "rbx"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -491,11 +491,7 @@ Module.new do
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.
   contents = File.read("#{app_template_path}/config/application.rb")
-  if RUBY_ENGINE == "ruby"
-    contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker zeitwerk).each { |r| require r }")
-  else
-    contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
-  end
+  contents.sub!(/^Bundler\.require.*/, "%w(turbolinks webpacker).each { |r| require r }")
   File.write("#{app_template_path}/config/application.rb", contents)
 
   require "rails"


### PR DESCRIPTION
As discussed with @matthewd in #35235.

In this alternative, we `require` the library as soon as `config.autoloader` is set to `:zeitwerk`. I have restored the single quotes in the `Gemfile` template too.