### PR TITLE
Non autoloaded directories with zeitwerk

### DIFF
--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -68,6 +68,9 @@ module ActiveSupport
                 Rails.autoloaders.once.push_dir(autoload_path)
               else
                 Rails.autoloaders.main.push_dir(autoload_path)
+                unless Rails.application.config.eager_load_paths.include?(autoload_path)
+                  Rails.autoloaders.main.do_not_eager_load(autoload_path)
+                end
               end
             end
 

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -156,6 +156,18 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_equal existing_autoload_paths, Rails.autoloaders.main.dirs
   end
 
+  test "autoload_paths not present in eager_load_paths are set as root dirs of main, and in the same order" do
+    add_to_config %(
+      config.autoload_paths << "\#{Rails.root}/lib"
+      config.autoload_paths << "\#{Rails.root}/eagerlib"
+      config.eager_load_paths << "\#{Rails.root}/eagerlib"
+    )
+    boot
+
+    assert_includes Rails.autoloaders.main.eager_load_exclusions, Rails.root.join('lib').to_s
+    refute_includes Rails.autoloaders.main.eager_load_exclusions, Rails.root.join('eagerlib').to_s
+  end
+
   test "autoload_once_paths go to the once autoloader, and in the same order" do
     extras = %w(e1 e2 e3)
     extras.each do |extra|


### PR DESCRIPTION
As discussed in https://github.com/fxn/zeitwerk/pull/22

Some older app might have paths that are autoloaded, but not eager_loaded.

This PR allow to keep that behavior while still migrating onto Zeitwerk.

@fxn @rafaelfranca @Edouard-chin