### PR TITLE
Fix Small Typo in Docs

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -53,7 +53,7 @@ module ActiveSupport
   #   crypt.encrypt_and_sign(parcel, expires_in: 1.month)
   #   crypt.encrypt_and_sign(doowad, expires_at: Time.now.end_of_year)
   #
-  # Then the messages can be verified and returned upto the expire time.
+  # Then the messages can be verified and returned up to the expire time.
   # Thereafter, verifying returns +nil+.
   #
   # === Rotating keys

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -71,7 +71,7 @@ module ActiveSupport
   #   @verifier.generate(parcel, expires_in: 1.month)
   #   @verifier.generate(doowad, expires_at: Time.now.end_of_year)
   #
-  # Then the messages can be verified and returned upto the expire time.
+  # Then the messages can be verified and returned up to the expire time.
   # Thereafter, the +verified+ method returns +nil+ while +verify+ raises
   # <tt>ActiveSupport::MessageVerifier::InvalidSignature</tt>.
   #


### PR DESCRIPTION
[ci skip]

Just changing 2 incorrect instances of "upto" to "up to" in the documentation. 