### PR TITLE
Fix loading `ActionMailbox::BaseController` when CSRF protection is disabled

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/base_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/base_controller.rb
@@ -3,7 +3,7 @@
 module ActionMailbox
   # The base class for all Action Mailbox ingress controllers.
   class BaseController < ActionController::Base
-    skip_forgery_protection
+    skip_forgery_protection if default_protect_from_forgery
 
     before_action :ensure_configured
 


### PR DESCRIPTION
When `default_protect_from_forgery` is false, `verify_authenticity_token` callback does not define and `skip_forgery_protection` raise exception.

Fixes #34837.