### PR TITLE
mysql2 adapter: default datetime attribute to precision = 0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -824,6 +824,11 @@ module ActiveRecord
             end
         end
 
+        ActiveRecord::Type.register(:datetime, adapter: :mysql2) do |**options|
+          options[:precision] ||= 0
+          Type::DateTime.new(**options)
+        end
+
         ActiveRecord::Type.register(:string, MysqlString, adapter: :mysql2)
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
     end

--- a/activerecord/test/cases/adapters/mysql2/attribute_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/attribute_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class Mysql2AttributeTest < ActiveRecord::Mysql2TestCase
+  setup do
+    @connection = ActiveRecord::Base.connection
+  end
+
+  test "precision for :datetime attribute is set to 0 by default" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "defaults"
+      attribute :ends_at, :datetime
+    end
+
+    assert_equal 0, klass.type_for_attribute(:ends_at).precision
+  end
+
+  test "inferred datetime attribute has precision of zero rather than nil" do
+    klass = Class.new(ActiveRecord::Base) do
+      # this table has a created_at column without fractional second precision
+      self.table_name = "ships"
+    end
+
+    assert_equal 0, klass.type_for_attribute(:created_at).precision
+  end
+end


### PR DESCRIPTION
### Summary
Problem:

Under the mysql2 adapter, when Active Record creates a datetime
attribute without declaration, it puts precision = 0.

https://github.com/rails/rails/blob/382a9563a3bc3dd1982f4db1258e8f0e7f5fac8e/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L586

When an attribute is explicitly declared, like
`attribute :created_at, :datetime`, the precision is set to `nil`
instead.

I beleive declaring `attribute :created_at, :dateimte` should
give the same result as not specifying.

Discussion:

This is a breaking change for users that had their declaration
as `attribute :created_at, :datetime`, because now `created_at`
is subject to rounding.
(See `activemodel/lib/active_model/type/date_time.rb`)

However, the alternative for users that want to switch to explicitly
declaring attribute is putting
`attribute :created_at, precision: 0`, which is not necessary in
other adapters such as `postgresql` and `sqlite`.

I think having precision as 0 is a better default, since it is
consistent with the inferred precision.
