### PR TITLE
mounted routes with non-word characters

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -119,7 +119,8 @@ module ActionDispatch
 
         class UnanchoredRegexp < AnchoredRegexp # :nodoc:
           def accept(node)
-            %r{\A#{visit node}(?:\b|\Z)}
+            path = visit node
+            path == "/" ? %r{\A/} : %r{\A#{path}(?:\b|\Z|/)}
           end
         end
 

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -27,6 +27,7 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
     }
 
     mount SprocketsApp, at: "/sprockets"
+    mount SprocketsApp, at: "/star*"
     mount SprocketsApp => "/shorthand"
 
     mount SinatraLikeApp, at: "/fakeengine", as: :fake
@@ -58,6 +59,14 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
   def test_mounting_at_root_path
     get "/omg"
     assert_equal " -- /omg", response.body
+
+    get "/~omg"
+    assert_equal " -- /~omg", response.body
+  end
+
+  def test_mounting_at_path_with_non_word_character
+    get "/star*/omg"
+    assert_equal "/star* -- /omg", response.body
   end
 
   def test_mounting_sets_script_name

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -34,17 +34,17 @@ module ActionDispatch
         end
 
         {
-          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?(?:\b|\Z)},
-          "/:controller/foo"             => %r{\A/(#{x})/foo(?:\b|\Z)},
-          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)(?:\b|\Z)},
-          "/:controller"                 => %r{\A/(#{x})(?:\b|\Z)},
-          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?(?:\b|\Z)},
-          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml(?:\b|\Z)},
-          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)(?:\b|\Z)},
-          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?(?:\b|\Z)},
-          "/:controller/*foo"            => %r{\A/(#{x})/(.+)(?:\b|\Z)},
-          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar(?:\b|\Z)},
-          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))(?:\b|\Z)},
+          "/:controller(/:action)"       => %r{\A/(#{x})(?:/([^/.?]+))?(?:\b|\Z|/)},
+          "/:controller/foo"             => %r{\A/(#{x})/foo(?:\b|\Z|/)},
+          "/:controller/:action"         => %r{\A/(#{x})/([^/.?]+)(?:\b|\Z|/)},
+          "/:controller"                 => %r{\A/(#{x})(?:\b|\Z|/)},
+          "/:controller(/:action(/:id))" => %r{\A/(#{x})(?:/([^/.?]+)(?:/([^/.?]+))?)?(?:\b|\Z|/)},
+          "/:controller/:action.xml"     => %r{\A/(#{x})/([^/.?]+)\.xml(?:\b|\Z|/)},
+          "/:controller.:format"         => %r{\A/(#{x})\.([^/.?]+)(?:\b|\Z|/)},
+          "/:controller(.:format)"       => %r{\A/(#{x})(?:\.([^/.?]+))?(?:\b|\Z|/)},
+          "/:controller/*foo"            => %r{\A/(#{x})/(.+)(?:\b|\Z|/)},
+          "/:controller/*foo/bar"        => %r{\A/(#{x})/(.+)/bar(?:\b|\Z|/)},
+          "/:foo|*bar"                   => %r{\A/(?:([^/.?]+)|(.+))(?:\b|\Z|/)},
         }.each do |path, expected|
           define_method(:"test_to_non_anchored_regexp_#{Regexp.escape(path)}") do
             path = Pattern.build(


### PR DESCRIPTION
### Summary

Fixes #35786, a regression introduced by ccc0597.

There are two special cases for which routing is broken:
1) If an engine is mounted to `/` then paths that start with a non-word character don't work (eg. `/~foo`).
2) If an engine is mounted to a path that ends with a non-word character (eg `/engine*`) then all routes to the engine don't work.

The underlying problem is that in those cases routes to the engine don't have a word boundary after the part where the engine is mounted (between `/` and `~` in `/~foo` and between `*` and `/` in `/engine*/foo`).
#<span></span>1 is handled by a conditional. #<span></span>2 is solved with an additional lookahead check for`/` in the regex.
