### PR TITLE
Raise error when don't resolve primary key from inverse of instance

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise error when an association exists `:primary_key` option and the inverse of association
+    don't exist `:primary_key` option because `set_inverse_instance` set wrong primary key.
+
+    Fixes #35803.
+
+    *Shojiro Yanagisawa*
+
 *   Assign all attributes before calling `build` to ensure the child record is visible in
     `before_add` and `after_add` callbacks for `has_many :through` associations.
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -242,6 +242,14 @@ module ActiveRecord
         end
       end
 
+      def check_validity_primary_key!
+        unless polymorphic?
+          if has_inverse? && inverse_of && options[:primary_key] && inverse_of.options[:primary_key].nil?
+            raise ArgumentError, "Cannot resolve primary key of inverse of assocition. Try adding :primary_key on inverse of association."
+          end
+        end
+      end
+
       # This shit is nasty. We need to avoid the following situation:
       #
       #   * An associated record is deleted via record.destroy
@@ -472,6 +480,7 @@ module ActiveRecord
 
       def check_validity!
         check_validity_of_inverse!
+        check_validity_primary_key!
       end
 
       def check_preloadable!
@@ -945,6 +954,7 @@ module ActiveRecord
         end
 
         check_validity_of_inverse!
+        check_validity_primary_key!
       end
 
       def constraints

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -290,6 +290,12 @@ class InverseHasOneTests < ActiveRecord::TestCase
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.dirty_face }
   end
+
+  def test_association_with_primary_key_that_dont_exist_inverse_of_association_with_primary_key_should_raise_an_error
+    error = assert_raise(ArgumentError) { Man.first.face_with_primary_key }
+    expected = "Cannot resolve primary key of inverse of assocition. Try adding :primary_key on inverse of association."
+    assert_equal expected, error.message
+  end
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
@@ -504,6 +510,12 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Man.first.secret_interests }
   end
 
+  def test_association_with_primary_key_that_dont_exist_inverse_of_association_with_primary_key_should_raise_an_error
+    error = assert_raise(ArgumentError) { Man.first.interests_with_primary_key }
+    expected = "Cannot resolve primary key of inverse of assocition. Try adding :primary_key on inverse of association."
+    assert_equal expected, error.message
+  end
+
   def test_child_instance_should_point_to_parent_without_saving
     man = Man.new
     i = Interest.create(topic: "Industrial Revolution Re-enactment")
@@ -625,6 +637,12 @@ class InverseBelongsToTests < ActiveRecord::TestCase
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.horrible_man }
+  end
+
+  def test_association_with_primary_key_that_dont_exist_inverse_of_association_with_primary_key_should_raise_an_error
+    error = assert_raise(ArgumentError) { Face.first.man_with_primary_key }
+    expected = "Cannot resolve primary key of inverse of assocition. Try adding :primary_key on inverse of association."
+    assert_equal expected, error.message
   end
 end
 

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -9,6 +9,8 @@ class Face < ActiveRecord::Base
   # These is a "broken" inverse_of for the purposes of testing
   belongs_to :horrible_man, class_name: "Man", inverse_of: :horrible_face
   belongs_to :horrible_polymorphic_man, polymorphic: true, inverse_of: :horrible_polymorphic_face
+  belongs_to :man_without_primary_key, class_name: "Man", inverse_of: :face_with_primary_key
+  belongs_to :man_with_primary_key, class_name: "Man", primary_key: "name", inverse_of: :face_without_primary_key
 
   validate do
     man

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -4,4 +4,5 @@ class Interest < ActiveRecord::Base
   belongs_to :man, inverse_of: :interests
   belongs_to :polymorphic_man, polymorphic: true, inverse_of: :polymorphic_interests
   belongs_to :zine, inverse_of: :interests
+  belongs_to :man_without_primary_key, inverse_of: :interests_with_primary_key
 end

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -10,6 +10,9 @@ class Man < ActiveRecord::Base
   has_one :dirty_face, class_name: "Face", inverse_of: :dirty_man
   has_many :secret_interests, class_name: "Interest", inverse_of: :secret_man
   has_one :mixed_case_monkey
+  has_one :face_with_primary_key, class_name: "Face", primary_key: "name", inverse_of: :man_without_primary_key
+  has_one :face_without_primary_key, class_name: "Face", inverse_of: :man_with_primary_key
+  has_many :interests_with_primary_key, class_name: "Interest", primary_key: "name", inverse_of: :man_without_primary_key
 end
 
 class Human < Man


### PR DESCRIPTION
### Summary

Raise error when an association exists `:primary_key` option and the inverse of association don't exist `:primary_key` option because `set_inverse_instance` set wrong primary key.

```rb
class Product < ActiveRecord::Base
  has_many :pictures, primary_key: :code, inverse_of: :product
end

class Picture < ActiveRecord::Base
  belongs_to :product
end

product = Product.create(code: 123)
product.pictures.build #=> raise error because inverse of instance don't resolve correct primary key.
```