### PR TITLE
check for collection param name

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1214,6 +1214,7 @@ module ActionDispatch
           end
 
           def nested_param
+            return param if param.to_s.start_with?("#{singular}_")
             :"#{singular}_#{param}"
           end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3338,6 +3338,26 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "0c0c0b68-d24b-11e1-a861-001ff3fffe6f", @request.params[:download]
   end
 
+  def test_explicit_custom_param
+    draw do
+      resources :profiles, param: :profile_username do
+        get :details, on: :member
+        resources :messages
+      end
+    end
+
+    get "/profiles/bob"
+    assert_equal "profiles#show", @response.body
+    assert_equal "bob", @request.params[:profile_username]
+
+    get "/profiles/bob/details"
+    assert_equal "bob", @request.params[:profile_username]
+
+    get "/profiles/bob/messages/34"
+    assert_equal "bob", @request.params[:profile_username]
+    assert_equal "34", @request.params[:id]
+  end
+
   def test_action_from_path_is_not_frozen
     draw do
       get "search" => "search"


### PR DESCRIPTION
### Summary

This PR allows a user to set a param name for resource routing that includes the expected collection name, as described in a long closed (stale) issue: https://github.com/rails/rails/issues/18855.

The idea being that if someone wanted to ensure that a resource id parameter _always_ had a specific name "user_profile" that didn't clash with nested resources they could do so.

### Other Information

I searched for any other issues or PRs that described this behavior to see if it was expressly unwanted but couldn't find much.  If this change is unwanted, 👍 to closing though it does seem like this gives a little bit more flexibility to users without much downside.

I haven't included benchmarks because the change is small and this didn't appear to be a codepath that was called an excessive number of times.  I'd be happy to provide benchmark if desired, though to be honest I'm not sure of the exact codepath I should benchmark.  💭 ?
