### PR TITLE
Add documentations to concern methods [ci skip]

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -110,7 +110,7 @@ module ActiveSupport
       base.instance_variable_set(:@_dependencies, [])
     end
 
-    def append_features(base)
+    def append_features(base) #:nodoc:
       if base.instance_variable_defined?(:@_dependencies)
         base.instance_variable_get(:@_dependencies) << self
         false

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -123,6 +123,9 @@ module ActiveSupport
       end
     end
 
+    # Evaluate given block in context of base class,
+    # so that you can write class macros here.
+    # When you define more than one +included+ block, it raises an exception.
     def included(base = nil, &block)
       if base.nil?
         if instance_variable_defined?(:@_included_block)
@@ -137,6 +140,26 @@ module ActiveSupport
       end
     end
 
+    # Define class methods from given block.
+    # You can define private class methods as well.
+    #
+    #   module Example
+    #     extend ActiveSupport::Concern
+    #
+    #     class_methods do
+    #       def foo; puts 'foo'; end
+    #
+    #       private
+    #         def bar; puts 'bar'; end
+    #     end
+    #   end
+    #
+    #   class Buzz
+    #     include Example
+    #   end
+    #
+    #   Buzz.foo # => "foo"
+    #   Buzz.bar # => private method 'bar' called for Buzz:Class(NoMethodError)
     def class_methods(&class_methods_module_definition)
       mod = const_defined?(:ClassMethods, false) ?
         const_get(:ClassMethods) :


### PR DESCRIPTION
### Summary

Add some documentations to concern methods (`included` and `class_methods`).
`append_features` is `:nodoc:` because users don't care about it.