### PR TITLE
Remove virtual_path from fallback templates

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -184,15 +184,19 @@ module ActionView
         template_paths = reject_files_external_to_app(template_paths) unless outside_app_allowed
 
         template_paths.map do |template|
-          handler, format, variant = extract_handler_and_format_and_variant(template)
-
-          FileTemplate.new(File.expand_path(template), handler,
-            virtual_path: path.virtual,
-            format: format,
-            variant: variant,
-            locals: locals
-          )
+          build_template(template, path.virtual, locals)
         end
+      end
+
+      def build_template(template, virtual_path, locals)
+        handler, format, variant = extract_handler_and_format_and_variant(template)
+
+        FileTemplate.new(File.expand_path(template), handler,
+          virtual_path: virtual_path,
+          format: format,
+          variant: variant,
+          locals: locals
+        )
       end
 
       def reject_files_external_to_app(files)
@@ -384,6 +388,10 @@ module ActionView
   class FallbackFileSystemResolver < FileSystemResolver #:nodoc:
     def self.instances
       [new(""), new("/")]
+    end
+
+    def build_template(template, virtual_path, locals)
+      super(template, nil, locals)
     end
   end
 end

--- a/actionview/test/template/fallback_file_system_resolver_test.rb
+++ b/actionview/test/template/fallback_file_system_resolver_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class FallbackFileSystemResolverTest < ActiveSupport::TestCase
+  def setup
+    @root_resolver = ActionView::FallbackFileSystemResolver.new("/")
+  end
+
+  def test_should_have_no_virtual_path
+    templates = @root_resolver.find_all("hello_world.erb", "#{FIXTURE_LOAD_PATH}/test", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    assert_equal 1, templates.size
+    assert_equal "Hello world!", templates[0].source
+    assert_nil templates[0].virtual_path
+  end
+end


### PR DESCRIPTION
In 9a343d148b96874a231b87906c9d6499b5e0b64a we removed a decorate method from `FallbackFileSystemResolver`, which previously would remove the `virtual_path` from the fallback templates (usually found via `render file:`).

This caused some breakage in rails-controller-testing (See https://github.com/rails/rails-controller-testing/pull/46). I'd prefer we didn't change this behaviour anyways.

This PR adds a private `build_template` method, which we can override to avoid setting a virtual_path instead of mutating the template.

cc @tenderlove @cpruitt 