### PR TITLE
Delegate `only` query method to relation as with `except`

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
-      :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except,
+      :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids
     ].freeze # :nodoc:

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       ActiveRecord::Batches.public_instance_methods(false) +
       ActiveRecord::Calculations.public_instance_methods(false) +
       ActiveRecord::FinderMethods.public_instance_methods(false) - [:raise_record_not_found_exception!] +
-      ActiveRecord::SpawnMethods.public_instance_methods(false) - [:spawn, :merge!, :only] +
+      ActiveRecord::SpawnMethods.public_instance_methods(false) - [:spawn, :merge!] +
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
         method.to_s.end_with?("=", "!", "value", "values", "clause")
       } - [:reverse_order, :arel, :extensions] + [

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1503,9 +1503,11 @@ class RelationTest < ActiveRecord::TestCase
 
     author_posts = relation.except(:order, :limit)
     assert_equal Post.where(author_id: 1).sort_by(&:id), author_posts.sort_by(&:id)
+    assert_equal author_posts.sort_by(&:id), relation.scoping { Post.except(:order, :limit).sort_by(&:id) }
 
     all_posts = relation.except(:where, :order, :limit)
     assert_equal Post.all.sort_by(&:id), all_posts.sort_by(&:id)
+    assert_equal all_posts.sort_by(&:id), relation.scoping { Post.except(:where, :order, :limit).sort_by(&:id) }
   end
 
   def test_only
@@ -1514,9 +1516,11 @@ class RelationTest < ActiveRecord::TestCase
 
     author_posts = relation.only(:where)
     assert_equal Post.where(author_id: 1).sort_by(&:id), author_posts.sort_by(&:id)
+    assert_equal author_posts.sort_by(&:id), relation.scoping { Post.only(:where).sort_by(&:id) }
 
     all_posts = relation.only(:order)
     assert_equal Post.order("id ASC").to_a, all_posts.to_a
+    assert_equal all_posts.to_a, relation.scoping { Post.only(:order).to_a }
   end
 
   def test_anonymous_extension


### PR DESCRIPTION
I've found the skewness of delegation methods between `except` and
`only` in a88b6f2.

The `only` method is closely similar with `except` as `SpawnMethods`.

https://github.com/rails/rails/blob/e056b9bfb07c4eb3bcc6672d885aadd72bec574f/activerecord/lib/active_record/relation/spawn_methods.rb#L53-L67

It is preferable both behaves the same way.