### PR TITLE
Use individual execution counters when calculating retry delay

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use individual execution counters when calculating retry delay.
+
+    *Patrik Bóna*
+
 *   Make job argument assertions with `Time`, `ActiveSupport::TimeWithZone`, and `DateTime` work by dropping microseconds. Microsecond precision is lost during serialization.
 
     *Gannon McGibbon*

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -54,7 +54,7 @@ module ActiveJob
           self.exception_executions[exceptions.to_s] = (exception_executions[exceptions.to_s] || 0) + 1
 
           if exception_executions[exceptions.to_s] < attempts
-            retry_job wait: determine_delay(wait), queue: queue, priority: priority, error: error
+            retry_job wait: determine_delay(seconds_or_duration_or_algorithm: wait, executions: exception_executions[exceptions.to_s]), queue: queue, priority: priority, error: error
           else
             if block_given?
               instrument :retry_stopped, error: error do
@@ -123,7 +123,7 @@ module ActiveJob
     end
 
     private
-      def determine_delay(seconds_or_duration_or_algorithm)
+      def determine_delay(seconds_or_duration_or_algorithm:, executions:)
         case seconds_or_duration_or_algorithm
         when :exponentially_longer
           (executions**4) + 2


### PR DESCRIPTION
Individual execution counters were introduced in #34352. However `#determine_delay` which is used to calculate retry delay still uses the global counter. This commit fixes it.