### PR TITLE
Fix Bcc header missing with emails from conductor and test helpers

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix Bcc header not being included with emails from `create_inbound_email_from` test helpers.
+
+    *jduff*
+
 *   Add `ApplicationMailbox.mailbox_for` to expose mailbox routing.
 
     *James Dabbs*

--- a/actionmailbox/lib/action_mailbox/test_helper.rb
+++ b/actionmailbox/lib/action_mailbox/test_helper.rb
@@ -14,7 +14,11 @@ module ActionMailbox
     #
     #   create_inbound_email_from_mail(from: "david@loudthinking.com", subject: "Hello!")
     def create_inbound_email_from_mail(status: :processing, **mail_options)
-      create_inbound_email_from_source Mail.new(mail_options).to_s, status: status
+      mail = Mail.new(mail_options)
+      # Bcc header is not encoded by default
+      mail[:bcc].include_in_headers = true if mail[:bcc]
+
+      create_inbound_email_from_source mail.to_s, status: status
     end
 
     # Create an +InboundEmail+ using the raw rfc822 +source+ as text.

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -30,6 +30,27 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
     end
   end
 
+  test "create inbound email with bcc" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_emails_path, params: {
+          mail: {
+            from: "Jason Fried <jason@37signals.com>",
+            bcc: "Replies <replies@example.com>",
+            subject: "Hey there",
+            body: "How's it going?"
+          }
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last.mail
+      assert_equal %w[ jason@37signals.com ], mail.from
+      assert_equal %w[ replies@example.com ], mail.bcc
+      assert_equal "Hey there", mail.subject
+      assert_equal "How's it going?", mail.body.decoded
+    end
+  end
+
   test "create inbound email with attachments" do
     with_rails_env("development") do
       assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do

--- a/actionmailbox/test/unit/router_test.rb
+++ b/actionmailbox/test/unit/router_test.rb
@@ -51,6 +51,15 @@ module ActionMailbox
       assert_equal inbound_email.mail, $processed_mail
     end
 
+    test "single string routing on bcc" do
+      @router.add_routes("first@example.com" => :first)
+
+      inbound_email = create_inbound_email_from_mail(to: "someone@example.com", bcc: "first@example.com", subject: "This is a reply")
+      @router.route inbound_email
+      assert_equal "FirstMailbox", $processed_by
+      assert_equal inbound_email.mail, $processed_mail
+    end
+
     test "single string routing case-insensitively" do
       @router.add_routes("first@example.com" => :first)
 


### PR DESCRIPTION
### Summary

`Bcc` header was not being included with emails created by the actionmailbox conductor or the `create_inbound_email_from` test helpers. This change marks the `Bcc` header to be included when the email is encoded in both of those cases, using the `include_in_headers` features from the mail gem found [here](https://github.com/mikel/mail/blob/6bc16b4bce4fe280b19523c939b14a30e32a8ba4/lib/mail/fields/bcc_field.rb#L43)