### PR TITLE
Ensure active record can load without Railties

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -78,7 +78,7 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
-    ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+    ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config.config)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     end
@@ -154,7 +154,7 @@ db_namespace = namespace :db do
 
     desc "Display status of migrations"
     task status: :load_config do
-      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+      ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
         ActiveRecord::Base.establish_connection(db_config.config)
         ActiveRecord::Tasks::DatabaseTasks.migrate_status
       end
@@ -224,7 +224,7 @@ db_namespace = namespace :db do
 
   desc "Runs setup if database does not exist, or runs migrations if it does"
   task prepare: :load_config do
-    ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+    ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config.config)
       db_namespace["migrate"].invoke
     rescue ActiveRecord::NoDatabaseError
@@ -295,7 +295,7 @@ db_namespace = namespace :db do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
     task dump: :load_config do
       require "active_record/schema_dumper"
-      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+      ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
         File.open(filename, "w:utf-8") do |file|
           ActiveRecord::Base.establish_connection(db_config.config)
@@ -318,7 +318,7 @@ db_namespace = namespace :db do
     namespace :cache do
       desc "Creates a db/schema_cache.yml file."
       task dump: :load_config do
-        ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+        ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
           ActiveRecord::Base.establish_connection(db_config.config)
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
@@ -330,7 +330,7 @@ db_namespace = namespace :db do
 
       desc "Clears a db/schema_cache.yml file."
       task clear: :load_config do
-        ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+        ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
           rm_f filename, verbose: false
         end
@@ -341,7 +341,7 @@ db_namespace = namespace :db do
   namespace :structure do
     desc "Dumps the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
     task dump: :load_config do
-      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
+      ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
         ActiveRecord::Base.establish_connection(db_config.config)
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :sql)
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(db_config.config, filename)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -142,6 +142,8 @@ module ActiveRecord
       end
 
       def for_each
+        return {} unless defined?(Rails)
+
         databases = Rails.application.config.load_database_yaml
         database_configs = ActiveRecord::DatabaseConfigurations.new(databases).configs_for(env_name: Rails.env)
 


### PR DESCRIPTION
I'm not sure how to test this as it only shows up when running rake tasks which we don't do anywhere in the active record tests - we only run the methods the rake tasks call.

--- 

When I added the rake tasks for multiple databases I accidentally made
it so you couldn't use Active Record without Railties.

Since getting the database configuration depends on being able to load
Railties (there is no other way to read and parse the yaml file and load
it) I've decided that using multiple databases outside of Rails is a
no-op.

I've changed the code here to return if Rails isn't defined. Then I
changed the other tasks to use `ActiveRecord::Tasks::DatabaseTasks.env`
instead of `Rails.env`. The multi-db tasks can keep using `Rails.env`
because they'll only be generated if we're using Rails and not just
Active Record.

Fixes #35902

cc/ @rafaelfranca @tenderlove @jhawthorn @matthewd 
cc/ @jhollinger
cc/ @gmcgibbon I saw you started a PR after I started this one but I think that it's better to just ignore the multi-db tasks when we're outside Rails.