### PR TITLE
Deprecate LookupContext#rendered_format

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -16,6 +16,8 @@ module ActionView
   # only once during the request, it speeds up all cache accesses.
   class LookupContext #:nodoc:
     attr_accessor :prefixes, :rendered_format
+    deprecate :rendered_format
+    deprecate :rendered_format=
 
     mattr_accessor :fallbacks, default: FallbackFileSystemResolver.instances
 
@@ -250,7 +252,6 @@ module ActionView
       @digest_cache = nil
       @cache = true
       @prefixes = prefixes
-      @rendered_format = nil
 
       @details = initialize_details({}, details)
       @view_paths = build_view_paths(view_paths)

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -26,6 +26,13 @@ module ActionView
     extend ActiveSupport::Concern
     include ActionView::ViewPaths
 
+    attr_reader :rendered_format
+
+    def initialize
+      @rendered_format = nil
+      super
+    end
+
     # Overwrite process to setup I18n proxy.
     def process(*) #:nodoc:
       old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
@@ -96,10 +103,6 @@ module ActionView
       _render_template(options)
     end
 
-    def rendered_format
-      Template::Types[lookup_context.rendered_format]
-    end
-
     private
 
       # Find and render a template based on the options given.
@@ -115,7 +118,8 @@ module ActionView
           renderer.render_to_object(context, options)
         end
 
-        lookup_context.rendered_format = rendered_template.format || lookup_context.formats.first
+        rendered_format = rendered_template.format || lookup_context.formats.first
+        @rendered_format = Template::Types[rendered_format]
 
         rendered_template.body
       end
@@ -124,7 +128,6 @@ module ActionView
       def _process_format(format)
         super
         lookup_context.formats = [format.to_sym]
-        lookup_context.rendered_format = lookup_context.formats.first
       end
 
       # Normalize args by converting render "foo" to render :action => "foo" and

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -17,6 +17,16 @@ class LookupContextTest < ActiveSupport::TestCase
     I18n.locale = :en
   end
 
+  test "rendered_format is deprecated" do
+    assert_deprecated do
+      @lookup_context.rendered_format = "foo"
+    end
+
+    assert_deprecated do
+      assert_equal "foo", @lookup_context.rendered_format
+    end
+  end
+
   test "allows to override default_formats with ActionView::Base.default_formats" do
     formats = ActionView::Base.default_formats
     ActionView::Base.default_formats = [:foo, :bar]


### PR DESCRIPTION
We no longer depend on `rendered_format` side effects, so we can remove
this method now. 🎉