### PR TITLE
Enforce test coverage for selected files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,3 +162,4 @@ end
 gem "ibm_db" if ENV["IBM_DB"]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
+gem 'single_cov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,6 +463,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.4)
       tilt (~> 2.0)
+    single_cov (1.3.0)
     sneakers (2.11.0)
       bunny (~> 2.12)
       concurrent-ruby (~> 1.0)
@@ -589,6 +590,7 @@ DEPENDENCIES
   selenium-webdriver (>= 3.5.0, < 3.13.0)
   sequel
   sidekiq
+  single_cov
   sneakers
   sprockets-export
   sqlite3 (~> 1.4)

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -2,6 +2,9 @@
 
 ORIG_ARGV = ARGV.dup
 
+require 'single_cov'
+SingleCov.setup :minitest, root: File.dirname(__dir__)
+
 require "active_support/core_ext/kernel/reporting"
 
 silence_warnings do

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -4,6 +4,8 @@ require "abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"
 
+SingleCov.covered! file: 'lib/active_support/cache/memory_store.rb'
+
 class MemoryStoreTest < ActiveSupport::TestCase
   def setup
     @cache = ActiveSupport::Cache.lookup_store(:memory_store, expires_in: 60)


### PR DESCRIPTION
### Summary

Makes selected tests fail when they have missing coverage

### Other Information

Can be added as needed and gives quick developer feedback ... could start with security critical code or whatever contributors feel like adding

Currently fails because I did not add coverage, but can add if this is an acceptable dependency/approach.

```
lib/active_support/cache/memory_store.rb new uncovered lines introduced (9 current vs 0 configured)
Lines missing coverage:
lib/active_support/cache/memory_store.rb:35
lib/active_support/cache/memory_store.rb:40
lib/active_support/cache/memory_store.rb:41
lib/active_support/cache/memory_store.rb:42
lib/active_support/cache/memory_store.rb:43
lib/active_support/cache/memory_store.rb:54:13-54:39
lib/active_support/cache/memory_store.rb:62:9-62:15
lib/active_support/cache/memory_store.rb:107
lib/active_support/cache/memory_store.rb:157:13-157:60
```

this would call out missing coverage for things like:

```
  # Delete all data stored in a given cache store.
  def clear(options = nil)
    synchronize do
      @data.clear
      @key_access.clear
      @cache_size = 0
    end
  end

 def inspect # :nodoc:
    "<##{self.class.name} entries=#{@data.size}, size=#{@cache_size}, options=#{@options.inspect}>"
  end

  # lib/active_support/cache/memory_store.rb:54:13-54:39
  delete_entry(key, options) if entry && entry.expired?

  # lib/active_support/cache/memory_store.rb:157:13-157:60
  @cache_size -= cached_size(key, entry) if entry

  # lib/active_support/cache/memory_store.rb:62:9-62:15
  def prune(target_size, max_time = nil)
    return if pruning?
```