### PR TITLE
[ci skip] Fixed typo in 5.1.6.2 release CHANGELOG

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 *   Only accept formats from registered mime types
 
-    A lack of filtering on mime types could allow an a attacker to read
+    A lack of filtering on mime types could allow an attacker to read
     arbitrary files on the target server or to perform a denial of service
     attack.
 


### PR DESCRIPTION
Fixed typo from `an a attacker` to `an attacker`.