### PR TITLE
Reword RDBMS note in ActiveRecord basics

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -45,7 +45,7 @@ relationships of the objects in an application can be easily stored and
 retrieved from a database without writing SQL statements directly and with less
 overall database access code.
 
-NOTE: If you are not familiar enough with relational database management systems (RDBMS) or structured query language (SQL), please go through [this tutorial](https://www.w3schools.com/sql/default.asp) (or [this one](http://www.sqlcourse.com/)) or study them by other means. Understanding how relational databases work is crucial to understanding Active Records and Rails in general.
+NOTE: Basic knowledge of relational database management systems (RDBMS) and structured query language (SQL) is helpful in order to fully understand Active Record. Please refer to [this tutorial](https://www.w3schools.com/sql/default.asp) (or [this one](http://www.sqlcourse.com/)) or study them by other means if you would like to learn more.
 
 ### Active Record as an ORM Framework
 


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/35260.

Rewords the RDBMS note in the ActiveRecord basics guide.

This may be an unpopular opinion, or promoting of bad behaviour, but I think a big advantage of ActiveRecord is that you don't actually need an intimate knowledge of SQL / RDBMS. Yes, they are helpful to know, and highly necessary in order to master ActiveRecord, but I wouldn't label them as crucial for beginners.
