### PR TITLE
Allow to specify custom attributes to update on conflict for upsert_all method

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   class InsertAll
     attr_reader :model, :connection, :inserts, :on_duplicate, :returning, :unique_by, :updatable_columns
 
-    def initialize(model, inserts, on_duplicate:, returning: nil, unique_by: nil, updatable_columns: nil)
+    def initialize(model, inserts, on_duplicate:, returning: nil, unique_by: nil, update: nil)
       raise ArgumentError, "Empty list of attributes passed" if inserts.blank?
 
       @model, @connection, @inserts, @on_duplicate, @returning, @unique_by = model, model.connection, inserts, on_duplicate, returning, unique_by
@@ -12,7 +12,7 @@ module ActiveRecord
       @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
       @returning = false if @returning == []
 
-      @updatable_columns = updatable_columns || default_updatable_columns
+      @updatable_columns = update || default_updatable_columns
 
       @on_duplicate = :skip if @on_duplicate == :update && @updatable_columns.empty?
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -191,8 +191,8 @@ module ActiveRecord
       # normal type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
-      def upsert(attributes, returning: nil, unique_by: nil, updatable_columns: nil)
-        upsert_all([ attributes ], returning: returning, unique_by: unique_by, updatable_columns: updatable_columns)
+      def upsert(attributes, returning: nil, unique_by: nil, update: nil)
+        upsert_all([ attributes ], returning: returning, unique_by: unique_by, update: update)
       end
 
       # Upserts (updates or inserts) multiple records into the database. This method constructs
@@ -254,8 +254,8 @@ module ActiveRecord
       #     { title: 'Clean Code', author: 'Robert', isbn: '2' }
       #   ], unique_by: { columns: %w[ isbn ] })
       #
-      def upsert_all(attributes, returning: nil, unique_by: nil, updatable_columns: nil)
-        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by, updatable_columns: updatable_columns).execute
+      def upsert_all(attributes, returning: nil, unique_by: nil, update: nil)
+        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by, update: update).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -191,8 +191,8 @@ module ActiveRecord
       # normal type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
-      def upsert(attributes, returning: nil, unique_by: nil)
-        upsert_all([ attributes ], returning: returning, unique_by: unique_by)
+      def upsert(attributes, returning: nil, unique_by: nil, updatable_columns: nil)
+        upsert_all([ attributes ], returning: returning, unique_by: unique_by, updatable_columns: updatable_columns)
       end
 
       # Upserts (updates or inserts) multiple records into the database. This method constructs
@@ -254,8 +254,8 @@ module ActiveRecord
       #     { title: 'Clean Code', author: 'Robert', isbn: '2' }
       #   ], unique_by: { columns: %w[ isbn ] })
       #
-      def upsert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
+      def upsert_all(attributes, returning: nil, unique_by: nil, updatable_columns: nil)
+        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by, updatable_columns: updatable_columns).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -144,22 +144,17 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_updates_only_defined_columns
-    skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
+    skip unless supports_insert_on_duplicate_update?
 
     yesterday = DateTime.new(2012, 8, 28, 22, 35, 0)
     now = DateTime.new(2012, 8, 29, 22, 35, 0)
+    book = Book.create(name: "Mysterious book", format: "E-Book", published_on: yesterday)
 
-    assert_difference "Book.count", +1 do
-      Book.upsert_all([{ name: "Mysterious book", author_id: 7, published_on: yesterday, format: "E-Book" }],
-                      unique_by: { columns: %i{author_id name} },
-                      updatable_columns: [:format])
-
-      Book.upsert_all([{ name: "Mysterious book", author_id: 7, published_on: now, format: "Paperback" }],
-                      unique_by: { columns: %i{author_id name} },
-                      updatable_columns: [:format])
-    end
+    Book.upsert_all([{ id: book.id, name: "Mysterious book", published_on: now, format: "Paperback" }],
+                    update: [:format])
 
     book = Book.find_by(name: "Mysterious book")
     assert_equal yesterday, book.published_on
+    assert_equal "Paperback", book.format
   end
 end


### PR DESCRIPTION
This allows to specify attributes to update on conflict. It opens door to handling timestamps updates manually in reasonable transparent way.

```ruby
now = Time.now
row = { slug: 'new-title', post: 'New post', created_at: now, updated_at: now }
Post.upsert(row1, unique_by: { columns: [:slug]}, update: [:post, :updated_at])
```

In combination with defaults (I'll try to add this in different PR) mentioned at https://github.com/rails/rails/issues/35493#issuecomment-471526290 it can provide easy and transparent way to handle timestamps. Anyway I think it should not be default behaviour since methods like `update_all` doesn't handle this on its own as well.

WDYT @boblail @dhh @kaspth :question:

references https://github.com/rails/rails/issues/35493 https://github.com/rails/rails/pull/35494

I'll update documentation once approved.