### PR TITLE
Fix lint `ShadowingOuterLocalVariable`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1157,9 +1157,9 @@ module ActiveRecord
         order_args.map! do |arg|
           case arg
           when Symbol
-            field = arg.to_s
-            arel_column(field) {
-              Arel.sql(connection.quote_table_name(field))
+            arg = arg.to_s
+            arel_column(arg) {
+              Arel.sql(connection.quote_table_name(arg))
             }.asc
           when Hash
             arg.map { |field, dir|


### PR DESCRIPTION
# What changed

I changed the variable name.

# Why this pull request

Because rubecop's offense `Lint / ShadowingOuterLocalVariable` was detected in` activerecord / lib / active_record / relation / query_methods.rb`.

# What became of it

## Before

```
$ rubocop activerecord/lib/active_record/relation/query_methods.rb 
Inspecting 1 file
W

Offenses:

activerecord/lib/active_record/relation/query_methods.rb:1165:24: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - field.
            arg.map { |field, dir|
                       ^^^^^

1 file inspected, 1 offense detected
```

## After

```
$ rubocop activerecord/lib/active_record/relation/query_methods.rb 

Inspecting 1 file
.

1 file inspected, no offenses detected
```