### PR TITLE
Fix database configuration when adding another config level

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -106,7 +106,7 @@ module ActiveRecord
 
         build_db_config = configs.each_pair.flat_map do |env_name, config|
           walk_configs(env_name.to_s, "primary", config)
-        end.compact
+        end.flatten.compact
 
         if url = ENV["DATABASE_URL"]
           build_url_config(url, build_db_config)

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -123,6 +123,8 @@ module TestHelpers
             adapter: sqlite3
             pool: 5
             timeout: 5000
+            variables:
+              statement_timeout: 1000
           development:
             primary:
               <<: *default


### PR DESCRIPTION
This is kind of hard to explain but if you have a database config with
another level like this:

```
development:
  primary:
    database: "my db"
    variables:
      statement_timeout: 1000
```

the database configurations code would chooke on the `variables` level
because it didn't know what to do with it.

We'd see the following error:

```
lib/active_record/database_configurations.rb:72:in
`block in find_db_config': undefined method `env_name' for [nil]:Array
(NoMethodError)
```

The problem here is that Rails does correctly identify this as not a
real configuration but returns `[nil]` along with the others. We need to
make sure to flatten the array and remove all the `nil`'s before
returning the `configurations` objects.

Fixes #35646
