### PR TITLE
Show deprecated message instead of raise exception in `compiled_method_container` method

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -273,11 +273,15 @@ module ActionView #:nodoc:
     end
 
     def compiled_method_container
-      raise NotImplementedError, <<~msg
-        Subclasses of ActionView::Base must implement `compiled_method_container`
-        or use the class method `with_empty_template_cache` for constructing
-        an ActionView::Base subclass that has an empty cache.
-      msg
+      if self.class == ActionView::Base
+        ActiveSupport::Deprecation.warn <<~eowarn
+          ActionView::Base instances must implement `compiled_method_container`
+          or use the class method `with_empty_template_cache` for constructing
+          an ActionView::Base instances that has an empty cache.
+        eowarn
+      end
+
+      self.class
     end
 
     def in_context(options, locals)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -367,6 +367,13 @@ module RenderTestCases
     end
   end
 
+  def test_without_compiled_method_container_is_deprecated
+    view = ActionView::Base.with_view_paths(ActionController::Base.view_paths)
+    assert_deprecated("ActionView::Base instances must implement `compiled_method_container`") do
+      assert_equal "Hello world!", view.render(file: "test/hello_world")
+    end
+  end
+
   def test_render_partial_without_object_does_not_put_partial_name_to_local_assigns
     assert_equal "false", @view.render(partial: "test/partial_name_in_local_assigns")
   end


### PR DESCRIPTION
Since #35036, the subclasses of `ActionView::Base` requires the `compiled_method_container` method.
This is incompatible. For example, `web-console` use view class that subclass of `ActionView::Base`, and does not work it now cause of this.

I am not sure that using `self.class` is correct, but I think that it is better to show a deprecate message rather than raise exception.