### PR TITLE
running test with_info_handler method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Calling test methods with `with_info_handler` method to allow minitest-hooks
+    plugin to work.
+
+    *Mauri Mustonen*
+
 *   Add support for supplying `locale` to `transliterate` and `parameterize`.
 
         I18n.backend.store_translations(:de, i18n: { transliterate: { rule: { "ü" => "ue" } } })

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -79,7 +79,9 @@ module ActiveSupport
               klass    = job[0]
               method   = job[1]
               reporter = job[2]
-              result   = Minitest.run_one_method(klass, method)
+              result = klass.with_info_handler reporter do
+                Minitest.run_one_method(klass, method)
+              end
 
               begin
                 queue.record(reporter, result)


### PR DESCRIPTION
### Summary

Execute test method with `with_info_handler` method to allow minitest-hooks plugin work correctly without errors. This PR resolves issue #35495.

### Other Information

This fix allows minitest-hooks gem to work with `before_all` and `after_all` methods. Problem is these methods get executed with each test method. At least tests are runnable with this fix. Maybe some information somehwere about this would be nice.
