### PR TITLE
Auto correct rubocop offenses

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -914,20 +914,18 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "notification for deliver" do
-    begin
-      events = []
-      ActiveSupport::Notifications.subscribe("deliver.action_mailer") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      BaseMailer.welcome(body: "Hello there").deliver_now
-
-      assert_equal 1, events.length
-      assert_equal "deliver.action_mailer", events[0].name
-      assert_not_nil events[0].payload[:message_id]
-    ensure
-      ActiveSupport::Notifications.unsubscribe "deliver.action_mailer"
+    events = []
+    ActiveSupport::Notifications.subscribe("deliver.action_mailer") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
     end
+
+    BaseMailer.welcome(body: "Hello there").deliver_now
+
+    assert_equal 1, events.length
+    assert_equal "deliver.action_mailer", events[0].name
+    assert_not_nil events[0].payload[:message_id]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "deliver.action_mailer"
   end
 
   private

--- a/railties/lib/rails/autoloaders.rb
+++ b/railties/lib/rails/autoloaders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Autoloaders # :nodoc:
     class << self


### PR DESCRIPTION
### Summary

I found rubocop warnings, so automatically corrected them.

Offenses:

```
railties/lib/rails/autoloaders.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
module Rails
^
actionmailer/test/base_test.rb:917:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body beginning.
actionmailer/test/base_test.rb:917:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
actionmailer/test/base_test.rb:917:5: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
    begin
    ^^^^^
actionmailer/test/base_test.rb:918:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
      events = []
  ^^^^
actionmailer/test/base_test.rb:930:1: C: [Corrected] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
actionmailer/test/base_test.rb:930:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
