### PR TITLE
Fix arity warning for template handlers

### DIFF
--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -45,12 +45,12 @@ module ActionView #:nodoc:
 
         unless params.find_all { |type, _| type == :req || type == :opt }.length >= 2
           ActiveSupport::Deprecation.warn <<~eowarn
-          Single arity template handlers are deprecated.  Template handlers must
+          Single arity template handlers are deprecated. Template handlers must
           now accept two parameters, the view object and the source for the view object.
           Change:
-            >> #{handler.class}#call(#{params.map(&:last).join(", ")})
+            >> #{handler}.call(#{params.map(&:last).join(", ")})
           To:
-            >> #{handler.class}#call(#{params.map(&:last).join(", ")}, source)
+            >> #{handler}.call(#{params.map(&:last).join(", ")}, source)
           eowarn
           handler = LegacyHandlerWrapper.new(handler)
         end


### PR DESCRIPTION
### Summary

The warning displayed a generic `Class` string instead of the class name (e.g. `Coffee::Rails::TemplateHandler`).

This makes it difficult to know which template handler is responsible for the warning and thus which one needs to be updated.

`extensions` could also be used and may lead to a better error message.

### Other Information

```ruby
handler.class # => Class

handler.to_s # => Coffee::Rails::TemplateHandler

Change:
  >> Class#call(template)
To:
  >> Class#call(template, source)

to

Change:
  >> Coffee::Rails::TemplateHandler.call(template)
To:
  >> Coffee::Rails::TemplateHandler.call(template, source)
```

A test would be great, not sure how I would do that though (either using an old gem version or mocking a template handler). At least it works in my manual testing.

I also fixed the instance method call to a class method call as this is how `Coffee::Rails::TemplateHandler` handles it:

```ruby
Coffee::Rails::TemplateHandler.call(OpenStruct.new(source: 'a = 1'), 'a = 1')
```