### PR TITLE
Return rendered template objects from renderers

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -286,7 +286,7 @@ module ActionView #:nodoc:
       self.class
     end
 
-    def in_context(options, locals)
+    def in_rendering_context(options)
       old_view_renderer  = @view_renderer
       old_lookup_context = @lookup_context
 

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -27,7 +27,7 @@ module ActionView
       def render(options = {}, locals = {}, &block)
         case options
         when Hash
-          in_context(options, locals) do |renderer|
+          in_rendering_context(options) do |renderer|
             if block_given?
               view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
             else

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -27,6 +27,46 @@ module ActionView
       raise NotImplementedError
     end
 
+    class RenderedCollection # :nodoc:
+      attr_reader :rendered_templates
+
+      def initialize(rendered_templates, spacer)
+        @rendered_templates = rendered_templates
+        @spacer = spacer
+      end
+
+      def body
+        @rendered_templates.map(&:body).join(@spacer.body).html_safe
+      end
+
+      def format
+        rendered_templates.first.format
+      end
+
+      class EmptyCollection
+        def format; nil; end
+        def body; nil; end
+      end
+
+      EMPTY = EmptyCollection.new
+    end
+
+    class RenderedTemplate # :nodoc:
+      attr_reader :body, :layout, :template
+
+      def initialize(body, layout, template)
+        @body = body
+        @layout = layout
+        @template = template
+      end
+
+      def format
+        template.formats.first
+      end
+
+      EMPTY_SPACER = Struct.new(:body).new
+    end
+
     private
 
       def extract_details(options) # :doc:
@@ -48,6 +88,14 @@ module ActionView
         return if formats.empty? || @lookup_context.html_fallback_for_js
 
         @lookup_context.formats = formats | @lookup_context.formats
+      end
+
+      def build_rendered_template(content, layout, template)
+        RenderedTemplate.new content, layout, template
+      end
+
+      def build_rendered_collection(templates, spacer)
+        RenderedCollection.new(templates, spacer)
       end
   end
 end

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -90,12 +90,12 @@ module ActionView
         @lookup_context.formats = formats | @lookup_context.formats
       end
 
-      def build_rendered_template(content, layout, template)
+      def build_rendered_template(content, template, layout = nil)
         RenderedTemplate.new content, layout, template
       end
 
       def build_rendered_collection(templates, spacer)
-        RenderedCollection.new(templates, spacer)
+        RenderedCollection.new templates, spacer
       end
   end
 end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -330,7 +330,7 @@ module ActionView
 
           spacer = if @options.key?(:spacer_template)
             spacer_template = find_template(@options[:spacer_template], @locals.keys)
-            build_rendered_template(spacer_template.render(view, @locals), nil, spacer_template)
+            build_rendered_template(spacer_template.render(view, @locals), spacer_template)
           else
             RenderedTemplate::EMPTY_SPACER
           end
@@ -364,7 +364,7 @@ module ActionView
 
           content = layout.render(view, locals) { content } if layout
           payload[:cache_hit] = view.view_renderer.cache_hits[template.virtual_path]
-          build_rendered_template(content, layout, template)
+          build_rendered_template(content, template, layout)
         end
       end
 
@@ -455,7 +455,7 @@ module ActionView
           content = template.render(view, locals)
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
-          build_rendered_template(content, layout, template)
+          build_rendered_template(content, template, layout)
         end
       end
 
@@ -477,7 +477,7 @@ module ActionView
           template = (cache[path] ||= find_template(path, keys + [as, counter, iteration]))
           content = template.render(view, locals)
           partial_iteration.iterate!
-          build_rendered_template(content, nil, template)
+          build_rendered_template(content, template)
         end
       end
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -84,7 +84,7 @@ module ActionView
       def fetch_or_cache_partial(cached_partials, template, order_by:)
         order_by.map do |cache_key|
           if content = cached_partials[cache_key]
-            build_rendered_template(content, nil, template)
+            build_rendered_template(content, template)
           else
             yield.tap do |rendered_partial|
               collection_cache.write(cache_key, rendered_partial.body)

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -19,10 +19,14 @@ module ActionView
 
     # Main render entry point shared by Action View and Action Controller.
     def render(context, options)
+      render_to_object(context, options).body
+    end
+
+    def render_to_object(context, options) # :nodoc:
       if options.key?(:partial)
-        render_partial(context, options)
+        render_partial_to_object(context, options)
       else
-        render_template(context, options)
+        render_template_to_object(context, options)
       end
     end
 
@@ -41,16 +45,24 @@ module ActionView
 
     # Direct access to template rendering.
     def render_template(context, options) #:nodoc:
-      TemplateRenderer.new(@lookup_context).render(context, options)
+      render_template_to_object(context, options).body
     end
 
     # Direct access to partial rendering.
     def render_partial(context, options, &block) #:nodoc:
-      PartialRenderer.new(@lookup_context).render(context, options, block)
+      render_partial_to_object(context, options, &block).body
     end
 
     def cache_hits # :nodoc:
       @cache_hits ||= {}
+    end
+
+    def render_template_to_object(context, options) #:nodoc:
+      TemplateRenderer.new(@lookup_context).render(context, options)
+    end
+
+    def render_partial_to_object(context, options, &block) #:nodoc:
+      PartialRenderer.new(@lookup_context).render(context, options, block)
     end
   end
 end

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -44,7 +44,7 @@ module ActionView
     # object that responds to each. This object is initialized with a block
     # that knows how to render the template.
     def render_template(view, template, layout_name = nil, locals = {}) #:nodoc:
-      return [super] unless layout_name && template.supports_streaming?
+      return [super.body] unless layout_name && template.supports_streaming?
 
       locals ||= {}
       layout   = layout_name && find_layout(layout_name, locals.keys, [formats.first])

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -61,7 +61,7 @@ module ActionView
         else
           content
         end
-        build_rendered_template(body, layout, template)
+        build_rendered_template(body, template, layout)
       end
 
       # This is the method which actually finds the layout using details in the lookup

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -109,10 +109,15 @@ module ActionView
         context = view_context
 
         context.assign assigns if assigns
-        lookup_context.rendered_format = nil if options[:formats]
         lookup_context.variants = variant if variant
 
-        context.view_renderer.render(context, options)
+        rendered_template = context.in_rendering_context(options) do |renderer|
+          renderer.render_to_object(context, options)
+        end
+
+        lookup_context.rendered_format = rendered_template.format || lookup_context.formats.first
+
+        rendered_template.body
       end
 
       # Assign the rendered format to look up context.

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -174,6 +174,10 @@ class TestController < ActionController::Base
     render inline: "<%= controller_name %>"
   end
 
+  def inline_rendered_format_without_format
+    render inline: "test"
+  end
+
   # :ported:
   def render_custom_code
     render plain: "hello world", status: 404
@@ -659,6 +663,7 @@ class RenderTest < ActionController::TestCase
     get :hello_world_from_rxml_using_action, to: "test#hello_world_from_rxml_using_action"
     get :hello_world_from_rxml_using_template, to: "test#hello_world_from_rxml_using_template"
     get :hello_world_with_layout_false, to: "test#hello_world_with_layout_false"
+    get :inline_rendered_format_without_format, to: "test#inline_rendered_format_without_format"
     get :layout_overriding_layout, to: "test#layout_overriding_layout"
     get :layout_test, to: "test#layout_test"
     get :layout_test_with_different_layout, to: "test#layout_test_with_different_layout"
@@ -1013,6 +1018,12 @@ class RenderTest < ActionController::TestCase
   def test_render_xml_with_layouts
     get :builder_layout_test
     assert_equal "<wrapper>\n<html>\n  <p>Hello </p>\n<p>This is grand!</p>\n</html>\n</wrapper>\n", @response.body
+  end
+
+  def test_rendered_format_without_format
+    get :inline_rendered_format_without_format
+    assert_equal "test", @response.body
+    assert_equal "text/html", @response.content_type
   end
 
   def test_partials_list

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -69,11 +69,6 @@ module RenderTestCases
     assert_match "<error>No Comment</error>", @view.render(template: "comments/empty", formats: [:xml])
   end
 
-  def test_rendered_format_without_format
-    @view.render(inline: "test")
-    assert_equal :html, @view.lookup_context.rendered_format
-  end
-
   def test_render_partial_implicitly_use_format_of_the_rendered_template
     @view.lookup_context.formats = [:json]
     assert_equal "Hello world", @view.render(template: "test/one", formats: [:html])

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -743,8 +743,15 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
   end
 
   teardown do
-    GC.start
     I18n.reload!
+  end
+
+  test "template body written to cache" do
+    customer = Customer.new("david", 1)
+    key = cache_key(customer, "test/_customer")
+    assert_nil ActionView::PartialRenderer.collection_cache.read(key)
+    @view.render(partial: "test/customer", collection: [customer], cached: true)
+    assert_equal "Hello: david", ActionView::PartialRenderer.collection_cache.read(key)
   end
 
   test "collection caching does not cache by default" do


### PR DESCRIPTION
This PR changes template renderers to return a more complex object instead of just a string.  The reason I wanted to do this is because the template renderers modify the lookup context, setting the `rendered_format` on it.  This mutation is extremely far from the owner of the lookup context (the controller).  The reason the mutation is so far from the controller is because the controller didn't know what types of templates had been rendered.  This PR changes the return value such that the controller can now know what was rendered, and the template renderers no longer need to mutate the lookup context.

Of course this introduces one or two more object allocations per template (one in the case of a partial, two in the case of a collection).  However, benchmarks between master and this branch seem comparable, so I think it's ok:

```ruby
require "benchmark/ips"
require "action_view"
require "action_pack"
require "action_controller"
require "stackprof"

class TestController < ActionController::Base
end

TestController.view_paths = [File.expand_path("test/benchmarks")]

# Create a bunch of data

controller_view = TestController.new.view_context

Benchmark.ips do |x|
  x.report("many partials") do
    controller_view.render("many_partials")
  end
end
```

#### This branch:

```
$ be ruby render_benchmark.rb
Warming up --------------------------------------
       many partials    52.000  i/100ms
Calculating -------------------------------------
       many partials    539.589  (± 3.5%) i/s -      2.704k in   5.017926s
```

#### Master:

```
$ be ruby render_benchmark.rb
Warming up --------------------------------------
       many partials    54.000  i/100ms
Calculating -------------------------------------
       many partials    560.691  (± 3.7%) i/s -      2.808k in   5.015547s
```

Since the controller now knows what type of templates were rendered, it can set the `rendered_format` property in one place.  We no longer have to do `@lookup_context.rendered_format ||=` because we can be confident that the top level rendered format is the one we want.

Additionally, I think we can now remove `rendered_format` from the lookup context and just set the content type directly on the response (but I'll follow up with that).