### PR TITLE
Remove need for upsert_all

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -520,7 +520,7 @@ module ActiveRecord
           sql << " ON DUPLICATE KEY UPDATE #{any_column}=#{any_column}"
         elsif insert.update_duplicates?
           sql << " ON DUPLICATE KEY UPDATE "
-          sql << insert.updatable_columns.map { |column| "#{column}=VALUES(#{column})" }.join(",")
+          sql << insert.upsert_sql { |column| "#{column}=VALUES(#{column})" }
         end
 
         sql

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -439,7 +439,7 @@ module ActiveRecord
           sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
         elsif insert.update_duplicates?
           sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
-          sql << insert.updatable_columns.map { |column| "#{column}=excluded.#{column}" }.join(",")
+          sql << insert.upsert_sql { |column| "#{column}=excluded.#{column}" }
         end
 
         sql << " RETURNING #{insert.returning}" if insert.returning

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -391,7 +391,7 @@ module ActiveRecord
           sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
         elsif insert.update_duplicates?
           sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
-          sql << insert.updatable_columns.map { |column| "#{column}=excluded.#{column}" }.join(",")
+          sql << insert.upsert_sql { |column| "#{column}=excluded.#{column}" }
         end
 
         sql

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  class InsertAll
+  class InsertAll # :nodoc:
     attr_reader :model, :connection, :inserts, :keys
     attr_reader :returning, :unique_by, :upsert
 

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -135,16 +135,16 @@ module ActiveRecord
         end
 
         def returning
-          quote_columns(insert_all.returning).join(",") if insert_all.returning
+          format_columns(insert_all.returning) if insert_all.returning
         end
 
         def conflict_target
           if index = insert_all.unique_by
-            sql = +"(#{quote_columns(index.columns).join(',')})"
+            sql = +"(#{format_columns(index.columns)})"
             sql << " WHERE #{index.where}" if index.where
             sql
           elsif update_duplicates?
-            "(#{quote_columns(insert_all.primary_keys).join(',')})"
+            "(#{format_columns(insert_all.primary_keys)})"
           end
         end
 
@@ -159,7 +159,7 @@ module ActiveRecord
           attr_reader :connection, :insert_all
 
           def columns_list
-            quote_columns(insert_all.keys).join(",")
+            format_columns(insert_all.keys)
           end
 
           def extract_types_from_columns_on(table_name, keys:)
@@ -169,6 +169,10 @@ module ActiveRecord
             raise UnknownAttributeError.new(model.new, unknown_column) if unknown_column
 
             keys.map { |key| [ key, connection.lookup_cast_type_from_column(columns[key]) ] }.to_h
+          end
+
+          def format_columns(columns)
+            quote_columns(columns).join(",")
           end
 
           def quote_columns(columns)

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -11,6 +11,8 @@ class InsertAllTest < ActiveRecord::TestCase
   fixtures :books
 
   def test_insert
+    skip unless supports_insert_on_duplicate_skip?
+
     id = 1_000_000
 
     assert_difference "Book.count", +1 do


### PR DESCRIPTION
In light of #35636 we're trying to extend upsert/upsert_all to handle both an array of columns or some update SQL.

This tries to tackle this problem in a different by replacing upsert_all with an upsert option on insert_all:

```ruby
Book.insert_all rows, upsert: true
Book.insert_all rows, upsert: %i( id name author_id )
Book.insert_all rows, upsert: "status = GREATEST(books.status, excluded.status)"
```

The latter two are not added in this PR, but that's how they'd look.

upsert_all still looks cleaner for the plain true case, so perhaps this would be better:

```ruby
Book.upsert_all rows, only: %i( id name author_id )
Book.upsert_all rows, with: "status = GREATEST(books.status, excluded.status)"
```

Though the minute differences between insert_all/insert_all! and upsert_all are quite hard to distinguish. And perhaps a method fewer is worth it for what is a rare call.

cc @boblail @palkan @janko @abhaynikam