### PR TITLE
Add validation to subclass in tests to avoid polluting parent class

### DIFF
--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -145,15 +145,17 @@ class ValidationsTest < ActiveRecord::TestCase
   end
 
   def test_validates_acceptance_of_with_undefined_attribute_methods
-    Topic.validates_acceptance_of(:approved)
-    topic = Topic.new(approved: true)
-    Topic.undefine_attribute_methods
+    klass = Class.new(Topic)
+    klass.validates_acceptance_of(:approved)
+    topic = klass.new(approved: true)
+    klass.undefine_attribute_methods
     assert topic.approved
   end
 
   def test_validates_acceptance_of_as_database_column
-    Topic.validates_acceptance_of(:approved)
-    topic = Topic.create("approved" => true)
+    klass = Class.new(Topic)
+    klass.validates_acceptance_of(:approved)
+    topic = klass.create("approved" => true)
     assert topic["approved"]
   end
 


### PR DESCRIPTION
These two tests currently both define acceptance validators on the same class, `Topic`. This means that in either one test or the other, there are not one but *two* instances of the LazilyDefineAttributes module builder included into the class, which can result in unpredictable results.

Subclassing `Topic` in each test avoids conflicts.