### PR TITLE
[ci skip] Fix `#upsert` method comment

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -178,7 +178,7 @@ module ActiveRecord
         InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning).execute
       end
 
-      # Updates or inserts (upserts) multiple records into the database in a
+      # Updates or inserts (upserts) a single record into the database in a
       # single SQL INSERT statement. It does not instantiate any models nor does
       # it trigger Active Record callbacks or validations. Though passed values
       # go through Active Record's type casting and serialization.


### PR DESCRIPTION
### Summary

In #35077, `#upsert` methods was added. 
Like `#insert` method, `#upsert` method updates or inserts only a single record.
So I corrected the comment for the method.
