### PR TITLE
Enable SQL statement cache for `find` on base class as with `find_by`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -161,7 +161,7 @@ module ActiveRecord
         return super if block_given? ||
                         primary_key.nil? ||
                         scope_attributes? ||
-                        columns_hash.include?(inheritance_column)
+                        columns_hash.key?(inheritance_column) && !base_class?
 
         id = ids.first
 


### PR DESCRIPTION
Related and follows d333d85254d27cd572e6ecce8ee850c107a4f340.