### PR TITLE
make SQLite3 `last_inserted_id` private and organize DatabaseStatement methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -4,6 +4,82 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module DatabaseStatements
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback) # :nodoc:
+        private_constant :READ_QUERY
+
+        def write_query?(sql) # :nodoc:
+          !READ_QUERY.match?(sql)
+        end
+
+        def execute(sql, name = nil) #:nodoc:
+          if preventing_writes? && write_query?(sql)
+            raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
+          end
+
+          materialize_transactions
+
+          log(sql, name) do
+            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              @connection.execute(sql)
+            end
+          end
+        end
+
+        def exec_query(sql, name = nil, binds = [], prepare: false)
+          if preventing_writes? && write_query?(sql)
+            raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
+          end
+
+          materialize_transactions
+
+          type_casted_binds = type_casted_binds(binds)
+
+          log(sql, name, binds, type_casted_binds) do
+            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              # Don't cache statements if they are not prepared
+              unless prepare
+                stmt = @connection.prepare(sql)
+                begin
+                  cols = stmt.columns
+                  unless without_prepared_statement?(binds)
+                    stmt.bind_params(type_casted_binds)
+                  end
+                  records = stmt.to_a
+                ensure
+                  stmt.close
+                end
+              else
+                stmt = @statements[sql] ||= @connection.prepare(sql)
+                cols = stmt.columns
+                stmt.reset!
+                stmt.bind_params(type_casted_binds)
+                records = stmt.to_a
+              end
+
+              ActiveRecord::Result.new(cols, records)
+            end
+          end
+        end
+
+        def exec_delete(sql, name = "SQL", binds = [])
+          exec_query(sql, name, binds)
+          @connection.changes
+        end
+        alias :exec_update :exec_delete
+
+        def begin_db_transaction #:nodoc:
+          log("begin transaction", nil) { @connection.transaction }
+        end
+
+        def commit_db_transaction #:nodoc:
+          log("commit transaction", nil) { @connection.commit }
+        end
+
+        def exec_rollback_db_transaction #:nodoc:
+          log("rollback transaction", nil) { @connection.rollback }
+        end
+
+
         private
           def execute_batch(sql, name = nil)
             if preventing_writes? && write_query?(sql)
@@ -17,6 +93,10 @@ module ActiveRecord
                 @connection.execute_batch2(sql)
               end
             end
+          end
+
+          def last_inserted_id(result)
+            @connection.last_insert_row_id
           end
 
           def build_fixture_statements(fixture_set)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -204,89 +204,9 @@ module ActiveRecord
       #--
       # DATABASE STATEMENTS ======================================
       #++
-
-      READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback) # :nodoc:
-      private_constant :READ_QUERY
-
-      def write_query?(sql) # :nodoc:
-        !READ_QUERY.match?(sql)
-      end
-
       def explain(arel, binds = [])
         sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
         SQLite3::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", []))
-      end
-
-      def exec_query(sql, name = nil, binds = [], prepare: false)
-        if preventing_writes? && write_query?(sql)
-          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
-        end
-
-        materialize_transactions
-
-        type_casted_binds = type_casted_binds(binds)
-
-        log(sql, name, binds, type_casted_binds) do
-          ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-            # Don't cache statements if they are not prepared
-            unless prepare
-              stmt = @connection.prepare(sql)
-              begin
-                cols = stmt.columns
-                unless without_prepared_statement?(binds)
-                  stmt.bind_params(type_casted_binds)
-                end
-                records = stmt.to_a
-              ensure
-                stmt.close
-              end
-            else
-              stmt = @statements[sql] ||= @connection.prepare(sql)
-              cols = stmt.columns
-              stmt.reset!
-              stmt.bind_params(type_casted_binds)
-              records = stmt.to_a
-            end
-
-            ActiveRecord::Result.new(cols, records)
-          end
-        end
-      end
-
-      def exec_delete(sql, name = "SQL", binds = [])
-        exec_query(sql, name, binds)
-        @connection.changes
-      end
-      alias :exec_update :exec_delete
-
-      def last_inserted_id(result)
-        @connection.last_insert_row_id
-      end
-
-      def execute(sql, name = nil) #:nodoc:
-        if preventing_writes? && write_query?(sql)
-          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
-        end
-
-        materialize_transactions
-
-        log(sql, name) do
-          ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-            @connection.execute(sql)
-          end
-        end
-      end
-
-      def begin_db_transaction #:nodoc:
-        log("begin transaction", nil) { @connection.transaction }
-      end
-
-      def commit_db_transaction #:nodoc:
-        log("commit transaction", nil) { @connection.commit }
-      end
-
-      def exec_rollback_db_transaction #:nodoc:
-        log("rollback transaction", nil) { @connection.rollback }
       end
 
       # SCHEMA STATEMENTS ========================================


### PR DESCRIPTION
### Summary
This PR
1. moves SQLite3 methods previously in the root adapter class into the `Sqlite3::DatabaseStatement` module if they're also in the `Abstract::DatabaseStatement` module.
2. makes SQLIte3's `last_inserted_id` private

The inspiration for this change was that when upgrading our `live_fixtures` gem to rails 5, tests passed when running against sqlite3, but when consuming the gem in a mysql database, the tests failed. This was because `last_inserted_id` was a private method for mysql.

If the first part of the change is considered "cosmetic" I'm happy to revert it. I think it's a good idea to make `last_inserted_id` private, though.