### PR TITLE
Corrected execution result of Enumerable#sum [ci skip]

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2001,7 +2001,7 @@ Addition only assumes the elements respond to `+`:
 ```ruby
 [[1, 2], [2, 3], [3, 4]].sum    # => [1, 2, 2, 3, 3, 4]
 %w(foo bar baz).sum             # => "foobarbaz"
-{a: 1, b: 2, c: 3}.sum          # => [:b, 2, :c, 3, :a, 1]
+{a: 1, b: 2, c: 3}.sum          # => [:a, 1, :b, 2, :c, 3]
 ```
 
 The sum of an empty collection is zero by default, but this is customizable:


### PR DESCRIPTION
Fixed execution result of sample code of Enumerable#sum.

```ruby
$ { a: 1, b: 2, c: 3 }.sum 
=> [:a, 1, :b, 2, :c, 3]
```

### environment

```ruby
$ ruby -v
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-linux]
$ rails -v
Rails 6.0.0.beta2
```