### PR TITLE
How to use `select` is updated [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -623,6 +623,8 @@ To select only a subset of fields from the result set, you can specify the subse
 For example, to select only `viewable_by` and `locked` columns:
 
 ```ruby
+Client.select(:viewable_by, :locked)
+# OR
 Client.select("viewable_by, locked")
 ```
 


### PR DESCRIPTION
`select` can also use symbol as the field specification, so we updated the usage code.