### PR TITLE
Add test case to guard the query count for relation cache (for #35982)

### DIFF
--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -17,9 +17,24 @@ class RelationCacheTest < ActionView::TestCase
   end
 
   def test_cache_relation_other
-    cache(Project.all) { concat("Hello World") }
+    assert_queries(1) do
+      cache(Project.all) { concat("Hello World") }
+    end
     assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")
   end
 
   def view_cache_dependencies; []; end
+
+  def assert_queries(num)
+    ActiveRecord::Base.connection.materialize_transactions
+    count = 0
+
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      count += 1 unless ["SCHEMA", "TRANSACTION"].include? payload[:name]
+    end
+
+    result = yield
+    assert_equal num, count, "#{count} instead of #{num} queries were executed."
+    result
+  end
 end


### PR DESCRIPTION
### Summary

This is related to https://github.com/rails/rails/issues/35982. Although the issue has been fixed, but as @kaspth stated in this comment https://github.com/rails/rails/issues/35982#issuecomment-484181074, we should have a test case that guards cache method's query count.

Bellow is the test result on `5-2-stable`, which the issue can be reproduced

```
F

Failure:
RelationCacheTest#test_cache_relation_other [/Users/st0012/projects/rails/actionview/test/activerecord/relation_cache_test.rb:20]:
2 instead of 1 queries were executed..
Expected: 1
  Actual: 2
```