### PR TITLE
Fix SQLite3 quoting to not put database and table in separate quotes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -12,10 +12,6 @@ module ActiveRecord
           quote_column_name(attr)
         end
 
-        def quote_table_name(name)
-          @quoted_table_names[name] ||= super.gsub(".", "\".\"").freeze
-        end
-
         def quote_column_name(name)
           @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
         end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1055,7 +1055,13 @@ module ActiveRecord
           case field
           when Symbol
             field = field.to_s
-            arel_column(field) { connection.quote_table_name(field) }
+            arel_column(field) do
+              table, sep, column = field.to_s.rpartition(".")
+              if table.present?
+                table = connection.quote_table_name(table)
+              end
+              "#{table}#{sep}#{connection.quote_column_name(column)}"
+            end
           when String
             arel_column(field) { field }
           when Proc

--- a/activerecord/test/cases/adapters/sqlite3/schema_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/schema_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# SQLite3 can have attached databases, which behave the same as a schema in PostgreSQL
+require "cases/helper"
+
+class SQLite3SchemaTest < ActiveRecord::SQLite3TestCase
+
+  class SchemaThing < ActiveRecord::Base
+    self.table_name = "test_schema.things"
+  end
+
+  def setup
+    original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Schema.define do
+      execute "ATTACH DATABASE ':memory:' AS test_schema;"
+      create_table "test_schema.things" do |t|
+        t.integer :number
+      end
+    end
+  ensure
+    ActiveRecord::Migration.verbose = original_verbose
+  end
+
+  teardown do
+    # To remove the attached databases, just wipe the connections.
+    ActiveRecord::Base.clear_all_connections!
+  end
+
+  def test_create
+    thing = SchemaThing.create!
+    assert_equal 1, thing.id
+  end
+
+  def test_first
+    SchemaThing.create!
+    thing = SchemaThing.first
+    assert_equal 1, thing.id
+  end
+end


### PR DESCRIPTION
This reverts a fix that broke schemas in SQLite3, and applies a different fix to solve the same test case.

This fixes #35292.

Basically, when passing a symbol with a dot to `pluck`, we are expecting it to be a table + a column. MySQL and PostgreSQL handled it fine, because quoting `schema + table` is the same as quoting `table + column`: `"part1"."part2"`. So a quote_table_name was being applied by pluck.

However, this is not the case in SQLite3, which wants `"schema.table"."column"` (note the schema and table in the same quotes), and so would generate `"table.column"`. The applied logic is instead to check for a dot, and if found, to quote each part separately.