### PR TITLE
Fixed spaces and indentation in the deprecation warning

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -155,8 +155,8 @@ module ActionView
 
         if block_given?
           ActiveSupport::Deprecation.warn <<~eowarn
-          Calling `with_fallbacks` with a block is deprecated.  Call methods on
-          the lookup context returned by `with_fallbacks` instead.
+            Calling `with_fallbacks` with a block is deprecated. Call methods on
+            the lookup context returned by `with_fallbacks` instead.
           eowarn
 
           begin

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -45,12 +45,12 @@ module ActionView #:nodoc:
 
         unless params.find_all { |type, _| type == :req || type == :opt }.length >= 2
           ActiveSupport::Deprecation.warn <<~eowarn
-          Single arity template handlers are deprecated.  Template handlers must
-          now accept two parameters, the view object and the source for the view object.
-          Change:
-            >> #{handler.class}#call(#{params.map(&:last).join(", ")})
-          To:
-            >> #{handler.class}#call(#{params.map(&:last).join(", ")}, source)
+            Single arity template handlers are deprecated. Template handlers must
+            now accept two parameters, the view object and the source for the view object.
+            Change:
+              >> #{handler.class}#call(#{params.map(&:last).join(", ")})
+            To:
+              >> #{handler.class}#call(#{params.map(&:last).join(", ")}, source)
           eowarn
           handler = LegacyHandlerWrapper.new(handler)
         end


### PR DESCRIPTION
While looking at the comment(https://github.com/rails/rails/issues/35417#issuecomment-467826466) on issue #35417 found deprecation message had unnecessary space in it. Fixed that and was checking why `ActiveSupport::Deprecation.warn <<~eowarn` where not indented properly when found unnecessary space in another deprecation message. 

Did not add `[ci skip]` because of changes are to the code. 

Feel free to close this PR if this is a cosmetic change 