### PR TITLE
Deprecate the usage of :class_name for :through association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Deprecate `:class_name` option for the `:through` association
+
+    Through association should always rely on the :class_name of its source
+    association. Example:
+
+    ```
+    Post.has_many :commenters, through: :comments,
+      source: :author, class_name: 'CommentAuthor'
+    post.comments.first.author.class # => Author
+    post.commenters.first.class # => CommentAuthor
+    ```
+
+    Using `:class_name` causes inconsistencies to the through association including
+    some bugs in preloading that assumes that through association uses the class
+    as its source association.
+
+    *Bogdan Gusiev*
+
 *   Fix sqlite3 collation parsing when using decimal columns.
 
     *Martin R. Schuster*

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1853,7 +1853,7 @@ module ActiveRecord
           hm_options[:through] = middle_reflection.name
           hm_options[:source] = join_model.right_reflection.name
 
-          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table, :class_name, :extend].each do |k|
+          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table, :extend].each do |k|
             hm_options[k] = options[k] if options.key? k
           end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -759,6 +759,16 @@ module ActiveRecord
         @delegate_reflection = delegate_reflection
         @klass = delegate_reflection.options[:anonymous_class]
         @source_reflection_name = delegate_reflection.options[:source]
+        if class_option = delegate_reflection.options[:class_name]
+          custom_message = class_option == source_reflection.class_name ?
+            "Remove the :class_name option because it matches the source association class name and is not needed" :
+            "Through association will always use the class of the source association specified.
+            Use a custom association with :class_name option as a through association :source to achieve the same behavior."
+          ActiveSupport::Deprecation.warn(
+            "Using a :class_name option for :through association is deprecated and will be removed in Rails 6.1. " +
+            custom_message
+          )
+        end
       end
 
       def through_reflection?

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -92,14 +92,15 @@ class Author < ActiveRecord::Base
   has_many :special_categories_with_conditions, -> { where(categorizations: { special: true }) }, through: :categorizations, source: :category
   has_many :nonspecial_categories_with_conditions, -> { where(categorizations: { special: false }) }, through: :categorizations, source: :category
 
-  has_many :categories_like_general, -> { where(name: "General") }, through: :categorizations, source: :category, class_name: "Category"
+  has_many :categories_like_general, -> { where(name: "General") }, through: :categorizations, source: :category
 
   has_many :categorized_posts, through: :categorizations, source: :post
   has_many :unique_categorized_posts, -> { distinct }, through: :categorizations, source: :post
 
-  has_many :nothings, through: :kateggorisatons, class_name: "Category"
+  has_many :nothings, through: :kateggorisatons
 
   has_many :author_favorites
+  has_many :author_favorites_with_scope, class_name: "AuthorFavoriteWithScope"
   has_many :favorite_authors, -> { order("name") }, through: :author_favorites
 
   has_many :taggings,        through: :posts, source: :taggings

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -31,7 +31,7 @@ class Member < ActiveRecord::Base
   has_many :clubs, through: :favourite_memberships
 
   has_many :tenant_memberships
-  has_many :tenant_clubs, through: :tenant_memberships, class_name: "Club", source: :club
+  has_many :tenant_clubs, through: :tenant_memberships, source: :club
 
   has_one :club_through_many, through: :favourite_memberships, source: :club
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -83,7 +83,7 @@ class Post < ActiveRecord::Base
   has_many :comments_with_extend_2, extend: [NamedExtension, NamedExtension2], class_name: "Comment", foreign_key: "post_id"
 
   has_many :author_favorites, through: :author
-  has_many :author_favorites_with_scope, through: :author, class_name: "AuthorFavoriteWithScope", source: "author_favorites"
+  has_many :author_favorites_with_scope, through: :author, source: "author_favorites_with_scope"
   has_many :author_categorizations, through: :author, source: :categorizations
   has_many :author_addresses, through: :author
   has_many :author_address_extra_with_address,


### PR DESCRIPTION
Through association should always relay on the :class_name of its source association. Example:

 ``` ruby
Post.has_many :commenters, through: :comments,
  source: :author, class_name: 'CommentAuthor'
post.comments.first.author.class # => Author
post.commenters.first.class # => CommentAuthor
```

That causes inconsistency to the through association general sense and
some bugs in preloading that assumes that principle to be true. Example failing test (pluggable to `test/cases/associations/has_many_through_association_test.rb` in current `master`):

``` ruby
fixtures :author_favorites
def test_preload_through_association_with_class_name
    posts = Post.preload(:author_favorites_with_scope).to_a
    assert_equal AuthorFavoriteWithScope, posts.flat_map(&:author_favorites_with_scope).first.class
end
```

I don't see a way around that but to forbid the usage of `class_name` option in a through association.

People who want to achive the same behavior would need to create a source association with custom `class_name`:

``` ruby
Comment.belongs_to :author, class_name: "CommentAuthor"
Post.has_many :commenters, through: :comments, source: :author
```

cc @rafaelfranca @kamipo 
