### PR TITLE
Instrument unhandled active job errors

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Instrument unhandled errors in perform and enqueue.
+
+    *Kaleb Lape*
+
 *   Make job argument assertions with `Time`, `ActiveSupport::TimeWithZone`, and `DateTime` work by dropping microseconds. Microsecond precision is lost during serialization.
 
     *Gannon McGibbon*

--- a/activejob/test/cases/instrumentation_test.rb
+++ b/activejob/test/cases/instrumentation_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "helper"
+require "jobs/rescue_job"
+require "jobs/hello_job"
+require "models/person"
+
+class InstrumentationTest < ActiveSupport::TestCase
+  def subscription_events(key)
+    [].tap do |events|
+      subscription = ActiveSupport::Notifications.subscribe(/#{key}\.active_job/) { |event|
+        events << event
+      }
+
+      yield
+
+      ActiveSupport::Notifications.unsubscribe(subscription)
+    end
+  end
+
+  test "do not instrument errors when already handled" do
+    events = subscription_events(:unhandled_error) {
+      RescueJob.perform_now("david")
+    }
+
+    assert_equal 0, events.length
+  end
+
+  test "instrument unhandled errors from perform" do
+    events = subscription_events(:unhandled_error) {
+      assert_raises(RescueJob::OtherError) do
+        RescueJob.perform_now("other")
+      end
+    }
+
+    assert_equal 1, events.length
+    assert_instance_of RescueJob::OtherError, events.first.payload[:error]
+  end
+
+  test "instrument unhandled errors from enqueue" do
+    events = subscription_events(:unhandled_error) {
+      assert_raises(ActiveJob::DeserializationError) do
+        HelloJob.perform_later Person.new(404)
+      end
+    }
+
+    assert_equal 1, events.length
+    assert_instance_of ActiveJob::DeserializationError, events.first.payload[:error]
+  end
+end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -488,6 +488,14 @@ Active Job
 | `:job`       | Job object                             |
 | `:error`     | The error that caused the discard      |
 
+### unhandled_error.active_job
+
+| Key          | Value                                  |
+| ------------ | -------------------------------------- |
+| `:adapter`   | QueueAdapter object processing the job |
+| `:job`       | Job object                             |
+| `:error`     | The unhandled error                    |
+
 Action Cable
 ------------
 


### PR DESCRIPTION
### Summary

Add instrumentation for unhandled Active Job errors. Subscribers on `unhandled_error.active_job` will receive an event whenever an error occurs that isn't already handled by `rescue_from` (i.e. `retry_on` and `discard_on`).

### Other Information

Today I am aware of a couple ways to accomplish this:
1) Subscribe to `(perform|enqueue).active_job` and check for `exception_object` in the payload.
2) Roll your own instrumentation in a base class or module.

The first technique actually yields every error including exceptions handled by `rescue_from`, so it doesn't completely meet the criteria for this PR. The second technique leads to nonstandard implementations, which could make codebases less approachable and make it harder to write general purpose tooling based on this instrumentation.