### PR TITLE
Various fixes in ActiveSupport::Notifications::Event

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -180,13 +180,13 @@ module ActiveSupport
 
           def start(name, id, payload)
             timestack = Thread.current[:_timestack] ||= []
-            timestack.push Time.now
+            timestack.push Concurrent.monotonic_time
           end
 
           def finish(name, id, payload)
             timestack = Thread.current[:_timestack]
             started = timestack.pop
-            @delegate.call(name, started, Time.now, id, payload)
+            @delegate.call(name, started, Concurrent.monotonic_time, id, payload)
           end
         end
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -68,7 +68,6 @@ module ActiveSupport
         @transaction_id = transaction_id
         @end            = ending
         @children       = []
-        @duration       = nil
         @cpu_time_start = 0
         @cpu_time_finish = 0
         @allocation_count_start = 0
@@ -125,7 +124,7 @@ module ActiveSupport
       #
       #   @event.duration # => 1000.138
       def duration
-        @duration ||= 1000.0 * (self.end - time)
+        1000.0 * (self.end - time)
       end
 
       def <<(event)

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -69,8 +69,8 @@ module ActiveSupport
         @end            = ending
         @children       = []
         @duration       = nil
-        @cpu_time_start = nil
-        @cpu_time_finish = nil
+        @cpu_time_start = 0
+        @cpu_time_finish = 0
         @allocation_count_start = 0
         @allocation_count_finish = 0
       end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -302,7 +302,7 @@ module Notifications
 
   class EventTest < TestCase
     def test_events_are_initialized_with_details
-      time = Time.now
+      time = Concurrent.monotonic_time
       event = event(:foo, time, time + 0.01, random_id, {})
 
       assert_equal :foo, event.name
@@ -310,15 +310,24 @@ module Notifications
       assert_in_delta 10.0, event.duration, 0.00001
     end
 
+    def test_event_cpu_time_and_idle_time_when_start_and_finish_is_not_called
+      time = Concurrent.monotonic_time
+      event = event(:foo, time, time + 0.01, random_id, {})
+
+      assert_equal 0, event.cpu_time
+      assert_in_delta 10.0, event.idle_time, 0.00001
+    end
+
+
     def test_events_consumes_information_given_as_payload
-      event = event(:foo, Time.now, Time.now + 1, random_id, payload: :bar)
+      event = event(:foo, Concurrent.monotonic_time, Concurrent.monotonic_time + 1, random_id, payload: :bar)
       assert_equal Hash[payload: :bar], event.payload
     end
 
     def test_event_is_parent_based_on_children
-      time = Time.utc(2009, 01, 01, 0, 0, 1)
+      time = Concurrent.monotonic_time
 
-      parent    = event(:foo, Time.utc(2009), Time.utc(2009) + 100, random_id, {})
+      parent    = event(:foo, Concurrent.monotonic_time, Concurrent.monotonic_time + 100, random_id, {})
       child     = event(:foo, time, time + 10, random_id, {})
       not_child = event(:foo, time, time + 100, random_id, {})
 


### PR DESCRIPTION
### Summary

#### 1. Fixed: #cpu_time doesn't work for a `ActiveSupport::Notifications::Fanout::Subscribers::Timed` subscriber

##### Before

```ruby
ActiveSupport::Notifications.subscribe 'sleep' do |event|
  puts "Allocations: #{event.allocations}"
  puts "CPU time: #{event.cpu_time}"
  puts "idle time: #{event.idle_time}"
end

ActiveSupport::Notifications.instrument 'sleep' do
  sleep 1
end
```

prints

```
Allocations: 1
CPU time: 0.11399999999994748
idle time: 1001.9520000154749
```

But, calling `#cpu_time` doesn't work for an `ActiveSupport::Notifications::Fanout::Subscribers::Timed` subscriber.

```ruby
ActiveSupport::Notifications.subscribe 'sleep' do |*args|
  # Here, '*args' contains only 5 things, viz.
  # 'name', 'started', 'finished', 'unique_id' and 'data'.
  # Since the event is already finished somewhere,
  # there's no use of calling  '#start!' and '#finish!'
  # on the below event object in this block.
  event = ActiveSupport::Notifications::Event.new(*args)
  # Allocations haven't been computed for this event, so it becomes zero.
  puts "Allocations: #{event.allocations}"
  # Therefore, the 'cpu_time_start' and 'cpu_time_finish' will be 'nil'
  # for this event.
  # Calling '#cpu_time' doesn't work on this event and throws
  # "NoMethodError (undefined method `-' for nil:NilClass):" error.
  puts "CPU time: #{event.cpu_time}"
  # Calling '#idle_time' also breaks with same error
  # since it relies on `#cpu_time`.
  puts "idle time: #{event.idle_time}"
end

ActiveSupport::Notifications.instrument 'sleep' do
  sleep 1
end
```

prints

```
Allocations: 0
Traceback (most recent call last):
[...]
Users/vishaltelangre/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/bundler/gems/rails-d1107f4d1e25/activesupport/lib/active_support/notifications/instrumenter.rb:99:in `cpu_time': undefined method `-' for nil:NilClass (NoMethodError)
```

##### After

With the fixes made in this PR, the above failing example now works and prints

```
Allocations: 0
CPU time: 0
idle time: 1003.7420000007842
```

#### 2. Used monotonic time to precisely record `started` and `finished` time values for the event subscribed by an `ActiveSupport::Notifications::Fanout::Subscribers::Timed` subscriber.

#### 3. Removed `@duration` instance variable from `ActiveSupport::Notifications::Event`

Because
- If we call `#start!` and `#finish!` manually on the event object, then the memoized duration value is being returned instead of calculating duration based on the updated values of `@end` and `@time`.
- We do not have instance variables such as `@cpu_time`, `@idle_time` and `@allocations`, so having `@duration` is unnecessary since we already have a method to compute and return the duration. 
- Getting rid of the unnecessary `@duration` instance variable saves an allocation.
- Having @duration instance variable shows `@duration: nil` when the event object is inspected before calling the `#duration` method on that event object. This adds unnecessary confusion since `@time` and `@end` already have values.