### PR TITLE
Do db version check when checking out connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -852,7 +852,9 @@ module ActiveRecord
 
         def checkout_new_connection
           raise ConnectionNotEstablished unless @automatic_reconnect
-          new_connection
+          connection = new_connection
+          connection.check_version! unless connection.version_checked?
+          connection
         end
 
         def checkout_and_verify(c)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -133,8 +133,6 @@ module ActiveRecord
         @advisory_locks_enabled = self.class.type_cast_config_to_boolean(
           config.fetch(:advisory_locks, true)
         )
-
-        check_version
       end
 
       def replica?
@@ -575,9 +573,14 @@ module ActiveRecord
         "INSERT #{insert.into} #{insert.values_list}"
       end
 
+      def check_version!
+      end
+
+      def version_checked?
+        !!schema_cache.database_version_checked
+      end
+
       private
-        def check_version
-        end
 
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -526,12 +526,15 @@ module ActiveRecord
         sql
       end
 
-      private
-        def check_version
-          if version < "5.5.8"
-            raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.5.8."
-          end
+      def check_version!
+        if version < "5.5.8"
+          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.5.8."
+        else
+          schema_cache.database_version_checked = true
         end
+      end
+
+      private
 
         def initialize_type_map(m = type_map)
           super

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -446,12 +446,15 @@ module ActiveRecord
         sql
       end
 
-      private
-        def check_version
-          if postgresql_version < 90300
-            raise "Your version of PostgreSQL (#{postgresql_version}) is too old. Active Record supports PostgreSQL >= 9.3."
-          end
+      def check_version!
+        if postgresql_version < 90300
+          raise "Your version of PostgreSQL (#{postgresql_version}) is too old. Active Record supports PostgreSQL >= 9.3."
+        else
+          schema_cache.database_version_checked = true
         end
+      end
+
+      private
 
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     class SchemaCache
       attr_reader :version
-      attr_accessor :connection
+      attr_accessor :connection, :database_version_checked
 
       def initialize(conn)
         @connection = conn

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -397,17 +397,19 @@ module ActiveRecord
         sql
       end
 
+      def check_version!
+        if sqlite_version < "3.8.0"
+          raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."
+        else
+          schema_cache.database_version_checked = true
+        end
+      end
+
       private
         # See https://www.sqlite.org/limits.html,
         # the default value is 999 when not configured.
         def bind_params_length
           999
-        end
-
-        def check_version
-          if sqlite_version < "3.8.0"
-            raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."
-          end
         end
 
         def initialize_type_map(m = type_map)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -212,6 +212,18 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_check_version_updates_schema_cache
+    @conn.check_version!
+
+    assert @conn.schema_cache.database_version_checked
+  end
+
+  def test_check_version_raises_for_unsupported_versions
+    @conn.stub(:version, "1") do
+      assert_raises { @conn.check_version! }
+    end
+  end
+
   private
 
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -442,6 +442,18 @@ module ActiveRecord
         end
       end
 
+      def test_check_version_updates_schema_cache
+        @connection.check_version!
+
+        assert @connection.schema_cache.database_version_checked
+      end
+
+      def test_check_version_raises_for_unsupported_versions
+        @connection.stub(:postgresql_version, 1_000) do
+          assert_raises { @connection.check_version! }
+        end
+      end
+
       private
 
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -635,6 +635,18 @@ module ActiveRecord
         end
       end
 
+      def test_check_version_updates_schema_cache
+        @conn.check_version!
+
+        assert @conn.schema_cache.database_version_checked
+      end
+
+      def test_check_version_raises_for_unsupported_versions
+        @conn.stub(:sqlite_version, "1") do
+          assert_raises { @conn.check_version! }
+        end
+      end
+
       private
 
         def assert_logged(logs)


### PR DESCRIPTION
### Summary

In #34227, there was some discussion around moving the database version check closer to the schema cache object (https://github.com/rails/rails/pull/34227#issuecomment-430390447). I tried moving the check in this PR.

Instead of doing the check when establishing new connection objects, the check is done when we checkout the connection in the connection pool. We won't do a check if the check was previously done in the connection pool (verified via the schema cache).

/cc @tenderlove
