### PR TITLE
 adding default value for ActiveRecord::Type::Json if nil

### DIFF
--- a/activerecord/lib/active_record/type/json.rb
+++ b/activerecord/lib/active_record/type/json.rb
@@ -10,6 +10,7 @@ module ActiveRecord
       end
 
       def deserialize(value)
+        value = '{}' if value.is_a?(::NilClass)
         return value unless value.is_a?(::String)
         ActiveSupport::JSON.decode(value) rescue nil
       end


### PR DESCRIPTION
### Summary
I was curious if a default value of an empty JSON object would be a good idea.
I didn't find a good way to implement this other then an 

```
  after_initialize :set_default_json_value
  def set_default_json_value
    self.data ||= {}
  end

```
Which still gave me trouble if I created any class method  that used the JSON column to create 
dynamic reader and writer methods.

To me it just seems weird to have a JSON type actually be a nil type.

Is  this is something you agree with?

If so i will update change log and docs

Thank you for your time.
