### PR TITLE
Find query_source_location using lazy Enumerator

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -110,7 +110,7 @@ module ActiveRecord
       end
 
       def extract_query_source_location(locations)
-        backtrace_cleaner.clean(locations).first
+        backtrace_cleaner.clean(locations.lazy).first
       end
   end
 end

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -122,7 +122,11 @@ module ActiveSupport
       end
 
       def noise(backtrace)
-        backtrace - silence(backtrace)
+        backtrace.select do |line|
+          @silencers.any? do |s|
+            s.call(line)
+          end
+        end
       end
   end
 end

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -17,6 +17,16 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal 1, result.length
   end
 
+  test "can filter for noise" do
+    backtrace = [ "(irb):1",
+                  "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+                  "bin/rails:4:in `<main>'" ]
+    result = @cleaner.clean(backtrace, :noise)
+    assert_equal "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'", result[0]
+    assert_equal "bin/rails:4:in `<main>'", result[1]
+    assert_equal 2, result.length
+  end
+
   test "should omit ActionView template methods names" do
     method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, locals: []).send :method_name
     backtrace = [ "app/views/application/index.html.erb:4:in `block in #{method_name}'"]


### PR DESCRIPTION
In development, `extract_query_source_location` is called on every SQL query. In my test app, a SQL query from the controller results in a stack trace 200 deep, with the first "clean" frame 60 in.

By filtering on `caller.lazy`, a lazy enumerator, instead of the full array, we only need to filter the backtrace up to the first non-noise stack frame.

This also updates noise to be able to deal with being passed a lazy enum. We don't need this anywhere, but it seemed better for this to be consistent.

[Benchmark:](https://gist.github.com/jhawthorn/bc8417d99846a543d098a3c606d3f2c3)
```
       clean(caller)      1.505k (± 3.7%) i/s -      7.550k in   5.022886s
clean(caller.lazy).to_a
                          1.258k (± 3.7%) i/s -      6.375k in   5.074642s
clean(caller, :noise)
                          1.474k (± 3.6%) i/s -      7.497k in   5.091694s
clean(caller.lazy).first
                          3.841k (± 3.7%) i/s -     19.482k in   5.079535s
```

There are a few more improvements I'd like to make to this later, running X regex against Y strings for Z queries ends up pretty expensive even for development. It would be really great if we had an interface to filter on `caller_locations` (Thread::Backtrace::Location) instead of `caller`.