### PR TITLE
The 'listen' gem should also be included on other Ruby implementations

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
+<% end -%>
 group :development do
 <%- unless options.api? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
@@ -75,7 +76,6 @@ group :test do
   gem 'chromedriver-helper'
 end
 <%- end -%>
-<% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -623,6 +623,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_listen_related_configuration_on_other_rubies
+    ruby_engine = Object.send(:remove_const, :RUBY_ENGINE)
+    Object.const_set(:RUBY_ENGINE, "MyRuby")
+    begin
+      run_generator
+      if RbConfig::CONFIG["host_os"] =~ /darwin|linux/
+        assert_listen_related_configuration
+      else
+        assert_no_listen_related_configuration
+      end
+    ensure
+      Object.send(:remove_const, :RUBY_ENGINE)
+      Object.const_set(:RUBY_ENGINE, ruby_engine)
+    end
+  end
+
   def test_non_inclusion_of_listen_related_configuration_if_skip_listen
     run_generator [destination_root, "--skip-listen"]
     assert_no_listen_related_configuration


### PR DESCRIPTION
### Summary

* This `if RUBY_ENGINE == 'ruby'` was meant to only skip `byebug` since its introduction in 059bdc3415b0f1fb436c56a399a41b90fe3e87f0. Listen was added in de6ad5665d2679944a9ee9407826ba88395a1003.
* Others gems already have appropriate checks for their inclusion.
* Test that the `listen` gem is included when `RUBY_ENGINE` is not `'ruby'`.

This is already fixed on `master` by https://github.com/rails/rails/pull/34243 (cc @deivid-rodriguez), but not yet for Rails 5.

### Other Information

I noticed this while generating a Rails app on TruffleRuby. `listen` is not included in the Gemfile, leading to an error while loading Rails for `bundle exec rails serve`.