### PR TITLE
Remove roflscaling

### DIFF
--- a/activerecord/lib/arel/visitors/mssql.rb
+++ b/activerecord/lib/arel/visitors/mssql.rb
@@ -106,7 +106,7 @@ module Arel # :nodoc: all
           collector = visit o.relation, collector
           if o.wheres.any?
             collector << " WHERE "
-            inject_join o.wheres, collector, AND
+            inject_join o.wheres, collector, " AND "
           else
             collector
           end

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -3,11 +3,6 @@
 module Arel # :nodoc: all
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
-      CUBE = "CUBE"
-      ROLLUP = "ROLLUP"
-      GROUPING_SETS = "GROUPING SETS"
-      LATERAL = "LATERAL"
-
       private
 
         def visit_Arel_Nodes_Matches(o, collector)

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -57,23 +57,22 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_Cube(o, collector)
-          collector << CUBE
+          collector << "CUBE"
           grouping_array_or_grouping_element o, collector
         end
 
         def visit_Arel_Nodes_RollUp(o, collector)
-          collector << ROLLUP
+          collector << "ROLLUP"
           grouping_array_or_grouping_element o, collector
         end
 
         def visit_Arel_Nodes_GroupingSet(o, collector)
-          collector << GROUPING_SETS
+          collector << "GROUPING SETS"
           grouping_array_or_grouping_element o, collector
         end
 
         def visit_Arel_Nodes_Lateral(o, collector)
-          collector << LATERAL
-          collector << SPACE
+          collector << "LATERAL "
           grouping_parentheses o, collector
         end
 

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -9,16 +9,6 @@ module Arel # :nodoc: all
     end
 
     class ToSql < Arel::Visitors::Visitor
-      WHERE    = " WHERE "    # :nodoc:
-      SPACE    = " "          # :nodoc:
-      COMMA    = ", "         # :nodoc:
-      GROUP_BY = " GROUP BY " # :nodoc:
-      ORDER_BY = " ORDER BY " # :nodoc:
-      WINDOW   = " WINDOW "   # :nodoc:
-      AND      = " AND "      # :nodoc:
-
-      DISTINCT = "DISTINCT"   # :nodoc:
-
       def initialize(connection)
         super()
         @connection = connection


### PR DESCRIPTION
roflscaling (using frozen string constants instead of literal
strings) was added in 2012, before frozen string literals were
added in Ruby 2.3.  Now that Rails no longer supports Ruby <2.3,
and all of these files use frozen string literals, there is
no reason to keep the roflscaling.

This does not delete or deprecate the related constants. Such
a change can be made in a later commit.

@tenderlove may want to review this as he added the roflscaling
in e2322265cc84ddd204fddbc1398db42179f6a31b.