### PR TITLE
Make reverse_sql_order work correctly if "nulls first/last" is in the middle of "order by".

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1095,7 +1095,10 @@ module ActiveRecord
             end
             o.split(",").map! do |s|
               s.strip!
-              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") || s.gsub!(/\s+(nulls)(\s+)(first|last)/i, ' DESC \1 \3') || (s << " DESC")
+              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") ||
+              s.gsub!(/\s+desc\s+(nulls)(\s+)(first|last)/i, ' ASC \1 \3') ||
+              s.gsub!(/(\s+asc)?\s+(nulls)(\s+)(first|last)/i, ' DESC \2 \4') ||
+              (s << " DESC")
             end
           else
             o

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1095,7 +1095,7 @@ module ActiveRecord
             end
             o.split(",").map! do |s|
               s.strip!
-              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") || (s << " DESC")
+              s.gsub!(/\sasc\Z/i, " DESC") || s.gsub!(/\sdesc\Z/i, " ASC") || s.gsub!(/\s+(nulls)(\s+)(first|last)/i, ' DESC \1 \3') || (s << " DESC")
             end
           else
             o

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -107,7 +107,7 @@ module ActiveRecord
       assert_equal "comments_count DESC", relation.order_values.last
     end
 
-    test "reverse_order! with 'foo NULLS FIRST'" do
+    test "reverse_order! with 'foo NULLS FIRST, bar'" do
       @relation = Post.order("foo NULLS FIRST, bar")
 
       relation.reverse_order!
@@ -116,8 +116,8 @@ module ActiveRecord
       assert_equal "bar DESC", relation.order_values.last
     end
 
-    test "reverse_order! with 'foo ASC NULLS FIRST'" do
-      @relation = Post.order("foo ASC NULLS FIRST, bar")
+    test "reverse_order! with 'foo ASC NULLS FIRST, bar ASC'" do
+      @relation = Post.order("foo ASC NULLS FIRST, bar ASC")
 
       relation.reverse_order!
 
@@ -125,7 +125,7 @@ module ActiveRecord
       assert_equal "bar DESC", relation.order_values.last
     end
 
-    test "reverse_order! with 'foo DESC NULLS FIRST'" do
+    test "reverse_order! with 'foo DESC NULLS FIRST, bar DESC'" do
       @relation = Post.order("foo DESC NULLS FIRST, bar DESC")
 
       relation.reverse_order!

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -107,6 +107,33 @@ module ActiveRecord
       assert_equal "comments_count DESC", relation.order_values.last
     end
 
+    test "reverse_order! with 'foo NULLS FIRST'" do
+      @relation = Post.order("foo NULLS FIRST, bar")
+
+      relation.reverse_order!
+
+      assert_equal "foo DESC NULLS FIRST", relation.order_values.first
+      assert_equal "bar DESC", relation.order_values.last
+    end
+
+    test "reverse_order! with 'foo ASC NULLS FIRST'" do
+      @relation = Post.order("foo ASC NULLS FIRST, bar")
+
+      relation.reverse_order!
+
+      assert_equal "foo DESC NULLS FIRST", relation.order_values.first
+      assert_equal "bar DESC", relation.order_values.last
+    end
+
+    test "reverse_order! with 'foo DESC NULLS FIRST'" do
+      @relation = Post.order("foo DESC NULLS FIRST, bar DESC")
+
+      relation.reverse_order!
+
+      assert_equal "foo ASC NULLS FIRST", relation.order_values.first
+      assert_equal "bar ASC", relation.order_values.last
+    end
+
     test "create_with!" do
       assert relation.create_with!(foo: "bar").equal?(relation)
       assert_equal({ foo: "bar" }, relation.create_with_value)


### PR DESCRIPTION
Having `order("CASE column1 WHEN 'data1' THEN 0 ELSE column2 END, column3.id NULLS FIRST, RANDOM()")` and adding `.last` i get exception from postgres because of invalid query syntax:
```
ORDER BY CASE column1 WHEN 'data1' THEN 0 ELSE column2 END DESC, column3.id NULLS FIRST DESC, RANDOM()
```

after making this patch it works correctly:
```
ORDER BY CASE column1 WHEN 'data1' THEN 0 ELSE column2 END DESC, column3.id DESC NULLS FIRST, RANDOM() DESC
```