### PR TITLE
Raise ActiveRecord::IrreversibleOrderError if nulls first/last is not a single ordering argument.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1111,7 +1111,7 @@ module ActiveRecord
         # Uses SQL function with multiple arguments.
         (order.include?(",") && order.split(",").find { |section| section.count("(") != section.count(")") }) ||
           # Uses "nulls first" like construction.
-          /nulls (first|last)\Z/i.match?(order)
+          /\bnulls\s+(?:first|last)\b/i.match?(order)
       end
 
       def build_order(arel)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -291,7 +291,16 @@ class RelationTest < ActiveRecord::TestCase
       Topic.order(Arel.sql("title NULLS FIRST")).reverse_order
     end
     assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order(Arel.sql("title  NULLS  FIRST")).reverse_order
+    end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
       Topic.order(Arel.sql("title nulls last")).reverse_order
+    end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order(Arel.sql("title NULLS FIRST, author_name")).reverse_order
+    end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order(Arel.sql("author_name, title nulls last")).reverse_order
     end
   end
 


### PR DESCRIPTION
This fix should allow AR to raise ActiveRecord::IrreversibleOrderError when an order has more than one argument and include 'nulls first/last'
Previously I received `foo NULLS FIRST DESC, bar DESC` from `foo NULLS FIRST, bar` trying to reverse order and it raised pg exception because of bad syntax.