### PR TITLE
added *.gem files to gitignore for new rails plugins

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -455,6 +455,22 @@ gem "yaffle", git: "https://github.com/rails/yaffle.git"
 After running `bundle install`, your gem functionality will be available to the application.
 
 When the gem is ready to be shared as a formal release, it can be published to [RubyGems](https://rubygems.org).
+
+Alternatively, you can benefit from Bundler's Rake tasks. You can see a full list with the following:
+
+```
+rake -T
+
+rake build
+# Build yaffle-0.0.1.gem into the pkg directory
+
+rake install
+# Build and install yaffle-0.0.1.gem into system gems
+
+rake release
+# Create tag v0.0.1 and build and push yaffle-0.0.1.gem to Rubygems
+```
+
 For more information about publishing gems to RubyGems, see: [Publishing your gem](https://guides.rubygems.org/publishing).
 
 RDoc Documentation

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -459,16 +459,16 @@ When the gem is ready to be shared as a formal release, it can be published to [
 Alternatively, you can benefit from Bundler's Rake tasks. You can see a full list with the following:
 
 ```
-rake -T
+bundle exec rake -T
 
-rake build
-# Build yaffle-0.0.1.gem into the pkg directory
+bundle exec rake build
+# Build yaffle-0.1.0.gem into the pkg directory
 
-rake install
-# Build and install yaffle-0.0.1.gem into system gems
+bundle exec rake install
+# Build and install yaffle-0.1.0.gem into system gems
 
-rake release
-# Create tag v0.0.1 and build and push yaffle-0.0.1.gem to Rubygems
+bundle exec rake release
+# Create tag v0.1.0 and build and push yaffle-0.1.0.gem to Rubygems
 ```
 
 For more information about publishing gems to RubyGems, see: [Publishing your gem](https://guides.rubygems.org/publishing).

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -16,4 +16,3 @@ pkg/
 <% end -%>
 <%= dummy_path %>/tmp/
 <% end -%>
-*.gem

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -16,3 +16,4 @@ pkg/
 <% end -%>
 <%= dummy_path %>/tmp/
 <% end -%>
+*.gem


### PR DESCRIPTION
### Summary

When I'm creating a new Gem with "rails plugin new" and when I want to publish gem I'm doing "gem build <file>.gemspec. It creates a <file>.gem file. And then I'm pushing it to rubygems.

After this, if I want to commit my changes to repo - I'm manually adding *.gem to .gitignore.

I think we can just add to gitignore such files.