### PR TITLE
Allow calling Encrypted/Signed cookies from Integration tests

### DIFF
--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -364,11 +364,9 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
     # Overwrite get to send SessionSecret in env hash
     def get(path, *args)
-      args[0] ||= {}
-      args[0][:env] ||= {}
-      args[0][:env]["action_dispatch.key_generator"] ||= Generator
-      args[0][:env]["action_dispatch.cookies_rotations"] = Rotations
-      args[0][:env]["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
+      request.env["action_dispatch.key_generator"] ||= Generator
+      request.env["action_dispatch.cookies_rotations"] = Rotations
+      request.env["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
       super(path, *args)
     end
 

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -60,13 +60,13 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       get "/set_session_value"
       assert_response :success
       assert cookies["_session_id"]
-      session_cookie = cookies.send(:hash_for)["_session_id"]
+      session_cookie = cookies["_session_id"]
 
       get "/call_reset_session"
       assert_response :success
       assert_not_equal [], headers["Set-Cookie"]
 
-      cookies << session_cookie # replace our new session_id with our old, pre-reset session_id
+      cookies["_session_id"] = session_cookie # replace our new session_id with our old, pre-reset session_id
 
       get "/get_session_value"
       assert_response :success

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -382,16 +382,12 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
 
     # Overwrite get to send SessionSecret in env hash
     def get(path, *args)
-      args[0] ||= {}
-      args[0][:headers] ||= {}
-      args[0][:headers].tap do |config|
-        config["action_dispatch.secret_key_base"] = SessionSecret
-        config["action_dispatch.authenticated_encrypted_cookie_salt"] = SessionSalt
-        config["action_dispatch.use_authenticated_cookie_encryption"] = true
+      request.env["action_dispatch.secret_key_base"] = SessionSecret
+      request.env["action_dispatch.authenticated_encrypted_cookie_salt"] = SessionSalt
+      request.env["action_dispatch.use_authenticated_cookie_encryption"] = true
 
-        config["action_dispatch.key_generator"] ||= Generator
-        config["action_dispatch.cookies_rotations"] ||= Rotations
-      end
+      request.env["action_dispatch.key_generator"] ||= Generator
+      request.env["action_dispatch.cookies_rotations"] ||= Rotations
 
       super(path, *args)
     end

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -70,14 +70,15 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
       with_test_route_set do
         get "/set_session_value"
         assert_response :success
+
         assert cookies["_session_id"]
-        session_cookie = cookies.send(:hash_for)["_session_id"]
+        session_cookie = cookies["_session_id"]
 
         get "/call_reset_session"
         assert_response :success
         assert_not_equal [], headers["Set-Cookie"]
 
-        cookies << session_cookie # replace our new session_id with our old, pre-reset session_id
+        cookies["_session_id"] = session_cookie # replace our new session_id with our old, pre-reset session_id
 
         get "/get_session_value"
         assert_response :success


### PR DESCRIPTION
### Summary

This makes possible to test signed/encrypted cookies on Integration tests. The methods
included on the integration test (cookies/request) are always returned
from ActionDispatch::TestProcess::FixtureFile making it more consistent
to the users. i.e: Not mixing up rack-test and Rails and Rails cookies jar.

To do that, the integration test always has a request env configured. This issue was brought up on https://github.com/rails/rails/issues/27145.

I borrowed a few bits of Cookie Handling from ActionController::TestCase, and also updated a few tests to call the correct method on Cookies::CookieJar.

### Other Information

This is my first 'more complicated' PR to rails. I'm not sure this if this is the best implementation, so please advice if I missed anything :)

The following won't work on rails master.
```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: '../rails' #github: "rails/rails", branch: "5-0-stable"
  gem "pry-byebug"
end

require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "www.example.com"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/" => "users#index"
  end
end

class UsersController < ActionController::Base
  def index
    render plain: cookies.encrypted[:current_user]
  end
end

require "minitest/autorun"
require "rack/test"

class UsersControllerTest < ActionDispatch::IntegrationTest
  def test_returns_success
    cookies.encrypted[:current_user] = 'some user'
    get "/"
    assert_equal 'some user', response.body
    assert_equal 200, status
  end

  private
    def app
      TestApp
    end
end

# Running:

# I, [2019-03-19T19:41:25.532539 #5268]  INFO -- : -----------------------------------------
# I, [2019-03-19T19:41:25.532727 #5268]  INFO -- : UsersControllerTest: test_returns_success
# I, [2019-03-19T19:41:25.532777 #5268]  INFO -- : -----------------------------------------
# E
# 
# Error:
# UsersControllerTest#test_returns_success:
# NoMethodError: undefined method `encrypted' for #<Rack::Test::CookieJar:0x00007faba34529e0>
```