### PR TITLE
FIX: ActionMailbox test helper argument list

### DIFF
--- a/actionmailbox/lib/action_mailbox/test_helper.rb
+++ b/actionmailbox/lib/action_mailbox/test_helper.rb
@@ -29,16 +29,16 @@ module ActionMailbox
       create_inbound_email_from_fixture(*args).tap(&:route)
     end
 
-    # Create an +InboundEmail+ from fixture using the same arguments as +create_inbound_email_from_mail+
-    # and immediately route it to processing.
+    # Create an +InboundEmail+ using the same arguments as +create_inbound_email_from_mail+ and immediately route it to
+    # processing.
     def receive_inbound_email_from_mail(**kwargs)
       create_inbound_email_from_mail(**kwargs).tap(&:route)
     end
 
-    # Create an +InboundEmail+ from fixture using the same arguments as +create_inbound_email_from_source+
-    # and immediately route it to processing.
-    def receive_inbound_email_from_source(**kwargs)
-      create_inbound_email_from_source(**kwargs).tap(&:route)
+    # Create an +InboundEmail+ using the same arguments as +create_inbound_email_from_source+ and immediately route it
+    # to processing.
+    def receive_inbound_email_from_source(*args)
+      create_inbound_email_from_source(*args).tap(&:route)
     end
   end
 end


### PR DESCRIPTION
`receive_inbound_email_from_source` should accept an argument list
(`*args`) instead of a keyword argument list (`**kwarg`), to allow for the 
`source` argument in `create_inbound_email_from_source`.

```ruby
create_inbound_email_from_source(source, status: :processing)
receive_inbound_email_from_source(source, status: :processing)
```

This previously resulted in an `ArgumentError`

```text
ArgumentError: wrong number of arguments (given 1, expected 0)
```

This PR also includes a correction to a small typo in the method comment.