### PR TITLE
Add `Numeric#in_cents` for convert numbers to cents representation

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric.rb
+++ b/activesupport/lib/active_support/core_ext/numeric.rb
@@ -3,3 +3,4 @@
 require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/numeric/conversions"
+require "active_support/core_ext/numeric/in_cents"

--- a/activesupport/lib/active_support/core_ext/numeric/in_cents.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/in_cents.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module InCents
+    def in_cents
+      return self if integer?
+
+      (self * 100).to_i
+    end
+  end
+end
+
+Numeric.prepend ActiveSupport::InCents

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -411,4 +411,34 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       require "active_support/core_ext/numeric/inquiry"
     end
   end
+
+  def test_in_cents_for_integer
+    assert_equal 1, 1.in_cents
+    assert_equal 0, 0.in_cents
+    assert_equal -1, (-1).in_cents
+  end
+
+  def test_in_cents_for_float
+    assert_equal 0, (0.0).in_cents
+    assert_equal -1, (-0.01).in_cents
+    assert_equal -10, (-0.1).in_cents
+    assert_equal -100, (-1.0).in_cents
+    assert_equal 1, (0.01).in_cents
+    assert_equal 10, (0.1).in_cents
+    assert_equal 100, (1.0).in_cents
+    assert_equal 1000, (10.0).in_cents
+    assert_equal 12345, (123.45).in_cents
+  end
+
+  def test_in_cents_for_big_decimal
+    assert_equal 0, BigDecimal.new("0.0").in_cents
+    assert_equal -1, BigDecimal.new("-0.01").in_cents
+    assert_equal -10, BigDecimal.new("-0.1").in_cents
+    assert_equal -100, BigDecimal.new("-1.0").in_cents
+    assert_equal 1, BigDecimal.new("0.01").in_cents
+    assert_equal 10, BigDecimal.new("0.1").in_cents
+    assert_equal 100, BigDecimal.new("1.0").in_cents
+    assert_equal 1000, BigDecimal.new("10.0").in_cents
+    assert_equal 12345, BigDecimal.new("123.45").in_cents
+  end
 end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1785,6 +1785,16 @@ Singular forms are aliased so you are able to say:
 
 NOTE: Defined in `active_support/core_ext/numeric/bytes.rb`.
 
+### In Cents
+
+Convert a `Float` or `BigDecimal` value into a `Integer` relative cents value. An Integer value retuns itself as cents value.
+
+```ruby
+(1.23).in_cents                     # => 123
+BigDecimal.new("123.45").in_cents   # => 12345
+1.in_cents                          # => 1
+```
+
 ### Time
 
 Enables the use of time calculations and declarations, like `45.minutes + 2.hours + 4.weeks`.


### PR DESCRIPTION
### Summary

Add `Numeric#in_cents` to convert a number to a cents representation, except to `Integer` values.
