### PR TITLE
Rails `DateTime` type is mapped to Oracle `TIMESTAMP` since Rails 5.0

### DIFF
--- a/activerecord/test/cases/date_test.rb
+++ b/activerecord/test/cases/date_test.rb
@@ -23,23 +23,13 @@ class DateTest < ActiveRecord::TestCase
 
     valid_dates.each do |date_src|
       topic = Topic.new("last_read(1i)" => date_src[0].to_s, "last_read(2i)" => date_src[1].to_s, "last_read(3i)" => date_src[2].to_s)
-      # Oracle DATE columns are datetime columns and Oracle adapter returns Time value
-      if current_adapter?(:OracleAdapter)
-        assert_equal(topic.last_read.to_date, Date.new(*date_src))
-      else
-        assert_equal(topic.last_read, Date.new(*date_src))
-      end
+      assert_equal(topic.last_read, Date.new(*date_src))
     end
 
     invalid_dates.each do |date_src|
       assert_nothing_raised do
         topic = Topic.new("last_read(1i)" => date_src[0].to_s, "last_read(2i)" => date_src[1].to_s, "last_read(3i)" => date_src[2].to_s)
-        # Oracle DATE columns are datetime columns and Oracle adapter returns Time value
-        if current_adapter?(:OracleAdapter)
-          assert_equal(topic.last_read.to_date, Time.local(*date_src).to_date, "The date should be modified according to the behavior of the Time object")
-        else
-          assert_equal(topic.last_read, Time.local(*date_src).to_date, "The date should be modified according to the behavior of the Time object")
-        end
+        assert_equal(topic.last_read, Time.local(*date_src).to_date, "The date should be modified according to the behavior of the Time object")
       end
     end
   end


### PR DESCRIPTION
### Summary

This pull request removes `if current_adapter?(:OracleAdapter)` condition from `DateTest`.

Kind of reverting https://github.com/rails/rails/commit/3a1cbc5c3b3bcb2de4be6e4469bb87b99759dc59

Rails `DateTime` type is mapped to Oracle `TIMESTAMP` since Rails 5.0.
```ruby
From: test/cases/date_test.rb @ line 26 :

    21:
    22:     invalid_dates = [[2007, 11, 31], [1993, 2, 29], [2007, 2, 29]]
    23:
    24:     valid_dates.each do |date_src|
    25:       topic = Topic.new("last_read(1i)" => date_src[0].to_s, "last_read(2i)" => date_src[1].to_s, "last_read(3i)" => date_src[2].to_s)
 => 26:       binding.irb
    27:       assert_equal(topic.last_read, Date.new(*date_src))
    28:     end
    29:
    30:     invalid_dates.each do |date_src|
    31:       assert_nothing_raised do

irb(#<DateTest:0x0000556618194668>):001:0> topic.last_read.class
=> Date
```

Refer rsim/oracle-enhanced#845
rails/rails#25897