### PR TITLE
Notes tags registration

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -481,6 +481,22 @@ lib/school.rb:
   * [ 17] [FIXME]
 ```
 
+#### Tags
+
+You can add more default tags to search for by using `config.annotations.register_tags`. It receives a list of tags.
+
+```ruby
+config.annotations.register_tags("DEPRECATEME", "TESTME")
+```
+
+```bash
+$ rails notes
+app/controllers/admin/users_controller.rb:
+  * [ 20] [TODO] do A/B testing on this
+  * [ 42] [TESTME] this needs more functional tests
+  * [132] [DEPRECATEME] ensure this method is deprecated in next release
+```
+
 #### Directories
 
 You can add more default directories to search from by using `config.annotations.register_directories`. It receives a list of directory names.

--- a/railties/lib/rails/commands/notes/notes_command.rb
+++ b/railties/lib/rails/commands/notes/notes_command.rb
@@ -5,7 +5,7 @@ require "rails/source_annotation_extractor"
 module Rails
   module Command
     class NotesCommand < Base # :nodoc:
-      class_option :annotations, aliases: "-a", desc: "Filter by specific annotations, e.g. Foobar TODO", type: :array, default: %w(OPTIMIZE FIXME TODO)
+      class_option :annotations, aliases: "-a", desc: "Filter by specific annotations, e.g. Foobar TODO", type: :array, default: Rails::SourceAnnotationExtractor::Annotation.tags
 
       def perform(*)
         require_application_and_environment!

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -29,6 +29,16 @@ module Rails
         directories.push(*dirs)
       end
 
+      def self.tags
+        @@tags ||= %w(OPTIMIZE FIXME TODO)
+      end
+
+      # Registers additional tags
+      #   Rails::SourceAnnotationExtractor::Annotation.register_tags("TESTME", "DEPRECATEME")
+      def self.register_tags(*additional_tags)
+        tags.push(*additional_tags)
+      end
+
       def self.extensions
         @@extensions ||= {}
       end
@@ -66,6 +76,8 @@ module Rails
     # Prints all annotations with tag +tag+ under the root directories +app+,
     # +config+, +db+, +lib+, and +test+ (recursively).
     #
+    # If +tag+ is <tt>nil</tt>, annotations with either default or registered tags are printed.
+    #
     # Specific directories can be explicitly set using the <tt>:dirs</tt> key in +options+.
     #
     #   Rails::SourceAnnotationExtractor.enumerate 'TODO|FIXME', dirs: %w(app lib), tag: true
@@ -75,7 +87,8 @@ module Rails
     # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
     #
     # This class method is the single entry point for the `rails notes` command.
-    def self.enumerate(tag, options = {})
+    def self.enumerate(tag = nil, options = {})
+      tag ||= Annotation.tags.join("|")
       extractor = new(tag)
       dirs = options.delete(:dirs) || Annotation.directories
       extractor.display(extractor.find(dirs), options)


### PR DESCRIPTION
### Summary

This PR adds to `SourceAnnotationExtractor::Annotation` a new method `register_tags` following the example of `register_directories`. It does not change the behavior of `rake notes` and allows tags registration through configuration.
