### PR TITLE
Fix dirty tracking after rollback.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix dirty tracking after rollback.
+
+    Fixes #15018, #30167, #33868.
+
+    *Ryuta Kamizono*
+
 *   Fix dirty tracking for `touch` to track saved changes.
 
     Fixes #33429.

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -46,6 +46,7 @@ module ActiveRecord
       #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
       #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
       def read_attribute_before_type_cast(attr_name)
+        sync_with_transaction_state
         @attributes[attr_name.to_s].value_before_type_cast
       end
 
@@ -60,6 +61,7 @@ module ActiveRecord
       #   task.attributes_before_type_cast
       #   # => {"id"=>nil, "title"=>nil, "is_done"=>true, "completed_on"=>"2012-10-21", "created_at"=>nil, "updated_at"=>nil}
       def attributes_before_type_cast
+        sync_with_transaction_state
         @attributes.values_before_type_cast
       end
 
@@ -71,6 +73,7 @@ module ActiveRecord
         end
 
         def attribute_came_from_user?(attribute_name)
+          sync_with_transaction_state
           @attributes[attribute_name].came_from_user?
         end
     end

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -156,6 +156,16 @@ module ActiveRecord
       end
 
       private
+        def mutations_from_database
+          sync_with_transaction_state
+          super
+        end
+
+        def mutations_before_last_save
+          sync_with_transaction_state
+          super
+        end
+
         def write_attribute_without_type_cast(attr_name, value)
           name = attr_name.to_s
           if self.class.attribute_alias?(name)

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -16,39 +16,33 @@ module ActiveRecord
 
       # Returns the primary key column's value.
       def id
-        sync_with_transaction_state
         primary_key = self.class.primary_key
         _read_attribute(primary_key) if primary_key
       end
 
       # Sets the primary key column's value.
       def id=(value)
-        sync_with_transaction_state
         primary_key = self.class.primary_key
         _write_attribute(primary_key, value) if primary_key
       end
 
       # Queries the primary key column's value.
       def id?
-        sync_with_transaction_state
         query_attribute(self.class.primary_key)
       end
 
       # Returns the primary key column's value before type cast.
       def id_before_type_cast
-        sync_with_transaction_state
         read_attribute_before_type_cast(self.class.primary_key)
       end
 
       # Returns the primary key column's previous value.
       def id_was
-        sync_with_transaction_state
         attribute_was(self.class.primary_key)
       end
 
       # Returns the primary key column's value from the database.
       def id_in_database
-        sync_with_transaction_state
         attribute_in_database(self.class.primary_key)
       end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -583,12 +583,6 @@ module ActiveRecord
       def initialize_internals_callback
       end
 
-      def thaw
-        if @attributes.frozen?
-          @attributes = @attributes.dup
-        end
-      end
-
       def custom_inspect_method_defined?
         self.class.instance_method(:inspect).owner != ActiveRecord::Base.instance_method(:inspect).owner
       end


### PR DESCRIPTION
Currently the rollback only restores primary key value, `new_record?`,
`destroyed?`, and `frozen?`. Since the `save` clears current dirty
attribute states, retrying save after rollback will causes no change
saved if partial writes is enabled (by default).

This makes `remember_transaction_record_state` remembers original values
then restores dirty attribute states after rollback.

Fixes #15018.
Fixes #30167.
Fixes #33868.
Fixes #33443.
Closes #33444.
Closes #34504.