### PR TITLE
Add version awareness to rails db:system:change

### DIFF
--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -35,8 +35,9 @@ module Rails
           end
 
           def edit_gemfile
-            database_gem_name, _ = gem_for_database
-            gsub_file("Gemfile", all_database_gems_regex, database_gem_name)
+            name, version = gem_for_database
+            gsub_file("Gemfile", all_database_gems_regex, name)
+            gsub_file("Gemfile", gem_entry_regex_for(name), gem_entry_for(name, *version))
           end
 
           private
@@ -47,6 +48,15 @@ module Rails
             def all_database_gems_regex
               all_database_gem_names = all_database_gems.map(&:first)
               /(\b#{all_database_gem_names.join('\b|\b')}\b)/
+            end
+
+            def gem_entry_regex_for(gem_name)
+              /^gem.*\b#{gem_name}\b.*/
+            end
+
+            def gem_entry_for(*gem_name_and_version)
+              gem_name_and_version.map! { |segment| "'#{segment}'" }
+              "gem #{gem_name_and_version.join(", ")}"
             end
         end
       end

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -40,7 +40,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use pg as the database for Active Record", content
-              assert_match "gem 'pg'", content
+              assert_match "gem 'pg', '>= 0.18', '< 2.0'", content
             end
           end
 
@@ -54,7 +54,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use mysql2 as the database for Active Record", content
-              assert_match "gem 'mysql2'", content
+              assert_match "gem 'mysql2', '>= 0.4.4'", content
             end
           end
 
@@ -68,7 +68,22 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match "gem 'sqlite3'", content
+              assert_match "gem 'sqlite3', '~> 1.3', '>= 1.3.6'", content
+            end
+          end
+
+          test "change from versioned gem to other versioned gem" do
+            run_generator ["--to", "sqlite3"]
+            run_generator ["--to", "mysql", "--force"]
+
+            assert_file("config/database.yml") do |content|
+              assert_match "adapter: mysql2", content
+              assert_match "database: test_app", content
+            end
+
+            assert_file("Gemfile") do |content|
+              assert_match "# Use mysql2 as the database for Active Record", content
+              assert_match "gem 'mysql2', '>= 0.4.4'", content
             end
           end
         end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/35520. `rails db:system:change` doesn't support switching out database gems locked to specific versions. This fixes that.

I opted for 2 gsubs to keep the logic simple, and keep support for comment substitutes. If we don't care about the comments, I can merge the two regexes to only sub the gem entry once.
