### PR TITLE
Add `ActiveRecord::Relation#extract_associated` for extracting associated record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveRecord::Relation#extract_associated` for extracting associated records from a relation. 
+
+    ```
+    account.memberships.extract_associated(:user)
+    # => Returns collection of User records
+    ```
+
+    *DHH*
+
 *   Add `ActiveRecord::Relation#annotate` for adding SQL comments to its queries.
 
     For example:

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :destroy_all, :delete_all, :update_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
+      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,
       :pluck, :pick, :ids

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -154,10 +154,10 @@ module ActiveRecord
       self
     end
 
-    # Extracts a named +association+ from the relation. The named association is first preloaded, 
+    # Extracts a named +association+ from the relation. The named association is first preloaded,
     # then the individual association records are collected from the relation. Like so:
     #
-    #   account.memberships.extract_associated(:user) 
+    #   account.memberships.extract_associated(:user)
     #   # => Returns collection of User records
     #
     # This is short-hand for:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -154,6 +154,19 @@ module ActiveRecord
       self
     end
 
+    # Extracts a named +association+ from the relation. The named association is first preloaded, 
+    # then the individual association records are collected from the relation. Like so:
+    #
+    #   account.memberships.extract_associated(:user) 
+    #   # => Returns collection of User records
+    #
+    # This is short-hand for:
+    #
+    #   account.memberships.preload(:user).collect(&:user)
+    def extract_associated(association)
+      preload(association).collect(&association)
+    end
+
     # Use to indicate that the given +table_names+ are referenced by an SQL string,
     # and should therefore be JOINed in any query rather than loaded separately.
     # This method only works in conjunction with #includes.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -602,6 +602,11 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_extracted_association
+    authors = Post.all.extract_associated(:author)
+    assert_equal Post.all.collect(&:author), authors
+  end
+
   def test_find_with_included_associations
     assert_queries(2) do
       posts = Post.includes(:comments).order("posts.id")

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -603,8 +603,10 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_extracted_association
-    authors = assert_queries(2) { Post.all.extract_associated(:author) }
-    assert_equal Post.all.collect(&:author), authors
+    relation_authors = assert_queries(2) { Post.all.extract_associated(:author) }
+    root_authors = assert_queries(2) { Post.extract_associated(:author) }
+    assert_equal relation_authors, root_authors
+    assert_equal Post.all.collect(&:author), relation_authors
   end
 
   def test_find_with_included_associations

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -603,7 +603,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_extracted_association
-    authors = Post.all.extract_associated(:author)
+    authors = assert_queries(2) { Post.all.extract_associated(:author) }
     assert_equal Post.all.collect(&:author), authors
   end
 


### PR DESCRIPTION
It's sometimes more convenient to access a certain set of records by going through a scoped relation and its associations. It's easy enough to do this today using #preload and #collect, but it's repetitive and not descriptive of the intent.

This is where `#extract_associated` comes in. Like so: 

```
account.memberships.extract_associated(:user)
```

Which is short-hand for and describing the intent of:

```
account.memberships.preload(:user).collect(&:user)
```