### PR TITLE
Adds a warning message for action text installer if application pack …

### DIFF
--- a/actiontext/lib/templates/installer.rb
+++ b/actiontext/lib/templates/installer.rb
@@ -29,4 +29,17 @@ if APPLICATION_PACK_PATH.exist?
       append_to_file APPLICATION_PACK_PATH, "\n#{line}"
     end
   end
+else
+  warn <<~WARNING
+    WARNING: Action Text can't locate your JavaScript bundle to add its package dependencies.
+
+    Add these lines to any bundles:
+
+    require("trix")
+    require("@rails/actiontext")
+
+    Alternatively, install and setup the webpacker gem then rerun `bin/rails action_text:install`
+    to have these dependencies added automatically.
+
+  WARNING
 end


### PR DESCRIPTION
fixes: #35845 

As per https://github.com/rails/rails/issues/35845#issuecomment-484511772 we have added a warning message to suggest the user add `webpacker` gem or require(..) files to bundler. 

Let me know if I can improve the warning message.

Screenshot: 
<img width="879" alt="1  abhaynikamAbhays-MacBook-Pro my-test-app-35845 (zsh) 2019-04-18 19-55-57" src="https://user-images.githubusercontent.com/7736232/56368471-2076c280-6215-11e9-8281-b03ce8f709cf.png">
