### PR TITLE
Fixed reselect throwing NoMethodError on ActiveRecord.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -11,7 +11,8 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_joins, :left_outer_joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,
-             :having, :create_with, :distinct, :references, :none, :unscope, :merge, to: :all
+             :having, :create_with, :distinct, :references, :none, :unscope, :merge,
+             :reselect, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :pick, :ids, to: :all
 

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids,
+      :pluck, :pick, :ids, :reselect,
     ]
 
     def test_delegate_querying_methods

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -16,5 +16,12 @@ module ActiveRecord
       expected = Post.select(:title).to_sql
       assert_equal expected, Post.select(:title, :body).reselect(:title).to_sql
     end
+
+    def test_reselect_with_default_scope_select
+      expected = Post.select(:title).to_sql
+      actual   = PostWithDefaultSelect.reselect(:title).to_sql
+
+      assert_equal expected, actual
+    end
   end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -212,6 +212,12 @@ class FirstPost < ActiveRecord::Base
   has_one  :comment,  foreign_key: :post_id
 end
 
+class PostWithDefaultSelect < ActiveRecord::Base
+  self.table_name = "posts"
+
+  default_scope { select(:author_id) }
+end
+
 class TaggedPost < Post
   has_many :taggings, -> { rewhere(taggable_type: "TaggedPost") }, as: :taggable
   has_many :tags, through: :taggings


### PR DESCRIPTION
Follow up on #33611

Following query throws `NoMethodError (undefined method `reselect' for #<Class ... >)`
```
Post.reselect(:title)
Post.reselect!(:title)
```

Created a bug script for the same issue: https://gist.github.com/abhaynikam/06e95a4022206f06354c93817651682e

Added a delegate to work directly on ActiveRecord. In the PR(#33611) description, it was mentioned `reselect` is similar to `rewhere` and `reorder`. Both(`rewhere` and `reorder`) work directly on ActiveRecord.

@r? @pixeltrix  
cc/ @willianveiga 