### PR TITLE
Improve Template#inspect output

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -207,7 +207,7 @@ module ActionView
     end
 
     def inspect
-      "#<#{self.class.name} #{short_identifier}>"
+      "#<#{self.class.name} #{short_identifier} locals=#{@locals.inspect}>"
     end
 
     # This method is responsible for properly setting the encoding of the

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -202,8 +202,12 @@ module ActionView
       end
     end
 
+    def short_identifier
+      @short_identifier ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", "") : identifier
+    end
+
     def inspect
-      @inspect ||= defined?(Rails.root) ? identifier.sub("#{Rails.root}/", "") : identifier
+      "#<#{self.class.name} #{short_identifier}>"
     end
 
     # This method is responsible for properly setting the encoding of the
@@ -377,7 +381,7 @@ module ActionView
       end
 
       def identifier_method_name
-        inspect.tr("^a-z_", "_")
+        short_identifier.tr("^a-z_", "_")
       end
 
       def instrument(action, &block) # :doc:

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -215,4 +215,14 @@ class TestERBTemplate < ActiveSupport::TestCase
   ensure
     silence_warnings { Encoding.default_external = old }
   end
+
+  def test_short_identifier
+    @template = new_template("hello")
+    assert_equal "hello template", @template.short_identifier
+  end
+
+  def test_template_inspect
+    @template = new_template("hello")
+    assert_equal "#<ActionView::Template hello template locals=[]>", @template.inspect
+  end
 end


### PR DESCRIPTION
This is a quality of life improvement for those developing ActionView itself (cc @tenderlove)

This PR first renames the existing `inspect` implementation to `short_identifier`. This improves the 👀 reading of `identifier_method_name`, which used to read `inspect.tr("^a-z_", "_")`, which is a bit awkward because it relies on what `inspect` _happens_ to return. `short_identifier.tr("^a-z_", "_")` conveys what it does better (and allows us to change `inspect` 🎉 ).

Inspect used to return a string like `app/views/home/index.html.erb`, which is confusing because I would normally expect to see a type and it isn't immediately obvious that that isn't a string, particularly when in an array (ie. `[some/template, another/template]` parses to me the same as `["some/template", "another/template"]` on first glance).

This PR changes inspect to return a string like:
```
#<ActionView::FileTemplate app/views/tags/_tag.html.erb locals=["name"]>
```

Including the class name makes it look more like most `#inspect` methods. I also added `locals` to this output because it's often different for the same identifier (we need to compile each set of locals separately). It _could_ be helpful to include handler, formats, and variants, but they should be inferable by the developer from the identifier, so I didn't include them.

I'd guess the reason we override inspect here in the first place is to avoid printing out the whole source code for the template.