### PR TITLE
Fixes missing method `path_for` when using MirrorService with DiskService as the primary service

### DIFF
--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -9,7 +9,7 @@ module ActiveStorage
   class Service::MirrorService < Service
     attr_reader :primary, :mirrors
 
-    delegate :download, :download_chunk, :exist?, :url, to: :primary
+    delegate :download, :download_chunk, :exist?, :url, :path_for, to: :primary
 
     # Stitch together from named services.
     def self.build(primary:, mirrors:, configurator:, **options) #:nodoc:

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -61,4 +61,8 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
         @service.url(@key, expires_in: 2.minutes, disposition: :inline, filename: filename, content_type: "text/plain")
     end
   end
+
+  test "path for file in primary service" do
+    assert_equal @service.primary.path_for(@key), @service.path_for(@key)
+  end
 end


### PR DESCRIPTION
fixes #35252 

@r? @georgeclaghorn 

cc/ @marcusmalmberg