### PR TITLE
Reword test names in credentials_test.rb

### DIFF
--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -63,7 +63,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     end
   end
 
-  test "edit command properly expand environment option" do
+  test "edit command properly expands environment option" do
     assert_match(/access_key_id: 123/, run_edit_command(environment: "prod"))
     Dir.chdir(app_path) do
       assert File.exist?("config/credentials/production.key")
@@ -79,7 +79,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_edit_command(environment: "qa"))
   end
 
-  test "edit command generate template file when the file does not exist" do
+  test "edit command generates template file when the file does not exist" do
     FileUtils.rm("#{app_path}/config/credentials.yml.enc")
     run_edit_command
 
@@ -92,7 +92,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_show_command)
   end
 
-  test "show command raise error when require_master_key is specified and key does not exist" do
+  test "show command raises error when require_master_key is specified and key does not exist" do
     remove_file "config/master.key"
     add_to_config "config.require_master_key = true"
 
@@ -112,7 +112,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_show_command(environment: "production"))
   end
 
-  test "show command properly expand environment option" do
+  test "show command properly expands environment option" do
     run_edit_command(environment: "production")
 
     output = run_show_command(environment: "prod")


### PR DESCRIPTION
I noticed that the test names in this file could be changed to read more naturally when I was going through #35718.
