### PR TITLE
Add ActiveRecord::Relation#take_unique and take_unique!

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -309,6 +309,9 @@ module ActiveRecord
   class ImmutableRelation < ActiveRecordError
   end
 
+  class NonUniqueResult < ActiveRecordError
+  end
+
   # TransactionIsolationError will be raised under the following conditions:
   #
   # * The adapter does not support setting the isolation level

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -104,6 +104,15 @@ module ActiveRecord
       take || raise_record_not_found_exception!
     end
 
+    def take_unique
+      records = take(2)
+      records.many? : raise NonUniqueResult : records.first
+    end
+
+    def take_unique!
+      take_unique || raise_record_not_found_exception
+    end
+
     # Find the first record (or first N records if a parameter is supplied).
     # If no order is defined it will order by primary key.
     #


### PR DESCRIPTION
This is not the same as #26206 - see https://github.com/rails/rails/pull/35068#issuecomment-458321781

### Summary
Sometimes we make a query expecting a single result, and if for whatever
reason it doesn't it's a sign of data inconsistency or code bug.

Other data access frameworks, like the famous Hibernate (for Java), have
a method that raises an error if the query returns more than one record.
Here's an example:
https://docs.jboss.org/hibernate/orm/3.2/api/org/hibernate/Query.html#uniqueResult()

Once the idea is approved, I'll add specs and documentation

