### PR TITLE
Fix preloader to never reset associations in case they are already loaded

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -4,45 +4,57 @@ module ActiveRecord
   module Associations
     class Preloader
       class ThroughAssociation < Association # :nodoc:
-        def run(preloader)
-          already_loaded     = owners.first.association(through_reflection.name).loaded?
-          through_scope      = through_scope()
-          through_preloaders = preloader.preload(owners, through_reflection.name, through_scope)
-          middle_records     = through_preloaders.flat_map(&:preloaded_records)
-          preloaders         = preloader.preload(middle_records, source_reflection.name, scope)
-          @preloaded_records = preloaders.flat_map(&:preloaded_records)
+        PRELOADER = ActiveRecord::Associations::Preloader.new
 
-          owners.each do |owner|
-            through_records = Array(owner.association(through_reflection.name).target)
+        def initialize(*)
+          super
+          @already_loaded = owners.first.association(through_reflection.name).loaded?
+        end
 
-            if already_loaded
+        def preloaded_records
+          @preloaded_records ||= source_preloaders.flat_map(&:preloaded_records)
+        end
+
+        def records_by_owner
+          return @records_by_owner if defined?(@records_by_owner)
+          source_records_by_owner = source_preloaders.map(&:records_by_owner).reduce(:merge)
+          through_records_by_owner = through_preloaders.map(&:records_by_owner).reduce(:merge)
+
+          @records_by_owner = owners.each_with_object({}) do |owner, result|
+            through_records = through_records_by_owner[owner] || []
+
+            if @already_loaded
               if source_type = reflection.options[:source_type]
                 through_records = through_records.select do |record|
                   record[reflection.foreign_type] == source_type
                 end
               end
-            else
-              owner.association(through_reflection.name).reset if through_scope
             end
 
-            result = through_records.flat_map do |record|
-              record.association(source_reflection.name).target
+            records = through_records.flat_map do |record|
+              source_records_by_owner[record]
             end
 
-            result.compact!
-            result.sort_by! { |rhs| preload_index[rhs] } if scope.order_values.any?
-            result.uniq! if scope.distinct_value
-            associate_records_to_owner(owner, result)
-          end
-
-          unless scope.empty_scope?
-            middle_records.each do |owner|
-              owner.association(source_reflection.name).reset if owner
-            end
+            records.compact!
+            records.sort_by! { |rhs| preload_index[rhs] } if scope.order_values.any?
+            records.uniq! if scope.distinct_value
+            result[owner] = records
           end
         end
 
         private
+          def source_preloaders
+            @source_preloaders ||= PRELOADER.preload(middle_records, source_reflection.name, scope)
+          end
+
+          def middle_records
+            through_preloaders.flat_map(&:preloaded_records)
+          end
+
+          def through_preloaders
+            @through_preloaders ||= PRELOADER.preload(owners, through_reflection.name, through_scope)
+          end
+
           def through_reflection
             reflection.through_reflection
           end
@@ -52,8 +64,8 @@ module ActiveRecord
           end
 
           def preload_index
-            @preload_index ||= @preloaded_records.each_with_object({}).with_index do |(id, result), index|
-              result[id] = index
+            @preload_index ||= preloaded_records.each_with_object({}).with_index do |(record, result), index|
+              result[record] = index
             end
           end
 
@@ -92,7 +104,7 @@ module ActiveRecord
               end
             end
 
-            scope unless scope.empty_scope?
+            scope
           end
       end
     end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -548,6 +548,15 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_through_association_preload_doesnt_reset_source_association_if_already_preloaded
+    blue = tags(:blue)
+    authors = Author.preload(posts: :first_blue_tags_2, misc_post_first_blue_tags_2: {}).to_a.sort_by(&:id)
+
+    assert_no_queries do
+      assert_equal [blue], authors[2].posts.first.first_blue_tags_2
+    end
+  end
+
   def test_nested_has_many_through_with_conditions_on_source_associations_preload_via_joins
     # Pointless condition to force single-query loading
     assert_includes_and_joins_equal(


### PR DESCRIPTION
### Summary

This patch fixes the issue when association is preloaded with a custom
preload scope which disposes the already preloaded target of the
association by reseting it.

When custom preload scope is used, the preloading is now performed into
a separated Hash `#records_by_owner` instead of the association.
It removes the necessity the reset the association after the preloading
is complete so that reset of the preloaded association never happens.

Preloading is still happening to the association when the preload scope
is empty.

### Motivation

The bug found can be considered small and also found analytically (by artificially finding the preload sequence that would break) - it wasn't encountered by anyone and has a pretty low chance to be found: it requires a custom association scope inside the through association and very specific sequence of arguments passed to `Relation#preload`.

IMO the implementation based on resetting the association after loading it just to take the loaded records is loose and leads to endless non-cases. I think I can invent failing tests forever :)

My main motivation for this change is this functionality: https://github.com/rails/rails/pull/32136
I consider this patch absolutely required to fix all the bugs described in: https://github.com/rails/rails/pull/32136#issuecomment-461384766

However, I didn't want to merge this patch into `load_associations` functionality because it kind of plays well on its own. Also the final version of `load_associations` will require even more changes for all bugs to be fixed which will make it hard to review.

cc @rafaelfranca @kamipo 
