### PR TITLE
Cache full MySQL version in schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -170,8 +170,11 @@ module ActiveRecord
       class Version
         include Comparable
 
-        def initialize(version_string)
+        attr_reader :full_version_string
+
+        def initialize(version_string, full_version_string = nil)
           @version = version_string.split(".").map(&:to_i)
+          @full_version_string = full_version_string
         end
 
         def <=>(version_string)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -51,12 +51,20 @@ module ActiveRecord
           end
       end
 
+      class Version < AbstractAdapter::Version # :nodoc:
+        def initialize(version_string, full_version_string)
+          super
+        end
+      end
+
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
       end
 
       def get_database_version #:nodoc:
-        Version.new(version_string)
+        full_version_string = get_full_version
+        version_string = version_string(full_version_string)
+        Version.new(version_string, full_version_string)
       end
 
       def mariadb? # :nodoc:
@@ -801,8 +809,8 @@ module ActiveRecord
           MismatchedForeignKey.new(options)
         end
 
-        def version_string
-          full_version.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
+        def version_string(full_version_string) # :nodoc:
+          full_version_string.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
         end
 
         class MysqlString < Type::String # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -51,12 +51,6 @@ module ActiveRecord
           end
       end
 
-      class Version < AbstractAdapter::Version # :nodoc:
-        def initialize(version_string, full_version_string)
-          super
-        end
-      end
-
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
       end
@@ -809,7 +803,7 @@ module ActiveRecord
           MismatchedForeignKey.new(options)
         end
 
-        def version_string(full_version_string) # :nodoc:
+        def version_string(full_version_string)
           full_version_string.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -125,11 +125,11 @@ module ActiveRecord
           super
         end
 
-        def full_version # :nodoc:
+        def full_version
           schema_cache.database_version.full_version_string
         end
 
-        def get_full_version # :nodoc:
+        def get_full_version
           @connection.server_info[:version]
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -125,8 +125,12 @@ module ActiveRecord
           super
         end
 
-        def full_version
-          @full_version ||= @connection.server_info[:version]
+        def full_version # :nodoc:
+          schema_cache.database_version.full_version_string
+        end
+
+        def get_full_version # :nodoc:
+          @connection.server_info[:version]
         end
     end
   end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -95,6 +95,10 @@ module ActiveRecord
 
         assert_no_queries do
           assert_equal @database_version.to_s, @cache.database_version.to_s
+
+          if current_adapter?(:Mysql2Adapter)
+            assert_not_nil @cache.database_version.full_version_string
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

In #35795, the database version is cached for all adapters via the schema cache. However, this didn't include the full MySQL version. Anything that uses the full MySQL version would need to query the database to get the full version even if they're using the schema cache.

Now the full MySQL version will be cached in the schema cache via the `Version` object.

/cc @tenderlove @eileencodes 
