### PR TITLE
Updated Action Text doc to mention about rich text field isn't backend by database column.

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -49,7 +49,9 @@ Run `rails action_text:install` to add the Yarn package and copy over the necess
 
 ## Examples
 
-Adding a rich text field to an existing model:
+Add a rich text field to an existing model.
+
+Note that rich text field can be added on the database column of the model or on a model attribute. In the following example, `content` can be database column for model `Message` or an model attribute accessor.
 
 ```ruby
 # app/models/message.rb


### PR DESCRIPTION
In the fix #35430, I learned that Action Text isn't backed by database column. Before doing the fix I checked the documentation to see if the test were intentional for Action Text but could not find any reference. 

After https://github.com/rails/rails/pull/35430#issuecomment-468123090 ,  it was cleared for me. 

@r? @georgeclaghorn I think it is important to specify that in the documentation. Since you had reviewed that PR and pointed me out, tagging you here. 

