### PR TITLE
Update migration version to 6.0 in the getting started doc [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -683,7 +683,7 @@ If you look in the `db/migrate/YYYYMMDDHHMMSS_create_articles.rb` file
 (remember, yours will have a slightly different name), here's what you'll find:
 
 ```ruby
-class CreateArticles < ActiveRecord::Migration[5.0]
+class CreateArticles < ActiveRecord::Migration[6.0]
   def change
     create_table :articles do |t|
       t.string :title
@@ -1555,7 +1555,7 @@ In addition to the model, Rails has also made a migration to create the
 corresponding database table:
 
 ```ruby
-class CreateComments < ActiveRecord::Migration[5.0]
+class CreateComments < ActiveRecord::Migration[6.0]
   def change
     create_table :comments do |t|
       t.string :commenter


### PR DESCRIPTION
### Summary

While looking at #35365 found that getting started doc has two migration files which had `ActiveRecord::Migration[5.0]` mentioned. Updated them to Rails 6.0

I could see we have similar migration version at other places in the documentation. I would like to update those as well. Let me know if I should go ahead and update those as well.
