### PR TITLE
Do not exclude paths in the global level of Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,9 +28,3 @@ engines:
 ratings:
   paths:
   - "**.rb"
-
-exclude_paths:
-  - ci/
-  - guides/
-  - tasks/
-  - tools/


### PR DESCRIPTION
We use only RuboCop in Code Climate and exclude paths are specified in RuboCop's setting.
The global level excludes paths should not be specified to match the behavior of local and CodeClimate.
