### PR TITLE
Symbolize mime types for consitency

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -225,7 +225,7 @@ CACHED
   end
 
   def test_skipping_fragment_cache_digesting
-    get :fragment_cached_without_digest, format: "html"
+    get :fragment_cached_without_digest, format: :html
     assert_response :success
     expected_body = "<body>\n<p>ERB</p>\n</body>\n"
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -334,7 +334,7 @@ module ActionController
       @controller.error_latch = Concurrent::CountDownLatch.new
 
       capture_log_output do |output|
-        get :overfill_buffer_and_die, format: "plain"
+        get :overfill_buffer_and_die, format: :plain
 
         t = Thread.new(response) { |resp|
           resp.await_commit

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -13,7 +13,7 @@ end
 class StarStarMimeControllerTest < ActionController::TestCase
   def test_javascript_with_format
     @request.accept = "text/javascript"
-    get :index, format: "js"
+    get :index, format: :js
     assert_match "function addition(a,b){ return a+b; }", @response.body
   end
 

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -80,7 +80,7 @@ module ContentType
     end
 
     test "sets Content-Type as application/xml when rendering *.xml.erb" do
-      get "/content_type/implied/i_am_xml_erb", params: { "format" => "xml" }
+      get "/content_type/implied/i_am_xml_erb", params: { format: :xml }
 
       assert_header "Content-Type", "application/xml; charset=utf-8"
     end
@@ -92,7 +92,7 @@ module ContentType
     end
 
     test "sets Content-Type as application/xml when rendering *.xml.builder" do
-      get "/content_type/implied/i_am_xml_builder", params: { "format" => "xml" }
+      get "/content_type/implied/i_am_xml_builder", params: { format: :xml }
 
       assert_header "Content-Type", "application/xml; charset=utf-8"
     end

--- a/actionpack/test/controller/new_base/render_layout_test.rb
+++ b/actionpack/test/controller/new_base/render_layout_test.rb
@@ -87,7 +87,7 @@ module ControllerLayouts
     XML_INSTRUCT = %Q(<?xml version="1.0" encoding="UTF-8"?>\n)
 
     test "if XML is selected, an HTML template is not also selected" do
-      get :index, params: { format: "xml" }
+      get :index, params: { format: :xml }
       assert_response XML_INSTRUCT
     end
 
@@ -97,7 +97,7 @@ module ControllerLayouts
     end
 
     test "a layout for JS is ignored even if explicitly provided for HTML" do
-      get :explicit, params: { format: "js" }
+      get :explicit, params: { format: :js }
       assert_response "alert('foo');"
     end
   end
@@ -121,7 +121,7 @@ module ControllerLayouts
     testing ControllerLayouts::FalseLayoutMethodController
 
     test "access false layout returned by a method/proc" do
-      get :index, params: { format: "js" }
+      get :index, params: { format: :js }
       assert_response "alert('foo');"
     end
   end

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -112,7 +112,7 @@ module RenderTemplate
     end
 
     test "rendering a builder template" do
-      get :builder_template, params: { "format" => "xml" }
+      get :builder_template, params: { format: :xml }
       assert_response "<html>\n  <p>Hello</p>\n</html>\n"
     end
 
@@ -127,7 +127,7 @@ module RenderTemplate
       assert_body "Hello <strong>this is also raw</strong> in an html template"
       assert_status 200
 
-      get :with_implicit_raw, params: { format: "text" }
+      get :with_implicit_raw, params: { format: :text }
 
       assert_body "Hello <strong>this is also raw</strong> in a text template"
       assert_status 200

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -23,7 +23,7 @@ class AlwaysPermittedParametersTest < ActiveSupport::TestCase
   test "allows both explicitly listed and always-permitted parameters" do
     params = ActionController::Parameters.new(
       book: { pages: 65 },
-      format: "json")
+      format: :json)
     permitted = params.permit book: [:pages]
     assert_predicate permitted, :permitted?
   end

--- a/actionpack/test/controller/render_js_test.rb
+++ b/actionpack/test/controller/render_js_test.rb
@@ -30,7 +30,7 @@ class RenderJSTest < ActionController::TestCase
   end
 
   def test_should_render_js_partial
-    get :show_partial, format: "js", xhr: true
+    get :show_partial, format: :js, xhr: true
     assert_equal "partial js", @response.body
   end
 end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -707,7 +707,7 @@ class ImplicitRenderTest < ActionController::TestCase
 
   def test_implicit_unknown_format_response
     assert_raises(ActionController::UnknownFormat) do
-      get :empty_action_with_template, format: "json"
+      get :empty_action_with_template, format: :json
     end
   end
 end

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -96,7 +96,7 @@ class RenderXmlTest < ActionController::TestCase
   end
 
   def test_should_use_implicit_content_type
-    get :implicit_content_type, format: "atom"
+    get :implicit_content_type, format: :atom
     assert_equal Mime[:atom], @response.content_type
   end
 end

--- a/actionpack/test/controller/renderers_test.rb
+++ b/actionpack/test/controller/renderers_test.rb
@@ -71,7 +71,7 @@ class RenderersTest < ActionController::TestCase
 
   def test_raises_missing_template_no_renderer
     assert_raise ActionView::MissingTemplate do
-      get :respond_to_mime, format: "csv"
+      get :respond_to_mime, format: :csv
     end
     assert_equal Mime[:csv], @response.content_type
     assert_equal "", @response.body
@@ -82,7 +82,7 @@ class RenderersTest < ActionController::TestCase
       send_data value.to_csv, type: Mime[:csv]
     end
     @request.accept = "text/csv"
-    get :respond_to_mime, format: "csv"
+    get :respond_to_mime, format: :csv
     assert_equal Mime[:csv], @response.content_type
     assert_equal "c,s,v", @response.body
   ensure

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -352,7 +352,7 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_not_allow_post_without_token_irrespective_of_format
-    assert_blocked { post :index, format: "xml" }
+    assert_blocked { post :index, format: :xml }
   end
 
   def test_should_not_allow_patch_without_token
@@ -515,7 +515,7 @@ module RequestForgeryProtectionTests
 
   def test_should_only_allow_same_origin_js_get_with_xhr_header
     assert_cross_origin_blocked { get :same_origin_js }
-    assert_cross_origin_blocked { get :same_origin_js, format: "js" }
+    assert_cross_origin_blocked { get :same_origin_js, format: :js }
     assert_cross_origin_blocked do
       @request.accept = "text/javascript"
       get :negotiate_same_origin
@@ -527,7 +527,7 @@ module RequestForgeryProtectionTests
     end
 
     assert_cross_origin_not_blocked { get :same_origin_js, xhr: true }
-    assert_cross_origin_not_blocked { get :same_origin_js, xhr: true, format: "js" }
+    assert_cross_origin_not_blocked { get :same_origin_js, xhr: true, format: :js }
     assert_cross_origin_not_blocked do
       @request.accept = "text/javascript"
       get :negotiate_same_origin, xhr: true
@@ -569,7 +569,7 @@ module RequestForgeryProtectionTests
   def test_should_allow_non_get_js_without_xhr_header
     session[:_csrf_token] = @token
     assert_cross_origin_not_blocked { post :same_origin_js, params: { custom_authenticity_token: @token } }
-    assert_cross_origin_not_blocked { post :same_origin_js, params: { format: "js", custom_authenticity_token: @token } }
+    assert_cross_origin_not_blocked { post :same_origin_js, params: { format: :js, custom_authenticity_token: @token } }
     assert_cross_origin_not_blocked do
       @request.accept = "text/javascript"
       post :negotiate_same_origin, params: { custom_authenticity_token: @token }
@@ -578,14 +578,14 @@ module RequestForgeryProtectionTests
 
   def test_should_only_allow_cross_origin_js_get_without_xhr_header_if_protection_disabled
     assert_cross_origin_not_blocked { get :cross_origin_js }
-    assert_cross_origin_not_blocked { get :cross_origin_js, format: "js" }
+    assert_cross_origin_not_blocked { get :cross_origin_js, format: :js }
     assert_cross_origin_not_blocked do
       @request.accept = "text/javascript"
       get :negotiate_cross_origin
     end
 
     assert_cross_origin_not_blocked { get :cross_origin_js, xhr: true }
-    assert_cross_origin_not_blocked { get :cross_origin_js, xhr: true, format: "js" }
+    assert_cross_origin_not_blocked { get :cross_origin_js, xhr: true, format: :js }
     assert_cross_origin_not_blocked do
       @request.accept = "text/javascript"
       get :negotiate_cross_origin, xhr: true

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -119,7 +119,7 @@ module TestUrlGeneration
     test "generating URLs with trailing slashes" do
       assert_equal "/bars.json", bars_path(
         trailing_slash: true,
-        format: "json"
+        format: :json
       )
     end
 
@@ -127,14 +127,14 @@ module TestUrlGeneration
       assert_equal "/bars.json?a=b", bars_path(
         trailing_slash: true,
         a: "b",
-        format: "json"
+        format: :json
       )
     end
 
     test "generating URLS with empty querystring" do
       assert_equal "/bars.json", bars_path(
         a: {},
-        format: "json"
+        format: :json
       )
     end
   end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1011,7 +1011,7 @@ class PolymorphicSessionsControllerTest < ActionController::TestCase
   def test_existing_nested_resource_with_params
     @controller = SessionsController.new
 
-    get :edit, params: { workshop_id: 1, id: 1, format: "json"  }
+    get :edit, params: { workshop_id: 1, id: 1, format: :json  }
     assert_equal %{/workshops/1/sessions/1.json\n<a href="/workshops/1/sessions/1.json">Session</a>}, @response.body
   end
 end

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -615,7 +615,7 @@ An incoming path of `/photos/1?user_id=2` will be dispatched to the `show` actio
 You can define defaults in a route by supplying a hash for the `:defaults` option. This even applies to parameters that you do not specify as dynamic segments. For example:
 
 ```ruby
-get 'photos/:id', to: 'photos#show', defaults: { format: 'jpg' }
+get 'photos/:id', to: 'photos#show', defaults: { format: :jpg }
 ```
 
 Rails would match `photos/12` to the `show` action of `PhotosController`, and set `params[:format]` to `"jpg"`.


### PR DESCRIPTION
### Summary

Mime types in params were spread across as strings and symbols. This PR symbolizes mime types for consistency across the codebase.
