### PR TITLE
Raise error when translation missing for model and attribute names

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `config.active_model.enforce_i18n_naming` to give the option of
+    *not* using humanized model and attribute names as the default translation
+    for `model_name.human` and `human_attribute_name`. `false` by default.
+
+    *Iain Beeston*
+
 *   Fix date value when casting a multiparameter date hash to not convert
     from Gregorian date to Julian date.
 

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -200,9 +200,9 @@ module ActiveModel
       end
 
       defaults << options[:default] if options[:default]
-      defaults << @human
+      defaults << @human unless ActiveModel::Naming.enforce_i18n_naming
 
-      options = { scope: [@klass.i18n_scope, :models], count: 1, default: defaults }.merge!(options.except(:default))
+      options = { scope: [@klass.i18n_scope, :models], count: 1, default: defaults, raise: true }.merge!(options.except(:default))
       I18n.translate(defaults.shift, options)
     end
 
@@ -233,6 +233,8 @@ module ActiveModel
   # is required to pass the \Active \Model Lint test. So either extending the
   # provided method below, or rolling your own is required.
   module Naming
+    mattr_accessor :enforce_i18n_naming, default: false # :nodoc:
+
     def self.extended(base) #:nodoc:
       base.silence_redefinition_of_method :model_name
       base.delegate :model_name, to: :class

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -16,5 +16,9 @@ module ActiveModel
     initializer "active_model.i18n_full_message" do
       ActiveModel::Errors.i18n_full_message = config.active_model.delete(:i18n_full_message) || false
     end
+
+    initializer "active_model.enforce_i18n_naming" do
+      ActiveModel::Naming.enforce_i18n_naming = config.active_model.delete(:enforce_i18n_naming) || false
+    end
   end
 end

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -42,7 +42,7 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
-      options   = { count: 1 }.merge!(options)
+      options   = { count: 1, raise: true }.merge!(options)
       parts     = attribute.to_s.split(".")
       attribute = parts.pop
       namespace = parts.join("/") unless parts.empty?
@@ -61,7 +61,7 @@ module ActiveModel
 
       defaults << :"attributes.#{attribute}"
       defaults << options.delete(:default) if options[:default]
-      defaults << attribute.humanize
+      defaults << attribute.humanize unless ActiveModel::Naming.enforce_i18n_naming
 
       options[:default] = defaults
       I18n.translate(defaults.shift, options)

--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -51,4 +51,17 @@ class RailtieTest < ActiveModel::TestCase
 
     assert_equal true, ActiveModel::Errors.i18n_full_message
   end
+
+  test "enforce i18n naming defaults to false" do
+    @app.initialize!
+
+    assert_equal false, ActiveModel::Naming.enforce_i18n_naming
+  end
+
+  test "enforce i18n naming can be enabled" do
+    @app.config.active_model.enforce_i18n_naming = true
+    @app.initialize!
+
+    assert_equal true, ActiveModel::Naming.enforce_i18n_naming
+  end
 end

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -39,6 +39,18 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "Name", Person.human_attribute_name("name", default: :default_name)
   end
 
+  def test_translated_model_attributes_raises_without_translation_when_translations_enforced
+    original_enforce_i18n_naming = ActiveModel::Naming.enforce_i18n_naming
+    begin
+      ActiveModel::Naming.enforce_i18n_naming = true
+
+      error = assert_raises(I18n::MissingTranslationData) { Person.human_attribute_name("name") }
+      assert_equal "translation missing: en.activemodel.attributes.person.name", error.message
+    ensure
+      ActiveModel::Naming.enforce_i18n_naming = original_enforce_i18n_naming
+    end
+  end
+
   def test_translated_model_attributes_with_symbols
     I18n.backend.store_translations "en", activemodel: { attributes: { person: { name: "person name attribute" } } }
     assert_equal "person name attribute", Person.human_attribute_name(:name)
@@ -97,6 +109,22 @@ class ActiveModelI18nTests < ActiveModel::TestCase
   def test_translated_model_names_with_ancestors_fallback
     I18n.backend.store_translations "en", activemodel: { models: { person: "person model" } }
     assert_equal "person model", Child.model_name.human
+  end
+
+  def test_translated_model_names_falling_back_to_default
+    assert_equal "Person", Person.model_name.human
+  end
+
+  def test_translated_model_names_raises_without_translation_when_translations_enforced
+    original_enforce_i18n_naming = ActiveModel::Naming.enforce_i18n_naming
+    begin
+      ActiveModel::Naming.enforce_i18n_naming = true
+
+      error = assert_raises(I18n::MissingTranslationData) { Person.model_name.human }
+      assert_equal "translation missing: en.activemodel.models.person", error.message
+    ensure
+      ActiveModel::Naming.enforce_i18n_naming = original_enforce_i18n_naming
+    end
   end
 
   def test_human_does_not_modify_options

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -306,6 +306,8 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.active_model.i18n_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files. This is `false` by default.
 
+* `config.active_model.enforce_i18n_naming` prevents rails from using the model and attribute names from your code as the default translation when calling `model_name.human` and `humanized_attribute_name`, and instead will warn you of the missing translation. It is `false` by default.
+
 ### Configuring Active Record
 
 `config.active_record` includes a variety of configuration options:

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -896,6 +896,13 @@ en:
 
 Then `User.human_attribute_name("role.admin")` will return "Admin".
 
+If a translation has not been set, the model name or attribute name will be the humanized form of the name you have used in your code (for example an attribute named `employee_salary` would default to "Employee salary"). If you would prefer to be warned of missing names (in the same way as other missing i18n translations), you can set the `active_model.enforce_i18n_naming` option in your configuration:
+
+```ruby
+  # config/application.rb
+  config.active_model.enforce_i18n_naming = true
+```
+
 NOTE: If you are using a class which includes `ActiveModel` and does not inherit from `ActiveRecord::Base`, replace `activerecord` with `activemodel` in the above key paths.
 
 #### Error Message Scopes


### PR DESCRIPTION
### Summary

Currently in ActiveModel, if you call `MyModel.model_name.human` or `MyModel.human_attribute_name(:my_attribute)` and you have _not_ defined a translation, the humanized form of the class name or attribute name is used (in those examples that would be "My model" and "My attribute" respectively). That's helpful when you're getting started, but if you have a multilingual app you might prefer a translation error to be raised instead (an error is never raised right now because the humanized form is always provided as a default, in case there is no translation).

To make missing translations easier to find, I've added a new config option that disables the humanized defaults, that way if a translation cannot be found, an error is raised just like it would be elsewhere in rails (for example in a view). By default the option is off and out of the box the behaviour hasn't changed. If you enable this, you must explicitly specify a translation for each model name and attribute if you wish to use `model_name.human` or `human_attribute_name` on it.