### PR TITLE
Fix bug in Range comparisons when comparing to excluded-end Range

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix bug in Range comparisons when comparing to an excluded-end Range
+
+    Before:
+
+        (1..10).cover?(1...11) => false
+
+    After:
+
+        (1..10).cover?(1...11) => true
+
+    With the same change for `Range#include?` and `Range#===`.
+
+     *Owen Stephens*
+
 *   Use weak references in descendants tracker to allow anonymous subclasses to
     be garbage collected.
 

--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -3,9 +3,10 @@
 module ActiveSupport
   module CompareWithRange
     # Extends the default Range#=== to support range comparisons.
-    #  (1..5) === (1..5) # => true
-    #  (1..5) === (2..3) # => true
-    #  (1..5) === (2..6) # => false
+    #  (1..5) === (1..5)  # => true
+    #  (1..5) === (2..3)  # => true
+    #  (1..5) === (1...6) # => true
+    #  (1..5) === (2..6)  # => false
     #
     # The native Range#=== behavior is untouched.
     #  ('a'..'f') === ('c') # => true
@@ -13,17 +14,20 @@ module ActiveSupport
     def ===(value)
       if value.is_a?(::Range)
         # 1...10 includes 1..9 but it does not include 1..10.
+        # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        super(value.first) && value.last.send(operator, last)
+        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
+        super(value.first) && value_max.send(operator, last)
       else
         super
       end
     end
 
     # Extends the default Range#include? to support range comparisons.
-    #  (1..5).include?(1..5) # => true
-    #  (1..5).include?(2..3) # => true
-    #  (1..5).include?(2..6) # => false
+    #  (1..5).include?(1..5)  # => true
+    #  (1..5).include?(2..3)  # => true
+    #  (1..5).include?(1...6) # => true
+    #  (1..5).include?(2..6)  # => false
     #
     # The native Range#include? behavior is untouched.
     #  ('a'..'f').include?('c') # => true
@@ -31,17 +35,20 @@ module ActiveSupport
     def include?(value)
       if value.is_a?(::Range)
         # 1...10 includes 1..9 but it does not include 1..10.
+        # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        super(value.first) && value.last.send(operator, last)
+        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
+        super(value.first) && value_max.send(operator, last)
       else
         super
       end
     end
 
     # Extends the default Range#cover? to support range comparisons.
-    #  (1..5).cover?(1..5) # => true
-    #  (1..5).cover?(2..3) # => true
-    #  (1..5).cover?(2..6) # => false
+    #  (1..5).cover?(1..5)  # => true
+    #  (1..5).cover?(2..3)  # => true
+    #  (1..5).cover?(1...6) # => true
+    #  (1..5).cover?(2..6)  # => false
     #
     # The native Range#cover? behavior is untouched.
     #  ('a'..'f').cover?('c') # => true
@@ -49,8 +56,10 @@ module ActiveSupport
     def cover?(value)
       if value.is_a?(::Range)
         # 1...10 covers 1..9 but it does not cover 1..10.
+        # 1..10 covers 1...11 but it does not cover 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        super(value.first) && value.last.send(operator, last)
+        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
+        super(value.first) && value_max.send(operator, last)
       else
         super
       end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -57,7 +57,7 @@ class RangeTest < ActiveSupport::TestCase
   end
 
   def test_should_include_other_with_exclusive_end
-    assert((1..10).include?(1...10))
+    assert((1..10).include?(1...11))
   end
 
   def test_should_compare_identical_inclusive
@@ -69,7 +69,7 @@ class RangeTest < ActiveSupport::TestCase
   end
 
   def test_should_compare_other_with_exclusive_end
-    assert((1..10) === (1...10))
+    assert((1..10) === (1...11))
   end
 
   def test_exclusive_end_should_not_include_identical_with_inclusive_end
@@ -91,6 +91,10 @@ class RangeTest < ActiveSupport::TestCase
   def test_cover_is_not_override
     range = (1..3)
     assert range.method(:include?) != range.method(:cover?)
+  end
+
+  def test_should_cover_other_with_exclusive_end
+    assert((1..10).cover?(1...11))
   end
 
   def test_overlaps_on_time


### PR DESCRIPTION
### Summary

I noticed that the addition of support for Range arguments to `#cover?` and friends in #32938 didn't correctly handle exclude-end arguments:

Before:
```ruby
(1..10).cover?(1...11) => false
```

After:
```ruby
(1..10).cover?(1...11) => true
```

### Other Information

See https://git.io/fjTtz for the commit against Ruby core that added
support for Range arguments, with similar handling of this case.