### PR TITLE
Simplify internal logic of ActiveRecord::AttributeMethods::Serialization

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -23,9 +23,10 @@ module ActiveRecord
         # serialized object must be of that class on assignment and retrieval.
         # Otherwise SerializationTypeMismatch will be raised.
         #
-        # Empty objects as <tt>{}</tt>, in the case of +Hash+, or <tt>[]</tt>, in the case of
-        # +Array+, will always be persisted as null. Therefore, database schema must allow null
-        # as default.
+        # With default YAMLColumn coder, empty objects as <tt>{}</tt>, in the case of +Hash+,
+        # or <tt>[]</tt>, in the case of +Array+, will always be persisted as null.
+        # This is applicable to any class which responds to +#empty?+.
+        # Therefore, database schema must allow null as default.
         #
         # Keep in mind that database adapters handle certain serialization tasks
         # for you. For instance: +json+ and +jsonb+ types in PostgreSQL will be

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -24,7 +24,8 @@ module ActiveRecord
         # Otherwise SerializationTypeMismatch will be raised.
         #
         # Empty objects as <tt>{}</tt>, in the case of +Hash+, or <tt>[]</tt>, in the case of
-        # +Array+, will always be persisted as null.
+        # +Array+, will always be persisted as null. Therefore, database schema must allow null
+        # as default.
         #
         # Keep in mind that database adapters handle certain serialization tasks
         # for you. For instance: +json+ and +jsonb+ types in PostgreSQL will be

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -15,6 +15,7 @@ module ActiveRecord
 
       def dump(obj)
         return if obj.nil?
+        return if obj.respond_to?(:empty?) && obj.empty?
 
         assert_valid_value(obj, action: "dump")
         YAML.dump obj

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -51,12 +51,6 @@ module ActiveRecord
         def null_equivalent?(value)
           value.nil? || value == coder.load(nil)
         end
-
-        def encoded(value)
-          unless default_value?(value)
-            coder.dump(value)
-          end
-        end
     end
   end
 end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -20,10 +20,8 @@ module ActiveRecord
       end
 
       def serialize(value)
-        return if value.nil?
-        unless default_value?(value)
-          super coder.dump(value)
-        end
+        return if null_equivalent?(value)
+        super coder.dump(value)
       end
 
       def inspect
@@ -50,8 +48,8 @@ module ActiveRecord
 
       private
 
-        def default_value?(value)
-          value == coder.load(nil)
+        def null_equivalent?(value)
+          value.nil? || value == coder.load(nil)
         end
 
         def encoded(value)

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -30,11 +30,8 @@ module ActiveRecord
         Kernel.instance_method(:inspect).bind(self).call
       end
 
-      def changed_in_place?(raw_old_value, value)
-        return false if value.nil?
-        raw_new_value = encoded(value)
-        raw_old_value.nil? != raw_new_value.nil? ||
-          subtype.changed_in_place?(raw_old_value, raw_new_value)
+      def changed_in_place?(raw_old_value, new_value)
+        deserialize(raw_old_value) != new_value
       end
 
       def accessor

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -16,11 +16,7 @@ module ActiveRecord
       end
 
       def deserialize(value)
-        if default_value?(value)
-          value
-        else
-          coder.load(super)
-        end
+        coder.load(super)
       end
 
       def serialize(value)

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -20,7 +20,6 @@ module ActiveRecord
       end
 
       def serialize(value)
-        return if null_equivalent?(value)
         super coder.dump(value)
       end
 
@@ -45,12 +44,6 @@ module ActiveRecord
       def force_equality?(value)
         coder.respond_to?(:object_class) && value.is_a?(coder.object_class)
       end
-
-      private
-
-        def null_equivalent?(value)
-          value.nil? || value == coder.load(nil)
-        end
     end
   end
 end


### PR DESCRIPTION
### Summary

This patch simplifies the logic of ActiveRecord::Serialization.
Also, this improves documentation on ActiveRecord::Serialization

Following patches are included.

* Detail documentation on the default value of serialized column.
* Remove unnecessary use of `ActiveRecord::Type::Serialized#default_value?`
* Simplify `ActiveRecord::Type::Serialized#changed_in_place?` following #29273
* Replace `default_value?` with `null_equivalent` so that it reflects internal logic

### Other Information
