### PR TITLE
Make application work without tmp directory

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -587,6 +587,7 @@ module Rails
 
           if !File.exist?(key_file)
             random_key = SecureRandom.hex(64)
+            FileUtils.mkdir_p(key_file.dirname)
             File.binwrite(key_file, random_key)
           end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -601,6 +601,9 @@ module ApplicationTests
         Rails.application.credentials.secret_key_base = nil
       RUBY
 
+      # For test that works even if tmp dir does not exist.
+      Dir.chdir(app_path) { FileUtils.remove_dir("tmp") }
+
       app "development"
 
       assert_not_nil app.secrets.secret_key_base


### PR DESCRIPTION
The tmp directory is added to version control in the newly created application. This was added in Rails 5.0.0(https://github.com/rails/rails/commit/f06ce4c12a396795a3b2c1812951d9277bcb3a82).

However, applications created before that are not guaranteed to have the
tmp directory. If the tmp directory does not exist, writing to the key file raise error.

This is a bit incompatible. So I fixed that create the directory before writing a key.