### PR TITLE
Stop encoding in secure_compare for speedup

### DIFF
--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -24,7 +24,7 @@ module ActiveSupport
     # The values are first processed by SHA256, so that we don't leak length info
     # via timing attacks.
     def secure_compare(a, b)
-      fixed_length_secure_compare(::Digest::SHA256.hexdigest(a), ::Digest::SHA256.hexdigest(b)) && a == b
+      fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
     end
     module_function :secure_compare
   end


### PR DESCRIPTION
Hex encoding is base 16 which makes the original input twice as big. We don't need to encode the SHA256 output bytes and the shorter output means we spend less time `fixed_length_secure_compare`.

Benchmark script:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
end

require "active_support"

module ActiveSupport
  module SecurityUtils
    def fast_secure_compare(a, b)
      fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
    end
    module_function :fast_secure_compare
  end
end

SCENARIOS = {
  "Same strings, length 16" => ["a" * 16, "a" * 16],
  "Different strings, length 16" => ["a" * 16, "b" * 16],
  "Same strings, length 32" => ["a" * 32, "a" * 32],
  "Different strings, length 32" => ["a" * 32, "b" * 32]
}

SCENARIOS.each_pair do |name, (a, b)|
  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("secure_compare") { ActiveSupport::SecurityUtils.secure_compare(a, b) }
    x.report("fast_secure_compare") { ActiveSupport::SecurityUtils.fast_secure_compare(a, b) }
    x.compare!
  end
end
```

Results from my MacBook 2018 (2.2 GHz Intel Core i7):
```
=========================== Same strings, length 16 ============================
Comparison:
 fast_secure_compare:   157901.1 i/s
      secure_compare:    91265.1 i/s - 1.73x  slower

========================= Different strings, length 16 =========================
Comparison:
 fast_secure_compare:   158115.6 i/s
      secure_compare:    91069.1 i/s - 1.74x  slower

=========================== Same strings, length 32 ============================
Comparison:
 fast_secure_compare:   158770.5 i/s
      secure_compare:    91677.7 i/s - 1.73x  slower

========================= Different strings, length 32 =========================
Comparison:
 fast_secure_compare:   156523.3 i/s
      secure_compare:    92266.6 i/s - 1.70x  slower
```

Real life benchmark when decrypting:
 ```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
end

require 'benchmark/ips'

Benchmark.ips do |x|
  salt  = SecureRandom.random_bytes(64)
  key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, 32)
  data  = 'my secret data my secret data'

  cbc = ActiveSupport::MessageEncryptor.new(key, cipher: 'aes-256-cbc')
  cbc_encrypted = cbc.encrypt_and_sign(data)

  x.report("aes-256-cbc decryption") do
    cbc.decrypt_and_verify(cbc_encrypted)
  end

  x.compare!
end
```
Results:
```
aes-256-cbc decryption, after PR:  28630.6 i/s
aes-256-cbc decryption, before PR: 24767.5 i/s (1.15x slower)
```