### PR TITLE
url_for recall option to be exposed

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -32,8 +32,8 @@ module ActionController
         host: request.host,
         port: request.optional_port,
         protocol: request.protocol,
-        _recall: request.path_parameters
-      }.merge!(super).freeze
+        recall: request.path_parameters
+      }.deep_merge!(super).freeze
 
       if (same_origin = _routes.equal?(request.routes)) ||
          (script_name = request.engine_script_name(_routes)) ||

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -673,8 +673,8 @@ module ActionDispatch
               prefix_options = options.slice(*_route.segment_keys)
               prefix_options[:relative_url_root] = ""
 
-              if options[:_recall]
-                prefix_options.reverse_merge!(options[:_recall].slice(*_route.segment_keys))
+              if options[:recall]
+                prefix_options.reverse_merge!(options[:recall].slice(*_route.segment_keys))
               end
 
               # We must actually delete prefix segment keys to avoid passing them to next url_for.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -797,7 +797,7 @@ module ActionDispatch
 
       # The +options+ argument must be a hash whose keys are *symbols*.
       def url_for(options, route_name = nil, url_strategy = UNKNOWN)
-        options = default_url_options.merge options
+        options = default_url_options.deep_merge(options)
 
         user = password = nil
 
@@ -806,7 +806,7 @@ module ActionDispatch
           password = options.delete :password
         end
 
-        recall = options.delete(:_recall) { {} }
+        recall = options.delete(:recall) { {} }
 
         original_script_name = options.delete(:original_script_name)
         script_name = find_script_name options

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -134,6 +134,7 @@ module ActionDispatch
       # * <tt>:port</tt> - Optionally specify the port to connect to.
       # * <tt>:anchor</tt> - An anchor name to be appended to the path.
       # * <tt>:params</tt> - The query parameters to be appended to the path.
+      # * <tt>:recall</tt> - The path parameters to be used.
       # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in "/archive/2009/"
       # * <tt>:script_name</tt> - Specifies application path relative to domain root. If provided, prepends application path.
       #


### PR DESCRIPTION
### Summary

There is no tests and I might be missing something, but I figured out it would be better to open somewhat of a draft than just an issue. (I'll be happy to close it and simply reopen issue if prefered)

This is an options that date some time back (https://github.com/rails/rails/commit/de79525d045b6ea2d83f325bdeeb9380510d045c) and I'm not certain why there was never a desire to finish exposing it.

From what I understand, it works exactly like the `params` options, but limited to the route path generation (what I'm looking for).

### The problems

Using route helpers, one can use `default_url_options` and it works most of the time well, but not in every cases.

#### Options deep merge

You'll see these is few `deep_merge` changes. 

The first issue I'm encountering is when using a complex option like `params`. 

- Having a default that would be `{ params: { a: 1 } }`
- Calling an url, eg.: `something_path(params: b: 2)`
- The default will be squashed away and return `"/something?b=2"`
- I was expecting to receive `"/something?a=1&b=2"`.

The same undesired merge behaviour would also apply to `recall`. 

Arguably, you could say I could be using `something_path(b: 2)` and it would generate the expected outcome. I'm trying to push away from using query parameters at the root of path helpers. When used in conjunction with user inputs, you then end up with possible url generation hijack where if there is a route parameter or a reserved keyword used it'll get used.
- Calling `something_url(params)`
- For `params => {host: hijack.com}`
- Would then generate `http://hijack.com/something`.

Should I open a stand along PR or issue for this?

#### Controlling path parameters (recall)

In one of my project, I'm experimenting with route scopes.

Something like:
```ruby
scope("/:scope", scope: /[a-z]{6}/) do
  get '/something', as: :something
end
```

Using the `default_url_options` in the current state does not allow me to pass in the `_recall` options per the previous problem.

Beyond that, I'd prefer to get some clarification as to why we would not want to expose it as a real option (`recall`) and if there is a legit reason for me to avoid it. If it is the case, then maybe it shouldn't be in the options in the first place.

Here again we could argue that my default options could be passed at the root of the object (eg.: `{scope: 'abcdef'}`. There is yet another issue with this. When rendering a route that is not part of this scope, it'll fallback to the default behaviour of appending unused params to the query params. 

```ruby
scope("/:scope", scope: /[a-z]{6}/) do
  get '/something', as: :something
end

get '/else', as: :something_else

default_url_options
=> {scope: 'abcdef'}

something_path
=> /abcdef/something

something_else_path
=> /something_else?scope=abcdef
```

### Other Information

- [ ] If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

