### PR TITLE
Deprecate custom patterns for PathResolver

### DIFF
--- a/actionview/test/template/resolver_patterns_test.rb
+++ b/actionview/test/template/resolver_patterns_test.rb
@@ -6,7 +6,10 @@ class ResolverPatternsTest < ActiveSupport::TestCase
   def setup
     path = File.expand_path("../fixtures", __dir__)
     pattern = ":prefix/{:formats/,}:action{.:formats,}{+:variants,}{.:handlers,}"
-    @resolver = ActionView::FileSystemResolver.new(path, pattern)
+
+    assert_deprecated do
+      @resolver = ActionView::FileSystemResolver.new(path, pattern)
+    end
   end
 
   def test_should_return_empty_list_for_unknown_path


### PR DESCRIPTION
Currently, FileSystemResolver can be built with a custom pattern, like:

``` ruby
ActionController::Base.view_paths = FileSystemResolver.new(
  Rails.root.join("app/views"),
  ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:handlers,}",
)
```

Unfortunately, allowing these custom glob patterns tie the implementation (`Dir.glob`) to the API we provide. We'd like to stop using globs to determine how templates are found.

It also doesn't really work, unless the pattern ends exactly the same as the default pattern (with `{.:formats,}{+:variants,}{.:handlers,}`), `extract_handler_and_format_and_variant` won't work. It expects the handler, format, and variant to be at the end of the template path, and in the same order as they are in the default pattern.

This deprecates specifying a custom path for `FileSystemResolver` and removes the pattern argument of `OptimizedFileSystemResolver#initialize`, which does not work with a custom pattern.

cc @tenderlove 