### PR TITLE
Catch exceptions raised in `parallelize_setup` and ensure tests fail when they occur

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -71,7 +71,9 @@ module ActiveSupport
           fork do
             DRb.stop_service
 
-            after_fork(worker)
+            begin
+              after_fork(worker)
+            rescue => setup_exception; end
 
             queue = DRbObject.new_with_uri(@url)
 
@@ -82,6 +84,8 @@ module ActiveSupport
               result = klass.with_info_handler reporter do
                 Minitest.run_one_method(klass, method)
               end
+
+              add_setup_exception(result, setup_exception) if setup_exception
 
               begin
                 queue.record(reporter, result)
@@ -106,6 +110,11 @@ module ActiveSupport
         @queue_size.times { @queue << nil }
         @pool.each { |pid| Process.waitpid pid }
       end
+
+      private
+        def add_setup_exception(result, setup_exception)
+          result.failures.prepend Minitest::UnexpectedError.new(setup_exception)
+        end
     end
   end
 end


### PR DESCRIPTION
### Summary

The changes here ensure that we catch any `StandardException`s that occur during the `after_fork` call (blocks passed into `parallelize_setup`) and record those exceptions with the test results.  This is work towards resolving https://github.com/rails/rails/issues/35835.  

This results in marking all of the tests as failed to bring attention to the issue & ensure it is addressed before proceeding.

/cc #35835
/cc @eileencodes 