### PR TITLE
Simplify ActionCable.createWebSocketURL and realphabetize exports

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -507,8 +507,8 @@
   exports.Subscription = Subscription;
   exports.Subscriptions = Subscriptions;
   exports.adapters = adapters;
-  exports.logger = logger;
   exports.createWebSocketURL = createWebSocketURL;
+  exports.logger = logger;
   exports.createConsumer = createConsumer;
   exports.getConfig = getConfig;
   Object.defineProperty(exports, "__esModule", {

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -477,15 +477,17 @@
     return Consumer;
   }();
   function createWebSocketURL(url) {
-    var webSocketURL = typeof url === "function" ? url() : url;
-    if (webSocketURL && !/^wss?:/i.test(webSocketURL)) {
+    if (typeof url === "function") {
+      url = url();
+    }
+    if (url && !/^wss?:/i.test(url)) {
       var a = document.createElement("a");
-      a.href = webSocketURL;
+      a.href = url;
       a.href = a.href;
       a.protocol = a.protocol.replace("http", "ws");
       return a.href;
     } else {
-      return webSocketURL;
+      return url;
     }
   }
   function createConsumer() {

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -58,16 +58,18 @@ export default class Consumer {
 }
 
 export function createWebSocketURL(url) {
-  const webSocketURL = typeof url === "function" ? url() : url
+  if (typeof url === "function") {
+    url = url()
+  }
 
-  if (webSocketURL && !/^wss?:/i.test(webSocketURL)) {
+  if (url && !/^wss?:/i.test(url)) {
     const a = document.createElement("a")
-    a.href = webSocketURL
+    a.href = url
     // Fix populating Location properties in IE. Otherwise, protocol will be blank.
     a.href = a.href
     a.protocol = a.protocol.replace("http", "ws")
     return a.href
   } else {
-    return webSocketURL
+    return url
   }
 }

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -15,8 +15,8 @@ export {
   Subscription,
   Subscriptions,
   adapters,
-  logger,
   createWebSocketURL,
+  logger,
 }
 
 export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -42,14 +42,15 @@ module("ActionCable", () => {
       assert.equal(consumer.url, testURL)
     })
 
-    test("uses function to generate URL", assert => {
+    test("dynamically computes URL from function", assert => {
       let dynamicURL = testURL
       const generateURL = () => {
         return dynamicURL
       }
+      const consumer = ActionCable.createConsumer(generateURL)
+      assert.equal(consumer.url, testURL)
 
       dynamicURL = `${testURL}foo`
-      const consumer = ActionCable.createConsumer(generateURL)
       assert.equal(consumer.url, `${testURL}foo`)
     })
   })


### PR DESCRIPTION
### Summary

This PR is a follow-up to 6d488a22d361d19e3de98c603d98e64ccea8a2f3. It removes an unneeded variable to simplify and shrink the `ActionCable.createWebSocketURL` function (c2c420aad12ef3e1c7ac361917454dfdef4f572a), improves the associated test case to verify the dynamic property (dfaaa90b0fc38a3d2f211d508b2618b7bdd88f43), and sorts the ActionCable exports alphabetically again, as per https://github.com/rails/rails/pull/34370#discussion_r238066735 (a132aed72ad4be53a0813018b9bb3840cc610a93).
