### PR TITLE
Use Puma 3.12 in newly generated applications

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -192,7 +192,7 @@ module Rails
       def web_server_gemfile_entry # :doc:
         return [] if options[:skip_puma]
         comment = "Use Puma as the app server"
-        GemfileEntry.new("puma", "~> 3.11", comment)
+        GemfileEntry.new("puma", "~> 3.12", comment)
       end
 
       def include_all_railties? # :doc:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -597,7 +597,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_defaults_to_puma_version
     run_generator [destination_root]
-    assert_gem "puma", "'~> 3.11'"
+    assert_gem "puma", "'~> 3.12'"
   end
 
   def test_generator_if_skip_puma_is_given


### PR DESCRIPTION
While working on issue  #35845, I noticed that the new Rails application has puma gem with version `3.11`. Since we had upgraded the `Puma` version in `master` in this commit(https://github.com/rails/rails/commit/efb706daad0e2e1039c6abb4879c837ef8bf4d10). I thought it would be better if the new Rails application to have the same version `3.12`.

Not sure if this is needed, please let me know if we should close it.