### PR TITLE
Update AS::Notifications::Instrumenter#instrument

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Update `ActiveSupport::Notifications::Instrumenter#instrument to make
+    passing a block optional. This will let users use
+    `ActiveSupport::Notifications` messaging features outside of
+    instrumentation.
+
+    *Ali Ibrahim*
+
 *   Fix `Time#advance` to work with dates before 1001-03-07
 
     Before:

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -20,7 +20,7 @@ module ActiveSupport
         # some of the listeners might have state
         listeners_state = start name, payload
         begin
-          yield payload
+          yield payload if block_given?
         rescue Exception => e
           payload[:exception] = [e.class.name, e.message]
           payload[:exception_object] = e

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -13,9 +13,10 @@ module ActiveSupport
         @notifier = notifier
       end
 
-      # Instrument the given block by measuring the time taken to execute it
-      # and publish it. Notice that events get sent even if an error occurs
-      # in the passed-in block.
+      # Given a block, instrument it by measuring the time taken to execute
+      # and publish it. Without a block, simply send a message via the
+      # notifier. Notice that events get sent even if an error occurs in the
+      # passed-in block.
       def instrument(name, payload = {})
         # some of the listeners might have state
         listeners_state = start name, payload

--- a/activesupport/test/notifications/instrumenter_test.rb
+++ b/activesupport/test/notifications/instrumenter_test.rb
@@ -44,6 +44,12 @@ module ActiveSupport
         assert_equal Hash[result: 2], payload
       end
 
+      def test_instrument_works_without_a_block
+        instrumenter.instrument("no.block", payload)
+        assert_equal 1, notifier.finishes.size
+        assert_equal "no.block", notifier.finishes.first.first
+      end
+
       def test_start
         instrumenter.start("foo", payload)
         assert_equal [["foo", instrumenter.id, payload]], notifier.starts

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -692,5 +692,16 @@ ActiveSupport::Notifications.subscribe "my.custom.event" do |name, started, fini
 end
 ```
 
+You also have the option to call instrument without passing a block. This lets you leverage the
+instrumentation infrastructure for other messaging uses.
+
+```ruby
+ActiveSupport::Notifications.instrument "my.custom.event", this: :data
+
+ActiveSupport::Notifications.subscribe "my.custom.event" do |name, started, finished, unique_id, data|
+  puts data.inspect # {:this=>:data}
+end
+```
+
 You should follow Rails conventions when defining your own events. The format is: `event.library`.
 If your application is sending Tweets, you should create an event named `tweet.twitter`.


### PR DESCRIPTION
### Summary

`ActiveSupport::Notifications` provides a powerful API for instrumentation by using a publish-subscribe pattern. We could leverage this for more use cases by opening up `ActiveSupport::Notifications` messaging for things other than instrumentation. To make that happen, I opened this PR to update `ActiveSupport::Notifications::Instrumenter#instrument` so passing a block is optional. This will let us use `#instrument` for general messaging in addition to instrumentation.

/cc @tenderlove @eileencodes 
