### PR TITLE
Save has_rich_text attribute with nested attributes

### DIFF
--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -31,8 +31,10 @@ module ActionText
 
           def #{name}=(body)
             self.#{name}.body = body
+            public_send(:#{name}).save if public_send(:#{name}).changed?
           end
         CODE
+
 
         has_one :"rich_text_#{name}", -> { where(name: name) }, class_name: "ActionText::RichText", as: :record, inverse_of: :record, dependent: :destroy
 

--- a/actiontext/test/dummy/app/assets/stylesheets/actiontext.scss
+++ b/actiontext/test/dummy/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/actiontext/test/dummy/app/javascript/packs/application.js
+++ b/actiontext/test/dummy/app/javascript/packs/application.js
@@ -1,1 +1,4 @@
 import "@rails/actiontext"
+
+require("trix")
+require("@rails/actiontext")

--- a/actiontext/test/dummy/app/models/message.rb
+++ b/actiontext/test/dummy/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
   has_rich_text :content
   has_rich_text :body
+  has_one :post
+  accepts_nested_attributes_for :post
 end

--- a/actiontext/test/dummy/app/models/post.rb
+++ b/actiontext/test/dummy/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+	belongs_to :message
+	has_rich_text :content
+end

--- a/actiontext/test/dummy/app/views/active_storage/blobs/_blob.html.erb
+++ b/actiontext/test/dummy/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/actiontext/test/dummy/db/migrate/20190314172401_create_posts.rb
+++ b/actiontext/test/dummy/db/migrate/20190314172401_create_posts.rb
@@ -1,0 +1,9 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.belongs_to :message
+
+      t.timestamps
+    end
+  end
+end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_05_172303) do
+ActiveRecord::Schema.define(version: 2019_03_14_172401) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -59,6 +59,13 @@ ActiveRecord::Schema.define(version: 2019_03_05_172303) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "message_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["message_id"], name: "index_posts_on_message_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -53,4 +53,15 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.body.to_plain_text
   end
+
+  test "save content after nested attributes update" do
+    message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
+    post = message.create_post!
+
+    message.update!(post_attributes: { content: "Test content", id: post.id })
+
+    message.reload
+
+    assert_equal "Test content", message.post.content.to_plain_text
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #35159 - This would fix saving `has_rich_text` attribute values in nested attributes updates.

For example;

```ruby
message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
post = message.create_post!

message.update!(post_attributes: { content: "Test content", id: post.id })

message.post.content # => "Test content"
```

