### PR TITLE
Oracle 12.2+ supports 128 byte identifier length

### DIFF
--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -109,18 +109,10 @@ module ActiveRecord
         add_index "test_models", ["hat_style", "hat_size"], unique: true
 
         rename_column "test_models", "hat_size", "size"
-        if current_adapter? :OracleAdapter
-          assert_equal ["i_test_models_hat_style_size"], connection.indexes("test_models").map(&:name)
-        else
-          assert_equal ["index_test_models_on_hat_style_and_size"], connection.indexes("test_models").map(&:name)
-        end
+        assert_equal ["index_test_models_on_hat_style_and_size"], connection.indexes("test_models").map(&:name)
 
         rename_column "test_models", "hat_style", "style"
-        if current_adapter? :OracleAdapter
-          assert_equal ["i_test_models_style_size"], connection.indexes("test_models").map(&:name)
-        else
-          assert_equal ["index_test_models_on_style_and_size"], connection.indexes("test_models").map(&:name)
-        end
+        assert_equal ["index_test_models_on_style_and_size"], connection.indexes("test_models").map(&:name)
       end
 
       def test_rename_column_does_not_rename_custom_named_index


### PR DESCRIPTION
### Summary

This pull request addresses the following failure with Oracle database 12.2 or higher which supports longer identifier, it used to be 30 byte.

```ruby
$ ARCONN=oracle bin/test test/cases/migration/columns_test.rb -n test_rename_column_with_multi_column_index
... snip ...

F

Failure:
ActiveRecord::Migration::ColumnsTest#test_rename_column_with_multi_column_index [/home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:113]:
--- expected
+++ actual
@@ -1 +1 @@
-["i_test_models_hat_style_size"]
+["index_test_models_on_hat_style_and_size"]

```

Kind of reverting #9395
Refer https://github.com/rsim/oracle-enhanced/pull/1703
