### PR TITLE
Support other optional parameters and quoted-strings on Content-Type parser

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -82,6 +82,7 @@ module ActionDispatch # :nodoc:
     SET_COOKIE   = "Set-Cookie"
     LOCATION     = "Location"
     NO_CONTENT_CODES = [100, 101, 102, 204, 205, 304]
+    CONTENT_TYPE_PARSER = /\A(?<type>[^;\s]+)?(?:.*;\s*charset=(?<quote>"?)(?<charset>[^;\s]+)\k<quote>)?/ # :nodoc:
 
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers
@@ -409,10 +410,8 @@ module ActionDispatch # :nodoc:
     NullContentTypeHeader = ContentTypeHeader.new nil, nil
 
     def parse_content_type(content_type)
-      if content_type
-        type, charset = content_type.split(/;\s*charset=/)
-        type = nil if type && type.empty?
-        ContentTypeHeader.new(type, charset)
+      if content_type && match = CONTENT_TYPE_PARSER.match(content_type)
+        ContentTypeHeader.new(match[:type], match[:charset])
       else
         NullContentTypeHeader
       end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -539,4 +539,38 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal('"202cb962ac59075b964b07152d234b70"', @response.headers["ETag"])
     assert_equal('"202cb962ac59075b964b07152d234b70"', @response.etag)
   end
+
+  test "response Content-Type with optional parameters" do
+    @app = lambda { |env|
+      [
+        200,
+        { "Content-Type" => "text/csv; charset=utf-16; header=present" },
+        ["Hello"]
+      ]
+    }
+
+    get "/"
+    assert_response :success
+
+    assert_equal("text/csv; charset=utf-16; header=present", @response.headers["Content-Type"])
+    assert_equal("text/csv", @response.content_type)
+    assert_equal("utf-16", @response.charset)
+  end
+
+  test "response Content-Type with quoted-string" do
+    @app = lambda { |env|
+      [
+        200,
+        { "Content-Type" => 'text/csv; header=present; charset="utf-16"' },
+        ["Hello"]
+      ]
+    }
+
+    get "/"
+    assert_response :success
+
+    assert_equal('text/csv; header=present; charset="utf-16"', @response.headers["Content-Type"])
+    assert_equal("text/csv", @response.content_type)
+    assert_equal("utf-16", @response.charset)
+  end
 end


### PR DESCRIPTION
### Summary

There is a possibility that Content-Type header includes optional parameters other than `charset`.

As an example, to indicate the presence or absence of the header line, text/csv type has optional `header` parameter like this:

```
Content-Type: text/csv; charset=utf-16; header=present
```

To exclude this type of optional parameters from `#charset`, I changed `#parse_content_type` implementation in this pull request.

### Other Information

- https://tools.ietf.org/html/rfc7111
- https://tools.ietf.org/html/rfc7231