### PR TITLE
Include Caching module for ActionController::API

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -117,6 +117,7 @@ module ActionController
       ApiRendering,
       Renderers::All,
       ConditionalGet,
+      Caching,
       BasicImplicitRender,
       StrongParameters,
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2216,6 +2216,19 @@ module ApplicationTests
       assert_equal :default, Rails.configuration.debug_exception_response_format
     end
 
+    test "action_controller.cache_store works for api_only app as well" do
+      add_to_config <<-RUBY
+        config.api_only = true
+        config.action_controller.cache_store = :memory_store
+      RUBY
+
+      app "development"
+
+      api_controller = Class.new(ActionController::API)
+
+      assert_equal(api_controller.cache_store.class, ActiveSupport::Cache::MemoryStore)
+    end
+
     test "controller force_ssl declaration can be used even if session_store is disabled" do
       make_basic_app do |application|
         application.config.session_store :disabled


### PR DESCRIPTION
As described in #35602, currently `ActionController::API` doesn't include `Caching` module, so it can't perform caching. And even if users include it later manually, it won't inherit application's default cache store for `config.action_controller`.
So the only way to solve this issue is to include Caching module in `ActionController::API` too.

This closes #35602
