### PR TITLE
Update comment for ActionView::Digestor.digest [ci skip]

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -9,9 +9,10 @@ module ActionView
     class << self
       # Supported options:
       #
-      # * <tt>name</tt>   - Template name
-      # * <tt>finder</tt>  - An instance of <tt>ActionView::LookupContext</tt>
-      # * <tt>dependencies</tt>  - An array of dependent views
+      # * <tt>name</tt>         - Template name
+      # * <tt>format</tt>       - Template format
+      # * <tt>finder</tt>       - An instance of <tt>ActionView::LookupContext</tt>
+      # * <tt>dependencies</tt> - An array of dependent views
       def digest(name:, format:, finder:, dependencies: nil)
         if dependencies.nil? || dependencies.empty?
           cache_key = "#{name}.#{format}"


### PR DESCRIPTION
The method was changed to accept an additional argument @ https://github.com/rails/rails/pull/35293/files#diff-7ee9dc74b44ac1e2c604f7bc0791475dL21.

I've updated the doc/comment to reflect that.

cc @tenderlove @kaspth 