### PR TITLE
Deprecate using class level querying methods if the receiver scope regarded as leaked

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate using class level querying methods if the receiver scope
+    regarded as leaked. Use `klass.unscoped` to avoid the leaking scope.
+
+    *Ryuta Kamizono*
+
 *   Allow applications to automatically switch connections.
 
     Adds a middleware and configuration options that can be used in your

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,9 +1,3 @@
-*   Fix `relation.create` to avoid leaking scope to initialization block and callbacks.
-
-    Fixes #9894, #17577.
-
-    *Ryuta Kamizono*
-
 *   Allow applications to automatically switch connections.
 
     Adds a middleware and configuration options that can be used in your

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -67,7 +67,6 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new(attributes = nil, &block)
-      block = klass.current_scope_restoring_block(&block)
       scoping { klass.new(attributes, &block) }
     end
 
@@ -93,11 +92,7 @@ module ActiveRecord
     #   users.create(name: nil) # validation on name
     #   # => #<User id: nil, name: nil, ...>
     def create(attributes = nil, &block)
-      if attributes.is_a?(Array)
-        attributes.collect { |attr| create(attr, &block) }
-      else
-        new(attributes, &block).tap(&:save)
-      end
+      scoping { klass.create(attributes, &block) }
     end
 
     # Similar to #create, but calls
@@ -107,11 +102,7 @@ module ActiveRecord
     # Expects arguments in the same format as
     # {ActiveRecord::Base.create!}[rdoc-ref:Persistence::ClassMethods#create!].
     def create!(attributes = nil, &block)
-      if attributes.is_a?(Array)
-        attributes.collect { |attr| create!(attr, &block) }
-      else
-        new(attributes, &block).tap(&:save!)
-      end
+      scoping { klass.create!(attributes, &block) }
     end
 
     def first_or_create(attributes = nil, &block) # :nodoc:

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -8,7 +8,7 @@ module ActiveRecord
   module SpawnMethods
     # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
-      @delegate_to_klass ? klass.all : clone
+      already_in_scope? ? klass.all : clone
     end
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -30,14 +30,6 @@ module ActiveRecord
       def current_scope=(scope)
         ScopeRegistry.set_value_for(:current_scope, self, scope)
       end
-
-      def current_scope_restoring_block(&block)
-        current_scope = self.current_scope(true)
-        -> *args do
-          self.current_scope = current_scope
-          yield(*args) if block_given?
-        end
-      end
     end
 
     def populate_with_current_scope_attributes # :nodoc:

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -27,6 +27,14 @@ module ActiveRecord
           scope = current_scope
 
           if scope
+            if scope._deprecated_scope_source
+              ActiveSupport::Deprecation.warn(<<~MSG.squish)
+                Class level methods will no longer inherit scoping from `#{scope._deprecated_scope_source}`
+                in Rails 6.1. To continue using the scoped relation, pass it into the block directly.
+                To instead access the full set of models, as Rails 6.1 will, use `#{name}.unscoped`.
+              MSG
+            end
+
             if self == scope.klass
               scope.clone
             else
@@ -180,7 +188,7 @@ module ActiveRecord
 
           if body.respond_to?(:to_proc)
             singleton_class.define_method(name) do |*args|
-              scope = all._exec_scope(*args, &body)
+              scope = all._exec_scope(name, *args, &body)
               scope = scope.extending(extension) if extension
               scope
             end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1536,7 +1536,7 @@ class BasicsTest < ActiveRecord::TestCase
     Bird.create!(name: "Bluejay")
 
     ActiveRecord::Base.connection.while_preventing_writes do
-      assert_nothing_raised { Bird.where(name: "Bluejay").explain }
+      assert_queries(2) { Bird.where(name: "Bluejay").explain }
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1169,9 +1169,11 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_first_or_create_with_after_initialize
     Bird.create!(color: "yellow", name: "canary")
-    parrot = Bird.where(color: "green").first_or_create do |bird|
-      bird.name = "parrot"
-      bird.enable_count = true
+    parrot = assert_deprecated do
+      Bird.where(color: "green").first_or_create do |bird|
+        bird.name = "parrot"
+        bird.enable_count = true
+      end
     end
     assert_equal 0, parrot.total_count
   end
@@ -1180,7 +1182,7 @@ class RelationTest < ActiveRecord::TestCase
     Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_create do |bird|
       bird.name = "parrot"
-      assert_equal 0, Bird.count
+      assert_deprecated { assert_equal 0, Bird.count }
     end
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
@@ -1224,9 +1226,11 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_first_or_create_bang_with_after_initialize
     Bird.create!(color: "yellow", name: "canary")
-    parrot = Bird.where(color: "green").first_or_create! do |bird|
-      bird.name = "parrot"
-      bird.enable_count = true
+    parrot = assert_deprecated do
+      Bird.where(color: "green").first_or_create! do |bird|
+        bird.name = "parrot"
+        bird.enable_count = true
+      end
     end
     assert_equal 0, parrot.total_count
   end
@@ -1235,7 +1239,7 @@ class RelationTest < ActiveRecord::TestCase
     Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_create! do |bird|
       bird.name = "parrot"
-      assert_equal 0, Bird.count
+      assert_deprecated { assert_equal 0, Bird.count }
     end
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
@@ -1287,9 +1291,11 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_first_or_initialize_with_after_initialize
     Bird.create!(color: "yellow", name: "canary")
-    parrot = Bird.where(color: "green").first_or_initialize do |bird|
-      bird.name = "parrot"
-      bird.enable_count = true
+    parrot = assert_deprecated do
+      Bird.where(color: "green").first_or_initialize do |bird|
+        bird.name = "parrot"
+        bird.enable_count = true
+      end
     end
     assert_equal 0, parrot.total_count
   end
@@ -1298,7 +1304,7 @@ class RelationTest < ActiveRecord::TestCase
     Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_initialize do |bird|
       bird.name = "parrot"
-      assert_equal 0, Bird.count
+      assert_deprecated { assert_equal 0, Bird.count }
     end
     assert_kind_of Bird, parrot
     assert_not_predicate parrot, :persisted?

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1167,13 +1167,21 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "green", parrot.color
   end
 
-  def test_first_or_create_with_block
-    canary = Bird.create!(color: "yellow", name: "canary")
+  def test_first_or_create_with_after_initialize
+    Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_create do |bird|
       bird.name = "parrot"
-      assert_equal canary, Bird.find_by!(name: "canary")
+      bird.enable_count = true
     end
-    assert_equal 1, parrot.total_count
+    assert_equal 0, parrot.total_count
+  end
+
+  def test_first_or_create_with_block
+    Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_create do |bird|
+      bird.name = "parrot"
+      assert_equal 0, Bird.count
+    end
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
     assert_equal "green", parrot.color
@@ -1214,13 +1222,21 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: "green").first_or_create! }
   end
 
-  def test_first_or_create_bang_with_valid_block
-    canary = Bird.create!(color: "yellow", name: "canary")
+  def test_first_or_create_bang_with_after_initialize
+    Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_create! do |bird|
       bird.name = "parrot"
-      assert_equal canary, Bird.find_by!(name: "canary")
+      bird.enable_count = true
     end
-    assert_equal 1, parrot.total_count
+    assert_equal 0, parrot.total_count
+  end
+
+  def test_first_or_create_bang_with_valid_block
+    Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_create! do |bird|
+      bird.name = "parrot"
+      assert_equal 0, Bird.count
+    end
     assert_kind_of Bird, parrot
     assert_predicate parrot, :persisted?
     assert_equal "green", parrot.color
@@ -1269,13 +1285,21 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "green", parrot.color
   end
 
-  def test_first_or_initialize_with_block
-    canary = Bird.create!(color: "yellow", name: "canary")
+  def test_first_or_initialize_with_after_initialize
+    Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_initialize do |bird|
       bird.name = "parrot"
-      assert_equal canary, Bird.find_by!(name: "canary")
+      bird.enable_count = true
     end
-    assert_equal 1, parrot.total_count
+    assert_equal 0, parrot.total_count
+  end
+
+  def test_first_or_initialize_with_block
+    Bird.create!(color: "yellow", name: "canary")
+    parrot = Bird.where(color: "green").first_or_initialize do |bird|
+      bird.name = "parrot"
+      assert_equal 0, Bird.count
+    end
     assert_kind_of Bird, parrot
     assert_not_predicate parrot, :persisted?
     assert_predicate parrot, :valid?

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -50,7 +50,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_calling_merge_at_first_in_scope
     Topic.class_eval do
-      scope :calling_merge_at_first_in_scope, Proc.new { merge(Topic.replied) }
+      scope :calling_merge_at_first_in_scope, Proc.new { merge(Topic.unscoped.replied) }
     end
     assert_equal Topic.calling_merge_at_first_in_scope.to_a, Topic.replied.to_a
   end
@@ -448,7 +448,9 @@ class NamedScopingTest < ActiveRecord::TestCase
   end
 
   def test_class_method_in_scope
-    assert_equal [topics(:second)], topics(:first).approved_replies.ordered
+    assert_deprecated do
+      assert_equal [topics(:second)], topics(:first).approved_replies.ordered
+    end
   end
 
   def test_nested_scoping

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -17,8 +17,8 @@ class Bird < ActiveRecord::Base
     throw(:abort)
   end
 
-  attr_accessor :total_count
+  attr_accessor :total_count, :enable_count
   after_initialize do
-    self.total_count = Bird.count
+    self.total_count = Bird.count if enable_count
   end
 end


### PR DESCRIPTION
This deprecates using class level querying methods if the receiver scope
regarded as leaked, since #32380 and #35186 may cause that silently
leaking information when people upgrade the app.

We need deprecation first before making those.