### PR TITLE
Quote empty ranges like other empty enumerables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Quote empty ranges like other empty enumerables.
+
+    *Patrick Rebsch*
+
 *   Add `insert_all`/`insert_all!`/`upsert_all` methods to `ActiveRecord::Persistence`,
     allowing bulk inserts akin to the bulk updates provided by `update_all` and
     bulk deletes by `delete_all`.

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -165,10 +165,11 @@ module ActiveRecord
 
         def quote_bound_value(value, c = connection)
           if value.respond_to?(:map) && !value.acts_like?(:string)
-            if value.respond_to?(:empty?) && value.empty?
+            quoted = value.map { |v| c.quote(v) }
+            if quoted.empty?
               c.quote(nil)
             else
-              value.map { |v| c.quote(v) }.join(",")
+              quoted.join(",")
             end
           else
             c.quote(value)

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -148,6 +148,19 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal "foo in (#{quoted_nil})", bind("foo in (?)", [])
   end
 
+  def test_bind_range
+    quoted_abc = %(#{ActiveRecord::Base.connection.quote('a')},#{ActiveRecord::Base.connection.quote('b')},#{ActiveRecord::Base.connection.quote('c')})
+    assert_equal "0", bind("?", 0..0)
+    assert_equal "1,2,3", bind("?", 1..3)
+    assert_equal quoted_abc, bind("?", "a"..."d")
+  end
+
+  def test_bind_empty_range
+    quoted_nil = ActiveRecord::Base.connection.quote(nil)
+    assert_equal quoted_nil, bind("?", 0...0)
+    assert_equal quoted_nil, bind("?", "a"..."a")
+  end
+
   def test_bind_empty_string
     quoted_empty = ActiveRecord::Base.connection.quote("")
     assert_equal quoted_empty, bind("?", "")


### PR DESCRIPTION
Resolves #35135.

Fixes the case where an empty range is provided as a bind variable. Active Record tried to map and join the range's items' quoted values, so when the range was empty, the resulting string would be empty which would often result in an invalid SQL statement.

There was a check in place to try to handle empty enumerables, but it only checked if the value responded to `empty?`, and since a `Range` doesn't have that method, the quoting method assumed that it wasn't empty and proceed to map it and use the result.

This fixes the problem by mapping first and then checking if the result is `empty?` since at that point it should always be an array.<sup>[[Thanks!]](https://github.com/rails/rails/pull/35449#pullrequestreview-211024151)</sup>