### PR TITLE
Use the -u switch for the `rails server` banner

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -255,7 +255,7 @@ module Rails
         end
 
         def self.banner(*)
-          "rails server [thin/puma/webrick] [options]"
+          "rails server -u [thin/puma/webrick] [options]"
         end
 
         def prepare_restart


### PR DESCRIPTION
- Because just passing the server argument to this command is
  deprecated in https://github.com/rails/rails/pull/32058