### PR TITLE
Ensure that the `_blob` association is properly loaded when attaching `::One`

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -30,6 +30,7 @@ module ActiveStorage
 
     def save
       record.public_send("#{name}_attachment=", attachment)
+      record.public_send("#{name}_blob=", blob)
     end
 
     private

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -16,6 +16,9 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
+
+    assert_not_empty @user.highlights_attachments
+    assert_equal @user.highlights_blobs.count, 2
   end
 
   test "attaching existing blobs from signed IDs to an existing record" do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -15,6 +15,9 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching an existing blob to an existing record" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
     assert_equal "funky.jpg", @user.avatar.filename.to_s
+
+    assert_not_nil @user.avatar_attachment
+    assert_not_nil @user.avatar_blob
   end
 
   test "attaching an existing blob from a signed ID to an existing record" do


### PR DESCRIPTION
# Background

I had first added these changes into a separate commit on https://github.com/rails/rails/pull/35390. 

Was encouraged by @georgeclaghorn [in this comment](https://github.com/rails/rails/pull/35390#discussion_r259695792) to open a separate PR for this change. 

# Overview

Consider a model with `One` and `Many` attachments configured:

```ruby
class User < ActiveRecord::Base
  has_one_attached :avatar
  has_many_attached :highlights
end
```

### One Attachment

After attaching `One` attachment (`:avatar`), we can see that the associated
`_blob` record (`:avatar_blob`) still returns as `nil`.

```ruby
user.avatar.attach(blob)
user.avatar_attachment.present?  => true
user.avatar_blob.present?        => false    # Incorrect!
```

This is a false negative. It happens because after the attachment and blob
are built:

  1. The record already has its `_blob` association loaded, as `nil`
  2. the `::Attachment` is associated with the record but the `::Blob` only gets
    associated with the `::Attachment`, not the record itself

In reality, the blob does in fact exist. We can verify this as follows:

```ruby
user.avatar.attach(blob)
user.avatar_attachment.blob.present?    => true  # Blob does exist!
```

The fix in this change is to simply assign the `::Blob` when assigning
the `::Attachment`. After this fix is applied, we correctly observe:

```ruby
user.avatar.attach(blob)
user.avatar_attachment.present?  => true
user.avatar_blob.present?        => true    # Woohoo!
```

### Many Attachments

We don't see this issue with `Many` attachments because the `_blob` association
is already loaded as part of attaching more/newer blobs.

```ruby
user.highlights.attach(blob)
user.highlights_attachments.any?    => true
user.highlights_blobs.any?          => true
```
