### PR TITLE
Dropping a db fails consistely across adapters.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -262,6 +262,11 @@ module ActiveRecord
         self.class::ADAPTER_NAME
       end
 
+      # Does the database for this adapter exist?
+      def self.database_exists?(config)
+        raise NotImplementedError
+      end
+
       # Does this adapter support DDL rollbacks in transactions? That is, would
       # CREATE TABLE or ALTER TABLE get rolled back by a transaction?
       def supports_ddl_transactions?

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -42,6 +42,12 @@ module ActiveRecord
         configure_connection
       end
 
+      def self.database_exists?(config)
+        !!ActiveRecord::Base.mysql2_connection(config)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       def supports_json?
         !mariadb? && database_version >= "5.7.8"
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -259,6 +259,12 @@ module ActiveRecord
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
 
+      def self.database_exists?(config)
+        !!ActiveRecord::Base.postgresql_connection(config)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       # Is this connection alive and ready for queries?
       def active?
         @lock.synchronize do

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -98,6 +98,16 @@ module ActiveRecord
         configure_connection
       end
 
+      def self.database_exists?(config)
+        config = config.symbolize_keys
+        if config[:database] == ":memory:"
+          return true
+        else
+          database_file = defined?(Rails.root) ? File.expand_path(config[:database], Rails.root) : config[:database]
+          File.exist?(database_file)
+        end
+      end
+
       def supports_ddl_transactions?
         true
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -97,7 +97,7 @@ module ActiveRecord
       end
 
       def root
-        @root ||= Rails.root if defined?(Rails.root)
+        @root ||= Rails.root
       end
 
       def env

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -66,6 +66,12 @@ module ActiveRecord
         run_cmd("mysql", args, "loading")
       end
 
+      def database_exists?
+        !!connection
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       private
 
         attr_reader :configuration

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -67,9 +67,7 @@ module ActiveRecord
       end
 
       def database_exists?
-        !!connection
-      rescue ActiveRecord::NoDatabaseError
-        false
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(configuration)
       end
 
       private

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -29,15 +29,7 @@ module ActiveRecord
         end
       end
 
-      def database_exists?
-        !!connection
-      rescue ActiveRecord::NoDatabaseError
-        false
-      end
-
       def drop
-        raise ActiveRecord::NoDatabaseError unless database_exists?
-
         establish_master_connection
         connection.drop_database configuration["database"]
       end
@@ -94,6 +86,10 @@ module ActiveRecord
         args.concat(Array(extra_flags)) if extra_flags
         args << configuration["database"]
         run_cmd("psql", args, "loading")
+      end
+
+      def database_exists?
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(configuration)
       end
 
       private

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -29,7 +29,15 @@ module ActiveRecord
         end
       end
 
+      def database_exists?
+        !!connection
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
+
       def drop
+        raise ActiveRecord::NoDatabaseError unless database_exists?
+
         establish_master_connection
         connection.drop_database configuration["database"]
       end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -20,11 +20,13 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_database_exists_returns_false_if_database_does_not_exist
-    config = ActiveRecord::Base.configurations["arunit"].dup
-    config[:database] = "non_extant_database"
+    error = ->(_) { raise Mysql2::Error.new("Unknown database")  }
+    config = ActiveRecord::Base.configurations["arunit"]
 
-    assert_not ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(config),
-      "expected database #{config[:database]} to not exist"
+    Mysql2::Client.stub(:new, error) do
+      assert_not ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(config),
+        "expected database to not exist"
+    end
   end
 
   def test_database_exists_returns_true_when_the_database_exists

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -19,6 +19,20 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_database_exists_returns_false_if_database_does_not_exist
+    config = ActiveRecord::Base.configurations["arunit"].dup
+    config[:database] = "non_extant_database"
+
+    assert_not ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(config),
+      "expected database #{config[:database]} to not exist"
+  end
+
+  def test_database_exists_returns_true_when_the_database_exists
+    config = ActiveRecord::Base.configurations["arunit"]
+    assert ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(config),
+     "expected database #{config[:database]} to exist"
+  end
+
   def test_columns_for_distinct_zero_orders
     assert_equal "posts.id",
       @conn.columns_for_distinct("posts.id", [])

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -23,6 +23,18 @@ module ActiveRecord
         end
       end
 
+      def test_database_exists_returns_false_when_the_database_does_not_exist
+        config = { database: "non_extant_database", adapter: "postgresql" }
+        assert_not ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),
+          "expected database #{config[:database]} to not exist"
+      end
+
+      def test_database_exists_returns_true_when_the_database_exists
+        config = ActiveRecord::Base.configurations["arunit"]
+        assert ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),
+          "expected database #{config[:database]} to exist"
+      end
+
       def test_primary_key
         with_example_table do
           assert_equal "id", @connection.primary_key("ex")

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -28,6 +28,15 @@ module ActiveRecord
         end
       end
 
+      def test_database_exists_returns_false_when_the_database_does_not_exist
+        assert_not SQLite3Adapter.database_exists?(adapter: "sqlite3", database: "non_extant_db")
+      end
+
+      def test_database_exists_returns_true_when_databae_exists
+        config = ActiveRecord::Base.configurations["arunit"]
+        assert SQLite3Adapter.database_exists?(config)
+      end
+
       unless in_memory_db?
         def test_connect_with_url
           original_connection = ActiveRecord::Base.remove_connection
@@ -49,6 +58,11 @@ module ActiveRecord
         ensure
           ActiveRecord::Base.establish_connection(original_connection)
         end
+      end
+
+      def test_database_exists_returns_true_for_an_in_memory_db
+        assert SQLite3Adapter.database_exists?(database: ":memory:"),
+          "Expected in memory database to exist"
       end
 
       def test_column_types

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -46,6 +46,37 @@ module ActiveRecord
   }
 
   class DatabaseTasksUtilsTask < ActiveRecord::TestCase
+    def setup
+      @old_env = ActiveRecord::Tasks::DatabaseTasks.env
+      @old_configurations = ActiveRecord::Base.configurations
+
+      ActiveRecord::Tasks::DatabaseTasks.env = "development"
+      ActiveRecord::Base.configurations = { development: @old_configurations["arunit"] }
+    end
+
+    def teardown
+      ActiveRecord::Tasks::DatabaseTasks.env = @old_env
+      ActiveRecord::Base.configurations = @old_configurations
+    end
+
+    def test_checking_the_protected_environment_does_not_create_a_new_db_if_does_not_exist
+      configuration = { development:
+        {
+          "database" => "/db/non_existent_database.sqlite3",
+          "adapter" => "sqlite3"
+        }
+      }
+      ActiveRecord::Base.configurations = configuration
+
+      adapter = ActiveRecord::Tasks::SQLiteDatabaseTasks.new(configuration[:development])
+
+      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+      assert_not_predicate adapter, :database_exists?
+    ensure
+      ActiveRecord::Tasks::DatabaseTasks.current_config = nil
+    end
+
     def test_raises_an_error_when_called_with_protected_environment
       protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Base.connection.migration_context.current_environment

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -175,7 +175,13 @@ if current_adapter?(:PostgreSQLAdapter)
               "schema_search_path" => "public"
             ]
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+            assert_called_on_instance_of(
+              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
+              :database_exists?,
+              returns: true
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+            end
           end
         end
       end
@@ -250,7 +256,13 @@ if current_adapter?(:PostgreSQLAdapter)
               ]
             ]
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            assert_called_on_instance_of(
+              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
+              :database_exists?,
+              returns: true
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            end
           end
         end
       end
@@ -295,7 +307,13 @@ if current_adapter?(:PostgreSQLAdapter)
               ]
             ]
           ) do
-            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            assert_called_on_instance_of(
+              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
+              :database_exists?,
+              returns: true
+            ) do
+              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
+            end
           end
         end
       end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -175,13 +175,7 @@ if current_adapter?(:PostgreSQLAdapter)
               "schema_search_path" => "public"
             ]
           ) do
-            assert_called_on_instance_of(
-              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
-              :database_exists?,
-              returns: true
-            ) do
-              ActiveRecord::Tasks::DatabaseTasks.drop @configuration
-            end
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration
           end
         end
       end
@@ -256,13 +250,7 @@ if current_adapter?(:PostgreSQLAdapter)
               ]
             ]
           ) do
-            assert_called_on_instance_of(
-              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
-              :database_exists?,
-              returns: true
-            ) do
-              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
-            end
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
           end
         end
       end
@@ -307,13 +295,7 @@ if current_adapter?(:PostgreSQLAdapter)
               ]
             ]
           ) do
-            assert_called_on_instance_of(
-              ActiveRecord::Tasks::PostgreSQLDatabaseTasks,
-              :database_exists?,
-              returns: true
-            ) do
-              ActiveRecord::Tasks::DatabaseTasks.purge @configuration
-            end
+            ActiveRecord::Tasks::DatabaseTasks.purge @configuration
           end
         end
       end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -23,7 +23,7 @@ if current_adapter?(:SQLite3Adapter)
 
       def test_db_checks_database_exists
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          assert_called_with(File, :exist?, [@database], returns: false) do
+          assert_called_with(File, :exist?, ["/rails/root/#{@database}"], returns: false) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
           end
         end


### PR DESCRIPTION
### Summary

Resolves issue: #32914. When dropping a DB on sqlite3 and on postgresql
if the database (say 'development' and 'test') did not exist the error messages
where inconsistent. On sqlite it would say something like:
```
$ rake db:drop
Dropped database 'db/development.sqlite3'
Database 'db/test.sqlite3' does not exist
```

This was also occuring for postgresql as well. This patch makes the
required fixes to make this experience consistent across adapdters.
After this patch dropping a non existent database should look like:

```
$ rake db:drop
Database 'db/test.sqlite3' does not exist
Database 'db/development.sqlite3' does not exist
```

Across all three: sqlite3, postgres, and mysql adapters.

The issue with `sqlite3` was that when checking if the operation was running on a protected environment we would end up making a connection and in `sqlite3` this causes the database to be created. 

The issue with postgres is that we were rescuing the `ActiveRecord::NoDatabaseError` which causes the incorrect error message to be displayed. 

We fix that by adding a new `db_exists?` method that checks wether a database exists, without making the connection. If the database does not exist we also don't need to do the check protected environment method and we can skip it that check as well. 

### Other Information

There are a couple of things I don't like about this PR. It introduces a bit of complexity and the issue isn't particularly severe, yes the experience is inconsistent but only in the aspect of the messaging the behaviour is still ultimately a correct no-op. 

There are some easter goodies (🐰 🥚 ) that can be extracted out into separate PRs. 
