### PR TITLE
support slice assignment on SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -199,8 +199,12 @@ module ActiveSupport #:nodoc:
       super(html_escape_interpolated_argument(value))
     end
 
-    def []=(index, value)
-      super(index, html_escape_interpolated_argument(value))
+    def []=(*args)
+      if args.count == 3
+        super(args[0], args[1], html_escape_interpolated_argument(args[2]))
+      else
+        super(args[0], html_escape_interpolated_argument(args[1]))
+      end
     end
 
     def +(other)

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -112,6 +112,38 @@ class SafeBufferTest < ActiveSupport::TestCase
     end
   end
 
+  test "can assign value into zero-index" do
+    buffer = ActiveSupport::SafeBuffer.new("012345")
+
+    buffer[0] = "<"
+
+    assert_equal "&lt;12345", buffer
+  end
+
+  test "can assign value into non zero-index" do
+    buffer = ActiveSupport::SafeBuffer.new("012345")
+
+    buffer[2] = "<"
+
+    assert_equal "01&lt;345", buffer
+  end
+
+  test "can assign value into slice" do
+    buffer = ActiveSupport::SafeBuffer.new("012345")
+
+    buffer[0, 3] = "<"
+
+    assert_equal "&lt;345", buffer
+  end
+
+  test "can assign value into offset slice" do
+    buffer = ActiveSupport::SafeBuffer.new("012345")
+
+    buffer[1, 3] = "<"
+
+    assert_equal "0&lt;45", buffer
+  end
+
   test "Should escape dirty buffers on add" do
     clean = "hello".html_safe
     @buffer.gsub!("", "<>")


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/33990/files#diff-f639a79f308e72f54af369291a4d5907R202 introduced `[]=` for `ActiveSupport::SafeBuffer`. 

This introduced an edge case when doing `buffer[0, 3] = '<'`

In this scenario, there are actually _three_ args, which results in a too many parameters exception.

This PR makes a slight adjustment to the method to handle this scenario.


