### PR TITLE
Give GeneratedAttributeMethods module a name

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
     RESTRICTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
 
-    class GeneratedAttributeMethods < Module #:nodoc:
+    class GeneratedAttributeMethodsBuilder < Module #:nodoc:
       include Mutex_m
     end
 
@@ -35,7 +35,8 @@ module ActiveRecord
       end
 
       def initialize_generated_modules # :nodoc:
-        @generated_attribute_methods = GeneratedAttributeMethods.new
+        @generated_attribute_methods = const_set(:GeneratedAttributeMethods, GeneratedAttributeMethodsBuilder.new)
+        private_constant :GeneratedAttributeMethods
         @attribute_methods_generated = false
         include @generated_attribute_methods
 
@@ -88,7 +89,7 @@ module ActiveRecord
           # If ThisClass < ... < SomeSuperClass < ... < Base and SomeSuperClass
           # defines its own attribute method, then we don't want to overwrite that.
           defined = method_defined_within?(method_name, superclass, Base) &&
-            ! superclass.instance_method(method_name).owner.is_a?(GeneratedAttributeMethods)
+            ! superclass.instance_method(method_name).owner.is_a?(GeneratedAttributeMethodsBuilder)
           defined || super
         end
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1083,7 +1083,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "generated attribute methods ancestors have correct class" do
     mod = Topic.send(:generated_attribute_methods)
-    assert_match %r(GeneratedAttributeMethods), mod.inspect
+    assert_match %r(Topic::GeneratedAttributeMethods), mod.inspect
   end
 
   private


### PR DESCRIPTION
### Summary

Currently, inspecting the ancestors of an AR class gives you something like this:

```ruby
=> [User (call 'User.connection' to establish a connection),
 User::GeneratedAssociationMethods,
 #<ActiveRecord::AttributeMethods::GeneratedAttributeMethods:0x000055ace0f05b08>,
 ApplicationRecord(abstract),
 ApplicationRecord::GeneratedAssociationMethods,
 #<ActiveRecord::AttributeMethods::GeneratedAttributeMethods:0x000055ace093c460>,
 ActiveRecord::Base,
 [...]
```

The second and fifth objects that appear in this list (after the model class itself) are *instances* of the `ActiveRecord::AttributeMethods::GeneratedAttributeMethods` [module builder](https://dejimata.com/2017/5/20/the-ruby-module-builder-pattern), included into every AR class to hold the class' attribute methods. These are *extremely important* modules for AR classes, probably the *most important* type of module in their ancestors, and they appear very prominently at the top of this list. But in their current form, most Rails developers probably have no idea what they are actually doing or why they are even there.

This is not helped by the fact that the generated *association* methods module is given its own name under the model namespace, in the case above, `User::GeneratedAssociationMethods`.

This PR brings some consistency and clarity to this situation by creating a constant under the model namespace to capture these generated attribute methods, so that the ancestor list above becomes:

```ruby
=> [User (call 'User.connection' to establish a connection),
 User::GeneratedAssociationMethods,
 User::GeneratedAttributeMethods,
 ApplicationRecord(abstract),
 ApplicationRecord::GeneratedAssociationMethods,
 ApplicationRecord::GeneratedAttributeMethods,
 ActiveRecord::Base,
 [...]
```

Now, rather than an instance of a module builder class, the AR model gets a (private) named module `User::GeneratedAttributeMethods`, which is much more readable and approachable than before, and which follows the same pattern as `User::GeneratedAssociationMethods`. Also, since this applies to all AR models, the parent class' attribute methods also appear in this form as `ApplicationRecord::GeneratedAttributeMethods`, and we eliminate all anonymous instances in model ancestors.

### Other Information

In addition to the change above, I have also renamed the previously-named `ActiveRecord::AttributeMethods::GeneratedAttributeMethods` to `ActiveRecord::AttributeMethods::GeneratedAttributeMethodsBuilder`, to emphasize that this is not a *module* but a *module builder* (class). Currently this is a point of inconsistency between generated association methods and generated attribute methods, which surely causes additional confusion to developers trying to understand how these modules work internally.