### PR TITLE
Fix postgres connection_active? to return false with nil connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -233,7 +233,7 @@ module ActiveRecord
           end
 
           def connection_active?
-            @connection.status == PG::CONNECTION_OK
+            @connection && @connection.status == PG::CONNECTION_OK
           rescue PG::Error
             false
           end


### PR DESCRIPTION
With current Rails master I get an error running migrations when using the postgres adapter.

I have to admit I am using my own fork of the activerecord-postgis-adapter on top, but this does not even show in the stacktrace, so I think this might be an issue in the vanilla version.

Here is the error:
```
$ rake db:migrate --trace
** Invoke db:migrate (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:load_config
** Execute db:migrate
** Invoke db:_dump (first_time)
** Execute db:_dump
** Invoke db:schema:dump (first_time)
** Invoke db:load_config
** Execute db:schema:dump
rake aborted!
NoMethodError: undefined method `status' for nil:NilClass
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:236:in `connection_active?'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:231:in `dealloc'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/statement_pool.rb:40:in `block in clear'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/statement_pool.rb:39:in `each_value'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/statement_pool.rb:39:in `clear'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:498:in `block in clear_cache!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:498:in `clear_cache!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:469:in `disconnect!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:303:in `block in disconnect!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:302:in `disconnect!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:440:in `block (3 levels) in disconnect'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:435:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:435:in `block (2 levels) in disconnect'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:434:in `block in disconnect'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:678:in `block in with_exclusively_acquired_all_connections'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:753:in `with_new_connections_blocked'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:676:in `with_exclusively_acquired_all_connections'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:433:in `disconnect'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:455:in `disconnect!'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:1040:in `remove_connection'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:958:in `establish_connection'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/connection_handling.rb:51:in `establish_connection'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:291:in `block (5 levels) in <main>'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:290:in `open'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:290:in `block (4 levels) in <main>'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:288:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:288:in `block (3 levels) in <main>'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `block in execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:183:in `invoke'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:92:in `block (2 levels) in <main>'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `block in execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:183:in `invoke'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/bundler/gems/rails-a2bd669ed240/activerecord/lib/active_record/railties/databases.rake:85:in `block (2 levels) in <main>'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `block in execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:273:in `execute'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:194:in `invoke_with_call_chain'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/task.rb:183:in `invoke'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:160:in `invoke_task'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:116:in `each'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:116:in `block in top_level'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:125:in `run_with_threads'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:110:in `top_level'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:83:in `block in run'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:186:in `standard_exception_handling'
/Users/jan/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/application.rb:80:in `run'
./bin/rake:5:in `<main>'
Tasks: TOP => db:schema:dump
```

The error is fixed for me by just being more defensive in the ``connection_active?`` check.
