### PR TITLE
Deduplicate Active Record reflection names

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -21,12 +21,12 @@ module ActiveRecord
 
       def add_reflection(ar, name, reflection)
         ar.clear_reflections_cache
-        name = name.to_s
+        name = -name.to_s
         ar._reflections = ar._reflections.except(name).merge!(name => reflection)
       end
 
       def add_aggregate_reflection(ar, name, reflection)
-        ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_s => reflection)
+        ar.aggregate_reflections = ar.aggregate_reflections.merge(-name.to_s => reflection)
       end
 
       private


### PR DESCRIPTION
While reading some memory profiles I noticed some common string duplication in Reflection:

```
Retained String Report
-----------------------------------
423  "shop"
361  /tmp/bundle/ruby/2.5.0/bundler/gems/rails-9b5401fcc962/activerecord/lib/active_record/reflection.rb:25
```

Unsurprisingly that `361` maps to the number of `belongs_to :shop` we have. So since that string is effectively used as a symbol, I think it makes sense to freeze and deduplicate it, also since it's derived from model names, it's likely to be used across Rails and the application codebase.

This won't be a huge saving, even for bigger apps, but it's also a very simple one to implement so it might be worth it.

@rafaelfranca @Edouard-chin 
