### PR TITLE
Allow autoloader inflectors to be swaped out

### DIFF
--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -55,10 +55,6 @@ module ActiveSupport
         private
 
           def setup_autoloaders
-            Rails.autoloaders.each do |autoloader|
-              autoloader.inflector = Inflector
-            end
-
             Dependencies.autoload_paths.each do |autoload_path|
               # Zeitwerk only accepts existing directories in `push_dir` to
               # prevent misconfigurations.

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -6,6 +6,7 @@ require "pathname"
 
 require "active_support"
 require "active_support/dependencies/autoload"
+require "active_support/dependencies/zeitwerk_integration"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/array/extract_options"

--- a/railties/lib/rails/autoloaders.rb
+++ b/railties/lib/rails/autoloaders.rb
@@ -7,13 +7,19 @@ module Rails
 
       def main
         if zeitwerk_enabled?
-          @main ||= Zeitwerk::Loader.new.tap { |loader| loader.tag = "rails.main" }
+          @main ||= Zeitwerk::Loader.new.tap do |loader|
+            loader.tag = "rails.main"
+            loader.inflector = ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector
+          end
         end
       end
 
       def once
         if zeitwerk_enabled?
-          @once ||= Zeitwerk::Loader.new.tap { |loader| loader.tag = "rails.once" }
+          @once ||= Zeitwerk::Loader.new.tap do |loader|
+            loader.tag = "rails.once"
+            loader.inflector = ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector
+          end
         end
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1167,6 +1167,8 @@ module ApplicationTests
       assert_instance_of Zeitwerk::Loader, Rails.autoloaders.once
       assert_equal "rails.once", Rails.autoloaders.once.tag
       assert_equal [Rails.autoloaders.main, Rails.autoloaders.once], Rails.autoloaders.to_a
+      assert_equal ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector, Rails.autoloaders.main.inflector
+      assert_equal ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector, Rails.autoloaders.once.inflector
 
       config.autoloader = :classic
       assert_not Rails.autoloaders.zeitwerk_enabled?
@@ -1181,6 +1183,8 @@ module ApplicationTests
       assert_instance_of Zeitwerk::Loader, Rails.autoloaders.once
       assert_equal "rails.once", Rails.autoloaders.once.tag
       assert_equal [Rails.autoloaders.main, Rails.autoloaders.once], Rails.autoloaders.to_a
+      assert_equal ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector, Rails.autoloaders.main.inflector
+      assert_equal ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector, Rails.autoloaders.once.inflector
 
       assert_raises(ArgumentError) { config.autoloader = :unknown }
     end


### PR DESCRIPTION
### Context

I'm working on enabling Zeitwerk in our app, and there is a bunch of special cases that makes us require a custom inflector.

Until https://github.com/rails/rails/commit/39b2a6374b49dba43606b1a806899e49aa055a81 was pushed, I could simply do `Rails.autoloaders.main.inflector = MyCustomInflector` in `config/application.rb`

But now it's overridden later in the chain by `setup_autoloaders`.

### Proposed change

By setting the ZeitwerkIntegration inflector immediately after the loader is initialized, it allows for swapping it out as early as one want.

cc @fxn @airhorns (👋) @rafaelfranca @Edouard-chin 