### PR TITLE
Add db:prepare rake task.

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -222,6 +222,14 @@ db_namespace = namespace :db do
   desc "Creates the database, loads the schema, and initializes with the seed data (use db:reset to also drop the database first)"
   task setup: ["db:schema:load_if_ruby", "db:structure:load_if_sql", :seed]
 
+  desc "Creates the database, loads the schema, run the migrations and initializes with the seed data (use db:reset to also drop the database first)"
+  task prepare: :load_config do
+    ActiveRecord::Base.connection
+    db_namespace["migrate"].invoke
+  rescue ActiveRecord::NoDatabaseError
+    db_namespace["setup"].invoke
+  end
+
   desc "Loads the seed data from db/seeds.rb"
   task seed: :load_config do
     db_namespace["abort_if_pending_migrations"].invoke

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -222,13 +222,16 @@ db_namespace = namespace :db do
   desc "Creates the database, loads the schema, and initializes with the seed data (use db:reset to also drop the database first)"
   task setup: ["db:schema:load_if_ruby", "db:structure:load_if_sql", :seed]
 
-  desc "Setup database if doesn’t exist already and run migrations"
+  desc "Runs setup if database does not exist, or runs migrations if it does"
   task prepare: :load_config do
-    ActiveRecord::Base.connection
-  rescue ActiveRecord::NoDatabaseError
-    db_namespace["setup"].invoke
-  else
-    db_namespace["migrate"].invoke
+    ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+      begin
+        ActiveRecord::Base.establish_connection(db_config.config)
+        db_namespace["migrate"].invoke
+      rescue ActiveRecord::NoDatabaseError
+        db_namespace["setup"].invoke
+      end
+    end
   end
 
   desc "Loads the seed data from db/seeds.rb"

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -222,7 +222,7 @@ db_namespace = namespace :db do
   desc "Creates the database, loads the schema, and initializes with the seed data (use db:reset to also drop the database first)"
   task setup: ["db:schema:load_if_ruby", "db:structure:load_if_sql", :seed]
 
-  desc "Creates the database, loads the schema, run the migrations and initializes with the seed data (use db:reset to also drop the database first)"
+  desc "Setup database if doesn’t exist already and run migrations"
   task prepare: :load_config do
     ActiveRecord::Base.connection
     db_namespace["migrate"].invoke

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -225,9 +225,10 @@ db_namespace = namespace :db do
   desc "Setup database if doesn’t exist already and run migrations"
   task prepare: :load_config do
     ActiveRecord::Base.connection
-    db_namespace["migrate"].invoke
   rescue ActiveRecord::NoDatabaseError
     db_namespace["setup"].invoke
+  else
+    db_namespace["migrate"].invoke
   end
 
   desc "Loads the seed data from db/seeds.rb"

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -225,12 +225,10 @@ db_namespace = namespace :db do
   desc "Runs setup if database does not exist, or runs migrations if it does"
   task prepare: :load_config do
     ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-      begin
-        ActiveRecord::Base.establish_connection(db_config.config)
-        db_namespace["migrate"].invoke
-      rescue ActiveRecord::NoDatabaseError
-        db_namespace["setup"].invoke
-      end
+      ActiveRecord::Base.establish_connection(db_config.config)
+      db_namespace["migrate"].invoke
+    rescue ActiveRecord::NoDatabaseError
+      db_namespace["setup"].invoke
     end
   end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -558,8 +558,15 @@ module ApplicationTests
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           output = rails("db:prepare")
-
           assert_match(/CreateBooks: migrated/, output)
+
+          output = rails("db:drop")
+          assert_match(/Dropped database/, output)
+
+          rails "generate", "model", "recipe", "title:string"
+          output = rails("db:prepare")
+          assert_match(/CreateBooks: migrated/, output)
+          assert_match(/CreateRecipes: migrated/, output)
         end
       end
     end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -553,6 +553,15 @@ module ApplicationTests
           end
         end
       end
+
+      test "db:prepare setup the database" do
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          output = rails("db:prepare")
+
+          assert_match /CreateBooks: migrated/, output
+        end
+      end
     end
   end
 end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -559,7 +559,7 @@ module ApplicationTests
           rails "generate", "model", "book", "title:string"
           output = rails("db:prepare")
 
-          assert_match /CreateBooks: migrated/, output
+          assert_match(/CreateBooks: migrated/, output)
         end
       end
     end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -190,7 +190,6 @@ module ApplicationTests
 
       test "db:create and db:drop works on all databases for env" do
         require "#{app_path}/config/environment"
-
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
           db_create_and_drop db_config.spec_name, db_config.config["database"]
         end


### PR DESCRIPTION
In favor of getting merging https://github.com/rails/rails/pull/33139#discussion_r195930751. I have implemented   `rake db:prepare` which creates the database, loads the schema, run the migrations and initializes with the seed data
(use db:reset to also drop the database first). This rake task runs in an idempotent way


cc @davidstosik @matthewd @guilleiguaran 