### PR TITLE
Lazy sync with transaction state on destroy

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -466,6 +466,7 @@ module ActiveRecord
 
     # Returns +true+ if the attributes hash has been frozen.
     def frozen?
+      sync_with_transaction_state
       @attributes.frozen?
     end
 
@@ -583,7 +584,7 @@ module ActiveRecord
       end
 
       def thaw
-        if frozen?
+        if @attributes.frozen?
           @attributes = @attributes.dup
         end
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -530,7 +530,6 @@ module ActiveRecord
     def destroy
       _raise_readonly_record_error if readonly?
       destroy_associations
-      self.class.connection.add_transaction_record(self)
       @_trigger_destroy_callback = if persisted?
         destroy_row > 0
       else

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -26,13 +26,15 @@ class TransactionTest < ActiveRecord::TestCase
   def test_raise_after_destroy
     assert_not_predicate @first, :frozen?
 
-    assert_raises(RuntimeError) {
-      Topic.transaction do
-        @first.destroy
-        assert_predicate @first, :frozen?
-        raise
+    assert_not_called(@first, :rolledback!) do
+      assert_raises(RuntimeError) do
+        Topic.transaction do
+          @first.destroy
+          assert_predicate @first, :frozen?
+          raise
+        end
       end
-    }
+    end
 
     assert_not_predicate @first, :frozen?
   end


### PR DESCRIPTION
This reverts commit 58410b3d566e6b93c7b71c0eec0fc11ec906b68e.

If we have any implicit commit/rollback callbacks, it is necessary to
add record to transaction explicitly like `:touch_deferred_attributes`.

https://github.com/rails/rails/blob/5f261d04d6f857d49c75124df809adfbd6cd5b5e/activerecord/lib/active_record/touch_later.rb#L9
https://github.com/rails/rails/blob/5f261d04d6f857d49c75124df809adfbd6cd5b5e/activerecord/lib/active_record/touch_later.rb#L25

But I can't find any other implicit commit/rollback callbacks in our
code base at least now.

I think the `self.class.connection.add_transaction_record(self)` line
doesn't cover any behavior.

cc @tenderlove 