### PR TITLE
Update CHANGELOGs for 5.2.2.1 release

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -13,7 +13,16 @@
 
 ## Rails 5.2.2.1 (March 11, 2019) ##
 
-*   No changes.
+*   Only accept formats from registered mime types
+
+    A lack of filtering on mime types could allow an a attacker to read
+    arbitrary files on the target server or to perform a denial of service
+    attack.
+
+    Fixes CVE-2019-5418
+    Fixes CVE-2019-5419
+
+    *John Hawthorn*, *Eileen M. Uchitelle*, *Aaron Patterson*
 
 
 ## Rails 5.2.2 (December 04, 2018) ##

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -9,7 +9,16 @@
 
 ## Rails 5.2.2.1 (March 11, 2019) ##
 
-*   No changes.
+*   Generate random development secrets
+
+    A random development secret is now generated to tmp/development_secret.txt
+
+    This avoids an issue where development mode servers were vulnerable to
+    remote code execution.
+
+    Fixes CVE-2019-5420
+
+    *Eileen M. Uchitelle*, *Aaron Patterson*, *John Hawthorn*
 
 
 ## Rails 5.2.2 (December 04, 2018) ##


### PR DESCRIPTION
Refs #35702

Updates CHANGELOGs for 5.2.2.1 release. Describing fixes for CVE-2019-5418, CVE-2019-5419, and CVE-2019-5420.

@rafaelfranca @eileencodes How's this? If it looks alright I can make the same change for 4-2, 5-0, 5-1, and master branches.