### PR TITLE
Add note about idle connection reaper to 5.2 release notes

### DIFF
--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -615,6 +615,10 @@ Please refer to the [Changelog][active-record] for detailed changes.
     the parent class was getting deleted when the child was not.
     ([Commit](https://github.com/rails/rails/commit/b0fc04aa3af338d5a90608bf37248668d59fc881))
 
+*   Idle database connections (previously just orphaned connections) are now
+    periodically reaped by the connection pool reaper.
+    ([Commit](https://github.com/rails/rails/pull/31221/commits/9027fafff6da932e6e64ddb828665f4b01fc8902))
+
 Active Model
 ------------
 


### PR DESCRIPTION
### Summary

This was a very (positively) impactful change for us with postgres + pgpool, as previously we had to be super careful not to leak connections across various areas like thread pools, puma workers, etc.

...but it's not mentioned in the changelog, so I found it by looking through source code. I think it deserves an honorable mention :)

### Other Information

(guidelines say that CHANGELOG modifications should go at the top of the file. Let me know if this should be moved to the top of the Active Record section in the 5.2 release notes)