### PR TITLE
Separate a method into controller and action

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -76,9 +76,11 @@ module ActionDispatch
     }
 
     def controller_class
-      params = path_parameters
-      params[:action] ||= "index"
-      controller_class_for(params[:controller])
+      controller_class_for(path_parameters[:controller])
+    end
+
+    def action_name
+      path_parameters[:action] ||= "index"
     end
 
     def controller_class_for(name)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -27,10 +27,10 @@ module ActionDispatch
         def dispatcher?; true; end
 
         def serve(req)
-          params     = req.path_parameters
           controller = controller req
+          action     = req.action_name
           res        = controller.make_response! req
-          dispatch(controller, params[:action], req, res)
+          dispatch(controller, action, req, res)
         rescue ActionController::RoutingError
           if @raise_on_name_error
             raise
@@ -868,6 +868,7 @@ module ActionDispatch
           if app.matches?(req) && app.dispatcher?
             begin
               req.controller_class
+              req.action_name
             rescue NameError
               raise ActionController::RoutingError, "A route matches #{path.inspect}, but references missing controller: #{params[:controller].camelize}Controller"
             end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -868,7 +868,6 @@ module ActionDispatch
           if app.matches?(req) && app.dispatcher?
             begin
               req.controller_class
-              req.action_name
             rescue NameError
               raise ActionController::RoutingError, "A route matches #{path.inspect}, but references missing controller: #{params[:controller].camelize}Controller"
             end


### PR DESCRIPTION
## Summary

This refactoring patch add `ActionDispatch::Request#action_name` as an idempotent and safe method, while reducing the side effect caused by `ActionDispatch::Request#controller_path`.

The `ActionDispatch::Request#controller_path` was first introduced in the following refactoring patch. Both the responsibility for getting controller_class and that for getting action_name have been encapsulated into the same method; `prepare_params!` before the refactoring and `controller_class` after the refactoring.

https://github.com/rails/rails/commit/4276b214f8a13a38ac7dc4911e90d295a8e40d5a?diff=split

I would like to further improve this refactoring. IMHO, the latter name `controller_class` is a little bit ambiguous to let it set default value to `params[:action]`, and to use the default value afterwards by another method.

Except for test codes, since this is used only in `ActionDispatch::Routing::RouteSet::Dispatcher`, I thought we can just separate the method for `controller_class` and `action_name`.

Because I heard that `recognize_path` is a private API and to be deprecated, I partially gave up beautifying the internal code of `recognize_path`. Calling 2 method in a row without using its result might seem a little bit awkward.

https://github.com/rails/rails/issues/28331#issuecomment-285440151

Although the current `test/dispatch/request_test.rb` does not contain specific test regarding `controller_path`, I am willing to add some tests there when the code is approved.