### PR TITLE
Define Rails.autoloaders.logger=

### DIFF
--- a/railties/lib/rails/autoloaders.rb
+++ b/railties/lib/rails/autoloaders.rb
@@ -24,6 +24,11 @@ module Rails
         end
       end
 
+      def logger=(logger)
+        callable_or_nil = logger.respond_to?(:debug) ? logger.method(:debug) : logger
+        each { |loader| loader.logger = callable_or_nil }
+      end
+
       def zeitwerk_enabled?
         Rails.configuration.autoloader == :zeitwerk
       end

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -206,4 +206,27 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_equal Module, Module.method(:const_missing).owner
     assert_equal :no_op, deps.unhook!
   end
+
+  test "autoloaders.logger=" do
+    boot
+
+    logger = ->(_msg) { }
+    Rails.autoloaders.logger = logger
+
+    Rails.autoloaders.each do |autoloader|
+      assert_equal logger, autoloader.logger
+    end
+
+    Rails.autoloaders.logger = Rails.logger
+
+    Rails.autoloaders.each do |autoloader|
+      assert_equal Rails.logger.method(:debug), autoloader.logger
+    end
+
+    Rails.autoloaders.logger = nil
+
+    Rails.autoloaders.each do |autoloader|
+      assert_nil autoloader.logger
+    end
+  end
 end


### PR DESCRIPTION
While we need some compatibility, I am exploring departing from `ActiveSupport::Dependencies` as public API in `:zeitwerk` mode.

`Rails.autoloaders` is gradually taking shape as an alternative, and

```ruby
Rails.autoloaders.logger = Rails.logger
```

goes in that direction. Let's see if this passes the test of time.

I will probably implement the `:debug` dance in Zeitwerk itself. Also, the test suite needs a reorganization. But for the time being this will suffice here for the next beta.