### PR TITLE
Bring back postgresql_version as an alias.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -425,6 +425,7 @@ module ActiveRecord
       def get_database_version
         @connection.server_version
       end
+      alias_method :postgresql_version, :get_database_version
 
       def default_index_type?(index) # :nodoc:
         index.using == :btree || super


### PR DESCRIPTION
Hello.

I have found out https://github.com/rails/rails/commit/1c6e508ade793b5f2676e9218ab2f4cc9474f9ce#diff-cc31fc1dd1e78db64638200f710b2f59L427 removed `postgresql_version` which is used in some "mainstream" gems. I'm not sure if that's public or private API (it is reachable at https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html#method-i-postgresql_version), anyway maybe it will be good idea to alias it or at least deprecate properly.

I did not huge research, but by quick look I have spotted that [Scenic](https://github.com/scenic-views/scenic) and [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) are affected.

WDYT?