### PR TITLE
Simplify and fasten NamedRouteCollection#define_url_helper

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -317,18 +317,16 @@ module ActionDispatch
           #
           def define_url_helper(mod, route, name, opts, route_key, url_strategy)
             helper = UrlHelper.create(route, opts, route_key, url_strategy)
-            mod.module_eval do
-              define_method(name) do |*args|
-                last = args.last
-                options = \
-                  case last
-                  when Hash
-                    args.pop
-                  when ActionController::Parameters
-                    args.pop.to_h
-                  end
-                helper.call self, args, options
-              end
+            mod.define_method(name) do |*args|
+              last = args.last
+              options = \
+                case last
+                when Hash
+                  args.pop
+                when ActionController::Parameters
+                  args.pop.to_h
+                end
+              helper.call self, args, options
             end
           end
       end


### PR DESCRIPTION
Somehow defining URL helpers is a huge part of our boot time:

```
==================================
  Mode: cpu(1000)
  Samples: 69414 (13.61% miss rate)
  GC: 17329 (24.96%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     14242  (20.5%)        6971  (10.0%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

A quick benchmark show that avoiding the `module_eval` could save a bit of performance:

```ruby
require 'benchmark/ips'

module Mod; end

Benchmark.ips do |x|
  x.report('module_eval+define_method') do
    Mod.module_eval do
      define_method(:foo) {}
    end
  end

  x.report('define_method') do
    Mod.define_method(:foo) {}
  end
end
```

```
Warming up --------------------------------------
module_eval+define_method
                        47.007k i/100ms
       define_method    57.659k i/100ms
Calculating -------------------------------------
module_eval+define_method
                        552.967k (± 7.4%) i/s -      2.773M in   5.046362s
       define_method    771.507k (± 5.0%) i/s -      3.863M in   5.020874s
```

I can't see any usefulness for that `module_eval`, except that `define_method` used to be private, so it might have been preferred over `send(:define_method)`, but since Rails 6 require MRI 2.5, we no longer have to care about it.


After this patch, the profile look like this:
```
==================================
  Mode: cpu(1000)
  Samples: 79194 (19.05% miss rate)
  GC: 21641 (27.33%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7415   (9.4%)        7126   (9.0%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

@rafaelfranca @Edouard-chin 