### PR TITLE
Fix deprecation warning about variants and formats

### DIFF
--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -24,7 +24,7 @@ class FixtureResolverTest < ActiveSupport::TestCase
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this text",       templates.first.source
     assert_equal "arbitrary/path",  templates.first.virtual_path
-    assert_equal [:html],           templates.first.formats
-    assert_equal ["variant"],       templates.first.variants
+    assert_equal :html,           templates.first.format
+    assert_equal "variant",       templates.first.variant
   end
 end


### PR DESCRIPTION
### Summary

- After https://github.com/rails/rails/pull/35408 and
  https://github.com/rails/rails/pull/35406, the `formats` and
  `variants` methods are deprecated in favor of `format` and `variant`.

I found this while working on failures in my other PR.