### PR TITLE
Add DEFAULT_{CREDENTIALS_ENC,MASTER_KEY}_PATH on encrypted_configuration

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -11,7 +11,10 @@ module ActiveSupport
     delegate :[], :fetch, to: :config
     delegate_missing_to :options
 
-    def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
+    DEFAULT_CREDENTIALS_ENC_PATH = File.join('config', 'credentials.yml.enc')
+    DEFAULT_MASTER_KEY_PATH = File.join('config', 'master.key')
+
+    def initialize(config_path: DEFAULT_CREDENTIALS_ENC_PATH, key_path: DEFAULT_MASTER_KEY_PATH, env_key:, raise_if_missing_key:)
       super content_path: config_path, key_path: key_path,
         env_key: env_key, raise_if_missing_key: raise_if_missing_key
     end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -463,7 +463,7 @@ module Rails
     # Or to decrypt with a file, that should be version control ignored, relative to +Rails.root+:
     #
     #   Rails.application.encrypted("config/special_tokens.yml.enc", key_path: "config/special_tokens.key")
-    def encrypted(path, key_path: "config/master.key", env_key: "RAILS_MASTER_KEY")
+    def encrypted(path, key_path: ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH, env_key: "RAILS_MASTER_KEY")
       ActiveSupport::EncryptedConfiguration.new(
         config_path: Rails.root.join(path),
         key_path: Rails.root.join(key_path),

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -79,11 +79,11 @@ module Rails
 
 
         def content_path
-          options[:environment] ? "config/credentials/#{options[:environment]}.yml.enc" : "config/credentials.yml.enc"
+          options[:environment] ? "config/credentials/#{options[:environment]}.yml.enc" : ActiveSupport::EncryptedConfiguration::DEFAULT_CREDENTIALS_ENC_PATH
         end
 
         def key_path
-          options[:environment] ? "config/credentials/#{options[:environment]}.key" : "config/master.key"
+          options[:environment] ? "config/credentials/#{options[:environment]}.key" : ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH
         end
 
 

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -10,7 +10,8 @@ module Rails
       include Helpers::Editor
 
       class_option :key, aliases: "-k", type: :string,
-        default: "config/master.key", desc: "The Rails.root relative path to the encryption key"
+        default: ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH,
+        desc: "The Rails.root relative path to the encryption key"
 
       no_commands do
         def help

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -34,8 +34,6 @@ module Rails
       private
         def credentials
           ActiveSupport::EncryptedConfiguration.new(
-            config_path: "config/credentials.yml.enc",
-            key_path: "config/master.key",
             env_key: "RAILS_MASTER_KEY",
             raise_if_missing_key: true
           )

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -760,7 +760,7 @@ module ApplicationTests
     test "require_master_key aborts app boot when missing key" do
       skip "can't run without fork" unless Process.respond_to?(:fork)
 
-      remove_file "config/master.key"
+      remove_file ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH
       add_to_config "config.require_master_key = true"
 
       error = capture(:stderr) do
@@ -772,7 +772,7 @@ module ApplicationTests
     end
 
     test "credentials does not raise error when require_master_key is false and master key does not exist" do
-      remove_file "config/master.key"
+      remove_file ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH
       add_to_config "config.require_master_key = false"
       app "development"
 

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -29,18 +29,18 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
     run_edit_command("config/tokens.yml.enc")
 
     Dir.chdir(app_path) do
-      assert_match "/config/master.key", File.read(".gitignore")
+      assert_match "/#{ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH}", File.read(".gitignore")
     end
   end
 
   test "edit command does not add master key when `RAILS_MASTER_KEY` env specified" do
     Dir.chdir(app_path) do
-      key = IO.binread("config/master.key").strip
-      FileUtils.rm("config/master.key")
+      key = IO.binread(ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH).strip
+      FileUtils.rm(ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH)
 
       switch_env("RAILS_MASTER_KEY", key) do
         run_edit_command("config/tokens.yml.enc")
-        assert_not File.exist?("config/master.key")
+        assert_not File.exist?(ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH)
       end
     end
   end
@@ -72,7 +72,7 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
   end
 
   test "show command does not raise error when require_master_key is false and master key does not exist" do
-    remove_file "config/master.key"
+    remove_file ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH
     add_to_config "config.require_master_key = false"
 
     assert_match(/Missing 'config\/master\.key' to decrypt data/, run_show_command("config/tokens.yml.enc"))

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -750,7 +750,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [File.join(destination_root, "myapp")]
     output = run_generator [File.join(destination_root, "myapp"), "--force"]
     assert_match(/force/, output)
-    assert_no_match("force  config/master.key", output)
+    assert_no_match("force  #{ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH}", output)
   end
 
   def test_application_name_with_spaces
@@ -1078,7 +1078,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     def test_master_key_is_only_readable_by_the_owner
       run_generator
 
-      stat = File.stat("config/master.key")
+      stat = File.stat(ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH)
       assert_equal "100600", sprintf("%o", stat.mode)
     end
   end


### PR DESCRIPTION
### Summary

This PR add const `ActiveSupport::EncryptedConfiguration::DEFAULT_MASTER_KEY_PATH` and `ActiveSupport::EncryptedConfiguration::DEFAULT_CREDENTIALS_ENC_PATH` to have the value available and use it on tests as default value