### PR TITLE
Expose helpers method in action controller

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,29 @@
+* Add #helpers method to `ActionController` that exposes all the helpers.
+This is so that insted of doing something like:
+
+    ```
+    class User < ActiveRecord::Base
+      include Rails.applicatioon.routes.url_helpers
+
+      def self.my_path
+        user_path(self)
+      end
+    end
+    ```
+
+One can use the shorthand:
+
+    ```
+    def self.my_path
+      ApplicationController.helpers.user_path(self)
+    end
+    ```
+
+And also avoid including a module in their models.
+
+  *Guilherme Mansur*
+
+
 * Fix strong parameters blocks all attributes even when only some keys are invalid (non-numerical). It should only block invalid key's values instead.
 
     *Stan Lo*

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -74,9 +74,13 @@ module ActionController
 
       # Provides a proxy to access helper methods from outside the view.
       def helpers
-        @helper_proxy ||= begin
-          proxy = ActionView::Base.empty
-          proxy.config = config.inheritable_copy
+        @helpers_proxy ||= begin
+          if defined?(renderer) && defined?(view_context)
+            proxy = renderer.helpers
+          else
+            proxy = ActionView::Base.empty
+            proxy.config = config.inheritable_copy
+          end
           proxy.extend(_helpers)
         end
       end

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -96,6 +96,18 @@ module ActionController
       instance.render_to_string(*args)
     end
 
+    def helpers # :nodoc:
+      raise "missing controller" unless controller
+
+      request = ActionDispatch::Request.new(@env)
+      request.routes = controller._routes
+
+      instance = controller.new
+      instance.set_request! request
+      instance.set_response! controller.make_response!(request)
+      instance.helpers
+    end
+
     private
       def normalize_keys(env)
         new_env = {}

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -84,6 +84,20 @@ module ActionDispatch
     #
     #   User.find(1).base_uri # => "/users/1"
     #
+    # Alternatively you can call the url helper directly from ApplicationController:
+    #
+    #   class User < ActiveRecord::Base
+    #
+    #     def base_uri
+    #       ApplicationController.helpers.base_uri
+    #     end
+    #   end
+    #
+    #   User.find(1).base_uri #=> "/users/1"
+    #
+    # This avoids including all of the methods in Rails.application.routes.url_helpers
+    # inside of the model.
+    #
     module UrlFor
       extend ActiveSupport::Concern
       include PolymorphicRoutes

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -74,6 +74,22 @@ module LocalAbcHelper
   def c() end
 end
 
+
+module MetalHelper
+  def metal
+    "This test is metal"
+  end
+end
+
+class MetalHelpersController < ActionController::Metal
+  include ActionController::Helpers
+  helper MetalHelper
+
+  def render_helper
+    self.response_body = self.class.helpers.metal
+  end
+end
+
 class HelperPathsTest < ActiveSupport::TestCase
   def test_helpers_paths_priority
     responses = HelpersPathsController.action(:index).call(ActionController::TestRequest::DEFAULT_ENV.dup)
@@ -229,6 +245,11 @@ class HelperTest < ActiveSupport::TestCase
     AllHelpersController.config.my_var = "smth"
 
     assert_equal "smth", AllHelpersController.helpers.config.my_var
+  end
+
+  def test_helper_for_metal_controller
+    assert_equal "This test is metal",
+      call_controller(MetalHelpersController, "render_helper").last.body
   end
 
   private


### PR DESCRIPTION
### Summary

Traditionally when someone needed the `url_helpers` in the model the suggested way, as in the docs, is to `include Rails.application.routes.url_helpers` in the model, i.e:  

``` ruby  
  class User < ActiveRecord::Base
    def base_uri
       user_path(self)
    end
  end
```

The problem with this approach is that we include the entirety of the `url_helpers` in our model interface, and end up mixing view and model concerns. 

A better approach is to not include the module but directly call the method in `Rails.application.routes.url_helpers` like: 

``` ruby
def base_uri
  Rails.application.routes.url_helpers.user_path(self)
end
```

The problem with this approach is this is quite a handful to write and this level of chaining requires a lot coupling to the intermediate structures.

What this PR is proposing is to expose all the `helpers` including the `url_helpers` through the existing `helpers` method like:

``` ruby
ApplicationController.helpers.user_path
```

### Other Information

It's true that this PR is not strictly needed since we can directly call `Rails.application.routes.url_helpers.user_path`, however I believe we should change the documentation to not recommend `include Rails.application.routes.url_helpers.user_path` since that pollutes the model interface. 

cc: @rafaelfranca 