### PR TITLE
Adding type option example to the documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -416,6 +416,7 @@ module ActiveRecord
       #
       #  t.references(:user)
       #  t.belongs_to(:supplier, foreign_key: true)
+      #  t.belongs_to(:supplier, foreign_key: true, trype: :integer)
       #
       # See {connection.add_reference}[rdoc-ref:SchemaStatements#add_reference] for details of the options you can use.
       def references(*args, **options)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -416,7 +416,7 @@ module ActiveRecord
       #
       #  t.references(:user)
       #  t.belongs_to(:supplier, foreign_key: true)
-      #  t.belongs_to(:supplier, foreign_key: true, trype: :integer)
+      #  t.belongs_to(:supplier, foreign_key: true, type: :integer)
       #
       # See {connection.add_reference}[rdoc-ref:SchemaStatements#add_reference] for details of the options you can use.
       def references(*args, **options)


### PR DESCRIPTION
It was hard for me looking https://api.rubyonrails.org/ to find that there was a type option. 

Adding this to the doc would be helpful especially for application with old tables where the references are still an`integer` not `bigint`