### PR TITLE
[ci skip] Move collection cache documentation to render section

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -130,39 +130,6 @@ module ActionView
       #   <%= some_helper_method(person) %>
       #
       # Now all you have to do is change that timestamp when the helper method changes.
-      #
-      # === Collection Caching
-      #
-      # When rendering a collection of objects that each use the same partial, a <tt>:cached</tt>
-      # option can be passed.
-      #
-      # For collections rendered such:
-      #
-      #   <%= render partial: 'projects/project', collection: @projects, cached: true %>
-      #
-      # The <tt>cached: true</tt> will make Action View's rendering read several templates
-      # from cache at once instead of one call per template.
-      #
-      # Templates in the collection not already cached are written to cache.
-      #
-      # Works great alongside individual template fragment caching.
-      # For instance if the template the collection renders is cached like:
-      #
-      #   # projects/_project.html.erb
-      #   <% cache project do %>
-      #     <%# ... %>
-      #   <% end %>
-      #
-      # Any collection renders will find those cached templates when attempting
-      # to read multiple templates at once.
-      #
-      # If your collection cache depends on multiple sources (try to avoid this to keep things simple),
-      # you can name all these dependencies as part of a block that returns an array:
-      #
-      #   <%= render partial: 'projects/project', collection: @projects, cached: -> project { [ project, current_user ] } %>
-      #
-      # This will include both records as part of the cache key and updating either of them will
-      # expire the cache.
       def cache(name = {}, options = {}, &block)
         if controller.respond_to?(:perform_caching) && controller.perform_caching
           name_options = options.slice(:skip_digest, :virtual_path)

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -24,6 +24,39 @@ module ActionView
       #
       # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter
       # as the locals hash.
+      #
+      # === Collection Caching
+      #
+      # When rendering a collection of objects that each use the same partial, a <tt>:cached</tt>
+      # option can be passed.
+      #
+      # For collections rendered such:
+      #
+      #   <%= render partial: 'projects/project', collection: @projects, cached: true %>
+      #
+      # The <tt>cached: true</tt> will make Action View's rendering read several templates
+      # from cache at once instead of one call per template.
+      #
+      # Templates in the collection not already cached are written to cache.
+      #
+      # Works great alongside individual template fragment caching.
+      # For instance if the template the collection renders is cached like:
+      #
+      #   # projects/_project.html.erb
+      #   <% cache project do %>
+      #     <%# ... %>
+      #   <% end %>
+      #
+      # Any collection renders will find those cached templates when attempting
+      # to read multiple templates at once.
+      #
+      # If your collection cache depends on multiple sources (try to avoid this to keep things simple),
+      # you can name all these dependencies as part of a block that returns an array:
+      #
+      #   <%= render partial: 'projects/project', collection: @projects, cached: -> project { [ project, current_user ] } %>
+      #
+      # This will include both records as part of the cache key and updating either of them will
+      # expire the cache.
       def render(options = {}, locals = {}, &block)
         case options
         when Hash


### PR DESCRIPTION
Ref: https://groups.google.com/forum/#!topic/rubyonrails-core/0mQgihYrBBA

As @kaspth mentioned, the cache option is available for render and documentation should be moved to the render method. 