### PR TITLE
Preserve config/routes.rb and config/locales/en.yml files when `rails app:update`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -101,10 +101,10 @@ module Rails
     end
 
     def config
-      empty_directory "config"
+      empty_directory "config" unless options[:update]
 
       inside "config" do
-        template "routes.rb"
+        template "routes.rb" unless options[:update]
         template "application.rb"
         template "environment.rb"
         template "cable.yml" unless options[:skip_action_cable]
@@ -114,7 +114,7 @@ module Rails
 
         directory "environments"
         directory "initializers"
-        directory "locales"
+        directory "locales" unless options[:update]
       end
     end
 
@@ -128,20 +128,18 @@ module Rails
 
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
-      inside "config" do
-        template "application.rb"
-        template "environment.rb"
-        template "cable.yml"   if !options[:skip_action_cable] && !action_cable_config_exist
-        template "puma.rb"     unless options[:skip_puma]
-        template "spring.rb"   if spring_install?
-        template "storage.yml" if !skip_active_storage? && !active_storage_config_exist
-
-        directory "environments"
-        directory "initializers"
-      end
+      config
 
       unless cookie_serializer_config_exist
         gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"
+      end
+
+      if !options[:skip_action_cable] && !action_cable_config_exist
+        template "config/cable.yml"
+      end
+
+      if !skip_active_storage? && !active_storage_config_exist
+        template "config/storage.yml"
       end
 
       if options[:skip_sprockets] && !assets_config_exist

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -128,18 +128,20 @@ module Rails
 
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
-      config
+      inside "config" do
+        template "application.rb"
+        template "environment.rb"
+        template "cable.yml"   if !options[:skip_action_cable] && !action_cable_config_exist
+        template "puma.rb"     unless options[:skip_puma]
+        template "spring.rb"   if spring_install?
+        template "storage.yml" if !skip_active_storage? && !active_storage_config_exist
+
+        directory "environments"
+        directory "initializers"
+      end
 
       unless cookie_serializer_config_exist
         gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"
-      end
-
-      if !options[:skip_action_cable] && !action_cable_config_exist
-        template "config/cable.yml"
-      end
-
-      if !skip_active_storage? && !active_storage_config_exist
-        template "config/storage.yml"
       end
 
       if options[:skip_sprockets] && !assets_config_exist

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -188,6 +188,36 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_overwrite_config_routes_file
+    app_root       = File.join(destination_root, "myapp")
+    run_generator [app_root]
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+
+      text = "Rails.application.routes.draw do\n  root to: 'welcome#index'\nend\n"
+      File.write("#{app_root}/config/routes.rb", text)
+
+      quietly { generator.send(:update_config_files) }
+      assert_file "#{app_root}/config/routes.rb", text
+    end
+  end
+
+  def test_app_update_does_not_overwrite_config_locales_en_file
+    app_root       = File.join(destination_root, "myapp")
+    run_generator [app_root]
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+
+      text = "en:\n  hello: 'Hello'\n  goodbye: 'Goodbye'\n"
+      File.write("#{app_root}/config/locales/en.yml", text)
+
+      quietly { generator.send(:update_config_files) }
+      assert_file "#{app_root}/config/locales/en.yml", text
+    end
+  end
+
   def test_app_update_generates_correct_session_key
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -191,14 +191,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_app_update_does_not_overwrite_config_routes_file
     app_root       = File.join(destination_root, "myapp")
     run_generator [app_root]
+
+    text = "Rails.application.routes.draw do\n  root to: 'welcome#index'\nend\n"
+    File.write("#{app_root}/config/routes.rb", text)
+
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true }, { destination_root: app_root, shell: @shell }
       generator.send(:app_const)
-
-      text = "Rails.application.routes.draw do\n  root to: 'welcome#index'\nend\n"
-      File.write("#{app_root}/config/routes.rb", text)
-
       quietly { generator.send(:update_config_files) }
+
       assert_file "#{app_root}/config/routes.rb", text
     end
   end
@@ -206,13 +207,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_app_update_does_not_overwrite_config_locales_en_file
     app_root       = File.join(destination_root, "myapp")
     run_generator [app_root]
+
+    text = "en:\n  hello: 'Hello'\n  goodbye: 'Goodbye'\n"
+    File.write("#{app_root}/config/locales/en.yml", text)
+
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true }, { destination_root: app_root, shell: @shell }
       generator.send(:app_const)
-
-      text = "en:\n  hello: 'Hello'\n  goodbye: 'Goodbye'\n"
-      File.write("#{app_root}/config/locales/en.yml", text)
-
       quietly { generator.send(:update_config_files) }
       assert_file "#{app_root}/config/locales/en.yml", text
     end


### PR DESCRIPTION
### Summary

When `rails app:update` is executed, config/routes.rb and config/locales/en.yml files would be overwritten by almost empty template files. This behavior is not what we expected in Rails upgrade process because they were edited so many times by framework users like files in app directory. They have many application logic and custom messages not like other configuration files.

I think rails app:update will be more usable if these files will not be overwritten because in many software, user generated contents are not erased during upgrading process.

I modified the `config_when_updating` method in `Rails::AppBuilder` and these config files are no longer target files for the `app:update` task.