### PR TITLE
Add test and change how format set in ActionMailer

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -974,9 +974,8 @@ module ActionMailer
 
         each_template(Array(templates_path), templates_name).map do |template|
           format = template.format || self.formats.first
-          self.formats = [format]
           {
-            body: render(template: template),
+            body: render(template: template, formats: [format]),
             content_type: Mime[format].to_s
           }
         end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -307,6 +307,16 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("HTML Implicit Multipart", email.parts[1].body.encoded)
   end
 
+  test "implicit multipart formats" do
+    email = BaseMailer.implicit_multipart_formats
+    assert_equal(2, email.parts.size)
+    assert_equal("multipart/alternative", email.mime_type)
+    assert_equal("text/plain", email.parts[0].mime_type)
+    assert_equal("Implicit Multipart [:text]", email.parts[0].body.encoded)
+    assert_equal("text/html", email.parts[1].mime_type)
+    assert_equal("Implicit Multipart [:html]", email.parts[1].body.encoded)
+  end
+
   test "implicit multipart with sort order" do
     order = ["text/html", "text/plain"]
     with_default BaseMailer, parts_order: order do

--- a/actionmailer/test/fixtures/base_mailer/implicit_multipart_formats.html.erb
+++ b/actionmailer/test/fixtures/base_mailer/implicit_multipart_formats.html.erb
@@ -1,0 +1,1 @@
+Implicit Multipart <%= formats.inspect %>

--- a/actionmailer/test/fixtures/base_mailer/implicit_multipart_formats.text.erb
+++ b/actionmailer/test/fixtures/base_mailer/implicit_multipart_formats.text.erb
@@ -1,0 +1,1 @@
+Implicit Multipart <%= formats.inspect %>

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -62,6 +62,10 @@ class BaseMailer < ActionMailer::Base
     mail(hash)
   end
 
+  def implicit_multipart_formats(hash = {})
+    mail(hash)
+  end
+
   def implicit_with_locale(hash = {})
     mail(hash)
   end


### PR DESCRIPTION
This comes from [this discussion](https://github.com/rails/rails/pull/35429#discussion_r260907810) in #35429. ~This PR will need a rebase if that is merged.~

Previously this used `self.formats=` to set the format which render would then use when finding templates. This worked, but was untested, and looked a little confusing because it was doing the mutation within a loop.

This commit replaces the assignment with passing `formats: [format]` into the render call, which makes it more obvious that that's the purpose. This also adds a test to verify the formats being used.

cc @kaspth and @tenderlove who both pointed out that the existing code looked odd