### PR TITLE
Use Dir#children and Dir#each_child in ActiveSupport::Cache::FileStore

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -18,7 +18,6 @@ module ActiveSupport
       DIR_FORMATTER = "%03X"
       FILENAME_MAX_SIZE = 228 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
       FILEPATH_MAX_SIZE = 900 # max is 1024, plus some room
-      EXCLUDED_DIRS = [".", ".."].freeze
       GITKEEP_FILES = [".gitkeep", ".keep"].freeze
 
       def initialize(cache_path, options = nil)
@@ -35,7 +34,7 @@ module ActiveSupport
       # file store directory except for .keep or .gitkeep. Be careful which directory is specified in your
       # config file when using +FileStore+ because everything in that directory will be deleted.
       def clear(options = nil)
-        root_dirs = exclude_from(cache_path, EXCLUDED_DIRS + GITKEEP_FILES)
+        root_dirs = (Dir.children(cache_path) - GITKEEP_FILES)
         FileUtils.rm_r(root_dirs.collect { |f| File.join(cache_path, f) })
       rescue Errno::ENOENT
       end
@@ -154,7 +153,7 @@ module ActiveSupport
         # Delete empty directories in the cache.
         def delete_empty_directories(dir)
           return if File.realpath(dir) == File.realpath(cache_path)
-          if exclude_from(dir, EXCLUDED_DIRS).empty?
+          if Dir.children(dir).empty?
             Dir.delete(dir) rescue nil
             delete_empty_directories(File.dirname(dir))
           end
@@ -167,8 +166,7 @@ module ActiveSupport
 
         def search_dir(dir, &callback)
           return if !File.exist?(dir)
-          Dir.foreach(dir) do |d|
-            next if EXCLUDED_DIRS.include?(d)
+          Dir.each_child(dir) do |d|
             name = File.join(dir, d)
             if File.directory?(name)
               search_dir(name, &callback)
@@ -192,11 +190,6 @@ module ActiveSupport
               num
             end
           end
-        end
-
-        # Exclude entries from source directory
-        def exclude_from(source, excludes)
-          Dir.entries(source).reject { |f| excludes.include?(f) }
         end
     end
   end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -101,7 +101,7 @@ class FileStoreTest < ActiveSupport::TestCase
     end
     assert File.exist?(cache_dir), "Parent of top level cache dir was deleted!"
     assert File.exist?(sub_cache_dir), "Top level cache dir was deleted!"
-    assert_empty Dir.entries(sub_cache_dir).reject { |f| ActiveSupport::Cache::FileStore::EXCLUDED_DIRS.include?(f) }
+    assert_empty Dir.children(sub_cache_dir)
   end
 
   def test_log_exception_when_cache_read_fails


### PR DESCRIPTION
### Summary
Both methods were introduced in Ruby 2.5 and fit this use case very
nicely: listing a directory's entries excluding the "." and ".." nodes.

The private method #exclude_from was removed as it no longer serves
its original purpose.