### PR TITLE
Fix typo to keep documentation consistent [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -92,7 +92,7 @@ module ActiveRecord
     #     Dog.create! # throws exception because we're on a replica
     #   end
     #
-    #   ActiveRecord::Base.connected_to(role: :unknown_ode) do
+    #   ActiveRecord::Base.connected_to(role: :unknown_role) do
     #     # raises exception due to non-existent role
     #   end
     #


### PR DESCRIPTION
### Summary

Fix typo to keep documentation consistent

The documentation for the `connected_to` method references a role when
describing a non existent role, however the typo `ode` is used. This changes the
word to `role` so it's a bit clearer and consistent with surrounding documentation.

