### PR TITLE
Allow to pass options to `csp_meta_tag`

### DIFF
--- a/actionview/lib/action_view/helpers/csp_helper.rb
+++ b/actionview/lib/action_view/helpers/csp_helper.rb
@@ -14,9 +14,11 @@ module ActionView
       # This is used by the Rails UJS helper to create dynamically
       # loaded inline <script> elements.
       #
-      def csp_meta_tag
+      def csp_meta_tag(**options)
         if content_security_policy?
-          tag("meta", name: "csp-nonce", content: content_security_policy_nonce)
+          options[:name] = "csp-nonce"
+          options[:content] = content_security_policy_nonce
+          tag("meta", options)
         end
       end
     end

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -16,6 +16,10 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   def test_csp_meta_tag
     assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
   end
+
+  def test_csp_meta_tag_with_options
+    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+  end
 end
 
 class CspHelperWithCspDisabledTest < ActionView::TestCase


### PR DESCRIPTION
Currently `csp_meta_tag` generates `name` attribute only.
However, in libraries like `Material-UI` and `JSS`, expect that the meta tag that contains the nonce with `property` attribute.

https://material-ui.com/css-in-js/advanced/#how-does-one-implement-csp
https://github.com/cssinjs/jss/blob/master/docs/csp.md

This patch allows `csp_meta_tag` to specify arbitrary options and allows `nonce` to be passed to those libraries.
