### PR TITLE
Port 5.2.2.1 changelog to 5-2-3 branch

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -15,7 +15,16 @@
 
 ## Rails 5.2.2.1 (March 11, 2019) ##
 
-*   No changes.
+*   Only accept formats from registered mime types
+
+    A lack of filtering on mime types could allow an attacker to read
+    arbitrary files on the target server or to perform a denial of service
+    attack.
+
+    Fixes CVE-2019-5418
+    Fixes CVE-2019-5419
+
+    *John Hawthorn*, *Eileen M. Uchitelle*, *Aaron Patterson*
 
 
 ## Rails 5.2.2 (December 04, 2018) ##

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -11,7 +11,16 @@
 
 ## Rails 5.2.2.1 (March 11, 2019) ##
 
-*   No changes.
+*   Generate random development secrets
+
+    A random development secret is now generated to tmp/development_secret.txt
+
+    This avoids an issue where development mode servers were vulnerable to
+    remote code execution.
+
+    Fixes CVE-2019-5420
+
+    *Eileen M. Uchitelle*, *Aaron Patterson*, *John Hawthorn*
 
 
 ## Rails 5.2.2 (December 04, 2018) ##


### PR DESCRIPTION
This will ensure that final release of 5.2.3 also contains the CHANGELOG of 5.2.2.1, as the CHANGELOG was added afterward.

https://github.com/rails/rails/blob/4aa6c328847bd42776f75befefbcc61cd1ec9f20/actionview/CHANGELOG.md
https://github.com/rails/rails/blob/4aa6c328847bd42776f75befefbcc61cd1ec9f20/railties/CHANGELOG.md

[ci skip]
