### PR TITLE
Relax table name detection in `from` to allow any extension like INDEX hint

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1091,12 +1091,15 @@ module ActiveRecord
         field = klass.attribute_alias(field) if klass.attribute_alias?(field)
         from = from_clause.name || from_clause.value
 
-        if klass.columns_hash.key?(field) &&
-            (!from || from == table.name || from == connection.quote_table_name(table.name))
+        if klass.columns_hash.key?(field) && (!from || table_name_matches?(from))
           arel_attribute(field)
         else
           yield
         end
+      end
+
+      def table_name_matches?(from)
+        /(?:\A|(?<!FROM)\s)(?:\b#{table.name}\b|#{connection.quote_table_name(table.name)})(?!\.)/i.match?(from.to_s)
       end
 
       def reverse_sql_order(order_query)


### PR DESCRIPTION
#35360 allows table name qualified if `from` has original table name.
But that is still too strict. We have a valid use case that `from` with
INDEX hint (e.g. `from("comments USE INDEX (PRIMARY)")`).
So I've relaxed the table name detection in `from` to allow any
extension like INDEX hint.

Fixes #35359.