### PR TITLE
should have kept using remote: true and not used local:

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1538,7 +1538,6 @@ module ActionView
           # responsibility of the caller to escape all the values.
           html_options[:action] = url_for(url_for_options || {})
           html_options[:"accept-charset"] = "UTF-8"
-          
           # local: true will disable ajax remote form
           html_options[:"data-remote"] = true unless local == true
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1524,6 +1524,8 @@ module ActionView
       end
 
       private
+        # local: true will turn off ajax
+        # missing form_with_generates_remote_forms will make local: false (turn on remote)
         def html_options_for_form_with(url_for_options = nil, model = nil, html: {}, local: !form_with_generates_remote_forms,
           skip_enforcing_utf8: nil, **options)
           html_options = options.slice(:id, :class, :multipart, :method, :data).merge(html)
@@ -1536,7 +1538,9 @@ module ActionView
           # responsibility of the caller to escape all the values.
           html_options[:action] = url_for(url_for_options || {})
           html_options[:"accept-charset"] = "UTF-8"
-          html_options[:"data-remote"] = true unless local
+          
+          # local: true will disable ajax remote form
+          html_options[:"data-remote"] = true unless local == true
 
           html_options[:authenticity_token] = options.delete(:authenticity_token)
 


### PR DESCRIPTION
### Summary

The documents changed from using remote: to local: to set remote forms. Then I discovered I need a config option set (form_with_generates_remote_forms) for it to toggle local: correctly.

I am not 100% sure this is a good change. Because anyone with form_with_generates_remote_forms missing from their Rails config could have all their remote forms turned on or off by default.

Logic Decision Tree (defaults)

1. missing ```form_with_generates_remote_forms```
old way, remote: false
new way, local: false (ajax on)

2. ```form_with_generates_remote_forms``` is true
old way, remote: true (ajax on)
new way, local: false (ajax on)

3. ```form_with_generates_remote_forms``` is false
old way, remote: false
new way, local: true (ajax off)

### Other Information

https://stackoverflow.com/questions/45221800/rails-5-1-2-form-with-is-not-showing-data-remote-true-in-the-html
