### PR TITLE
Adding validations for `size` and `content_type`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 
+*   Add Active Storage Validations for Size and Content Type
+
+    *Abhishek Chandrasekhar*
+
 *   [Rename npm package](https://github.com/rails/rails/pull/34905) from
     [`activestorage`](https://www.npmjs.com/package/activestorage) to
     [`@rails/activestorage`](https://www.npmjs.com/package/@rails/activestorage).

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -104,6 +104,31 @@ Variation of image attachment:
 <%= image_tag user.avatar.variant(resize_to_limit: [100, 100]) %>
 ```
 
+## Validations
+
+Active Storage supports attachment validations on the following properties:
+
+* Size
+* Content Type
+
+```ruby
+class User < ActiveRecord::Base
+  has_one_attached :avatar
+
+  # Validating Size
+  # Accepts options for: `:in`, `:minimum`, `:maximum`
+  validates :avatar, attachment_size: { in: 0..1.megabyte }
+  validates :avatar, attachment_size: 0..1.megabyte
+
+  # Validating Content Type
+  # Accepts options for: `:in`, `:not`
+  validates :avatar, attachment_content_type: { in: %w[image/jpeg image/png] }
+  validates :avatar, attachment_content_type: "image/jpeg"
+end
+```
+
+See the [rails guides](https://edgeguides.rubyonrails.org/active_storage_overview.html#validations) for more information.
+
 ## Direct uploads
 
 Active Storage, with its included JavaScript library, supports uploading directly from the client to the cloud.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -40,6 +40,7 @@ module ActiveStorage
   autoload :Service
   autoload :Previewer
   autoload :Analyzer
+  autoload :Validations
 
   mattr_accessor :logger
   mattr_accessor :verifier
@@ -62,4 +63,8 @@ module ActiveStorage
     autoload :ImageProcessingTransformer
     autoload :MiniMagickTransformer
   end
+end
+
+ActiveSupport.on_load(:i18n) do
+  I18n.load_path << File.expand_path("active_storage/locale/en.yml", __dir__)
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -81,6 +81,7 @@ module ActiveStorage
 
       ActiveSupport.on_load(:active_record) do
         include ActiveStorage::Attached::Model
+        include ActiveStorage::Validations
       end
     end
 

--- a/activestorage/lib/active_storage/locale/en.yml
+++ b/activestorage/lib/active_storage/locale/en.yml
@@ -1,0 +1,8 @@
+en:
+  errors:
+    # The values :model, :attribute ,and :value are always available for interpolation
+    # The value :count is available when applicable. Can be used for pluralization.
+    messages:
+      in_between: "must be between %{minimum} and %{maximum}"
+      minimum: "must be greater than or equal to %{minimum}"
+      maximum: "must be less than or equal to %{maximum}"

--- a/activestorage/lib/active_storage/validations.rb
+++ b/activestorage/lib/active_storage/validations.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "active_model"
+require "active_support/concern"
+require "active_support/core_ext/array/wrap"
+require "active_storage/validations/base_validator"
+require "active_storage/validations/attachment_size_validator"
+require "active_storage/validations/attachment_content_type_validator"
+
+module ActiveStorage
+  # Provides the class-level DSL for declaring ActiveStorage validations
+  module Validations
+    extend ActiveSupport::Concern
+
+    included do
+      extend  HelperMethods
+      include HelperMethods
+    end
+
+    module ClassMethods
+      # A helper method to run various Active Storage attachment validators.
+      #
+      # Effectively the same as the <tt>ActiveModel::Validations#validates</tt>
+      # method but more readable since it does not require the +attachment_+
+      # prefix for its keys.
+      #
+      #   validates_attachment :avatar, size: { in: 2..4.megabytes }
+      #   validates_attachment :avatar, content_type: { in: "image/jpeg" }
+      #
+      # Like the <tt>ActiveModel::Validations#validates</tt>, it also
+      # supports shortcut options which can handle ranges, arrays, and strings.
+      #
+      #   validates_attachment :avatar, size: 2..4.megabytes
+      #   validates_attachment :avatar, content_type: "image/jpeg"
+      #
+      # When using shortcut form, ranges and arrays are passed to the
+      # validator as if they were specified with the +:in+ option, while other
+      # types including regular expressions and strings are passed as if they
+      # were specified using +:with+.
+      def validates_attachment(*attributes)
+        options = attributes.extract_options!.dup
+
+        ActiveStorage::Validations.constants.each do |constant|
+          if constant.to_s =~ /\AAttachment(.+)Validator\z/
+            validator_kind = $1.underscore.to_sym
+
+            if options.has_key?(validator_kind)
+              validator_options = options.delete(validator_kind)
+              validator_options = parse_shortcut_options(validator_options)
+
+              conditional_options = options.slice(:if, :unless)
+
+              Array.wrap(validator_options).each do |local_options|
+                method_name = ActiveStorage::Validations.const_get(constant.to_s).helper_method_name
+                send(method_name, attributes, local_options.merge(conditional_options))
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+        def parse_shortcut_options(options)
+          _parse_validates_options(options)
+        end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/validations/attachment_content_type_validator.rb
+++ b/activestorage/lib/active_storage/validations/attachment_content_type_validator.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class AttachmentContentTypeValidator < BaseValidator
+      AVAILABLE_CHECKS = %i[in not]
+
+      def self.helper_method_name
+        :validates_attachment_content_type
+      end
+
+      def initialize(options = {})
+        # <tt>ActiveModel::Validations#validates</tt> allows for shortcut
+        # options. It automatically stores ranges and arrays in
+        # <tt>options[:in]</tt> and everything else in <tt>options[:with]</tt>.
+        # Since content type validation allows specifying a single content
+        # type as a string it needs to be manually captured here.
+        options[:in] ||= options[:with] if options[:with].is_a?(String)
+
+        super
+      end
+
+      def validate_each(record, attribute, value)
+        @record = record
+        @name = attribute
+
+        error_key_for_check_name = { in: :inclusion, not: :exclusion }
+
+        each_blob do |blob|
+          each_check do |check_name, check_value|
+            next if passes_check?(blob, check_name, check_value)
+
+            error_key = error_key_for_check_name[check_name.to_sym]
+            record.errors.add(@name, error_key, error_options)
+          end
+        end
+      end
+
+      def check_validity!
+        if options_blank?
+          raise(
+            ArgumentError,
+            "You must pass either :in or :not to the validator"
+          )
+        end
+
+        if options_redundant?
+          raise(ArgumentError, "Cannot pass both :in and :not")
+        end
+      end
+
+      private
+
+        def options_redundant?
+          options.has_key?(:in) && options.has_key?(:not)
+        end
+
+        def passes_check?(blob, check_name, check_value)
+          case check_name.to_sym
+          when :in
+            check_value.include?(blob.content_type)
+          when :not
+            !check_value.include?(blob.content_type)
+          end
+        end
+    end
+
+    module HelperMethods
+      # Validates the content type of the ActiveStorage attachments. Happens by
+      # default on save.
+      #
+      #   class Employee < ActiveRecord::Base
+      #     has_one_attached :avatar
+      #
+      #     validates_attachment_content_type :avatar, in: %w[image/jpeg audio/ogg]
+      #     validates_attachment_content_type :avatar, in: "image/jpeg"
+      #   end
+      #
+      # Configuration options:
+      # * <tt>in</tt> - a +Array+ or +String+ of allowable content types
+      # * <tt>not</tt> - a +Array+ or +String+ of content types to exclude
+      # * <tt>:message</tt> - A custom error message which overrides the
+      #   default error message.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_attachment_content_type(*attributes)
+        validates_with AttachmentContentTypeValidator, _merge_attributes(attributes)
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/validations/attachment_size_validator.rb
+++ b/activestorage/lib/active_storage/validations/attachment_size_validator.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class AttachmentSizeValidator < BaseValidator
+      AVAILABLE_CHECKS = %i[minimum maximum in]
+
+      def self.helper_method_name
+        :validates_attachment_size
+      end
+
+      def initialize(options = {})
+        super
+        error_options.merge!(
+          minimum: to_human_size(minimum),
+          maximum: to_human_size(maximum)
+        )
+      end
+
+      def validate_each(record, attribute, value)
+        @record = record
+        @name = attribute
+
+        each_blob do |blob|
+          each_check do |check_name, check_value|
+            next if passes_check?(blob, check_name, check_value)
+
+            error_key = check_name == :in ? :in_between : check_name
+            record.errors.add(@name, error_key, error_options)
+          end
+        end
+      end
+
+      def check_validity!
+        if options_blank?
+          raise(
+            ArgumentError,
+            "You must pass either :minimum, :maximum, or :in to the validator"
+          )
+        end
+
+        if options_redundant?
+          raise(
+            ArgumentError,
+            "Cannot pass :minimum or :maximum if already passing :in"
+          )
+        end
+      end
+
+      private
+
+        def options_redundant?
+          options.has_key?(:in) &&
+            (options.has_key?(:minimum) || options.has_key?(:minimum))
+        end
+
+        def minimum
+          @minimum ||= options[:minimum] || options[:in].try(:min) || 0
+        end
+
+        def maximum
+          @maximum ||= options[:maximum] || options[:in].try(:max) || Float::INFINITY
+        end
+
+        def to_human_size(size)
+          return "∞" if size == Float::INFINITY
+          ActiveSupport::NumberHelper.number_to_human_size(size)
+        end
+
+        def passes_check?(blob, check_name, check_value)
+          case check_name.to_sym
+          when :in
+            check_value.include?(blob.byte_size)
+          when :minimum
+            blob.byte_size >= check_value
+          when :maximum
+            blob.byte_size <= check_value
+          end
+      end
+    end
+
+    module HelperMethods
+      # Validates the size (in bytes) of the ActiveStorage attachments. Happens
+      # by default on save.
+      #
+      #   class Employee < ActiveRecord::Base
+      #     has_one_attached :avatar
+      #
+      #     validates_attachment_size :avatar, in: 0..2.megabytes
+      #   end
+      #
+      # Configuration options:
+      # * <tt>in</tt> - a +Range+ of bytes (e.g. +0..1.megabyte+),
+      # * <tt>maximum</tt> - equivalent to +in: 0..options[:maximum]+
+      # * <tt>minimum</tt> - equivalent to +in: options[:minimum]..Infinity+
+      # * <tt>:message</tt> - A custom error message which overrides the
+      #   default error message. The following keys are available for
+      #   interpolation within the message: +model+, +attribute+, +value+,
+      #   +minimum+, and +maximum+.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_attachment_size(*attributes)
+        validates_with AttachmentSizeValidator, _merge_attributes(attributes)
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/validations/base_validator.rb
+++ b/activestorage/lib/active_storage/validations/base_validator.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Validations
+    class BaseValidator < ActiveModel::EachValidator
+      def initialize(options = {})
+        super
+        @error_options = { message: options[:message] }
+      end
+
+      private
+        attr_reader :error_options
+
+        def available_checks
+          self.class::AVAILABLE_CHECKS
+        end
+
+        def options_blank?
+          available_checks.none? { |arg| options.has_key?(arg) }
+        end
+
+        def options_redundant?
+          raise NotImplementedError, "Subclasses must implement an options_redundant? method"
+        end
+
+        def each_blob(&block)
+          changes = attachment_changes
+
+          blobs =
+            case
+            when marked_for_creation? then changes.try(:blob) || changes.blobs
+            when marked_for_deletion? then []
+            else
+              @record.send(blob_association)
+            end
+
+          blobs = [blobs].flatten.compact
+          blobs.each { |blob| yield(blob) }
+        end
+
+        def each_check(&block)
+          options.slice(*available_checks).each do |name, value|
+            yield(name, value)
+          end
+        end
+
+        def passes_check?(blob, check_name, check_value)
+          raise NotImplementedError, "Subclasses must implement a passes_check?(blob, check_name, check_value) method"
+        end
+
+        def attachment_changes
+          @attachment_changes ||= @record.attachment_changes[@name.to_s]
+        end
+
+        def marked_for_creation?
+          [
+            ActiveStorage::Attached::Changes::CreateOne,
+            ActiveStorage::Attached::Changes::CreateMany
+          ].include?(attachment_changes.class)
+        end
+
+        def marked_for_deletion?
+          [
+            ActiveStorage::Attached::Changes::DeleteOne,
+            ActiveStorage::Attached::Changes::DeleteMany
+          ].include?(attachment_changes.class)
+        end
+
+        def blob_association
+          @record.respond_to?("#{@name}_blob") ? "#{@name}_blob" : "#{@name}_blobs"
+        end
+    end
+  end
+end

--- a/activestorage/test/models/validations/attachment_content_type_validator_test.rb
+++ b/activestorage/test/models/validations/attachment_content_type_validator_test.rb
@@ -1,0 +1,423 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::AttachmentContentTypeValidatorTest < ActiveSupport::TestCase
+  VALIDATOR = ActiveStorage::Validations::AttachmentContentTypeValidator
+
+  setup do
+    @old_validators = User._validators.deep_dup
+    @old_callbacks = User._validate_callbacks.deep_dup
+
+    @blob = create_blob(filename: "funky.jpg")
+    @user = User.create(name: "Anjali")
+
+    @content_types = %w[text/plain image/jpeg]
+    @bad_content_types = %w[audio/ogg application/pdf]
+  end
+
+  teardown do
+    User.destroy_all
+    ActiveStorage::Blob.all.each(&:purge)
+
+    User.clear_validators!
+    # NOTE: `clear_validators!` clears both registered validators and any
+    # callbacks registered by `validate()`, so ensure that both are restored
+    User._validators = @old_validators if @old_validators
+    User._validate_callbacks = @old_callbacks if @old_callbacks
+  end
+
+  test "record has no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    assert @user.save
+  end
+
+  test "new record, creating attachments" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    @user = User.new(name: "Rohini")
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    assert @user.save
+  end
+
+  test "persisted record, creating attachments" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    assert @user.save
+  end
+
+  test "persisted record, updating attachments" do
+    old_blob = create_blob(filename: "town.jpg")
+    @user.avatar.attach(old_blob)
+    @user.highlights.attach(old_blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    assert @user.save
+  end
+
+  test "persisted record, updating some other field" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    @user.name = "Rohini"
+
+    assert @user.save
+  end
+
+  test "persisted record, destroying attachments" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    @user.avatar.detach
+    @user.highlights.detach
+
+    assert @user.save
+  end
+
+  test "destroying record with attachments" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types)
+
+    @user.avatar.detach
+    @user.highlights.detach
+
+    assert @user.destroy
+    assert_not @user.persisted?
+  end
+
+  test "new record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    @user = User.new(name: "Rohini")
+
+    assert @user.save
+  end
+
+  test "persisted record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    assert @user.save
+  end
+
+  test "destroying record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types)
+
+    assert @user.destroy
+    assert_not @user.persisted?
+  end
+
+  test "specifying :in option as String" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types.first)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types.first)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types.first)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @content_types.first)
+
+    assert @user.save
+  end
+
+  test "specifying :not option" do
+    User.validates_with(VALIDATOR, attributes: :avatar, not: @content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, not: @content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is reserved"], @user.errors.messages[:avatar]
+    assert_equal ["is reserved"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, not: @bad_content_types)
+    User.validates_with(VALIDATOR, attributes: :highlights, not: @bad_content_types)
+
+    assert @user.save
+  end
+
+  test "specifying :not option as a String" do
+    User.validates_with(VALIDATOR, attributes: :avatar, not: @content_types.first)
+    User.validates_with(VALIDATOR, attributes: :highlights, not: @content_types.first)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is reserved"], @user.errors.messages[:avatar]
+    assert_equal ["is reserved"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, not: @bad_content_types.first)
+    User.validates_with(VALIDATOR, attributes: :highlights, not: @bad_content_types.first)
+
+    assert @user.save
+  end
+
+  test "specifying no options" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_with(VALIDATOR, attributes: :avatar)
+    end
+
+    assert_equal(
+      "You must pass either :in or :not to the validator",
+      exception.message
+    )
+  end
+
+  test "specifying redundant options" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_with(VALIDATOR, attributes: :avatar, in: @content_types, not: @bad_content_types)
+    end
+
+    assert_equal("Cannot pass both :in and :not", exception.message)
+  end
+
+  test "validating with `validates()`" do
+    User.validates(:avatar, attachment_content_type: { in: @bad_content_types })
+    User.validates(:highlights, attachment_content_type: { in: @bad_content_types })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates(:avatar, attachment_content_type: { in: @content_types })
+    User.validates(:highlights, attachment_content_type: { in: @content_types })
+
+    assert @user.save
+  end
+
+  test "validating with `validates()`, String shortcut option" do
+    User.validates(:avatar, attachment_content_type: @bad_content_types.first)
+    User.validates(:highlights, attachment_content_type: @bad_content_types.first)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates(:avatar, attachment_content_type: @content_types.first)
+    User.validates(:highlights, attachment_content_type: @content_types.first)
+
+    assert @user.save
+  end
+
+  test "validating with `validates()`, Array shortcut option" do
+    User.validates(:avatar, attachment_content_type: @bad_content_types)
+    User.validates(:highlights, attachment_content_type: @bad_content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates(:avatar, attachment_content_type: @content_types)
+    User.validates(:highlights, attachment_content_type: @content_types)
+
+    assert @user.save
+  end
+
+  test "validating with `validates()`, invalid shortcut option" do
+    exception = assert_raise(ArgumentError) do
+      User.validates(:avatar, attachment_content_type: :foo)
+    end
+
+    assert_equal(
+      "You must pass either :in or :not to the validator",
+      exception.message
+    )
+  end
+
+  test "validating with `validates_attachment()`" do
+    User.validates_attachment(:avatar, content_type: { in: @bad_content_types })
+    User.validates_attachment(:highlights, content_type: { in: @bad_content_types })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment(:avatar, content_type: { in: @content_types })
+    User.validates_attachment(:highlights, content_type: { in: @content_types })
+
+    assert @user.save
+  end
+
+  test "validating with `validates_attachment()`, String shortcut option" do
+    User.validates_attachment(:avatar, content_type: @bad_content_types.first)
+    User.validates_attachment(:highlights, content_type: @bad_content_types.first)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment(:avatar, content_type: @content_types.first)
+    User.validates_attachment(:highlights, content_type: @content_types.first)
+
+    assert @user.save
+  end
+
+  test "validating with `validates_attachment()`, Array shortcut option" do
+    User.validates_attachment(:avatar, content_type: @bad_content_types)
+    User.validates_attachment(:highlights, content_type: @bad_content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment(:avatar, content_type: @content_types)
+    User.validates_attachment(:highlights, content_type: @content_types)
+
+    assert @user.save
+  end
+
+  test "validating with `validates_attachment()`, invalid shortcut option" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_attachment(:highlights, content_type: :foo)
+    end
+
+    assert_equal(
+      "You must pass either :in or :not to the validator",
+      exception.message
+    )
+  end
+
+  test "validating with `validates_attachment_content_type()`" do
+    User.validates_attachment_content_type(:avatar, in: @bad_content_types)
+    User.validates_attachment_content_type(:highlights, in: @bad_content_types)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["is not included in the list"], @user.errors.messages[:avatar]
+    assert_equal ["is not included in the list"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment_content_type(:avatar, in: @content_types)
+    User.validates_attachment_content_type(:highlights, in: @content_types)
+
+    assert @user.save
+  end
+
+  test "specifying a :message option" do
+    message = "Content Type not valid for %{model}#%{attribute}"
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types, message: message)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types, message: message)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal(
+      ["Content Type not valid for User#Avatar"],
+      @user.errors.messages[:avatar]
+    )
+    assert_equal(
+      ["Content Type not valid for User#Highlights"],
+      @user.errors.messages[:highlights]
+    )
+  end
+
+  test "inheritance of default ActiveModel options" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_content_types, if: Proc.new { false })
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_content_types, if: Proc.new { false })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert @user.save
+  end
+end

--- a/activestorage/test/models/validations/attachment_size_validator_test.rb
+++ b/activestorage/test/models/validations/attachment_size_validator_test.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::AttachmentSizeValidatorTest < ActiveSupport::TestCase
+  VALIDATOR = ActiveStorage::Validations::AttachmentSizeValidator
+
+  setup do
+    @old_validators = User._validators.deep_dup
+    @old_callbacks = User._validate_callbacks.deep_dup
+
+    @blob = create_blob(filename: "funky.jpg")
+    @user = User.create(name: "Anjali")
+
+    @byte_size = @blob.byte_size
+
+    @minimum = @byte_size - 1
+    @maximum = @byte_size + 1
+    @range = @minimum..@maximum
+
+    @bad_minimum = 50.gigabytes
+    @bad_maximum = 1.byte
+    @bad_range = 50.gigabytes..51.gigabytes
+  end
+
+  teardown do
+    User.destroy_all
+    ActiveStorage::Blob.all.each(&:purge)
+
+    User.clear_validators!
+    # NOTE: `clear_validators!` clears both registered validators and any
+    # callbacks registered by `validate()`, so ensure that both are restored
+    User._validators = @old_validators if @old_validators
+    User._validate_callbacks = @old_callbacks if @old_callbacks
+  end
+
+  test "record has no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    assert @user.save
+  end
+
+  test "new record, creating attachments" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    @user = User.new(name: "Rohini")
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    assert @user.save
+  end
+
+  test "persisted record, creating attachments" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    assert @user.save
+  end
+
+  test "persisted record, updating attachments" do
+    other_blob = create_blob(filename: "town.jpg")
+    @user.avatar.attach(other_blob)
+    @user.highlights.attach(other_blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    assert @user.save
+  end
+
+  test "persisted record, updating some other field" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    @user.name = "Rohini"
+
+    assert @user.save
+  end
+
+  test "persisted record, destroying attachments" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    @user.avatar.detach
+    @user.highlights.detach
+
+    assert @user.save
+  end
+
+  test "destroying record with attachments" do
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @range)
+
+    @user.avatar.detach
+    @user.highlights.detach
+
+    assert @user.destroy
+    assert_not @user.persisted?
+  end
+
+  test "new record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    @user = User.new(name: "Rohini")
+
+    assert @user.save
+  end
+
+  test "persisted record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    assert @user.save
+  end
+
+  test "destroying record, with no attachment" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range)
+
+    assert @user.destroy
+    assert_not @user.persisted?
+  end
+
+  test "specifying :minimum option" do
+    User.validates_with(VALIDATOR, attributes: :avatar, minimum: @bad_minimum)
+    User.validates_with(VALIDATOR, attributes: :highlights, minimum: @bad_minimum)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be greater than or equal to 50 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be greater than or equal to 50 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, minimum: @minimum)
+    User.validates_with(VALIDATOR, attributes: :highlights, minimum: @minimum)
+
+    assert @user.save
+  end
+
+  test "specifying :maximum option" do
+    User.validates_with(VALIDATOR, attributes: :avatar, maximum: @bad_maximum)
+    User.validates_with(VALIDATOR, attributes: :highlights, maximum: @bad_maximum)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be less than or equal to 1 Byte"], @user.errors.messages[:avatar]
+    assert_equal ["must be less than or equal to 1 Byte"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, maximum: @maximum)
+    User.validates_with(VALIDATOR, attributes: :highlights, maximum: @maximum)
+
+    assert @user.save
+  end
+
+  test "specifying both :minimum and :maximum options" do
+    User.validates_with(VALIDATOR, attributes: :avatar, minimum: @bad_minimum, maximum: @bad_maximum)
+    User.validates_with(VALIDATOR, attributes: :highlights, minimum: @bad_minimum, maximum: @bad_maximum)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    errors = ["must be greater than or equal to 50 GB",
+      "must be less than or equal to 1 Byte"]
+    assert_equal errors, @user.errors.messages[:avatar]
+    assert_equal errors, @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_with(VALIDATOR, attributes: :avatar, minimum: @minimum, maximum: @maximum)
+    User.validates_with(VALIDATOR, attributes: :highlights, minimum: @minimum, maximum: @maximum)
+
+    assert @user.save
+  end
+
+  test "specifying no options" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_with(VALIDATOR, attributes: :avatar)
+    end
+
+    assert_equal(
+      "You must pass either :minimum, :maximum, or :in to the validator",
+      exception.message
+    )
+  end
+
+  test "specifying redundant options" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_with(VALIDATOR, attributes: :avatar, in: @range, minimum: @minimum)
+    end
+
+    assert_equal(
+      "Cannot pass :minimum or :maximum if already passing :in",
+      exception.message
+    )
+  end
+
+  test "validating with `validates()`" do
+    User.validates(:avatar, attachment_size: { in: @bad_range })
+    User.validates(:highlights, attachment_size: { in: @bad_range })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates(:avatar, attachment_size: { in: @range })
+    User.validates(:highlights, attachment_size: { in: @range })
+
+    assert @user.save
+  end
+
+  test "validating with `validates()`, Range shortcut option" do
+    User.validates(:avatar, attachment_size: @bad_range)
+    User.validates(:highlights, attachment_size: @bad_range)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates(:avatar, attachment_size: @range)
+    User.validates(:highlights, attachment_size: @range)
+
+    assert @user.save
+  end
+
+  test "validating with `validates()`, invalid shortcut option" do
+    exception = assert_raise(ArgumentError) do
+      User.validates(:avatar, attachment_size: "foo")
+    end
+
+    assert_equal(
+      "You must pass either :minimum, :maximum, or :in to the validator",
+      exception.message
+    )
+  end
+
+  test "validating with `validates_attachment()`" do
+    User.validates_attachment(:avatar, size: { in: @bad_range })
+    User.validates_attachment(:highlights, size: { in: @bad_range })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment(:avatar, size: { in: @range })
+    User.validates_attachment(:highlights, size: { in: @range })
+
+    assert @user.save
+  end
+
+  test "validating with `validates_attachment()`, Range shortcut option" do
+    User.validates_attachment(:avatar, size: @bad_range)
+    User.validates_attachment(:highlights, size: @bad_range)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment(:avatar, size: @range)
+    User.validates_attachment(:highlights, size: @range)
+
+    assert @user.save
+  end
+
+  test "validating with `validates_attachment()`, invalid shortcut option" do
+    exception = assert_raise(ArgumentError) do
+      User.validates_attachment(:avatar, size: "foo")
+    end
+
+    assert_equal(
+      "You must pass either :minimum, :maximum, or :in to the validator",
+      exception.message
+    )
+  end
+
+  test "validating with `validates_attachment_size()`" do
+    User.validates_attachment_size(:avatar, in: @bad_range)
+    User.validates_attachment_size(:highlights, in: @bad_range)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:avatar]
+    assert_equal ["must be between 50 GB and 51 GB"], @user.errors.messages[:highlights]
+
+    User.clear_validators!
+
+    User.validates_attachment_size(:avatar, in: @range)
+    User.validates_attachment_size(:highlights, in: @range)
+
+    assert @user.save
+  end
+
+  test "specifying a :message option" do
+    message = "Validating %{model}#%{attribute}. The min is %{minimum} and "\
+      "the max is %{maximum}"
+
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range, message: message)
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range, message: message)
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert_not @user.valid?
+    assert_equal(
+      ["Validating User#Avatar. The min is 50 GB and the max is 51 GB"],
+      @user.errors.messages[:avatar]
+    )
+    assert_equal(
+      ["Validating User#Highlights. The min is 50 GB and the max is 51 GB"],
+      @user.errors.messages[:highlights]
+    )
+  end
+
+  test "inheritance of default ActiveModel options" do
+    User.validates_with(VALIDATOR, attributes: :avatar, in: @bad_range, if: Proc.new { false })
+    User.validates_with(VALIDATOR, attributes: :highlights, in: @bad_range, if: Proc.new { false })
+
+    @user.avatar.attach(@blob)
+    @user.highlights.attach(@blob)
+
+    assert @user.save
+  end
+end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -9,6 +9,7 @@ After reading this guide, you will know:
 
 * How to attach one or many files to a record.
 * How to delete an attached file.
+* How to validate an attached file.
 * How to link to an attached file.
 * How to use variants to transform images.
 * How to generate an image representation of a non-image file, such as a PDF or a video.
@@ -366,6 +367,56 @@ user.avatar.purge
 user.avatar.purge_later
 ```
 
+Validating Files
+----------------
+
+Active Storage supports attachment validations on the following properties:
+
+* Size
+* Content Type
+
+### Size
+
+Validates the size (in bytes) of the attached `Blob` object:
+
+    ```ruby
+    validates :avatar, attachment_size: { in: 0..1.megabyte }
+    validates :avatar, attachment_size: { minimum: 17.kilobytes }
+    validates :avatar, attachment_size: { maximum: 38.megabytes }
+    ```
+
+Also accepts a `Range` as a shortcut option for `:in`:
+
+    ```ruby
+    validates :avatar, attachment_size: 0..1.megabyte
+    ```
+
+### Content Type
+
+Validates the content type of the attached `Blob` object:
+
+    ```ruby
+    validates :avatar, attachment_content_type: { in: %w[image/jpeg image/png] }
+    validates :avatar, attachment_content_type: { not: %w[application/pdf] }
+    ```
+
+Also accepts a `Array` or `String` as a shortcut option for `:in`:
+
+    ```ruby
+    validates :avatar, attachment_content_type: %w[image/jpeg image/png]
+    validates :avatar, attachment_content_type: "image/jpeg"
+    ```
+
+### Validation Helper
+
+Active Storage also provides a more readable validation helper named
+`validates_attachment()` which provides the same functionality as `validates()`
+but does not require the `attachment_` prefix on keys:
+
+    ```ruby
+    validates_attachment :avatar, size: { in: 0..1.megabyte }, content_type: "image/jpeg"
+    ```
+
 Linking to Files
 ----------------
 
@@ -467,7 +518,6 @@ video and muPDF for PDFs, and on macOS also XQuartz and Poppler.
 These libraries are not provided by Rails. You must install them yourself to
 use the built-in previewers. Before you install and use third-party software,
 make sure you understand the licensing implications of doing so.
-
 
 Direct Uploads
 --------------


### PR DESCRIPTION
# Background

Adds ActiveModel validations for Size and Content Type to Active Storage attachments. 

This feature was [discussed here](https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/bO09MczO-nA) on the rails-core mailing list in late 2018. 

The above discussion also mentions why it is difficult to validate `Presence` on Active Storage attachments. A separate change can/will be filed after that discussion reaches a resolution. 

# Scope

- [x] Adds Active Storage validations on Size
- [x] Adds Active Storage validations on Content Type
- [x] Adds validation helper: `validates_attachment()`
- [x] Minor fix when loading the `_blob` association (more information inline)
- [x] Tests
- [x] Updating Active Storage `README`
- [x] Updating Rails Edge Guides
- [x] Updating `CHANGELOG`

### Validating Size

Adds validators to validate the size (in bytes) of the attached `Blob` object:

```ruby
validates :avatar, attachment_size: { in: 0..1.megabyte }
validates :avatar, attachment_size: { minimum: 1.kilobyte }
validates :avatar, attachment_size: { maximum: 12.megabytes }
```

Also accepts a `Range` as a shortcut option for `:in`:

```ruby
validates :avatar, attachment_size: 0..1.megabyte
```

### Validating Content Type

Validates the content type of the attached `Blob` object:

```ruby
validates :avatar, attachment_content_type: { in: %w[image/jpeg image/png] }
validates :avatar, attachment_content_type: { not: %w[application/pdf] }
```

Also accepts a `Array` or `String` as a shortcut option for `:in`:

```ruby
validates :avatar, attachment_content_type: %w[image/jpeg image/png]
validates :avatar, attachment_content_type: "image/jpeg"
```

### Validation Helper

Provides a more readable validation helper named `validates_attachment()` which provides the same functionality as `validates()` but does not require the `attachment_` prefix on keys:

```ruby
validates_attachment :avatar, size: { in: 0..1.megabyte }, content_type: "image/jpeg"
```

The inspiration here came from Thoughtbot's Paperclip library which [implements similar functionality](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/validators.rb#L35). 

# Thanks

- @igorkasyanchuk - For creating the [`active_storage_validations`](https://github.com/igorkasyanchuk/active_storage_validations) library that laid the groundwork for this change
- Everyone who worked on validations for [Paperclip Attachments](https://github.com/thoughtbot/paperclip/tree/master/lib/paperclip/validators), which served as inspiration.

