### PR TITLE
Refactored the RenderedCollection class to use attr_reader for spacer

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -28,7 +28,7 @@ module ActionView
     end
 
     class RenderedCollection # :nodoc:
-      attr_reader :rendered_templates
+      attr_reader :rendered_templates, :spacer
 
       def initialize(rendered_templates, spacer)
         @rendered_templates = rendered_templates
@@ -36,7 +36,7 @@ module ActionView
       end
 
       def body
-        @rendered_templates.map(&:body).join(@spacer.body).html_safe
+        rendered_templates.map(&:body).join(spacer.body).html_safe
       end
 
       def format


### PR DESCRIPTION
Follow on #35265

Found that `RenderedCollection` class had attr_reader defined for `rendered_templates` but was not used. Refactored code to add reader for `spacer` and fixed the usage of it. 

@r? @tenderlove 