### PR TITLE
[Rails::MailersController] Do not leak I18n global setting changes

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -5,8 +5,9 @@ require "rails/application_controller"
 class Rails::MailersController < Rails::ApplicationController # :nodoc:
   prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATH
 
+  around_action :set_locale, only: :preview
+  before_action :find_preview, only: :preview
   before_action :require_local!, unless: :show_previews?
-  before_action :find_preview, :set_locale, only: :preview
 
   helper_method :part_query, :locale_query
 
@@ -92,6 +93,8 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
     end
 
     def set_locale
-      I18n.locale = params[:locale] || I18n.default_locale
+      I18n.with_locale(params[:locale] || I18n.default_locale) do
+        yield
+      end
     end
 end

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -515,6 +515,13 @@ module ApplicationTests
       assert_match '<option selected value="locale=ja">ja', last_response.body
     end
 
+    test "preview does not leak I18n global setting changes" do
+      I18n.with_locale(:en) do
+        get "/rails/mailers/notifier/foo.txt?locale=ja"
+        assert_equal :en, I18n.locale
+      end
+    end
+
     test "mailer previews create correct links when loaded on a subdirectory" do
       mailer "notifier", <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
### Summary

Originally added here: https://github.com/rails/rails/pull/31596

Using the action mailer specifying a locale to the preview would leak a global I18n setting change (`I18n.locale`).

Since it is only exposed in development, this is not that big of a deal, only corrupt instances running in development.
https://github.com/rails/rails/blob/ed9acb4fcc793ce1ab68a0e5076dc9458cc7f218/actionmailer/lib/action_mailer/railtie.rb#L29
https://github.com/rails/rails/blob/b49e38b76b0998b0a8312d8c08c98728d3de2006/actionmailer/lib/action_mailer/railtie.rb#L85-L90

Using `I18n.with_locale(locale) {...}` will make certain the previous value is restored.

