### PR TITLE
Add mention about `process_middleware.action_dispatch` in the guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -203,6 +203,15 @@ INFO. Additional keys may be added by the caller.
 | ------- | ---------------- |
 | `:keys` | Unpermitted keys |
 
+Action Dispatch
+---------------
+
+### process_middleware.action_dispatch
+
+| Key           | Value                  |
+| ------------- | ---------------------- |
+| `:middleware` | Name of the middleware |
+
 Action View
 -----------
 
@@ -424,7 +433,7 @@ INFO. Cache stores may add their own keys
 ```
 
 Active Job
---------
+----------
 
 ### enqueue_at.active_job
 


### PR DESCRIPTION


We added ActiveSupport::Notifications instrumentation of the processing of each middleware in the stack,
See 04ae0b0b5e594e0bb99c5cd608921745977bcdcd.
