### PR TITLE
Enforce policy allowing only subclasses of ActiveModel::Attribute to call new

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -5,6 +5,12 @@ require "active_support/core_ext/object/duplicable"
 module ActiveModel
   class Attribute # :nodoc:
     class << self
+      private :new
+
+      def inherited(subclass)
+        subclass.singleton_class.send(:public, :new)
+      end
+
       def from_database(name, value, type)
         FromDatabase.new(name, value, type)
       end


### PR DESCRIPTION
### Summary

The intention is that `ActiveModel::Attribute.new` should only be called by subclasses, but nothing enforces this.

This PR makes `new` a private method, using the `inherited` hook to change this back to `public` for subclasses. This way, all existing subclasses can function as normal, but anybody trying to call `new` directly on the parent `Attribute` class will have to use `send`, conveying the message that this is not the intended usage.