### PR TITLE
Revert 5-2-stable backport of #35549 

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -82,7 +82,6 @@ module ActionDispatch # :nodoc:
     SET_COOKIE   = "Set-Cookie".freeze
     LOCATION     = "Location".freeze
     NO_CONTENT_CODES = [100, 101, 102, 204, 205, 304]
-    CONTENT_TYPE_PARSER = /\A(?<type>[^;\s]+)?(?:.*;\s*charset=(?<quote>"?)(?<charset>[^;\s]+)\k<quote>)?/ # :nodoc:
 
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers
@@ -410,8 +409,10 @@ module ActionDispatch # :nodoc:
     NullContentTypeHeader = ContentTypeHeader.new nil, nil
 
     def parse_content_type(content_type)
-      if content_type && match = CONTENT_TYPE_PARSER.match(content_type)
-        ContentTypeHeader.new(match[:type], match[:charset])
+      if content_type
+        type, charset = content_type.split(/;\s*charset=/)
+        type = nil if type && type.empty?
+        ContentTypeHeader.new(type, charset)
       else
         NullContentTypeHeader
       end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -539,38 +539,4 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal('"202cb962ac59075b964b07152d234b70"', @response.headers["ETag"])
     assert_equal('"202cb962ac59075b964b07152d234b70"', @response.etag)
   end
-
-  test "response Content-Type with optional parameters" do
-    @app = lambda { |env|
-      [
-        200,
-        { "Content-Type" => "text/csv; charset=utf-16; header=present" },
-        ["Hello"]
-      ]
-    }
-
-    get "/"
-    assert_response :success
-
-    assert_equal("text/csv; charset=utf-16; header=present", @response.headers["Content-Type"])
-    assert_equal("text/csv", @response.content_type)
-    assert_equal("utf-16", @response.charset)
-  end
-
-  test "response Content-Type with quoted-string" do
-    @app = lambda { |env|
-      [
-        200,
-        { "Content-Type" => 'text/csv; header=present; charset="utf-16"' },
-        ["Hello"]
-      ]
-    }
-
-    get "/"
-    assert_response :success
-
-    assert_equal('text/csv; header=present; charset="utf-16"', @response.headers["Content-Type"])
-    assert_equal("text/csv", @response.content_type)
-    assert_equal("utf-16", @response.charset)
-  end
 end


### PR DESCRIPTION
This reverts commit 4185881d09bb6077228aa82fcb7c0da7373d8aa3.

We bumped on this when upgrading. IMO it's a great change in 6.0, but is a potentially breaking change that shouldn't be backported to 5-2-stable.

cc @eileencodes @kamipo