### PR TITLE
Fall back to parent locale before falling back to the :errors namespace

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,27 @@
+
+*   Changed how validation error translation strings are fetched: The new behaviour
+    will first try the more specific keys, including doing locale fallback, then try
+    the less specific ones.
+    
+    For example this is the order keys will now be tried for a `blank` error on a
+    `product`'s `title` attribute with current locale set to `en-US`:
+ 
+        en-US.activerecord.errors.models.product.attributes.title.blank
+        en-US.activerecord.errors.models.product.blank
+        en-US.activerecord.errors.messages.blank
+        
+        en.activerecord.errors.models.product.attributes.title.blank
+        en.activerecord.errors.models.product.blank
+        en.activerecord.errors.messages.blank
+        
+        en-US.errors.attributes.title.blank
+        en-US.errors.messages.blank
+        
+        en.errors.attributes.title.blank
+        en.errors.messages.blank
+ 
+    *Hugo Vacher*
+
 ## Rails 6.0.0.beta2 (February 25, 2019) ##
 
 *   Fix date value when casting a multiparameter date hash to not convert

--- a/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -4,16 +4,20 @@ require "cases/helper"
 require "models/topic"
 
 class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
+  class Backend < I18n::Backend::Simple
+    include I18n::Backend::Fallbacks
+  end
+
   def setup
     Topic.clear_validators!
     @topic = Topic.new
-    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend = Backend.new
   end
 
   def reset_i18n_load_path
     @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
     I18n.load_path.clear
-    I18n.backend = I18n::Backend::Simple.new
+    I18n.backend = Backend.new
     yield
   ensure
     I18n.load_path.replace @old_load_path
@@ -81,6 +85,18 @@ class I18nGenerateMessageValidationTest < ActiveRecord::TestCase
     reset_i18n_load_path do
       I18n.backend.store_translations "en", activerecord: { errors: { models: { topic: { attributes: { title: { taken: "Custom taken message" } } } } } }
       assert_equal "Custom taken message", @topic.errors.generate_message(:title, :taken, value: "title")
+    end
+  end
+
+  test "activerecord attributes scope falls back to parent locale before it falls back to the :errors namespace" do
+    reset_i18n_load_path do
+      I18n.backend.store_translations "en", activerecord: { errors: { models: { topic: { attributes: { title: { taken: "custom en message" } } } } } }
+      I18n.backend.store_translations "en-US", errors: { messages: { taken: "generic en-US fallback" } }
+
+      I18n.with_locale "en-US" do
+        assert_equal "custom en message", @topic.errors.generate_message(:title, :taken, value: "title")
+        assert_equal "generic en-US fallback", @topic.errors.generate_message(:heading, :taken, value: "heading")
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Right now, validation messages always fall back to generic messages before falling back to another locale.

This causes users using sub-locales to sometimes see Generic error messages instead of more specific ones (if not as localized).

For example, because those generic messages are defined [inside `rails-i18n`](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-US.yml#L111-L146), for people using this gem, it is not possible to overwrite specific error message for all english locales (as an example) without adding them to all the sub locales `en-CA`, `en-US` etc..

**TLDR**: This is what the fallback order looks like for a `blank` error on a `product`'s `title` field with locale`en-US` (from top to bottom):
```
en-US.activerecord.errors.models.product.attributes.title.blank
en-US.activerecord.errors.models.product.blank
en-US.activerecord.errors.messages.blank
en-US.errors.attributes.title.blank
en-US.errors.messages.blank

en.activerecord.errors.models.product.attributes.title.blank
en.activerecord.errors.models.product.blank
en.activerecord.errors.messages.blank
en.errors.attributes.title.blank
en.errors.messages.blank
```

And this is what it looks like after this PR:

```
en-US.activerecord.errors.models.product.attributes.title.blank
en-US.activerecord.errors.models.product.blank
en-US.activerecord.errors.messages.blank

en.activerecord.errors.models.product.attributes.title.blank
en.activerecord.errors.models.product.blank
en.activerecord.errors.messages.blank

en-US.errors.attributes.title.blank
en-US.errors.messages.blank

en.errors.attributes.title.blank
en.errors.messages.blank
```

### Backward compatibility

It it possible that some users rely on the current behaviour, I can't think of a scenario where it would make sense, but it does change the current behaviour.