### PR TITLE
Change the deprecation message for dynamic routes segment to 6.1

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -591,14 +591,14 @@ module ActionDispatch
         if route.segment_keys.include?(:controller)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :controller segment in a route is deprecated and
-            will be removed in Rails 6.0.
+            will be removed in Rails 6.1.
           MSG
         end
 
         if route.segment_keys.include?(:action)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :action segment in a route is deprecated and
-            will be removed in Rails 6.0.
+            will be removed in Rails 6.1.
           MSG
         end
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -197,7 +197,7 @@ module ActiveRecord
             "Dangerous query method (method whose arguments are used as raw " \
             "SQL) called with non-attribute argument(s): " \
             "#{unexpected.map(&:inspect).join(", ")}. Non-attribute " \
-            "arguments will be disallowed in Rails 6.0. This method should " \
+            "arguments will be disallowed in Rails 6.1. This method should " \
             "not be called with user-provided values, such as request " \
             "parameters or model attributes. Known-safe values can be passed " \
             "by wrapping them in Arel.sql()."


### PR DESCRIPTION
While working on some another issue, I came across this code. Since `:action` and `:controller` was supposed to be removed in Rails `6.0` and I could not see anything related to the removal, I have updated the message to say it would be removed in `6.1`. 

Also, I am not aware of this code so removing the code for `:action` and `:controller` may take time for me. I am assuming Rails 6 would be released soon, so, for now, I have updated the version to say `6.1`

After change: 
<img width="1078" alt="rails-issue-36041" src="https://user-images.githubusercontent.com/7736232/56443015-5b115580-6310-11e9-9370-ad1fe2b0931b.png">
