### PR TITLE
ActionMailer - wait until after initialization before using config

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -46,7 +46,7 @@ module Rails
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
-          paths.add "app/mailers",         eager_load: true
+          paths.add "app/mailers"
           paths.add "app/views"
 
           paths.add "lib",                 load_path: true

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -46,7 +46,7 @@ module Rails
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
-          paths.add "app/mailers"
+          paths.add "app/mailers",         glob: "**/*.rb"
           paths.add "app/views"
 
           paths.add "lib",                 load_path: true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -290,10 +290,13 @@ module ApplicationTests
 
       app "development"
 
-      assert_nil PostsMailer.instance_variable_get(:@action_methods)
+      error = assert_raise(NameError) do
+        PostsMailer
+      end
+      assert_match(/uninitialized constant ApplicationTests::ConfigurationTest::PostsMailer/, error.message)
     end
 
-    test "eager loads mailer actions in production" do
+    test "does not eager loads mailer actions in production" do
       app_file "app/mailers/posts_mailer.rb", <<-RUBY
         class PostsMailer < ActionMailer::Base
           def noop_email;end
@@ -307,7 +310,10 @@ module ApplicationTests
 
       app "production"
 
-      assert_equal %w(noop_email).to_set, PostsMailer.instance_variable_get(:@action_methods)
+      error = assert_raise(NameError) do
+        PostsMailer
+      end
+      assert_match(/uninitialized constant ApplicationTests::ConfigurationTest::PostsMailer/, error.message)
     end
 
     test "does not eager load attribute methods in development" do


### PR DESCRIPTION
### Summary

Wait until initialization has completed before we assign `config.action_mailer` to `ActionMailer::Base`.

Eager loading of `app/mailers` must also be disabled.

### Other Information

The ActionMailer railtie looks at `config.action_mailer` and assigns these options to `ActionMailer::Base`. However, it was previously doing so as soon as soon as `ActionMailer` was loaded (`ActiveSupport.on_load(:action_mailer)`).

We now wait for initialization to complete (`ActiveSupport.on_load(:after_initialize)`) _as well_ as the `ActionMailer` being loaded.

This is an important change because `ActionMailer` (and its config) is explicitly designed to be extensible, specifically ActionMailer allows third-party gems to register additional "delivery methods".

Delivery methods can be registered with third-party Railtie by using:

```ruby
class Railtie < ::Rails::Railtie
  initializer "foo_mail.register_delivery_method" do
    ActionMailer::Base.add_delivery_method :foo, FooMailer
  end
end
```

or ideally:


```ruby
class Railtie < ::Rails::Railtie
  initializer "foo_mail.register_delivery_method" do
    ActiveSupport.on_load(:action_mailer) do
      add_delivery_method :foo, FooMailer
    end
  end
end
```

`add_delivery_method` adds support for `ActionMailer::Base.foo_settings` and `config.action_mailer.foo_settings` (https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/delivery_methods.rb#L51).

However, calling `add_delivery_method` requires `ActionMailer` to be loaded, and _prior_ to this commit, the config would already have been assigned on `ActionMailer::Base`, so there's no opportunity to do:

```ruby
config.action_mailer.foo_settings = {
    foo_auth: 'bar'
} 
```

If you were previously to put the above in your environment config, you'd get an error because when `ActionMailer` when `ActionMailer` is eager loaded in production, third-party gems haven't run their initializers so `undefined method 'foo_settings=' for ActionMailer::Base:Class` is raised (e.g. https://github.com/mailgun/mailgun-ruby/issues/104).

Instead, if you were to move your logic into `app/initializers/foo_mail.rb` e.g.

```ruby
Rails.application.configure do
  config.action_mailer.delivery_method = :foo
  config.action_mailer.foo_settings = {
      api_key: ENV['FOO_API_KEY'],
      domain: ENV['FOO_DOMAIN'],
  }
end
```

this _silently_ fails _in production_ (with eager loading enabled), because we're (without this PR) assigning the config _after_ `ActionMailer` has been loaded (and the config copied across), so although we've set the config it is never used and out of sync with `ActionMailer::Base`, which for example still returns `:smtp` for `ActionMailer::Base.delivery_method`, even though `Rails.application.config.action_mailer.delivery_method` correctly returns `:foo`.

This commit resolves the issue by ensuring we wait until all initializers have run _before_ settings up `ActionMailer::Base` with options from `action_mailer.config`.

We can now in `app/initializers/foo_mailer.rb` do:

```ruby
ActiveSupport.on_load(:action_mailer) do
  Rails.application.configure do
      config.action_mailer.delivery_method = :foo
      config.action_mailer.foo_settings = {
        api_key: ENV['FOO_API_KEY'],
        domain: ENV['FOO_DOMAIN'],
      }
  end
end
```