### PR TITLE
feat(js): Dynamic Actioncable WebSocket URL

### DIFF
--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -30,14 +30,20 @@ export function getConfig(name) {
 }
 
 export function createWebSocketURL(url) {
-  if (url && !/^wss?:/i.test(url)) {
+  let webSocketURL
+  if (typeof url === 'function') {
+    webSocketURL = url()
+  } else {
+    webSocketURL = url
+  }
+  if (webSocketURL && !/^wss?:/i.test(webSocketURL)) {
     const a = document.createElement("a")
-    a.href = url
+    a.href = webSocketURL
     // Fix populating Location properties in IE. Otherwise, protocol will be blank.
     a.href = a.href
     a.protocol = a.protocol.replace("http", "ws")
     return a.href
   } else {
-    return url
+    return webSocketURL
   }
 }

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -30,12 +30,8 @@ export function getConfig(name) {
 }
 
 export function createWebSocketURL(url) {
-  let webSocketURL
-  if (typeof url === 'function') {
-    webSocketURL = url()
-  } else {
-    webSocketURL = url
-  }
+  const webSocketURL = typeof url === 'function' ? url() : url;
+
   if (webSocketURL && !/^wss?:/i.test(webSocketURL)) {
     const a = document.createElement("a")
     a.href = webSocketURL

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -41,5 +41,13 @@ module("ActionCable", () => {
 
       assert.equal(consumer.url, testURL)
     })
+
+    test("uses function to generate URL", assert => {
+      const generateURL = () => {
+        return testURL
+      }
+      const consumer = ActionCable.createConsumer(generateURL)
+      assert.equal(consumer.url, testURL)
+    })
   })
 })


### PR DESCRIPTION
### Summary

Allow createWebSocketURL fn to accept a function to generate the websocket URL rather than a string.

Closes #33064 

Please let me know if you would like me to update CHANGELOG.

I believe this would require a need to update the docs to document this functionality, but I am not exactly sure where it would best be placed, any help here is appreciated!

