### PR TITLE
Action Cable: support channel_prefix for Postgres subscription adapter

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   PostgreSQL subscription adapters now support `channel_prefix` option in cable.yml
+
+    Avoids channel name collisions when multiple apps use the same database for Action Cable.
+
+    *Vladimir Dementyev*
+
 *   Allow passing custom configuration to `ActionCable::Server::Base`.
 
     You can now create a standalone Action Cable server with a custom configuration

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -8,6 +8,8 @@ require "digest/sha1"
 module ActionCable
   module SubscriptionAdapter
     class PostgreSQL < Base # :nodoc:
+      prepend ChannelPrefix
+
       def initialize(*)
         super
         @listener = nil

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -7,6 +7,7 @@ require "active_record"
 
 class PostgresqlAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest
+  include ChannelPrefixTest
 
   def setup
     database_config = { "adapter" => "postgresql", "database" => "activerecord_unittest" }


### PR DESCRIPTION
### Summary

The same DB could be used by multiple apps (or engines, see #34714), thus we need a way to avoid naming conflicts.

The functionality has been already implemented for Redis (#27425), we only need to include the module.

