### PR TITLE
Updated links from http to https in guides, docs, etc

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
 ### Steps to reproduce
 <!-- (Guidelines for creating a bug report are [available
-here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->
+here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->
 
 ### Expected behavior
 <!-- Tell us what should happen -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,6 @@ CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the f
 
 Finally, if your pull request affects documentation or any non-code
 changes, guidelines for those changes are [available
-here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
+here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
 
 Thanks for contributing to Rails! -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ The Rails team is committed to fostering a welcoming community.
 
 **Our Code of Conduct can be found here**:
 
-http://rubyonrails.org/conduct/
+https://rubyonrails.org/conduct/
 
 For a history of updates, see the page history here:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 #### **Did you find a bug?**
 
 * **Do not open up a GitHub issue if the bug is a security vulnerability
-  in Rails**, and instead to refer to our [security policy](http://rubyonrails.org/security/).
+  in Rails**, and instead to refer to our [security policy](https://rubyonrails.org/security/).
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/rails/rails/issues).
 
@@ -14,7 +14,7 @@
   * [**Action Pack** (controllers, routing) issues](https://github.com/rails/rails/blob/master/guides/bug_report_templates/action_controller_master.rb)
   * [**Generic template** for other issues](https://github.com/rails/rails/blob/master/guides/bug_report_templates/generic_master.rb)
 
-* For more detailed information on submitting a bug report and creating an issue, visit our [reporting guidelines](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#reporting-an-issue).
+* For more detailed information on submitting a bug report and creating an issue, visit our [reporting guidelines](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#reporting-an-issue).
 
 #### **Did you write a patch that fixes a bug?**
 
@@ -22,7 +22,7 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, please read the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide to know more about coding conventions and benchmarks.
+* Before submitting, please read the [Contributing to Ruby on Rails](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide to know more about coding conventions and benchmarks.
 
 #### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
 
@@ -40,9 +40,9 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 #### **Do you want to contribute to the Rails documentation?**
 
-* Please read [Contributing to the Rails Documentation](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).
+* Please read [Contributing to the Rails Documentation](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).
 
-Ruby on Rails is a volunteer effort. We encourage you to pitch in and [join the team](http://contributors.rubyonrails.org)!
+Ruby on Rails is a volunteer effort. We encourage you to pitch in and [join the team](https://contributors.rubyonrails.org)!
 
 Thanks! :heart: :heart: :heart:
 

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -13,7 +13,7 @@ You can read more about Action Cable in the [Action Cable Overview](https://edge
 
 API documentation is at:
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.author   = ["Pratik Naik", "David Heinemeier Hansson"]
   s.email    = ["pratiknaik@gmail.com", "david@loudthinking.com"]
-  s.homepage = "http://rubyonrails.org"
+  s.homepage = "https://rubyonrails.org"
 
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*", "app/assets/javascripts/action_cable.js"]
   s.require_path = "lib"

--- a/actionmailbox/test/dummy/config/locales/en.yml
+++ b/actionmailbox/test/dummy/config/locales/en.yml
@@ -27,7 +27,7 @@
 #   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   hello: "Hello world"

--- a/actionmailbox/test/dummy/config/routes.rb
+++ b/actionmailbox/test/dummy/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :messages
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -128,7 +128,7 @@ Action Mailer is released under the MIT license:
 
 API documentation is at
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.author   = "David Heinemeier Hansson"
   s.email    = "david@loudthinking.com"
-  s.homepage = "http://rubyonrails.org"
+  s.homepage = "https://rubyonrails.org"
 
   s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "lib/**/*"]
   s.require_path = "lib"

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -46,7 +46,7 @@ Action Pack is released under the MIT license:
 
 API documentation is at:
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.author   = "David Heinemeier Hansson"
   s.email    = "david@loudthinking.com"
-  s.homepage = "http://rubyonrails.org"
+  s.homepage = "https://rubyonrails.org"
 
   s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "lib/**/*"]
   s.require_path = "lib"

--- a/actiontext/test/dummy/config/locales/en.yml
+++ b/actiontext/test/dummy/config/locales/en.yml
@@ -27,7 +27,7 @@
 #   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   hello: "Hello world"

--- a/actiontext/test/dummy/config/routes.rb
+++ b/actiontext/test/dummy/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :messages
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -27,7 +27,7 @@ Action View is released under the MIT license:
 
 API documentation is at
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/actionview/app/assets/javascripts/README.md
+++ b/actionview/app/assets/javascripts/README.md
@@ -52,5 +52,5 @@ Run `bundle exec rake ujs:server` first, and then run the web tests by visiting 
 rails-ujs is released under the [MIT License](MIT-LICENSE).
 
 [data]: https://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-attributes "Embedding custom non-visible data with the data-* attributes"
-[validator]: http://validator.w3.org/
-[csrf]: http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html
+[validator]: https://validator.w3.org/
+[csrf]: https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html

--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -38,7 +38,7 @@ module ActionView #:nodoc:
 
       # Converts the array to a comma-separated sentence where the last element is
       # joined by the connector word. This is the html_safe-aware version of
-      # ActiveSupport's {Array#to_sentence}[http://api.rubyonrails.org/classes/Array.html#method-i-to_sentence].
+      # ActiveSupport's {Array#to_sentence}[https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence].
       #
       def to_sentence(array, options = {})
         options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -114,7 +114,7 @@ module ActionView
 
       # Delegates to <tt>I18n.localize</tt> with no additional functionality.
       #
-      # See http://rubydoc.info/github/svenfuchs/i18n/master/I18n/Backend/Base:localize
+      # See https://www.rubydoc.info/github/svenfuchs/i18n/master/I18n/Backend/Base:localize
       # for more information.
       def localize(*args)
         I18n.localize(*args)

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -22,7 +22,7 @@ switch between them without having to rewrite your jobs.
 
 To learn how to use your preferred queuing backend see its adapter
 documentation at
-[ActiveJob::QueueAdapters](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
+[ActiveJob::QueueAdapters](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
 
 Declare a job like so:
 
@@ -86,7 +86,7 @@ by default has been mixed into Active Record classes.
 
 Active Job has built-in adapters for multiple queuing backends (Sidekiq,
 Resque, Delayed Job and others). To get an up-to-date list of the adapters
-see the API Documentation for [ActiveJob::QueueAdapters](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
+see the API Documentation for [ActiveJob::QueueAdapters](https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html).
 
 **Please note:** We are not accepting pull requests for new adapters. We
 encourage library authors to provide an ActiveJob adapter as part of
@@ -121,7 +121,7 @@ Active Job is released under the MIT license:
 
 API documentation is at:
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -253,7 +253,7 @@ Active Model is released under the MIT license:
 
 API documentation is at:
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -4,7 +4,7 @@ Active Storage makes it simple to upload and reference files in cloud services l
 
 Files can be uploaded from the server to the cloud or directly from the client to the cloud.
 
-Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) or [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image) supported transformation.
+Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) or [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image) supported transformation.
 
 ## Compared to other storage solutions
 
@@ -149,7 +149,7 @@ Active Storage is released under the [MIT License](https://opensource.org/licens
 
 API documentation is at:
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports for the Ruby on Rails project can be filed here:
 

--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -849,7 +849,7 @@ Credits
 -------
 
 See the
-[full list of contributors to Rails](http://contributors.rubyonrails.org/)
+[full list of contributors to Rails](https://contributors.rubyonrails.org/)
 for the many people who spent many hours making Rails, the stable and robust
 framework it is. Kudos to all of them.
 

--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -207,7 +207,7 @@ Credits
 -------
 
 See the
-[full list of contributors to Rails](http://contributors.rubyonrails.org/)
+[full list of contributors to Rails](https://contributors.rubyonrails.org/)
 for the many people who spent many hours making Rails, the stable and robust
 framework it is. Kudos to all of them.
 

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -63,7 +63,7 @@ INFO: Page Caching has been removed from Rails 4. See the [actionpack-page_cachi
 
 Page Caching cannot be used for actions that have before filters - for example, pages that require authentication. This is where Action Caching comes in. Action Caching works like Page Caching except the incoming web request hits the Rails stack so that before filters can be run on it before the cache is served. This allows authentication and other restrictions to be run while still serving the result of the output from a cached copy.
 
-INFO: Action Caching has been removed from Rails 4. See the [actionpack-action_caching gem](https://github.com/rails/actionpack-action_caching). See [DHH's key-based cache expiration overview](http://signalvnoise.com/posts/3113-how-key-based-cache-expiration-works) for the newly-preferred method.
+INFO: Action Caching has been removed from Rails 4. See the [actionpack-action_caching gem](https://github.com/rails/actionpack-action_caching). See [DHH's key-based cache expiration overview](https://signalvnoise.com/posts/3113-how-key-based-cache-expiration-works) for the newly-preferred method.
 
 ### Fragment Caching
 

--- a/railties/README.rdoc
+++ b/railties/README.rdoc
@@ -29,7 +29,7 @@ Railties is released under the MIT license:
 
 API documentation is at
 
-* http://api.rubyonrails.org
+* https://api.rubyonrails.org
 
 Bug reports can be filed for the Ruby on Rails project here:
 

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.author   = "David Heinemeier Hansson"
   s.email    = "david@loudthinking.com"
-  s.homepage = "http://rubyonrails.org"
+  s.homepage = "https://rubyonrails.org"
 
   s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "RDOC_MAIN.rdoc", "exe/**/*", "lib/**/{*,.[a-z]*}"]
   s.require_path = "lib"


### PR DESCRIPTION
Converted few links which can be converted to HTTPS after PR #35492

ref: https://github.com/rails/rails/pull/35492#issuecomment-470872285

@r? @vipulnsward 