### PR TITLE
Squash warning: possibly useless use of a constant in void context

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1721,7 +1721,7 @@ module ApplicationTests
         end
       EOS
 
-      app_file "config/initializers/autoload.rb", "D"
+      app_file "config/initializers/autoload.rb", "D.class"
 
       app "development"
 
@@ -1749,7 +1749,7 @@ module ApplicationTests
         end
       EOS
 
-      app_file "config/initializers/autoload.rb", "D"
+      app_file "config/initializers/autoload.rb", "D.class"
 
       app "production"
 


### PR DESCRIPTION
Before:

```
railties$ /home/u/.rbenv/versions/2.6.2/bin/ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/configuration_test.rb
# ...snip 
# Running:

............................./home/u/code/rails/tmp/d20190416-10371-2ozp3s/app/config/initializers/autoload.rb:1: warning: possibly useless use of a constant in void context
.................................../home/u/code/rails/tmp/d20190416-10412-rjz2ld/app/config/initializers/autoload.rb:1: warning: possibly useless use of a constant in void context
......................................................................................................................
```


See:

https://buildkite.com/rails/rails/builds/60511#841e2c5a-91ec-45bb-8dbd-e51486049f6d
https://buildkite.com/rails/rails/builds/60511#841e2c5a-91ec-45bb-8dbd-e51486049f6d