### PR TITLE
Mark output of strip_tags as html_safe

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -102,7 +102,7 @@ module ActionView
       #   strip_tags("> A quote from Smith & Wesson")
       #   # => &gt; A quote from Smith &amp; Wesson
       def strip_tags(html)
-        self.class.full_sanitizer.sanitize(html)
+        self.class.full_sanitizer.sanitize(html)&.html_safe
       end
 
       # Strips all link tags from +html+ leaving just the link text.

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -33,6 +33,10 @@ class SanitizeHelperTest < ActionView::TestCase
     assert_equal "", strip_tags("<script>")
   end
 
+  def test_strip_tags_is_marked_safe
+    assert_predicate strip_tags("&"), :html_safe?
+  end
+
   def test_strip_tags_will_not_encode_special_characters
     assert_equal "test\r\n\r\ntest", strip_tags("test\r\n\r\ntest")
   end


### PR DESCRIPTION
### Summary

Since #28061, the output of `strip_tags` encodes HTML entities like `&amp;`, and
should thus be considered "html safe". The result should be printed without
further escaping, else double-encoding will occur.