### PR TITLE
Replace “can not” with “cannot”.

### DIFF
--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -204,7 +204,7 @@ module ActiveModel
       assert_not_predicate unchanged, :changed?
     end
 
-    test "an attribute can not be mutated if it has not been read,
+    test "an attribute cannot be mutated if it has not been read,
       and skips expensive calculations" do
       type_which_raises_from_all_methods = Object.new
       attribute = Attribute.from_database(:foo, "bar", type_which_raises_from_all_methods)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -68,7 +68,7 @@ module ActiveRecord
 
   # Raised by {ActiveRecord::Base#save!}[rdoc-ref:Persistence#save!] and
   # {ActiveRecord::Base.create!}[rdoc-ref:Persistence::ClassMethods#create!]
-  # methods when a record is invalid and can not be saved.
+  # methods when a record is invalid and cannot be saved.
   class RecordNotSaved < ActiveRecordError
     attr_reader :record
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     ONE_AS_ONE = "1 AS one"
 
     # Find by id - This can either be a specific id (1), a list of ids (1, 5, 6), or an array of ids ([5, 6, 10]).
-    # If one or more records can not be found for the requested ids, then ActiveRecord::RecordNotFound will be raised.
+    # If one or more records cannot be found for the requested ids, then ActiveRecord::RecordNotFound will be raised.
     # If the primary key is an integer, find by id coerces its arguments by using +to_i+.
     #
     #   Person.find(1)          # returns the object for ID = 1

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1117,7 +1117,7 @@ module ActiveRecord
             o.reverse
           when String
             if does_not_support_reverse?(o)
-              raise IrreversibleOrderError, "Order #{o.inspect} can not be reversed automatically"
+              raise IrreversibleOrderError, "Order #{o.inspect} cannot be reversed automatically"
             end
             o.split(",").map! do |s|
               s.strip!

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -25,7 +25,7 @@ module ActiveRecord
           if finder_class.primary_key
             relation = relation.where.not(finder_class.primary_key => record.id_in_database)
           else
-            raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
+            raise UnknownPrimaryKey.new(finder_class, "Cannot validate uniqueness for persisted record without primary key.")
           end
         end
         relation = scope_relation(record, relation)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -555,7 +555,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       abc.save!
     end
     assert_match(/\AUnknown primary key for table dashboards in model/, e.message)
-    assert_match(/Can not validate uniqueness for persisted record without primary key.\z/, e.message)
+    assert_match(/Cannot validate uniqueness for persisted record without primary key.\z/, e.message)
   end
 
   def test_validate_uniqueness_ignores_itself_when_primary_key_changed

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -484,7 +484,7 @@ add_foreign_key :articles, :authors
 
 This adds a new foreign key to the `author_id` column of the `articles`
 table. The key references the `id` column of the `authors` table. If the
-column names can not be derived from the table names, you can use the
+column names cannot be derived from the table names, you can use the
 `:column` and `:primary_key` options.
 
 Rails will generate a name for every foreign key starting with


### PR DESCRIPTION
### Summary
This pull request replaces "can not" with "cannot" throughout the project. Cannot is the more usual and professional phrasing and therefore less distracting and confusing.

### Other Information
A summary of opinions on the topic:  https://www.dailywritingtips.com/cannot-or-can-not/

> Both cannot and can not are acceptable spellings, but the first is much more usual. You would use can not when the ‘not’ forms part of another construction such as ‘not only.’

