### PR TITLE
Deduplicate and freeze SqlTypeMetadata instances

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/metadata_registry.rb
+++ b/activerecord/lib/active_record/connection_adapters/metadata_registry.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "digest/md5"
+
+module ActiveRecord
+  module ConnectionAdapters # :nodoc:
+    module MetadataRegistry
+      REGISTRY = {}
+
+      class << self
+        def fetch(type, *args)
+          key = Digest::MD5.hexdigest(Marshal.dump([type.name, args]))
+          REGISTRY[key] ||= yield.freeze
+        end
+      end
+
+      module Concern
+        def new(*args)
+          MetadataRegistry.fetch(self, *args) { super }
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "active_record/connection_adapters/metadata_registry"
+
 module ActiveRecord
   # :stopdoc:
   module ConnectionAdapters
     class SqlTypeMetadata
+      extend MetadataRegistry::Concern
+
       attr_reader :sql_type, :type, :limit, :precision, :scale
 
       def initialize(sql_type: nil, type: nil, limit: nil, precision: nil, scale: nil)


### PR DESCRIPTION
While investigating our apps memory usage, Active Record's schema info appeared to be a significant part of our production memory usage.

However, most of the time database schema contain a lot of duplications, many names are repeated (`id`, `updated_at`, `created_at`, `name`, etc), and some column metadata are overly common, e.g `"varchar(255)"`.

Unfortunately, most AR metadata contain both the column and the table name, making deduplication impossible, however there's one metadata that doesn't contain any of these: `SqlTypeMetadata`.

In our app with 2 shards loaded (out of more than 100), we have over `11k` `SqlTypeMetadata` instances:

```
>> ObjectSpace.each_object(ActiveRecord::ConnectionAdapters::SqlTypeMetadata).to_a.size
=> 11813
```

After applying this PR, it's down to `91`:

```
>> ObjectSpace.each_object(ActiveRecord::ConnectionAdapters::SqlTypeMetadata).to_a.size 
=> 91
```

This leads me to believe that this patch would yield memory saving even for small applications.

#### Why MetadataRegistry isn't directly inside SqlTypeMetadata ?

A couple reasons. First since we're using heavy sharding, we'd see huge saving by simply including it in `Column`, and `IndexDefinition`. So having it available is useful for us.

That being said, I'd like to attempt to refactor `Column` and `IndexDefiniton` to not include `table_name`, this would allow them to benefit from the same deduplication for very common column definitions like primary keys and timestamps.

@rafaelfranca @Edouard-chin 