### PR TITLE
Allows insert_all on relation to associate reference keys

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -301,6 +301,10 @@ module ActiveRecord
           target.any? { |record| record.new_record? || record.changed? }
       end
 
+      def insert_all_attributes(attributes)
+        attributes.map { |a| a.merge(creation_attributes) }
+      end
+
       private
         # We have some records loaded from the database (persisted) and some that are
         # in-memory (memory). The same record may be represented in the persisted array

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -317,6 +317,12 @@ module ActiveRecord
       end
       alias_method :new, :build
 
+      def insert_all(attributes, returning: nil, unique_by: nil)
+        attributes = @association.insert_all_attributes(attributes)
+
+        super
+      end
+
       # Returns a new object of the collection type that has been instantiated with
       # attributes, linked to this object and that has already been saved (if it
       # passes the validations).

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -2,13 +2,14 @@
 
 require "cases/helper"
 require "models/book"
+require "models/author"
 
 class ReadonlyNameBook < Book
   attr_readonly :name
 end
 
 class InsertAllTest < ActiveRecord::TestCase
-  fixtures :books
+  fixtures :books, :authors
 
   def test_insert
     assert_difference "Book.count", +1 do
@@ -30,6 +31,17 @@ class InsertAllTest < ActiveRecord::TestCase
         { name: "About Face", author_id: 1 },
         { name: "Eloquent Ruby", author_id: 1 },
       ]
+    end
+  end
+
+  def test_relation_insert_all
+    @david = authors(:david)
+
+    assert_difference "Book.count", +2 do
+      @david.books.insert_all!([
+        { name: "Rework" },
+        { name: "Patterns of Enterprise Application Architecture" }
+      ])
     end
   end
 


### PR DESCRIPTION
I tried to resolve `author.posts.insert_all(data)` to auto assign foreign key. As mentioned by @boblail here(https://github.com/rails/rails/issues/35493#issuecomment-472908159) and similarly by https://github.com/rails/rails/issues/35493#issuecomment-471526290

cc/ @kaspth