### PR TITLE
Validate types assigned to LookupContext#formats=

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -280,7 +280,7 @@ module ActionView
     # add :html as fallback to :js.
     def formats=(values)
       if values
-        values = values.compact
+        values = values.dup
         values.concat(default_formats) if values.delete "*/*"
         values.uniq!
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -284,9 +284,9 @@ module ActionView
         values.concat(default_formats) if values.delete "*/*"
         values.uniq!
 
-        invalid_types = (values - Template::Types.symbols)
-        unless invalid_types.empty?
-          raise ArgumentError, "Invalid formats: #{invalid_types.map(&:inspect).join(", ")}"
+        invalid_values = (values - Template::Types.symbols)
+        unless invalid_values.empty?
+          raise ArgumentError, "Invalid formats: #{invalid_values.map(&:inspect).join(", ")}"
         end
 
         if values == [:js]

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -284,6 +284,11 @@ module ActionView
         values.concat(default_formats) if values.delete "*/*"
         values.uniq!
 
+        invalid_types = (values - Template::Types.symbols)
+        unless invalid_types.empty?
+          raise ArgumentError, "Invalid formats: #{invalid_types.map(&:inspect).join(", ")}"
+        end
+
         if values == [:js]
           values << :html
           @html_fallback_for_js = true

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -282,6 +282,8 @@ module ActionView
       if values
         values = values.compact
         values.concat(default_formats) if values.delete "*/*"
+        values.uniq!
+
         if values == [:js]
           values << :html
           @html_fallback_for_js = true

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -280,6 +280,7 @@ module ActionView
     # add :html as fallback to :js.
     def formats=(values)
       if values
+        values = values.compact
         values.concat(default_formats) if values.delete "*/*"
         if values == [:js]
           values << :html

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -127,7 +127,7 @@ module ActionView
       # Assign the rendered format to look up context.
       def _process_format(format)
         super
-        lookup_context.formats = [format.to_sym]
+        lookup_context.formats = [format.to_sym] if format.to_sym
       end
 
       # Normalize args by converting render "foo" to render :action => "foo" and

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -72,7 +72,7 @@ class LookupContextTest < ActiveSupport::TestCase
 
   test "handles explicitly defined */* formats fallback to :js" do
     @lookup_context.formats = [:js, Mime::ALL]
-    assert_equal [:js, *Mime::SET.symbols], @lookup_context.formats
+    assert_equal [:js, *Mime::SET.symbols].uniq, @lookup_context.formats
   end
 
   test "adds :html fallback to :js formats" do

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -65,11 +65,6 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_equal Mime::SET.to_a, @lookup_context.formats
   end
 
-  test "ignores nil format" do
-    @lookup_context.formats = [:html, nil, :text]
-    assert_equal [:html, :text], @lookup_context.formats
-  end
-
   test "handles explicitly defined */* formats fallback to :js" do
     @lookup_context.formats = [:js, Mime::ALL]
     assert_equal [:js, *Mime::SET.symbols].uniq, @lookup_context.formats

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -82,10 +82,10 @@ class LookupContextTest < ActiveSupport::TestCase
 
   test "raises on invalid format assignment" do
     ex = assert_raises ArgumentError do
-      @lookup_context.formats = [:html, :javascript]
+      @lookup_context.formats = [:html, :invalid, "also bad"]
     end
 
-    assert_equal "Invalid formats: :javascript", ex.message
+    assert_equal 'Invalid formats: :invalid, "also bad"', ex.message
   end
 
   test "provides getters and setters for locale" do

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -65,6 +65,11 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_equal Mime::SET.to_a, @lookup_context.formats
   end
 
+  test "ignores nil format" do
+    @lookup_context.formats = [:html, nil, :text]
+    assert_equal [:html, :text], @lookup_context.formats
+  end
+
   test "handles explicitly defined */* formats fallback to :js" do
     @lookup_context.formats = [:js, Mime::ALL]
     assert_equal [:js, *Mime::SET.symbols], @lookup_context.formats

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -80,6 +80,14 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_equal [:js, :html], @lookup_context.formats
   end
 
+  test "raises on invalid format assignment" do
+    ex = assert_raises ArgumentError do
+      @lookup_context.formats = [:html, :javascript]
+    end
+
+    assert_equal "Invalid formats: :javascript", ex.message
+  end
+
   test "provides getters and setters for locale" do
     @lookup_context.locale = :pt
     assert_equal :pt, @lookup_context.locale

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -38,7 +38,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
           end
         else
           @part = find_preferred_part(request.format, Mime[:html], Mime[:text])
-          render action: "email", layout: false, formats: %w[html]
+          render action: "email", layout: false, formats: [:html]
         end
       else
         raise AbstractController::ActionNotFound, "Email '#{@email_action}' not found in #{@preview.name}"


### PR DESCRIPTION
This was developed when looking into CVE-2019-5418, but wasn't required to fix the vulnerability.

This is a developer quality of life improvement, to ensure that unknown formats aren't assigned to the LookupContext (which it would previously accept, but wouldn't work 100% correctly due to caching).

This also now avoids mutating the values passed in, removes `nil`s, and makes the formats uniq.

cc @tenderlove @kaspth