### PR TITLE
Stop the connection reaper thread when pool is thrown away

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
@@ -12,7 +12,7 @@ class PreparedStatementsDisabledTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def teardown
-    @conn.release_connection
+    ActiveRecord::Base.remove_connection @conn.spec.name
     ActiveRecord::Base.establish_connection :arunit
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1341,6 +1341,8 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_equal klass.connection_handler, orig_handler
     assert_equal thread_connection_handler, new_handler
+
+    new_handler.shutdown!
   end
 
   test "new threads get default the default connection handler" do
@@ -1381,6 +1383,8 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_equal after_handler, new_handler
     assert_equal orig_handler, klass.connection_handler
+
+    new_handler.shutdown!
   end
 
   # Note: This is a performance optimization for Array#uniq and Hash#[] with

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -52,6 +52,8 @@ module ActiveRecord
         assert_not_predicate @adapter, :in_use?
 
         assert_equal @adapter, pool.connection
+      ensure
+        pool.shutdown! if pool
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -16,6 +16,11 @@ module ActiveRecord
         @pool = @handler.establish_connection(ActiveRecord::Base.configurations["arunit"])
       end
 
+      def teardown
+        @handler.shutdown!
+        super
+      end
+
       def test_default_env_fall_back_to_default_env_when_rails_env_or_rack_env_is_empty_string
         original_rails_env = ENV["RAILS_ENV"]
         original_rack_env  = ENV["RACK_ENV"]

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1363,7 +1363,7 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       assert_equal rw_conn, ro_conn
     end
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.connection_handler }
+    ARTest.restore_default_connection_handler
   end
 
   private
@@ -1376,5 +1376,6 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       yield
     ensure
       ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
+      new_pool.shutdown! if new_pool
     end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -73,7 +73,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     mw.call({})
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+    ARTest.restore_default_connection_handler
   end
 
   def test_query_cache_across_threads
@@ -537,7 +537,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       mw.call({})
     end
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+    ARTest.restore_default_connection_handler
   end
 
   private
@@ -550,6 +550,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       yield
     ensure
       ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
+      new_pool.shutdown! if new_pool
     end
 
     def middleware(&app)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -968,7 +968,7 @@ module ActiveRecord
       def teardown
         SchemaMigration.delete_all
         InternalMetadata.delete_all
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        ARTest.restore_default_connection_handler
       end
 
       def test_truncate_tables

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -33,6 +33,11 @@ else
       Tag.destroy_all
     end
 
+    teardown do
+      Tag.remove_connection
+      Tag2.remove_connection
+    end
+
     # It is impossible to properly test read uncommitted. The SQL standard only
     # specifies what must not happen at a certain level, not what must happen. At
     # the read uncommitted level, there is nothing that must not happen.

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -26,4 +26,11 @@ module ARTest
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2
   end
+
+  def self.restore_default_connection_handler
+    ActiveRecord::Base.connection_handlers.each_value do |handler|
+      handler.shutdown! unless handler == ActiveRecord::Base.default_connection_handler
+    end
+    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+  end
 end


### PR DESCRIPTION
### Summary

A ConnectionPool's reaper thread is never stopped. While in production
this won't matter much, it creates a lot of threads during testing.
Also, in reaper_test.rb reapers with a very high frequency are created
but never stopped. These cause unnecessary CPU load and slow down testing.

Since the threads keep running and have a reference to the ConnectionPool
itself, GC can't collect the pool.

The method of shutting down implemented here is possibly racy, but it
won't matter much since the worst case is that the thread gets shutdown
an interval later.

### Other Information

This has been found during testing of JRuby's activerecord-jdbc-adapter.
During a run of the PostgreSQL tests, this commit brings down the live
threads at the end of testing from ~213 to ~18 (which includes JVM and
JRuby threads). Some minor leaks remain, mostly from
  test/cases/connection_adapters/connection_handlers_multi_db_test.rb

A typicall run of the AR tests for PostgreSQL:
![threads-before](https://user-images.githubusercontent.com/400625/55993012-4993d200-5cae-11e9-8f0f-a766f31cfa54.png)

After this patch:
![threads-after](https://user-images.githubusercontent.com/400625/55993024-5284a380-5cae-11e9-923b-793fe0336757.png)
