### PR TITLE
Bump RuboCop to 0.67.2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,6 +25,6 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-66
+    channel: rubocop-0-67
 
 exclude_patterns: []

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.5
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "uglifier", ">= 1.3.0", require: false
 gem "json", ">= 2.0.0"
 
 gem "rubocop", ">= 0.47", require: false
+gem "rubocop-performance", require: false
 
 group :doc do
   gem "sdoc", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,7 @@ GEM
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
     retriable (3.1.2)
-    rubocop (0.66.0)
+    rubocop (0.67.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -419,6 +419,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     ruby-progressbar (1.10.0)
     ruby-vips (2.0.13)
       ffi (~> 1.9)
@@ -581,6 +583,7 @@ DEPENDENCIES
   resque
   resque-scheduler
   rubocop (>= 0.47)
+  rubocop-performance
   sass-rails
   sdoc (~> 1.0)
   selenium-webdriver (>= 3.5.0, < 3.13.0)

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ResolverSharedTests
   attr_reader :tmpdir
 
@@ -7,7 +9,7 @@ module ResolverSharedTests
     end
   end
 
-  def with_file(filename, source="File at #{filename}")
+  def with_file(filename, source = "File at #{filename}")
     path = File.join(tmpdir, filename)
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, source)
@@ -103,7 +105,7 @@ module ResolverSharedTests
     c = context.find("hello_world", "test", false, [], {})
 
     # disable_cache should give us a new object
-    refute_same a, b
+    assert_not_same a, b
 
     # but it should not clear the cache
     assert_same a, c

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -209,7 +209,7 @@ module ActiveRecord
           config = {
             "default_env" => {
               "animals" => { adapter: "sqlite3", database: "db/animals.sqlite3" },
-              "primary"  => { adapter: "sqlite3", database: "db/primary.sqlite3" }
+              "primary" => { adapter: "sqlite3", database: "db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -236,7 +236,7 @@ module ActiveRecord
           config = {
             "default_env" => {
               "animals" => { adapter: "sqlite3", database: "db/animals.sqlite3" },
-              "primary"  => { adapter: "sqlite3", database: "db/primary.sqlite3" }
+              "primary" => { adapter: "sqlite3", database: "db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config


### PR DESCRIPTION
Performance cops will be extracted from RuboCop to RuboCop Performance
when next RuboCop 0.68 will be released.
https://github.com/rubocop-hq/rubocop/issues/5977

RuboCop 0.67 is its transition period.

Since rails/rails repository uses Performance cops, This PR added
rubocop-performance gem to Gemfile.

And this PR fixes some offenses using the following auto-correct.

```console
% bundle exec rubocop -a

Offenses:

activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb:212:26:
C: [Corrected] Layout/SpaceAroundOperators: Operator =
> should be surrounded by a single space.
              "primary"  => { adapter: "sqlite3", database: "db/primary.sqlite3" }
                         ^^
activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb:239:26:
C: [Corrected] Layout/SpaceAroundOperators: Operator => should be
surrounded by a single space.
              "primary"  => { adapter: "sqlite3", database: "db/primary.sqlite3" }
                         ^^
actionview/test/template/resolver_shared_tests.rb:1:1: C: [Corrected]
Style/FrozenStringLiteralComment: Missing magic comment #
frozen_string_literal: true.
module ResolverSharedTests
^
actionview/test/template/resolver_shared_tests.rb:10:33: C: [Corrected]
Layout/SpaceAroundEqualsInParameterDefault: Surrounding space missing in
default value assignment.
  def with_file(filename, source="File at #{filename}")
                                ^
actionview/test/template/resolver_shared_tests.rb:106:5: C: [Corrected]
Rails/RefuteMethods: Prefer assert_not_same over refute_same.
    refute_same a, b
    ^^^^^^^^^^^

2760 files inspected, 5 offenses detected, 5 offenses corrected
```

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
