### PR TITLE
Add Procfile by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Generate a default Procfile that includes a `web` and `release` command which tell platforms how to boot the server and migrate the database.
+
+    *Richard Schneeman*
+
 ## Rails 6.0.0.beta2 (February 25, 2019) ##
 
 *   Fix non-symbol access to nested hashes returned from `Rails::Application.config_for`

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -66,6 +66,10 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def procfile
+      template "Procfile"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run "git init", capture: options[:quiet]
@@ -288,6 +292,7 @@ module Rails
         build(:rakefile)
         build(:ruby_version)
         build(:configru)
+        build(:procfile)
         build(:gitignore)   unless options[:skip_git]
         build(:gemfile)     unless options[:skip_gemfile]
         build(:version_control)

--- a/railties/lib/rails/generators/rails/app/templates/Procfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Procfile.tt
@@ -1,0 +1,4 @@
+web: bundle exec bin/rails server
+<% unless options.skip_active_record? -%>
+release: bundle exec bin/rails db:migrate
+<% end %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -7,6 +7,7 @@ require "generators/shared_generator_tests"
 DEFAULT_APP_FILES = %w(
   .gitignore
   .ruby-version
+  Procfile
   README.md
   Gemfile
   Rakefile
@@ -122,6 +123,24 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+'application', 'data-turbolinks-track': 'reload'/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/javascript/packs/application.js")
+  end
+
+  def test_procfile
+    run_generator
+
+    assert_file "Procfile" do |content|
+      assert_match(/web: bundle exec bin\/rails server/, content)
+      assert_match(/release: bundle exec bin\/rails db:migrate/, content)
+    end
+  end
+
+  def test_generator_skips_release_phase_in_procfile_when_active_record_is_skipped
+    run_generator [destination_root, "--skip-active-record"]
+
+    assert_file "Procfile" do |content|
+      assert_match(/web: bundle exec bin\/rails server/, content)
+      assert_no_match(/release:/, content)
+    end
   end
 
   def test_application_job_file_present


### PR DESCRIPTION
The Procfile is a semi-standard that is supported on Heroku, CloudFoundry, Foreman, and more. It is used to communicate with a platform what processes exist that need to be run to boot an application. This PR adds a `Procfile` to be generated by Rails along with a `web` process that instructs platforms how to boot the rails server, and the `release` command which instructs platforms what needs to be done after a build is complete to allow the application to be ready to serve traffic.

The driver of this PR was a conversation with @DHH where he identified a list of items that would allow running Rails on a platform even with fewer steps. Several of these were directly turned into a ticket and have been implemented such as #34710. One of them that was identified was to communicate to a platform that migrations need to be done after a deploy. This auto migration logic can be accomplished using the `release` command in a Procfile.
