### PR TITLE
Address uninitialized constant PostgresqlAdapterTest::ChannelPrefixTest (NameError)

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require_relative "common"
+require_relative "channel_prefix"
 
 require "active_record"
 


### PR DESCRIPTION
### Summary

This pull request addresses the following error.
It has been reported at https://travis-ci.org/rails/rails/jobs/493530508#L1533

```ruby
$ cd actioncable
$ bundle exec ruby -w -Itest test/subscription_adapter/postgresql_test.rb
Traceback (most recent call last):
	1: from test/subscription_adapter/postgresql_test.rb:8:in `<main>'
test/subscription_adapter/postgresql_test.rb:10:in `<class:PostgresqlAdapterTest>': uninitialized constant PostgresqlAdapterTest::ChannelPrefixTest (NameError)
```

Follow up #35276