### PR TITLE
Update description of `collection.destroy` in `has_and_belongs_to_many`

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2030,7 +2030,7 @@ The `collection.delete` method removes one or more objects from the collection b
 
 ##### `collection.destroy(object, ...)`
 
-The `collection.destroy` method removes one or more objects from the collection by deleting records in the join table. This does not destroy the objects.
+The collection.destroy method removes one or more objects from the collection by running destroy on each object.
 
 ```ruby
 @part.assemblies.destroy(@assembly1)


### PR DESCRIPTION
Fixed description when n: n relation is implemented with `has_and_belongs_to_many`.
If  execute `collection.destroy (object, ...)`, I think the object associated with `collection` will be destroyed, but what about it?

For example, it works as follows.

```
$ @part.assemblies.include?(@assembly1)
=> true
$ @part.assemblies.destroy(@assembly1)
$ @part.assemblies.include?(@assembly1)
=> false
```