### PR TITLE
Raise UnknownAttributeError when unknown column is passed to insert_all and friends

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -92,7 +92,15 @@ module ActiveRecord
 
         def values_list
           columns = connection.schema_cache.columns_hash(model.table_name)
+
+          column_names = columns.keys.to_set
           keys = insert_all.keys.to_set
+          unknown_columns = keys - column_names
+
+          unless unknown_columns.empty?
+            raise UnknownAttributeError.new(model.new, unknown_columns.first)
+          end
+
           types = keys.map { |key| [ key, connection.lookup_cast_type_from_column(columns[key]) ] }.to_h
 
           values_list = insert_all.inserts.map do |attributes|

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -136,4 +136,10 @@ class InsertAllTest < ActiveRecord::TestCase
 
     assert_equal ["Out of the Silent Planet", "Perelandra"], Book.where(isbn: "1974522598").order(:name).pluck(:name)
   end
+
+  def test_insert_all_raises_on_unknown_attribute
+    assert_raise ActiveRecord::UnknownAttributeError do
+      Book.insert_all! [{ unknown_attribute: "Test" }]
+    end
+  end
 end


### PR DESCRIPTION
Since we typecast values in `InsertAll`, we can check if all columns are known to model and raise more friendly `UnknownAttributeError` when not.

## before:

```ruby
Book.insert_all [{ unknown_attribute: 'Test' }]
NoMethodError: undefined method `oid' for nil:NilClass
    /home/retro/code/oss/rails/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb:78:in `lookup_cast_type_from_column'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:104:in `block in values_list'
    /home/retro/.rubies/ruby-2.5.3/lib/ruby/2.5.0/set.rb:338:in `each_key'
    /home/retro/.rubies/ruby-2.5.3/lib/ruby/2.5.0/set.rb:338:in `each'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:104:in `map'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:104:in `values_list'
    /home/retro/code/oss/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:430:in `build_insert_sql'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:64:in `to_sql'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:21:in `execute'
    /home/retro/code/oss/rails/activerecord/lib/active_record/persistence.rb:125:in `insert_all'
    test/cases/insert_all_test.rb:142:in `test_insert_all_raises_on_unknown_attribute'
```

## after:

```ruby
Book.insert_all [{ unknown_attribute: 'Test' }]
ActiveModel::UnknownAttributeError: unknown attribute 'unknown_attribute' for Book.
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:101:in `values_list'
    /home/retro/code/oss/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:430:in `build_insert_sql'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:64:in `to_sql'
    /home/retro/code/oss/rails/activerecord/lib/active_record/insert_all.rb:21:in `execute'
    /home/retro/code/oss/rails/activerecord/lib/active_record/persistence.rb:125:in `insert_all'
    test/cases/insert_all_test.rb:142:in `test_insert_all_raises_on_unknown_attribute'
```

which is the same error `create` raises for same attributes

```ruby
Book.create({ unknown_attribute: 'Test' })
ActiveModel::UnknownAttributeError: unknown attribute 'unknown_attributes' for Book.
    /home/retro/code/oss/rails/activemodel/lib/active_model/attribute_assignment.rb:53:in `_assign_attribute'
    /home/retro/code/oss/rails/activemodel/lib/active_model/attribute_assignment.rb:44:in `block in _assign_attributes'
    /home/retro/code/oss/rails/activemodel/lib/active_model/attribute_assignment.rb:43:in `each'
    /home/retro/code/oss/rails/activemodel/lib/active_model/attribute_assignment.rb:43:in `_assign_attributes'
    /home/retro/code/oss/rails/activerecord/lib/active_record/attribute_assignment.rb:22:in `_assign_attributes'
    /home/retro/code/oss/rails/activemodel/lib/active_model/attribute_assignment.rb:35:in `assign_attributes'
    /home/retro/code/oss/rails/activerecord/lib/active_record/core.rb:327:in `initialize'
    /home/retro/code/oss/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /home/retro/code/oss/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /home/retro/code/oss/rails/activerecord/lib/active_record/persistence.rb:37:in `create'
    test/cases/insert_all_test.rb:142:in `test_insert_all_raises_on_unknown_attribute'

```