### PR TITLE
Replace chromedriver-helper with webdrivers 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem "webmock"
 
 group :ujs do
   gem "qunit-selenium"
-  gem "chromedriver-helper"
+  gem "webdrivers"
 end
 
 # Add your own local bundler stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,8 +110,6 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     amq-protocol (2.3.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     ast (2.4.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.111.0)
@@ -185,9 +183,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -282,7 +277,6 @@ GEM
     image_processing (1.7.1)
       mini_magick (~> 4.0)
       ruby-vips (>= 2.0.13, < 3)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jaro_winkler (1.5.2-java)
     jdbc-mysql (5.1.46)
@@ -336,6 +330,7 @@ GEM
     mysql2 (0.5.2)
     mysql2 (0.5.2-x64-mingw32)
     mysql2 (0.5.2-x86-mingw32)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nio4r (2.3.1-java)
     nokogiri (1.9.1)
@@ -501,6 +496,11 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
     wdm (0.1.1)
+    webdrivers (3.7.0)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -540,7 +540,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.0)
   byebug
   capybara (>= 2.15)
-  chromedriver-helper
   connection_pool
   dalli
   delayed_job
@@ -587,6 +586,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   w3c_validators
   wdm (>= 0.1.0)
+  webdrivers
   webmock
   webpacker (~> 4.0)
   websocket-client-simple!

--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -5,7 +5,7 @@ require "qunit/selenium/test_runner"
 if ARGV[1]
   driver = ::Selenium::WebDriver.for(:remote, url: ARGV[1], desired_capabilities: :chrome)
 else
-  require "chromedriver-helper"
+  require "webdrivers"
 
   driver_options = Selenium::WebDriver::Chrome::Options.new
   driver_options.add_argument("--headless")

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -69,8 +69,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  # Easy installation and use of web drivers to run system tests with browsers
+  gem 'webdrivers'
 end
 <%- end -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -617,7 +617,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "capybara"
     assert_no_gem "selenium-webdriver"
-    assert_no_gem "chromedriver-helper"
+    assert_no_gem "webdrivers"
 
     assert_no_directory("test")
   end
@@ -626,7 +626,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-system-test"]
     assert_no_gem "capybara"
     assert_no_gem "selenium-webdriver"
-    assert_no_gem "chromedriver-helper"
+    assert_no_gem "webdrivers"
 
     assert_directory("test")
 


### PR DESCRIPTION
chromedriver-helper is deprecated in favour of webdrivers: https://github.com/flavorjones/chromedriver-helper/issues/83

Closes https://github.com/rails/rails/issues/35731