### PR TITLE
Bugfix: Fix false autosave for has_one :through association

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -457,8 +457,14 @@ module ActiveRecord
       # If the record is new or it has changed, returns true.
       def record_changed?(reflection, record, key)
         record.new_record? ||
-          (record.has_attribute?(reflection.foreign_key) && record[reflection.foreign_key] != key) ||
+          association_foreign_key_changed?(reflection, record, key) ||
           record.will_save_change_to_attribute?(reflection.foreign_key)
+      end
+
+      def association_foreign_key_changed?(reflection, record, key)
+        return false if reflection.through_reflection?
+
+        record.has_attribute?(reflection.foreign_key) && record[reflection.foreign_key] != key
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.


### PR DESCRIPTION
### Summary

Fixes #35680 

### Other Information

The problem occurred, when a `has one through` association contains a foreign key (it belongs to the intermediate association).

For example, Comment belongs to Post, Post belongs to Author, and Author `has_one :first_comment, through: :first_post`.

In this case, the value of the foreign key is comparing with the original record, and since they are likely different, the association is marked as changed.  So it updates every time when the origin record updates.
