### PR TITLE
Adds named_captures to MatchData to emulate Regex

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -136,6 +136,10 @@ module ActionDispatch
             Array.new(length - 1) { |i| self[i + 1] }
           end
 
+          def named_captures
+            @names.zip(captures).to_h
+          end
+
           def [](x)
             idx = @offsets[x - 1] + x
             @match[idx]

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -280,6 +280,15 @@ module ActionDispatch
           assert_equal "list", match[1]
           assert_equal "rss", match[2]
         end
+
+        def test_named_captures
+          path = Path::Pattern.from_string "/books(/:action(.:format))"
+
+          uri = "/books/list.rss"
+          match = path =~ uri
+          named_captures = { "action" => "list", "format" => "rss" }
+          assert_equal named_captures, match.named_captures
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

This change adds a `named_captures` method to
`ActionDispatch::Journey::Path::MatchData` in order to emulate a similar
method present on `Regex`'s `MatchData` present in Ruby core.

This method can be useful for introspection of routes without the need
to use `zip` while testing or developing in Rails core.

### Other Information

Admittedly this change started from believing `MatchData` was the Ruby core's `MatchData` and wondering why `named_captures` wasn't being used while debugging an issue. After realizing it wasn't, I'd figured it might make a nice addition.
