### PR TITLE
Add attachment and attachments field generators

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
@@ -6,6 +6,12 @@ class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:rich_text?).each do |attribute| -%>
   has_rich_text :<%= attribute.name %>
 <% end -%>
+<% attributes.select(&:attachment?).each do |attribute| -%>
+  has_one_attached :<%= attribute.name %>
+<% end -%>
+<% attributes.select(&:attachments?).each do |attribute| -%>
+  has_many_attached :<%= attribute.name %>
+<% end -%>
 <% attributes.select(&:token?).each do |attribute| -%>
   has_secure_token<% if attribute.name != "token" %> :<%= attribute.name %><% end %>
 <% end -%>

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -21,6 +21,9 @@
   <div class="field">
     <%%= form.label :password_confirmation %>
     <%%= form.password_field :password_confirmation %>
+<% elsif attribute.attachments? -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
@@ -3,7 +3,15 @@
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
 <p>
   <strong><%= attribute.human_name %>:</strong>
+<% if attribute.attachment? -%>
+  <%%= link_to @<%= singular_table_name %>.<%= attribute.column_name %>.filename, @<%= singular_table_name %>.<%= attribute.column_name %> %>
+<% elsif attribute.attachments? -%>
+  <%% @<%= singular_table_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
+    <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
+  <%% end %>
+<% else -%>
   <%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>
+<% end -%>
 </p>
 
 <% end -%>

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -68,14 +68,15 @@ module Rails
 
       def field_type
         @field_type ||= case type
-                        when :integer              then :number_field
-                        when :float, :decimal      then :text_field
-                        when :time                 then :time_select
-                        when :datetime, :timestamp then :datetime_select
-                        when :date                 then :date_select
-                        when :text                 then :text_area
-                        when :rich_text            then :rich_text_area
-                        when :boolean              then :check_box
+                        when :integer                  then :number_field
+                        when :float, :decimal          then :text_field
+                        when :time                     then :time_select
+                        when :datetime, :timestamp     then :datetime_select
+                        when :date                     then :date_select
+                        when :text                     then :text_area
+                        when :rich_text                then :rich_text_area
+                        when :boolean                  then :check_box
+                        when :attachment, :attachments then :file_field
                         else
                           :text_field
         end
@@ -83,15 +84,17 @@ module Rails
 
       def default
         @default ||= case type
-                     when :integer                             then 1
-                     when :float                               then 1.5
-                     when :decimal                             then "9.99"
-                     when :datetime, :timestamp, :time         then Time.now.to_s(:db)
-                     when :date                                then Date.today.to_s(:db)
-                     when :string                              then name == "type" ? "" : "MyString"
-                     when :text                                then "MyText"
-                     when :boolean                             then false
-                     when :references, :belongs_to, :rich_text then nil
+                     when :integer                     then 1
+                     when :float                       then 1.5
+                     when :decimal                     then "9.99"
+                     when :datetime, :timestamp, :time then Time.now.to_s(:db)
+                     when :date                        then Date.today.to_s(:db)
+                     when :string                      then name == "type" ? "" : "MyString"
+                     when :text                        then "MyText"
+                     when :boolean                     then false
+                     when :references, :belongs_to,
+                          :attachment, :attachments,
+                          :rich_text                   then nil
                      else
                        ""
         end
@@ -157,8 +160,16 @@ module Rails
         type == :rich_text
       end
 
+      def attachment?
+        type == :attachment
+      end
+
+      def attachments?
+        type == :attachments
+      end
+
       def virtual?
-        rich_text?
+        rich_text? || attachment? || attachments?
       end
 
       def inject_options

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -187,6 +187,7 @@ module Rails
 
         def attributes_names # :doc:
           @attributes_names ||= attributes.each_with_object([]) do |a, names|
+            next if a.attachments?
             names << a.column_name
             names << "password_confirmation" if a.password_digest?
             names << "#{a.name}_type" if a.polymorphic?

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -32,6 +32,14 @@ module Rails
       hook_for :helper, as: :scaffold do |invoked|
         invoke invoked, [ controller_name ]
       end
+
+      private
+
+        def permitted_params
+          params = attributes_names.map { |name| ":#{name}" }.join(", ")
+          params += attributes.select(&:attachments?).map { |a| ", #{a.name}: []" }.join
+          params
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -54,7 +54,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
-      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
       <%- end -%>
     end
 end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -61,7 +61,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
-      params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      params.require(:<%= singular_table_name %>).permit(<%= permitted_params %>)
       <%- end -%>
     end
 end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -42,6 +42,12 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_field_type :rich_text, :rich_text_area
   end
 
+  def test_field_type_returns_file_field
+    %w(attachment attachments).each do |attribute_type|
+      assert_field_type attribute_type, :file_field
+    end
+  end
+
   def test_field_type_with_unknown_type_returns_text_field
     %w(foo bar baz).each do |attribute_type|
       assert_field_type attribute_type, :text_field
@@ -88,7 +94,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   end
 
   def test_default_value_is_nil
-    %w(references belongs_to rich_text).each do |attribute_type|
+    %w(references belongs_to rich_text attachment attachments).each do |attribute_type|
       assert_field_default_value attribute_type, nil
     end
   end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -368,32 +368,38 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_add_migration_ignores_virtual_attributes
     migration = "add_rich_text_content_to_messages"
-    run_generator [migration, "content:rich_text"]
+    run_generator [migration, "content:rich_text", "video:attachment", "photos:attachments"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_no_match(/add_column :messages, :content, :rich_text/, change)
+        assert_no_match(/add_column :messages, :video, :attachment/, change)
+        assert_no_match(/add_column :messages, :photos, :attachments/, change)
       end
     end
   end
 
   def test_create_table_migration_ignores_virtual_attributes
-    run_generator ["create_messages", "content:rich_text"]
+    run_generator ["create_messages", "content:rich_text", "video:attachment", "photos:attachments"]
     assert_migration "db/migrate/create_messages.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/create_table :messages/, change)
         assert_no_match(/  t\.rich_text :content/, change)
+        assert_no_match(/  t\.attachment :video/, change)
+        assert_no_match(/  t\.attachments :photos/, change)
       end
     end
   end
 
   def test_remove_migration_with_virtual_attributes
     migration = "remove_content_from_messages"
-    run_generator [migration, "content:rich_text"]
+    run_generator [migration, "content:rich_text", "video:attachment", "photos:attachments"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_no_match(/remove_column :messages, :content, :rich_text/, change)
+        assert_no_match(/remove_column :messages, :video, :attachment/, change)
+        assert_no_match(/remove_column :messages, :photos, :attachments/, change)
       end
     end
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -509,8 +509,28 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/message.rb", expected_file
   end
 
+  def test_model_with_attachment_attribute_adds_has_one_attached
+    run_generator ["message", "video:attachment"]
+    expected_file = <<~FILE
+      class Message < ApplicationRecord
+        has_one_attached :video
+      end
+    FILE
+    assert_file "app/models/message.rb", expected_file
+  end
+
+  def test_model_with_attachments_attribute_adds_has_many_attached
+    run_generator ["message", "photos:attachments"]
+    expected_file = <<~FILE
+      class Message < ApplicationRecord
+        has_many_attached :photos
+      end
+    FILE
+    assert_file "app/models/message.rb", expected_file
+  end
+
   def test_skip_virtual_fields_in_fixtures
-    run_generator ["message", "content:rich_text"]
+    run_generator ["message", "content:rich_text", "video:attachment", "photos:attachments"]
 
     assert_generated_fixture("test/fixtures/messages.yml",
                              "one" => nil, "two" => nil)

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -80,6 +80,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_controller_permit_attachment_attributes
+    run_generator ["Message", "video:attachment", "photos:attachments"]
+
+    assert_file "app/controllers/messages_controller.rb" do |content|
+      assert_match(/def message_params/, content)
+      assert_match(/params\.require\(:message\)\.permit\(:video, photos: \[\]\)/, content)
+    end
+  end
+
   def test_helper_are_invoked_with_a_pluralized_name
     run_generator
     assert_file "app/helpers/users_helper.rb", /module UsersHelper/
@@ -274,6 +283,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/post users_url, params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}, as: :json/, content)
       assert_match(/patch user_url\(@user\), params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}, as: :json/, content)
       assert_no_match(/assert_redirected_to/, content)
+    end
+  end
+
+  def test_api_only_generates_params_for_attachments
+    run_generator ["Message", "video:attachment", "photos:attachments", "--api"]
+
+    assert_file "app/controllers/messages_controller.rb" do |content|
+      assert_match(/def message_params/, content)
+      assert_match(/params\.require\(:message\)\.permit\(:video, photos: \[\]\)/, content)
     end
   end
 end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -471,6 +471,24 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_scaffold_generator_attachments
+    run_generator ["message", "video:attachment", "photos:attachments", "images:attachments"]
+
+    assert_file "app/models/message.rb", /has_one_attached :video/
+    assert_file "app/models/message.rb", /has_many_attached :photos/
+
+    assert_file "app/controllers/messages_controller.rb" do |content|
+      assert_instance_method :message_params, content do |m|
+        assert_match(/permit\(:video, photos: \[\], images: \[\]\)/, m)
+      end
+    end
+
+    assert_file "app/views/messages/_form.html.erb" do |content|
+      assert_match(/^\W{4}<%= form\.file_field :video %>/, content)
+      assert_match(/^\W{4}<%= form\.file_field :photos, multiple: true %>/, content)
+    end
+  end
+
   def test_scaffold_generator_database
     with_secondary_database_configuration do
       run_generator ["posts", "--database=secondary"]


### PR DESCRIPTION
Adds two new field generators for models `attachment` and `attachments` which will generate `has_one_attached` and `has_many_attached` in models. 

It also generates file fields for each, adding `multiple: true` to has_many_attached, and renders links to the files on the show action.

Hopefully this makes it a lot easier for people to get started using ActiveStorage and ActionText. 👍 

This is similar to the addition of the `rich_text` field generators added in #35781.