### PR TITLE
Available :required option with migration generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -5,7 +5,7 @@ require "rails/generators/active_record"
 module ActiveRecord
   module Generators # :nodoc:
     class MigrationGenerator < Base # :nodoc:
-      argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
+      argument :attributes, type: :array, default: [], banner: "field[:type][:required][:index] field[:type][:required][:index]"
 
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
       class_option :database, type: :string, aliases: %i(db), desc: "The database for your migration. By default, the current environment's primary database is used."

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -5,7 +5,7 @@ require "rails/generators/active_record"
 module ActiveRecord
   module Generators # :nodoc:
     class ModelGenerator < Base # :nodoc:
-      argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
+      argument :attributes, type: :array, default: [], banner: "field[:type][:required][:index] field[:type][:required][:index]"
 
       check_class_collision
 

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
@@ -9,5 +9,8 @@ class <%= class_name %> < <%= parent_class_name.classify %>
 <% if attributes.any?(&:password_digest?) -%>
   has_secure_password
 <% end -%>
+<% attributes.select { |a| !a.reference? && a.required? }.each do |attribute| -%>
+  validates :<%= attribute.name %>, presence: true
+<% end -%>
 end
 <% end -%>

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -234,7 +234,7 @@ Rails comes with a generator for data models too.
 ```bash
 $ rails generate model
 Usage:
-  rails generate model NAME [field[:type][:index] field[:type][:index]] [options]
+  rails generate model NAME [field[:type][:required][:index] field[:type][:required][:index]] [options]
 
 ...
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Available required option for all types with model/migration generator.
+
+    *Yoshiyuki Hirano*
+
 *   Fix non-symbol access to nested hashes returned from `Rails::Application.config_for`
     being broken by allowing non-symbol access with a deprecation notice.
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -5,32 +5,17 @@ require "active_support/time"
 module Rails
   module Generators
     class GeneratedAttribute # :nodoc:
-      INDEX_OPTIONS = %w(index uniq)
-      UNIQ_INDEX_OPTIONS = %w(uniq)
-
       attr_accessor :name, :type
       attr_reader   :attr_options
       attr_writer   :index_name
 
       class << self
         def parse(column_definition)
-          name, type, has_index = column_definition.split(":")
-
-          # if user provided "name:index" instead of "name:string:index"
-          # type should be set blank so GeneratedAttribute's constructor
-          # could set it to :string
-          has_index, type = type, nil if INDEX_OPTIONS.include?(type)
-
-          type, attr_options = *parse_type_and_options(type)
+          name, *definition = column_definition.split(":")
+          type, attr_options = *parse_type_and_options(definition)
           type = type.to_sym if type
 
-          if type && reference?(type)
-            if UNIQ_INDEX_OPTIONS.include?(has_index)
-              attr_options[:index] = { unique: true }
-            end
-          end
-
-          new(name, type, has_index, attr_options)
+          new(name, type, attr_options)
         end
 
         def reference?(type)
@@ -41,29 +26,49 @@ module Rails
 
           # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
           # when declaring options curly brackets should be used
-          def parse_type_and_options(type)
+          def parse_type_and_options(definition)
+            type, *provided_options = definition
+            options = {}
+
+            # if user provided "name:index" instead of "name:string:index" or
+            # provided "name:required" instead of "name:string:required",
+            # type should be set blank so GeneratedAttribute's constructor
+            # could set it to :string
+            if %w(required index uniq).include?(type)
+              provided_options << type
+              type = nil
+            end
+
+            if provided_options.include?("required")
+              options[:required] = true
+            end
+
+            if provided_options.include?("uniq")
+              options[:index] = { unique: true }
+            elsif provided_options.include?("index")
+              options[:index] = true
+            end
+
             case type
             when /(string|text|binary|integer)\{(\d+)\}/
-              return $1, limit: $2.to_i
+              return $1, options.merge(limit: $2.to_i)
             when /decimal\{(\d+)[,.-](\d+)\}/
-              return :decimal, precision: $1.to_i, scale: $2.to_i
+              return :decimal, options.merge(precision: $1.to_i, scale: $2.to_i)
             when /(references|belongs_to)\{(.+)\}/
               type = $1
-              provided_options = $2.split(/[,.-]/)
-              options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
-              return type, options
+              provided_attr_options = $2.split(/[,.-]/)
+              attr_options = Hash[provided_attr_options.map { |opt| [opt.to_sym, true] }]
+              return type, options.merge(attr_options)
             else
-              return type, {}
+              return type, options
             end
           end
       end
 
-      def initialize(name, type = nil, index_type = false, attr_options = {})
-        @name           = name
-        @type           = type || :string
-        @has_index      = INDEX_OPTIONS.include?(index_type)
-        @has_uniq_index = UNIQ_INDEX_OPTIONS.include?(index_type)
-        @attr_options   = attr_options
+      def initialize(name, type = nil, attr_options = {})
+        @name         = name
+        @type         = type || :string
+        @attr_options = attr_options
       end
 
       def field_type
@@ -137,11 +142,11 @@ module Rails
       end
 
       def has_index?
-        @has_index
+        !!attr_options[:index]
       end
 
       def has_uniq_index?
-        @has_uniq_index
+        attr_options[:index].is_a?(Hash) && !!attr_options.dig(:index, :unique)
       end
 
       def password_digest?
@@ -162,6 +167,10 @@ module Rails
 
       def options_for_migration
         @attr_options.dup.tap do |options|
+          if has_index?
+            options.delete(:index)
+          end
+
           if required?
             options.delete(:required)
             options[:null] = false

--- a/railties/lib/rails/generators/rails/migration/migration_generator.rb
+++ b/railties/lib/rails/generators/rails/migration/migration_generator.rb
@@ -3,7 +3,7 @@
 module Rails
   module Generators
     class MigrationGenerator < NamedBase # :nodoc:
-      argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
+      argument :attributes, type: :array, default: [], banner: "field[:type][:required][:index] field[:type][:required][:index]"
       hook_for :orm, required: true, desc: "ORM to be invoked"
     end
   end

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -7,7 +7,7 @@ module Rails
     class ModelGenerator < NamedBase # :nodoc:
       include Rails::Generators::ModelHelpers
 
-      argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
+      argument :attributes, type: :array, default: [], banner: "field[:type][:required][:index] field[:type][:required][:index]"
       hook_for :orm, required: true, desc: "ORM to be invoked"
     end
   end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -144,10 +144,35 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_equal "post_id", create_generated_attribute("belongs_to", "post").column_name
   end
 
-  def test_parse_required_attribute_with_index
+  def test_parse_braced_required_attribute_with_index
     att = Rails::Generators::GeneratedAttribute.parse("supplier:references{required}:index")
     assert_equal "supplier", att.name
     assert_equal :references, att.type
+    assert_predicate att, :has_index?
+    assert_predicate att, :required?
+  end
+
+  def test_parse_required_attribute_with_index
+    att = Rails::Generators::GeneratedAttribute.parse("supplier:references:required:index")
+    assert_equal "supplier", att.name
+    assert_equal :references, att.type
+    assert_predicate att, :has_index?
+    assert_predicate att, :required?
+  end
+
+  def test_parse_required_integer_attribute_with_unique_index
+    att = Rails::Generators::GeneratedAttribute.parse("supplier_id:integer{8}:required:uniq")
+    assert_equal "supplier_id", att.name
+    assert_equal :integer, att.type
+    assert_predicate att, :has_index?
+    assert_predicate att, :has_uniq_index?
+    assert_predicate att, :required?
+  end
+
+  def test_parse_required_string_attribute_with_index
+    att = Rails::Generators::GeneratedAttribute.parse("attr_name:required:index")
+    assert_equal "attr_name", att.name
+    assert_equal :string, att.type
     assert_predicate att, :has_index?
     assert_predicate att, :required?
   end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -86,6 +86,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_remove_migration_with_attributes_and_required_option
+    migration = "remove_title_body_from_posts"
+    run_generator [migration, "title:string:required", "body:text:required"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_column :posts, :title, :string, null: false/, change)
+        assert_match(/remove_column :posts, :body, :text, null: false/, change)
+      end
+    end
+  end
+
   def test_remove_migration_with_table_having_to_in_title
     migration = "remove_email_address_from_sent_to_user"
     run_generator [migration, "email_address:string"]
@@ -177,6 +189,23 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
         assert_match(/add_column :books, :content, :string, limit: 255/, change)
         assert_match(/add_column :books, :price, :decimal, precision: 1, scale: 2/, change)
         assert_match(/add_column :books, :discount, :decimal, precision: 3, scale: 4/, change)
+      end
+      assert_match(/add_index :books, :title/, content)
+      assert_match(/add_index :books, :price/, content)
+      assert_match(/add_index :books, :discount, unique: true/, content)
+    end
+  end
+
+  def test_add_migration_with_attributes_index_declaration_and_attributes_required_declaration_and_attribute_options
+    migration = "add_title_and_content_to_books"
+    run_generator [migration, "title:string{40}:required:index", "content:string{255}:required", "price:decimal{1,2}:index:required", "discount:decimal{3.4}:required:uniq"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :books, :title, :string, limit: 40, null: false/, change)
+        assert_match(/add_column :books, :content, :string, limit: 255, null: false/, change)
+        assert_match(/add_column :books, :price, :decimal, precision: 1, scale: 2, null: false/, change)
+        assert_match(/add_column :books, :discount, :decimal, precision: 3, scale: 4, null: false/, change)
       end
       assert_match(/add_index :books, :title/, content)
       assert_match(/add_index :books, :price/, content)

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -19,11 +19,11 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_model_with_missing_attribute_type
-    run_generator ["post", "title", "body:text", "author"]
+    run_generator ["post", "title:required", "body:text", "author"]
 
     assert_migration "db/migrate/create_posts.rb" do |m|
       assert_method :change, m do |up|
-        assert_match(/t\.string :title/, up)
+        assert_match(/t\.string :title, null: false/, up)
         assert_match(/t\.text :body/, up)
         assert_match(/t\.string :author/, up)
       end
@@ -228,6 +228,12 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_migration "db2/migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
   ensure
     Rails.application.config.paths["db/migrate"] = old_paths
+  end
+
+  def test_model_with_required_attribute_generates_presence_validations
+    run_generator ["user", "name:string:required", "age:integer:required"]
+    assert_file "app/models/user.rb", /validates :name, presence: true/
+    assert_file "app/models/user.rb", /validates :age, presence: true/
   end
 
   def test_model_with_references_attribute_generates_belongs_to_associations


### PR DESCRIPTION
### Summary

Available `:required` option for all types with model/migration generator.

If user execute `bin/rails g model User name:required:index age:integer:required`,
then it generate these files:

#### generated migration file

It's added null options automatically.

```diff
  class CreateUsers < ActiveRecord::Migration[5.2]
    def change
      create_table :users do |t|
-       t.string :name
+       t.string :name, null: false
-       t.integer :age
+       t.integer :age, null: false

        t.timestamps
      end
      add_index :users, :name
    end
  end
```

#### generated model file

It's added presence validations automatically.

```diff
  class User < ApplicationRecord
+    validates :name, presence: true
+    validates :age, presence: true
  end
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
