### PR TITLE
When skipping duplicates in bulk insert on MySQL, avoid assigning an AUTONUMBER column when not specified

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -516,8 +516,8 @@ module ActiveRecord
         sql = +"INSERT #{insert.into} #{insert.values_list}"
 
         if insert.skip_duplicates?
-          any_column = quote_column_name(insert.model.columns.first.name)
-          sql << " ON DUPLICATE KEY UPDATE #{any_column}=#{any_column}"
+          no_op_column = quote_column_name(insert.keys.first)
+          sql << " ON DUPLICATE KEY UPDATE #{no_op_column}=#{no_op_column}"
         elsif insert.update_duplicates?
           sql << " ON DUPLICATE KEY UPDATE "
           sql << insert.updatable_columns.map { |column| "#{column}=VALUES(#{column})" }.join(",")

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       class Builder
         attr_reader :model
 
-        delegate :skip_duplicates?, :update_duplicates?, to: :insert_all
+        delegate :skip_duplicates?, :update_duplicates?, :keys, to: :insert_all
 
         def initialize(insert_all)
           @insert_all, @model, @connection = insert_all, insert_all.model, insert_all.connection
@@ -122,7 +122,7 @@ module ActiveRecord
         end
 
         def values_list
-          types = extract_types_from_columns_on(model.table_name, keys: insert_all.keys)
+          types = extract_types_from_columns_on(model.table_name, keys: keys)
 
           values_list = insert_all.map_key_with_value do |key, value|
             bind = Relation::QueryAttribute.new(key, value, types[key])

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -104,6 +104,44 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_with_skip_duplicates_and_autonumber_id_not_given
+    skip unless supports_insert_on_duplicate_skip?
+
+    assert_difference "Book.count", 1 do
+      # These two books are duplicates according to an index on %i[author_id name]
+      # but their IDs are not specified so they will be assigned different IDs
+      # by autonumber. We will get an exception from MySQL if we attempt to skip
+      # one of these records by assigning its ID.
+      Book.insert_all [
+        { author_id: 8, name: "Refactoring" },
+        { author_id: 8, name: "Refactoring" }
+      ]
+    end
+  end
+
+  def test_insert_all_with_skip_duplicates_and_autonumber_id_given
+    skip unless supports_insert_on_duplicate_skip?
+
+    assert_difference "Book.count", 1 do
+      Book.insert_all [
+        { id: 200, author_id: 8, name: "Refactoring" },
+        { id: 201, author_id: 8, name: "Refactoring" }
+      ]
+    end
+  end
+
+  def test_skip_duplicates_strategy_does_not_secretly_upsert
+    skip unless supports_insert_on_duplicate_skip?
+
+    book = Book.create!(author_id: 8, name: "Refactoring", format: "EXPECTED")
+
+    assert_no_difference "Book.count" do
+      Book.insert(author_id: 8, name: "Refactoring", format: "UNEXPECTED")
+    end
+
+    assert_equal "EXPECTED", book.reload.format
+  end
+
   def test_insert_all_will_raise_if_duplicates_are_skipped_only_for_a_certain_conflict_target
     skip unless supports_insert_on_duplicate_skip? && supports_insert_conflict_target?
 


### PR DESCRIPTION
### Summary

If `id` is an `AUTONUMBER` column, then my former strategy of assigning `no_op_column` to an arbitrary column would fail in this specific scenario:

1. `model.columns.first` is an AUTONUMBER column
2. `model.columns.first` is not assigned in the insert attributes

I added three tests: the first test covers the actual error; the second test documents that this _isn't_ a problem when a value is given for the AUTONUMBER column and the third test ensures that this no-op strategy to achieve _skip duplicates_ for MySQL isn't secretly doing an UPSERT.

### Reproduce Locally

To see the exception, you can run this script:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "master"
  gem "mysql2"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "mysql2", database: "activerecord_unittest")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :articles, force: true do |t|
    t.string :title, null: false
    t.string :slug, null: false
    t.string :author, null: false

    t.index :slug, unique: true
  end
end

class Article < ActiveRecord::Base; end

class BugTest < Minitest::Test
  def test_upsert_all
    Article.insert_all(
      [
        { title: "Article 1", slug: "article", author: "Jane" },
        { title: "Article 2", slug: "article", author: "John" }
      ]
    )

    assert_equal 1, Article.count
  end
end
```