### PR TITLE
Fix test flakyness due to `test_truncate_tables`

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -490,6 +490,8 @@ module ActiveRecord
       @connection.truncate("posts")
 
       assert_equal 0, Post.count
+    ensure
+      reset_fixtures('posts')
     end
 
     def test_truncate_with_query_cache
@@ -501,6 +503,7 @@ module ActiveRecord
 
       assert_equal 0, Post.count
     ensure
+      reset_fixtures('posts')
       @connection.disable_query_cache!
     end
 
@@ -514,6 +517,8 @@ module ActiveRecord
       assert_equal 0, Post.count
       assert_equal 0, Author.count
       assert_equal 0, AuthorAddress.count
+    ensure
+      reset_fixtures('posts', 'authors', 'author_addresses')
     end
 
     def test_truncate_tables_with_query_cache
@@ -529,6 +534,7 @@ module ActiveRecord
       assert_equal 0, Author.count
       assert_equal 0, AuthorAddress.count
     ensure
+      reset_fixtures('posts', 'authors', 'author_addresses')
       @connection.disable_query_cache!
     end
 
@@ -551,6 +557,16 @@ module ActiveRecord
         assert_nothing_raised { sub.save! }
       end
     end
+
+    private
+
+      def reset_fixtures(*fixture_names)
+        ActiveRecord::FixtureSet.reset_cache
+
+        fixture_names.each do |fixture_name|
+          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, fixture_name)
+        end
+      end
   end
 end
 


### PR DESCRIPTION
### Summary

Fixes: https://github.com/rails/rails/issues/35941

The order that caused the test two fail was if the tests ran in the following order:
1. `test_nested_has_many_through_with_conditions_on_through_associations_preload_via_joins` 
2. `test_truncate`
3. `eager_load_includes_full_sti_class_test` would run `test_class_names_with_find_by` and `test_class_names`

The first test uses `fixtures :taggings, :posts` this would insert a set of `Tagging` and `Post` records in the database. 

When `test_truncate` would run it would call `TRUNCATE TABLE posts` which also resets the `AUTOINCREMENT` value. The `Posts` would be deleted but the `Taggings` remained in the database. 

When the posts in `test_class_names_with_find_by` and `test_class_names_with_find_by` would have an ID that equal to the previous `Posts` deleted in the `truncate_tables` test, this would cause `post.tagging` to return the old taggins despite the fact that we expected them to be `nil`, causing the tests to fail. 

The approach I took to fix this, is to store the `Post` values before the `test_truncate_tables` and reset them once the test is done. 

### Other Information

A couple of other approaches I thought of: 
* running this within a transaction: wasn't possible because `TRUNCATE` is a DDL statment and causes an implicit commit inside a transaction.
* clearing the taggings before the running the tests in `eager_load_includes_full_sti_class_test` in the setup. I thought the current approach was simpler since we wouldn't have to run the `destroy_all` before ever test case. 

cc: @kamipo and @rafaelfranca 