### PR TITLE
Tip to use rails from local bin folder if schema doesn't exist

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -350,7 +350,7 @@ module ActiveRecord
 
       def check_schema_file(filename)
         unless File.exist?(filename)
-          message = +%{#{filename} doesn't exist yet. Run `rails db:migrate` to create it, then try again.}
+          message = +%{#{filename} doesn't exist yet. Run `bin/rails db:migrate` to create it, then try again.}
           message << %{ If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.} if defined?(::Rails.root)
           Kernel.abort message
         end


### PR DESCRIPTION
Tip to use `bin/rails` instead of global `rails` if schema doesn't exist.