### PR TITLE
Remove unnecessary `current_adapter?(:OracleAdapter)` for index length

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1271,12 +1271,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_include_has_many_using_primary_key
     expected = Firm.find(1).clients_using_primary_key.sort_by(&:name)
-    # Oracle adapter truncates alias to 30 characters
-    if current_adapter?(:OracleAdapter)
-      firm = Firm.all.merge!(includes: :clients_using_primary_key, order: "clients_using_primary_keys_companies"[0, 30] + ".name").find(1)
-    else
-      firm = Firm.all.merge!(includes: :clients_using_primary_key, order: "clients_using_primary_keys_companies.name").find(1)
-    end
+    firm = Firm.all.merge!(includes: :clients_using_primary_key, order: "clients_using_primary_keys_companies.name").find(1)
     assert_no_queries do
       assert_equal expected, firm.clients_using_primary_key
     end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -158,14 +158,11 @@ module ActiveRecord
         connection.add_index("testings", ["last_name", "first_name"])
         connection.remove_index("testings", column: ["last_name", "first_name"])
 
-        # Oracle adapter cannot have specified index name larger than 30 characters
-        # Oracle adapter is shortening index name when just column list is given
-        unless current_adapter?(:OracleAdapter)
-          connection.add_index("testings", ["last_name", "first_name"])
-          connection.remove_index("testings", name: :index_testings_on_last_name_and_first_name)
-          connection.add_index("testings", ["last_name", "first_name"])
-          connection.remove_index("testings", "last_name_and_first_name")
-        end
+        connection.add_index("testings", ["last_name", "first_name"])
+        connection.remove_index("testings", name: :index_testings_on_last_name_and_first_name)
+        connection.add_index("testings", ["last_name", "first_name"])
+        connection.remove_index("testings", "last_name_and_first_name")
+
         connection.add_index("testings", ["last_name", "first_name"])
         connection.remove_index("testings", ["last_name", "first_name"])
 


### PR DESCRIPTION
### Summary

Follow up #35455. There are two more test cases unnecessary `if current_adapter?(:OracleAdapter)`

Test result with this commit:
```ruby
$ ARCONN=oracle bin/test test/cases/associations/eager_test.rb -n test_include_has_many_using_primary_key
Using oracle
Run options: -n test_include_has_many_using_primary_key --seed 62842

.

Finished in 50.280024s, 0.0199 runs/s, 0.0398 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```

```ruby
$ ARCONN=oracle bin/test test/cases/migration/index_test.rb -n test_add_index
Using oracle
Run options: -n test_add_index --seed 52034

.

Finished in 13.152620s, 0.0760 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
$
```