### PR TITLE
Improve wording in cache documentation

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -492,7 +492,7 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       #
-      # All implementations may not support this method.
+      # Some implementations may not support this method.
       def delete_matched(matcher, options = nil)
         raise NotImplementedError.new("#{self.class.name} does not support delete_matched")
       end
@@ -501,7 +501,7 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       #
-      # All implementations may not support this method.
+      # Some implementations may not support this method.
       def increment(name, amount = 1, options = nil)
         raise NotImplementedError.new("#{self.class.name} does not support increment")
       end
@@ -510,7 +510,7 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       #
-      # All implementations may not support this method.
+      # Some implementations may not support this method.
       def decrement(name, amount = 1, options = nil)
         raise NotImplementedError.new("#{self.class.name} does not support decrement")
       end
@@ -519,7 +519,7 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       #
-      # All implementations may not support this method.
+      # Some implementations may not support this method.
       def cleanup(options = nil)
         raise NotImplementedError.new("#{self.class.name} does not support cleanup")
       end
@@ -529,7 +529,7 @@ module ActiveSupport
       #
       # The options hash is passed to the underlying cache implementation.
       #
-      # All implementations may not support this method.
+      # Some implementations may not support this method.
       def clear(options = nil)
         raise NotImplementedError.new("#{self.class.name} does not support clear")
       end


### PR DESCRIPTION
### Summary

The changes are pretty much self-explanatory - fixed a few sentences that look slightly wrong to me.
