### PR TITLE
Update configuration of `app` directory and use oxford comma [skip ci]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -217,8 +217,8 @@ important parts about namespacing, and is discussed later in the
 #### `app` Directory
 
 Inside the `app` directory are the standard `assets`, `controllers`, `helpers`,
-`mailers`, `models` and `views` directories that you should be familiar with
-from an application. The `helpers`, `mailers` and `models` directories are
+`jobs`, `mailers`, `models`, and `views` directories that you should be familiar with
+from an application. The `helpers`, `mailers`, and `models` directories are
 empty, so they aren't described in this section. We'll look more into models in
 a future section, when we're writing the engine.
 


### PR DESCRIPTION
### Summary

#### Update configuration of `app` directory

The `jobs` directory is included under the` app` of the skeleton structure created by `rails plugin new blorgh --mountable`.

```
$ rails -v
Rails 6.0.0.beta3
$ rails plugin new blorgh --mountable
create
create  README.md
create  Rakefile
create  blorgh.gemspec
create  MIT-LICENSE
create  .gitignore
create  Gemfile
create  app
create  app/controllers/blorgh/application_controller.rb
create  app/helpers/blorgh/application_helper.rb
create  app/jobs/blorgh/application_job.rb
create  app/mailers/blorgh/application_mailer.rb
create  app/models/blorgh/application_record.rb
create  app/views/layouts/blorgh/application.html.erb
create  app/assets/images/blorgh
create  app/assets/images/blorgh/.keep
create  config/routes.rb
create  lib/blorgh.rb
create  lib/tasks/blorgh_tasks.rake
create  lib/blorgh/version.rb
create  lib/blorgh/engine.rb
create  app/assets/config/blorgh_manifest.js
create  app/assets/stylesheets/blorgh/application.css
create  bin/rails
create  test/test_helper.rb
create  test/blorgh_test.rb
append  Rakefile
create  test/integration/navigation_test.rb
vendor_app  test/dummy

$ ls blorgh/app/
assets  controllers  helpers  jobs  mailers  models  views
```

### Use oxford comma

Use oxford comma according to the guide line.

https://guides.rubyonrails.org/api_documentation_guidelines.html#oxford-comma: