### PR TITLE
Remove unused method_name from AttributeMethodMatch

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -387,7 +387,7 @@ module ActiveModel
         class AttributeMethodMatcher #:nodoc:
           attr_reader :prefix, :suffix, :method_missing_target
 
-          AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)
+          AttributeMethodMatch = Struct.new(:target, :attr_name)
 
           def initialize(options = {})
             @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
@@ -398,7 +398,7 @@ module ActiveModel
 
           def match(method_name)
             if @regex =~ method_name
-              AttributeMethodMatch.new(method_missing_target, $1, method_name)
+              AttributeMethodMatch.new(method_missing_target, $1)
             end
           end
 

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -264,6 +264,5 @@ class AttributeMethodsTest < ActiveModel::TestCase
 
     assert_equal "foo",            match.attr_name
     assert_equal "attribute_test", match.target
-    assert_equal "foo_test",       match.method_name
   end
 end


### PR DESCRIPTION
The match object only needs to know the attribute name and the target, not the method name it matched.