### PR TITLE
Register features loaded by the classic autoloader in $LOADED_FEATURES when switching to Zeitwerk

### DIFF
--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -86,6 +86,7 @@ module ActiveSupport
           def decorate_dependencies
             Dependencies.unhook!
             Dependencies.singleton_class.prepend(Decorations)
+            $LOADED_FEATURES.concat(Dependencies.loaded.map { |path| "#{path}.rb" })
             Object.class_eval { alias_method :require_dependency, :require }
           end
       end


### PR DESCRIPTION
This change can seem weird, and the justification a bit controversial, but please bear with me.

I've setup a repro repository here: https://github.com/casperisfine/repro-double-loading. I reduced the repro as much as possible so it seems like a very use case, but I believe it's very much legitimate.

What's is happening is that Zeitwerk only take over after some part of the initialization process happened, which mean until `ZeitwerkIntegration.take_over` is called, the classic autoloader can load constants.

In case `config.cache_classes = false`, `ActiveSupport::Dependencies` will use `Kernel#load`, hence the files it loaded won't appear in `$LOADED_FEATURES`.

Then, once `Zeitwerk` takes over, `require_dependency` is replace by the native `Kernel#require`. So if for some reason a file that was loaded by `AS::Dependencies` is required again, the file will be loaded twice, causing all sorts of problems (redefined constant warnings, etc).

### The patch

The change is very simple, we simply merge `AS::Dependencies` loaded features set with the global loaded features.

@Edouard-chin @rafaelfranca @fxn 