### PR TITLE
Add defaults option to ActiveRecord::InsertAll.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -64,8 +64,8 @@ module ActiveRecord
       # serialization.
       #
       # See <tt>ActiveRecord::Persistence#insert_all</tt> for documentation.
-      def insert(attributes, returning: nil, unique_by: nil)
-        insert_all([ attributes ], returning: returning, unique_by: unique_by)
+      def insert(attributes, returning: nil, unique_by: nil, defaults: {})
+        insert_all([ attributes ], returning: returning, unique_by: unique_by, defaults: defaults)
       end
 
       # Inserts multiple records into the database. This method constructs a single SQL INSERT
@@ -121,8 +121,8 @@ module ActiveRecord
       #     { id: 1, title: 'Eloquent Ruby', author: 'Russ' }
       #   ])
       #
-      def insert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+      def insert_all(attributes, returning: nil, unique_by: nil, defaults: {})
+        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, defaults: defaults).execute
       end
 
       # Inserts a single record into the database. This method constructs a single SQL INSERT
@@ -132,8 +132,8 @@ module ActiveRecord
       # serialization.
       #
       # See <tt>ActiveRecord::Persistence#insert_all!</tt> for documentation.
-      def insert!(attributes, returning: nil)
-        insert_all!([ attributes ], returning: returning)
+      def insert!(attributes, returning: nil, defaults: {})
+        insert_all!([ attributes ], returning: returning, defaults: defaults)
       end
 
       # Inserts multiple records into the database. This method constructs a single SQL INSERT
@@ -180,8 +180,8 @@ module ActiveRecord
       #     { id: 1, title: 'Eloquent Ruby', author: 'Russ' }
       #   ])
       #
-      def insert_all!(attributes, returning: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning).execute
+      def insert_all!(attributes, returning: nil, defaults: {})
+        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning, defaults: defaults).execute
       end
 
       # Upserts (updates or inserts) a single record into the database. This method constructs
@@ -191,8 +191,8 @@ module ActiveRecord
       # normal type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
-      def upsert(attributes, returning: nil, unique_by: nil)
-        upsert_all([ attributes ], returning: returning, unique_by: unique_by)
+      def upsert(attributes, returning: nil, unique_by: nil, defaults: {})
+        upsert_all([ attributes ], returning: returning, unique_by: unique_by, defaults: defaults)
       end
 
       # Upserts (updates or inserts) multiple records into the database. This method constructs
@@ -254,8 +254,8 @@ module ActiveRecord
       #     { title: 'Clean Code', author: 'Robert', isbn: '2' }
       #   ], unique_by: { columns: %w[ isbn ] })
       #
-      def upsert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
+      def upsert_all(attributes, returning: nil, unique_by: nil, defaults: {})
+        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by, defaults: defaults).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -142,4 +142,26 @@ class InsertAllTest < ActiveRecord::TestCase
       Book.insert_all! [{ unknown_attribute: "Test" }]
     end
   end
+
+  def test_insert_all_defaults
+    skip unless supports_insert_on_duplicate_skip?
+
+    defaults = { published_on: Date.new(1938, 4, 1) }
+    Book.insert_all([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598" }], defaults: defaults)
+
+    book = Book.find_by(name: "Out of the Silent Planet")
+    assert_equal defaults[:published_on], book.published_on
+  end
+
+  def test_insert_all_defaults_not_used_when_specified
+    skip unless supports_insert_on_duplicate_skip?
+
+    defaults = { published_on: Date.new(1938, 4, 1) }
+    published_on = Date.new(1940, 4, 1)
+    Book.insert_all([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598", published_on: published_on }], defaults: defaults)
+
+    book = Book.find_by(name: "Out of the Silent Planet")
+    assert_not_equal defaults[:published_on], book.published_on
+    assert_equal published_on, book.published_on
+  end
 end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -144,21 +144,17 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_defaults
-    skip unless supports_insert_on_duplicate_skip?
-
     defaults = { published_on: Date.new(1938, 4, 1) }
-    Book.insert_all([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598" }], defaults: defaults)
+    Book.insert_all!([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598" }], defaults: defaults)
 
     book = Book.find_by(name: "Out of the Silent Planet")
     assert_equal defaults[:published_on], book.published_on
   end
 
   def test_insert_all_defaults_not_used_when_specified
-    skip unless supports_insert_on_duplicate_skip?
-
     defaults = { published_on: Date.new(1938, 4, 1) }
     published_on = Date.new(1940, 4, 1)
-    Book.insert_all([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598", published_on: published_on }], defaults: defaults)
+    Book.insert_all!([{ name: "Out of the Silent Planet", author_id: 7, isbn: "1974522598", published_on: published_on }], defaults: defaults)
 
     book = Book.find_by(name: "Out of the Silent Planet")
     assert_not_equal defaults[:published_on], book.published_on


### PR DESCRIPTION
mainly extracted from https://github.com/rails/rails/pull/35494

If same key is used in data hash and also in defaults, data hash one is used.

I'll update documentation once approved.