### PR TITLE
Properly expand the environment's name in all commands

### DIFF
--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/core_ext/class/attribute"
 
 module Rails
   module Command
@@ -8,16 +9,16 @@ module Rails
       extend ActiveSupport::Concern
 
       included do
-        class_option :environment, aliases: "-e", type: :string,
-          desc: "Specifies the environment to run this console under (test/development/production)."
+        class_attribute :environment_desc, default: "Specifies the environment to run this #{self.command_name} under (test/development/production)."
+        class_option :environment, aliases: "-e", type: :string, desc: environment_desc
       end
 
       private
-        def extract_environment_option_from_argument
+        def extract_environment_option_from_argument(default_environment: Rails::Command.environment)
           if options[:environment]
             self.options = options.merge(environment: acceptable_environment(options[:environment]))
           else
-            self.options = options.merge(environment: Rails::Command.environment)
+            self.options = options.merge(environment: default_environment)
           end
         end
 

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -2,14 +2,15 @@
 
 require "active_support"
 require "rails/command/helpers/editor"
+require "rails/command/environment_argument"
 
 module Rails
   module Command
     class CredentialsCommand < Rails::Command::Base # :nodoc:
       include Helpers::Editor
+      include EnvironmentArgument
 
-      class_option :environment, aliases: "-e", type: :string,
-        desc: "Uses credentials from config/credentials/:environment.yml.enc encrypted by config/credentials/:environment.key key"
+      self.environment_desc = "Uses credentials from config/credentials/:environment.yml.enc encrypted by config/credentials/:environment.key key"
 
       no_commands do
         def help
@@ -20,6 +21,7 @@ module Rails
       end
 
       def edit
+        extract_environment_option_from_argument(default_environment: nil)
         require_application!
 
         ensure_editor_available(command: "bin/rails credentials:edit") || (return)
@@ -37,6 +39,7 @@ module Rails
       end
 
       def show
+        extract_environment_option_from_argument(default_environment: nil)
         require_application!
 
         say credentials.read.presence || missing_credentials_message

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require "rails/command/environment_argument"
+
 module Rails
   module Command
     class RunnerCommand < Base # :nodoc:
-      class_option :environment, aliases: "-e", type: :string,
-        default: Rails::Command.environment.dup,
-        desc: "The environment for the runner to operate under (test/development/production)"
+      include EnvironmentArgument
+
+      self.environment_desc = "The environment for the runner to operate under (test/development/production)"
 
       no_commands do
         def help
@@ -19,6 +21,8 @@ module Rails
       end
 
       def perform(code_or_file = nil, *command_argv)
+        extract_environment_option_from_argument
+
         unless code_or_file
           help
           exit 1

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -6,6 +6,7 @@ require "rails"
 require "active_support/deprecation"
 require "active_support/core_ext/string/filters"
 require "rails/dev_caching"
+require "rails/command/environment_argument"
 
 module Rails
   class Server < ::Rack::Server
@@ -91,6 +92,8 @@ module Rails
 
   module Command
     class ServerCommand < Base # :nodoc:
+      include EnvironmentArgument
+
       # Hard-coding a bunch of handlers here as we don't have a public way of
       # querying them from the Rack::Handler registry.
       RACK_SERVERS = %w(cgi fastcgi webrick lsws scgi thin puma unicorn)
@@ -109,8 +112,6 @@ module Rails
         desc: "Uses a custom rackup configuration.", banner: :file
       class_option :daemon, aliases: "-d", type: :boolean, default: false,
         desc: "Runs server as a Daemon."
-      class_option :environment, aliases: "-e", type: :string,
-        desc: "Specifies the environment to run this server under (development/test/production).", banner: :name
       class_option :using, aliases: "-u", type: :string,
         desc: "Specifies the Rack server used to run the application (thin/puma/webrick).", banner: :name
       class_option :pid, aliases: "-P", type: :string, default: DEFAULT_PID_PATH,
@@ -130,6 +131,7 @@ module Rails
       end
 
       def perform
+        extract_environment_option_from_argument
         set_application_directory!
         prepare_restart
 

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -109,6 +109,10 @@ module ApplicationTests
       assert_match "production", rails("runner", "-e", "production", "puts Rails.env")
     end
 
+    def test_environment_option_is_properly_expanded
+      assert_match "production", rails("runner", "-e", "prod", "puts Rails.env")
+    end
+
     def test_runner_detects_syntax_errors
       output = rails("runner", "puts 'hello world", allow_failure: true)
       assert_not_predicate $?, :success?

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -63,6 +63,14 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "edit command properly expand environment option" do
+    assert_match(/access_key_id: 123/, run_edit_command(environment: "prod"))
+    Dir.chdir(app_path) do
+      assert File.exist?("config/credentials/production.key")
+      assert File.exist?("config/credentials/production.yml.enc")
+    end
+  end
+
   test "edit command does not raise when an initializer tries to access non-existent credentials" do
     app_file "config/initializers/raise_when_loaded.rb", <<-RUBY
       Rails.application.credentials.missing_key!
@@ -93,6 +101,12 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     run_edit_command(environment: "production")
 
     assert_match(/access_key_id: 123/, run_show_command(environment: "production"))
+  end
+
+  test "show command properly expand environment option" do
+    run_edit_command(environment: "production")
+
+    assert_match(/access_key_id: 123/, run_show_command(environment: "prod"))
   end
 
   private

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -22,6 +22,12 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
     assert_nil options[:server]
   end
 
+  def test_environment_option_is_properly_expanded
+    args = ["-e", "prod"]
+    options = parse_arguments(args)
+    assert_equal "production", options[:environment]
+  end
+
   def test_explicit_using_option
     args = ["-u", "thin"]
     options = parse_arguments(args)
@@ -285,6 +291,8 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
     end
 
     def parse_arguments(args = [])
-      Rails::Command::ServerCommand.new([], args).server_options
+      command = Rails::Command::ServerCommand.new([], args)
+      command.send(:extract_environment_option_from_argument)
+      command.server_options
     end
 end


### PR DESCRIPTION
Since 3777701f1380f3814bd5313b225586dec64d4104, the environment's name is automatically expanded in console and dbconsole commands.
In order to match the behavior between the commands, fixes it to have the same behavior of all the commands.
    
This behavior is defined in `EnvironmentArgument`. Since `EnvironmentArgument` also defines the environment option, it is reused.
However, since desc was not content that can be used in all comments, fixed desc to be defined for each command.
