### PR TITLE
Update callbacks skipping methods in guide.

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -239,13 +239,12 @@ Skipping Callbacks
 
 Just as with validations, it is also possible to skip callbacks by using the following methods:
 
-* `decrement`
+* `decrement!`
 * `decrement_counter`
 * `delete`
 * `delete_all`
-* `increment`
+* `increment!`
 * `increment_counter`
-* `toggle`
 * `update_column`
 * `update_columns`
 * `update_all`


### PR DESCRIPTION
**Summary**
This PR updates the callbacks skipping methods mentioned in the guides.

I recently came across code for `increment`,  `decrement` and `toggle` methods.
These methods are just updating the attribute, without persisting the changes in the database, and therefore, wont affect the object lifecycle.

On the other hand, methods `increment!` and `decrement!` persist the changes in the database without invoking any callbacks [The guide does not mentions them]