### PR TITLE
Preserve html_safe? status on ActiveSupport::SafeBuffer#*

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Preserve `html_safe?` status on `ActiveSupport::SafeBuffer#*`.
+
+    Before:
+
+        ("<br />".html_safe * 2).html_safe? #=> nil
+
+    After:
+
+        ("<br />".html_safe * 2).html_safe? #=> true
+
+    *Ryo Nakamura*
+
 *   Calling test methods with `with_info_handler` method to allow minitest-hooks
     plugin to work.
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -213,6 +213,12 @@ module ActiveSupport #:nodoc:
       dup.concat(other)
     end
 
+    def *(*)
+      new_safe_buffer = super
+      new_safe_buffer.instance_variable_set(:@html_safe, @html_safe)
+      new_safe_buffer
+    end
+
     def %(args)
       case args
       when Hash

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -150,6 +150,14 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_equal "hello&lt;&gt;", clean + @buffer
   end
 
+  test "Should preserve html_safe? status on multiplication" do
+    multiplied_safe_buffer = "<br />".html_safe * 2
+    assert_predicate multiplied_safe_buffer, :html_safe?
+
+    multiplied_unsafe_buffer = @buffer.gsub("", "<>") * 2
+    assert_not_predicate multiplied_unsafe_buffer, :html_safe?
+  end
+
   test "Should concat as a normal string when safe" do
     clean = "hello".html_safe
     @buffer.gsub!("", "<>")


### PR DESCRIPTION
### Summary

```rb
separator = tag(:br) * 2 #=> "<br /><br />"
separator.html_safe? #=> `nil` on Rails 5.2.3, but it would be nice if this returns `true`.
```
