### PR TITLE
Fix `pluck` and `select` with `from` if `from` has original table name

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1068,8 +1068,10 @@ module ActiveRecord
 
       def arel_column(field)
         field = klass.attribute_alias(field) if klass.attribute_alias?(field)
+        from = from_clause.name || from_clause.value
 
-        if klass.columns_hash.key?(field) && !from_clause.value
+        if klass.columns_hash.key?(field) &&
+            (!from || from == table.name || from == connection.quote_table_name(table.name))
           arel_attribute(field)
         else
           yield

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -182,6 +182,42 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_select_with_original_table_name_in_from
+    relation = Comment.joins(:post).select(:id).order(:id)
+    subquery = Comment.from(Comment.table_name).joins(:post).select(:id).order(:id)
+    assert_equal relation.map(&:id), subquery.map(&:id)
+  end
+
+  def test_pluck_with_original_table_name_in_from
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from(Comment.table_name).joins(:post).order(:id)
+    assert_equal relation.pluck(:id), subquery.pluck(:id)
+  end
+
+  def test_select_with_quoted_original_table_name_in_from
+    relation = Comment.joins(:post).select(:id).order(:id)
+    subquery = Comment.from(Comment.quoted_table_name).joins(:post).select(:id).order(:id)
+    assert_equal relation.map(&:id), subquery.map(&:id)
+  end
+
+  def test_pluck_with_quoted_original_table_name_in_from
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from(Comment.quoted_table_name).joins(:post).order(:id)
+    assert_equal relation.pluck(:id), subquery.pluck(:id)
+  end
+
+  def test_select_with_subquery_in_from_uses_original_table_name
+    relation = Comment.joins(:post).select(:id).order(:id)
+    subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).select(:id).order(:id)
+    assert_equal relation.map(&:id), subquery.map(&:id)
+  end
+
+  def test_pluck_with_subquery_in_from_uses_original_table_name
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).order(:id)
+    assert_equal relation.pluck(:id), subquery.pluck(:id)
+  end
+
   def test_select_with_subquery_in_from_does_not_use_original_table_name
     relation = Comment.group(:type).select("COUNT(post_id) AS post_count, type")
     subquery = Comment.from(relation).select("type", "post_count")

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -207,6 +207,9 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_select_with_subquery_in_from_uses_original_table_name
+    if current_adapter?(:SQLite3Adapter) && ENV["TRAVIS"]
+      skip "https://travis-ci.org/rails/rails/jobs/496726410#L1198-L1208"
+    end
     relation = Comment.joins(:post).select(:id).order(:id)
     subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).select(:id).order(:id)
     assert_equal relation.map(&:id), subquery.map(&:id)


### PR DESCRIPTION
This is caused by 0ee96d1.

Since #18744, `select` columns doesn't be qualified by table name if
using `from`. 0ee96d1 follows that for `pluck` as well.

But people depends that `pluck` columns are qualified even if using
`from`.

So I've fixed that to be qualified if `from` has the original table name
to keep the behavior as much as before.

Fixes #35359.

cc @eileencodes 