### PR TITLE
Match evented checker behavior on dir with no exts

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -131,7 +131,9 @@ module ActiveSupport
           ext = @ph.normalize_extension(file.extname)
 
           file.dirname.ascend do |dir|
-            if @dirs.fetch(dir, []).include?(ext)
+            matching = @dirs[dir]
+
+            if matching && (matching.empty? || matching.include?(ext))
               break true
             elsif dir == @lcsp || dir.root?
               break false

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -186,6 +186,18 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
+  test "should execute the block if files change in a watched directory any extensions" do
+    i = 0
+
+    checker = new_checker([], tmpdir => []) { i += 1 }
+
+    touch(tmpfile("foo.rb"))
+    wait
+
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
   test "should execute the block if files change in a watched directory several extensions" do
     i = 0
 


### PR DESCRIPTION
When `FileUpdateChecker` is passed a directory and given an empty array of extensions to match on, it will match any extension.

Previously, `EventedFileUpdateChecker` would never match any files when given an empty array of exts. This commit makes `EventedFileUpdateChecker` match `FileUpdateChecker`, and watch all extensions when given an empty array.