### PR TITLE
[WIP] Allow rake tasks to be loaded without rails

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -142,8 +142,10 @@ module ActiveRecord
       end
 
       def for_each
-        databases = Rails.application.config.load_database_yaml
-        database_configs = ActiveRecord::DatabaseConfigurations.new(databases).configs_for(env_name: Rails.env)
+        databases = defined?(Rails) ? Rails.application.config.load_database_yaml : []
+        database_configs = ActiveRecord::DatabaseConfigurations.new(databases).configs_for(
+          env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+        )
 
         # if this is a single database application we don't want tasks for each primary database
         return if database_configs.count == 1


### PR DESCRIPTION
### Summary

Allow Active Record's rake tasks to be loaded without Rails. There are other references to Rails in database tasks, but these are the only one blocking setting up databases on https://github.com/rails/rails/issues/35902.

I think migrations and rollbacks should also work, so I'll try to fix those too:

### TODO:

- [ ] Fix `rake db:migrate`
- [ ] Fix `rake db:rollback`


Closes https://github.com/rails/rails/issues/35902.