### PR TITLE
Let Zeitwerk integration unhook AS::Dependencies

### DIFF
--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -31,6 +31,10 @@ module ActiveSupport
           l = verbose ? (logger || Rails.logger).method(:debug) : nil
           Rails.autoloaders.each { |autoloader| autoloader.logger = l }
         end
+
+        def unhook!
+          :no_op
+        end
       end
 
       class << self
@@ -69,6 +73,7 @@ module ActiveSupport
           end
 
           def decorate_dependencies
+            Dependencies.unhook!
             Dependencies.singleton_class.prepend(Decorations)
             Object.class_eval { alias_method :require_dependency, :require }
           end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -34,6 +34,22 @@ class LoadingTest < ActiveSupport::TestCase
     assert_equal "omg", p.title
   end
 
+  test "constants without a matching file raise NameError" do
+    app_file "app/models/post.rb", <<-RUBY
+      class Post
+        NON_EXISTING_CONSTANT
+      end
+    RUBY
+
+    boot_app
+
+    e = assert_raise(NameError) { User }
+    assert_equal "uninitialized constant #{self.class}::User", e.message
+
+    e = assert_raise(NameError) { Post }
+    assert_equal "uninitialized constant Post::NON_EXISTING_CONSTANT", e.message
+  end
+
   test "concerns in app are autoloaded" do
     app_file "app/controllers/concerns/trackable.rb", <<-CONCERN
       module Trackable

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -179,9 +179,10 @@ module ApplicationTests
       def db_fixtures_load(expected_database)
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
+          reload
           rails "db:migrate", "db:fixtures:load"
+
           assert_match expected_database, ActiveRecord::Base.connection_config[:database]
-          require "#{app_path}/app/models/book"
           assert_equal 2, Book.count
         end
       end
@@ -201,8 +202,9 @@ module ApplicationTests
         require "#{app_path}/config/environment"
 
         rails "generate", "model", "admin::book", "title:string"
+        reload
         rails "db:migrate", "db:fixtures:load"
-        require "#{app_path}/app/models/admin/book"
+
         assert_equal 2, Admin::Book.count
       end
 

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -170,6 +170,7 @@ module ApplicationTests
         rails "generate", "model", "book", "title:string"
         rails "generate", "model", "dog", "name:string"
         write_models_for_animals
+        reload
       end
 
       test "db:create and db:drop works on all databases for env" do

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -199,4 +199,11 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
       assert_nil autoloader.logger
     end
   end
+
+  test "unhooks" do
+    boot
+
+    assert_equal Module, Module.method(:const_missing).owner
+    assert_equal :no_op, deps.unhook!
+  end
 end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -458,12 +458,19 @@ module TestHelpers
       end
     end
   end
+
+  module Reload
+    def reload
+      ActiveSupport::Dependencies.clear
+    end
+  end
 end
 
 class ActiveSupport::TestCase
   include TestHelpers::Paths
   include TestHelpers::Rack
   include TestHelpers::Generation
+  include TestHelpers::Reload
   include ActiveSupport::Testing::Stream
   include ActiveSupport::Testing::MethodCallAssertions
 end


### PR DESCRIPTION
With this patch we unhook `ActiveSupport::Dependencies` in `:zeitwerk` mode.

This doesn't make a difference for autoloadable constants, because `autoload` runs before `const_missing`, but when constants are missing the backtraces include `dependencies.rb`, which may be confusing. That also opens unnecessarily the door to potential gotchas, as seen in #35278.