### PR TITLE
Updated the test description for i18n-customize-full-message after rename in #35789

### DIFF
--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -32,20 +32,20 @@ class RailtieTest < ActiveModel::TestCase
     assert_equal true, ActiveModel::SecurePassword.min_cost
   end
 
-  test "i18n full message defaults to false" do
+  test "i18n customize full message defaults to false" do
     @app.initialize!
 
     assert_equal false, ActiveModel::Errors.i18n_customize_full_message
   end
 
-  test "i18n full message can be disabled" do
+  test "i18n customize full message can be disabled" do
     @app.config.active_model.i18n_customize_full_message = false
     @app.initialize!
 
     assert_equal false, ActiveModel::Errors.i18n_customize_full_message
   end
 
-  test "i18n full message can be enabled" do
+  test "i18n customize full message can be enabled" do
     @app.config.active_model.i18n_customize_full_message = true
     @app.initialize!
 


### PR DESCRIPTION
Updated the test description for `i18n-customize-full-message` option after it was renamed in PR #35789. 