### PR TITLE
Preserve scope for insert_all and friends.

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -6,6 +6,7 @@ module ActiveRecord
     attr_reader :on_duplicate, :returning, :unique_by
 
     def initialize(scope, inserts, on_duplicate:, returning: nil, unique_by: nil)
+      raise ArgumentError, "Bulk insert is currently not supported for through relations" if scope.try(:proxy_association).try(:reflection).try(:through_reflection?)
       raise ArgumentError, "Empty list of attributes passed" if inserts.blank?
 
       @model = scope.model

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -121,7 +121,7 @@ module ActiveRecord
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
       def insert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(scope_for_association, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
       end
 
       # Inserts a single record into the database in a single SQL INSERT
@@ -175,7 +175,7 @@ module ActiveRecord
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
       def insert_all!(attributes, returning: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning).execute
+        InsertAll.new(scope_for_association, attributes, on_duplicate: :raise, returning: returning).execute
       end
 
       # Updates or inserts (upserts) a single record into the database in a
@@ -240,7 +240,7 @@ module ActiveRecord
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
       def upsert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(scope_for_association, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -121,7 +121,7 @@ module ActiveRecord
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
       def insert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(scope_for_association, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(scope_for_association(current_scope || relation), attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
       end
 
       # Inserts a single record into the database in a single SQL INSERT
@@ -175,7 +175,7 @@ module ActiveRecord
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
       def insert_all!(attributes, returning: nil)
-        InsertAll.new(scope_for_association, attributes, on_duplicate: :raise, returning: returning).execute
+        InsertAll.new(scope_for_association(current_scope || relation), attributes, on_duplicate: :raise, returning: returning).execute
       end
 
       # Updates or inserts (upserts) a single record into the database in a
@@ -240,7 +240,7 @@ module ActiveRecord
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
       def upsert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(scope_for_association, attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
+        InsertAll.new(scope_for_association(current_scope || relation), attributes, on_duplicate: :update, returning: returning, unique_by: unique_by).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -101,10 +101,6 @@ module ActiveRecord
       end
     end
 
-    def insert_all(attributes, returning: nil, unique_by: nil)
-      InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
-    end
-
     # Similar to #create, but calls
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!]
     # on the base class. Raises an exception if a validation error occurs.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -101,6 +101,10 @@ module ActiveRecord
       end
     end
 
+    def insert_all(attributes, returning: nil, unique_by: nil)
+      InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+    end
+
     # Similar to #create, but calls
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!]
     # on the base class. Raises an exception if a validation error occurs.

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -4,6 +4,8 @@ require "cases/helper"
 require "models/author"
 require "models/book"
 require "models/speedometer"
+require "models/subscription"
+require "models/subscriber"
 
 class ReadonlyNameBook < Book
   attr_readonly :name
@@ -306,8 +308,12 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal 2, Book.where(format: "X").count
   end
 
-  private
+  def test_insert_all_has_many_through
+    book = Book.first
+    assert_raise(ArgumentError) { book.subscribers.insert_all([ { nick: "Jimmy" } ]) }
+  end
 
+  private
     def capture_log_output
       output = StringIO.new
       old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(output)

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/author"
 require "models/book"
 require "models/speedometer"
 
@@ -279,7 +280,29 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_on_relation
+    skip unless supports_insert_on_duplicate_skip?
+
+    author = Author.create!(name: "Jimmy")
+
+    assert_difference "author.books.count", +1 do
+      author.books.insert_all([{ name: "My little book", isbn: "1974522598" }])
+    end
+  end
+
+  def test_insert_all_on_relation_precedence
+    skip unless supports_insert_on_duplicate_skip?
+
+    author = Author.create!(name: "Jimmy")
+    second_author = Author.create!(name: "Bob")
+
+    assert_difference "author.books.count", +1 do
+      author.books.insert_all([{ name: "My little book", isbn: "1974522598", author_id: second_author.id }])
+    end
+  end
+
   private
+
     def capture_log_output
       output = StringIO.new
       old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(output)

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -301,6 +301,11 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_create_with
+    Book.create_with(format: "X").insert_all([ { name: "A" }, { name: "B" } ])
+    assert_equal 2, Book.where(format: "X").count
+  end
+
   private
 
     def capture_log_output


### PR DESCRIPTION
Alternative approach to https://github.com/rails/rails/pull/35626 based on https://github.com/rails/rails/pull/35635 using `scope_for_create` to assign relation defaults reverse merged with passed defaults as an argument => relation scope is used only if the same key is not present in defaults or in data hash.

It is implemented directly on relation = all associations should be supported as well.

```ruby
Author.first.books.where(published: true).insert_all([{ name: "My little book", isbn: "197452259"}])
```

Creates one book with assigned author and `published: true` taken from where relation.

If approved, I can add all friend methods (`upsert_all`, `insert_all!`, `insert`, `upsert`, `insert!`) and add some documentations as well.