### PR TITLE
Include final newline in generated .ruby-version

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" -%>
+<%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -968,6 +968,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
       else
         assert_match(/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}/, content)
       end
+
+      assert content.end_with?("\n"), "expected .ruby-version to end with newline"
     end
   end
 


### PR DESCRIPTION
### Summary

I guess it is best practice to have a final newline. `rbenv local 2.5.3` also has that behavior in this particular case with `.ruby-version`. And lastly, if you edit `.ruby-version` in an editor like Atom, it will (by default) automatically add the final newline.