### PR TITLE
Make `Redis.cache.fetch_multi([])` not throw an error

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -361,6 +361,7 @@ module ActiveSupport
         def read_multi_mget(*names)
           options = names.extract_options!
           options = merged_options(options)
+          return {} if names == []
 
           keys = names.map { |name| normalize_key(name, options) }
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -140,6 +140,12 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    def test_fetch_multi_without_names
+      assert_not_called(@cache.redis, :mget) do
+        @cache.fetch_multi() { }
+      end
+    end
+
     def test_increment_expires_in
       assert_called_with @cache.redis, :incrby, [ "#{@namespace}:foo", 1 ] do
         assert_called_with @cache.redis, :expire, [ "#{@namespace}:foo", 60 ] do


### PR DESCRIPTION
### Summary

This PR fixes a problem with the Redis Cache store. It used to be that if you call `Rails.cache.fetch_multi([])` (without providing any key names) it would throw

```
     Redis::CommandError:
       ERR wrong number of arguments for 'mget' command
```

because it tries to call the Redis `mget` command without passing any arguments. Now we just early return `{}`.

### Other Information

This is how it used to work with `redis-store/redis-activesupport`, which already early returned `{}` if it detected this case:

https://github.com/redis-store/redis-activesupport/blob/bc6770004596882640fd9f2efada14d6917f7ef3/lib/active_support/cache/redis_store.rb#L121

I discovered this from a failing spec in our production code after we upgraded to the built-in Redis cache store from `redis-rails`. Sometimes we pass in arrays to `fetch_multi` that might be empty, and in those cases we expect just an empty response, not an error.
