### PR TITLE
Fix ActiveRecord STI when using the Zeitwerk autoloader:

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -133,7 +133,7 @@ module ActiveRecord
       # Returns the class of the target. belongs_to polymorphic overrides this to look at the
       # polymorphic_type field on the owner.
       def klass
-        reflection.klass
+        reflection.compute_class(reflection.class_name)
       end
 
       def extensions


### PR DESCRIPTION
Fix ActiveRecord STI when using the Zeitwerk autoloader:

- STI is currently broken when code reloads using Zeitwerk.
  The error you'll get is `ActiveRecord::SubclassNotFound: Invalided single-table inheritance type: A is not a subclass of B`
  This get raised by AR in https://github.com/rails/rails/blob/15ca8ad0c1e94d11d0deb02535bc286e077d43ce/activerecord/lib/active_record/inheritance.rb#L243
  when it tries to find the STI class.

  The issue is basically this
  ```
  autoload :B, './b'

  array = [B]
  p array.include?(B) # true

  Object.send(:remove_const, :B)
  $LOADED_FEATURES.pop

  autoload :B, './b'

  p array.include?(B) # false
  ```

  The problem is due to a memoization of a variable which keeps an
  outdated reference to a constant after Zeitwerk made his reset/setup
  autoloading dance.

  The memoization happens here https://github.com/rails/rails/blob/15ca8ad0c1e94d11d0deb02535bc286e077d43ce/activerecord/lib/active_record/reflection.rb#L379
  and is used to build the AssociationRelation https://github.com/rails/rails/blob/15ca8ad0c1e94d11d0deb02535bc286e077d43ce/activerecord/lib/active_record/associations/association.rb#L228

  It took me some time to figure out the problem, and there is two
  questions that remains unanswered to me:

  1. Is the performance impact going to be a problem after this change?
  2. How did it work before with the classic autoloader

cc/ @rafael @fxn @byroot 
