### PR TITLE
Optionally disable attribute discovery

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1064,7 +1064,7 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        elsif klass.ignored_columns.any?
+        elsif klass.ignored_columns.any? || !klass.define_attributes_from_schema
           arel.project(*klass.column_names.map { |field| arel_attribute(field) })
         else
           arel.project(table[Arel.star])

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -294,3 +294,38 @@ class AttributedDeveloper < ActiveRecord::Base
 
   self.ignored_columns += ["name"]
 end
+
+class OnlyAttributedDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  self.define_attributes_from_schema = false
+
+  attribute :id, :integer
+  attribute :name, :string
+  attribute :salary, :integer
+end
+
+class OnlyAttributedDeveloperWithOverriddenDefault < ActiveRecord::Base
+  self.table_name = "developers"
+  self.define_attributes_from_schema = false
+
+  attribute :id, :integer
+  attribute :name, :string
+  attribute :salary, :integer, default: 10
+end
+
+class OnlyAttributedDeveloperWithNoId < ActiveRecord::Base
+  self.table_name = "developers"
+  self.define_attributes_from_schema = false
+
+  attribute :name, :string
+  attribute :salary, :integer
+end
+
+class OnlyAttributedDeveloperWithIgnoredColumn < ActiveRecord::Base
+  self.table_name = "developers"
+  self.define_attributes_from_schema = false
+  self.ignored_columns = ["name"]
+
+  attribute :id, :integer
+  attribute :name, :string
+end


### PR DESCRIPTION
Continuing work @kirs did with #27903

Changes since his work:

1. Avoided the incompatibility between ignored_columns and
define_attributes_from_schema=false. You can have an ignored column,
with an attribute with the same name that works the same as attributes
not backed by a column
2. Don't SELECT * when specifying the columns

I investigated not modifying the columns hash as was suggested/requested here https://github.com/rails/rails/pull/27903#discussion_r127726722), however it seems this is just an allow_list to ignored_columns`s disallow_list, and should work the same way. 

Perhaps ignored_columns should also not modify the columns_hash, though that seems like a significant change and is probably beyond the scope of this PR.