### PR TITLE
Add test that the listen gem is included when RUBY_ENGINE is not 'ruby'

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -678,6 +678,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_listen_related_configuration_on_other_rubies
+    ruby_engine = Object.send(:remove_const, :RUBY_ENGINE)
+    Object.const_set(:RUBY_ENGINE, "MyRuby")
+    begin
+      run_generator
+      if RbConfig::CONFIG["host_os"] =~ /darwin|linux/
+        assert_listen_related_configuration
+      else
+        assert_no_listen_related_configuration
+      end
+    ensure
+      Object.send(:remove_const, :RUBY_ENGINE)
+      Object.const_set(:RUBY_ENGINE, ruby_engine)
+    end
+  end
+
   def test_non_inclusion_of_listen_related_configuration_if_skip_listen
     run_generator [destination_root, "--skip-listen"]
     assert_no_listen_related_configuration


### PR DESCRIPTION
### Summary

This adds a test for a bug which was present in both Rails 6 and 5.2.
The bug was fixed by #34243 on master and #35482 on Rails 5.2.

cc @y-yagi @deivid-rodriguez