### PR TITLE
Reset column info after making Topic tz-aware

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -711,6 +711,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       record.written_on = "Jan 01 00:00:00 2014"
       assert_equal record, YAML.load(YAML.dump(record))
     end
+  ensure
+    # NOTE: Reset column info because global topics
+    # don't have tz-aware attributes by default.
+    Topic.reset_column_information
   end
 
   test "setting a time zone-aware time in the current time zone" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/35194.

This is a really strange bug.

For some reason, `.reload_schema_from_cache` called by `Topic.reset_column_information` can change how date time columns behave. It seems to change included modules of `ActiveRecord::Type::DateTime` instances, _but only sometimes_.

In the expected flow, the value cast starts [here](https://github.com/rails/rails/blob/a20b00db3fd2e05a960c1d68cc7bce64733e49e7/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb#L11) and includes `[ActiveRecord::Type::Internal::Timezone, #<ActiveModel::Type::Helpers::AcceptsMultiparameterTime:0x00007f8cae260358>, ActiveModel::Type::Helpers::TimeValue, ActiveSupport::ToJsonWithActiveSupportEncoder, ActiveSupport::Dependencies::Loadable, JSON::Ext::Generator::GeneratorMethods::Object, ActiveSupport::Tryable, Kernel]`. In the failing test case, the value cast starts [here](https://github.com/rails/rails/blob/a20b00db3fd2e05a960c1d68cc7bce64733e49e7/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb#L8) and includes `[ActiveSupport::Tryable, #<Module:0x00007f8b010f1e58>]`.

This seems to be triggered by initializing a new topic in `AttributeMethodsTest#test_YAML_dumping_a_record_with_time_zone-aware_attribute` after resetting column info in a previous test. My proposed solution is more of a band-aid to minimize the blast radius of attribute changes between tests (this was already being done for other tests in `AttributeMethodsTest`).

