### PR TITLE
Reset sid on session reset

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -79,8 +79,8 @@ module ActionDispatch
       def destroy
         clear
         options = self.options || {}
-        @by.send(:delete_session, @req, options.id(@req), options)
-
+        id = @by.send(:delete_session, @req, options.id(@req), options)
+        options[:id] = id if id.present?
         # Load the new sid to be written with the response.
         @loaded = false
         load_for_write!


### PR DESCRIPTION
### Summary

Previously, the new generated id from SessionStore.delete_session was being ignored by ActionDispatch::Request::Session and the cached id was being used again.
The destroy method of the ActionDispatch::Request::Session should work similarly to the Rack::SessionHash by reseting the cached 'id' to what is returned from the SessionStore "delete_session" method.

### Other Information
https://github.com/rails/rails/issues/35587
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
