### PR TITLE
[ci skip] Updated the doc after renaming Template::File -> Template::RawFile in #35826

### DIFF
--- a/actionview/lib/action_view/template/raw_file.rb
+++ b/actionview/lib/action_view/template/raw_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionView #:nodoc:
-  # = Action View File Template
+  # = Action View RawFile Template
   class Template #:nodoc:
     class RawFile #:nodoc:
       attr_accessor :type, :format


### PR DESCRIPTION
Since `Template::File` was renamed to `Template::RawFile` in #35826. The comment was not updated. I am not very confident if this is needed, still raised a PR for it. Feel free to close it if this change is not necessary. 