### PR TITLE
Autoscale secure password computation cost

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Autoscale `has_secure_password` cost over time.
+
+    Scales up password hashing cost over time to keep up with attackers'
+    offline cracking capability. Increase current default BCrypt cost
+    from 12 to 13, targeting at least 100ms to check a password.
+
+    Rehashes passwords with newer cost when they're authenticated.
+
+    *Jeremy Daer*
+
 *   Fix date value when casting a multiparameter date hash to not convert
     from Gregorian date to Julian date.
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -198,22 +198,20 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal @user, @user.authenticate_recovery_password("42password")
   end
 
-  test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
+  test "authenticate updates outdated cost factor" do
+    @user.password = "secret"
     ActiveModel::SecurePassword.min_cost = false
 
-    @user.password = "secret"
-    assert_equal BCrypt::Engine::DEFAULT_COST, @user.password_digest.cost
+    assert_not_equal ActiveModel::SecurePassword.cost, @user.password_digest.cost
+    assert_equal @user, @user.authenticate("secret")
+    assert_equal ActiveModel::SecurePassword.cost, @user.password_digest.cost
   end
 
-  test "Password digest cost honors bcrypt cost attribute when min_cost is false" do
-    original_bcrypt_cost = BCrypt::Engine.cost
+  test "Password digest cost uses default when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
-    BCrypt::Engine.cost = 5
 
     @user.password = "secret"
-    assert_equal BCrypt::Engine.cost, @user.password_digest.cost
-  ensure
-    BCrypt::Engine.cost = original_bcrypt_cost
+    assert_equal ActiveModel::SecurePassword.cost, @user.password_digest.cost
   end
 
   test "Password digest cost can be set to bcrypt min cost to speed up tests" do


### PR DESCRIPTION
Scale up password hashing cost over time to keep up with attackers' offline cracking capability.
- Ensure apps don't get stuck with increasingly stale estimates of compute cost. Start with a BCrypt cost factor of 13, aiming for >100ms compute time today. Scale up the default BCrypt cost every 18 months, roughly following a Moore's Law expectation of CPU scaling.
- Doesn't base default cost on `BCrypt::Engine.calibrate` since that reflects local hashing cost, not attacker hashing cost. Doesn't rely on upstream bcrypt to introduce new cost factor defaults since upgrading a library dependency is a separate concern from calibrating runtime defaults.

Rehash passwords with newer cost when they're authenticated.
- On successful authentication, rehash passwords that had originally been hashed with an outdated, lower cost. Ensures old passwords don't grow increasingly vulnerable to offline cracking.