### PR TITLE
ActiveJob time argument assertion documentation

### DIFF
--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -1710,28 +1710,28 @@ class PerformedJobsTest < ActiveJob::TestCase
 
   def test_assert_performed_with_time
     now = Time.now
-    args = [{ argument1: { now: now } }]
+    args = [{ argument1: { now: now }, argument2: now }]
 
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now })
+    assert_performed_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
     end
   end
 
   def test_assert_performed_with_date_time
     now = DateTime.now
-    args = [{ argument1: { now: now } }]
+    args = [{ argument1: { now: now }, argument2: now }]
 
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now })
+    assert_performed_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
     end
   end
 
   def test_assert_performed_with_time_with_zone
     now = Time.now.in_time_zone("Tokyo")
-    args = [{ argument1: { now: now } }]
+    args = [{ argument1: { now: now }, argument2: now }]
 
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now })
+    assert_performed_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
     end
   end
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1733,6 +1733,25 @@ class ProductTest < ActiveSupport::TestCase
 end
 ```
 
+### Asserting Time Arguments in Jobs
+
+When serializing job arguments, `Time`, `DateTime`, and `ActiveSupport::TimeWithZone` lose microsecond precision. This means comparing deserialized time with actual time doesn't always work. To compensate for the loss of precision, `assert_enqueued_with` and `assert_performed_with` will remove microseconds from time objects in argument assertions.
+
+```ruby
+require 'test_helper'
+
+class ProductTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'that product is reserved at a given time' do
+    now = Time.now
+    assert_performed_with(job: ReservationJob, args: [product, now]) do
+      product.reserve(now)
+    end
+  end
+end
+```
+
 Testing Action Cable
 --------------------
 


### PR DESCRIPTION
### Summary

Followup on https://github.com/rails/rails/pull/35713.  Actually uses `assert_performed_with` in `assert_performed_with` time argument tests, and adds documentation about testing deserialized time.
