### PR TITLE
Document option forwarding in ActiveRecord::Base.attribute

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -41,6 +41,9 @@ module ActiveRecord
       # +range+ (PostgreSQL only) specifies that the type should be a range (see the
       # examples below).
       #
+      # When using a symbol for +cast_type+, extra options are forwarded to the
+      # constructor of the type object.
+      #
       # ==== Examples
       #
       # The type detected by Active Record can be overridden.
@@ -111,6 +114,16 @@ module ActiveRecord
       #       my_int_array: [1, 2, 3],
       #       my_float_range: 1.0..3.5
       #     }
+      #
+      # Passing options to the type constructor
+      #
+      #   # app/models/my_model.rb
+      #   class MyModel < ActiveRecord::Base
+      #     attribute :small_int, :integer, limit: 2
+      #   end
+      #
+      #   MyModel.create(small_int: 65537)
+      #   # => Error: 65537 is out of range for the limit of two bytes
       #
       # ==== Creating Custom Types
       #

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -56,6 +56,17 @@ module ActiveRecord
       assert_equal 255, UnoverloadedType.type_for_attribute("overloaded_string_with_limit").limit
     end
 
+    test "extra options are forwarded to the type caster constructor" do
+      klass = Class.new(OverloadedType) do
+        attribute :starts_at, :datetime, precision: 3, limit: 2, scale: 1
+      end
+
+      starts_at_type = klass.type_for_attribute(:starts_at)
+      assert_equal 3, starts_at_type.precision
+      assert_equal 2, starts_at_type.limit
+      assert_equal 1, starts_at_type.scale
+    end
+
     test "nonexistent attribute" do
       data = OverloadedType.new(non_existent_decimal: 1)
 


### PR DESCRIPTION
### Summary

This has been supported for a while but we didn't have documentation
for it. Since I depend on this working for the future, I would like to
document it so it becomes officially supported. There were some
test cases that make use of this in the repo, but I thought I'd add an
explicit one.

