### PR TITLE
Oracle database can run `delete`  with `order by` and`fetch first n rows only`

### DIFF
--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -80,25 +80,23 @@ class DeleteAllTest < ActiveRecord::TestCase
     assert_equal pets.count, pets.delete_all
   end
 
-  unless current_adapter?(:OracleAdapter)
-    def test_delete_all_with_order_and_limit_deletes_subset_only
-      author = authors(:david)
-      limited_posts = Post.where(author: author).order(:id).limit(1)
-      assert_equal 1, limited_posts.size
-      assert_equal 2, limited_posts.limit(2).size
-      assert_equal 1, limited_posts.delete_all
-      assert_raise(ActiveRecord::RecordNotFound) { posts(:welcome) }
-      assert posts(:thinking)
-    end
+  def test_delete_all_with_order_and_limit_deletes_subset_only
+    author = authors(:david)
+    limited_posts = Post.where(author: author).order(:id).limit(1)
+    assert_equal 1, limited_posts.size
+    assert_equal 2, limited_posts.limit(2).size
+    assert_equal 1, limited_posts.delete_all
+    assert_raise(ActiveRecord::RecordNotFound) { posts(:welcome) }
+    assert posts(:thinking)
+  end
 
-    def test_delete_all_with_order_and_limit_and_offset_deletes_subset_only
-      author = authors(:david)
-      limited_posts = Post.where(author: author).order(:id).limit(1).offset(1)
-      assert_equal 1, limited_posts.size
-      assert_equal 2, limited_posts.limit(2).size
-      assert_equal 1, limited_posts.delete_all
-      assert_raise(ActiveRecord::RecordNotFound) { posts(:thinking) }
-      assert posts(:welcome)
-    end
+  def test_delete_all_with_order_and_limit_and_offset_deletes_subset_only
+    author = authors(:david)
+    limited_posts = Post.where(author: author).order(:id).limit(1).offset(1)
+    assert_equal 1, limited_posts.size
+    assert_equal 2, limited_posts.limit(2).size
+    assert_equal 1, limited_posts.delete_all
+    assert_raise(ActiveRecord::RecordNotFound) { posts(:thinking) }
+    assert posts(:welcome)
   end
 end


### PR DESCRIPTION
### Summary

Since https://github.com/rails/arel/pull/337 Oracle adapter uses better top N query using `fetch first n rows only`, which can remove this unless condition.

* This commit passes with Oracle database
```ruby
$ ARCONN=oracle bin/test test/cases/relation/delete_all_test.rb -n test_delete_all_with_order_and_limit_deletes_subset_only
Using oracle
Run options: -n test_delete_all_with_order_and_limit_deletes_subset_only --seed 1081

.

Finished in 8.068626s, 0.1239 runs/s, 0.6197 assertions/s.
1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
$
```

* SQL statement includes `ORDER BY` and `FETCH FIRST n ROWS ONLY`

```sql
  Post Destroy (12.5ms)  DELETE FROM "POSTS" WHERE "POSTS"."ID" IN (SELECT "POSTS"."ID" FROM "POSTS" WHERE "POSTS"."AUTHOR_ID" = :a1 ORDER BY "POSTS"."ID" ASC FETCH FIRST :a2 ROWS ONLY)  [["author_id", 1], ["LIMIT", 1]]
```