### PR TITLE
Make Active Storage missing adapter errors more descriptive

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/numeric/bytes"
-require "azure/storage"
-require "azure/storage/core/auth/shared_access_signature"
+
+begin
+  require "azure/storage"
+  require "azure/storage/core/auth/shared_access_signature"
+rescue LoadError
+  raise(
+    ActiveStorage::MissingAdapterError,
+    "Add the azure-storage gem to your Gemfile " \
+    "in order to use the Azure Storage service:\n\n" \
+    "  gem \"azure-storage\", require: false"
+  )
+end
 
 module ActiveStorage
   # Wraps the Microsoft Azure Storage Blob Service as an Active Storage service.

--- a/activestorage/lib/active_storage/service/configurator.rb
+++ b/activestorage/lib/active_storage/service/configurator.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module ActiveStorage
+  class MissingAdapterError < StandardError
+  end
+
   class Service::Configurator #:nodoc:
     attr_reader :configurations
 
@@ -27,8 +30,6 @@ module ActiveStorage
       def resolve(class_name)
         require "active_storage/service/#{class_name.to_s.underscore}_service"
         ActiveStorage::Service.const_get(:"#{class_name.camelize}Service")
-      rescue LoadError
-        raise "Missing service adapter for #{class_name.inspect}"
       end
   end
 end

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
-gem "google-cloud-storage", "~> 1.11"
-require "google/cloud/storage"
+begin
+  gem "google-cloud-storage", "~> 1.11"
+  require "google/cloud/storage"
+rescue LoadError, Gem::LoadError
+  raise(
+    ActiveStorage::MissingAdapterError,
+    "Add the google-cloud-storage (~> 1.11) gem to your Gemfile " \
+    "in order to use the GCS service:\n\n" \
+    "  gem \"google-cloud-storage\", \"~> 1.11\", require: false"
+  )
+end
 
 module ActiveStorage
   # Wraps the Google Cloud Storage as an Active Storage service. See ActiveStorage::Service for the generic API

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
-require "aws-sdk-s3"
+begin
+  require "aws-sdk-s3"
+rescue LoadError
+  raise(
+    ActiveStorage::MissingAdapterError,
+    "Add the aws-sdk-s3 gem to your Gemfile " \
+    "in order to use the S3 service:\n\n" \
+    "  gem \"aws-sdk-s3\", require: false"
+  )
+end
+
 require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage


### PR DESCRIPTION
### Summary

When a user hasn't added a specific AS adapter dependency we raising something like:

```
Missing service adapter for "S3"
```

Which could be confusing: what is "adapter"? What should I do to solve this?

This PR makes exception messages more descriptive and actionable (i.e. "do X to solve this").
