### PR TITLE
Replaced usage of where.delete/destroy_all with delete/destroy_by

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -95,7 +95,7 @@ module ActiveRecord
   #
   #     private
   #       def delete_parents
-  #         self.class.where(parent_id: id).delete_all
+  #         self.class.delete_by(parent_id: id)
   #       end
   #   end
   #

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1323,7 +1323,7 @@ module ActiveRecord
       def record_version_state_after_migrating(version)
         if down?
           migrated.delete(version)
-          ActiveRecord::SchemaMigration.where(version: version.to_s).delete_all
+          ActiveRecord::SchemaMigration.delete_by(version: version.to_s)
         else
           migrated << version
           ActiveRecord::SchemaMigration.create!(version: version.to_s)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -161,7 +161,7 @@ module ActiveRecord
       #   # Delete multiple rows
       #   Todo.delete([2,3,4])
       def delete(id_or_array)
-        where(primary_key => id_or_array).delete_all
+        delete_by(primary_key => id_or_array)
       end
 
       def _insert_record(values) # :nodoc:

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -99,7 +99,7 @@ class Topic < ActiveRecord::Base
     end
 
     def destroy_children
-      self.class.where("parent_id = #{id}").delete_all
+      self.class.delete_by(parent_id: id)
     end
 
     def set_email_address

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -314,7 +314,7 @@ method:
 
 ```ruby
 # find and delete all users named David
-User.where(name: 'David').destroy_all
+User.destroy_by(name: 'David')
 
 # delete all users
 User.destroy_all


### PR DESCRIPTION
Follow up on #35316.

Replaced the usage of `where().delete/destroy_all` with `delete/destroy_by`.