### PR TITLE
Do not register reloaders if config.cache_classes is set to true

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -56,19 +56,21 @@ module I18n
       # Restore available locales check so it will take place from now on.
       I18n.enforce_available_locales = enforce_available_locales
 
-      directories = watched_dirs_with_extensions(reloadable_paths)
-      reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do
-        I18n.load_path.keep_if { |p| File.exist?(p) }
-        I18n.load_path |= reloadable_paths.flat_map(&:existent)
+      unless app.config.cache_classes
+        directories = watched_dirs_with_extensions(reloadable_paths)
+        reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do
+          I18n.load_path.keep_if { |p| File.exist?(p) }
+          I18n.load_path |= reloadable_paths.flat_map(&:existent)
 
-        I18n.reload!
-      end
+          I18n.reload!
+        end
 
-      app.reloaders << reloader
-      app.reloader.to_run do
-        reloader.execute_if_updated { require_unload_lock! }
+        app.reloaders << reloader
+        app.reloader.to_run do
+          reloader.execute_if_updated { require_unload_lock! }
+        end
+        reloader.execute
       end
-      reloader.execute
 
       @i18n_inited = true
     end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -169,11 +169,7 @@ module Rails
           app.reloader.check = lambda do
             app.reloaders.map(&:updated?).any?
           end
-        else
-          app.reloader.check = lambda { true }
-        end
 
-        if config.reload_classes_only_on_change
           reloader = config.file_watcher.new(*watchable_args, &callback)
           reloaders << reloader
 
@@ -190,6 +186,8 @@ module Rails
             end
           end
         else
+          app.reloader.check = lambda { true }
+
           app.reloader.to_complete do
             class_unload!(&callback)
           end


### PR DESCRIPTION
While doing some memory profiling on our app in `production` environment, we noticed that `Rails.application.reloaders` was holding a very big amount of strings (file paths).

Seeing these in production was surprising, because code reloading is explicitly disabled. 

This PR removes the main code reloader as well as the I18n reloader if `config.cache_classes == true`. There's also the routes reloader, but I haven't really figured how to disable it as well.

cc @rafaelfranca @Edouard-chin @csfrancis 
And also @fxn maybe it's interesting to you.