### PR TITLE
Make `test_select_with_subquery_in_from_uses_original_table_name` work with old SQLite3

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -207,14 +207,9 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_select_with_subquery_in_from_uses_original_table_name
-    if current_adapter?(:SQLite3Adapter) && ENV["CI"]
-      skip <<~MSG
-        https://travis-ci.org/rails/rails/jobs/496726410#L1198-L1208
-        https://buildkite.com/rails/rails/builds/58981#2423c707-7c56-4639-a76e-8db4fd1e5cf3/102-111
-      MSG
-    end
     relation = Comment.joins(:post).select(:id).order(:id)
-    subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).select(:id).order(:id)
+    # Avoid subquery flattening by adding distinct to work with SQLite < 3.20.0.
+    subquery = Comment.from(Comment.all.distinct, Comment.quoted_table_name).joins(:post).select(:id).order(:id)
     assert_equal relation.map(&:id), subquery.map(&:id)
   end
 


### PR DESCRIPTION
It seems that the reason why the `test_select_with_subquery_in_from_uses_original_table_name` does not pass is that the return value of `sqlite3_column_name()` is wrong due to subquery flattening.

This seems to have been fixed with 3.20.0(https://sqlite.org/changes.html#version_3_20_0).
But CI uses the old version(maybe 3.11.0), I added `DISTINCT` to avoid optimization by subquery flattening.

Ref: https://sqlite.org/optoverview.html#flattening
