### PR TITLE
Handle up/down for multiple databases

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -155,6 +155,20 @@ module ActiveRecord
         end
       end
 
+      def raise_for_multi_db(environment = env, command:)
+        db_configs = ActiveRecord::Base.configurations.configs_for(env_name: environment)
+
+        if db_configs.count > 1
+          dbs_list = []
+
+          db_configs.each do |db|
+            dbs_list << "#{command}:#{db.spec_name}"
+          end
+
+          raise "You're using a multiple database application. To use `#{command}` you must run the namespaced task with a VERSION. Available tasks are #{dbs_list.to_sentence}."
+        end
+      end
+
       def create_current(environment = env)
         each_current_configuration(environment) { |configuration|
           create configuration


### PR DESCRIPTION
This change adds the ability to run up/down for a database in a multi-db
environment.

If you have an app with a primary and animals database the following
tasks will be generated:

```
VERSION=123 rake db:migrate:up:primary
VERSION=123 rake db:migrate:up:primary

VERSION=123 rake db:migrate:down:primary
VERSION=123 rake db:migrate:up:animals
```

I didn't generate descriptions with them since we don't generate a
description for a single database application.

In addition to this change I've made it so if your application has
multiple databases Rails will raise if you try to run `up` or `down`
without a namespace. This is because we don't know which DB you want to
run `up` or `down` against unless the app tells us, so it's safer to
just block it and recommend using namespaced versions of up/down
respectively.

The output for the raise looks like:

```
You're using a multiple database application. To use `db:migrate:down`
you must run the namespaced task with a VERSION. Available tasks are
db:migrate:down:primary and db:migrate:down:animals.
```

cc/ @rafaelfranca @tenderlove @matthewd 