### PR TITLE
Correct sample code indentation in AR Callbacks guide

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -67,13 +67,14 @@ class User < ApplicationRecord
   after_validation :set_location, on: [ :create, :update ]
 
   private
-    def normalize_name
-      self.name = name.downcase.titleize
-    end
 
-    def set_location
-      self.location = LocationService.query(self)
-    end
+  def normalize_name
+    self.name = name.downcase.titleize
+  end
+
+  def set_location
+    self.location = LocationService.query(self)
+  end
 end
 ```
 


### PR DESCRIPTION
### Summary

Some indentation looks off in one of the sample code blocks in the Callback Registration section of the AR Callbacks guide
