### PR TITLE
Add the `Mime::Type::InvalidMimeType` error in the default rescue_response:

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -60,7 +60,11 @@ module ActionDispatch
         log_error(request, wrapper)
 
         if request.get_header("action_dispatch.show_detailed_exceptions")
-          content_type = request.formats.first
+          begin
+            content_type = request.formats.first
+          rescue Mime::Type::InvalidMimeType
+            render_for_api_request(Mime[:text], wrapper)
+          end
 
           if api_request?(content_type)
             render_for_api_request(content_type, wrapper)

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -12,6 +12,7 @@ module ActionDispatch
       "ActionController::UnknownHttpMethod"          => :method_not_allowed,
       "ActionController::NotImplemented"             => :not_implemented,
       "ActionController::UnknownFormat"              => :not_acceptable,
+      "Mime::Type::InvalidMimeType"                  => :not_acceptable,
       "ActionController::MissingExactTemplate"       => :not_acceptable,
       "ActionController::InvalidAuthenticityToken"   => :unprocessable_entity,
       "ActionController::InvalidCrossOriginRequest"  => :unprocessable_entity,

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -21,8 +21,12 @@ module ActionDispatch
     def call(env)
       request      = ActionDispatch::Request.new(env)
       status       = request.path_info[1..-1].to_i
-      content_type = request.formats.first
-      body         = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      begin
+        content_type = request.formats.first
+      rescue Mime::Type::InvalidMimeType
+        content_type = Mime[:text]
+      end
+      body = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
 
       render(status, content_type, body)
     end

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -58,6 +58,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise ActionController::NotImplemented
       when "/unprocessable_entity"
         raise ActionController::InvalidAuthenticityToken
+      when "/invalid_mimetype"
+        raise Mime::Type::InvalidMimeType
       when "/not_found_original_exception"
         begin
           raise AbstractController::ActionNotFound.new
@@ -178,6 +180,10 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/parameter_missing", headers: { "action_dispatch.show_exceptions" => true }
     assert_response 400
     assert_match(/ActionController::ParameterMissing/, body)
+
+    get "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => true }
+    assert_response 406
+    assert_match(/Mime::Type::InvalidMimeType/, body)
   end
 
   test "rescue with text error for xhr request" do

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -9,6 +9,8 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/not_found"
         raise AbstractController::ActionNotFound
+      when "/invalid_mimetype"
+        raise Mime::Type::InvalidMimeType
       when "/bad_params", "/bad_params.json"
         begin
           raise StandardError.new
@@ -61,6 +63,10 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
 
     get "/unknown_http_method", env: { "action_dispatch.show_exceptions" => true }
     assert_response 405
+    assert_equal "", body
+
+    get "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => true }
+    assert_response 406
     assert_equal "", body
   end
 


### PR DESCRIPTION
Add the `Mime::Type::InvalidMimeType` error in the default rescue_response:

- https://github.com/rails/rails/pull/35604 introduced a vulnerability fix
  to raise an error in case the `HTTP_ACCEPT` headers contains malformated
  mime type.

  This will cause applications to throw a 500 if a User Agent sends an
  invalid header.

  This PR adds the `InvalidMimeType` in the default `rescue_responses` from
  the ExceptionWrapper and will return a 406. I looked up the HTTP/1.1
  RFC and it doesn't stand what should be returned when the UA
  sends malformated mime type. Decided to go for 406 as it seemed to be the
  status the better suited for this.

cc/ @rafaelfranca @jhawthorn 