### PR TITLE
[skip ci] Add examples for has_{one,many} :through :source and :source_type

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1305,6 +1305,21 @@ The `:source` option specifies the source association name for a `has_one :throu
 
 The `:source_type` option specifies the source association type for a `has_one :through` association that proceeds through a polymorphic association.
 
+```ruby
+class Book < ApplicationRecord
+  has_one :format, polymorphic: true
+  has_one :dust_jacket, through: :format, source: :dust_jacket, source_type: "Hardback"
+end
+
+class Paperback < ApplicationRecord; end
+
+class Hardback < ApplicationRecord
+  has_one :dust_jacket
+end
+
+class DustJacket < ApplicationRecord; end
+```
+
 ##### `:through`
 
 The `:through` option specifies a join model through which to perform the query. `has_one :through` associations were discussed in detail [earlier in this guide](#the-has-one-through-association).

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1717,6 +1717,20 @@ The `:source` option specifies the source association name for a `has_many :thro
 
 The `:source_type` option specifies the source association type for a `has_many :through` association that proceeds through a polymorphic association.
 
+```ruby
+class Author < ApplicationRecord
+  has_many :books
+  has_many :paperbacks, through: :books, source: :format, source_type: "Paperback"
+end
+
+class Book < ApplicationRecord
+  has_one :format, polymorphic: true
+end
+
+class Hardback < ApplicationRecord; end
+class Paperback < ApplicationRecord; end
+```
+
 ##### `:through`
 
 The `:through` option specifies a join model through which to perform the query. `has_many :through` associations provide a way to implement many-to-many relationships, as discussed [earlier in this guide](#the-has-many-through-association).


### PR DESCRIPTION
### Summary
I've often been confused about `source` and `source_type`. I thought it would be helpful to provide some examples here.
