### PR TITLE
Adds default trix content attachmment partial path

### DIFF
--- a/actiontext/lib/action_text/attachable.rb
+++ b/actiontext/lib/action_text/attachable.rb
@@ -67,6 +67,10 @@ module ActionText
       super.merge(attachable_sgid: attachable_sgid)
     end
 
+    def to_trix_content_attachment_partial_path
+      to_partial_path
+    end
+
     def to_rich_text_attributes(attributes = {})
       attributes.dup.tap do |attrs|
         attrs[:sgid] = attachable_sgid

--- a/actiontext/test/dummy/app/models/page.rb
+++ b/actiontext/test/dummy/app/models/page.rb
@@ -1,0 +1,4 @@
+class Page < ApplicationRecord
+  include ActionText::Attachable
+end
+

--- a/actiontext/test/dummy/db/migrate/20190305172303_create_pages.rb
+++ b/actiontext/test/dummy/db/migrate/20190305172303_create_pages.rb
@@ -1,0 +1,9 @@
+class CreatePages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :pages do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_03_185713) do
+ActiveRecord::Schema.define(version: 2019_03_05_172303) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,12 @@ ActiveRecord::Schema.define(version: 2018_10_03_185713) do
 
   create_table "messages", force: :cascade do |t|
     t.string "subject"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "pages", force: :cascade do |t|
+    t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -32,7 +32,8 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal attachable.byte_size, trix_attachment.attributes["filesize"]
     assert_equal "Captioned", trix_attachment.attributes["caption"]
 
-    assert_nil trix_attachment.attributes["content"]
+    assert_not_nil attachable.to_trix_content_attachment_partial_path
+    assert_not_nil trix_attachment.attributes["content"]
   end
 
   test "converts to TrixAttachment with content" do
@@ -47,6 +48,11 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
 
     assert_not_nil attachable.to_trix_content_attachment_partial_path
     assert_not_nil trix_attachment.attributes["content"]
+  end
+
+  test "defaults trix partial to model partial" do
+    attachable = Page.create! title: "Homepage"
+    assert_equal "pages/page", attachable.to_trix_content_attachment_partial_path
   end
 
   private


### PR DESCRIPTION
### Summary

ActionText automatically renders out the `to_partial_path` for attachables when rendering rich text. However, when you edit the rich text field, attachments don't render the same partial path for Trix making it seem like your attachments disappeared.

This makes it so attachables use the same partial path for rendering to html and to Trix. This way they'll render consistently in both cases.

cc @georgeclaghorn 