### PR TITLE
Remove `required: true` from the model generator template

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
@@ -1,7 +1,7 @@
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:reference?).each do |attribute| -%>
-  belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', required: true' if attribute.required? %>
+  belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %>
 <% end -%>
 <% attributes.select(&:rich_text?).each do |attribute| -%>
   has_rich_text :<%= attribute.name %>

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -414,23 +414,12 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_required_belongs_to_adds_required_association
-    run_generator ["account", "supplier:references{required}"]
-
-    expected_file = <<~FILE
-      class Account < ApplicationRecord
-        belongs_to :supplier, required: true
-      end
-    FILE
-    assert_file "app/models/account.rb", expected_file
-  end
-
   def test_required_polymorphic_belongs_to_generages_correct_model
     run_generator ["account", "supplier:references{required,polymorphic}"]
 
     expected_file = <<~FILE
       class Account < ApplicationRecord
-        belongs_to :supplier, polymorphic: true, required: true
+        belongs_to :supplier, polymorphic: true
       end
     FILE
     assert_file "app/models/account.rb", expected_file
@@ -441,7 +430,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
     expected_file = <<~FILE
       class Account < ApplicationRecord
-        belongs_to :supplier, polymorphic: true, required: true
+        belongs_to :supplier, polymorphic: true
       end
     FILE
     assert_file "app/models/account.rb", expected_file


### PR DESCRIPTION
### Summary

`belongs_to` association have `required: true` by default
https://github.com/rails/rails/pull/18937 onwards so we don't need it
in the generator template.
We still need the code for required in the command line generator as
it adds `null: false` in the migration.
