### PR TITLE
Deduplicate strings held by the router

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -116,7 +116,7 @@ module ActionController
 
       RACK_VALUE_TRANSLATION = {
         https: ->(v) { v ? "on" : "off" },
-        method: ->(v) { v.upcase },
+        method: ->(v) { -v.upcase },
       }
 
       def rack_key_for(key)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -115,9 +115,9 @@ module ActionDispatch
           @defaults = defaults
           @set = set
 
-          @to                 = to
-          @default_controller = controller
-          @default_action     = default_action
+          @to                 = intern(to)
+          @default_controller = intern(controller)
+          @default_action     = intern(default_action)
           @ast                = ast
           @anchor             = anchor
           @via                = via
@@ -222,6 +222,10 @@ module ActionDispatch
         private :build_path
 
         private
+          def intern(object)
+            object.is_a?(String) ? -object : object
+          end
+
           def add_wildcard_options(options, formatted, path_ast)
             # Add a constraint for wildcard route to make it non-greedy and match the
             # optional format part of the route by default.

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3379,13 +3379,13 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_match(/:param option can't contain colon/, ex.message)
   end
 
-  def test_action_from_path_is_not_frozen
+  def test_action_from_path_is_frozen
     draw do
       get "search" => "search"
     end
 
     get "/search"
-    assert_not_predicate @request.params[:action], :frozen?
+    assert_predicate @request.params[:action], :frozen?
   end
 
   def test_multiple_positional_args_with_the_same_name


### PR DESCRIPTION
While profiling our application I saw quite a lot of duplicated strings coming from the router:

```
948  "show"
412  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:1934
282  [REDACTED]
132  /tmp/bundle/ruby/2.5.0/gems/responders-2.4.1/lib/action_controller/respond_with.rb:40
 47  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:340


731  "update"
585  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:1934
106  /tmp/bundle/ruby/2.5.0/gems/responders-2.4.1/lib/action_controller/respond_with.rb:40
 23  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:340


698  "index"
441  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:1934
126  /tmp/bundle/ruby/2.5.0/gems/responders-2.4.1/lib/action_controller/respond_with.rb:40
 59  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:340
 21  [REDACTED]
 20  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:322


619  "GET"
588  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_controller/renderer.rb:119


563  "create"
398  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:1934
120  /tmp/bundle/ruby/2.5.0/gems/responders-2.4.1/lib/action_controller/respond_with.rb:40
 21  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-8901400b2f0d/actionpack/lib/action_dispatch/routing/mapper.rb:340
```

So here's I'm trying to reduce these duplications as to reclaim a bit of memory. The whole thing rely on [`String#-@`](https://ruby-doc.org/core-2.5.5/String.html#method-i-2D-40) which starting in MRI 2.5 will freeze and possibly intern the string.

@rafaelfranca @Edouard-chin 