### PR TITLE
[ci skip] Fix typos

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -74,7 +74,7 @@ module ActionController
     # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt> for details.
     # * <tt>:file</tt> - Renders an explicit template file. Add <tt>:locals</tt> to pass in, if so desired.
     #   It shouldn’t be used directly with unsanitized user input due to lack of validation.
-    # * <tt>:inline</tt> - Renders a ERB template string.
+    # * <tt>:inline</tt> - Renders an ERB template string.
     # * <tt>:plain</tt> - Renders provided text and sets the content type as <tt>text/plain</tt>.
     # * <tt>:html</tt> - Renders the provided HTML safe string, otherwise
     #   performs HTML escape on the string first. Sets the content type as <tt>text/html</tt>.

--- a/actionview/test/ujs/public/vendor/jquery-2.2.0.js
+++ b/actionview/test/ujs/public/vendor/jquery-2.2.0.js
@@ -5578,7 +5578,7 @@ var iframe,
 	};
 
 /**
- * Retrieve the actual display of a element
+ * Retrieve the actual display of an element
  * @param {String} name nodeName of the element
  * @param {Object} doc Document object
  */


### PR DESCRIPTION

Fixes typos in the documentation for `a element` -> `an element` and `a ERB` -> `an ERB`.