### PR TITLE
Ensure that rendered templates always have a format

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -28,6 +28,10 @@ module ActionView
     end
 
     class RenderedCollection # :nodoc:
+      def self.empty(format)
+        EmptyCollection.new format
+      end
+
       attr_reader :rendered_templates
 
       def initialize(rendered_templates, spacer)
@@ -44,11 +48,14 @@ module ActionView
       end
 
       class EmptyCollection
-        def format; nil; end
+        attr_reader :format
+
+        def initialize(format)
+          @format = format
+        end
+
         def body; nil; end
       end
-
-      EMPTY = EmptyCollection.new
     end
 
     class RenderedTemplate # :nodoc:

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -326,7 +326,7 @@ module ActionView
       def render_collection(view, template)
         identifier = (template && template.identifier) || @path
         instrument(:collection, identifier: identifier, count: @collection.size) do |payload|
-          return RenderedCollection::EMPTY if @collection.blank?
+          return RenderedCollection.empty(@lookup_context.formats.first) if @collection.blank?
 
           spacer = if @options.key?(:spacer_template)
             spacer_template = find_template(@options[:spacer_template], @locals.keys)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -29,7 +29,12 @@ module ActionView
           @lookup_context.with_fallbacks.find_file(options[:file], nil, false, keys, @details)
         elsif options.key?(:inline)
           handler = Template.handler_for_extension(options[:type] || "erb")
-          Template.new(options[:inline], "inline template", handler, locals: keys)
+          format = if handler.respond_to?(:default_format)
+            handler.default_format
+          else
+            @lookup_context.formats.first
+          end
+          Template.new(options[:inline], "inline template", handler, locals: keys, format: format)
         elsif options.key?(:template)
           if options[:template].respond_to?(:render)
             options[:template]

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -118,8 +118,7 @@ module ActionView
           renderer.render_to_object(context, options)
         end
 
-        rendered_format = rendered_template.format || lookup_context.formats.first
-        @rendered_format = Template::Types[rendered_format]
+        @rendered_format = Template::Types[rendered_template.format]
 
         rendered_template.body
       end


### PR DESCRIPTION
This removes one call to `lookup_context` and also eliminates a
conditional in `_render_template`.
