### PR TITLE
Deprecate render layout with an absolute path

### DIFF
--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -84,6 +84,7 @@ module ActionView
         when String
           begin
             if layout.start_with?("/")
+              ActiveSupport::Deprecation.warn "Rendering layouts from an absolute path is deprecated."
               @lookup_context.with_fallbacks.find_template(layout, nil, false, [], details)
             else
               @lookup_context.find_template(layout, nil, false, [], details)

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -233,7 +233,9 @@ class LayoutSetInResponseTest < ActionController::TestCase
 
   def test_absolute_pathed_layout
     @controller = AbsolutePathLayoutController.new
-    get :hello
+    assert_deprecated do
+      get :hello
+    end
     assert_equal "layout_test.erb hello.erb", @response.body.strip
   end
 end


### PR DESCRIPTION
This has similar problems as render file:.

I've never seen this used, and believe it's a relic from when all templates could be rendered from an absolute path.

This and either #35688 or #35791 will let us fully deprecate `LookupContext#with_fallbacks`, and allow us to remove this code path in the template resolver 🎉.