### PR TITLE
Add hash methods "deep_camelize_keys" and "camelize_keys"

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -70,7 +70,7 @@ class Hash
   # nested hashes and arrays.
   #
   #  hash = { my_profile: { first_name: 'Willian', 'last_name' => 'Veiga' } }
-  #  hash.camelize_keys
+  #  hash.deep_camelize_keys
   #  # => { myProfile: { firstName: 'Willian', 'lastName' => 'Veiga' } }
   def deep_camelize_keys
     deep_transform_keys { |key| _camelize_key(key) }

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -54,6 +54,28 @@ class Hash
     end
   end
 
+  # Returns a new hash with all keys converted to camelCase.
+  # The key type is preserved.
+  #
+  #  hash = { first_name: 'Willian', 'last_name' => 'Veiga' }
+  #  hash.camelize_keys
+  #  # => { firstName: 'Willian', 'lastName' => 'Veiga' }
+  def camelize_keys
+    transform_keys { |key| _camelize_key(key) }
+  end
+
+  # Returns a new hash with all keys converted to camelCase.
+  # The key type is preserved.
+  # This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #  hash = { my_profile: { first_name: 'Willian', 'last_name' => 'Veiga' } }
+  #  hash.camelize_keys
+  #  # => { myProfile: { firstName: 'Willian', 'lastName' => 'Veiga' } }
+  def deep_camelize_keys
+    deep_transform_keys { |key| _camelize_key(key) }
+  end
+
   # Returns a new hash with all keys converted by the block operation.
   # This includes the keys from the root hash and from all
   # nested hashes and arrays.
@@ -112,6 +134,12 @@ class Hash
   end
 
   private
+    def _camelize_key(key)
+      return key.to_s.camelize(:lower).to_sym if key.is_a?(Symbol)
+      return key.camelize(:lower) if key.is_a?(String)
+      key
+    end
+
     # support methods for deep transforming nested hashes and arrays
     def _deep_transform_keys_in_object(object, &block)
       case object

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -27,10 +27,14 @@ class HashExtTest < ActiveSupport::TestCase
     @symbol_array_of_hashes = { a: [ { b: 2 }, { c: 3 }, 4 ] }
     @mixed_array_of_hashes = { a: [ { b: 2 }, { "c" => 3 }, 4 ] }
     @upcase_array_of_hashes = { "A" => [ { "B" => 2 }, { "C" => 3 }, 4 ] }
+    @mixed_snake_case = { first_name: "John", "last_name" => "Doe" }
+    @nested_mixed_snake_case = { my_profile: { first_name: "John", "last_name" => "Doe" } }
   end
 
   def test_methods
     h = {}
+    assert_respond_to h, :camelize_keys
+    assert_respond_to h, :deep_camelize_keys
     assert_respond_to h, :deep_transform_keys
     assert_respond_to h, :deep_transform_keys!
     assert_respond_to h, :deep_transform_values
@@ -47,6 +51,23 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :to_options!
     assert_respond_to h, :except
     assert_respond_to h, :except!
+  end
+
+  def test_camelize_keys
+    assert_equal @strings, @strings.camelize_keys
+    assert_equal @symbols, @symbols.camelize_keys
+    assert_equal @integers, @integers.camelize_keys
+    assert_equal @illegal_symbols, @illegal_symbols.camelize_keys
+    assert_equal({ firstName: "John", "lastName" => "Doe" }, @mixed_snake_case.camelize_keys)
+  end
+
+  def test_deep_camelize_keys
+      assert_equal @strings, @strings.deep_camelize_keys
+      assert_equal @symbols, @symbols.deep_camelize_keys
+      assert_equal @integers, @integers.deep_camelize_keys
+      assert_equal @illegal_symbols, @illegal_symbols.deep_camelize_keys
+      assert_equal({ firstName: "John", "lastName" => "Doe" }, @mixed_snake_case.deep_camelize_keys)
+      assert_equal({ myProfile: { firstName: "John", "lastName" => "Doe" } }, @nested_mixed_snake_case.deep_camelize_keys)
   end
 
   def test_deep_transform_keys

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -62,12 +62,12 @@ class HashExtTest < ActiveSupport::TestCase
   end
 
   def test_deep_camelize_keys
-      assert_equal @strings, @strings.deep_camelize_keys
-      assert_equal @symbols, @symbols.deep_camelize_keys
-      assert_equal @integers, @integers.deep_camelize_keys
-      assert_equal @illegal_symbols, @illegal_symbols.deep_camelize_keys
-      assert_equal({ firstName: "John", "lastName" => "Doe" }, @mixed_snake_case.deep_camelize_keys)
-      assert_equal({ myProfile: { firstName: "John", "lastName" => "Doe" } }, @nested_mixed_snake_case.deep_camelize_keys)
+    assert_equal @strings, @strings.deep_camelize_keys
+    assert_equal @symbols, @symbols.deep_camelize_keys
+    assert_equal @integers, @integers.deep_camelize_keys
+    assert_equal @illegal_symbols, @illegal_symbols.deep_camelize_keys
+    assert_equal({ firstName: "John", "lastName" => "Doe" }, @mixed_snake_case.deep_camelize_keys)
+    assert_equal({ myProfile: { firstName: "John", "lastName" => "Doe" } }, @nested_mixed_snake_case.deep_camelize_keys)
   end
 
   def test_deep_transform_keys


### PR DESCRIPTION
### Summary

Sometimes  programmers need to send JSON data to JavaScript apps using camelCase object keys:

```
render json: {
  myProfile: {
    firstName: 'John',
    lastName: 'Doe'
  }
}
```

Unlike Javascript code, Rails applications use snake_case. It would be great to code JSON objects in snake_case and convert them to camelCase:

```
render json: {
  my_profile: {
    first_name: 'John',
    last_name: 'Doe'
  }
}.deep_camelize_keys
```
This pull request adds the methods `deep_camelize_keys` and `camelize_keys` to the Hash class.