### PR TITLE
[ci skip] nodoc supports_* methods overridden in adapter subclass

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -67,56 +67,56 @@ module ActiveRecord
         true
       end
 
-      def supports_index_sort_order?
+      def supports_index_sort_order? #:nodoc:
         !mariadb? && database_version >= "8.0.1"
       end
 
-      def supports_expression_index?
+      def supports_expression_index? #:nodoc:
         !mariadb? && database_version >= "8.0.13"
       end
 
-      def supports_transaction_isolation?
+      def supports_transaction_isolation? #:nodoc:
         true
       end
 
-      def supports_explain?
+      def supports_explain? #:nodoc:
         true
       end
 
-      def supports_indexes_in_create?
+      def supports_indexes_in_create? #:nodoc:
         true
       end
 
-      def supports_foreign_keys?
+      def supports_foreign_keys? #:nodoc:
         true
       end
 
-      def supports_views?
+      def supports_views? #:nodoc:
         true
       end
 
-      def supports_datetime_with_precision?
+      def supports_datetime_with_precision? #:nodoc:
         mariadb? || database_version >= "5.6.4"
       end
 
-      def supports_virtual_columns?
+      def supports_virtual_columns? #:nodoc:
         mariadb? || database_version >= "5.7.5"
       end
 
       # See https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html for more details.
-      def supports_optimizer_hints?
+      def supports_optimizer_hints? #:nodoc:
         !mariadb? && database_version >= "5.7.7"
       end
 
-      def supports_advisory_locks?
+      def supports_advisory_locks? #:nodoc:
         true
       end
 
-      def supports_insert_on_duplicate_skip?
+      def supports_insert_on_duplicate_skip? #:nodoc:
         true
       end
 
-      def supports_insert_on_duplicate_update?
+      def supports_insert_on_duplicate_update? #:nodoc:
         true
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -42,23 +42,23 @@ module ActiveRecord
         configure_connection
       end
 
-      def supports_json?
+      def supports_json? #:nodoc:
         !mariadb? && database_version >= "5.7.8"
       end
 
-      def supports_comments?
+      def supports_comments? #:nodoc:
         true
       end
 
-      def supports_comments_in_create?
+      def supports_comments_in_create? #:nodoc:
         true
       end
 
-      def supports_savepoints?
+      def supports_savepoints? #:nodoc:
         true
       end
 
-      def supports_lazy_transactions?
+      def supports_lazy_transactions? #:nodoc:
         true
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -148,64 +148,64 @@ module ActiveRecord
       include PostgreSQL::SchemaStatements
       include PostgreSQL::DatabaseStatements
 
-      def supports_bulk_alter?
+      def supports_bulk_alter? #:nodoc:
         true
       end
 
-      def supports_index_sort_order?
+      def supports_index_sort_order? #:nodoc:
         true
       end
 
-      def supports_partial_index?
+      def supports_partial_index? #:nodoc:
         true
       end
 
-      def supports_expression_index?
+      def supports_expression_index? #:nodoc:
         true
       end
 
-      def supports_transaction_isolation?
+      def supports_transaction_isolation? #:nodoc:
         true
       end
 
-      def supports_foreign_keys?
+      def supports_foreign_keys? #:nodoc:
         true
       end
 
-      def supports_validate_constraints?
+      def supports_validate_constraints? #:nodoc:
         true
       end
 
-      def supports_views?
+      def supports_views? #:nodoc:
         true
       end
 
-      def supports_datetime_with_precision?
+      def supports_datetime_with_precision? #:nodoc:
         true
       end
 
-      def supports_json?
+      def supports_json? #:nodoc:
         true
       end
 
-      def supports_comments?
+      def supports_comments? #:nodoc:
         true
       end
 
-      def supports_savepoints?
+      def supports_savepoints? #:nodoc:
         true
       end
 
-      def supports_insert_returning?
+      def supports_insert_returning? #:nodoc:
         true
       end
 
-      def supports_insert_on_conflict?
+      def supports_insert_on_conflict? #:nodoc:
         database_version >= 90500
       end
-      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
-      alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
-      alias supports_insert_conflict_target? supports_insert_on_conflict?
+      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict? #:nodoc:
+      alias supports_insert_on_duplicate_update? supports_insert_on_conflict? #:nodoc:
+      alias supports_insert_conflict_target? supports_insert_on_conflict? #:nodoc:
 
       def index_algorithms
         { concurrently: "CONCURRENTLY" }
@@ -314,32 +314,32 @@ module ActiveRecord
         execute("SET standard_conforming_strings = on", "SCHEMA")
       end
 
-      def supports_ddl_transactions?
+      def supports_ddl_transactions? #:nodoc:
         true
       end
 
-      def supports_advisory_locks?
+      def supports_advisory_locks? #:nodoc:
         true
       end
 
-      def supports_explain?
+      def supports_explain? #:nodoc:
         true
       end
 
-      def supports_extensions?
+      def supports_extensions? #:nodoc:
         true
       end
 
-      def supports_ranges?
+      def supports_ranges? #:nodoc:
         true
       end
       deprecate :supports_ranges?
 
-      def supports_materialized_views?
+      def supports_materialized_views? #:nodoc:
         true
       end
 
-      def supports_foreign_tables?
+      def supports_foreign_tables? #:nodoc:
         true
       end
 
@@ -347,14 +347,14 @@ module ActiveRecord
         database_version >= 90400
       end
 
-      def supports_optimizer_hints?
+      def supports_optimizer_hints? #:nodoc:
         unless defined?(@has_pg_hint_plan)
           @has_pg_hint_plan = extension_available?("pg_hint_plan")
         end
         @has_pg_hint_plan
       end
 
-      def supports_lazy_transactions?
+      def supports_lazy_transactions? #:nodoc:
         true
       end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -98,19 +98,19 @@ module ActiveRecord
         configure_connection
       end
 
-      def supports_ddl_transactions?
+      def supports_ddl_transactions? #:nodoc:
         true
       end
 
-      def supports_savepoints?
+      def supports_savepoints? #:nodoc:
         true
       end
 
-      def supports_partial_index?
+      def supports_partial_index? #:nodoc:
         true
       end
 
-      def supports_expression_index?
+      def supports_expression_index? #:nodoc:
         database_version >= "3.9.0"
       end
 
@@ -118,28 +118,28 @@ module ActiveRecord
         true
       end
 
-      def supports_foreign_keys?
+      def supports_foreign_keys? #:nodoc:
         true
       end
 
-      def supports_views?
+      def supports_views? #:nodoc:
         true
       end
 
-      def supports_datetime_with_precision?
+      def supports_datetime_with_precision? #:nodoc:
         true
       end
 
-      def supports_json?
+      def supports_json? #:nodoc:
         true
       end
 
-      def supports_insert_on_conflict?
+      def supports_insert_on_conflict? #:nodoc:
         database_version >= "3.24.0"
       end
-      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
-      alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
-      alias supports_insert_conflict_target? supports_insert_on_conflict?
+      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict? #:nodoc:
+      alias supports_insert_on_duplicate_update? supports_insert_on_conflict? #:nodoc:
+      alias supports_insert_conflict_target? supports_insert_on_conflict? #:nodoc:
 
       def active?
         !@connection.closed?
@@ -157,7 +157,7 @@ module ActiveRecord
         @connection.close rescue nil
       end
 
-      def supports_index_sort_order?
+      def supports_index_sort_order? #:nodoc:
         true
       end
 
@@ -177,11 +177,11 @@ module ActiveRecord
         @connection.encoding.to_s
       end
 
-      def supports_explain?
+      def supports_explain? #:nodoc:
         true
       end
 
-      def supports_lazy_transactions?
+      def supports_lazy_transactions? #:nodoc:
         true
       end
 


### PR DESCRIPTION
### Summary

AbstractMysqladapter#supports_bulk_alter? is nodoc-ed, but other
supports_* method in adapter subclass is not.
This commit fixes such inconsistency and expose doc in AbstractAdapter only.

