### PR TITLE
Add a way to index nested models' validation errors by their attribute

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add a way to index nested models' validation errors by their attribute.
+
+    Example:
+
+        class Violin < ActiveRecord::Base
+          has_many :tuning_pegs, index_errors: :string
+          accepts_nested_attributes_for :tuning_pegs
+        end
+
+        class TuningPeg < ActiveRecord::Base
+          belongs_to :violin
+          validates_numericality_of :pitch
+        end
+
+        violin = Violin.new(
+          tuning_pegs_attributes: [
+            { string: 1 },
+            { string: 2, pitch: 450.0 },
+            { string: 3, pitch: 440.0 },
+            { string: 4 }
+          ]
+        )
+        violin.valid? # => false
+        violin.errors.to_json # => {"tuning_pegs[1].pitch":["is not a number"],"tuning_pegs[4].pitch":["is not a number"]}
+
+    *Felix Borzik*
+
 *   Deprecate `DatabaseConfigurations#to_h`. These connection hashes are still available via `ActiveRecord::Base.configurations.configs_for`.
 
     *Eileen Uchitelle*, *John Crepezzi*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -327,6 +327,7 @@ module ActiveRecord
         unless valid = record.valid?(context)
           if reflection.options[:autosave]
             indexed_attribute = !index.nil? && (reflection.options[:index_errors] || ActiveRecord::Base.index_nested_attribute_errors)
+            index = record.public_send(reflection.options[:index_errors]) if reflection.options[:index_errors].is_a?(Symbol)
 
             record.errors.group_by_attribute.each { |attribute, errors|
               attribute = normalize_reflection_attribute(indexed_attribute, reflection, index, attribute)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -31,6 +31,7 @@ require "models/member"
 require "models/member_detail"
 require "models/organization"
 require "models/guitar"
+require "models/violin"
 require "models/tuning_peg"
 require "models/reply"
 
@@ -452,6 +453,21 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     ActiveRecord::Base.index_nested_attribute_errors = old_attribute_config
   end
 
+  def test_errors_should_be_indexed_by_attribute_value_when_passed_as_array
+    violin = Violin.new
+    tuning_peg_valid = TuningPeg.new(pitch: 440.0, string_number: 2)
+    tuning_peg_invalid = TuningPeg.new(string_number: 4)
+
+    violin.tuning_pegs = [tuning_peg_valid, tuning_peg_invalid]
+
+    assert_not_predicate tuning_peg_invalid, :valid?
+    assert_predicate tuning_peg_valid, :valid?
+    assert_not_predicate violin, :valid?
+    assert_equal ["is not a number"], violin.errors["tuning_pegs[4].pitch"]
+    assert_not_equal ["is not a number"], violin.errors["tuning_pegs[0].pitch"]
+    assert_not_equal ["is not a number"], violin.errors["tuning_pegs.pitch"]
+  end
+
   def test_errors_details_should_be_set
     molecule = Molecule.new
     valid_electron = Electron.new(name: "electron")
@@ -478,6 +494,21 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_not_predicate guitar, :valid?
     assert_equal [{ error: :not_a_number, value: nil }], guitar.errors.details[:"tuning_pegs[1].pitch"]
     assert_equal [], guitar.errors.details[:"tuning_pegs.pitch"]
+  end
+
+  def test_errors_details_should_be_indexed_by_attribute_value_when_passed_as_array
+    violin = Violin.new
+    tuning_peg_valid = TuningPeg.new(pitch: 440.0, string_number: 2)
+    tuning_peg_invalid = TuningPeg.new(string_number: 4)
+
+    violin.tuning_pegs = [tuning_peg_valid, tuning_peg_invalid]
+
+    assert_not_predicate tuning_peg_invalid, :valid?
+    assert_predicate tuning_peg_valid, :valid?
+    assert_not_predicate violin, :valid?
+    assert_equal [{ error: :not_a_number, value: nil }], violin.errors.details[:"tuning_pegs[4].pitch"]
+    assert_equal [], violin.errors.details[:"tuning_pegs.pitch"]
+    assert_not_equal [{ error: :not_a_number, value: nil }], violin.errors.details[:"tuning_pegs[1].pitch"]
   end
 
   def test_errors_details_should_be_indexed_when_global_flag_is_set

--- a/activerecord/test/models/tuning_peg.rb
+++ b/activerecord/test/models/tuning_peg.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TuningPeg < ActiveRecord::Base
-  belongs_to :guitar
+  belongs_to :guitar, optional: true
+  belongs_to :violin, optional: true
   validates_numericality_of :pitch
 end

--- a/activerecord/test/models/violin.rb
+++ b/activerecord/test/models/violin.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Violin < ActiveRecord::Base
+  has_many :tuning_pegs, index_errors: :string_number
+  accepts_nested_attributes_for :tuning_pegs
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -962,6 +962,8 @@ ActiveRecord::Schema.define do
 
   create_table :tuning_pegs, force: true do |t|
     t.integer :guitar_id
+    t.integer :violin_id
+    t.integer :string_number
     t.float :pitch
   end
 
@@ -976,6 +978,10 @@ ActiveRecord::Schema.define do
 
   create_table :vertices, force: true do |t|
     t.column :label, :string
+  end
+
+  create_table :violins, force: true do |t|
+    t.string :color
   end
 
   create_table "warehouse-things", force: true do |t|


### PR DESCRIPTION
### Summary

Error messages do not include any information regarding nested models by default. #19686 made it possible to return nested model index together with its error.

This PR allows to map errors by nested models' attribute. Default behavior is not changed. When `index_errors` option is set to a symbol, it will be read from a nested model's record, and set as an error index.

Example:
```ruby
class Violin < ActiveRecord::Base
  has_many :tuning_pegs, index_errors: :string_number
  accepts_nested_attributes_for :tuning_pegs
end

class TuningPeg < ActiveRecord::Base
  belongs_to :violin
  validates_numericality_of :pitch
end

violin = Violin.new(
  tuning_pegs_attributes: [
    { string_number: 1 },
    { string_number: 2, pitch: 450.0 },
    { string_number: 3, pitch: 440.0 },
    { string_number: 4 }
  ]
)
violin.valid? # => false
violin.errors.to_json # => {"tuning_pegs[1].pitch":["is not a number"],"tuning_pegs[4].pitch":["is not a number"]}
```