### PR TITLE
Template has one variant

### DIFF
--- a/actionview/lib/action_view/file_template.rb
+++ b/actionview/lib/action_view/file_template.rb
@@ -22,11 +22,11 @@ module ActionView
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.
     def marshal_dump # :nodoc:
-      [ @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variants ]
+      [ @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variant ]
     end
 
     def marshal_load(array) # :nodoc:
-      @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variants = *array
+      @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variant = *array
       @compile_mutex = Mutex.new
     end
   end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -122,10 +122,10 @@ module ActionView
 
     extend Template::Handlers
 
-    attr_accessor :locals, :variants, :virtual_path
+    attr_accessor :locals, :virtual_path
 
     attr_reader :source, :identifier, :handler, :original_encoding, :updated_at
-    attr_reader :variable, :format
+    attr_reader :variable, :format, :variant
 
     def initialize(source, identifier, handler, format: nil, variant: nil, **details)
       unless format
@@ -149,15 +149,14 @@ module ActionView
 
       @updated_at        = details[:updated_at] || Time.now
       @format            = format
-      @variants          = [variant]
+      @variant           = variant
       @compile_mutex     = Mutex.new
     end
 
-    def formats=(_)
-    end
-    deprecate :formats=
-
+    deprecate def formats=(_); end
     deprecate def formats; Array(format); end
+    deprecate def variants=(_); end
+    deprecate def variants; [variant]; end
 
     # Returns whether the underlying handler supports streaming. If so,
     # a streaming buffer *may* be passed when it starts rendering.
@@ -258,11 +257,11 @@ module ActionView
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.
     def marshal_dump # :nodoc:
-      [ @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variants ]
+      [ @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variant ]
     end
 
     def marshal_load(array) # :nodoc:
-      @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variants = *array
+      @source, @identifier, @handler, @compiled, @original_encoding, @locals, @virtual_path, @updated_at, @format, @variant = *array
       @compile_mutex = Mutex.new
     end
 

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -127,7 +127,7 @@ module ActionView
     attr_reader :source, :identifier, :handler, :original_encoding, :updated_at
     attr_reader :variable, :format
 
-    def initialize(source, identifier, handler, format: nil, **details)
+    def initialize(source, identifier, handler, format: nil, variant: nil, **details)
       unless format
         ActiveSupport::Deprecation.warn "ActionView::Template#initialize requires a format parameter"
         format = :html
@@ -149,7 +149,7 @@ module ActionView
 
       @updated_at        = details[:updated_at] || Time.now
       @format            = format
-      @variants          = [details[:variant]]
+      @variants          = [variant]
       @compile_mutex     = Mutex.new
     end
 

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -196,7 +196,6 @@ module ActionView
       cached = nil
       templates.each do |t|
         t.locals         = locals
-        t.variants       = details[:variants] || []      if t.variants.empty?
         t.virtual_path ||= (cached ||= build_path(*path_info))
       end
     end


### PR DESCRIPTION
This converts Template objects to only have one variant because they can only have one variant.  Instead of storing a single element array, just store the variant directly on the template object.

Similar to #35406