### PR TITLE
Only clear ActionView caches in dev when files change

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Only clear ActionView cache in development on file changes
+
+    To speed up development mode, view caches are only cleared when files in
+    the view paths have changed. Applications which have implemented custom
+    ActionView::Resolver subclasses may need to add their own cache clearing.
+
+    *John Hawthorn*
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   Only accept formats from registered mime types

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -81,6 +81,7 @@ module ActionView
     end
   end
 
+  autoload :CacheExpiry
   autoload :TestCase
 
   def self.eager_load!

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ActionView
+  class CacheExpiry
+    class Executor
+      def initialize(watcher:)
+        @cache_expiry = CacheExpiry.new(watcher: watcher)
+      end
+
+      def before(target)
+        @cache_expiry.clear_cache_if_necessary
+      end
+    end
+
+    def initialize(watcher:)
+      @watched_dirs = nil
+      @watcher_class = watcher
+      @watcher = nil
+    end
+
+    def clear_cache_if_necessary
+      watched_dirs = dirs_to_watch
+      if watched_dirs != @watched_dirs
+        @watched_dirs = watched_dirs
+        @watcher = @watcher_class.new([], watched_dirs) do
+          clear_cache
+        end
+        @watcher.execute
+      else
+        @watcher.execute_if_updated
+      end
+    end
+
+    def clear_cache
+      ActionView::LookupContext::DetailsKey.clear
+    end
+
+    private
+
+      def dirs_to_watch
+        fs_paths = all_view_paths.grep(FileSystemResolver)
+        fs_paths.map(&:path).sort.uniq
+      end
+
+      def all_view_paths
+        ActionView::ViewPaths.all_view_paths.flat_map(&:paths)
+      end
+  end
+end

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -6,12 +6,6 @@ module ActionView
   class Digestor
     @@digest_mutex = Mutex.new
 
-    module PerExecutionDigestCacheExpiry
-      def self.before(target)
-        ActionView::LookupContext::DetailsKey.clear
-      end
-    end
-
     class << self
       # Supported options:
       #

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -81,7 +81,7 @@ module ActionView
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
         unless ActionView::Resolver.caching?
-          app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
+          app.executor.to_run ActionView::CacheExpiry::Executor.new(watcher: app.config.file_watcher)
         end
       end
     end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -280,6 +280,8 @@ module ActionView
 
   # A resolver that loads files from the filesystem.
   class FileSystemResolver < PathResolver
+    attr_reader :path
+
     def initialize(path, pattern = nil)
       raise ArgumentError, "path already is a Resolver class" if path.is_a?(Resolver)
       super(pattern)


### PR DESCRIPTION
Builds on #35623 and  #35628

This changes the dev-mode actionview cache expiration, which used to run before each request, to only change if any files in the view directories have changed.

This should make dev mode template rendering the same speed as production! ⚡️ (though I'm sure there will be other dev mode things slowing it down)

## Todo
- [x] ~Find out what people use that isn't a `FileSystemResolver`~ Make a changelog entry that those with non-FileSystemResolver resolvers will need to clear caches themselves if they want dev mode reloading.
- [x] We will no longer get dev-mode reloading when using `render file:` (we can't exactly listen to all changes on`/`). Decide if that's okay.
- [x] Measure how much it improves dev mode