### PR TITLE
Use `googleauth` gem 0.8.0 if Ruby version is 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,12 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.8", require: false
+  if RUBY_VERSION < "2.3.0"
+    # google-auth-library-ruby 0.8.1 needs Ruby 2.3
+    # If Ruby version is 2.3.0 or higher, let google-cloud-storage find
+    # the googleauth gem version.
+    gem "googleauth", "<= 0.8.0", require: false
+  end
   gem "azure-storage", require: false
 
   gem "mini_magick"


### PR DESCRIPTION
### Summary

This pull request uses `googleauth` gem 0.8.0 if Ruby version is 2.2 for `5-2-stable` branch
because `googleauth` 0.8.1 requires Ruby 2.3 to support indented here document `<<~`.

This pull request addresses the following error.
https://travis-ci.org/rails/rails/jobs/512320216#L1788

```ruby
/home/travis/build/rails/rails/activesupport/lib/active_support/dependencies.rb:291:in `require': /home/travis/.rvm/gems/ruby-2.2.10/gems/googleauth-0.8.1/lib/googleauth/application_default.rb:37: syntax error, unexpected << (SyntaxError)
    NOT_FOUND_ERROR = <<~ERROR_MESSAGE.freeze
```

If Ruby version is 2.3+, we do not have to specify the `googleauth` gem version because `google-cloud-storage` and `google-api-client` gem will find the required `goolgeauth` gem version by itself.

Refer https://github.com/rails/rails/pull/35807#issuecomment-478305519
