### PR TITLE
Don't override @set_cookies on CookieJar#update_cookies_from_jar'

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -338,7 +338,7 @@ module ActionDispatch
 
       def update_cookies_from_jar
         request_jar = @request.cookie_jar.instance_variable_get(:@cookies)
-        set_cookies = request_jar.reject { |k, _| @delete_cookies.key?(k) }
+        set_cookies = request_jar.reject { |k, _| @delete_cookies.key?(k) || @set_cookies.key?(k) }
 
         @cookies.update set_cookies if set_cookies
       end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -123,6 +123,11 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def set_cookie_if_not_present
+      cookies["user_name"] = "alice" unless cookies["user_name"].present?
+      head :ok
+    end
+
     def logout
       cookies.delete("user_name")
       head :ok
@@ -1126,6 +1131,14 @@ class CookiesTest < ActionController::TestCase
     cookies.encrypted["foo"] = "bar"
     get :noop
     assert_equal "bar", @controller.encrypted_cookie
+  end
+
+  def test_cookie_override
+    get :set_cookie_if_not_present
+    assert_equal "alice", cookies["user_name"]
+    cookies["user_name"] = "bob"
+    get :set_cookie_if_not_present
+    assert_equal "bob", cookies["user_name"]
   end
 
   def test_signed_cookie_with_expires_set_relatively


### PR DESCRIPTION
### Summary

When building the cookie_jar for the current test request.
It was possible for this method to override keys currently being set on the test itself.
In situations such as when making two requests mixing creating the cookie on the test and the controller.

### Other Information

This issue was brought up on https://github.com/rails/rails/pull/27586 as a regression, but it still seems to be failing on master. I think this issue is only affecting controller specs, as Cookiejar#update_cookies_from_jar is only being called from there. Maybe that should be moved to ActionController::TestCase?

The following report should be passing now:

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "5-0-stable"
  gem "pry-byebug"
end

require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.session_store :cookie_store, key: "cookie_store_key"
  secrets.secret_token    = "secret_token"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    resources :users, only: [:index]
  end
end

class UsersController < ActionController::Base
  def index
    unless cookies[:name].present?
      cookies[:name] = "Alice"
    end
    render plain: "Home"
  end
end

require "minitest/autorun"
require "rack/test"

class UsersControllerTest < ActionController::TestCase
  setup do
    @controller = UsersController.new
    @routes = Rails.application.routes
  end

  test '#index sets a cookie if it is not already present' do
    get :index
    assert_response :ok
    assert_equal "Alice", cookies[:name]

    cookies[:name] = "Bob"

    get :index
    assert_response :ok
    assert_equal "Bob", cookies[:name]
  end
end```