### PR TITLE
Fix AS CHANGELOG typo

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Update `ActiveSupport::Notifications::Instrumenter#instrument to make
+*   Update `ActiveSupport::Notifications::Instrumenter#instrument` to make
     passing a block optional. This will let users use
     `ActiveSupport::Notifications` messaging features outside of
     instrumentation.


### PR DESCRIPTION
### Summary

I forgot a closing `` ` `` when I updated the CHANGELOG in #35705 🤦🏾‍♂️.

/cc @eileencodes 
