### PR TITLE
Make plain matcher match first, not last

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -402,10 +402,6 @@ module ActiveModel
           def method_name(attr_name)
             @method_name % attr_name
           end
-
-          def plain?
-            prefix.empty? && suffix.empty?
-          end
         end
     end
 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -352,11 +352,7 @@ module ActiveModel
 
         def attribute_method_matchers_matching(method_name)
           attribute_method_matchers_cache.compute_if_absent(method_name) do
-            # Bump plain matcher to last place so that only methods that do not
-            # match any other pattern match the actual attribute name.
-            # This is currently only needed to support legacy usage.
-            matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
-            matchers.map { |matcher| matcher.match(method_name) }.compact
+            attribute_method_matchers.map { |matcher| matcher.match(method_name) }.compact
           end
         end
 


### PR DESCRIPTION
The original code deleted here takes the "plain" matcher with a blank prefix and blank suffix and puts it at the end of the matchers array such that it is de-prioritized among all matchers. The comment explaining this code, originally from commimt 8b8b7143efe dated in 2011, is in a context where detection from matchers
happened immediately. In that situation, the plain matcher would indeed always match first and no others would ever be used.

However, the current code does not immediately detect one match but rather maps matchers to matches for the method_name. Detection only happens later for matches whose attribute name is valid.

In this context, there is no need to bump the plain matcher to the end of the array, since it will only be selected if the attribute name it captures matches a valid attribute name.