### PR TITLE
Add cookies_httponly_default config option.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Set all cookies to httpOnly by default for new applications.
+
+    Add `cookies_httponly_default` configuration option. Set to `false` by default
+    but enabled for new applications. Provides secure-by-default behavior by restricting
+    script access to cookies. Session cookies are already httpOnly by default.
+
+    Fixes #1449
+
+    *Tyler Naumu*
+
 *   Make debug exceptions works in an environment where ActiveStorage is not loaded.
 
     *Tomoyuki Kurosawa*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -166,7 +166,7 @@ module ActionDispatch
   # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
   #   Default is +false+.
   # * <tt>:httponly</tt> - Whether this cookie is accessible via scripting or
-  #   only HTTP. Defaults to +false+.
+  #   only HTTP. Defaults to +config.action_dispatch.cookies_httponly_default+.
   class Cookies
     HTTP_HEADER   = "Set-Cookie"
     GENERATOR_KEY = "action_dispatch.key_generator"
@@ -354,6 +354,8 @@ module ActionDispatch
 
         options[:path] ||= "/"
 
+        options[:httponly] = cookies_httponly_default unless options.key?(:httponly)
+
         if options[:domain] == :all || options[:domain] == "all"
           # If there is a provided tld length then we use it otherwise default domain regexp.
           domain_regexp = options[:tld_length] ? /([^.]+\.?){#{options[:tld_length]}}$/ : DOMAIN_REGEXP
@@ -426,6 +428,7 @@ module ActionDispatch
       end
 
       mattr_accessor :always_write_cookie, default: false
+      mattr_accessor :cookies_httponly_default, default: false
 
       private
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -50,6 +50,9 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      config.action_dispatch.cookies_httponly_default = false if config.action_dispatch.cookies_httponly_default.nil?
+      ActionDispatch::Cookies::CookieJar.cookies_httponly_default = config.action_dispatch.cookies_httponly_default
+
       ActionDispatch.test_app = app
     end
   end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -140,6 +140,11 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def authenticate_with_httponly_false
+      cookies["user_name"] = { value: "david", httponly: false }
+      head :ok
+    end
+
     def authenticate_with_secure
       cookies["user_name"] = { value: "david", secure: true }
       head :ok
@@ -396,6 +401,30 @@ class CookiesTest < ActionController::TestCase
     get :authenticate_with_http_only
     assert_cookie_header "user_name=david; path=/; HttpOnly"
     assert_equal({ "user_name" => "david" }, @response.cookies)
+  end
+
+  def test_setting_cookie_with_httponly_false
+    get :authenticate_with_httponly_false
+    assert_cookie_header "user_name=david; path=/"
+    assert_equal({ "user_name" => "david" }, @response.cookies)
+  end
+
+  def test_setting_cookie_with_httponly_default
+    old_httponly, @request.cookie_jar.cookies_httponly_default = @request.cookie_jar.cookies_httponly_default, true
+    get :authenticate
+    assert_cookie_header "user_name=david; path=/; HttpOnly"
+    assert_equal({ "user_name" => "david" }, @response.cookies)
+  ensure
+    @request.cookie_jar.cookies_httponly_default = old_httponly
+  end
+
+  def test_setting_cookie_httponly_false_with_httponly_default_true
+    old_httponly, @request.cookie_jar.cookies_httponly_default = @request.cookie_jar.cookies_httponly_default, true
+    get :authenticate_with_httponly_false
+    assert_cookie_header "user_name=david; path=/"
+    assert_equal({ "user_name" => "david" }, @response.cookies)
+  ensure
+    @request.cookie_jar.cookies_httponly_default = old_httponly
   end
 
   def test_setting_cookie_with_secure

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -502,6 +502,9 @@ Defaults to `'signed cookie'`.
 * `config.action_dispatch.use_cookies_with_metadata` enables writing
   cookies with the purpose and expiry metadata embedded. It defaults to `true`.
 
+* `config.action_dispatch.cookies_httponly_default` controls whether
+  cookies are set to httpOnly by default. It defaults to `false`.
+
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)
   for more information. It defaults to `true`.
@@ -880,6 +883,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 - `config.action_view.default_enforce_utf8`: `false`
 - `config.action_dispatch.use_cookies_with_metadata`: `true`
+- `config.action_dispatch.cookies_httponly_default`: `true`
 - `config.action_mailer.delivery_job`: `"ActionMailer::MailDeliveryJob"`
 - `config.active_job.return_false_on_aborted_enqueue`: `true`
 - `config.active_storage.queues.analysis`: `:active_storage_analysis`

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -749,6 +749,7 @@ GET http://www.attacker.com/_app_session=836c1c25278e5b321d6bea4f19cb57e2
 ```
 
 You can mitigate these attacks (in the obvious way) by adding the **httpOnly** flag to cookies, so that document.cookie may not be read by JavaScript. HTTP only cookies can be used from IE v6.SP1, Firefox v2.0.0.5, Opera 9.5, Safari 4, and Chrome 1.0.154 onwards. But other, older browsers (such as WebTV and IE 5.5 on Mac) can actually cause the page to fail to load. Be warned that cookies [will still be visible using Ajax](https://www.owasp.org/index.php/HTTPOnly#Browsers_Supporting_HttpOnly), though.
+Since Rails sets all cookies to httpOnly by default, this only applies to cookies you've set with `httponly: false`.
 
 ##### Defacement
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -126,6 +126,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.use_cookies_with_metadata = true
+            action_dispatch.cookies_httponly_default = true
           end
 
           if respond_to?(:action_mailer)

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -26,6 +26,22 @@ module ApplicationTests
       FileUtils.rm_rf(new_app) if File.directory?(new_app)
     end
 
+    test "cookies_httponly_default is true by default" do
+      require "rails"
+      require "#{app_path}/config/environment"
+      assert_equal true, ActionDispatch::Cookies::CookieJar.cookies_httponly_default
+    end
+
+    test "cookies_httponly_default can be overridden" do
+      add_to_config <<-RUBY
+        config.action_dispatch.cookies_httponly_default = false
+      RUBY
+
+      require "rails"
+      require "#{app_path}/config/environment"
+      assert_equal false, ActionDispatch::Cookies::CookieJar.cookies_httponly_default
+    end
+
     test "always_write_cookie is true by default in development" do
       require "rails"
       Rails.env = "development"


### PR DESCRIPTION
### Summary
In the pursuit of "secure by default," Rails should provide the ability to mark all cookies as httpOnly.
An individual cookie can be marked as not httpOnly as before with`httponly: false`.

Backwards-compatibility provided via configuration. New projects will default to `true`.

This was brought up as an issue way back in 2011, #1449. The corresponding mailing list thread does not appear to have made any decisions: https://groups.google.com/d/msg/rubyonrails-core/yDzoifkfqvc/5j4eYHz-d1AJ

Possible alternative (cookies_default_options): https://github.com/rails/rails/pull/27439

If we want to pursue the solution in #27439, I may have bandwidth to run with it if the original author does not.

We needed this sort functionality at my day job. We've chosen to monkey-patch
`ActionDispatch::Cookies::CookieJar#handle_options`:
```ruby
module CookieJarExtensions
  def handle_options(options)
    super

     options[:httponly] = true unless options.key?(:httponly)
  end
end

ActionDispatch::Cookies::CookieJar.class_eval do
  prepend CookieJarExtensions
end
```

But it would be awesome if Rails supported this out of the box!

### Other Information
I attempted to update all the documentation I could find; please direct me to any other locations I missed!