### PR TITLE
Remove :all symbol from Mime::ALL

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -315,7 +315,7 @@ module Mime
     include Singleton
 
     def initialize
-      super "*/*", :all
+      super "*/*", nil
     end
 
     def all?; true; end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -158,6 +158,12 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def handle_any_with_template
+    respond_to do |type|
+      type.any { render "test/hello_world" }
+    end
+  end
+
   def all_types_with_layout
     respond_to do |type|
       type.html
@@ -570,6 +576,13 @@ class RespondToControllerTest < ActionController::TestCase
     @request.accept = "application/json, application/xml, */*"
     get :json_xml_or_html
     assert_equal "HTML", @response.body
+  end
+
+  def test_handle_any_with_template
+    @request.accept = "*/*"
+
+    get :handle_any_with_template
+    assert_equal "Hello world!", @response.body
   end
 
   def test_html_type_with_layout


### PR DESCRIPTION
`Mime[:all]` doesn't work, and `.all` isn't a valid file extension (we wouldn't want a file named `welcome.all.erb`, and that wouldn't make sense), so it definitely shouldn't be used as the `#symbol` for `Mime::ALL`.

This also makes `Mime::ALL` better match how `*/*` is parsed from an Accept header (also without a symbol).

This fixes the issue reported by @Edouard-chin in https://github.com/rails/rails/pull/35661#commitcomment-32933775