### PR TITLE
Deprecate ActionView::PathSet as argument to ActionView::Base.new

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -213,6 +213,8 @@ module ActionView #:nodoc:
         context.lookup_context
       when Array
         ActionView::LookupContext.new(context)
+      when ActionView::PathSet
+        ActionView::LookupContext.new(context)
       when nil
         ActionView::LookupContext.new([])
       else

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -360,6 +360,10 @@ module RenderTestCases
     assert_deprecated do
       ActionView::Base.new ["/a"]
     end
+
+    assert_deprecated do
+      ActionView::Base.new ActionView::PathSet.new ["/a"]
+    end
   end
 
   def test_without_compiled_method_container_is_deprecated


### PR DESCRIPTION
Currently, `ActionView::Base.new` will raise a `NotImplementedError` if given an instance of `ActionView::PathSet` on initialization. For example, `ActionController::Base.view_paths` will return an instance of `ActionView::PathSet` so the following will raise a `NotImplementedError `:

`view = ActionView::Base.new(ActionController::Base.view_paths, assigns = {})`

This commit prevents the raised error in favor of a deprecation warning.

@tenderlove Is it sufficient here to add this single `when ActionView::PathSet` to the case in `build_lookup_context` or are there other cases we also need to consider?