### PR TITLE
Re-add Template#updated_at as deprecated

### DIFF
--- a/actionview/lib/action_view/file_template.rb
+++ b/actionview/lib/action_view/file_template.rb
@@ -22,11 +22,11 @@ module ActionView
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.
     def marshal_dump # :nodoc:
-      [ @identifier, @handler, @compiled, @locals, @virtual_path, @format, @variant ]
+      [ @identifier, @handler, @compiled, @locals, @virtual_path, @updated_at, @format, @variant ]
     end
 
     def marshal_load(array) # :nodoc:
-      @identifier, @handler, @compiled, @locals, @virtual_path, @format, @variant = *array
+      @identifier, @handler, @compiled, @locals, @virtual_path, @updated_at, @format, @variant = *array
       @compile_mutex = Mutex.new
     end
   end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -122,10 +122,10 @@ module ActionView
 
     extend Template::Handlers
 
-    attr_reader :source, :identifier, :handler, :original_encoding
+    attr_reader :source, :identifier, :handler, :original_encoding, :updated_at
     attr_reader :variable, :format, :variant, :locals, :virtual_path
 
-    def initialize(source, identifier, handler, format: nil, variant: nil, locals: nil, virtual_path: nil)
+    def initialize(source, identifier, handler, format: nil, variant: nil, locals: nil, virtual_path: nil, updated_at: nil)
       unless locals
         ActiveSupport::Deprecation.warn "ActionView::Template#initialize requires a locals parameter"
         locals = []
@@ -144,12 +144,19 @@ module ActionView
         $1.to_sym
       end
 
+      if updated_at
+        ActiveSupport::Deprecation.warn "ActionView::Template#updated_at is deprecated"
+        @updated_at        = updated_at
+      else
+        @updated_at        = Time.now
+      end
       @format            = format
       @variant           = variant
       @compile_mutex     = Mutex.new
     end
 
     deprecate :original_encoding
+    deprecate :updated_at
     deprecate def virtual_path=(_); end
     deprecate def locals=(_); end
     deprecate def formats=(_); end
@@ -260,11 +267,11 @@ module ActionView
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.
     def marshal_dump # :nodoc:
-      [ @source, @identifier, @handler, @compiled, @locals, @virtual_path, @format, @variant ]
+      [ @source, @identifier, @handler, @compiled, @locals, @virtual_path, @updated_at, @format, @variant ]
     end
 
     def marshal_load(array) # :nodoc:
-      @source, @identifier, @handler, @compiled, @locals, @virtual_path, @format, @variant = *array
+      @source, @identifier, @handler, @compiled, @locals, @virtual_path, @updated_at, @format, @variant = *array
       @compile_mutex = Mutex.new
     end
 


### PR DESCRIPTION
As requested in https://github.com/rails/rails/pull/35623#discussion_r266246229 this re-adds `ActionView::Template#updated_at` as a deprecated method.

I didn't re-add the behaviour to the resolver to set the `updated_at` based on the file's `mtime`, because it's _probably_ unnecessary. Not doing this also allows deprecating the `updated_at:` keyword to `Template#initialize` (which is probably more likely to be used than the getter).

cc @kamipo @rafaelfranca @tenderlove 