### PR TITLE
Added missing guide links in documentation and minor wording fix - Closed

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -13,6 +13,8 @@ Additionally, an Action Mailer class can be used to process incoming email,
 such as allowing a blog to accept new posts from an email (which could even
 have been sent from a phone).
 
+You can read more about Action Mailer in the {Action Mailer Basics}[https://edgeguides.rubyonrails.org/action_mailer_basics.html] guide.
+
 == Sending emails
 
 The framework works by initializing any instance variables you want to be

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -23,6 +23,7 @@ by default and Action View rendering is implicitly triggered by Action
 Controller. However, these modules are designed to function on their own and
 can be used outside of Rails.
 
+You can read more about Action Pack in the {Action Controller Overview}[https://guides.rubyonrails.org/action_controller_overview.html] guide.
 
 == Download and installation
 

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -5,6 +5,8 @@ view helpers that assist when building HTML forms, Atom feeds and more.
 Template formats that Action View handles are ERB (embedded Ruby, typically
 used to inline short Ruby snippets inside HTML), and XML Builder.
 
+You can read more about Action View in the {Action View Overview}[https://edgeguides.rubyonrails.org/action_view_overview.html] guide.
+
 == Download and installation
 
 The latest version of Action View can be installed with RubyGems:

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -1,4 +1,4 @@
-# Active Job -- Make work happen later
+# Active Job – Make work happen later
 
 Active Job is a framework for declaring jobs and making them run on a variety
 of queuing backends. These jobs can be everything from regularly scheduled
@@ -17,6 +17,7 @@ about API differences between Delayed Job and Resque. Picking your queuing
 backend becomes more of an operational concern, then. And you'll be able to
 switch between them without having to rewrite your jobs.
 
+You can read more about Active Job in the [Active Job Basics](https://edgeguides.rubyonrails.org/active_job_basics.html) guide.
 
 ## Usage
 

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -5,6 +5,8 @@ They allow for Action Pack helpers to interact with non-Active Record models,
 for example. Active Model also helps with building custom ORMs for use outside of
 the Rails framework.
 
+You can read more about Active Model in the {Active Model Basics}[https://edgeguides.rubyonrails.org/active_model_basics.html] guide.
+
 Prior to Rails 3.0, if a plugin or gem developer wanted to have an object
 interact with Action Pack helpers, it was required to either copy chunks of
 code from Rails, or monkey patch entire helpers to make them handle objects

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -13,6 +13,8 @@ columns. Although these mappings can be defined explicitly, it's recommended
 to follow naming conventions, especially when getting started with the
 library.
 
+You can read more about Active Record in the {Active Record Basics}[https://edgeguides.rubyonrails.org/active_record_basics.html] guide.
+
 A short rundown of some of the major features:
 
 * Automated mapping between classes and tables, attributes and columns.

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -6,6 +6,8 @@ Files can be uploaded from the server to the cloud or directly from the client t
 
 Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) or [Vips](http://www.rubydoc.info/gems/ruby-vips/Vips/Image) supported transformation.
 
+You can read more about Active Storage in the [Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html) guide.
+
 ## Compared to other storage solutions
 
 A key difference to how Active Storage works compared to other attachment solutions in Rails is through the use of built-in [Blob](https://github.com/rails/rails/blob/master/activestorage/app/models/active_storage/blob.rb) and [Attachment](https://github.com/rails/rails/blob/master/activestorage/app/models/active_storage/attachment.rb) models (backed by Active Record). This means existing application models do not need to be modified with additional columns to associate with files. Active Storage uses polymorphic associations via the `Attachment` join model, which then connects to the actual `Blob`.

--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -5,6 +5,7 @@ extensions that were found useful for the Rails framework. These additions
 reside in this package so they can be loaded as needed in Ruby projects
 outside of Rails.
 
+You can read more about Active Support in the {Active Support Core Extensions}[https://edgeguides.rubyonrails.org/active_support_core_extensions.html] guide.
 
 == Download and installation
 


### PR DESCRIPTION
### Summary
* [ActiveJob] README title textual change.
* [ActiveJob] Added Active Job Basic missing guide link in README.
* [ActionMailer] Added Action Mailer Basic missing guide link in README.

I have moved these improvements to the latest new https://github.com/rails/rails/pull/35559  . Please have a look and review the latest PR https://github.com/rails/rails/pull/35559