### PR TITLE
Raise exception when building invalid mime type

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -170,6 +170,7 @@ module Mime
       def parse(accept_header)
         if !accept_header.include?(",")
           accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
+          return [] unless accept_header
           parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)].compact
         else
           list, index = [], 0
@@ -221,7 +222,15 @@ module Mime
 
     attr_reader :hash
 
+    MIME_NAME = "[a-zA-Z0-9][a-zA-Z0-9#{Regexp.escape('!#$&-^_.+')}]{0,126}"
+    MIME_REGEXP = /\A(?:\*\/\*|#{MIME_NAME}\/(?:\*|#{MIME_NAME}))\z/
+
+    class InvalidMimeType < StandardError; end
+
     def initialize(string, symbol = nil, synonyms = [])
+      unless MIME_REGEXP.match?(string)
+        raise InvalidMimeType, "#{string.inspect} is not a valid MIME type"
+      end
       @symbol, @synonyms = symbol, synonyms
       @string = string
       @hash = [@string, @synonyms, @symbol].hash

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -38,8 +38,8 @@ module ActionDispatch
     end
 
     def self.parser(content_type)
-      mime = Mime::Type.lookup(content_type)
-      encoder(mime ? mime.ref : nil).response_parser
+      type = Mime::Type.lookup(content_type).ref if content_type
+      encoder(type).response_parser
     end
 
     def self.encoder(name)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -174,4 +174,36 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_not (Mime[:js] !~ "application/javascript")
     assert Mime[:html] =~ "application/xhtml+xml"
   end
+
+  test "can be initialized with wildcards" do
+    assert_equal "*/*", Mime::Type.new("*/*").to_s
+    assert_equal "text/*", Mime::Type.new("text/*").to_s
+    assert_equal "video/*", Mime::Type.new("video/*").to_s
+  end
+
+  test "invalid mime types raise error" do
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("too/many/slash")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("missingslash")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("text/html, text/plain")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("*/html")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new(nil)
+    end
+  end
 end

--- a/actionview/test/template/html_test.rb
+++ b/actionview/test/template/html_test.rb
@@ -8,9 +8,9 @@ class HTMLTest < ActiveSupport::TestCase
   end
 
   test "formats returns string for recognized MIME type when MIME does not have symbol" do
-    foo = Mime::Type.lookup("foo")
+    foo = Mime::Type.lookup("text/foo")
     assert_nil foo.to_sym
-    assert_equal "foo", ActionView::Template::HTML.new("", foo).format
+    assert_equal "text/foo", ActionView::Template::HTML.new("", foo).format
   end
 
   test "formats returns string for unknown MIME type" do


### PR DESCRIPTION
This only allows mime types to be in the form `text/html`, `text/*`, or `*/*`.

This required a few minor test/code changes where previously `nil` was used as a mime string.

Thanks @pixeltrix and @georgeclaghorn for help with the regex ❤️

cc @tenderlove @eileencodes 