### PR TITLE
Support read queries with leading characters while preventing writes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       end
 
       def self.build_read_query_regexp(*parts) # :nodoc:
-        parts = parts.map { |part| /\A\s*#{part}/i }
+        parts = parts.map { |part| /\A[\(\s]*#{part}/i }
         Regexp.union(*parts)
       end
 

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -204,6 +204,14 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
+    @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
+
+    @conn.while_preventing_writes do
+      assert_equal 1, @conn.execute("(\n( SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594' ) )").entries.count
+    end
+  end
+
   private
 
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -432,6 +432,16 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
+        with_example_table do
+          @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          @connection.while_preventing_writes do
+            assert_equal 1, @connection.execute("(\n( SELECT * FROM ex WHERE data = '138853948594' ) )").entries.count
+          end
+        end
+      end
+
       private
 
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -625,6 +625,16 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          @conn.while_preventing_writes do
+            assert_equal 1, @conn.execute("  SELECT data from ex WHERE data = '138853948594'").count
+          end
+        end
+      end
+
       private
 
         def assert_logged(logs)


### PR DESCRIPTION
### Summary

#34505 introduced the ability to block writes even if the database allows it. It added a `READ_QUERY` regex to help determine if a query was a read or a write. The regex is built using `ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp` and it doesn't account for reads with leading parenthesis and/or spaces.

https://github.com/rails/rails/blob/67732efcb658807929be0e968642ee1d90b3c986/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L104-L106

This would cause read queries like unions (`(SELECT ...) UNION (SELECT ...)`) to be treated as writes.

In this PR, I update the regex allow for leading parenthesis and/or spaces.
