### PR TITLE
Add section on PostgreSQL to the guides index [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -157,6 +157,7 @@
       description: This guide explains how to effectively use Rails to develop a JSON API application.
     -
       name: Active Record and PostgreSQL
+      work_in_progress: true
       url: active_record_postgresql.html
       description: This guide covers PostgreSQL specific usage of Active Record.
 

--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -155,6 +155,10 @@
       name: Using Rails for API-only Applications
       url: api_app.html
       description: This guide explains how to effectively use Rails to develop a JSON API application.
+    -
+      name: Active Record and PostgreSQL
+      url: active_record_postgresql.html
+      description: This guide covers PostgreSQL specific usage of Active Record.
 
 -
   name: Extending Rails


### PR DESCRIPTION
### Summary

Add the already available section on Active Record and PostgreSQL to the guides index.

### Other Information

While searching for ActiveRecord datatypes I stumbled upon this guide: https://guides.rubyonrails.org/active_record_postgresql.html 

Since it is rather old (and complete), but still not listed on the main guides index I considered this a mistake. Please feel free to reject this PR if that section should not be included as part of the index.