### PR TITLE
Format 'RETURNING' text in the docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -88,7 +88,7 @@ module ActiveRecord
       #   (Postgres-only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
-      #   or <tt>returning: false</tt> to omit the underlying RETURNING SQL
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
       #   clause entirely.
       #
       # [:unique_by]
@@ -157,7 +157,7 @@ module ActiveRecord
       #   (Postgres-only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
-      #   or <tt>returning: false</tt> to omit the underlying RETURNING SQL
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
       #   clause entirely.
       #
       # ==== Examples
@@ -205,7 +205,7 @@ module ActiveRecord
       #   (Postgres-only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
-      #   or <tt>returning: false</tt> to omit the underlying RETURNING SQL
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
       #   clause entirely.
       #
       # [:unique_by]


### PR DESCRIPTION
Made a change to the formatting of the 'RETURNING' text to be the same as what it was in master before #35546.

Refer:
https://github.com/rails/rails/blob/6a5c8b91998c56e50b5cc934d968947cd319f735/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L76