### PR TITLE
Document int Primary Key issue with `create_or_find_by`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -197,6 +197,10 @@ module ActiveRecord
     #   if a DELETE between those two statements is run by another client. But for most applications,
     #   that's a significantly less likely condition to hit.
     # * It relies on exception handling to handle control flow, which may be marginally slower.
+    # * The primary key may auto-increment on each create, even if it fails. This can accelerate
+    #   the problem of running out of integers, if the underlying table is still stuck on a primary
+    #   key of type int (note: All Rails apps since 5.0+ have defaulted to bigint, which is not liable
+    #   to this problem).
     #
     # This method will return a record if all given attributes are covered by unique constraints
     # (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted


### PR DESCRIPTION
### Summary

This commit addresses the issue in https://github.com/rails/rails/issues/35543 by making note of the growing primary key issue with `create_or_find_by`.

### Initial Problem
Each time `create_or_find_by` hits `ActiveRecord::RecordNotUnique`, it rolls back, but the auto-increment does not. The fact that auto-increment does not roll back seems to be expected behavior from PostgreSQL and MySQL. This should only be a concern with `int` primary keys, given their small key range.