### PR TITLE
Fix Getting Started guide to state the correct number of files created by the controller generator

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1652,7 +1652,7 @@ controller. Again, we'll use the same generator we used before:
 $ rails generate controller Comments
 ```
 
-This creates five files and one empty directory:
+This creates four files and one empty directory:
 
 | File/Directory                               | Purpose                                  |
 | -------------------------------------------- | ---------------------------------------- |


### PR DESCRIPTION
### Summary

In e8546aba904fb6685ef2e61f1623c64e699a2c9c (https://github.com/rails/rails/pull/34053), the Getting Started guide was updated to reflect the removal of CoffeeScript stubs being generated by the controller generator. However, the comment above the table of generated files wasn't updated, so it incorrectly remained "This creates five files and one empty directory". This fixes it to now say "This creates four files and one empty directory".
