### PR TITLE
Improve == and hash methods on various schema cache structs to be allocation free.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -63,19 +63,24 @@ module ActiveRecord
 
       def ==(other)
         other.is_a?(Column) &&
-          attributes_for_hash == other.attributes_for_hash
+          name == other.name &&
+          default == other.default &&
+          sql_type_metadata == other.sql_type_metadata &&
+          null == other.null &&
+          default_function == other.default_function &&
+          collation == other.collation
       end
       alias :eql? :==
 
       def hash
-        attributes_for_hash.hash
+        Column.hash ^
+          name.hash ^
+          default.hash ^
+          sql_type_metadata.hash ^
+          null.hash ^
+          default_function.hash ^
+          collation.hash
       end
-
-      protected
-
-        def attributes_for_hash
-          [self.class, name, default, sql_type_metadata, null, default_function, collation, comment]
-        end
     end
 
     class NullColumn < Column

--- a/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
@@ -16,19 +16,16 @@ module ActiveRecord
 
         def ==(other)
           other.is_a?(MySQL::TypeMetadata) &&
-            attributes_for_hash == other.attributes_for_hash
+            __getobj__ == other.__getobj__ &&
+            extra == other.extra
         end
         alias eql? ==
 
         def hash
-          attributes_for_hash.hash
+          TypeMetadata.hash ^
+            __getobj__.hash ^
+            extra.hash
         end
-
-        protected
-
-          def attributes_for_hash
-            [self.class, @type_metadata, extra]
-          end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
@@ -22,19 +22,20 @@ module ActiveRecord
 
       def ==(other)
         other.is_a?(PostgreSQLTypeMetadata) &&
-          attributes_for_hash == other.attributes_for_hash
+          __getobj__ == other.__getobj__ &&
+          oid == other.oid &&
+          fmod == other.fmod &&
+          array == other.array
       end
       alias eql? ==
 
       def hash
-        attributes_for_hash.hash
+        PostgreSQLTypeMetadata.hash ^
+          __getobj__.hash ^
+          oid.hash ^
+          fmod.hash ^
+          array.hash
       end
-
-      protected
-
-        def attributes_for_hash
-          [self.class, @type_metadata, oid, fmod]
-        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -16,19 +16,22 @@ module ActiveRecord
 
       def ==(other)
         other.is_a?(SqlTypeMetadata) &&
-          attributes_for_hash == other.attributes_for_hash
+          sql_type == other.sql_type &&
+          type == other.type &&
+          limit == other.limit &&
+          precision == other.precision &&
+          scale == other.scale
       end
       alias eql? ==
 
       def hash
-        attributes_for_hash.hash
+        SqlTypeMetadata.hash ^
+          sql_type.hash ^
+          type.hash ^
+          limit.hash ^
+          precision.hash >> 1 ^
+          scale.hash >> 2
       end
-
-      protected
-
-        def attributes_for_hash
-          [self.class, sql_type, type, limit, precision, scale]
-        end
     end
   end
 end


### PR DESCRIPTION
### Context

Right now this might seem like needless ROFLscaling because these methods aren't exactly hotspots. However in https://github.com/rails/rails/pull/35855 we're exploring the possibility of deduplicating these objects, hence it will become somewhat of a hotspot.

### Allocation free

The previous implementation would allocate 2 arrays per comparisons.

I tried relying on Struct, but they do allocate one Hash inside `Struct#hash`.

That new implementation should be fully allocation free as shown by this profile: https://gist.github.com/casperisfine/db11788526b6720c62168e464a9c4bd6

### Speed

While I was at it, I also ran a speed benchmark, the result are pretty good:

```
Warming up --------------------------------------
          Orginal ==    66.978k i/100ms
       Orginal #hash    38.182k i/100ms
              New ==   165.441k i/100ms
           New #hash   145.549k i/100ms
Calculating -------------------------------------
          Orginal ==    846.966k (± 4.4%) i/s -      4.287M in   5.073426s
       Orginal #hash    457.440k (± 7.2%) i/s -      2.291M in   5.038573s
              New ==      2.877M (± 7.3%) i/s -     14.393M in   5.032400s
           New #hash      2.366M (± 8.1%) i/s -     11.789M in   5.018887s
```

@rafaelfranca @Edouard-chin @csfrancis @kaspth @matthewd @tenderlove 