### PR TITLE
[skip ci] Rails 5.1+ supports bigint primary key

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -199,7 +199,7 @@ module ActiveRecord
     # * It relies on exception handling to handle control flow, which may be marginally slower.
     # * The primary key may auto-increment on each create, even if it fails. This can accelerate
     #   the problem of running out of integers, if the underlying table is still stuck on a primary
-    #   key of type int (note: All Rails apps since 5.0+ have defaulted to bigint, which is not liable
+    #   key of type int (note: All Rails apps since 5.1+ have defaulted to bigint, which is not liable
     #   to this problem).
     #
     # This method will return a record if all given attributes are covered by unique constraints


### PR DESCRIPTION
### Summary

Follow up #35573

