### PR TITLE
[35364] Fix `host` lookup for `compute_asset_host`.

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -273,7 +273,7 @@ module ActionView
       # (proc or otherwise).
       def compute_asset_host(source = "", options = {})
         request = self.request if respond_to?(:request)
-        host = options[:host]
+        host = options.fetch(:host, nil) || options.fetch("host", nil)
         host ||= config.asset_host if defined? config.asset_host
 
         if host

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -153,7 +153,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" />),
     %(stylesheet_link_tag("bank", :host => "assets.example.com")) => %(<link href="http://assets.example.com/stylesheets/bank.css" media="screen" rel="stylesheet" />),
-
+    %(stylesheet_link_tag("bank", host: "assets.example.com")) => %(<link href="http://assets.example.com/stylesheets/bank.css" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" media="screen" rel="stylesheet" />),
@@ -489,6 +489,11 @@ class AssetTagHelperTest < ActionView::TestCase
     @controller.config.asset_host = "assets.example.com"
     @controller.config.default_asset_host_protocol = :relative
     assert_dom_equal %(<link href="//assets.example.com/stylesheets/wellington.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("wellington")
+  end
+
+  def test_stylesheet_link_tag_with_host_as_option
+    @controller.config.asset_host = "assets.example.com"
+    assert_dom_equal %(<link href="//external-cdn.example.com/stylesheets/wellington.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("wellington", host: "external-cdn.example.com", protocol: :relative)
   end
 
   def test_javascript_include_tag_without_request


### PR DESCRIPTION
### Summary

The `*_link_tag` methods are stringfying keys, and when passing the
`host` as a parameter it passess as `'host' => 'example.com'` and the
`compute_asset_host` expects something like `host: 'example.com'`.

### Other Information

Fixes rails/rails#35364