### PR TITLE
Rename method_missing_target to target

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -286,12 +286,12 @@ module ActiveModel
           method_name = matcher.method_name(attr_name)
 
           unless instance_method_already_implemented?(method_name)
-            generate_method = "define_method_#{matcher.method_missing_target}"
+            generate_method = "define_method_#{matcher.target}"
 
             if respond_to?(generate_method, true)
               send(generate_method, attr_name.to_s)
             else
-              define_proxy_call true, generated_attribute_methods, method_name, matcher.method_missing_target, attr_name.to_s
+              define_proxy_call true, generated_attribute_methods, method_name, matcher.target, attr_name.to_s
             end
           end
         end
@@ -362,7 +362,7 @@ module ActiveModel
         # Define a method `name` in `mod` that dispatches to `send`
         # using the given `extra` args. This falls back on `define_method`
         # and `send` if the given names cannot be compiled.
-        def define_proxy_call(include_private, mod, name, send, *extra)
+        def define_proxy_call(include_private, mod, name, target, *extra)
           defn = if NAME_COMPILABLE_REGEXP.match?(name)
             "def #{name}(*args)"
           else
@@ -371,34 +371,34 @@ module ActiveModel
 
           extra = (extra.map!(&:inspect) << "*args").join(", ")
 
-          target = if CALL_COMPILABLE_REGEXP.match?(send)
-            "#{"self." unless include_private}#{send}(#{extra})"
+          body = if CALL_COMPILABLE_REGEXP.match?(target)
+            "#{"self." unless include_private}#{target}(#{extra})"
           else
-            "send(:'#{send}', #{extra})"
+            "send(:'#{target}', #{extra})"
           end
 
           mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
             #{defn}
-              #{target}
+              #{body}
             end
           RUBY
         end
 
         class AttributeMethodMatcher #:nodoc:
-          attr_reader :prefix, :suffix, :method_missing_target
+          attr_reader :prefix, :suffix, :target
 
           AttributeMethodMatch = Struct.new(:target, :attr_name)
 
           def initialize(options = {})
             @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
             @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
-            @method_missing_target = "#{@prefix}attribute#{@suffix}"
+            @target = "#{@prefix}attribute#{@suffix}"
             @method_name = "#{prefix}%s#{suffix}"
           end
 
           def match(method_name)
             if @regex =~ method_name
-              AttributeMethodMatch.new(method_missing_target, $1)
+              AttributeMethodMatch.new(target, $1)
             end
           end
 

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -91,7 +91,7 @@ module ActiveModel
         @attributes.fetch_value(name)
       end
 
-      # Handle *= for method_missing.
+      # Dispatch target for <tt>*=</tt> attribute methods.
       def attribute=(attribute_name, value)
         write_attribute(attribute_name, value)
       end

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -165,17 +165,17 @@ module ActiveModel
       mutations_from_database.changed_attribute_names
     end
 
-    # Handles <tt>*_changed?</tt> for +method_missing+.
+    # Dispatch target for <tt>*_changed?</tt> attribute methods.
     def attribute_changed?(attr_name, **options) # :nodoc:
       mutations_from_database.changed?(attr_name.to_s, options)
     end
 
-    # Handles <tt>*_was</tt> for +method_missing+.
+    # Dispatch target for <tt>*_was</tt> attribute methods.
     def attribute_was(attr_name) # :nodoc:
       mutations_from_database.original_value(attr_name.to_s)
     end
 
-    # Handles <tt>*_previously_changed?</tt> for +method_missing+.
+    # Dispatch target for <tt>*_previously_changed?</tt> attribute methods.
     def attribute_previously_changed?(attr_name) # :nodoc:
       mutations_before_last_save.changed?(attr_name.to_s)
     end
@@ -253,22 +253,22 @@ module ActiveModel
         @mutations_before_last_save ||= ActiveModel::NullMutationTracker.instance
       end
 
-      # Handles <tt>*_change</tt> for +method_missing+.
+      # Dispatch target for <tt>*_change</tt> attribute methods.
       def attribute_change(attr_name)
         mutations_from_database.change_to_attribute(attr_name.to_s)
       end
 
-      # Handles <tt>*_previous_change</tt> for +method_missing+.
+      # Dispatch target for <tt>*_previous_change</tt> attribute methods.
       def attribute_previous_change(attr_name)
         mutations_before_last_save.change_to_attribute(attr_name.to_s)
       end
 
-      # Handles <tt>*_will_change!</tt> for +method_missing+.
+      # Dispatch target for <tt>*_will_change!</tt> attribute methods.
       def attribute_will_change!(attr_name)
         mutations_from_database.force_change(attr_name.to_s)
       end
 
-      # Handles <tt>restore_*!</tt> for +method_missing+.
+      # Dispatch target for <tt>restore_*!</tt> attribute methods.
       def restore_attribute!(attr_name)
         attr_name = attr_name.to_s
         if attribute_changed?(attr_name)

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -65,7 +65,7 @@ module ActiveRecord
 
       private
 
-        # Handle *_before_type_cast for method_missing.
+        # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
         def attribute_before_type_cast(attribute_name)
           read_attribute_before_type_cast(attribute_name)
         end

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       end
 
       private
-        # Handle *? for method_missing.
+        # Dispatch target for <tt>*?</tt> attribute methods.
         def attribute?(attribute_name)
           query_attribute(attribute_name)
         end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -58,7 +58,7 @@ module ActiveRecord
           value
         end
 
-        # Handle *= for method_missing.
+        # Dispatch target for <tt>*=</tt> attribute methods.
         def attribute=(attribute_name, value)
           _write_attribute(attribute_name, value)
         end


### PR DESCRIPTION
The term `method_missing_target` is extremely misleading and confusing since **by far** the most frequent caller for these "handler methods" (`attribute_was`, etc.) are methods defined from columns in the schema (i.e. `title_was`, etc.), and not `method_missing`.