### PR TITLE
Add two time zones to ActiveSupport::TimeZone

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `Bahia => America/Bahia`, and `Manaus => America/Manaus` to TimeZone.MAPPING.
+*   Add `Bahia => America/Bahia`, and `Manaus => America/Manaus` to ActiveSupport::TimeZone Keys.
 
     *Gabriel Fontoura Dos Santos*
 *   New autoloading based on [Zeitwerk](https://github.com/fxn/zeitwerk).

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Add `Bahia => America/Bahia`, and `Manaus => America/Manaus` to TimeZone.MAPPING.
+
+    *Gabriel Fontoura Dos Santos*
 *   New autoloading based on [Zeitwerk](https://github.com/fxn/zeitwerk).
 
     *Xavier Noria*

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -7,7 +7,7 @@ module ActiveSupport
   # The TimeZone class serves as a wrapper around TZInfo::Timezone instances.
   # It allows us to do the following:
   #
-  # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
+  # * Limit the set of zones provided by TZInfo to a meaningful subset of 136
   #   zones.
   # * Retrieve and display zones with a friendlier name
   #   (e.g., "Eastern Time (US & Canada)" instead of "America/New_York").
@@ -56,6 +56,8 @@ module ActiveSupport
       "La Paz"                       => "America/La_Paz",
       "Santiago"                     => "America/Santiago",
       "Newfoundland"                 => "America/St_Johns",
+      "Manaus"                       => "America/Manaus",
+      "Bahia"                        => "America/Bahia",
       "Brasilia"                     => "America/Sao_Paulo",
       "Buenos Aires"                 => "America/Argentina/Buenos_Aires",
       "Montevideo"                   => "America/Montevideo",


### PR DESCRIPTION
### Add more two Brazilian times zones for the ActiveSupport::TimeZone::MAPPING.

The two new keys:
    "Manaus"                       => "America/Manaus",
    "Bahia"                          => "America/Bahia",

These Time Zones are already available inside the TZInfo gem. Adding these two zones will help a lot.

### Tests

These time zones are already tested inside the TZInfo.