### PR TITLE
Update find or create by

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -166,14 +166,18 @@ module ActiveRecord
     #
     # If this might be a problem for your application, please see #create_or_find_by.
     def find_or_create_by(attributes, &block)
-      find_by(attributes) || create(attributes, &block)
+      find_by(attributes) || transaction(requires_new: true) { create(attributes, &block) }
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(attributes)
     end
 
     # Like #find_or_create_by, but calls
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
     # is raised if the created record is invalid.
     def find_or_create_by!(attributes, &block)
-      find_by(attributes) || create!(attributes, &block)
+      find_by(attributes) || transaction(requires_new: true) { create!(attributes, &block) }
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(attributes)
     end
 
     # Attempts to create a record with the given attributes in a table that has a unique constraint


### PR DESCRIPTION
### Summary

> > I've come around to the idea that `find_or_create_or_find_by` is a better behavior in our case (though I'd never suggest rails having that method).
> 
> I'd like to consider making that the behaviour of `find_or_create_by`, if you're interested in PRing it.
> 
> To me the ideal would be that they both have similar[ly rare] failure scenarios, and the choice of `find_or_create_by` vs `create_or_find_by` would boil down to whether you, on average, expect the row to exist.. and thus which one is more likely to save you a query.
- [Original inspiration for this PR](https://github.com/rails/rails/issues/35543#issuecomment-471817428)

I believe these are the changes needed to make `find_or_create_by` fail in similar ways to `create_or_find_by`, but I'm struggling to find an appropriate way to validate that through tests.