### PR TITLE
Add `secret_key_base` when creating new credential file

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -56,7 +56,11 @@ module Rails
         end
 
         def ensure_credentials_have_been_added
-          encrypted_file_generator.add_encrypted_file_silently(content_path, key_path)
+          if options[:environment]
+            encrypted_file_generator.add_encrypted_file_silently(content_path, key_path)
+          else
+            credentials_generator.add_credentials_file_silently
+          end
         end
 
         def change_credentials_in_system_editor
@@ -95,6 +99,13 @@ module Rails
           require "rails/generators/rails/encrypted_file/encrypted_file_generator"
 
           Rails::Generators::EncryptedFileGenerator.new
+        end
+
+        def credentials_generator
+          require "rails/generators"
+          require "rails/generators/rails/credentials/credentials_generator"
+
+          Rails::Generators::CredentialsGenerator.new
         end
     end
   end

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -79,6 +79,15 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_edit_command(environment: "qa"))
   end
 
+  test "edit command generate template file when the file does not exist" do
+    FileUtils.rm("#{app_path}/config/credentials.yml.enc")
+    run_edit_command
+
+    output = run_show_command
+    assert_match(/access_key_id: 123/, output)
+    assert_match(/secret_key_base/, output)
+  end
+
   test "show credentials" do
     assert_match(/access_key_id: 123/, run_show_command)
   end
@@ -106,7 +115,9 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
   test "show command properly expand environment option" do
     run_edit_command(environment: "production")
 
-    assert_match(/access_key_id: 123/, run_show_command(environment: "prod"))
+    output = run_show_command(environment: "prod")
+    assert_match(/access_key_id: 123/, output)
+    assert_no_match(/secret_key_base/, output)
   end
 
   private


### PR DESCRIPTION
Since `secret_key_base` is expected to be included in credential file, `secret_key_base` should be included even if re-create the file. This is the same behavior as creating a new app.
When env is specified, it may be unnecessary, so I added it only when not specifying env.
