### PR TITLE
Removed unused layout attribute from RenderedTemplate

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -59,11 +59,10 @@ module ActionView
     end
 
     class RenderedTemplate # :nodoc:
-      attr_reader :body, :layout, :template
+      attr_reader :body, :template
 
-      def initialize(body, layout, template)
+      def initialize(body, template)
         @body = body
-        @layout = layout
         @template = template
       end
 
@@ -97,8 +96,8 @@ module ActionView
         @lookup_context.formats = formats | @lookup_context.formats
       end
 
-      def build_rendered_template(content, template, layout = nil)
-        RenderedTemplate.new content, layout, template
+      def build_rendered_template(content, template)
+        RenderedTemplate.new content, template
       end
 
       def build_rendered_collection(templates, spacer)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -364,7 +364,7 @@ module ActionView
 
           content = layout.render(view, locals) { content } if layout
           payload[:cache_hit] = view.view_renderer.cache_hits[template.virtual_path]
-          build_rendered_template(content, template, layout)
+          build_rendered_template(content, template)
         end
       end
 
@@ -455,7 +455,7 @@ module ActionView
           content = template.render(view, locals)
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
-          build_rendered_template(content, template, layout)
+          build_rendered_template(content, template)
         end
       end
 

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -66,7 +66,7 @@ module ActionView
         else
           content
         end
-        build_rendered_template(body, template, layout)
+        build_rendered_template(body, template)
       end
 
       # This is the method which actually finds the layout using details in the lookup


### PR DESCRIPTION
Added another follow up for #35265. I could see `layout` was added in `RenderedTemplate` class but was never used. 

Removed the dependency for layout from RenderedTemplate and updated wherever used. 

@r? @tenderlove 