### PR TITLE
Hash / HashWithIndifferentAccess speed improvements

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -10,7 +10,7 @@ class Hash
   # This is useful for limiting a set of parameters to everything but a few known toggles:
   #   @person.update(params[:person].except(:admin))
   def except(*keys)
-    dup.except!(*keys)
+    slice(*self.keys - keys)
   end
 
   # Removes the given keys from hash and returns it.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -293,6 +293,9 @@ module ActiveSupport
       super(convert_key(key))
     end
 
+    def except(*keys)
+      slice(*self.keys - keys.map { |key| convert_key(key) })
+    end
     alias_method :without, :except
 
     def stringify_keys!; self end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -239,7 +239,7 @@ module ActiveSupport
     #   hash.fetch_values('a', 'c') { |key| 'z' } # => ["x", "z"]
     #   hash.fetch_values('a', 'c') # => KeyError: key not found: "c"
     def fetch_values(*indices, &block)
-      indices.collect { |key| fetch(key, &block) }
+      super(*indices.map { |key| convert_key(key) }, &block)
     end
 
     # Returns a shallow copy of the hash.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -225,8 +225,8 @@ module ActiveSupport
     #   hash[:a] = 'x'
     #   hash[:b] = 'y'
     #   hash.values_at('a', 'b') # => ["x", "y"]
-    def values_at(*indices)
-      indices.collect { |key| self[convert_key(key)] }
+    def values_at(*keys)
+      super(*keys.map { |key| convert_key(key) })
     end
 
     # Returns an array of the values at the specified indices, but also


### PR DESCRIPTION
### Summary

This changes improves the speed of `Hash#except`, `HashWithIndifferentAccess#except`, `HashWithIndifferentAccess#values_at` and `HashWithIndifferentAccess#fetch_values` by using ruby native methods.

### Benchmarks

```
Warming up --------------------------------------
     Hash new except   144.256k i/100ms
     Hash old except   104.493k i/100ms
Calculating -------------------------------------
     Hash new except      2.380M (± 1.6%) i/s -     11.973M in   5.032136s
     Hash old except      1.475M (± 2.1%) i/s -      7.419M in   5.031036s

Comparison:
     Hash new except:  2379993.2 i/s
     Hash old except:  1475361.3 i/s - 1.61x  slower
```
```
Warming up --------------------------------------
     HWIA new except    35.468k i/100ms
     HWIA old except    27.393k i/100ms
Calculating -------------------------------------
     HWIA new except    381.621k (± 3.1%) i/s -      1.915M in   5.024013s
     HWIA old except    298.944k (± 2.1%) i/s -      1.507M in   5.042050s

Comparison:
     HWIA new except:   381620.8 i/s
     HWIA old except:   298943.8 i/s - 1.28x  slower
```
```
Warming up --------------------------------------
   HWIA new value_at   105.698k i/100ms
   HWIA old value_at    85.136k i/100ms
Calculating -------------------------------------
   HWIA new value_at      1.448M (± 1.4%) i/s -      7.293M in   5.036060s
   HWIA old value_at      1.102M (± 1.7%) i/s -      5.534M in   5.023380s

Comparison:
   HWIA new value_at:  1448464.1 i/s
   HWIA old value_at:  1101935.4 i/s - 1.31x  slower
```
```
Warming up --------------------------------------
HWIA new fetch_values
                        95.077k i/100ms
HWIA old fetch_values
                        87.582k i/100ms
Calculating -------------------------------------
HWIA new fetch_values
                          1.446M (± 3.6%) i/s -      7.226M in   5.003683s
HWIA old fetch_values
                          1.070M (±13.6%) i/s -      5.255M in   5.025374s

Comparison:
HWIA new fetch_values:  1446069.4 i/s
HWIA old fetch_values:  1070392.3 i/s - 1.35x  slower
```
[Source](https://gist.github.com/timoschilling/368cf3c61bcb3d49ce8cd6b44384fd12)

```
Hash#except
New total allocated: 384 bytes (4 objects)
Old total allocated: 312 bytes (3 objects)

HashWithIndifferentAccess#except
New total allocated: 1240 bytes (11 objects)
Old total allocated: 1712 bytes (14 objects)

HashWithIndifferentAccess#values_at
New total allocated: 200 bytes (5 objects)
Old total allocated: 160 bytes (4 objects)

HashWithIndifferentAccess#fetch_values
New total allocated: 200 bytes (5 objects)
Old total allocated: 240 bytes (6 objects)
```