### PR TITLE
Add `-e/--environment` option to `rails initializers`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `-e/--environment` option to `rails initializers`.
+
+    *Yuji Yaginuma*
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   No changes.

--- a/railties/lib/rails/commands/initializers/initializers_command.rb
+++ b/railties/lib/rails/commands/initializers/initializers_command.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
+require "rails/command/environment_argument"
+
 module Rails
   module Command
     class InitializersCommand < Base # :nodoc:
+      include EnvironmentArgument
+
       desc "initializers", "Print out all defined initializers in the order they are invoked by Rails."
       def perform
+        extract_environment_option_from_argument
+        ENV["RAILS_ENV"] = options[:environment]
+
         require_application_and_environment!
 
         Rails.application.initializers.tsort_each do |initializer|

--- a/railties/test/commands/initializers_test.rb
+++ b/railties/test/commands/initializers_test.rb
@@ -25,8 +25,24 @@ class Rails::Command::InitializersTest < ActiveSupport::TestCase
     assert final_output.include?("set_added_test_module")
   end
 
+
+  test "prints out initializers only specified in environment option" do
+    add_to_config <<-RUBY
+      initializer(:set_added_development_module) { } if Rails.env.development?
+      initializer(:set_added_production_module) { } if Rails.env.production?
+    RUBY
+
+    output = run_initializers_command.split("\n")
+    assert_includes output, "AppTemplate::Application.set_added_development_module"
+    assert_not_includes output, "AppTemplate::Application.set_added_production_module"
+
+    output = run_initializers_command(["-e", "production"]).split("\n")
+    assert_not_includes output, "AppTemplate::Application.set_added_development_module"
+    assert_includes output, "AppTemplate::Application.set_added_production_module"
+  end
+
   private
-    def run_initializers_command
-      rails "initializers"
+    def run_initializers_command(args = [])
+      rails "initializers", args
     end
 end


### PR DESCRIPTION
This allows specifying the environment as would any other rails commands.