### PR TITLE
Propagate the content-type in the upload of the variant

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -106,7 +106,7 @@ class ActiveStorage::Variant
     end
 
     def upload(file)
-      service.upload(key, file)
+      service.upload(key, file, content_type: content_type)
     end
 
 


### PR DESCRIPTION
### Summary
Propagate the content-type in the upload of the variant so that if the file is uploaded to a remote service, eg S3, the file stored in that service is going to keep the metadata about the content-type, so it will be possible to get it correctly when the file is downloaded directly from a url like `REMOTE_SERVICE_HOST + model.attachment.variant("111x222").key`

### Other Information
How to reproduce the bug with S3 backend service:
* Get the path of a file variant from rails console with something like `model.attachment.variant("111x222").key`
* Get the bucket url from your `bucket` configuration from `config/storage.yml`
* Get the file using `curl`:

```
curl -I 'https://YOUR_S3_BUCKET_BASE_URL/variants/000000c3an/ab039d17f0304d5a3ca7bfc1000000000'

HTTP/2 200 
content-type: image/jpeg
content-length: 4824
date: Tue, 05 Mar 2019 15:47:47 GMT
...
```

If the file was uploaded with this fix, the HTTP response will contatain the correct `content-type` header, otherwise it is missing