### PR TITLE
Follow up to #35753 and rescue InvalidMimeType for all exception_app:

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -21,11 +21,7 @@ module ActionDispatch
     def call(env)
       request      = ActionDispatch::Request.new(env)
       status       = request.path_info[1..-1].to_i
-      begin
-        content_type = request.formats.first
-      rescue Mime::Type::InvalidMimeType
-        content_type = Mime[:text]
-      end
+      content_type = request.formats.first
       body = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
 
       render(status, content_type, body)

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -50,6 +50,8 @@ module ActionDispatch
         request.path_info = "/#{status}"
         response = @exceptions_app.call(request.env)
         response[1]["X-Cascade"] == "pass" ? pass_response(status) : response
+      rescue Mime::Type::InvalidMimeType => e
+        [406, { "Content-Type" => "text/plain" }, [e.message]]
       rescue Exception => failsafe_error
         $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
         FAILSAFE_RESPONSE

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -9,8 +9,6 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/not_found"
         raise AbstractController::ActionNotFound
-      when "/invalid_mimetype"
-        raise Mime::Type::InvalidMimeType
       when "/bad_params", "/bad_params.json"
         begin
           raise StandardError.new
@@ -67,7 +65,15 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
 
     get "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => true }
     assert_response 406
-    assert_equal "", body
+    assert_equal '"*" is not a valid MIME type', body
+  end
+
+  test "rescue Mime::Type::InvalidMimeType error when using a custom exception_app" do
+    @app = ActionDispatch::ShowExceptions.new(Boomer.new, ->(env) { ActionDispatch::Request.new(env).formats })
+
+    get "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => true }
+    assert_response 406
+    assert_equal '"*" is not a valid MIME type', body
   end
 
   test "localize rescue error page" do


### PR DESCRIPTION
Follow up to #35753 and rescue InvalidMimeType for all exception_app:

- Rescuing the InvalidMimeType error in the PublicException class
  wasn't a good idea because if an app has a custom exception_class
  it will cause the same issue.

  This PR move the rescue around calling the exception_app.

cc/ @rafaelfranca @byroot @jhawthorn 