### PR TITLE
Add default value `ActiveSupport::Deprecation.silenced` [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -727,7 +727,7 @@ There are a few configuration options available in Active Support:
 
 * `ActiveSupport::Deprecation.silence` takes a block in which all deprecation warnings are silenced.
 
-* `ActiveSupport::Deprecation.silenced` sets whether or not to display deprecation warnings.
+* `ActiveSupport::Deprecation.silenced` sets whether or not to display deprecation warnings. The default is `false`.
 
 ### Configuring Active Job
 


### PR DESCRIPTION
Since the initial value of `ActiveSupport :: Deprecation.silenced` has been added.
Please check.
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation.rb#L42