### PR TITLE
[ci skip] Doc for shallow: false options should use <tt> for better readability. 

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1402,7 +1402,7 @@ module ActionDispatch
         #   as a comment on a blog post like <tt>/posts/a-long-permalink/comments/1234</tt>
         #   to be shortened to just <tt>/comments/1234</tt>.
         #
-        #   Set shallow: false on a child resource to ignore a parent's shallow parameter.
+        #   Set <tt>shallow: false</tt> on a child resource to ignore a parent's shallow parameter.
         #
         # [:shallow_path]
         #   Prefixes nested shallow routes with the specified path.


### PR DESCRIPTION
PR after #24405 

As per https://edgeguides.rubyonrails.org/api_documentation_guidelines.html#fixed-width-font we should use `<tt>` for `shallow: false` option. In most of the documentation, we are using `<tt>` for similar options details.
