### PR TITLE
Trigger Zeitwerk eager loading when calling Engine#eager_load!

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -73,10 +73,6 @@ module Rails
       initializer :eager_load! do
         if config.eager_load
           ActiveSupport.run_load_hooks(:before_eager_load, self)
-          # Checks defined?(Zeitwerk) instead of zeitwerk_enabled? because we
-          # want to eager load any dependency managed by Zeitwerk regardless of
-          # the autoloading mode of the application.
-          Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
           config.eager_load_namespaces.each(&:eager_load!)
         end
       end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -472,6 +472,11 @@ module Rails
     # Eager load the application by loading all ruby
     # files inside eager_load paths.
     def eager_load!
+      # Checks defined?(Zeitwerk) instead of zeitwerk_enabled? because we
+      # want to eager load any dependency managed by Zeitwerk regardless of
+      # the autoloading mode of the application.
+      Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
+
       if Rails.autoloaders.zeitwerk_enabled?
         eager_load_with_zeitwerk!
       else


### PR DESCRIPTION
This change might seem weird as appear as only cosmetic, however I'd try to describe the use case.

We have a bunch of tests that perform sanity checks of all sorts on models and other classes, by iterating over all of them through the use of `Class#descendants`.

Hence these tests need the application to be eager loaded, otherwise they won't find all the models. On CI it's no big deal as we fully eager load the application, but locally we don't want to spend 2 minutes loading the app to run a single test unless that test needs it.

Because of this we have a test helper that trigger autoloading of the application on the fly by calling `Rails.application.config.eager_load_namespaces.each(&:eager_load!)`.



@fxn @Edouard-chin @rafaelfranca 