### PR TITLE
Only override async adapter when seeding

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only force `:async` ActiveJob adapter to `:inline` during seeding.
+
+    *BatedUrGonnaDie*
+
 *   The `connection` option of `rails dbconsole` command is deprecated in
     favor of `database` option.
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -550,7 +550,13 @@ module Rails
     # Blog::Engine.load_seed
     def load_seed
       seed_file = paths["db/seeds.rb"].existent.first
-      with_inline_jobs { load(seed_file) } if seed_file
+      return unless seed_file
+
+      if config.active_job.queue_adapter == :async
+        with_inline_jobs { load(seed_file) }
+      else
+        load(seed_file)
+      end
     end
 
     # Add configured load paths to Ruby's load path, and remove duplicate entries.

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -879,7 +879,7 @@ YAML
       assert Bukkits::Engine.config.bukkits_seeds_loaded
     end
 
-    test "jobs are ran inline while loading seeds" do
+    test "jobs are ran inline while loading seeds with async adapter configured" do
       app_file "db/seeds.rb", <<-RUBY
         Rails.application.config.seed_queue_adapter = ActiveJob::Base.queue_adapter
       RUBY
@@ -889,6 +889,19 @@ YAML
 
       assert_instance_of ActiveJob::QueueAdapters::InlineAdapter, Rails.application.config.seed_queue_adapter
       assert_instance_of ActiveJob::QueueAdapters::AsyncAdapter, ActiveJob::Base.queue_adapter
+    end
+
+    test "jobs are ran with original adapter while loading seeds with custom adapter configured" do
+      app_file "db/seeds.rb", <<-RUBY
+        Rails.application.config.seed_queue_adapter = ActiveJob::Base.queue_adapter
+      RUBY
+
+      boot_rails
+      Rails.application.config.active_job.queue_adapter = :delayed_job
+      Rails.application.load_seed
+
+      assert_instance_of ActiveJob::QueueAdapters::DelayedJobAdapter, Rails.application.config.seed_queue_adapter
+      assert_instance_of ActiveJob::QueueAdapters::DelayedJobAdapter, ActiveJob::Base.queue_adapter
     end
 
     test "skips nonexistent seed data" do


### PR DESCRIPTION
### Summary

Only override the ActiveJob adapter if it is set to `:async` during the seeding process.  This stops jobs that are queued with `wait_until: xxx` from throwing an error.

Closes #35812