### PR TITLE
Rename "method" to "matcher" in map block

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -355,7 +355,7 @@ module ActiveModel
             # Must try to match prefixes/suffixes first, or else the matcher with no prefix/suffix
             # will match every time.
             matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
-            matchers.map { |method| method.match(method_name) }.compact
+            matchers.map { |matcher| matcher.match(method_name) }.compact
           end
         end
 


### PR DESCRIPTION
The "method" here is an instance of `ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher`, so it should be called "matcher".