### PR TITLE
Add missing require to active_storage.rb

### DIFF
--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -26,6 +26,7 @@
 require "active_record"
 require "active_support"
 require "active_support/rails"
+require "active_support/core_ext/numeric/time"
 
 require "active_storage/version"
 require "active_storage/errors"


### PR DESCRIPTION
Since b21f50d8ae36d9b50b673579e17bccbe55363b34, requiring `active_storage` on its own has failed with the following error:

    activestorage/lib/active_storage.rb:55:in `<module:ActiveStorage>': undefined method `minutes' for 5:Integer (NoMethodError)

I discovered this while trying to get the rspec-rails test suite to pass on Rails master, as it [requires `active_storage` outside the context of a full application](https://github.com/rspec/rspec-rails/blob/7720e7b1c8c60f033a8e1f9c61f6ca12c84121f4/example_app_generator/spec/support/default_preview_path#L10).