### PR TITLE
handle long or duplicated screenshot filenames

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -39,7 +39,8 @@ module ActionDispatch
 
         private
           def image_name
-            failed? ? "failures_#{method_name}" : method_name
+            name = method_name[0...225]
+            failed? ? "failures_#{name}" : name
           end
 
           def image_path

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -36,6 +36,14 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     end
   end
 
+  test "image name truncates names over 225 characters" do
+    new_test = DrivenBySeleniumWithChrome.new("x" * 400)
+
+    Rails.stub :root, Pathname.getwd do
+      assert_equal Rails.root.join("tmp/screenshots/#{"x" * 225}.png").to_s, new_test.send(:image_path)
+    end
+  end
+
   test "defaults to simple output for the screenshot" do
     new_test = DrivenBySeleniumWithChrome.new("x")
     assert_equal "simple", new_test.send(:output_type)


### PR DESCRIPTION
Fixes #32346

Long screenshot filenames in system tests had been throwing `Errno::ENAMETOOLONG`. This was mostly a problem with a Linux/RSpec combo because the EXT4 filesystem limits filenames to 255 characters, and RSpec Rails uses the full `describe`/`context`/`it` nesting in the filename. This commit rescues `Errno::ENAMETOOLONG` and truncates the name to its first 225 characters plus the seconds since epoch.

This commit also handles duplicate filenames, which become more common when truncating. E.g, a long `describe`/`context` nesting may have the same first 225 chars for many tests. It was already possible though, especially with multiple manual screenshots:
```ruby
take_screenshot
click_on(something) # I'm trying to isolate this effect
take_screenshot
```
With this commit, duplicate filenames have a unique suffix appended instead of overwriting the existing file.

Other changes:
- improve testing slightly
  - address some previously untested behavior
  - make a few tests more isolated
  - break down some lib methods to make them more testable
- remove `#absolute_image_path` because `#image_path` had become absolute
- tiny refactors