### PR TITLE
Make Zeitwerk use the ActiveSupport inflector so it matches exceptional inflections

### DIFF
--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -59,7 +59,10 @@ module ActiveSupport
               end
             end
 
-            Rails.autoloaders.each(&:setup)
+            Rails.autoloaders.each do |loader|
+              loader.inflector = ActiveSupport::Inflector
+              loader.setup
+            end
           end
 
           def autoload_once?(autoload_path)

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -54,6 +54,14 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_same Admin::User, deps.constantize("Admin::User")
   end
 
+  test "constantize uses the activesupport inflections to produce constant names" do
+    app_file "app/controllers/graphql_controller.rb", "class GraphQLController; end"
+    app_file "config/initializers/inflections.rb", "ActiveSupport::Inflector.inflections(:en) { |inflect| inflect.acronym \"GraphQL\" }"
+    boot
+
+    assert_same GraphQLController, deps.constantize("GraphQLController")
+  end
+
   test "constantize raises if the constant is unknown" do
     boot
 


### PR DESCRIPTION
### Summary

Zeitwork uses a default inflector that’s different than ActiveSupport’s to define which modules can be autoloader based on filesystem paths. If these two inflectors disagree on the filename<->constant conversion, then the modules created for autoloading can be named one thing and the actual constants defined in those files can be named something else. Because the ActiveSupport::Inflector can be customized, it’s possible for the two inflectors to disagree. In Rails 5, only the ActiveSupport::Inflector was used to constantize, so any exceptions applied to it in an initializer or whatever would apply to the autoloader as well. If we make Zeitwork use the ActiveSupport inflector, then they should agree again, and backwards compatibility should be maintained.

Zeitwork supports custom inflectors and expects it's `inflector` to have a very similar interface to ActiveSupports so I am guessing this was always intended (@fxn can probably say more), but I think the question is if this should be the default or not. I think it should because it maintains backwards compatibility with the way things worked with the classic autoloader, and it allows users one more notch of control over the "magic" constant discovery that Rails does. 
