### PR TITLE
Rename `i18n_full_message` config option to `i18n_customize_full_message`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -130,7 +130,7 @@
 
     *Unathi Chonco*
 
-*   Add `config.active_model.i18n_full_message` in order to control whether
+*   Add `config.active_model.i18n_customize_full_message` in order to control whether
     the `full_message` error format can be overridden at the attribute or model
     level in the locale files. This is `false` by default.
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -63,9 +63,9 @@ module ActiveModel
     MESSAGE_OPTIONS = [:message]
 
     class << self
-      attr_accessor :i18n_full_message # :nodoc:
+      attr_accessor :i18n_customize_full_message # :nodoc:
     end
-    self.i18n_full_message = false
+    self.i18n_customize_full_message = false
 
     attr_reader :messages, :details
 
@@ -413,7 +413,7 @@ module ActiveModel
       return message if attribute == :base
       attribute = attribute.to_s
 
-      if self.class.i18n_full_message && @base.class.respond_to?(:i18n_scope)
+      if self.class.i18n_customize_full_message && @base.class.respond_to?(:i18n_scope)
         attribute = attribute.remove(/\[\d\]/)
         parts = attribute.split(".")
         attribute_name = parts.pop

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -13,8 +13,8 @@ module ActiveModel
       ActiveModel::SecurePassword.min_cost = Rails.env.test?
     end
 
-    initializer "active_model.i18n_full_message" do
-      ActiveModel::Errors.i18n_full_message = config.active_model.delete(:i18n_full_message) || false
+    initializer "active_model.i18n_customize_full_message" do
+      ActiveModel::Errors.i18n_customize_full_message = config.active_model.delete(:i18n_customize_full_message) || false
     end
   end
 end

--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -35,20 +35,20 @@ class RailtieTest < ActiveModel::TestCase
   test "i18n full message defaults to false" do
     @app.initialize!
 
-    assert_equal false, ActiveModel::Errors.i18n_full_message
+    assert_equal false, ActiveModel::Errors.i18n_customize_full_message
   end
 
   test "i18n full message can be disabled" do
-    @app.config.active_model.i18n_full_message = false
+    @app.config.active_model.i18n_customize_full_message = false
     @app.initialize!
 
-    assert_equal false, ActiveModel::Errors.i18n_full_message
+    assert_equal false, ActiveModel::Errors.i18n_customize_full_message
   end
 
   test "i18n full message can be enabled" do
-    @app.config.active_model.i18n_full_message = true
+    @app.config.active_model.i18n_customize_full_message = true
     @app.initialize!
 
-    assert_equal true, ActiveModel::Errors.i18n_full_message
+    assert_equal true, ActiveModel::Errors.i18n_customize_full_message
   end
 end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -13,8 +13,8 @@ class I18nValidationTest < ActiveModel::TestCase
     I18n.backend = I18n::Backend::Simple.new
     I18n.backend.store_translations("en", errors: { messages: { custom: nil } })
 
-    @original_i18n_full_message = ActiveModel::Errors.i18n_full_message
-    ActiveModel::Errors.i18n_full_message = true
+    @original_i18n_customize_full_message = ActiveModel::Errors.i18n_customize_full_message
+    ActiveModel::Errors.i18n_customize_full_message = true
   end
 
   def teardown
@@ -22,7 +22,7 @@ class I18nValidationTest < ActiveModel::TestCase
     I18n.load_path.replace @old_load_path
     I18n.backend = @old_backend
     I18n.backend.reload!
-    ActiveModel::Errors.i18n_full_message = @original_i18n_full_message
+    ActiveModel::Errors.i18n_customize_full_message = @original_i18n_customize_full_message
   end
 
   def test_full_message_encoding
@@ -47,7 +47,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_doesnt_use_attribute_format_without_config
-    ActiveModel::Errors.i18n_full_message = false
+    ActiveModel::Errors.i18n_customize_full_message = false
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { person: { attributes: { name: { format: "%{message}" } } } } } })
@@ -58,7 +58,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_uses_attribute_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { person: { attributes: { name: { format: "%{message}" } } } } } })
@@ -69,7 +69,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_uses_model_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { person: { format: "%{message}" } } } })
@@ -80,7 +80,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_uses_deeply_nested_model_attributes_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
@@ -91,7 +91,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_uses_deeply_nested_model_model_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { 'person/contacts/addresses': { format: "%{message}" } } } })
@@ -102,7 +102,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_attributes_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
@@ -113,7 +113,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_model_format
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { 'person/contacts/addresses': { format: "%{message}" } } } })
@@ -124,7 +124,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_with_indexed_deeply_nested_attributes_and_i18n_attribute_name
-    ActiveModel::Errors.i18n_full_message = true
+    ActiveModel::Errors.i18n_customize_full_message = true
 
     I18n.backend.store_translations("en", activemodel: {
       attributes: { 'person/contacts/addresses': { country: "Country" } }
@@ -136,7 +136,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_with_indexed_deeply_nested_attributes_without_i18n_config
-    ActiveModel::Errors.i18n_full_message = false
+    ActiveModel::Errors.i18n_customize_full_message = false
 
     I18n.backend.store_translations("en", activemodel: {
       errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
@@ -147,7 +147,7 @@ class I18nValidationTest < ActiveModel::TestCase
   end
 
   def test_errors_full_messages_with_i18n_attribute_name_without_i18n_config
-    ActiveModel::Errors.i18n_full_message = false
+    ActiveModel::Errors.i18n_customize_full_message = false
 
     I18n.backend.store_translations("en", activemodel: {
       attributes: { 'person/contacts[0]/addresses[0]': { country: "Country" } }

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -310,7 +310,7 @@ All these configuration options are delegated to the `I18n` library.
 
 ### Configuring Active Model
 
-* `config.active_model.i18n_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files. This is `false` by default.
+* `config.active_model.i18n_customize_full_message` is a boolean value which controls whether the `full_message` error format can be overridden at the attribute or model level in the locale files. This is `false` by default.
 
 ### Configuring Active Record
 


### PR DESCRIPTION
- I feel `i18n_customize_full_messages` explains the meaning of the
  config better.
- Followup of https://github.com/rails/rails/pull/32956
