### PR TITLE
Round parts values for ActiveSupport::Duration#inspect

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -66,6 +66,12 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "1 month and 1 day",               (1.month + 1.day).inspect
     assert_equal "6 months and -2 days",            (6.months - 2.days).inspect
     assert_equal "10 seconds",                      10.seconds.inspect
+    assert_equal "6 minutes and 40 seconds",        (5.minutes + 100.seconds).inspect
+    assert_equal "6 hours and 40 minutes",          (5.hours + 100.minutes).inspect
+    assert_equal "1 day and 1 hour",                25.hours.inspect
+    assert_equal "1 day, 1 minute, and 40 seconds", (1.day + 100.seconds).inspect
+    assert_equal "1 hour, 1 minute, and 5 seconds", (1.hour + 65.seconds).inspect
+    assert_equal "1 year and 2 months",             14.months.inspect
     assert_equal "10 years, 2 months, and 1 day",   (10.years + 2.months + 1.day).inspect
     assert_equal "10 years, 2 months, and 1 day",   (10.years + 1.month  + 1.day + 1.month).inspect
     assert_equal "10 years, 2 months, and 1 day",   (1.day + 10.years + 2.months).inspect


### PR DESCRIPTION
This is for #35443 

### Summary

**I'm not an expert about date/time formation, so this is just an attempt based on what I saw on the specification**

According to ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601)
Individual date and time values cannot exceed their moduli (e.g. a value of 13 for the month or 25 for the hour would not be permissible)

So I added `ActiveSupport::Duration#rounded_parts`. With it we can round `{seconds: 100}` to `{seconds: 40, minutes: 1}` or `{months: 14}` to `{months: 2, year: 1}`. And I used the `rounded_parts` to replace `parts` as the source of `#inspect`.