### PR TITLE
Use table_prefix_name and table_suffix_name for the Active Storage tables [Fixes #35811]

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use the `table_name_prefix` and `table_name_suffix` config options
+    while calculating name of the Active Storage related tables.
+
+    Fixes #35811.
+
+    *Prathamesh Sonpatki*
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   No changes.

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/module/delegation"
 # but it is possible to associate many different records with the same blob. A foreign-key constraint
 # on the attachments table prevents blobs from being purged if they’re still attached to any records.
 class ActiveStorage::Attachment < ActiveRecord::Base
-  self.table_name = "active_storage_attachments"
+  self.table_name = "#{table_name_prefix}active_storage_attachments#{table_name_suffix}"
 
   belongs_to :record, polymorphic: true, touch: true
   belongs_to :blob, class_name: "ActiveStorage::Blob"

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -24,7 +24,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   include Identifiable
   include Representable
 
-  self.table_name = "active_storage_blobs"
+  self.table_name = "#{table_name_prefix}active_storage_blobs#{table_name_suffix}"
 
   has_secure_token :key
   store :metadata, accessors: [ :analyzed, :identified ], coder: ActiveRecord::Coders::JSON

--- a/activestorage/test/models/table_name_prefix_suffix_test.rb
+++ b/activestorage/test/models/table_name_prefix_suffix_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../dummy/config/environment.rb"
+
+class ActiveStorage::TableNamePrefixSuffixTest < ActiveSupport::TestCase
+  setup do
+    ActiveRecord::Base.table_name_prefix = "bcx_"
+    ActiveRecord::Base.table_name_suffix = "_classic"
+  end
+
+  teardown do
+    ActiveRecord::Base.table_name_prefix = ""
+    ActiveRecord::Base.table_name_suffix = ""
+  end
+
+  test "table name prefix and suffix are added to the active storage tables properly" do
+    assert_equal "bcx_active_storage_blobs_classic", ActiveStorage::Blob.table_name
+    assert_equal "bcx_active_storage_attachments_classic", ActiveStorage::Attachment.table_name
+  end
+end


### PR DESCRIPTION
### Summary

- Without this change, it was ignoring the global or local config set for
  table_name_prefix and table_name_suffix.

### Other Information

~I could not come up with a nice way to test this change. Because of this line~
https://github.com/rails/rails/blob/6fb3ac1536d60bc12cf531e83e4060fe1fdf3d87/activestorage/test/test_helper.rb#L37 the constant `ActiveStorage::Blob` is already defined so the `table_name_prefix` setting done in the test file after loading `test_helper` has no effect. One option was to set the `table_name_prefix` and `table_name_suffix` before loading `ActiveStorate::Blob` in the test helper but it would have applied that change to all the tests.

#### Update

Test is added

[Fixes #35811]