### PR TITLE
Added multi_excerpt()

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -204,6 +204,23 @@ module ActionView
         [prefix, affix, postfix].join
       end
 
+      # Returns a summary of +text+ in the form of +phrase+ excerpts
+      # <tt>:omission</tt> option (which defaults to "...") will be prepended/appended accordingly
+      #
+      #   multi_excerpt('This string is is a very long long long string ', 'string', radius: 5)
+      #   # => ...This string is i...long string ...
+      def multi_excerpt(text, phrase, options = {})
+        return unless text && phrase
+
+        radius   = options.fetch(:radius, 10)
+        omission = options.fetch(:omission, "...")
+
+        raise if phrase.is_a? Regexp
+        regex = /.{,#{radius}}#{Regexp.escape(phrase)}.{,#{radius}}/i
+        parts = text.scan(regex)
+        "#{omission}#{parts.join(omission)}#{omission}"
+      end
+
       # Attempts to pluralize the +singular+ word unless +count+ is 1. If
       # +plural+ is supplied, it will use that when count is > 1, otherwise
       # it will use the Inflector to determine the plural form for the given locale,

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -353,6 +353,10 @@ class TextHelperTest < ActionView::TestCase
                  excerpt("This is a beautiful morning", "a", separator: nil)
   end
 
+  def test_multi_excerpt
+    assert_equal("...This string is i...long string ...", multi_excerpt('This string is is a very long long long string ', 'string', radius: 5))
+  end
+
   def test_word_wrap
     assert_equal("my very very\nvery long\nstring", word_wrap("my very very very long string", line_width: 15))
   end


### PR DESCRIPTION
### Summary

Some time ago I needed to summarize an article/blog in a landing page for SEO purposes,
and the combination of excerpt() and hightlight() wasn't enough for the job.
So I had an attempt at implementing a `multi_excerpt()` to complement
the pre existing `excerpt()` method.


