### PR TITLE
Add Changelog entry for #35732.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Replace `chromedriver-helper` gem with `webdrivers` in default Gemfile.
+   `chromedriver-helper` is deprecated as of March 31, 2019 and won't
+   recieve any further updates.
+
+    *Guillermo Iguaran‮*
+
 *   Applications running in `:zeitwerk` mode that use `bootsnap` need
     to upgrade `bootsnap` to at least 1.4.2.
 


### PR DESCRIPTION
### Summary

Adds a Changelog entry for #35732, about `chromedriver-helper` being replaced by the `webdrivers` gem.

cc: @guilleiguaran does this phrasing work?