### PR TITLE
Fixed description of the `cache_key_with_version` method [skip ci]

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -302,7 +302,7 @@ class Product < ApplicationRecord
 end
 ```
 
-NOTE: Notice that in this example we used the `cache_key_with_version` method, so the resulting cache key will be something like `products/233-20140225082222765838000/competing_price`. `cache_key_with_version` generates a string based on the model's `id` and `updated_at` attributes. This is a common convention and has the benefit of invalidating the cache whenever the product is updated. In general, when you use low-level caching for instance level information, you need to generate a cache key.
+NOTE: Notice that in this example we used the `cache_key_with_version` method, so the resulting cache key will be something like `products/233-20140225082222765838000/competing_price`. `cache_key_with_version` generates a string based on the model's class name, `id`, and `updated_at` attributes. This is a common convention and has the benefit of invalidating the cache whenever the product is updated. In general, when you use low-level caching for instance level information, you need to generate a cache key.
 
 ### SQL Caching
 


### PR DESCRIPTION
### Summary
The `cache_key` method is called in the` cache_key_with_version` method.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/integration.rb#L107-L113

Within the `cache_key` method,` model_name` is used for the return value in any case.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/integration.rb#L64-L81

I think that `cache_key_with_version` correctly generates a string based on the model's class name, id and updated_at attributes.