### PR TITLE
Fix invalid suggestion in null origin error message

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -431,7 +431,7 @@ module ActionController #:nodoc:
         The browser returned a 'null' origin for a request with origin-based forgery protection turned on. This usually
         means you have the 'no-referrer' Referrer-Policy header enabled, or that the request came from a site that
         refused to give its origin. This makes it impossible for Rails to verify the source of the requests. Likely the
-        best solution is to change your referrer policy to something less strict like same-origin or strict-same-origin.
+        best solution is to change your referrer policy to something less strict like same-origin or strict-origin.
         If you cannot change the referrer policy, you can disable origin checking with the
         Rails.application.config.action_controller.forgery_protection_origin_check setting.
       MSG


### PR DESCRIPTION
### Summary

The very helpful "Null origin message" added in #30780 refers to an invalid value (`strict-same-origin`) for the `Referrer-Policy` header. This PR fixes the error message so that it only suggests valid directives for this header.

### Other Information

A complete list of valid directives for the `Referrer-Policy` header can be found here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
