### PR TITLE
[Textual] Text Amendments on README - Request feedback on an idea for a feature textual addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Trying to report a possible security vulnerability in Rails? Please
 check out our [security policy](https://rubyonrails.org/security/) for
 guidelines about how to proceed.
 
+If you'd like feedback on an idea for a feature before doing the work to make a patch, please send an email to the [rails-core mailing](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) list.
+
 Everyone interacting in Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the Rails [code of conduct](https://rubyonrails.org/conduct/).
 
 ## Code Status


### PR DESCRIPTION
### Summary

There is a small Textual Amendment with in the **Contributing** section of  **README** file. I am observing that there should be some information about the  **Ruby on Rails: Core - Official Forum**" on README with the **link of forum**. It's pretty much difficult at the moment to reach at the **Ruby on Rails: Core google forum**. 

There should be at least some information about the role of the **Ruby on Rails: Core - Official Forum**

#### Suggested amendment on README:
* If you'd like feedback on an idea for a feature before doing the work to make a patch, please send an email to the [rails-core mailing](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) list.
