### PR TITLE
Make SchemaCache loading faster

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make SchemaCache loading faster. This changes deprecate loading the SchemaCache from
+    a Psych dump as it's relatively slow. The SchemaCache dump is now serialized/deserialized
+    "manually".
+
+    *Edouard Chin*
+
 *   Fix circular `autosave: true` causes invalid records to be saved.
 
     Prior to the fix, when there was a circular series of `autosave: true`

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -62,6 +62,7 @@ module ActiveRecord
   autoload :Sanitization
   autoload :Schema
   autoload :SchemaDumper
+  autoload :SchemaCacheSerializer
   autoload :SchemaMigration
   autoload :Scoping
   autoload :Serialization

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1198,6 +1198,10 @@ module ActiveRecord
         SchemaDumper.create(self, options)
       end
 
+      def schema_cache_serializer
+        SchemaCacheSerializer.new(self)
+      end
+
       private
         def column_options_keys
           [:limit, :precision, :scale, :default, :null, :collation, :comment]

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1198,7 +1198,7 @@ module ActiveRecord
         SchemaDumper.create(self, options)
       end
 
-      def schema_cache_serializer
+      def schema_cache_serializer # :nodoc:
         SchemaCacheSerializer.new(self)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -770,6 +770,7 @@ module ActiveRecord
             each_hash(result)
           end
         end
+        public :column_definitions
 
         def create_table_info(table_name) # :nodoc:
           exec_query("SHOW CREATE TABLE #{quote_table_name(table_name)}", "SCHEMA").first["Create Table"]

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -532,6 +532,12 @@ module ActiveRecord
         end
       end
 
+      def index_definitions(table_name)
+        execute_and_free("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA") do |result|
+          each_hash(result)
+        end
+      end
+
       private
 
         def initialize_type_map(m = type_map)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -161,7 +161,7 @@ module ActiveRecord
             MySQL::TableDefinition.new(self, *args)
           end
 
-          def new_column_from_field(table_name, field)
+          def new_column_from_field(table_name, field) # :nodoc:
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
             default, default_function = field[:Default], nil
 
@@ -182,6 +182,7 @@ module ActiveRecord
               comment: field[:Comment].presence
             )
           end
+          public :new_column_from_field
 
           def fetch_type_metadata(sql_type, extra = "")
             MySQL::TypeMetadata.new(super(sql_type), extra: extra)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -6,47 +6,50 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
+          new_indexes_from_fields(index_definitions(table_name), table_name)
+        end
+
+        def new_indexes_from_fields(fields, _table)
           indexes = []
           current_index = nil
-          execute_and_free("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA") do |result|
-            each_hash(result) do |row|
-              if current_index != row[:Key_name]
-                next if row[:Key_name] == "PRIMARY" # skip the primary key
-                current_index = row[:Key_name]
 
-                mysql_index_type = row[:Index_type].downcase.to_sym
-                case mysql_index_type
-                when :fulltext, :spatial
-                  index_type = mysql_index_type
-                when :btree, :hash
-                  index_using = mysql_index_type
-                end
+          fields.each do |row|
+            if current_index != row[:Key_name]
+              next if row[:Key_name] == "PRIMARY" # skip the primary key
+              current_index = row[:Key_name]
 
-                indexes << [
-                  row[:Table],
-                  row[:Key_name],
-                  row[:Non_unique].to_i == 0,
-                  [],
-                  lengths: {},
-                  orders: {},
-                  type: index_type,
-                  using: index_using,
-                  comment: row[:Index_comment].presence
-                ]
+              mysql_index_type = row[:Index_type].downcase.to_sym
+              case mysql_index_type
+              when :fulltext, :spatial
+                index_type = mysql_index_type
+              when :btree, :hash
+                index_using = mysql_index_type
               end
 
-              if row[:Expression]
-                expression = row[:Expression]
-                expression = +"(#{expression})" unless expression.start_with?("(")
-                indexes.last[-2] << expression
-                indexes.last[-1][:expressions] ||= {}
-                indexes.last[-1][:expressions][expression] = expression
-                indexes.last[-1][:orders][expression] = :desc if row[:Collation] == "D"
-              else
-                indexes.last[-2] << row[:Column_name]
-                indexes.last[-1][:lengths][row[:Column_name]] = row[:Sub_part].to_i if row[:Sub_part]
-                indexes.last[-1][:orders][row[:Column_name]] = :desc if row[:Collation] == "D"
-              end
+              indexes << [
+                row[:Table],
+                row[:Key_name],
+                row[:Non_unique].to_i == 0,
+                [],
+                lengths: {},
+                orders: {},
+                type: index_type,
+                using: index_using,
+                comment: row[:Index_comment].presence
+              ]
+            end
+
+            if row[:Expression]
+              expression = row[:Expression]
+              expression = +"(#{expression})" unless expression.start_with?("(")
+              indexes.last[-2] << expression
+              indexes.last[-1][:expressions] ||= {}
+              indexes.last[-1][:expressions][expression] = expression
+              indexes.last[-1][:orders][expression] = :desc if row[:Collation] == "D"
+            else
+              indexes.last[-2] << row[:Column_name]
+              indexes.last[-1][:lengths][row[:Column_name]] = row[:Sub_part].to_i if row[:Sub_part]
+              indexes.last[-1][:orders][row[:Column_name]] = :desc if row[:Collation] == "D"
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -632,7 +632,7 @@ module ActiveRecord
             PostgreSQL::AlterTable.new create_table_definition(name)
           end
 
-          def new_column_from_field(table_name, field)
+          def new_column_from_field(table_name, field) # :nodoc:
             column_name, type, default, notnull, oid, fmod, collation, comment = field
             type_metadata = fetch_type_metadata(column_name, type, oid.to_i, fmod.to_i)
             default_value = extract_value_from_default(default)
@@ -653,6 +653,7 @@ module ActiveRecord
               serial: serial
             )
           end
+          public :new_column_from_field
 
           def fetch_type_metadata(column_name, sql_type, oid, fmod)
             cast_type = get_oid_type(oid, fmod, column_name, sql_type)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -820,7 +820,7 @@ module ActiveRecord
         # Query implementation notes:
         #  - format_type includes the column size constraint, e.g. varchar(50)
         #  - ::regclass is a function that gives the id for a table name
-        def column_definitions(table_name)
+        def column_definitions(table_name) # :nodoc:
           query(<<~SQL, "SCHEMA")
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                      pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
@@ -834,6 +834,7 @@ module ActiveRecord
                ORDER BY a.attnum
           SQL
         end
+        public :column_definitions
 
         def extract_table_ref_from_insert_sql(sql)
           sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -132,6 +132,15 @@ module ActiveRecord
         @indexes = @indexes || {}
       end
 
+      def load(cache)
+        @version = cache[:version]
+        @columns = cache[:columns]
+        @columns_hash = cache[:columns_hash]
+        @primary_keys = cache[:primary_keys]
+        @data_sources = cache[:data_sources]
+        @indexes = cache[:indexes]
+      end
+
       private
         def prepare_data_sources
           connection.data_sources.each { |source| @data_sources[source] = true }

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -6,9 +6,11 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
-          exec_query("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA").map do |row|
-            # Indexes SQLite creates implicitly for internal use start with "sqlite_".
-            # See https://www.sqlite.org/fileformat2.html#intschema
+          new_indexes_from_fields(index_definitions(table_name), table_name)
+        end
+
+        def new_indexes_from_fields(fields, table_name)
+          fields.map do |row|
             next if row["name"].starts_with?("sqlite_")
 
             index_sql = query_value(<<~SQL, "SCHEMA")

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -93,7 +93,7 @@ module ActiveRecord
             SQLite3::TableDefinition.new(self, *args)
           end
 
-          def new_column_from_field(table_name, field)
+          def new_column_from_field(table_name, field) # :nodoc:
             default = \
               case field["dflt_value"]
               when /^null$/i
@@ -109,6 +109,7 @@ module ActiveRecord
             type_metadata = fetch_type_metadata(field["type"])
             Column.new(field["name"], default, type_metadata, field["notnull"].to_i == 0, collation: field["collation"])
           end
+          public :new_column_from_field
 
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -423,12 +423,13 @@ module ActiveRecord
           register_class_with_limit m, %r(int)i, SQLite3Integer
         end
 
-        def table_structure(table_name)
+        def table_structure(table_name) # :nodoc:
           structure = exec_query("PRAGMA table_info(#{quote_table_name(table_name)})", "SCHEMA")
           raise(ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'") if structure.empty?
           table_structure_with_collation(table_name, structure)
         end
         alias column_definitions table_structure
+        public :column_definitions
 
         # See: https://www.sqlite.org/lang_altertable.html
         # SQLite has an additional restriction on the ALTER TABLE statement

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -407,6 +407,10 @@ module ActiveRecord
         end
       end
 
+      def index_definitions(table_name)
+        exec_query("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA")
+      end
+
       private
         # See https://www.sqlite.org/limits.html,
         # the default value is 999 when not configured.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
     config.active_record.sqlite3.represent_boolean_as_integer = nil
 
-    config.active_record.schema_cache_tables_to_skip = []
+    config.active_record.table_to_ignore_on_schema_cache = []
 
     config.eager_load_namespaces << ActiveRecord
 
@@ -123,11 +123,11 @@ end_error
       end
     end
 
-    initializer "active_record.schema_cache_serializer_tables_to_skip" do
-      tables_to_skip = config.active_record.delete(:schema_cache_tables_to_skip)
+    initializer "active_record.schema_cache_serializer_tables_to_ignore" do
+      tables_to_ignore = config.active_record.delete(:table_to_ignore_on_schema_cache)
 
       ActiveSupport.on_load(:active_record) do
-        SchemaCacheSerializer.tables_to_skip.concat(tables_to_skip)
+        SchemaCacheSerializer.tables_to_ignore.concat(tables_to_ignore)
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -136,20 +136,9 @@ end_error
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
             filename = File.join(app.config.paths["db"].first, "schema_cache.yml")
+            current_version = ActiveRecord::Migrator.current_version
 
-            if File.file?(filename)
-              current_version = ActiveRecord::Migrator.current_version
-
-              next if current_version.nil?
-
-              cache = YAML.load(File.read(filename))
-              if cache.version == current_version
-                connection.schema_cache = cache
-                connection_pool.schema_cache = cache.dup
-              else
-                warn "Ignoring db/schema_cache.yml because it has expired. The current schema version is #{current_version}, but the one in the cache is #{cache.version}."
-              end
-            end
+            Tasks::DatabaseTasks.load_schema_cache(connection, filename, current_version)
           end
         end
       end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -31,6 +31,8 @@ module ActiveRecord
     config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
     config.active_record.sqlite3.represent_boolean_as_integer = nil
 
+    config.active_record.schema_cache_tables_to_skip = []
+
     config.eager_load_namespaces << ActiveRecord
 
     rake_tasks do
@@ -118,6 +120,14 @@ end_error
             end
           end
         end
+      end
+    end
+
+    initializer "active_record.schema_cache_serializer_tables_to_skip" do
+      tables_to_skip = config.active_record.delete(:schema_cache_tables_to_skip)
+
+      ActiveSupport.on_load(:active_record) do
+        SchemaCacheSerializer.tables_to_skip.concat(tables_to_skip)
       end
     end
 

--- a/activerecord/lib/active_record/schema_cache_serializer.rb
+++ b/activerecord/lib/active_record/schema_cache_serializer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class SchemaCacheSerializer # :nodoc:
+    cattr_accessor :tables_to_skip, default: ["ar_internal_metadata"], instance_writer: false
+
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def serialize
+      serialized_schema = { columns: {}, data_sources: {}, primary_keys: {}, indexes: {} }
+      @connection.schema_cache.clear!
+
+      @connection.data_sources.each do |table|
+        next if tables_to_skip.include?(table)
+
+        serialized_schema[:columns][table] = @connection.send(:column_definitions, table).to_a
+        serialized_schema[:indexes][table] = @connection.send(:index_definitions, table).to_a
+        serialized_schema[:data_sources][table] = true
+        serialized_schema[:primary_keys][table] = @connection.primary_key(table)
+      end
+      serialized_schema[:version] = @connection.migration_context.current_version
+
+      serialized_schema
+    end
+
+    def deserialize(schema_cache_file)
+      return unless File.exist?(schema_cache_file)
+
+      cache = YAML.load_file(schema_cache_file)
+
+      if cache.is_a?(ActiveRecord::ConnectionAdapters::SchemaCache)
+        cache
+      elsif cache.is_a?(Hash)
+        columns, columns_hash = deserialize_columns(cache[:columns])
+
+        {
+          version: cache[:version],
+          primary_keys: cache[:primary_keys],
+          data_sources: cache[:data_sources],
+          indexes: deserialize_indexes(cache[:indexes]),
+          columns: columns,
+          columns_hash: columns_hash
+        }
+      end
+    end
+
+    private
+      def deserialize_columns(serialized_schema)
+        columns = {}
+        columns_hash = {}
+
+        serialized_schema.each do |table, serialized_columns|
+          columns[table] = serialized_columns.map do |sc|
+            @connection.send(:new_column_from_field, table, sc)
+          end
+
+          columns_hash[table] = Hash[columns[table].map { |col| [col.name, col] } ]
+        end
+
+        [columns, columns_hash]
+      end
+
+      def deserialize_indexes(serialized_schema)
+        indexes = {}
+
+        serialized_schema.each do |table, serialized_indexes|
+          indexes[table] = @connection.send(:new_indexes_from_fields, serialized_indexes, table)
+        end
+
+        indexes
+      end
+  end
+end

--- a/activerecord/test/cases/schema_cache_serializer_test.rb
+++ b/activerecord/test/cases/schema_cache_serializer_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "fileutils"
+
+class SchemaCacheSerializerTest < ActiveRecord::TestCase
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @schema_cache_serializer = ActiveRecord::SchemaCacheSerializer.new(@connection)
+    @previous_schema_cache = @connection.schema_cache.dup
+  end
+
+  teardown do
+    @connection.schema_cache = @previous_schema_cache
+  end
+
+  test "#serialize the schema_cache contain all columns" do
+    serialized_schema = @schema_cache_serializer.serialize
+
+    assert serialized_schema[:columns]["accounts"]
+    assert serialized_schema[:columns]["admin_accounts"]
+  end
+
+  test "#serialize the schema_cache contain all indexes" do
+    serialized_schema = @schema_cache_serializer.serialize
+
+    assert serialized_schema[:indexes]["accounts"]
+    assert serialized_schema[:indexes]["admin_accounts"]
+  end
+
+  test "#serialize the schema_cache contain all data_sources" do
+    serialized_schema = @schema_cache_serializer.serialize
+
+    assert serialized_schema[:data_sources]["accounts"]
+    assert serialized_schema[:data_sources]["admin_accounts"]
+  end
+
+  test "#serialize the schema_cache contain all primary_keys" do
+    serialized_schema = @schema_cache_serializer.serialize
+
+    assert serialized_schema[:primary_keys]["accounts"]
+    assert serialized_schema[:primary_keys]["admin_accounts"]
+  end
+
+  test "#serialize does not dump the `tables_to_skip` in the cache" do
+    previous_tables_to_skip = @schema_cache_serializer.tables_to_skip.dup
+    @schema_cache_serializer.class.tables_to_skip << "accounts"
+    @schema_cache_serializer.class.tables_to_skip << "admin_accounts"
+
+    serialized_schema = @schema_cache_serializer.serialize
+
+    assert_not serialized_schema[:primary_keys]["accounts"]
+    assert_not serialized_schema[:primary_keys]["admin_accounts"]
+  ensure
+    @schema_cache_serializer.class.tables_to_skip = previous_tables_to_skip
+  end
+
+  test "#deserialize works when using a SchemaCache dumped with Psych" do
+    assert_nothing_raised do
+      @schema_cache_serializer.deserialize("test/assets/schema_dump_5_1.yml")
+    end
+  end
+
+  test "#deserialize adds `columns_hash`" do
+    filepath = "/tmp/my_schema_cache.yml"
+    File.write(filepath, YAML.dump(@schema_cache_serializer.serialize))
+
+    schema_cache = @schema_cache_serializer.deserialize(filepath)
+
+    assert schema_cache[:columns_hash]["accounts"]
+    assert schema_cache[:columns_hash]["admin_accounts"]
+  ensure
+    FileUtils.rm(filepath)
+  end
+
+  test "#deserialize returns prematurely when file does not exists" do
+    assert_nil @schema_cache_serializer.deserialize("/path/to/unexisting_file.yml")
+  end
+
+  test "round trip serialization/deserialization" do
+    fill_schema_cache("admin_users")
+    column_witness = @connection.schema_cache.columns("admin_users")
+    index_witness = @connection.schema_cache.indexes("admin_users").first
+
+    filepath = "/tmp/my_schema_cache.yml"
+    File.write(filepath, YAML.dump(@schema_cache_serializer.serialize))
+
+    schema_cache = @schema_cache_serializer.deserialize(filepath)
+
+    assert_equal column_witness, schema_cache[:columns]["admin_users"]
+    index = schema_cache[:indexes]["admin_users"].first
+    assert_equal index_witness.name, index.name
+    assert_equal index_witness.columns, index.columns
+    assert_equal index_witness.using, index.using
+  ensure
+    FileUtils.rm(filepath)
+  end
+
+  private
+    def fill_schema_cache(*tables)
+      tables.each { |table| @previous_schema_cache.add(table) }
+    end
+end

--- a/activerecord/test/cases/schema_cache_serializer_test.rb
+++ b/activerecord/test/cases/schema_cache_serializer_test.rb
@@ -42,17 +42,17 @@ class SchemaCacheSerializerTest < ActiveRecord::TestCase
     assert serialized_schema[:primary_keys]["admin_accounts"]
   end
 
-  test "#serialize does not dump the `tables_to_skip` in the cache" do
-    previous_tables_to_skip = @schema_cache_serializer.tables_to_skip.dup
-    @schema_cache_serializer.class.tables_to_skip << "accounts"
-    @schema_cache_serializer.class.tables_to_skip << "admin_accounts"
+  test "#serialize does not dump the `tables_to_ignore` in the cache" do
+    previous_tables_to_ignore = @schema_cache_serializer.tables_to_ignore.dup
+    @schema_cache_serializer.class.tables_to_ignore << "accounts"
+    @schema_cache_serializer.class.tables_to_ignore << "admin_accounts"
 
     serialized_schema = @schema_cache_serializer.serialize
 
     assert_not serialized_schema[:primary_keys]["accounts"]
     assert_not serialized_schema[:primary_keys]["admin_accounts"]
   ensure
-    @schema_cache_serializer.class.tables_to_skip = previous_tables_to_skip
+    @schema_cache_serializer.class.tables_to_ignore = previous_tables_to_ignore
   end
 
   test "#deserialize works when using a SchemaCache dumped with Psych" do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -381,6 +381,11 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
+* `config.active_record.schema_cache_tables_to_skip` allows to filter out tables that shouldn't
+  be part of the dumped schema cache. This is useful if you have tables that are for exemple
+  used to keep track of schema changes (like the internal `ar_internal_metadata` but it could be other
+  tables if you use LHMS for instance).
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -381,7 +381,7 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
-* `config.active_record.schema_cache_tables_to_skip` allows to filter out tables that shouldn't
+* `config.active_record.table_to_ignore_on_schema_cache` allows to filter out tables that shouldn't
   be part of the dumped schema cache. This is useful if you have tables that are for exemple
   used to keep track of schema changes (like the internal `ar_internal_metadata` but it could be other
   tables if you use LHMS for instance).


### PR DESCRIPTION
Make SchemaCache loading faster:

- A benchmark of the time it takes to load the schema cache will give
  you a first overview of what this PR is about:

  ```
  Warming up --------------------------------------
               Before     1.000  i/100ms
               Now        1.000  i/100ms
  Calculating -------------------------------------
               Before     0.872  (± 0.0%) i/s -      9.000  in  10.381223s
               Now        7.209  (±13.9%) i/s -     70.000  in  10.067905s
  ```
  This benchmark was done on a SchemaCache that contained 428 tables
  and more than 5k columns.

  I first dug into SchemaCache in our application has we were dumping
  the Schema and loading it manually. It felt weird and I decided to
  get rid of that code in order to dump it like like Rails does,
  with Psych.
  By curiosity I benchmarked and realized that our implementation was
  8 times faster.

  I'm not familiar enough with Psych to understand why it was so much
  slower, but after some exploration in a stackprof dump it seemed
  obvious that the times was majoritaly spent allocating objects and
  parsing node/tree.

  This implementation serializes the SchemaCache with the raw data we
  get from the 'SHOW FULL FIELDS' query.
  A new  SchemaCacheSerializer then iterate over the YAML and recreate the Column
  and IndexDefinition object one by one.

  The dumped schema cache YAML will look like this
<details>
<summary> Please expand </summary>

```yml
:columns:
  achievements:
  - :Field: id
    :Type: bigint(20)
    :Collation: 
    :Null: 'NO'
    :Key: PRI
    :Default: 
    :Extra: auto_increment
    :Privileges: select,insert,update,references
    :Comment: ''
:indexes:
  achievements:
  - :Table: achievements
    :Non_unique: 0
    :Key_name: PRIMARY
    :Seq_in_index: 1
    :Column_name: id
    :Collation: A
    :Cardinality: 0
    :Sub_part: 
    :Packed: 
    :Null: ''
    :Index_type: BTREE
    :Comment: ''
    :Index_comment: ''
:data_sources:
  achievements: true
:primary_keys:
  achievements: id
:version: 201901221501932  
```
</details>

  The SchemaCacheSerializer also has an option to skip tables that you
  don't want to include in the dump. It's useful if for instance you
  have tables that are related to schema change (like the internal
  ar_internal_metadata, but also others if you use LHMs).

  The Serializer support SchemaCache dumped with Psych, however it's
  deprecated and should be remove in the next version of Rails.

  In order to achieve this I had to extract code related to building indexes into their own methods.
  It created big chunks that I grouped into a commit to make things easier for review.


@rafaelfranca @kaspth  cc/ @byroot (I was thinking about adding the coder plug in a latter PR, but maybe I should do it here directly?)