### PR TITLE
Update Rake to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,7 @@ GEM
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)


### PR DESCRIPTION
Fixes railties ApplicationTests failures in Ruby 2.7.

Rake 12.3.2 includes a [Fix for test fails caused by 2.6 warnings](https://github.com/ruby/rake/pull/297). Upadting prevents failures of:

- `RakeTests::RakeMigrationsTest#test_migration_status_when_schema_migrations_table_is_not_present`
- `RakeDbsTest#test_db:structure:dump_does_not_dump_schema_information_when_no_migrations_are_used`
- `BinSetupTest#test_bin_setup_output`

See [failures log](https://gist.githubusercontent.com/utilum/30e081cc38b5d90e18be8cede6385b10/raw/2b89e568977d4f1fe010726a9a561c10e59c8df8/tests.log).

ruby 2.7.0dev (2019-04-18 trunk 67602) [x86_64-linux]