### PR TITLE
ActiveRecord: Fix error message when foreign key references inexistant table

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/foreign_keys_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/foreign_keys_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+if ActiveRecord::Base.connection.supports_foreign_keys?
+  class Mysql2ForeignKeysTest < ActiveRecord::Mysql2TestCase
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table(:table001_tests, force: true)
+    end
+
+    teardown do
+      @connection.drop_table :table001_tests, if_exists: true
+    end
+
+    class CreateTable002TestMigration < ActiveRecord::Migration::Current
+      def up
+        create_table :table002_tests do |t|
+          t.references :table001_test, foreign_key: true, index: true
+          t.references :table003_test, foreign_key: true, index: true
+        end
+      end
+
+      def down
+        drop_table :table002_test, if_exists: true
+      end
+    end
+
+    def test_foreign_key_references_inexistant_table
+      migration = CreateTable002TestMigration.new
+      begin
+        silence_stream($stdout) { migration.migrate(:up) }
+      rescue ActiveRecord::StatementInvalid => e
+        assert_match "table003_tests", e.message
+        assert_no_match "table001_test_id", e.message
+      end
+    ensure
+      silence_stream($stdout) { migration.migrate(:down) }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #36013 

Fixes ActiveRecord::MismatchedForeignKey error message when `create_table` fails because a foreign key references a table that does not exist.

**Previous behavior:**
The very first foreign key of the SQL query is extracted with a regex. The error message says that the type of this foreign key does not match the targeted primary key column's type.

The problem is that the very first foreign key of the SQL query is not always the erroneous one. Also, the error might be due to the targeted table not existing.

**New behavior:**
We now loop on each foreign key of the `create_table` statement. If one targets a table that does not exist, we build an appropriate error message mentionning the name of the missing table. Otherwise we fallback to the previous behavior.