### PR TITLE
Subscribe only one time for subscriptions with the same identifier

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -362,7 +362,9 @@
       this.subscriptions.push(subscription);
       this.consumer.ensureActiveConnection();
       this.notify(subscription, "initialized");
-      this.sendCommand(subscription, "subscribe");
+      if (this.findAll(subscription.identifier).length === 1) {
+        this.sendCommand(subscription, "subscribe");
+      }
       return subscription;
     };
     Subscriptions.prototype.remove = function remove(subscription) {

--- a/actioncable/app/javascript/action_cable/subscriptions.js
+++ b/actioncable/app/javascript/action_cable/subscriptions.js
@@ -28,7 +28,9 @@ export default class Subscriptions {
     this.subscriptions.push(subscription)
     this.consumer.ensureActiveConnection()
     this.notify(subscription, "initialized")
-    this.sendCommand(subscription, "subscribe")
+    if (this.findAll(subscription.identifier).length === 1) {
+      this.sendCommand(subscription, "subscribe")
+    }
     return subscription
   }
 

--- a/actioncable/test/javascript/src/unit/subscriptions_test.js
+++ b/actioncable/test/javascript/src/unit/subscriptions_test.js
@@ -28,4 +28,44 @@ module("ActionCable.Subscriptions", () => {
 
     consumer.subscriptions.create(channel)
   })
+
+  consumerTest("subscribe only once when two subscriptions use the same channel", ({consumer, server, assert, done}) => {
+    const channel = "chat"
+    let messageReceived = 0
+    
+    server.on("message", (message) => {
+      messageReceived++
+      const data = JSON.parse(message)
+      assert.equal(data.identifier, JSON.stringify({channel}))
+
+      switch (messageReceived) {
+        case 1:
+          assert.equal(data.command, "subscribe")
+          break
+        case 2:
+          assert.equal(data.command, "message")
+          assert.deepEqual(data.data, JSON.stringify({action: { subscriptionNumber: 1 }}))
+          break
+        case 3:
+          assert.equal(data.command, "message")
+          assert.deepEqual(data.data, JSON.stringify({action: { subscriptionNumber: 2 }}))
+          done()
+          break
+      }
+    })
+
+    consumer.subscriptions.create(channel, {
+      connected() {
+        this.perform({subscriptionNumber: 1})
+      }
+    })
+
+    const subscription = consumer.subscriptions.create(channel, {
+      connected() {
+        this.perform({subscriptionNumber: 2})
+      }
+    })
+
+    server.broadcastTo(subscription, {message_type: "confirmation"})
+  })
 })


### PR DESCRIPTION
### Summary

When removing a subscription, the `"unsubscribe"` command is sent only if there are no more subscriptions with the same identifier. However, the `"subscribe"` command is sent each time we add a new subscription regardless of the identifier, resulting into warnings like `Already subscribed to {"channel": "..."}`.

Actioncable could send the `"subscribe"` command only once per channel identifier, and each subscriptions with the same identifier will still receive their callbacks.

### Other Information
N/A
