### PR TITLE
Ensure `update_all` series cares about optimistic locking

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure `update_all` series cares about optimistic locking.
+
+    *Ryuta Kamizono*
+
 *   Don't allow `where` with non numeric string matches to 0 values.
 
     *Ryuta Kamizono*

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -352,7 +352,7 @@ class DirtyTest < ActiveRecord::TestCase
       Person.where(id: person.id).update_all(first_name: "baz")
     end
 
-    old_lock_version = person.lock_version
+    old_lock_version = person.lock_version + 1
 
     with_partial_writes Person, true do
       assert_no_queries { 2.times { person.save! } }


### PR DESCRIPTION
Implicitly updating the lock version without knowing the current version
is meaningless.