### PR TITLE
Fix Code Climate exclude patterns config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,3 +28,5 @@ engines:
 ratings:
   paths:
   - "**.rb"
+
+exclude_paths: []


### PR DESCRIPTION
I removed `exclude_paths` by a737143. I had mistaken that exclude paths
would not be used if removed `exclude_paths` config.

However, in the absence of `exclude_paths`, the default setting used and it contains `test`.
https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
https://docs.codeclimate.com/docs/excluding-files-and-folders#section-auto-generated-file-and-folder-exclusions

As we need to target the test, specify an empty array to prevent the default from being used.
