### PR TITLE
AbstractController::Translation#t: dup options

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -11,6 +11,7 @@ module AbstractController
     # to translate many keys within the same controller / action and gives you a
     # simple framework for scoping them consistently.
     def translate(key, options = {})
+      options = options.dup
       if key.to_s.first == "."
         path = controller_path.tr("/", ".")
         defaults = [:"#{path}#{key}"]


### PR DESCRIPTION
So I've caught a bug when I was re-using a single hash instance of translation options in a few places in my code, and then noticed that my hash had some extra elements I didn't put there :)

Turns out we had that mutating helper all the time right under our noses!

OK, so now options will be duplicated **every** time. It could be better for performance to only duplicate those options inside relevant `if` clause, but I decided that this way we will be sure that nobody forgets to perform this operation in case of further changes.