### PR TITLE
[ci skip] Updated docs to reflect index: true option not available as column modifier

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -465,7 +465,6 @@ number of digits after the decimal point.
 * `default`      Allows to set a default value on the column. Note that if you
 are using a dynamic value (such as a date), the default will only be calculated
 the first time (i.e. on the date the migration is applied).
-* `index`        Adds an index for the column.
 * `comment`      Adds a comment for the column.
 
 Some adapters may support additional options; see the adapter specific API docs


### PR DESCRIPTION
fixes #35752 

As discussed in the issue, guides needed to be updated to shows that `index: true` is not a correct option. 
