### PR TITLE
Explicitly require rails-html-sanitizer gem in ActionText helpers

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails-html-sanitizer"
+
 module ActionText
   module ContentHelper
     SANITIZER          = Rails::Html::Sanitizer.white_list_sanitizer


### PR DESCRIPTION
### Summary

If the [`action_text.helper` initializer][0] runs after `ActionController::Base` has been loaded, but before the `rails-html-sanitizer` gem has been `require`d, then the reference to the constant `Rails::Html` in the body of the `ActionText::ContentHelper` module raises an `uninitialized constant` exception.

[0]: https://github.com/rails/rails/blob/21703382393c87212c27c988420ee5c133c1aa9f/actiontext/lib/action_text/engine.rb#L31-L35

This proposed change adds an explicit `require` statement to ensure that `Rails::Html` is available before it is referenced.

Fixes #35480 