### PR TITLE
Ensure multiple anonymous modules are not included into test classes

### DIFF
--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -7,21 +7,23 @@ require "models/reply"
 require "models/person"
 
 class AcceptanceValidationTest < ActiveModel::TestCase
-  def teardown
-    Topic.clear_validators!
+  teardown do
+    self.class.send(:remove_const, :TestClass)
   end
 
   def test_terms_of_service_agreement_no_acceptance
-    Topic.validates_acceptance_of(:terms_of_service)
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service)
 
-    t = Topic.new("title" => "We should not be confirmed")
+    t = klass.new("title" => "We should not be confirmed")
     assert_predicate t, :valid?
   end
 
   def test_terms_of_service_agreement
-    Topic.validates_acceptance_of(:terms_of_service)
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service)
 
-    t = Topic.new("title" => "We should be confirmed", "terms_of_service" => "")
+    t = klass.new("title" => "We should be confirmed", "terms_of_service" => "")
     assert_predicate t, :invalid?
     assert_equal ["must be accepted"], t.errors[:terms_of_service]
 
@@ -30,9 +32,10 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   end
 
   def test_eula
-    Topic.validates_acceptance_of(:eula, message: "must be abided")
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:eula, message: "must be abided")
 
-    t = Topic.new("title" => "We should be confirmed", "eula" => "")
+    t = klass.new("title" => "We should be confirmed", "eula" => "")
     assert_predicate t, :invalid?
     assert_equal ["must be abided"], t.errors[:eula]
 
@@ -41,9 +44,10 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   end
 
   def test_terms_of_service_agreement_with_accept_value
-    Topic.validates_acceptance_of(:terms_of_service, accept: "I agree.")
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service, accept: "I agree.")
 
-    t = Topic.new("title" => "We should be confirmed", "terms_of_service" => "")
+    t = klass.new("title" => "We should be confirmed", "terms_of_service" => "")
     assert_predicate t, :invalid?
     assert_equal ["must be accepted"], t.errors[:terms_of_service]
 
@@ -52,9 +56,10 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   end
 
   def test_terms_of_service_agreement_with_multiple_accept_values
-    Topic.validates_acceptance_of(:terms_of_service, accept: [1, "I concur."])
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service, accept: [1, "I concur."])
 
-    t = Topic.new("title" => "We should be confirmed", "terms_of_service" => "")
+    t = klass.new("title" => "We should be confirmed", "terms_of_service" => "")
     assert_predicate t, :invalid?
     assert_equal ["must be accepted"], t.errors[:terms_of_service]
 
@@ -66,9 +71,10 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_acceptance_of_for_ruby_class
-    Person.validates_acceptance_of :karma
+    klass = define_test_class(Person)
+    klass.validates_acceptance_of :karma
 
-    p = Person.new
+    p = klass.new
     p.karma = ""
 
     assert_predicate p, :invalid?
@@ -76,13 +82,21 @@ class AcceptanceValidationTest < ActiveModel::TestCase
 
     p.karma = "1"
     assert_predicate p, :valid?
-  ensure
-    Person.clear_validators!
   end
 
   def test_validates_acceptance_of_true
-    Topic.validates_acceptance_of(:terms_of_service)
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service)
 
-    assert_predicate Topic.new(terms_of_service: true), :valid?
+    assert_predicate klass.new(terms_of_service: true), :valid?
   end
+
+  private
+
+    # Acceptance validator includes anonymous module into class, which cannot
+    # be cleared, so to avoid multiple inclusions we use a named subclass which
+    # we can remove in teardown.
+    def define_test_class(parent)
+      self.class.const_set(:TestClass, Class.new(parent))
+    end
 end


### PR DESCRIPTION
Similar to #35966. By the end of the tests here, the `Topic` class has something like five modules included in it. That doesn't seem like a very good idea.

I've used named subclasses then cleaned up by removing the constant, which is not ideal but better than polluting the original class.