### PR TITLE
Fix the deprecation warning about `config.active_job.return_false_on_aborted_enqueue`

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -67,7 +67,7 @@ module ActiveJob
           false
         else
           ActiveSupport::Deprecation.warn(
-            "Rails 6.0 will return false when the enqueuing is aborted. Make sure your code doesn't depend on it" \
+            "Rails 6.1 will return false when the enqueuing is aborted. Make sure your code doesn't depend on it" \
             " returning the instance of the job and set `config.active_job.return_false_on_aborted_enqueue = true`" \
             " to remove the deprecations."
           )

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -784,7 +784,7 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.custom_serializers` allows to set custom argument serializers. Defaults to `[]`.
 
-* `config.active_job.return_false_on_aborted_enqueue` change the return value of `#enqueue` to false instead of the job instance when the enqueuing is aborted. Defaults to `false`.
+* `config.active_job.return_false_on_aborted_enqueue` change the return value of `#enqueue` to false instead of the job instance when the enqueuing is aborted. Defaults to `true`.
 
 ### Configuring Action Cable
 


### PR DESCRIPTION
- It will return false in Rails 6.1 not 6.0. Also fixed the default
  value which is true for new applications.
cc @rafaelfranca 