### PR TITLE
Remove outdated debugging plugins

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -962,15 +962,8 @@ Plugins for Debugging
 There are some Rails plugins to help you to find errors and debug your
 application. Here is a list of useful plugins for debugging:
 
-* [Footnotes](https://github.com/josevalim/rails-footnotes) Every Rails page has
-footnotes that give request information and link back to your source via
-TextMate.
 * [Query Trace](https://github.com/ruckus/active-record-query-trace/tree/master) Adds query
 origin tracing to your logs.
-* [Query Reviewer](https://github.com/nesquena/query_reviewer) This Rails plugin
-not only runs "EXPLAIN" before each of your select queries in development, but
-provides a small DIV in the rendered output of each page with the summary of
-warnings for each query that it analyzed.
 * [Exception Notifier](https://github.com/smartinez87/exception_notification/tree/master)
 Provides a mailer object and a default set of templates for sending email
 notifications when errors occur in a Rails application.


### PR DESCRIPTION
Footnote and Query review are outdated, unmaintained, 
and Query review is for rails 3.

### Summary

Some of the recommended debugging plugins listed in this doc are no longer up-to-date.

### Other Information
