### PR TITLE
Use `assert_queries(0)` instead of `assert_no_queries`

### DIFF
--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -121,7 +121,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     assert reply.save
 
     topics = Topic.all.merge!(includes: :replies, order: ["topics.id", "replies_topics.id"]).to_a
-    assert_no_queries do
+    assert_queries(0) do
       assert_equal 2, topics[0].replies.size
       assert_equal 0, topics[1].replies.size
     end


### PR DESCRIPTION
### Summary

Use `assert_queries(0)` instead of `assert_no_queries` to ignore metadata queries
Fix #35665

```ruby
$ ARCONN=mysql2 bin/test test/cases/scoping/named_scoping_test.rb test/cases/tasks/database_tasks_test.rb test/cases/associations/cascaded_eager_loading_test.rb test/cases/associations/eager_singularization_test.rb -n "/^(?:NamedScopingTest#(?:test_many_should_not_fire_query_if_scope_loaded)|ActiveRecord::DatabaseTasksDumpSchemaCacheTest#(?:test_dump_schema_cache)|CascadedEagerLoadingTest#(?:test_eager_association_loading_with_has_many_sti_and_subclasses)|EagerSingularizationTest#(?:test_eager_no_extra_singularization_has_many_through_belongs_to))$/" --seed 16818
Using mysql2
Run options: -n "/^(?:NamedScopingTest#(?:test_many_should_not_fire_query_if_scope_loaded)|ActiveRecord::DatabaseTasksDumpSchemaCacheTest#(?:test_dump_schema_cache)|CascadedEagerLoadingTest#(?:test_eager_association_loading_with_has_many_sti_and_subclasses)|EagerSingularizationTest#(?:test_eager_no_extra_singularization_has_many_through_belongs_to))$/" --seed 16818

...F

Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_has_many_sti_and_subclasses [/home/yahonda/git/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:124]:
1 instead of 0 queries were executed.
Queries:
SHOW FULL FIELDS FROM `topics`.
Expected: 0
  Actual: 1

bin/test test/cases/associations/cascaded_eager_loading_test.rb:119

Finished in 6.894609s, 0.5802 runs/s, 1.0153 assertions/s.
4 runs, 7 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information

Here are definitions of `assert_no_queries` and `assert_queries`

https://github.com/rails/rails/blob/15ca8ad0c1e94d11d0deb02535bc286e077d43ce/activerecord/test/cases/test_case.rb#L50-L68

I'm wondering if this pull request should replace other `assert_no_queries` with `assert_queries(0)` of `CascadedEagerLoadingTest` yet.