### PR TITLE
Don't determine `always_write_cookie` based on environment

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -46,9 +46,9 @@ module ActionDispatch
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)
-
-      config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
-      ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
+      if !config.action_dispatch.always_write_cookie.nil?
+        ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
+      end
 
       ActionDispatch.test_app = app
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -532,6 +532,9 @@ Defaults to `'signed cookie'`.
 
   Any exceptions that are not configured will be mapped to 500 Internal Server Error.
 
+* `config.action_dispatch.always_write_cookie` enables writing
+  secure flagged cookies although running app with non-ssl mode. It defaults to `false`.
+
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -26,29 +26,21 @@ module ApplicationTests
       FileUtils.rm_rf(new_app) if File.directory?(new_app)
     end
 
-    test "always_write_cookie is true by default in development" do
+    test "always_write_cookie is false by default" do
       require "rails"
       Rails.env = "development"
       require "#{app_path}/config/environment"
-      assert_equal true, ActionDispatch::Cookies::CookieJar.always_write_cookie
-    end
-
-    test "always_write_cookie is false by default in production" do
-      require "rails"
-      Rails.env = "production"
-      require "#{app_path}/config/environment"
-      assert_equal false, ActionDispatch::Cookies::CookieJar.always_write_cookie
+      assert_equal false,  ActionDispatch::Cookies::CookieJar.always_write_cookie
     end
 
     test "always_write_cookie can be overridden" do
       add_to_config <<-RUBY
-        config.action_dispatch.always_write_cookie = false
+        config.action_dispatch.always_write_cookie = true
       RUBY
 
       require "rails"
-      Rails.env = "development"
       require "#{app_path}/config/environment"
-      assert_equal false, ActionDispatch::Cookies::CookieJar.always_write_cookie
+      assert_equal true, ActionDispatch::Cookies::CookieJar.always_write_cookie
     end
 
     test "signed cookies with SHA512 digest and rotated out SHA256 and SHA1 digests" do


### PR DESCRIPTION
### Summary

In development environment, it allows to write cookie, while it doesn't in other environments. This is a bit confusing. Upon writing cookies - such general behavior, discrepancy across environments should be better smoothed.

By updating docs, people would know this configuration directive
`config.always_write_cookie` to control the conditions to write cookies.

### Other Information
Related code:
+ Writing cookies upon Rails env introduced in   https://github.com/rails/rails/commit/2d5a12a50bcd83fcc99865de759b82e661b28698
+ `always_write_cookie` flag introduced in https://github.com/rails/rails/pull/3739
+ Conditions to control whether to write cookies or not https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/cookies.rb#L450

Google forum post:
https://groups.google.com/forum/?fromgroups&hl=en#!topic/rubyonrails-core/bNd_QfZJ6_8

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
