### PR TITLE
Squish the deprecation messages across the codebase 

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -242,7 +242,7 @@ module ActionView #:nodoc:
       @_config = ActiveSupport::InheritableOptions.new
 
       unless formats == NULL
-        ActiveSupport::Deprecation.warn <<~eowarn
+        ActiveSupport::Deprecation.warn <<~eowarn.squish
         Passing formats to ActionView::Base.new is deprecated
         eowarn
       end
@@ -251,7 +251,7 @@ module ActionView #:nodoc:
       when ActionView::LookupContext
         @lookup_context = lookup_context
       else
-        ActiveSupport::Deprecation.warn <<~eowarn
+        ActiveSupport::Deprecation.warn <<~eowarn.squish
         ActionView::Base instances should be constructed with a lookup context,
         assignments, and a controller.
         eowarn
@@ -278,7 +278,7 @@ module ActionView #:nodoc:
 
     def compiled_method_container
       if self.class == ActionView::Base
-        ActiveSupport::Deprecation.warn <<~eowarn
+        ActiveSupport::Deprecation.warn <<~eowarn.squish
           ActionView::Base instances must implement `compiled_method_container`
           or use the class method `with_empty_template_cache` for constructing
           an ActionView::Base instances that has an empty cache.

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -154,7 +154,7 @@ module ActionView
         view_paths = build_view_paths((@view_paths.paths + self.class.fallbacks).uniq)
 
         if block_given?
-          ActiveSupport::Deprecation.warn <<~eowarn
+          ActiveSupport::Deprecation.warn <<~eowarn.squish
           Calling `with_fallbacks` with a block is deprecated.  Call methods on
           the lookup context returned by `with_fallbacks` instead.
           eowarn

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1051,7 +1051,7 @@ module ActiveRecord
 
       def assume_migrated_upto_version(version, migrations_paths = nil)
         unless migrations_paths.nil?
-          ActiveSupport::Deprecation.warn(<<~MSG)
+          ActiveSupport::Deprecation.warn(<<~MSG.squish)
             Passing migrations_paths to #assume_migrated_upto_version is deprecated and will be removed in Rails 6.1.
           MSG
         end

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -64,7 +64,7 @@ class ActiveStorage::Variation
         begin
           require "image_processing"
         rescue LoadError
-          ActiveSupport::Deprecation.warn <<~WARNING
+          ActiveSupport::Deprecation.warn <<~WARNING.squish
             Generating image variants will require the image_processing gem in Rails 6.1.
             Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
           WARNING

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -22,7 +22,7 @@ module ActiveStorage
         def operations
           transformations.each_with_object([]) do |(name, argument), list|
             if name.to_s == "combine_options"
-              ActiveSupport::Deprecation.warn <<~WARNING
+              ActiveSupport::Deprecation.warn <<~WARNING.squish
                 Active Storage's ImageProcessing transformer doesn't support :combine_options,
                 as it always generates a single ImageMagick command. Passing :combine_options will
                 not be supported in Rails 6.1.

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -264,7 +264,7 @@ module Rails
 
         def deprecate_positional_rack_server_and_rewrite_to_option(original_options)
           if using
-            ActiveSupport::Deprecation.warn(<<~MSG)
+            ActiveSupport::Deprecation.warn(<<~MSG.squish)
               Passing the Rack server name as a regular argument is deprecated
               and will be removed in the next Rails version. Please, use the -u
               option instead.


### PR DESCRIPTION
Before:

prathamesh@Prathameshs-MacBook-Pro-2 blog *$ rails server thin
DEPRECATION WARNING: Passing the Rack server name as a regular argument is deprecated
and will be removed in the next Rails version. Please, use the -u
option instead.

After:

prathamesh@Prathameshs-MacBook-Pro-2 squish_app *$ rails server thin
DEPRECATION WARNING: Passing the Rack server name as a regular argument is deprecated and will be removed in the next Rails version. Please, use the -u option instead.