### PR TITLE
Mention more ActiveStorage hooks in Active Support Instrumentation guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -545,6 +545,14 @@ Active Storage
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
+### service_download_chunk.active_storage
+
+| Key          | Value                           |
+| ------------ | ------------------------------- |
+| `:key`       | Secure token                    |
+| `:service`   | Name of the service             |
+| `:range`     | Byte range attempted to be read |
+
 ### service_download.active_storage
 
 | Key          | Value               |
@@ -581,6 +589,23 @@ Active Storage
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 | `:url`       | Generated URL       |
+
+### service_update_metadata.active_storage
+
+| Key             | Value                          |
+| --------------- | ------------------------------ |
+| `:key`          | Secure token                   |
+| `:service`      | Name of the service            |
+| `:content_type` | HTTP Content-Type field        |
+| `:disposition`  | HTTP Content-Disposition field |
+
+INFO. The only ActiveStorage service that provides this hook so far is GCS.
+
+### preview.active_storage
+
+| Key          | Value               |
+| ------------ | ------------------- |
+| `:key`       | Secure token        |
 
 Railties
 --------


### PR DESCRIPTION
### Summary

This PR adds the following three hooks that were missing in _Active Support Instrumentation_ guide:

- `service_download_chunk.active_storage`
- `service_update_metadata.active_storage`
- `preview.active_storage`
