### PR TITLE
Fix warnings from Guides generation

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -150,7 +150,7 @@ module RailsGuides
         puts "Generating #{guide} as #{output_file}"
         layout = @kindle ? "kindle/layout" : "layout"
 
-        view = ActionView::Base.with_view_paths(
+        view = ActionView::Base.with_empty_template_cache.with_view_paths(
           [@source_dir],
           edge:     @edge,
           version:  @version,


### PR DESCRIPTION
After https://github.com/rails/rails/pull/35281  and https://github.com/rails/rails/pull/35036 AV warns about not having the compiled container.

Use suggested `with_empty_template_cache` to overcome warning

