### PR TITLE
Attributes declared after instance created have no attribute methods defined

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -207,6 +207,7 @@ module ActiveRecord
       # methods in ActiveModel::Type::Value for more details.
       def attribute(name, cast_type = Type::Value.new, **options)
         name = name.to_s
+        ([self] + descendants).each(&:undefine_attribute_methods)
         reload_schema_from_cache
 
         self.attributes_to_define_after_schema_loads =

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -232,7 +232,11 @@ module ActiveRecord
 
       parent.attribute(:foo, Type::Value.new)
 
-      assert_equal(:bar, child.new(foo: :bar).foo)
+      instance = child.new(foo: :bar)
+      assert_equal(:bar, instance.foo)
+
+      # Test that method is defined and we are not relying on method_missing
+      assert(instance.methods.include?(:foo))
     end
 
     test "attributes not backed by database columns are not dirty when unchanged" do


### PR DESCRIPTION
### Summary

This spec is supposed to check that attributes added after subclasses load are inherited, but that's not what it's doing. The call to the method `foo` is actually falling through to method missing and no actual method `foo` is defined, which is why the test I've added here fails.

The problem is I believe actually more serious than just the inheritance case tested here: any situation where you have already created an instance of a class, and then you define a new attribute with `attribute`, will suffer from the same issue.

So e.g.:

```ruby
class Post < ApplicationRecord
end

Post.new

Post.attribute :foo
```

In this situation, no `foo` method will be defined because `define_attribute_methods` was already called when the first post was created, so `@attribute_methods_generated` is true and AR will not re-define them.

~So I believe what needs to be done is something like this:~

```diff
def attribute(name, cast_type = Type::Value.new, **options)
  name = name.to_s
  reload_schema_from_cache
+ undefine_attribute_methods

  self.attributes_to_define_after_schema_loads =
    attributes_to_define_after_schema_loads.merge(
      name => [cast_type, options]
    )
+ define_attribute_methods
end
```

~This passes the spec here, but other stuff fails, and this feels very heavy-handed.~ *(see below)*

Any idea where we should go with this? It's quite likely that there are many applications which may be falling through to method missing like this for attributes defined in this way, which would incur serious performance degradation.