### PR TITLE
Added after_save_commit callback to the list of available callbacks in guide [ci skip]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -94,7 +94,7 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 * `around_create`
 * `after_create`
 * `after_save`
-* `after_commit/after_rollback`
+* `after_commit/after_rollback/after_save_commit`
 
 ### Updating an Object
 
@@ -106,7 +106,7 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 * `around_update`
 * `after_update`
 * `after_save`
-* `after_commit/after_rollback`
+* `after_commit/after_rollback/after_save_commit`
 
 ### Destroying an Object
 


### PR DESCRIPTION
Guide has a list of available calls for listed here(https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks). Since a new callback was added in #35804, added the callback in the list as per the order in which callbacks are called.