### PR TITLE
[ci skip] Add ActiveRecord::Relation#extract_associated method to the active_record_querying.md

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -65,6 +65,7 @@ The methods are:
 * `distinct`
 * `eager_load`
 * `extending`
+* `extract_associated`
 * `from`
 * `group`
 * `having`


### PR DESCRIPTION
`ActiveRecord::Relation#extract_associated` method was added in #35784. All the querying methods are listed in the `active_record_querying.md` guide so raised a PR to add the method in the list.