### PR TITLE
Output junit format test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 pkg/
 /tmp/
 /yarn-error.log
+/test-reports/

--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,7 @@ instance_eval File.read local_gemfile if File.exist? local_gemfile
 group :test do
   gem "minitest-bisect"
   gem "minitest-retry"
+  gem "minitest-reporters"
 
   platforms :mri do
     gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     amq-protocol (2.3.0)
+    ansi (1.5.0)
     ast (2.4.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.111.0)
@@ -316,6 +317,11 @@ GEM
     minitest-bisect (1.4.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.0)
+    minitest-reporters (1.3.6)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-retry (0.1.9)
       minitest (>= 5.0)
     minitest-server (1.0.5)
@@ -555,6 +561,7 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   minitest-bisect
+  minitest-reporters
   minitest-retry
   mysql2 (>= 0.4.10)
   nokogiri (>= 1.8.1)

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -41,3 +41,5 @@ class ActionCable::TestCase < ActiveSupport::TestCase
     end
   end
 end
+
+require_relative "../../tools/test_common"

--- a/actionmailbox/test/test_helper.rb
+++ b/actionmailbox/test/test_helper.rb
@@ -54,3 +54,5 @@ class BounceMailer < ActionMailer::Base
     end
   end
 end
+
+require_relative "../../tools/test_common"

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -49,3 +49,5 @@ class ActiveSupport::TestCase
       skip message if defined?(JRUBY_VERSION)
     end
 end
+
+require_relative "../../tools/test_common"

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -382,3 +382,5 @@ end
 class DrivenBySeleniumWithHeadlessFirefox < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_firefox
 end
+
+require_relative "../../tools/test_common"

--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -31,3 +31,5 @@ class ActiveSupport::TestCase
       ActiveStorage::Blob.create_after_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
     end
 end
+
+require_relative "../../tools/test_common"

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -205,3 +205,5 @@ class ActiveSupport::TestCase
       skip message if defined?(JRUBY_VERSION)
     end
 end
+
+require_relative "../../tools/test_common"

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -16,3 +16,5 @@ else
 end
 
 require "active_support/testing/autorun"
+
+require_relative "../../tools/test_common"

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -25,3 +25,5 @@ class ActiveModel::TestCase < ActiveSupport::TestCase
       skip message if defined?(JRUBY_VERSION)
     end
 end
+
+require_relative "../../../tools/test_common"

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -202,3 +202,5 @@ module InTimeZone
       ActiveRecord::Base.time_zone_aware_attributes = old_tz
     end
 end
+
+require_relative "../../../tools/test_common"

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -101,3 +101,5 @@ end
 class Group < ActiveRecord::Base
   has_one_attached :avatar
 end
+
+require_relative "../../tools/test_common"

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -40,3 +40,5 @@ class ActiveSupport::TestCase
       skip message if defined?(JRUBY_VERSION)
     end
 end
+
+require_relative "../../tools/test_common"

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -32,3 +32,5 @@ class ActiveSupport::TestCase
       skip message if defined?(JRUBY_VERSION)
     end
 end
+
+require_relative "../../tools/test_common"

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -1,0 +1,15 @@
+if ENV["BUILDKITE"]
+  require "minitest/reporters"
+  require "fileutils"
+
+  module Minitest
+    def self.plugin_rails_ci_junit_format_test_report_for_buildkite_init(*)
+      dir = File.join(__dir__, "../test-reports/#{ENV['BUILDKITE_JOB_ID']}")
+      reporter << Minitest::Reporters::JUnitReporter.new(dir, false)
+      FileUtils.mkdir_p(dir)
+    end
+  end
+
+  Minitest.load_plugins
+  Minitest.extensions.unshift "rails_ci_junit_format_test_report_for_buildkite"
+end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Hi, I'm interested in analyzing Rails CI.

I created a tool to find flaky tests.

app: https://has-it-failed.herokuapp.com/
repo: https://github.com/mtsmfm/has-it-failed
slides: https://speakerdeck.com/mtsmfm/analyze-rails-ci

I wrote a parser to extract which test was failed from raw logs.

https://github.com/mtsmfm/has-it-failed/blob/75eb7f367d42b68ba3ff89d6a1618d03ef7692d5/parser/rails_ci.pegjs

But of course, it's not perfect and in some case failed to parse.
As you may know, junit format test report is de facto standard to output machine readable test result.
Unfortunately, TravisCI doesn't provide data store for build artifacts so we need AWS account.
https://docs.travis-ci.com/user/uploading-artifacts/

I heard Rails team is trying to use buildkite so let's upload test report!
https://buildkite.com/docs/pipelines/artifacts

`Minitest::Reporters::JUnitReporter` outputs test report to `<subdir of rails/rails>/test/reports/*.xml` by default.

What do you think?