### PR TITLE
Improve log messages for #insert_all` / `#upsert_all` etc. methods

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -21,7 +21,10 @@ module ActiveRecord
     end
 
     def execute
-      connection.exec_query to_sql, "Bulk Insert"
+      message = "#{model} "
+      message += "Bulk " if inserts.many?
+      message += (on_duplicate == :update ? "Upsert" : "Insert")
+      connection.exec_query to_sql, message
     end
 
     def updatable_columns

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -143,6 +143,42 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_logs_message_including_model_name
+    skip unless supports_insert_conflict_target?
+
+    capture_log_output do |output|
+      Book.insert(name: "Rework", author_id: 1)
+      assert_match "Book Insert", output.string
+    end
+  end
+
+  def test_insert_all_logs_message_including_model_name
+    skip unless supports_insert_conflict_target?
+
+    capture_log_output do |output|
+      Book.insert_all [{ name: "Remote", author_id: 1 }, { name: "Renote", author_id: 1 }]
+      assert_match "Book Bulk Insert", output.string
+    end
+  end
+
+  def test_upsert_logs_message_including_model_name
+    skip unless supports_insert_on_duplicate_update?
+
+    capture_log_output do |output|
+      Book.upsert(name: "Remote", author_id: 1)
+      assert_match "Book Upsert", output.string
+    end
+  end
+
+  def test_upsert_all_logs_message_including_model_name
+    skip unless supports_insert_on_duplicate_update?
+
+    capture_log_output do |output|
+      Book.upsert_all [{ name: "Remote", author_id: 1 }, { name: "Renote", author_id: 1 }]
+      assert_match "Book Bulk Upsert", output.string
+    end
+  end
+
   def test_upsert_all_updates_existing_records
     skip unless supports_insert_on_duplicate_update?
 
@@ -186,4 +222,17 @@ class InsertAllTest < ActiveRecord::TestCase
       Book.insert_all! [{ unknown_attribute: "Test" }]
     end
   end
+
+  private
+
+    def capture_log_output
+      output = StringIO.new
+      old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(output)
+
+      begin
+        yield output
+      ensure
+        ActiveRecord::Base.logger = old_logger
+      end
+    end
 end


### PR DESCRIPTION
### Summary

In #35077, `#insert_all` / `#upsert_all` / `#insert` / `#upsert` etc. methods are added. But Active Record logs only “Bulk Insert” log messages when they are invoked.

This pull request improves the log messages to use correct words for how invoked them.

```ruby
Book.insert_all [{ name: "Remote", author_id: 1 }, { name: "Renote", author_id: 1 }]
```

- Before:  `Bulk Insert (0.5.ms)`
- After: `Book Bulk Insert (0.5.ms)`

```ruby
Book.upsert_all [{ name: "Remote", author_id: 1 }, { name: "Renote", author_id: 1 }]
```

- Before:  `Bulk Insert (0.5.ms)`
- After: `Book Bulk Upsert (0.5.ms)`

```ruby
Book.insert(name: "Rework", author_id: 1)
```

- Before:  `Bulk Insert (0.5.ms)`
- After: `Book Insert (0.5.ms)`

```ruby
Book.upsert(name: "Rework", author_id: 1)
```

- Before:  `Bulk Insert (0.5.ms)`
- After: `Book Upsert (0.5.ms)`