### PR TITLE
Deduplicate various metadata in schema cache structs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -20,10 +20,14 @@ module ActiveRecord
         using: nil,
         comment: nil
       )
-        @table = table
-        @name = name
+        @table = intern(table)
+        @name = intern(name)
         @unique = unique
-        @columns = columns
+        @columns = if columns.is_a?(Array)
+          columns.map { |c| intern(c) }.freeze
+        else
+          intern(columns)
+        end
         @lengths = concise_options(lengths)
         @orders = concise_options(orders)
         @opclasses = concise_options(opclasses)
@@ -40,6 +44,10 @@ module ActiveRecord
           else
             options
           end
+        end
+
+        def intern(value)
+          value.is_a?(String) ? -value : value
         end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -16,14 +16,14 @@ module ActiveRecord
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
       def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment: nil, **)
-        @name = name.freeze
-        @table_name = table_name
+        @name = intern(name)
+        @table_name = intern(table_name)
         @sql_type_metadata = sql_type_metadata
         @null = null
-        @default = default
-        @default_function = default_function
-        @collation = collation
-        @comment = comment
+        @default = intern(default)
+        @default_function = intern(default_function)
+        @collation = intern(collation)
+        @comment = intern(comment)
       end
 
       def has_default?
@@ -43,14 +43,14 @@ module ActiveRecord
       end
 
       def init_with(coder)
-        @name = coder["name"]
-        @table_name = coder["table_name"]
+        @name = intern(coder["name"])
+        @table_name = intern(coder["table_name"])
         @sql_type_metadata = coder["sql_type_metadata"]
         @null = coder["null"]
-        @default = coder["default"]
-        @default_function = coder["default_function"]
-        @collation = coder["collation"]
-        @comment = coder["comment"]
+        @default = intern(coder["default"])
+        @default_function = intern(coder["default_function"])
+        @collation = intern(coder["collation"])
+        @comment = intern(coder["comment"])
       end
 
       def encode_with(coder)
@@ -78,6 +78,12 @@ module ActiveRecord
 
         def attributes_for_hash
           [self.class, name, default, sql_type_metadata, null, table_name, default_function, collation]
+        end
+
+      private
+
+        def intern(value)
+          value.is_a?(String) ? -value : value
         end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         def initialize(type_metadata, extra: "")
           super(type_metadata)
           @type_metadata = type_metadata
-          @extra = extra
+          @extra = -extra
         end
 
         def ==(other)

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -7,7 +7,7 @@ module ActiveRecord
       attr_reader :sql_type, :type, :limit, :precision, :scale
 
       def initialize(sql_type: nil, type: nil, limit: nil, precision: nil, scale: nil)
-        @sql_type = sql_type
+        @sql_type = intern(sql_type)
         @type = type
         @limit = limit
         @precision = precision
@@ -28,6 +28,12 @@ module ActiveRecord
 
         def attributes_for_hash
           [self.class, sql_type, type, limit, precision, scale]
+        end
+
+      private
+
+        def intern(value)
+          value.is_a?(String) ? -value : value
         end
     end
   end


### PR DESCRIPTION
I've been running `memory_profiler` against our app, and ActiveRecord metadata is showing up quite a lot:

```
retained objects by class
-----------------------------------
   4700925  String
    322954  Array
    317773  ActiveRecord::ConnectionAdapters::MySQL::Column
    317773  ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
    317773  ActiveRecord::ConnectionAdapters::SqlTypeMetadata

Retained String Report
-----------------------------------
    295199  ""
    294148  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456


     99192  "bigint(20)"
     99191  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     93414  "utf8mb4_general_ci"
     93414  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     72934  "varchar(255)"
     72933  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     67064  "datetime"
     67059  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     53131  "id"
     52233  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     25939  "auto_increment"
     25937  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     25826  "shop_id"
     25633  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     25532  "created_at"
     25442  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     25274  "updated_at"
     25207  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     19808  "tinyint(1)"
     19807  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     12403  "0"
     12383  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     8686  "text"
     8476  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     6449  "utf8_general_ci"
     6449  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     6034  "1"
     5995  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     5808  "decimal(20,2)"
     5807  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     5773  "mediumtext"
     5771  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456

     5089  "int(11)"
     5088  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456
```

(And the list goes on and on).

It's particularly bad in our app because we're heavily sharded, so each `Column` is duplicated for each database, so I'd like to deduplicate these as well, I'm working on that in https://github.com/rails/rails/pull/35855

However even if the various metadata classes are deduplicated, some values are very frequent as shown by the profile, so I believe it's absolutely worth deduplicating them. Even on small apps many of the strings shown above would be duplicated quite a lot.

@rafaelfranca @Edouard-chin @csfrancis
