### PR TITLE
Delete documentation inconsistency 'finally' for AR callbacks [ci skip] 

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -310,7 +310,7 @@ end
 
 ### Using `:if` and `:unless` with a `Proc`
 
-Finally, it is possible to associate `:if` and `:unless` with a `Proc` object. This option is best suited when writing short validation methods, usually one-liners:
+it is possible to associate `:if` and `:unless` with a `Proc` object. This option is best suited when writing short validation methods, usually one-liners:
 
 ```ruby
 class Order < ApplicationRecord

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -310,7 +310,7 @@ end
 
 ### Using `:if` and `:unless` with a `Proc`
 
-it is possible to associate `:if` and `:unless` with a `Proc` object. This option is best suited when writing short validation methods, usually one-liners:
+It is possible to associate `:if` and `:unless` with a `Proc` object. This option is best suited when writing short validation methods, usually one-liners:
 
 ```ruby
 class Order < ApplicationRecord

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -934,7 +934,7 @@ end
 
 ### Using a Proc with `:if` and `:unless`
 
-it's possible to associate `:if` and `:unless` with a `Proc` object
+It is possible to associate `:if` and `:unless` with a `Proc` object
 which will be called. Using a `Proc` object gives you the ability to write an
 inline condition instead of a separate method. This option is best suited for
 one-liners.

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -934,7 +934,7 @@ end
 
 ### Using a Proc with `:if` and `:unless`
 
-Finally, it's possible to associate `:if` and `:unless` with a `Proc` object
+it's possible to associate `:if` and `:unless` with a `Proc` object
 which will be called. Using a `Proc` object gives you the ability to write an
 inline condition instead of a separate method. This option is best suited for
 one-liners.


### PR DESCRIPTION
The preamble 'finally' is described in item 8.2 of the AR callback.
However, since it is not the last item, the expression 'finally' is contradictory.

When item 8.3 was added, I guessed that item 8.2 was supposed to be "finally" deleted, so I deleted it.