### PR TITLE
Fix for migration active_storage migration

### DIFF
--- a/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
+++ b/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
@@ -1,6 +1,8 @@
 class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
   def up
-    unless foreign_key_exists?(:active_storage_attachments, column: :blob_id)
+    return if foreign_key_exists?(:active_storage_attachments, column: :blob_id)
+
+    if table_exists?(:active_storage_attachments) && table_exists?(:active_storage_blobs)
       add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
     end
   end

--- a/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
+++ b/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
@@ -2,7 +2,7 @@ class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord:
   def up
     return if foreign_key_exists?(:active_storage_attachments, column: :blob_id)
 
-    if table_exists?(:active_storage_attachments) && table_exists?(:active_storage_blobs)
+    if table_exists?(:active_storage_blobs)
       add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
     end
   end


### PR DESCRIPTION
Closes #35621

Updating to rails 6.0.0.beta3 if the command rake `app:update` is used a new migration file is generated:

```ruby
# db/migrate/add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.active_storage.rb
class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
  def up
    unless foreign_key_exists?(:active_storage_attachments, column: :blob_id)
  		add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
    end
  end
end
```

**If the project does not have previously installed active storage** this mgiration causes an error:
    ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "active_storage_attachments" does not exist

The solution would be to check first if the tables exist:
```ruby
class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
  def up
    return if foreign_key_exists?(:active_storage_attachments, column: :blob_id)

    if table_exists?(:active_storage_blobs) && table_exists?(:active_storage_attachments)
      add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
    end
  end
end