### PR TITLE
add `.indexes` to `ModelSchema::ClassMethods`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add class method `.indexes` to `ActiveRecord::Base`
+
+    Example:
+
+    `Post.indexes` as a shortcut for `ActiveRecord::Base.connection.indexes(:posts)`
+
+    *lxxxvi*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -291,6 +291,11 @@ module ActiveRecord
         @ignored_columns = columns.map(&:to_s)
       end
 
+      # The list of indexes associated with the model
+      def indexes
+        connection.indexes(table_name)
+      end
+
       def sequence_name
         if base_class?
           @sequence_name ||= reset_sequence_name

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -26,6 +26,7 @@ require "models/joke"
 require "models/bird"
 require "models/car"
 require "models/bulb"
+require "models/teacup"
 require "concurrent/atomic/count_down_latch"
 
 class FirstAbstractClass < ActiveRecord::Base
@@ -298,6 +299,11 @@ class BasicsTest < ActiveRecord::TestCase
     # This mutator is protected in the class definition
     topic.send(:approved=, true)
     assert topic.instance_variable_get("@custom_approved")
+  end
+
+  def test_indexes
+    assert_equal 1, Teacup.indexes.count
+    assert_equal "index_teacups_names", Teacup.indexes[0].name
   end
 
   def test_initialize_with_attributes

--- a/activerecord/test/models/teacup.rb
+++ b/activerecord/test/models/teacup.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class Teacup < ActiveRecord::Base; end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -916,6 +916,11 @@ ActiveRecord::Schema.define do
     t.datetime :ending
   end
 
+  create_table :teacups, force: true do |t|
+    t.string :name
+    t.index [:name], name: "index_teacups_names"
+  end
+
   create_table :topics, force: true do |t|
     t.string   :title, limit: 250, **case_sensitive_options
     t.string   :author_name, **case_sensitive_options


### PR DESCRIPTION
### Summary

This PR introduces a simple shortcut for `ActiveRecord::Base.connection.indexes(:posts)`: `Post.indexes`. 

What are your thoughts?
