### PR TITLE
Fix ActiveRecord query attribute method when given value does't respond to to_i method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix query attribute method on user-defined attribute to be aware of typecasted value.
+
+    For example the following code no longer return false as casted non-empty string.
+
+    ```
+    class Post < ActiveRecord::Base
+      attribute :user_defined_text, :text
+    end
+
+    Post.new(user_defined_text: "false").user_defined_text? # => true
+    ```
+
+    *Yuji Kamijima*
+
 *   Quote empty ranges like other empty enumerables.
 
     *Patrick Rebsch*

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -16,8 +16,7 @@ module ActiveRecord
         when true        then true
         when false, nil  then false
         else
-          column = self.class.columns_hash[attr_name]
-          if column.nil?
+          if !type_for_attribute(attr_name) { false }
             if Numeric === value || value !~ /[^0-9]/
               !value.to_i.zero?
             else

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -439,6 +439,22 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  test "user defined text attribute predicate" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      attribute :user_defined_text, :text
+    end
+
+    topic = klass.new(user_defined_text: "text")
+    assert_predicate topic, :user_defined_text?
+
+    ActiveModel::Type::Boolean::FALSE_VALUES.each do |value|
+      topic = klass.new(user_defined_text: value)
+      assert_predicate topic, :user_defined_text?
+    end
+  end
+
   test "number attribute predicate" do
     [nil, 0, "0"].each do |value|
       assert_equal false, Developer.new(salary: value).salary?
@@ -456,6 +472,53 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     [true, "true", "1", 1].each do |value|
       assert_equal true, Topic.new(approved: value).approved?
     end
+  end
+
+  test "user defined date attribute predicate" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      attribute :user_defined_date, :date
+    end
+
+    topic = klass.new(user_defined_date: Date.current)
+    assert_predicate topic, :user_defined_date?
+  end
+
+  test "user defined datetime attribute predicate" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      attribute :user_defined_datetime, :datetime
+    end
+
+    topic = klass.new(user_defined_datetime: Time.current)
+    assert_predicate topic, :user_defined_datetime?
+  end
+
+  test "user defined time attribute predicate" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      attribute :user_defined_time, :time
+    end
+
+    topic = klass.new(user_defined_time: Time.current)
+    assert_predicate topic, :user_defined_time?
+  end
+
+  test "user defined json attribute predicate" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      attribute :user_defined_json, :json
+    end
+
+    topic = klass.new(user_defined_json: { key: "value" })
+    assert_predicate topic, :user_defined_json?
+
+    topic = klass.new(user_defined_json: {})
+    assert_not_predicate topic, :user_defined_json?
   end
 
   test "custom field attribute predicate" do


### PR DESCRIPTION
### Summary
Fix a bug of ActiveRecord query method that occurs below error when given Date data-type.

```
NoMethodError: undefined method `to_i' for Thu, 14 Feb 2019:Date
``` 