### PR TITLE
Used alias for Array#without and Enumerable#without

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,16 +1,16 @@
-*   Allow Array#excluding and Enumerable#excluding to deal with a passed array gracefully.
+*   Allow `Array#excluding` and `Enumerable#excluding` to deal with a passed array gracefully.
 
         [ 1, 2, 3, 4, 5 ].excluding([4, 5]) => [ 1, 2, 3 ]
 
     *DHH*
 
-*   Renamed Array#without and Enumerable#without to Array#excluding and Enumerable#excluding, to create parity with 
-    Array#including and Enumerable#including. Retained the old names as aliases.
+*   Renamed `Array#without` and `Enumerable#without` to `Array#excluding` and `Enumerable#excluding`, to create parity with
+    `Array#including` and `Enumerable#including`. Retained the old names as aliases.
 
     *DHH*
 
-*   Added Array#including and Enumerable#including to conveniently enlarge a collection with more members using a method rather than an operator:
-    
+*   Added `Array#including` and `Enumerable#including` to conveniently enlarge a collection with more members using a method rather than an operator:
+
         [ 1, 2, 3 ].including(4, 5) => [ 1, 2, 3, 4, 5 ]
         post.authors.including(Current.person) => All the authors plus the current person!
 

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -47,11 +47,7 @@ class Array
   def excluding(*elements)
     self - elements.flatten(1)
   end
-
-  # Alias for #excluding.
-  def without(*elements)
-    excluding(*elements)
-  end
+  alias :without :excluding
 
   # Equal to <tt>self[1]</tt>.
   #

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -128,11 +128,7 @@ module Enumerable
     elements.flatten!(1)
     reject { |element| elements.include?(element) }
   end
-
-  # Alias for #excluding.
-  def without(*elements)
-    excluding(*elements)
-  end
+  alias :without :excluding
 
   # Convert an enumerable to an array based on the given key.
   #


### PR DESCRIPTION
- Used `alias` for `Array#without` and `Enumerable#without` to `Array#excluding` and `Enumerable#excluding`
- Updated change log to show methods names properly.
