### PR TITLE
Don't round microseconds when there aren't any.

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -44,7 +44,7 @@ module ActiveModel
 
           def value_is_rounding_candidate?(value)
             value.respond_to?(:usec) &&
-              (value.usec.positive? || value.respond_to?(:nsec) && (value.nsec % 1000).positive?)
+              (value.usec.positive? || value.respond_to?(:nsec) && value.nsec.positive?)
           end
 
           def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -26,7 +26,7 @@ module ActiveModel
             number_of_insignificant_digits = 6 - precision
             round_power = 10**number_of_insignificant_digits
             updated_usec = value.usec - value.usec % round_power
-            value.change(usec: updated_usec) if updated_usec != value.usec
+            return value.change(usec: updated_usec) if updated_usec != value.usec
           end
 
           value

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -22,10 +22,13 @@ module ActiveModel
         end
 
         def apply_seconds_precision(value)
-          return value unless precision && precision < 6 && value.respond_to?(:usec) && value.usec.positive?
-          number_of_insignificant_digits = 6 - precision
-          round_power = 10**number_of_insignificant_digits
-          value.change(usec: value.usec - value.usec % round_power)
+          if precision && precision < 6 && value.respond_to?(:usec) && value.usec.positive?
+            number_of_insignificant_digits = 6 - precision
+            round_power = 10**number_of_insignificant_digits
+            value.change(usec: value.usec - value.usec % round_power)
+          else
+            value
+          end
         end
 
         def type_cast_for_schema(value)

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -22,7 +22,7 @@ module ActiveModel
         end
 
         def apply_seconds_precision(value)
-          return value unless precision && value.respond_to?(:usec)
+          return value unless precision && value.respond_to?(:usec) && value.usec.positive?
           number_of_insignificant_digits = 6 - precision
           round_power = 10**number_of_insignificant_digits
           value.change(usec: value.usec - value.usec % round_power)

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -22,14 +22,14 @@ module ActiveModel
         end
 
         def apply_seconds_precision(value)
-          if precision && value.respond_to?(:usec) && value.usec.positive?
+          if precision && value_is_rounding_candidate?(value)
             number_of_insignificant_digits = 6 - precision
             round_power = 10**number_of_insignificant_digits
             updated_usec = value.usec - value.usec % round_power
-            return value.change(usec: updated_usec) if updated_usec != value.usec
+            value.change(usec: updated_usec)
+          else
+            value
           end
-
-          value
         end
 
         def type_cast_for_schema(value)
@@ -41,6 +41,11 @@ module ActiveModel
         end
 
         private
+
+          def value_is_rounding_candidate?(value)
+            value.respond_to?(:usec) &&
+              (value.usec.positive? || value.respond_to?(:nsec) && (value.nsec % 1000).positive?)
+          end
 
           def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
             # Treat 0000-00-00 00:00:00 as nil.

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -27,9 +27,9 @@ module ActiveModel
             round_power = 10**number_of_insignificant_digits
             updated_usec = value.usec - value.usec % round_power
             value.change(usec: updated_usec) if updated_usec != value.usec
-          else
-            value
           end
+
+          value
         end
 
         def type_cast_for_schema(value)

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -22,10 +22,11 @@ module ActiveModel
         end
 
         def apply_seconds_precision(value)
-          if precision && precision < 6 && value.respond_to?(:usec) && value.usec.positive?
+          if precision && value.respond_to?(:usec) && value.usec.positive?
             number_of_insignificant_digits = 6 - precision
             round_power = 10**number_of_insignificant_digits
-            value.change(usec: value.usec - value.usec % round_power)
+            updated_usec = value.usec - value.usec % round_power
+            value.change(usec: updated_usec) if updated_usec != value.usec
           else
             value
           end

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -22,7 +22,7 @@ module ActiveModel
         end
 
         def apply_seconds_precision(value)
-          return value unless precision && value.respond_to?(:usec) && value.usec.positive?
+          return value unless precision && precision < 6 && value.respond_to?(:usec) && value.usec.positive?
           number_of_insignificant_digits = 6 - precision
           round_power = 10**number_of_insignificant_digits
           value.change(usec: value.usec - value.usec % round_power)


### PR DESCRIPTION
* When dealing w/ Time instances that have no microseconds,
  skip doing any precision logic on them.

Sample benchmark results:

===================== Time - No Precision, No Milliseconds =====================

Warming up --------------------------------------
                old?    24.642k i/100ms
                new?   117.499k i/100ms
Calculating -------------------------------------
                old?    276.648k (±21.8%) i/s -      1.306M in   5.023403s
                new?      1.644M (±19.2%) i/s -      7.872M in   5.013681s

Comparison:
                new?:  1643874.2 i/s
                old?:   276647.7 i/s - 5.94x  slower

================== Time - No Precision, Includes Milliseconds ==================

Warming up --------------------------------------
                old?    23.376k i/100ms
                new?    25.212k i/100ms
Calculating -------------------------------------
                old?    285.805k (±21.3%) i/s -      1.356M in   5.022266s
                new?    301.691k (±19.3%) i/s -      1.462M in   5.075615s

Comparison:
                new?:   301690.7 i/s
                old?:   285805.1 i/s - same-ish: difference falls within error

================== Time - Include Precision, No Milliseconds ===================

Warming up --------------------------------------
                old?    26.540k i/100ms
                new?   123.456k i/100ms
Calculating -------------------------------------
                old?    292.486k (±28.0%) i/s -      1.274M in   5.048784s
                new?      1.789M (±12.7%) i/s -      8.889M in   5.065824s

Comparison:
                new?:  1788969.3 i/s
                old?:   292486.1 i/s - 6.12x  slower

=============== Time - Include Precision, Includes Milliseconds ================

Warming up --------------------------------------
                old?    20.501k i/100ms
                new?    18.281k i/100ms
Calculating -------------------------------------
                old?    207.049k (±19.8%) i/s -    984.048k in   5.025614s
                new?    211.098k (±16.9%) i/s -      1.024M in   5.031450s

Comparison:
                new?:   211098.2 i/s
                old?:   207049.5 i/s - same-ish: difference falls within error

### Summary

When doing some work in our API, which uses Sinatra + ActiveRecord, In one of our "data-heavy" API endpoints, when using rack-mini-profiler and inspecting the flamegraph, I noticed a curious number of samples spent in `ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision`, in many of them about 10% of the time for that call.

In our case, we are using MySQL 5.6.10 database, with default (0) precision datetime/timestamp columns, so for those the precision is `0`, and all of our values we are pulling out of the *database* have `0` usec values.

Given this, the code in `apply_seconds_precision` was still trying to do the calculations and update the `usec` value from.... `0` to `0`!

This one line change I'm proposing checks for this edge case in the existing guard block and adds one more condition for the early return.

### Other Information

Sample benchmark run was included in my commit message, here is the benchmark itself for posterity:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
end

require "active_model"

# Current code for ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
def apply_precision_old(precision, value)
  return value unless precision && value.respond_to?(:usec)
  number_of_insignificant_digits = 6 - precision
  round_power = 10**number_of_insignificant_digits
  value.change(usec: value.usec - value.usec % round_power)
end

# Propposed code for ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
# that checks for positive usec before doing further calculations
def apply_precision_new(precision, value)
  return value unless precision && value.respond_to?(:usec) && value.usec.positive?
  number_of_insignificant_digits = 6 - precision
  round_power = 10**number_of_insignificant_digits
  value.change(usec: value.usec - value.usec % round_power)
end

# Enumerate some representative scenarios here.
#
# It is very easy to make an optimization that improves performance for a
# specific scenario you care about but regresses on other common cases.
# Therefore, you should test your change against a list of representative
# scenarios. Ideally, they should be based on real-world scenarios extracted
# from production applications.
SCENARIOS = {
  "Time - No Precision, No Milliseconds"            => [0, Time.utc(2019,1,1,12,0,1)],
  "Time - No Precision, Includes Milliseconds"      => [0, Time.utc(2019,1,1,12,0,1,5123)],
  "Time - Include Precision, No Milliseconds"       => [6, Time.utc(2019,1,1,12,0,1)],
  "Time - Include Precision, Includes Milliseconds" => [6, Time.utc(2019,1,1,12,0,1,5123)],
}

SCENARIOS.each_pair do |name, args|
  puts
  puts " #{name} ".center(80, "=")
  puts

  precision, time = args

  Benchmark.ips do |x|
    x.report("old?") { apply_precision_old(precision, time.dup) }
    x.report("new?") { apply_precision_new(precision, time.dup) }
    x.compare!
  end
end
```

Are there other scenarios I should be benchmarking?

Thanks in advance.