### PR TITLE
Add blank_line option to simple_format

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add blank_line option to simple_format
+
+    *Hiroaki Osawa*
+
 *   Only clear ActionView cache in development on file changes
 
     To speed up development mode, view caches are only cleared when files in

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -276,7 +276,7 @@ module ActionView
       # ==== Options
       # * <tt>:sanitize</tt> - If +false+, does not sanitize +text+.
       # * <tt>:wrapper_tag</tt> - String representing the wrapper tag, defaults to <tt>"p"</tt>
-      #
+      # * <tt>:blank_line</tt> - If +true+, add <br /> for blank line. default false
       # ==== Examples
       #   my_text = "Here is some basic text...\n...with a line break."
       #
@@ -291,6 +291,9 @@ module ActionView
       #   simple_format(more_text)
       #   # => "<p>We want to put a paragraph...</p>\n\n<p>...right there.</p>"
       #
+      #   simple_format(more_text, {}, blank_line: true)
+      #   # => "<p>We want to put a paragraph...\n<br /><br />...right there.</p>"
+      #
       #   simple_format("Look ma! A class!", class: 'description')
       #   # => "<p class='description'>Look ma! A class!</p>"
       #
@@ -303,6 +306,7 @@ module ActionView
         wrapper_tag = options.fetch(:wrapper_tag, :p)
 
         text = sanitize(text) if options.fetch(:sanitize, true)
+        text = text.gsub(/\r\n\r\n|\n\n/, "\n<br />") if options.fetch(:blank_line, false)
         paragraphs = split_paragraphs(text)
 
         if paragraphs.empty?

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -65,6 +65,10 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, { wrapper_tag: "div" })
   end
 
+  def test_simple_format_with_blank_line_and_multi_line_breaks
+    assert_equal "<p>We want to put a br...\n<br /><br />..right there.</p>", simple_format("We want to put a br...\n\n..right there.", {}, { blank_line: true })
+  end
+
   def test_simple_format_should_not_change_the_text_passed
     text = "<b>Ok</b><script>code!</script>"
     text_clone = text.dup
@@ -80,7 +84,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_simple_format_does_not_modify_the_options_hash
-    options = { wrapper_tag: :div, sanitize: false }
+    options = { wrapper_tag: :div, sanitize: false, blank_line: true }
     passed_options = options.dup
     simple_format("some text", {}, passed_options)
     assert_equal options, passed_options


### PR DESCRIPTION
### Summary

I think that simple_foramt method needed the option to output an empty line created by breaking
Because when People want to output a new line, often want to output an empty line at the same time

For example

```ruby
simple_format("We want to put a br...\n\n..right there.", {}, { blank_line: true })
# => <p>We want to put a br...\n<br /><br />..right there.</p>
```

Let me know if there's anything to be clarified/updated.
Hope it makes sense!