### PR TITLE
Use googleauth 0.8.0 to support Ruby 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.8", require: false
+  gem "googleauth", "<= 0.8.0", require: false
   gem "azure-storage", require: false
 
   gem "mini_magick"


### PR DESCRIPTION
### Summary

This pull request uses googleauth 0.8.0 to support Ruby 2.2 because 5-2-stable Active Storage unit test has been failing.

https://travis-ci.org/rails/rails/jobs/512320216#L1788

```ruby
/home/travis/build/rails/rails/activesupport/lib/active_support/dependencies.rb:291:in `require': /home/travis/.rvm/gems/ruby-2.2.10/gems/googleauth-0.8.1/lib/googleauth/application_default.rb:37: syntax error, unexpected << (SyntaxError)
    NOT_FOUND_ERROR = <<~ERROR_MESSAGE.freeze
```

googleapis/google-auth-library-ruby#203 introduces indented here document `<<~` which is available only for Ruby 2.3 https://bugs.ruby-lang.org/issues/9098

