### PR TITLE
Add locale option to #parameterize

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -162,6 +162,11 @@ class String
 
   # Replaces special characters in a string so that it may be used as part of a 'pretty' URL.
   #
+  # If the optional parameter +locale+ is specified,
+  # the word will be parameterized as a word of that language.
+  # By default, this parameter is set to <tt>nil</tt> and it will use
+  # configured I18n.locale
+  #
   #   class Person
   #     def to_param
   #       "#{id}-#{name.parameterize}"
@@ -187,8 +192,8 @@ class String
   #
   #   <%= link_to(@person.name, person_path) %>
   #   # => <a href="/person/1-Donald-E-Knuth">Donald E. Knuth</a>
-  def parameterize(separator: "-", preserve_case: false)
-    ActiveSupport::Inflector.parameterize(self, separator: separator, preserve_case: preserve_case)
+  def parameterize(separator: "-", preserve_case: false, locale: nil)
+    ActiveSupport::Inflector.parameterize(self, separator: separator, preserve_case: preserve_case, locale: locale)
   end
 
   # Creates the name of a table like Rails does for models to table names. This method

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -51,19 +51,18 @@ module ActiveSupport
     #
     # Now you can have different transliterations for each locale:
     #
-    #   I18n.locale = :en
-    #   transliterate('Jürgen')
+    #   transliterate('Jürgen', locale: :en)
     #   # => "Jurgen"
     #
-    #   I18n.locale = :de
-    #   transliterate('Jürgen')
+    #   transliterate('Jürgen', locale: :de)
     #   # => "Juergen"
-    def transliterate(string, replacement = "?")
+    def transliterate(string, replacement = "?", locale: nil)
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
 
       I18n.transliterate(
         ActiveSupport::Multibyte::Unicode.tidy_bytes(string).unicode_normalize(:nfc),
-        replacement: replacement
+        replacement: replacement,
+        locale: locale
       )
     end
 
@@ -89,9 +88,9 @@ module ActiveSupport
     #  parameterize("^très|Jolie-- ", separator: "_") # => "tres_jolie--"
     #  parameterize("^très_Jolie-- ", separator: ".") # => "tres_jolie--"
     #
-    def parameterize(string, separator: "-", preserve_case: false)
+    def parameterize(string, separator: "-", preserve_case: false, locale: nil)
       # Replace accented chars with their ASCII equivalents.
-      parameterized_string = transliterate(string)
+      parameterized_string = transliterate(string, locale)
 
       # Turn unwanted chars into the separator.
       parameterized_string.gsub!(/[^a-z0-9\-_]+/i, separator)


### PR DESCRIPTION
### Summary

`parameterize` is triggering `I18n#transliterate`. This method already
accepts a locale. It would be cleaner if, similar to other string inflection
methods, `parameterize` also accepted 'locale' as a parameter.

https://github.com/ruby-i18n/i18n/blob/master/lib/i18n.rb#L268

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
