### PR TITLE
[ci skip] Renamed formats -> format in test after #35406

### DIFF
--- a/actionview/test/template/text_test.rb
+++ b/actionview/test/template/text_test.rb
@@ -3,7 +3,7 @@
 require "abstract_unit"
 
 class TextTest < ActiveSupport::TestCase
-  test "formats always return :text" do
+  test "format always return :text" do
     assert_equal :text, ActionView::Template::Text.new("").format
   end
 


### PR DESCRIPTION
In here #35406 `formats` was renamed to `format`. Updated the test description for same.

@r? @tenderlove 