### PR TITLE
[ci skip] Mark ActiveRecord::TouchLater as private doc

### DIFF
--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   # = Active Record Touch Later
-  module TouchLater
+  module TouchLater # :nodoc:
     extend ActiveSupport::Concern
 
     included do


### PR DESCRIPTION
When I was working on #35866 issue tried to search for `touch_later`, the doc for touch later was present, but it did not have anything documented. 

Marked the doc as private. Raised a separate PR because if we don't need this change then it can be closed. 

Link: https://api.rubyonrails.org/classes/ActiveRecord/TouchLater.html

Screenshot: 
<img width="1440" alt="touch-later-api-doc" src="https://user-images.githubusercontent.com/7736232/55604779-27222600-578f-11e9-92e7-86401e667c0b.png">
