### PR TITLE
Adds a warning message

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,7 @@ module Rails
 
     private
       def setup_instruction_warning
-        render plain: 'Please follow the setup instructions for Action Mailbox'
+        render plain: "Please follow the setup instructions for Action Mailbox"
       end
 
       def new_mail

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -2,6 +2,8 @@
 
 module Rails
   class Conductor::ActionMailbox::InboundEmailsController < Rails::Conductor::BaseController
+    rescue_from ActiveRecord::StatementInvalid, with: :setup_instruction_warning
+
     def index
       @inbound_emails = ActionMailbox::InboundEmail.order(created_at: :desc)
     end
@@ -19,6 +21,10 @@ module Rails
     end
 
     private
+      def setup_instruction_warning
+        render plain: 'Please follow the setup instructions for Action Mailbox'
+      end
+
       def new_mail
         Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
           params[:mail][:attachments].to_a.each do |attachment|


### PR DESCRIPTION
### Summary

When visiting conductor routes without setting up Action Mailbox, display a plain warning message instead of throwing ActiveRecord::StatementInvalid.

fixes #35155