### PR TITLE
Allow passing a custom message to DeprecatedInstanceVariableProxy

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -86,11 +86,12 @@ module ActiveSupport
     #   example.request.to_s
     #   # => "special_request"
     class DeprecatedInstanceVariableProxy < DeprecationProxy
-      def initialize(instance, method, var = "@#{method}", deprecator = ActiveSupport::Deprecation.instance)
+      def initialize(instance, method, var = "@#{method}", deprecator = ActiveSupport::Deprecation.instance, message = nil)
         @instance = instance
         @method = method
         @var = var
         @deprecator = deprecator
+        @message = message
       end
 
       private
@@ -99,7 +100,10 @@ module ActiveSupport
         end
 
         def warn(callstack, called, args)
-          @deprecator.warn("#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}. Args: #{args.inspect}", callstack)
+          message = @message || "#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}."
+          message = [message, "Args: #{args.inspect}"].join(" ")
+
+          @deprecator.warn(message, callstack)
         end
     end
 

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -384,6 +384,23 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_difference("deprecator.messages.size") { klass.new.old_request.to_s }
   end
 
+  def test_deprecated_instance_variable_with_given_message
+    deprecator = deprecator_with_messages
+
+    klass = Class.new do
+      define_method(:initialize) do
+        @request = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :request, :@request, deprecator, "Do not use this instance variable.")
+        @_request = :a_request
+      end
+      def request; @_request end
+      def old_request; @request end
+    end
+
+    klass.new.old_request.to_s
+    assert_match(/Do not use this instance variable./, deprecator.messages.last)
+  end
+
+
   def test_delegate_deprecator_instance
     klass = Class.new do
       attr_reader :last_message


### PR DESCRIPTION
### Summary

Sometimes you need to deprecate an instance variable but you don't want to change the old return value. At the moment, there's no way to do that if you just need to return the same thing but with a deprecation message.

This commit allows passing a custom message to this deprecation.

### Other Information

Here's an example:

```ruby
def method
  @new_content = Content.build
  @old_content = OldContent.build
end
```

if I want to deprecate `@old_content`  at the moment I should write:

```ruby
def method
  @new_content = Content.build
  @old_content = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(
    self,
    old_content,
    :@new_content,
    ActiveSupport::Deprecation.instance
  )
end

def old_content
  OldContent.build  
end
```

But this prints the following deprecation warning:

```text
old_content.to_s

DEPRECATION WARNING: @old_content is deprecated! Call old_content.to_s instead of @old_content.to_s. Args: [] (called from ...)
```

I'd like to have a custom message so I can deprecate with the foloowing message:

```text
old_content.to_s

DEPRECATION WARNING: @old_content is deprecated! You should use @new_content now please notice that it returns an instance of OldContent instead.
```