### PR TITLE
Prefer render template: over render file: in tests

### DIFF
--- a/actionview/test/fixtures/actionpack/test/hello.builder
+++ b/actionview/test/fixtures/actionpack/test/hello.builder
@@ -1,4 +1,4 @@
 xml.html do
   xml.p "Hello #{@name}"
-  xml << render(file: "test/greeting")
+  xml << render(template: "test/greeting")
 end

--- a/actionview/test/fixtures/test/hello.builder
+++ b/actionview/test/fixtures/test/hello.builder
@@ -1,4 +1,4 @@
 xml.html do
   xml.p "Hello #{@name}"
-  xml << render(file: "test/greeting")
+  xml << render(template: "test/greeting")
 end

--- a/actionview/test/fixtures/test/layout_render_file.erb
+++ b/actionview/test/fixtures/test/layout_render_file.erb
@@ -1,2 +1,2 @@
 <% content_for :title do %>title<% end -%>
-<%= render :file => 'layouts/yield' -%>
+<%= render template: 'layouts/yield' -%>

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -24,7 +24,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
   def test_template_with_ruby_keyword_locals
     assert_equal "The class is foo",
-      render(file: "test/render_file_with_ruby_keyword_locals", locals: { class: "foo" })
+      render(template: "test/render_file_with_ruby_keyword_locals", locals: { class: "foo" })
   end
 
   def test_template_with_invalid_identifier_locals
@@ -34,7 +34,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
       "d-a-s-h-e-s": "",
       "white space": "",
     }
-    assert_equal locals.inspect, render(file: "test/render_file_inspect_local_assigns", locals: locals)
+    assert_equal locals.inspect, render(template: "test/render_file_inspect_local_assigns", locals: locals)
   end
 
   def test_template_with_delegation_reserved_keywords
@@ -44,36 +44,36 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
       args: "three",
       block: "four",
     }
-    assert_equal "one two three four", render(file: "test/test_template_with_delegation_reserved_keywords", locals: locals)
+    assert_equal "one two three four", render(template: "test/test_template_with_delegation_reserved_keywords", locals: locals)
   end
 
   def test_template_with_unicode_identifier
-    assert_equal "🎂", render(file: "test/render_file_unicode_local", locals: { 🎃: "🎂" })
+    assert_equal "🎂", render(template: "test/render_file_unicode_local", locals: { 🎃: "🎂" })
   end
 
   def test_template_with_instance_variable_identifier
-    assert_equal "bar", render(file: "test/render_file_instance_variable", locals: { "@foo": "bar" })
+    assert_equal "bar", render(template: "test/render_file_instance_variable", locals: { "@foo": "bar" })
   end
 
   def test_template_gets_recompiled_when_using_different_keys_in_local_assigns
-    assert_equal "one", render(file: "test/render_file_with_locals_and_default")
-    assert_equal "two", render(file: "test/render_file_with_locals_and_default", locals: { secret: "two" })
+    assert_equal "one", render(template: "test/render_file_with_locals_and_default")
+    assert_equal "two", render(template: "test/render_file_with_locals_and_default", locals: { secret: "two" })
   end
 
   def test_template_changes_are_not_reflected_with_cached_templates
-    assert_equal "Hello world!", render(file: "test/hello_world")
+    assert_equal "Hello world!", render(template: "test/hello_world")
     modify_template "test/hello_world.erb", "Goodbye world!" do
-      assert_equal "Hello world!", render(file: "test/hello_world")
+      assert_equal "Hello world!", render(template: "test/hello_world")
     end
-    assert_equal "Hello world!", render(file: "test/hello_world")
+    assert_equal "Hello world!", render(template: "test/hello_world")
   end
 
   def test_template_changes_are_reflected_with_uncached_templates
-    assert_equal "Hello world!", render_without_cache(file: "test/hello_world")
+    assert_equal "Hello world!", render_without_cache(template: "test/hello_world")
     modify_template "test/hello_world.erb", "Goodbye world!" do
-      assert_equal "Goodbye world!", render_without_cache(file: "test/hello_world")
+      assert_equal "Goodbye world!", render_without_cache(template: "test/hello_world")
     end
-    assert_equal "Hello world!", render_without_cache(file: "test/hello_world")
+    assert_equal "Hello world!", render_without_cache(template: "test/hello_world")
   end
 
   private

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -67,6 +67,7 @@ module RenderTestCases
   def test_render_template_with_format
     assert_match "<h1>No Comment</h1>", @view.render(template: "comments/empty", formats: [:html])
     assert_match "<error>No Comment</error>", @view.render(template: "comments/empty", formats: [:xml])
+    assert_match "<error>No Comment</error>", @view.render(template: "comments/empty", formats: :xml)
   end
 
   def test_render_partial_implicitly_use_format_of_the_rendered_template
@@ -124,7 +125,7 @@ module RenderTestCases
 
   def test_render_raw_is_html_safe_and_does_not_escape_output
     buffer = ActiveSupport::SafeBuffer.new
-    buffer << @view.render(file: "plain_text")
+    buffer << @view.render(template: "plain_text")
     assert_equal true, buffer.html_safe?
     assert_equal buffer, "<%= hello_world %>\n"
   end
@@ -137,22 +138,22 @@ module RenderTestCases
     assert_equal "4", @view.render(inline: "(2**2).to_s", type: :ruby)
   end
 
-  def test_render_file_with_localization_on_context_level
+  def test_render_template_with_localization_on_context_level
     old_locale, @view.locale = @view.locale, :da
-    assert_equal "Hey verden", @view.render(file: "test/hello_world")
+    assert_equal "Hey verden", @view.render(template: "test/hello_world")
   ensure
     @view.locale = old_locale
   end
 
-  def test_render_file_with_dashed_locale
+  def test_render_template_with_dashed_locale
     old_locale, @view.locale = @view.locale, :"pt-BR"
-    assert_equal "Ola mundo", @view.render(file: "test/hello_world")
+    assert_equal "Ola mundo", @view.render(template: "test/hello_world")
   ensure
     @view.locale = old_locale
   end
 
-  def test_render_file_at_top_level
-    assert_equal "Elastica", @view.render(file: "/shared")
+  def test_render_template_at_top_level
+    assert_equal "Elastica", @view.render(template: "/shared")
   end
 
   def test_render_file_with_full_path
@@ -369,7 +370,7 @@ module RenderTestCases
   def test_without_compiled_method_container_is_deprecated
     view = ActionView::Base.with_view_paths(ActionController::Base.view_paths)
     assert_deprecated("ActionView::Base instances must implement `compiled_method_container`") do
-      assert_equal "Hello world!", view.render(file: "test/hello_world")
+      assert_equal "Hello world!", view.render(template: "test/hello_world")
     end
   end
 
@@ -549,28 +550,28 @@ module RenderTestCases
   def test_render_ignores_templates_with_malformed_template_handlers
     %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
       assert File.exist?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), "Malformed file (#{name}~) which should be ignored does not exists"
-      assert_raises(ActionView::MissingTemplate) { @view.render(file: "test/malformed/#{name}") }
+      assert_raises(ActionView::MissingTemplate) { @view.render(template: "test/malformed/#{name}") }
     end
   end
 
   def test_render_with_layout
     assert_equal %(<title></title>\nHello world!\n),
-      @view.render(file: "test/hello_world", layout: "layouts/yield")
+      @view.render(template: "test/hello_world", layout: "layouts/yield")
   end
 
   def test_render_with_layout_which_has_render_inline
     assert_equal %(welcome\nHello world!\n),
-      @view.render(file: "test/hello_world", layout: "layouts/yield_with_render_inline_inside")
+      @view.render(template: "test/hello_world", layout: "layouts/yield_with_render_inline_inside")
   end
 
   def test_render_with_layout_which_renders_another_partial
     assert_equal %(partial html\nHello world!\n),
-      @view.render(file: "test/hello_world", layout: "layouts/yield_with_render_partial_inside")
+      @view.render(template: "test/hello_world", layout: "layouts/yield_with_render_partial_inside")
   end
 
   def test_render_partial_with_html_only_extension
     assert_equal %(<h1>partial html</h1>\nHello world!\n),
-      @view.render(file: "test/hello_world", layout: "layouts/render_partial_html")
+      @view.render(template: "test/hello_world", layout: "layouts/render_partial_html")
   end
 
   def test_render_layout_with_block_and_yield
@@ -625,17 +626,17 @@ module RenderTestCases
 
   def test_render_with_nested_layout
     assert_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
-      @view.render(file: "test/nested_layout", layout: "layouts/yield")
+      @view.render(template: "test/nested_layout", layout: "layouts/yield")
   end
 
   def test_render_with_file_in_layout
     assert_equal %(\n<title>title</title>\n\n),
-      @view.render(file: "test/layout_render_file")
+      @view.render(template: "test/layout_render_file")
   end
 
   def test_render_layout_with_object
     assert_equal %(<title>David</title>),
-      @view.render(file: "test/layout_render_object")
+      @view.render(template: "test/layout_render_object")
   end
 
   def test_render_with_passing_couple_extensions_to_one_register_template_handler_function_call
@@ -687,7 +688,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
 
   def test_render_utf8_template_with_magic_comment
     with_external_encoding Encoding::ASCII_8BIT do
-      result = @view.render(file: "test/utf8_magic", formats: [:html], layouts: "layouts/yield")
+      result = @view.render(template: "test/utf8_magic", formats: [:html], layouts: "layouts/yield")
       assert_equal Encoding::UTF_8, result.encoding
       assert_equal "\nРусский \nтекст\n\nUTF-8\nUTF-8\nUTF-8\n", result
     end
@@ -695,7 +696,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
 
   def test_render_utf8_template_with_default_external_encoding
     with_external_encoding Encoding::UTF_8 do
-      result = @view.render(file: "test/utf8", formats: [:html], layouts: "layouts/yield")
+      result = @view.render(template: "test/utf8", formats: [:html], layouts: "layouts/yield")
       assert_equal Encoding::UTF_8, result.encoding
       assert_equal "Русский текст\n\nUTF-8\nUTF-8\nUTF-8\n", result
     end
@@ -703,14 +704,14 @@ class LazyViewRenderTest < ActiveSupport::TestCase
 
   def test_render_utf8_template_with_incompatible_external_encoding
     with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(file: "test/utf8", formats: [:html], layouts: "layouts/yield") }
+      e = assert_raises(ActionView::Template::Error) { @view.render(template: "test/utf8", formats: [:html], layouts: "layouts/yield") }
       assert_match "Your template was not saved as valid Shift_JIS", e.cause.message
     end
   end
 
   def test_render_utf8_template_with_partial_with_incompatible_encoding
     with_external_encoding Encoding::SHIFT_JIS do
-      e = assert_raises(ActionView::Template::Error) { @view.render(file: "test/utf8_magic_with_bare_partial", formats: [:html], layouts: "layouts/yield") }
+      e = assert_raises(ActionView::Template::Error) { @view.render(template: "test/utf8_magic_with_bare_partial", formats: [:html], layouts: "layouts/yield") }
       assert_match "Your template was not saved as valid Shift_JIS", e.cause.message
     end
   end

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -284,7 +284,7 @@ module ActionView
       @controller.controller_path = "test"
 
       @customers = [DeveloperStruct.new("Eloy"), DeveloperStruct.new("Manfred")]
-      assert_match(/Hello: EloyHello: Manfred/, render(file: "test/list"))
+      assert_match(/Hello: EloyHello: Manfred/, render(template: "test/list"))
     end
 
     test "is able to render partials from templates and also use instance variables after view has been referenced" do
@@ -293,7 +293,7 @@ module ActionView
       view
 
       @customers = [DeveloperStruct.new("Eloy"), DeveloperStruct.new("Manfred")]
-      assert_match(/Hello: EloyHello: Manfred/, render(file: "test/list"))
+      assert_match(/Hello: EloyHello: Manfred/, render(template: "test/list"))
     end
 
     test "is able to use helpers that depend on the view flow" do

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -127,20 +127,20 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_finds_translation_scoped_by_partial
-    assert_equal "Foo", view.render(file: "translations/templates/found").strip
+    assert_equal "Foo", view.render(template: "translations/templates/found").strip
   end
 
   def test_finds_array_of_translations_scoped_by_partial
-    assert_equal "Foo Bar", @view.render(file: "translations/templates/array").strip
+    assert_equal "Foo Bar", @view.render(template: "translations/templates/array").strip
   end
 
   def test_default_lookup_scoped_by_partial
-    assert_equal "Foo", view.render(file: "translations/templates/default").strip
+    assert_equal "Foo", view.render(template: "translations/templates/default").strip
   end
 
   def test_missing_translation_scoped_by_partial
     expected = '<span class="translation_missing" title="translation missing: en.translations.templates.missing.missing">Missing</span>'
-    assert_equal expected, view.render(file: "translations/templates/missing").strip
+    assert_equal expected, view.render(template: "translations/templates/missing").strip
   end
 
   def test_translate_does_not_mark_plain_text_as_safe_html


### PR DESCRIPTION
Many tests were using `render file:`, but were only testing the behaviour of `render template:` (`file:` just allows more paths / is less secure than `template:`).

The reason for so many `render file:` is probably that it was the old default.

This commit replaces `render file:` with `render template:` anywhere the test wasn't specifically interested in testing `render file:`. This still leaves plenty of tests against `render file:`

Changing these tests is necessary for #35688 (though IMO should be done even without that change).
