### PR TITLE
Fixed update nested attributes for rich_text field

### DIFF
--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -30,6 +30,7 @@ module ActionText
           end
 
           def #{name}=(body)
+            super
             self.#{name}.body = body
           end
         CODE

--- a/actiontext/test/dummy/app/models/person.rb
+++ b/actiontext/test/dummy/app/models/person.rb
@@ -1,6 +1,10 @@
 class Person < ApplicationRecord
   include ActionText::Attachable
 
+  has_one :post
+
+  accepts_nested_attributes_for :post
+
   def to_trix_content_attachment_partial_path
     "people/trix_content_attachment"
   end

--- a/actiontext/test/dummy/app/models/post.rb
+++ b/actiontext/test/dummy/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  has_rich_text :content
+end

--- a/actiontext/test/dummy/db/migrate/20190227181641_create_posts.rb
+++ b/actiontext/test/dummy/db/migrate/20190227181641_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.string :content
+      t.references :person
+
+      t.timestamps
+    end
+  end
+end

--- a/actiontext/test/dummy/db/migrate/20190227193828_add_columns_to_message.rb
+++ b/actiontext/test/dummy/db/migrate/20190227193828_add_columns_to_message.rb
@@ -1,0 +1,6 @@
+class AddColumnsToMessage < ActiveRecord::Migration[6.0]
+  def change
+    add_column :messages, :content, :string
+    add_column :messages, :body, :string
+  end
+end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_03_185713) do
+ActiveRecord::Schema.define(version: 2019_02_27_193828) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -47,12 +47,23 @@ ActiveRecord::Schema.define(version: 2018_10_03_185713) do
     t.string "subject"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "content"
+    t.string "body"
   end
 
   create_table "people", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.string "content"
+    t.integer "person_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["person_id"], name: "index_posts_on_person_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -53,4 +53,22 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.body.to_plain_text
   end
+
+  test "update content" do
+    message = Message.create!(subject: "Greetings", content: "<h1>Hello world</h1>")
+    assert_equal "Hello world", message.content.to_plain_text
+
+    message.update!(content: "<h1>Yay! You’re on Rails!</h1>")
+    assert_equal "Yay! You’re on Rails!", message.content.to_plain_text
+  end
+
+  test "create/update nested attributes content" do
+    david = Person.create!(name: "David", post_attributes: { content: "<h1>Hello world</h1>" })
+    post = david.post
+
+    assert_equal "Hello world", post.content.to_plain_text
+
+    david.update!(post_attributes: { content: "<h1>Yay! You’re on Rails!</h1>", id: post.id })
+    assert_equal "Yay! You’re on Rails!", post.reload.content.to_plain_text
+  end
 end


### PR DESCRIPTION
fixes #35159 

When update using nested attributes is performed on the field which has `has_rich_text` then field value was not getting updated. 

```
class Message < ApplicationRecord
    # also occurs with `has_many`
    has_one :post

    accepts_nested_attributes_for :post
end

class Post < ApplicationRecord
    has_rich_text :content
end
```

Following test is failing on master. This PR fixes the issue.
```
test "can update post from within message" do
    message = Message.create!(title: "Seasons")
    post = message.create_post!

    # test updating post directly from the message
    message.update!(post_attributes: { content: "Test content", id: post.id })

    # it appears that everything updated?
    assert_equal "Test content", message.post.content.to_plain_text

    # let's reload the model and double check
    message.reload

    # this fails. The content is never saved.
    assert_equal "Test content", message.post.content.to_plain_text
end
```
