### PR TITLE
Rename `connection` option to `database` in `dbconsole` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The `connection` option of `rails dbconsole` command is deprecated in
+    favor of `database` option.
+
+    *Yuji Yaginuma*
+
 *   Replace `chromedriver-helper` gem with `webdrivers` in default Gemfile.
    `chromedriver-helper` is deprecated as of March 31, 2019 and won't
    recieve any further updates.

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+require "active_support/core_ext/string/filters"
 require "rails/command/environment_argument"
 
 module Rails
@@ -89,15 +91,15 @@ module Rails
 
     def config
       @config ||= begin
-        # We need to check whether the user passed the connection the
+        # We need to check whether the user passed the database the
         # first time around to show a consistent error message to people
         # relying on 2-level database configuration.
-        if @options["connection"] && configurations[connection].blank?
-          raise ActiveRecord::AdapterNotSpecified, "'#{connection}' connection is not configured. Available configuration: #{configurations.inspect}"
-        elsif configurations[environment].blank? && configurations[connection].blank?
+        if @options["database"] && configurations[database].blank?
+          raise ActiveRecord::AdapterNotSpecified, "'#{database}' database is not configured. Available configuration: #{configurations.inspect}"
+        elsif configurations[environment].blank? && configurations[database].blank?
           raise ActiveRecord::AdapterNotSpecified, "'#{environment}' database is not configured. Available configuration: #{configurations.inspect}"
         else
-          configurations[connection] || configurations[environment].presence
+          configurations[database] || configurations[environment].presence
         end
       end
     end
@@ -106,8 +108,8 @@ module Rails
       Rails.respond_to?(:env) ? Rails.env : Rails::Command.environment
     end
 
-    def connection
-      @options.fetch(:connection, "primary")
+    def database
+      @options.fetch(:database, "primary")
     end
 
     private
@@ -156,11 +158,21 @@ module Rails
       class_option :connection, aliases: "-c", type: :string,
         desc: "Specifies the connection to use."
 
+      class_option :database, aliases: "--db", type: :string,
+        desc: "Specifies the database to use."
+
       def perform
         extract_environment_option_from_argument
 
         # RAILS_ENV needs to be set before config/application is required.
         ENV["RAILS_ENV"] = options[:environment]
+
+        if options["connection"]
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `connection` option is deprecated and will be removed in Rails 6.1. Please use `database` option instead.
+          MSG
+          options["database"] = options["connection"]
+        end
 
         require_application_and_environment!
         Rails::DBConsole.start(options)

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -216,22 +216,22 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     end
   end
 
-  def test_specifying_a_custom_connection_and_environment
+  def test_specifying_a_custom_database_and_environment
     stub_available_environments(["development"]) do
-      dbconsole = parse_arguments(["-c", "custom", "-e", "development"])
+      dbconsole = parse_arguments(["--db", "custom", "-e", "development"])
 
       assert_equal "development", dbconsole[:environment]
-      assert_equal "custom", dbconsole.connection
+      assert_equal "custom", dbconsole.database
     end
   end
 
-  def test_specifying_a_missing_connection
+  def test_specifying_a_missing_database
     app_db_config({}) do
       e = assert_raises(ActiveRecord::AdapterNotSpecified) do
-        Rails::Command.invoke(:dbconsole, ["-c", "i_do_not_exist"])
+        Rails::Command.invoke(:dbconsole, ["--db", "i_do_not_exist"])
       end
 
-      assert_includes e.message, "'i_do_not_exist' connection is not configured."
+      assert_includes e.message, "'i_do_not_exist' database is not configured."
     end
   end
 
@@ -243,6 +243,18 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
       assert_includes e.message, "'test' database is not configured."
     end
+  end
+
+  def test_connection_options_is_deprecate
+    command = Rails::Command::DbconsoleCommand.new([], ["-c", "custom"])
+    Rails::DBConsole.stub(:start, nil) do
+      assert_deprecated("`connection` option is deprecated") do
+        command.perform
+      end
+    end
+
+    assert_equal "custom", command.options["connection"]
+    assert_equal "custom", command.options["database"]
   end
 
   def test_print_help_short


### PR DESCRIPTION
We introduced `connection` option for specifying spec with 1acd9a6464668d4d54ab30d016829f60b70dbbeb.
But now we are using the `database` to specify the same value in other commands.

* https://github.com/rails/rails/blob/0a0f115031b64b5335fa88543c40df4194dfb428/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb#L11
* https://github.com/rails/rails/blob/0a0f115031b64b5335fa88543c40df4194dfb428/activerecord/lib/rails/generators/active_record/model/model_generator.rb#L17

The options provided to the users should be uniform. Since the term "database" is used in rake task etc, So I want to be able to use it in `dbconsole` command.

Also I deprecated the `connection` option because I think that it would be confusing if there are multiple options to specify a same value.

