### PR TITLE
Copy the forking isolated test runner from railties

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -80,9 +80,19 @@ end
 
         require "bundler/setup" unless defined?(Bundler)
 
-        # Every test file loads this first, so doing it post-fork gains
-        # us nothing.
-        require "cases/helper"
+        # Every test file loads "cases/helper" first, so doing it
+        # post-fork gains us nothing.
+
+        # We need to dance around minitest autorun, though.
+        require "minitest"
+        Minitest.instance_eval do
+          alias _original_autorun autorun
+          def autorun
+            # no-op
+          end
+          require "cases/helper"
+          alias autorun _original_autorun
+        end
 
         failing_files = []
 
@@ -114,6 +124,8 @@ end
           Process.waitpid fork {
             ARGV.clear.concat test_options
             Rake.application = nil
+
+            Minitest.autorun
 
             load file
           }

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -66,7 +66,27 @@ end
         adapter_short = adapter == "db2" ? adapter : adapter[/^[a-z0-9]+/]
         puts [adapter, adapter_short].inspect
 
+        dash_i = [
+          "test",
+          "lib",
+          "../activesupport/lib",
+          "../activemodel/lib"
+        ].map { |dir| File.expand_path(dir, __dir__) }
+
+        dash_i.reverse_each do |x|
+          $:.unshift(x) unless $:.include?(x)
+        end
+        $-w = true
+
+        require "bundler/setup" unless defined?(Bundler)
+
+        # Every test file loads this first, so doing it post-fork gains
+        # us nothing.
+        require "cases/helper"
+
         failing_files = []
+
+        test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
 
         test_files = (Dir["test/cases/**/*_test.rb"].reject {
           |x| x.include?("/adapters/")
@@ -81,8 +101,24 @@ end
 
         test_files.each do |file|
           puts "--- #{file}"
-          success = sh(Gem.ruby, "-w", "-Itest", file)
-          unless success
+          fake_command = Shellwords.join([
+            FileUtils::RUBY,
+            "-w",
+            *dash_i.map { |dir| "-I#{Pathname.new(dir).relative_path_from(Pathname.pwd)}" },
+            file,
+          ])
+          puts fake_command
+
+          # We could run these in parallel, but pretty much all of the
+          # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
+          Process.waitpid fork {
+            ARGV.clear.concat test_options
+            Rake.application = nil
+
+            load file
+          }
+
+          unless $?.success?
             failing_files << file
             puts "^^^ +++"
           end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -11,6 +11,12 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
   def setup
     @underlying = ActiveRecord::Base.connection
     @specification = ActiveRecord::Base.remove_connection
+
+    # Clear out connection info from other pids (like a fork parent) too
+    pool_map = ActiveRecord::Base.connection_handler.instance_variable_get(:@owner_to_pool)
+    (pool_map.keys - [Process.pid]).each do |other_pid|
+      pool_map.delete(other_pid)
+    end
   end
 
   teardown do


### PR DESCRIPTION
All the tests have a substantial chunk of identical setup effort (in cases/helper.rb); this makes isolated tests run much faster, without any change to the variety of how we load files.

A copy will do for now, but we should definitely extract this if it looks like it's going to spread further. (Especially as forks are not so great for cross-platform support.)