### PR TITLE
add example of getting lock from ActiveRecord::Relation

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -9,6 +9,8 @@ module ActiveRecord
     # lock on the selected rows:
     #   # select * from accounts where id=1 for update
     #   Account.lock.find(1)
+    #   # select * from accounts where name="grace" for update
+    #   Account.lock.where(name: "grace").load
     #
     # Call <tt>lock('some locking clause')</tt> to use a database-specific locking clause
     # of your own such as 'LOCK IN SHARE MODE' or 'FOR UPDATE NOWAIT'. Example:


### PR DESCRIPTION
### Summary

the query isn't executed until a method like load/to_a/etc. is called on it.

I think it makes it more obvious how to generically get a lock on all matching rows, `find` is kind of the exception because it loads the result.

### Other Information

real query would look something like this if not simplified for the doc:

```sql
SELECT "accounts".* FROM "accounts" WHERE "accounts"."name" = $1 FOR UPDATE
[["name", "grace"]]
```

current documentation: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html

(maybe could use a better context)