### PR TITLE
Rename `Template::File` to `Template::RawFile`

### DIFF
--- a/actionview/lib/action_view/file_template.rb
+++ b/actionview/lib/action_view/file_template.rb
@@ -11,7 +11,7 @@ module ActionView
     end
 
     def source
-      ::File.binread @filename
+      File.binread @filename
     end
 
     def refresh(_)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -27,7 +27,7 @@ module ActionView
           Template::HTML.new(options[:html], formats.first)
         elsif options.key?(:file)
           if File.exist?(options[:file])
-            Template::File.new(options[:file])
+            Template::RawFile.new(options[:file])
           else
             ActiveSupport::Deprecation.warn "render file: should be given the absolute path to a file"
             @lookup_context.with_fallbacks.find_file(options[:file], nil, false, keys, @details)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -113,7 +113,7 @@ module ActionView
 
     eager_autoload do
       autoload :Error
-      autoload :File
+      autoload :RawFile
       autoload :Handlers
       autoload :HTML
       autoload :Inline

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -104,7 +104,7 @@ module ActionView
       def line_number
         @line_number ||=
           if file_name
-            regexp = /#{Regexp.escape ::File.basename(file_name)}:(\d+)/
+            regexp = /#{Regexp.escape File.basename(file_name)}:(\d+)/
             $1 if message =~ regexp || backtrace.find { |line| line =~ regexp }
           end
       end

--- a/actionview/lib/action_view/template/raw_file.rb
+++ b/actionview/lib/action_view/template/raw_file.rb
@@ -3,7 +3,7 @@
 module ActionView #:nodoc:
   # = Action View File Template
   class Template #:nodoc:
-    class File #:nodoc:
+    class RawFile #:nodoc:
       attr_accessor :type, :format
 
       def initialize(filename)


### PR DESCRIPTION
`Template::File` was introduced in https://github.com/rails/rails/pull/35688. This can cause some issues in applications in cases where `File` is used inside of view templates. For example, calling `File.basename` within a view template will resolve to `Template::File.basename` which is not a defined method.

This _could_ be can be addressed within templates by calling `::File.basename`, but discussions with @jhawthorn and @tenderlove indicated that this is probably more of an inconvenience than is warranted for the applications that would be forced to make changes and might cause unnecessary confusion in the long term when errors are raised.

This PR renames `Template::File` to `Template::RawFile`.