### PR TITLE
Allow custom cache-control header in AC::Live

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -146,7 +146,7 @@ module ActionController
 
       def write(string)
         unless @response.committed?
-          @response.set_header "Cache-Control", "no-cache"
+          @response.headers["Cache-Control"] ||= "no-cache"
           @response.delete_header "Content-Length"
         end
 

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -51,9 +51,15 @@ module ActionController
         assert_equal ["omg"], @response.body_parts
       end
 
-      def test_cache_control_is_set
+      def test_cache_control_is_set_by_default
         @response.stream.write "omg"
         assert_equal "no-cache", @response.headers["Cache-Control"]
+      end
+
+      def test_cache_control_is_set_manually
+        @response.set_header("Cache-Control", "public")
+        @response.stream.write "omg"
+        assert_equal "public", @response.headers["Cache-Control"]
       end
 
       def test_content_length_is_removed


### PR DESCRIPTION
Fixes issue https://github.com/rails/rails/issues/35312

Rails should not override Cache-Control header if one set manually