### PR TITLE
Introduce delete_by and destroy_by methods to ActiveRecord::Relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Introduces ActiveRecord::Relation#delete_by and ActiveRecord::Relation#destroy_by.
+
+    `destroy_by` allows relation to find all the records matching the condition and perform
+    `destroy_all` on the matched records.
+
+    Example:
+
+        Person.destroy_by(name: 'David')
+        Person.destroy_by(name: 'David', rating: 4)
+
+        david = Person.find_by(name: 'David')
+        david.posts.destroy_by(id: [1, 2, 3])
+
+    `delete_by` allows relation to find all the records matching the condition and perform
+    `delete_all` on the matched records.
+
+    Example:
+
+        Person.delete_by(name: 'David')
+        Person.delete_by(name: 'David', rating: 4)
+
+        david = Person.find_by(name: 'David')
+        david.posts.delete_by(id: [1, 2, 3])
+
+    *Abhay Nikam*
+
 *   Don't allow `where` with invalid value matches to nil values.
 
     Fixes #33624.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :create_or_find_by, :create_or_find_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
-    delegate :destroy_all, :delete_all, :update_all, to: :all
+    delegate :destroy_all, :delete_all, :update_all, :delete_by, :destroy_by, to: :all
     delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_joins, :left_outer_joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -507,6 +507,32 @@ module ActiveRecord
       affected
     end
 
+    # Finds and destroys all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).destroy_all</tt>.
+    # Returns the collection of objects that were destroyed.
+    #
+    # If no record is found, returns empty array.
+    #
+    #   Person.destroy_by(id: 13)
+    #   Person.destroy_by(name: 'Spartacus', rating: 4)
+    #   Person.destroy_by("published_at < ?", 2.weeks.ago)
+    def destroy_by(*args)
+      where(*args).destroy_all
+    end
+
+    # Finds and deletes all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
+    # Returns the number of rows affected.
+    #
+    # If no record is found, returns <tt>0</tt> as zero rows were affected.
+    #
+    #   Person.delete_by(id: 13)
+    #   Person.delete_by(name: 'Spartacus', rating: 4)
+    #   Person.delete_by("published_at < ?", 2.weeks.ago)
+    def delete_by(*args)
+      where(*args).delete_all
+    end
+
     # Causes the records to be loaded from the database if they have not
     # been loaded already. You can use this if for some reason you need
     # to explicitly load some records before actually using them. The

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1686,6 +1686,24 @@ class RelationTest < ActiveRecord::TestCase
     assert_predicate topics, :loaded?
   end
 
+  def test_delete_by
+    david = authors(:david)
+
+    assert_difference("Post.count", -3) { david.posts.delete_by(body: "hello") }
+
+    deleted = Author.delete_by(id: david.id)
+    assert_equal 1, deleted
+  end
+
+  def test_destroy_by
+    david = authors(:david)
+
+    assert_difference("Post.count", -3) { david.posts.destroy_by(body: "hello") }
+
+    destroyed = Author.destroy_by(id: david.id)
+    assert_equal [david], destroyed
+  end
+
   test "find_by with hash conditions returns the first matching record" do
     assert_equal posts(:eager_other), Post.order(:id).find_by(author_id: 2)
   end


### PR DESCRIPTION
closes #35304 

Adds `delete_by` and `destroy_by` as relation methods to add missing symmetry.

@r? @dhh 