### PR TITLE
Drop microseconds in job argument assertions

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make job argument assertions with `Time`, `ActiveSupport::TimeWithZone`, and `DateTime` work by dropping microseconds. Microsecond precision is lost during serialization.
+
+    *Gannon McGibbon*
+
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   No changes.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -631,6 +631,20 @@ module ActiveJob
       def prepare_args_for_assertion(args)
         args.dup.tap do |arguments|
           arguments[:at] = arguments[:at].to_f if arguments[:at]
+          arguments[:args] = round_time_arguments(arguments[:args]) if arguments[:args]
+        end
+      end
+
+      def round_time_arguments(argument)
+        case argument
+        when Time, ActiveSupport::TimeWithZone, DateTime
+          argument.change(usec: 0)
+        when Hash
+          argument.transform_values { |value| round_time_arguments(value) }
+        when Array
+          argument.map { |element| round_time_arguments(element) }
+        else
+          argument
         end
       end
 

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -581,6 +581,33 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_with_time
+    now = Time.now
+    args = [{ argument1: [now] }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: [now])
+    end
+  end
+
+  def test_assert_enqueued_with_date_time
+    now = DateTime.now
+    args = [{ argument1: [now] }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: [now])
+    end
+  end
+
+  def test_assert_enqueued_with_time_with_zone
+    now = Time.now.in_time_zone("Tokyo")
+    args = [{ argument1: [now] }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: [now])
+    end
+  end
+
   def test_assert_enqueued_with_with_no_block_args
     assert_raise ArgumentError do
       NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
@@ -1678,6 +1705,33 @@ class PerformedJobsTest < ActiveJob::TestCase
       assert_performed_with(job: MultipleKwargsJob, args: args) do
         MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
       end
+    end
+  end
+
+  def test_assert_performed_with_time
+    now = Time.now
+    args = [{ argument1: { now: now } }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now })
+    end
+  end
+
+  def test_assert_performed_with_date_time
+    now = DateTime.now
+    args = [{ argument1: { now: now } }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now })
+    end
+  end
+
+  def test_assert_performed_with_time_with_zone
+    now = Time.now.in_time_zone("Tokyo")
+    args = [{ argument1: { now: now } }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now })
     end
   end
 


### PR DESCRIPTION
### Summary

When serializing arguments for Active Jobs, `Time`, `DateTime`, and `ActiveSupport::TimeInZone` all lose a certain degree of precision eg. `now = Time.now; Time.iso8601(now.iso8601) == now`. We can fix this by adding precision (`now = Time.now; Time.iso8601(now.iso8601(20)) == now`), but that adds unnecessary size to job payloads. Instead, I've opted to modify the test helper to drop microseconds (and nanoseconds) from passed in time job arguments.

