### PR TITLE
Relax version constraint to allow using tzinfo-2.0

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "i18n",            ">= 0.7", "< 2"
-  s.add_dependency "tzinfo",          "~> 1.1"
+  s.add_dependency "tzinfo",          ">= 1.1", "< 3"
   s.add_dependency "minitest",        "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "zeitwerk",        "~> 1.3"


### PR DESCRIPTION
## Summary

This change is to allow using `tzinfo-2.x` in a project that also includes `activesupport`.

## Other Information

### Motivation

Currently, the *bundle* for a project that uses both `activesupport` and `tzinfo-2.0` resolves to a much older version of activesupport (`v3.2.22.5` since that version doesn't have a dependency on `tzinfo`)