### PR TITLE
Add exists? Method to ApplicationRecord

### DIFF
--- a/activerecord/lib/rails/generators/active_record/application_record/templates/application_record.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/application_record/templates/application_record.rb.tt
@@ -1,5 +1,9 @@
 <% module_namespacing do -%>
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def exists?
+    present?
+  end
 end
 <% end -%>


### PR DESCRIPTION
This change fixes ApplicationRecord objects' inability to respond to exists? matchers during RSpec testing.