### PR TITLE
Avoid LazilyDefinedAttributes being included multiple times in class, and remove methods after first use

### DIFF
--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -91,10 +91,35 @@ class AcceptanceValidationTest < ActiveModel::TestCase
     assert_predicate klass.new(terms_of_service: true), :valid?
   end
 
+  def test_lazy_attribute_module_included_only_once
+    klass = define_test_class(Topic)
+    assert_difference -> { klass.ancestors.count }, 1 do
+      2.times { klass.validates_acceptance_of(:something_to_accept) }
+      2.times { klass.validates_acceptance_of(:something_else_to_accept) }
+    end
+  end
+
+  def test_lazy_attributes_module_included_again_if_needed
+    klass = define_test_class(Topic)
+    assert_difference -> { klass.ancestors.count }, 1 do
+      klass.validates_acceptance_of(:something_to_accept)
+    end
+    topic = klass.new
+    topic.something_to_accept
+    assert_difference -> { klass.ancestors.count }, 1 do
+      klass.validates_acceptance_of(:something_else_to_accept)
+    end
+    assert topic.respond_to?(:something_else_to_accept)
+  end
+
+  def test_lazy_attributes_respond_to?
+    klass = define_test_class(Topic)
+    klass.validates_acceptance_of(:terms_of_service)
+    topic = klass.new
+    assert topic.respond_to?(:terms_of_service)
+  end
+
   private
-    # Acceptance validator includes anonymous module into class, which cannot
-    # be cleared, so to avoid multiple inclusions we use a named subclass which
-    # we can remove in teardown.
     def define_test_class(parent)
       self.class.const_set(:TestClass, Class.new(parent))
     end


### PR DESCRIPTION
Solution to issues in #35968 and #35966. Also fixes #34659.

### Summary

Currently, the acceptance validator includes an anonymous module in order to override `method_missing` and `respond_to_missing?` so that the validator can catch calls to attribute methods and define attribute accessors lazily (to avoid a schema load).

The problem with this is that each call to `validates` on a model will include another module into the class. I've already fixed a bunch of tests to avoid polluting test classes as a result of this, but the underlying problem is still there.

This PR gets around the issue using a normal module and grabbing the attributes from the validators on the model, which are accessible within method_missing and respond_to_missing?

@kamipo If this seems like a reasonable solution, I'd like to revert at least #35968 before merging.