### PR TITLE
Fixes ActiveRecord::NotNullViolation for timestamp on insert_all, insert and upsert_all

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -2,12 +2,13 @@
 
 module ActiveRecord
   class InsertAll
-    attr_reader :model, :connection, :inserts, :on_duplicate, :returning, :unique_by
+    attr_reader :model, :connection, :inserts, :on_duplicate, :returning, :unique_by,
+                :defaults
 
-    def initialize(model, inserts, on_duplicate:, returning: nil, unique_by: nil)
+    def initialize(model, inserts, defaults:, on_duplicate:, returning: nil, unique_by: nil)
       raise ArgumentError, "Empty list of attributes passed" if inserts.blank?
 
-      @model, @connection, @inserts, @on_duplicate, @returning, @unique_by = model, model.connection, inserts, on_duplicate, returning, unique_by
+      @model, @connection, @inserts, @on_duplicate, @returning, @unique_by, @defaults = model, model.connection, inserts, on_duplicate, returning, unique_by, defaults
 
       @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
       @returning = false if @returning == []
@@ -22,7 +23,7 @@ module ActiveRecord
     end
 
     def keys
-      inserts.first.keys.map(&:to_s)
+      inserts.first.keys.map(&:to_s) | defaults.keys
     end
 
     def updatable_columns
@@ -80,7 +81,7 @@ module ActiveRecord
       class Builder
         attr_reader :model
 
-        delegate :skip_duplicates?, :update_duplicates?, to: :insert_all
+        delegate :skip_duplicates?, :update_duplicates?, :defaults, to: :insert_all
 
         def initialize(insert_all)
           @insert_all, @model, @connection = insert_all, insert_all.model, insert_all.connection
@@ -105,13 +106,14 @@ module ActiveRecord
 
           values_list = insert_all.inserts.map do |attributes|
             attributes = attributes.stringify_keys
+            attributes_keys_with_defaults = attributes.keys | defaults.keys
 
-            unless attributes.keys.to_set == keys
+            unless attributes_keys_with_defaults.to_set == keys
               raise ArgumentError, "All objects being inserted must have the same keys"
             end
 
             keys.map do |key|
-              bind = Relation::QueryAttribute.new(key, attributes[key], types[key])
+              bind = Relation::QueryAttribute.new(key, attributes[key] || defaults[key], types[key])
               connection.with_yaml_fallback(bind.value_for_database)
             end
           end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -122,7 +122,7 @@ module ActiveRecord
       #   ])
       #
       def insert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(self, attributes, defaults: _insert_defaults, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
       end
 
       # Inserts a single record into the database. This method constructs a single SQL INSERT
@@ -181,7 +181,7 @@ module ActiveRecord
       #   ])
       #
       def insert_all!(attributes, returning: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning).execute
+        InsertAll.new(self, attributes, defaults: _insert_defaults, on_duplicate: :raise, returning: returning).execute
       end
 
       # Upserts (updates or inserts) a single record into the database. This method constructs
@@ -255,7 +255,7 @@ module ActiveRecord
       #   ], unique_by: { columns: %w[ isbn ] })
       #
       def upsert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(self, attributes, defaults: _upsert_defaults, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of
@@ -407,6 +407,14 @@ module ActiveRecord
         dm.wheres = constraints
 
         connection.delete(dm, "#{self} Destroy")
+      end
+
+      def _insert_defaults
+        {}
+      end
+
+      def _upsert_defaults
+        {}
       end
 
       private

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -83,6 +83,22 @@ module ActiveRecord
         def current_time_from_proper_timezone
           default_timezone == :utc ? Time.now.utc : Time.now
         end
+
+        def _insert_defaults
+          if record_timestamps
+            super.merge(touch_attributes_with_time(*timestamp_attributes_for_create_in_model))
+          else
+            super
+          end
+        end
+
+        def _upsert_defaults
+          if record_timestamps
+            super.merge(touch_attributes_with_time(*timestamp_attributes_for_update_in_model))
+          else
+            super
+          end
+        end
     end
 
   private


### PR DESCRIPTION
fixes #35493 

### Summary
When `t.timestamp` is set for a new model then it adds `NOT NULL` constraint on `created_at` and `updated_at` due to which `insert_all`, `insert` and `upsert_all` fails unless `created_at` and `updated_at` values are given.

```
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :content

    t.timestamps
  end
end
```

Following should fail. Please check issue(#35493) for reproduction script.

```
Post.insert_all([
  { content: "first" },
  { content: "second" }
])
```

@r? @sikachu 