### PR TITLE
Fix rails guides generation

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -164,7 +164,7 @@ module RailsGuides
 
           # Generate the special pages like the home.
           # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
-          result = view.render(layout: layout, formats: [$1], file: $`)
+          result = view.render(layout: layout, formats: [$1.to_sym], file: $`)
         else
           body = File.read("#{@source_dir}/#{guide}")
           result = RailsGuides::Markdown.new(


### PR DESCRIPTION
### Summary

When generating docs from https://github.com/rails/rails-docs-server I was getting:

```
`formats=': Invalid formats: "html"
```

The cause is an internal API change that validates formats against a list of valid symbols, e.g. `:html`, etc. While this was sending the format as a string, e.g. "html", thus triggering the "invalid formats".

This fixes #35697 and https://github.com/rails/rails-docs-server/issues/20.

### Other Information

cc: @fxn @rafaelfranca 

No need for changelog as this is internal. Also doesn't affect the documentation ironically.

In theory I could add tests for this (I will try if requested), but at least it fixes the guides documentation generation (e.g. "works on my machine").