### PR TITLE
Allow a capitalized type name as an argument for generate commands

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -7,7 +7,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
 <% elsif attribute.token? -%>
       t.string :<%= attribute.name %><%= attribute.inject_options %>
 <% else -%>
-      t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
+      t.<%= attribute.type.downcase %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>
 <% end -%>
 <% if options[:timestamps] %>


### PR DESCRIPTION
### Summary
Hi there.


At the moment, you can have pretty much any string as an `type` argument for generate commands like shown below↓

`rails g model User name:String age:Integer`

Obviously you don't need to take some outrageous cases into consideration but I thought it would be a good idea to rescue a case where people capitalize `type` arguments like above by downcasing them when necessary internally.