### PR TITLE
Educate in the use of destroy!

### DIFF
--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -73,7 +73,7 @@ module Rails
 
       # DELETE destroy
       def destroy
-        "#{name}.destroy"
+        "#{name}.destroy!"
       end
     end
   end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -40,7 +40,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@user\.destroy/, m)
+        assert_match(/@user\.destroy!/, m)
         assert_match(/User was successfully destroyed/, m)
       end
 
@@ -254,7 +254,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@user\.destroy/, m)
+        assert_match(/@user\.destroy!/, m)
       end
     end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -51,7 +51,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@product_line\.destroy/, m)
+        assert_match(/@product_line\.destroy!/, m)
       end
 
       assert_instance_method :set_product_line, content do |m|
@@ -141,7 +141,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@product_line\.destroy/, m)
+        assert_match(/@product_line\.destroy!/, m)
       end
     end
 
@@ -266,7 +266,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@admin_role\.destroy/, m)
+        assert_match(/@admin_role\.destroy!/, m)
       end
 
       assert_instance_method :set_admin_role, content do |m|


### PR DESCRIPTION
### Summary
Besides helping product development with automatic code generation, Generators also are used to educate in how an application in Rails could be built and how public API should be used.

In terms of public API education I think we are already doing a great work with the actions `create` and `update` by using the methods `#create` and `#update` without bang and then taking advantage of their boolean return value to display an appropriate response. However, at the same time we are encouraging the use of `#destroy` (without a bang) without doing anything in case the record can't be destroyed, which would hide potential bugs. This patch changes that by recommending the use of `#destroy!`, which raises an exception in case the record can't be destroyed.
