### PR TITLE
Bumps Zeitwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ PATH
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 1.2)
+      zeitwerk (~> 1.3)
     rails (6.0.0.beta1)
       actioncable (= 6.0.0.beta1)
       actionmailbox (= 6.0.0.beta1)
@@ -517,7 +517,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (1.2.0)
+    zeitwerk (1.3.0)
 
 PLATFORMS
   java

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 1.1"
   s.add_dependency "minitest",        "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
-  s.add_dependency "zeitwerk",        "~> 1.2"
+  s.add_dependency "zeitwerk",        "~> 1.3"
 end

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -28,7 +28,7 @@ module ActiveSupport
         end
 
         def verbose=(verbose)
-          l = verbose ? (logger || Rails.logger).method(:debug) : nil
+          l = verbose ? logger || Rails.logger : nil
           Rails.autoloaders.each { |autoloader| autoloader.logger = l }
         end
 

--- a/railties/lib/rails/autoloaders.rb
+++ b/railties/lib/rails/autoloaders.rb
@@ -25,8 +25,7 @@ module Rails
       end
 
       def logger=(logger)
-        callable_or_nil = logger.respond_to?(:debug) ? logger.method(:debug) : logger
-        each { |loader| loader.logger = callable_or_nil }
+        each { |loader| loader.logger = logger }
       end
 
       def zeitwerk_enabled?

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -214,13 +214,13 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     Rails.autoloaders.logger = logger
 
     Rails.autoloaders.each do |autoloader|
-      assert_equal logger, autoloader.logger
+      assert_same logger, autoloader.logger
     end
 
     Rails.autoloaders.logger = Rails.logger
 
     Rails.autoloaders.each do |autoloader|
-      assert_equal Rails.logger.method(:debug), autoloader.logger
+      assert_same Rails.logger, autoloader.logger
     end
 
     Rails.autoloaders.logger = nil

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -164,7 +164,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_equal %i(main_autoloader), $zeitwerk_integration_reload_test
   end
 
-  test "verbose = true sets the debug method of the dependencies logger if present" do
+  test "verbose = true sets the dependencies logger if present" do
     boot
 
     logger = Logger.new(File::NULL)
@@ -172,17 +172,17 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     ActiveSupport::Dependencies.verbose = true
 
     Rails.autoloaders.each do |autoloader|
-      assert_equal logger.method(:debug), autoloader.logger
+      assert_same logger, autoloader.logger
     end
   end
 
-  test "verbose = true sets the debug method of the Rails logger as fallback" do
+  test "verbose = true sets the Rails logger as fallback" do
     boot
 
     ActiveSupport::Dependencies.verbose = true
 
     Rails.autoloaders.each do |autoloader|
-      assert_equal Rails.logger.method(:debug), autoloader.logger
+      assert_same Rails.logger, autoloader.logger
     end
   end
 


### PR DESCRIPTION
With Zeitwerk 1.3.0 we can simplify a bit logging related code.