### PR TITLE
Update comment in new_framework_defaults_6

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -2,7 +2,7 @@
 #
 # This file contains migration options to ease your Rails 6.0 upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
+# Once upgraded uncomment defaults one by one to migrate to the new default.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 


### PR DESCRIPTION
Comment at the top of the `new_framework_defaults_6_0` file dates back to Rails 5.0, where after upgrade the defaults were set to `false` and had to be switched to `true` manually. 

Now, the flags are commented, but contain the correct default values. _Flip_ is a bit confusing in that case, it might be read as if the flags should be switched.