### PR TITLE
Update API doc for #includes on unnecessary #references

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -100,7 +100,7 @@ module ActiveRecord
     #
     # === conditions
     #
-    # If you want to add conditions to your included models you'll have
+    # If you want to add string conditions to your included models, you'll have
     # to explicitly reference them. For example:
     #
     #   User.includes(:posts).where('posts.name = ?', 'example')
@@ -111,6 +111,12 @@ module ActiveRecord
     #
     # Note that #includes works with association names while #references needs
     # the actual table name.
+    #
+    # If you pass the conditions via hash, you don't need to call #references
+    # explicitly, as #where references the tables for you. For example, this
+    # will work correctly:
+    #
+    #    User.includes(:posts).where(posts: { name: 'example' })
     def includes(*args)
       check_if_method_has_arguments!(:includes, args)
       spawn.includes!(*args)


### PR DESCRIPTION
### Summary

Update doc for #includes to clarify that #references is unnecessary when conditions are passed into #includes as a hash.

### Context

The current doc implies that `#references` should always be used when `#includes` has conditions referencing other tables. However, since [this commit](https://github.com/rails/rails/commit/306dc1a499908ba105e6b0fe8b8e01824c5e04d7), hash conditions for `includes` no longer require explicit `references` calls. This behavior is undocumented and has created lots of confusion during code review. 