### PR TITLE
[ci skip] The `find` method coerces the given arguments to integer if the `primary key` is integer

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
     # Find by id - This can either be a specific id (1), a list of ids (1, 5, 6), or an array of ids ([5, 6, 10]).
     # If one or more records can not be found for the requested ids, then ActiveRecord::RecordNotFound will be raised.
-    # If the primary key is not an integer, find by id coerces its arguments using +to_i+.
+    # If the primary key is an integer, find by id coerces its arguments by using +to_i+.
     #
     #   Person.find(1)          # returns the object for ID = 1
     #   Person.find("1")        # returns the object for ID = 1


### PR DESCRIPTION
I misread the documentation and thought that, it coerces the given values to integer if they are not but it coerces the values to integer if the primary key of the model integer.