### PR TITLE
 Revert "Pass HTML responses as plain-text in rails-ujs" 

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -69,7 +69,7 @@ processResponse = (response, type) ->
       script.setAttribute('nonce', cspNonce())
       script.text = response
       document.head.appendChild(script).parentNode.removeChild(script)
-    else if type.match(/\bxml\b/)
+    else if type.match(/\b(xml|html|svg)\b/)
       parser = new DOMParser()
       type = type.replace(/;.+/, '') # remove something like ';charset=utf-8'
       try response = parser.parseFromString(response, type)

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -128,6 +128,17 @@ asyncTest('execution of JS code does not modify current DOM', 1, function() {
   })
 })
 
+asyncTest('HTML document should be parsed', 1, function() {
+  buildForm({ method: 'post', 'data-type': 'html' })
+
+  $('form').append('<input type="text" name="content_type" value="text/html">')
+  $('form').append('<input type="text" name="content" value="<p>hello</p>">')
+
+  submit(function(e, data, status, xhr) {
+    ok(data instanceof HTMLDocument, 'returned data should be an HTML document')
+  })
+})
+
 asyncTest('XML document should be parsed', 1, function() {
   buildForm({ method: 'post', 'data-type': 'html' })
 

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -128,17 +128,6 @@ asyncTest('execution of JS code does not modify current DOM', 1, function() {
   })
 })
 
-asyncTest('HTML content should be plain-text', 1, function() {
-  buildForm({ method: 'post', 'data-type': 'html' })
-
-  $('form').append('<input type="text" name="content_type" value="text/html">')
-  $('form').append('<input type="text" name="content" value="<p>hello</p>">')
-
-  submit(function(e, data, status, xhr) {
-    ok(data === '<p>hello</p>', 'returned data should be a plain-text string')
-  })
-})
-
 asyncTest('XML document should be parsed', 1, function() {
   buildForm({ method: 'post', 'data-type': 'html' })
 


### PR DESCRIPTION
### Summary

This reverts commit 48e44edfd0a8a7a29aa8fad39638ac0ee5243f42.

See discussion in #32287

For HTML content in `ajax:success` handlers, `event.detail[0]` should
be an `HTMLDocument` instance.
