### PR TITLE
Add config.disable_sandbox option to Rails console

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -86,6 +86,8 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
     end
     ```
 
+* `config.disable_sandbox` controls whether or not someone could start a console in sandbox mode, as a long session of sandbox console could lead database server to run out of memory.
+
 * `config.eager_load` when `true`, eager loads all registered `config.eager_load_namespaces`. This includes your application, engines, Rails frameworks, and any other registered namespace.
 
 * `config.eager_load_namespaces` registers namespaces that are eager loaded when `config.eager_load` is `true`. All namespaces in the list must respond to the `eager_load!` method.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `config.disable_sandbox` option to Rails console.
+
+    This setting will disable `rails console --sandbox` mode, preventing
+    developer from accidentally starting a sandbox console, left it inactive,
+    and cause the database server to run out of memory.
+
+    *Prem Sichanugrist*
+
 *   Add `-e/--environment` option to `rails initializers`.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -18,7 +18,8 @@ module Rails
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
-                    :content_security_policy_nonce_generator, :require_master_key, :credentials
+                    :content_security_policy_nonce_generator, :require_master_key, :credentials,
+                    :disable_sandbox
 
       attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
 
@@ -65,6 +66,7 @@ module Rails
         @credentials.content_path                = default_credentials_content_path
         @credentials.key_path                    = default_credentials_key_path
         @autoloader                              = :classic
+        @disable_sandbox                         = false
       end
 
       def load_defaults(target_version)

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -26,6 +26,12 @@ module Rails
       @options = options
 
       app.sandbox = sandbox?
+
+      if sandbox? && app.config.disable_sandbox
+        puts "Error: Unable to start console in sandbox mode as sandbox mode is disabled (config.disable_sandbox is true)."
+        exit 1
+      end
+
       app.load_console
 
       @console = app.config.console || IRB

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2476,6 +2476,22 @@ module ApplicationTests
       assert_includes Rails.application.config.hosts, ".localhost"
     end
 
+    test "disable_sandbox is false by default" do
+      app "development"
+
+      assert_equal false, Rails.configuration.disable_sandbox
+    end
+
+    test "disable_sandbox can be overridden" do
+      add_to_config <<-RUBY
+        config.disable_sandbox = true
+      RUBY
+
+      app "development"
+
+      assert Rails.configuration.disable_sandbox
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -123,13 +123,17 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     assert_output "> ", @primary
   end
 
-  def spawn_console(options)
-    Process.spawn(
+  def spawn_console(options, wait_for_prompt: true)
+    pid = Process.spawn(
       "#{app_path}/bin/rails console #{options}",
       in: @replica, out: @replica, err: @replica
     )
 
-    assert_output "> ", @primary, 30
+    if wait_for_prompt
+      assert_output "> ", @primary, 30
+    end
+
+    pid
   end
 
   def test_sandbox
@@ -146,6 +150,17 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "Post.transaction { Post.create; raise }"
     write_prompt "Post.count", "=> 0"
     @primary.puts "quit"
+  end
+
+  def test_sandbox_when_sandbox_is_disabled
+    add_to_config <<-RUBY
+      config.disable_sandbox = true
+    RUBY
+
+    output = `#{app_path}/bin/rails console --sandbox`
+
+    assert_includes output, "sandbox mode is disabled"
+    assert_equal 1, $?.exitstatus
   end
 
   def test_environment_option_and_irb_option

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -129,7 +129,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     def build_app(console)
       mocked_console = Class.new do
         attr_accessor :sandbox
-        attr_reader :console
+        attr_reader :console, :disable_sandbox
 
         def initialize(console)
           @console = console


### PR DESCRIPTION
### Summary

A long-running `rails console --sandbox` could cause a database server to become out-of-memory as it's holding on to changes that happen on the database.

Given that it's common for Ruby on Rails application with huge traffic to have separate write database and read database, we should allow the developers to disable this sandbox option to prevent someone
from accidentally causing the Denial-of-Service on their server.

### Other Information

This situation is actually happened to us 😅. Someone opened a tmux session with `rails console --sandbox` and forgot about it. We tried to trace down who ran it, and kill the session to bring the service back online.

I felt like this is not a situation that only us would run into, as it could bite someone one day and took down their system, so I think having a sandbox mode as a configurable option is a good idea especially in a Rails application that already have a separate read and write database cluster.