### PR TITLE
Clarify exists check in logs

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -314,7 +314,7 @@ module ActiveRecord
 
       relation = construct_relation_for_exists(conditions)
 
-      skip_query_cache_if_necessary { connection.select_one(relation.arel, "#{name} Exists") } ? true : false
+      skip_query_cache_if_necessary { connection.select_one(relation.arel, "#{name} Exists?") } ? true : false
     end
 
     # This method is called whenever no records are found with either a single


### PR DESCRIPTION
The default log messages for Model.exists?, when called from .save
on an object which uses scoped uniqueness validation like:

    class Example < ApplicationRecord
      validates :field, uniqueness: {scope: parent_id}
    end

can result in slightly misleading logs.

An example case:

    ↳ app/controllers/example_controller.rb:23
    (0.2ms)  begin transaction
    ↳ app/controllers/example_controller.rb:39
    Example Exists (0.2ms)  SELECT  1 AS one FROM "examples" WHERE "examples"."field" IS NULL AND "examples"."parent_id" = ? LIMIT ?  [["parent_id", 123], ["LIMIT", 1]]
    ↳ app/controllers/example_controller.rb:39
    (0.1ms)  rollback transaction

To me, a Rails newbie, this parsed as the following:

- started the transaction to create a thing
- found that your object exists already!
- so we rolled back the transaction

(even though the actual cause of the transaction is something that happens
after the Exists check.)

All this does is add a question mark to the message, to make it clear in the
log that this is a check, not a confirmation.

This may be kind of silly, but it may save some future goofs by newbs like me.