### PR TITLE
[ci skip] Fix guides to link to edgeapi if on EDGE env

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -16,7 +16,7 @@ HTML
       end
 
       def link(url, title, content)
-        if url.start_with?("http://api.rubyonrails.org")
+        if %r{https?://api\.rubyonrails\.org}.match?(url)
           %(<a href="#{api_link(url)}">#{content}</a>)
         elsif title
           %(<a href="#{url}" title="#{title}">#{content}</a>)
@@ -115,7 +115,7 @@ HTML
         end
 
         def api_link(url)
-          if %r{http://api\.rubyonrails\.org/v\d+\.}.match?(url)
+          if %r{https?://api\.rubyonrails\.org/v\d+\.}.match?(url)
             url
           elsif edge
             url.sub("api", "edgeapi")


### PR DESCRIPTION
### Summary

Fix https://github.com/rails/rails/issues/35809

### Other Information

based on the issue

> When reading https://edgeguides.rubyonrails.org, all links to the Rails API should point to https://edgeapi.rubyonrails.org, not https://api.rubyonrails.org
> 
> Here is the sample link: https://edgeguides.rubyonrails.org/form_helpers.html
