### PR TITLE
Update regular expression for checking valid MIME type

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -223,7 +223,10 @@ module Mime
     attr_reader :hash
 
     MIME_NAME = "[a-zA-Z0-9][a-zA-Z0-9#{Regexp.escape('!#$&-^_.+')}]{0,126}"
-    MIME_REGEXP = /\A(?:\*\/\*|#{MIME_NAME}\/(?:\*|#{MIME_NAME}))\z/
+    MIME_PARAMETER_KEY = "[a-zA-Z0-9][a-zA-Z0-9#{Regexp.escape('!#$&-^_.+')}]{0,126}"
+    MIME_PARAMETER_VALUE = "#{Regexp.escape('"')}?[a-zA-Z0-9][a-zA-Z0-9#{Regexp.escape('!#$&-^_.+')}]{0,126}#{Regexp.escape('"')}?"
+    MIME_PARAMETER = "\s*\;\s+#{MIME_PARAMETER_KEY}(?:\=#{MIME_PARAMETER_VALUE})?"
+    MIME_REGEXP = /\A(?:\*\/\*|#{MIME_NAME}\/(?:\*|#{MIME_NAME})(?:\s*#{MIME_PARAMETER}\s*)*)\z/
 
     class InvalidMimeType < StandardError; end
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -181,6 +181,13 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal "video/*", Mime::Type.new("video/*").to_s
   end
 
+  test "can be initialized with parameters" do
+    assert_equal "text/html; parameter", Mime::Type.new("text/html; parameter").to_s
+    assert_equal "text/html; parameter=abc", Mime::Type.new("text/html; parameter=abc").to_s
+    assert_equal 'text/html; parameter="abc"', Mime::Type.new('text/html; parameter="abc"').to_s
+    assert_equal 'text/html; parameter=abc; parameter2="xyz"', Mime::Type.new('text/html; parameter=abc; parameter2="xyz"').to_s
+  end
+
   test "invalid mime types raise error" do
     assert_raises Mime::Type::InvalidMimeType do
       Mime::Type.new("too/many/slash")
@@ -188,6 +195,14 @@ class MimeTypeTest < ActiveSupport::TestCase
 
     assert_raises Mime::Type::InvalidMimeType do
       Mime::Type.new("missingslash")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new("improper/semicolon;")
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.new('improper/semicolon; parameter=abc; parameter2="xyz";')
     end
 
     assert_raises Mime::Type::InvalidMimeType do


### PR DESCRIPTION
MIME Type validation regular expression does not allow for MIME types initialized with strings that contain parameters after the MIME type name.

See Rails PR: https://github.com/rails/rails/commit/b5e8942c95078945ff09a83b2fc03a0ae7e35953#diff-c5146df11f35304765e9ceebed108f57R226

For example, the following will not work:

```ruby
Mime::Type.register "text/html; fragment", :html_fragment
```

This updates the regular expression to fix the issue and adds some tests for MIME types with parameters and invalid trailing semicolons. This allows for:

* Parameters with or without values
* Parameters with quoted or unquoted values
    - (If a value has an opening double quotation character it should always have a closing and vice versa, but this does not check for that)

 This may need to be updated for specific lengths of parameter keys/values or specifically allowed/disallowed characters. This is a pass to get parameters working and/or get feedback on other necessary changes.

CC: @jhawthorn