### PR TITLE
update_at/on note for ActiveRecord::Relation.update_all

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -414,10 +414,10 @@ module ActiveRecord
       update_all updates
     end
 
-    # Touches all records in the current relation without instantiating records first with the updated_at/on attributes
+    # Touches all records in the current relation without instantiating records first with the +updated_at+/+updated_on+ attributes
     # set to the current time or the time specified.
     # This method can be passed attribute names and an optional time argument.
-    # If attribute names are passed, they are updated along with updated_at/on attributes.
+    # If attribute names are passed, they are updated along with +updated_at+/+updated_on+ attributes.
     # If no time argument is passed, the current time is used as default.
     #
     # === Examples

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -338,6 +338,8 @@ module ActiveRecord
     # trigger Active Record callbacks or validations. However, values passed to #update_all will still go through
     # Active Record's normal type casting and serialization.
     #
+    # Note: As Active Record callbacks are not triggered, this method will not automatically update +updated_at+/+updated_on+ columns.
+    #
     # ==== Parameters
     #
     # * +updates+ - A string, array, or hash representing the SET part of an SQL statement.


### PR DESCRIPTION
### Summary

Could be helpful to add a note for `ActiveRecord::Relation.update_all` that `updated_at`/`updated_on` columns aren't updated. Even though the prior paragraph mentions callbacks I think we could be more explicit here and mention what that means for `updated_at`/`updated_on` columns.