### PR TITLE
Add rake db:prepare entry to the CHANGELOG.md

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `rake db:prepare` runs setup if database does not exist, or runs migrations if it does.
+
+    *Roberto Miranda*
+
 *   Add `after_save_commit` callback as shortcut for `after_commit :hook, on: [ :create, :update ]`.
 
     *DHH*


### PR DESCRIPTION
Adding a missing entry into the `CHANGELOG.md` file.

ref https://github.com/rails/rails/pull/35768#issuecomment-479396632 