### PR TITLE
Allows rich_text_area_tag to add translated placeholder text if placeholder option set to true

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/placeholderable"
+
 module ActionText
   module TagHelper
     cattr_accessor(:id, instance_accessor: false) { 0 }
@@ -35,6 +37,8 @@ end
 
 module ActionView::Helpers
   class Tags::ActionText < Tags::Base
+    include Tags::Placeholderable
+
     delegate :dom_id, to: ActionView::RecordIdentifier
 
     def render

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -5,6 +5,26 @@ require "test_helper"
 class ActionText::FormHelperTest < ActionView::TestCase
   tests ActionText::TagHelper
 
+  def form_with(*)
+    @output_buffer = super
+  end
+
+  teardown do
+    I18n.backend.reload!
+  end
+
+  setup do
+    I18n.backend.store_translations("placeholder",
+      activerecord: {
+        attributes: {
+          message: {
+            title: "Story title"
+          }
+        }
+      }
+    )
+  end
+
   test "form with rich text area" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_text_area :content
@@ -61,7 +81,33 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
-  def form_with(*)
-    @output_buffer = super
+  test "form with rich text area having placeholder without locale" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :content, placeholder: true
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<trix-editor placeholder="Content" id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
+  test "form with rich text area having placeholder with locale" do
+    I18n.with_locale :placeholder do
+      form_with model: Message.new, scope: :message do |form|
+        form.rich_text_area :title, placeholder: true
+      end
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
+        '<trix-editor placeholder="Story title" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
   end
 end


### PR DESCRIPTION
fixes #35351

### Summary

If a form with `rich_text_area` has the option set as `placeholder: true` and has a locale set for the form field then the placeholder text should be translated and shown. 

Example: 
```
en:
  activerecord:
    attributes:
      message:
        title: Set a title for your message
        content: Write your message
```

```
<%= form_with(model: message) do |form| %>
  <div class="field">
    <%= form.label :title %>
    <%= form.text_field :title, placeholder: true %>
  </div>

  <div class="field">
    <%= form.label :content %>
    <%= form.rich_text_area :content, placeholder: true %>
  </div>
<% end %>
```

#### Expected: 
`text_field` translate placeholder value and sets it to `Set a title for your message`. similarly, for `rich_text_area` should have translated placeholder.
