### PR TITLE
Make aliases of `database` option in generators work

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
-      class_option :database, type: :string, aliases: %i(db), desc: "The database for your migration. By default, the current environment's primary database is used."
+      class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
       def create_migration_file
         set_local_assigns!

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       class_option :parent, type: :string, desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
-      class_option :database, type: :string, aliases: %i(db), desc: "The database for your model's migration. By default, the current environment's primary database is used."
+      class_option :database, type: :string, aliases: %i(--db), desc: "The database for your model's migration. By default, the current environment's primary database is used."
 
       # creates the migration file for the model.
       def create_migration_file

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -265,6 +265,17 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_database_puts_migrations_in_configured_folder_with_aliases
+    with_secondary_database_configuration do
+      run_generator ["create_books", "--db=secondary"]
+      assert_migration "db/secondary_migrate/create_books.rb" do |content|
+        assert_method :change, content do |change|
+          assert_match(/create_table :books/, change)
+        end
+      end
+    end
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -403,6 +403,17 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_database_puts_migrations_in_configured_folder_with_aliases
+    with_secondary_database_configuration do
+      run_generator ["account", "--db=secondary"]
+      assert_migration "db/secondary_migrate/create_accounts.rb" do |content|
+        assert_method :change, content do |change|
+          assert_match(/create_table :accounts/, change)
+        end
+      end
+    end
+  end
+
   def test_required_belongs_to_adds_required_association
     run_generator ["account", "supplier:references{required}"]
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -479,6 +479,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_scaffold_generator_database_with_aliases
+    with_secondary_database_configuration do
+      run_generator ["posts", "--db=secondary"]
+
+      assert_migration "db/secondary_migrate/create_posts.rb"
+    end
+  end
+
   def test_scaffold_generator_password_digest
     run_generator ["user", "name", "password:digest"]
 


### PR DESCRIPTION
Thor automatically adds `-` if aliases do not start with `-`.
https://github.com/erikhuda/thor/blob/0879c1773d188902d54f95174f33961ac33111f8/lib/thor/parser/options.rb#L53

But Thor follows a convention of one-dash-one-letter options. So, even if `-` is added to `db`, it does not work.
https://github.com/erikhuda/thor/blob/0879c1773d188902d54f95174f33961ac33111f8/lib/thor/parser/options.rb#L4

Follow up #34021.