### PR TITLE
Properly handle cached queries with too many bind parameters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -96,6 +96,12 @@ module ActiveRecord
         if @query_cache_enabled && !locked?(arel)
           arel = arel_from_relation(arel)
           sql, binds = to_sql_and_binds(arel, binds)
+
+          if binds.length > bind_params_length
+            sql, binds = unprepared_statement { to_sql_and_binds(arel) }
+            preparable = false
+          end
+
           cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable) }
         else
           super

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -44,6 +44,16 @@ if ActiveRecord::Base.connection.prepared_statements
         assert_equal 0, topics.count
       end
 
+      def test_too_many_binds_with_query_cache
+        Topic.connection.enable_query_cache!
+        bind_params_length = @connection.send(:bind_params_length)
+        topics = Topic.where(id: (1 .. bind_params_length + 1).to_a)
+        assert_equal Topic.count, topics.count
+
+        topics = Topic.where.not(id: (1 .. bind_params_length + 1).to_a)
+        assert_equal 0, topics.count
+      end
+
       def test_bind_from_join_in_subquery
         subquery = Author.joins(:thinking_posts).where(name: "David")
         scope = Author.from(subquery, "authors").where(id: 1)


### PR DESCRIPTION
### Summary
This fixes a bug caused by having too many bind parameters in a query. Queries without the query cache already work correctly by switching to using an unprepared statement. This change adds the same bind parameter length check to the QueryCache. See https://github.com/rails/rails/issues/35251