### PR TITLE
Make docs on form_with_generates_ids config option match the value

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -592,7 +592,7 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.form_with_generates_remote_forms` determines whether `form_with` generates remote forms or not. This defaults to `true`.
 
-* `config.action_view.form_with_generates_ids` determines whether `form_with` generates ids on inputs. This defaults to `true`.
+* `config.action_view.form_with_generates_ids` determines whether `form_with` generates ids on inputs. This defaults to `false`.
 
 * `config.action_view.default_enforce_utf8` determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8. This defaults to `false`.
 


### PR DESCRIPTION
### Summary

The `config.action_view.form_with_generates_ids` value is [`false` by default](https://github.com/rails/rails/commit/21cd5b3031b0c022439a88cb750c1e00cd07f1e3), but the information in the 5.2 docs indicates it should be `true`.