### PR TITLE
Rename `ActionView::Base#run`

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -267,7 +267,7 @@ module ActionView #:nodoc:
       _prepare_context
     end
 
-    def run(method, template, locals, buffer, &block)
+    def _run(method, template, locals, buffer, &block)
       _old_output_buffer, _old_virtual_path, _old_template = @output_buffer, @virtual_path, @current_template
       @current_template = template
       @output_buffer = buffer

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -173,7 +173,7 @@ module ActionView
     def render(view, locals, buffer = ActionView::OutputBuffer.new, &block)
       instrument_render_template do
         compile!(view)
-        view.run(method_name, self, locals, buffer, &block)
+        view._run(method_name, self, locals, buffer, &block)
       end
     rescue => e
       handle_render_error(view, e)

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -27,7 +27,7 @@ module ActionView
               include action_view_erb_handler_context._routes.url_helpers
               class_eval("define_method(:_template) { |local_assigns, output_buffer| #{src} }", @filename || "(erubi)", 0)
             }.empty
-            view.run(:_template, nil, {}, ActionView::OutputBuffer.new)
+            view._run(:_template, nil, {}, ActionView::OutputBuffer.new)
           end
 
         private


### PR DESCRIPTION
### Summary

There was a recent change by @tenderlove to Action view which introduced `ActionView::Base#run` [1].

We ran into an issue with our application because one of the core concepts in our domain model is a `Run` which is exposed in most of our views as a helper method also called `run`, which now conflicts with this new method.

In order to save us having to rewrite a substantial part of our app I was wondering if we might be able to rename this method instead to something like `#call` or perhaps `#exec`?

[1] https://github.com/rails/rails/commit/c740ebdaf5
