### PR TITLE
Bring back postgresql_version as an alias.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -425,6 +425,7 @@ module ActiveRecord
       def get_database_version
         @connection.server_version
       end
+      alias :postgresql_version :database_version
 
       def default_index_type?(index) # :nodoc:
         index.using == :btree || super


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/35907 which I wasn't able to update for some reason.

pingie @kamipo 