### PR TITLE
Add actionable error for ActionMailbox Install step

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/base_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/base_controller.rb
@@ -6,9 +6,19 @@ module Rails
     layout "rails/conductor"
     before_action :ensure_development_env
 
+    rescue_from ActiveRecord::StatementInvalid, with: :raise_table_missing_error
+
     private
       def ensure_development_env
         head :forbidden unless Rails.env.development?
+      end
+
+      def raise_table_missing_error(exception)
+        if exception.message.match?(%r{#{ActionMailbox::InboundEmail.table_name}})
+          raise ActionMailbox::InboundEmailTableMissingError
+        else
+          raise exception
+        end
       end
   end
 end

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_mailbox/mail_ext"
+require "action_mailbox/errors"
 
 module ActionMailbox
   extend ActiveSupport::Autoload

--- a/actionmailbox/lib/action_mailbox/errors.rb
+++ b/actionmailbox/lib/action_mailbox/errors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActionMailbox
+  class Error < StandardError; end
+
+  class InboundEmailTableMissingError < Error
+    include ActiveSupport::ActionableError
+
+    action "Install Action Mailbox" do
+      Rails::Command.invoke "action_mailbox:install"
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -13,9 +13,6 @@
     <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
       <br />To resolve this issue run: rails active_storage:install
     <% end %>
-    <% if defined?(ActionMailbox) && @exception.message.match?(%r{#{ActionMailbox::InboundEmail.table_name}}) %>
-      <br />To resolve this issue run: rails action_mailbox:install
-    <% end %>
   </h2>
 
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
@@ -6,8 +6,6 @@
 <%= @exception.message %>
 <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
 To resolve this issue run: rails active_storage:install
-<% if defined?(ActionMailbox) && @exception.message.match?(%r{#{ActionMailbox::InboundEmail.table_name}}) %>
-To resolve this issue run: rails action_mailbox:install
 <% end %>
 
 <%= render template: "rescues/_source" %>


### PR DESCRIPTION
### Summary

- Earlier we used to show a message to tell user to manually install
  action_mailbox if the related table does not exist. Now we can use
  actionable errors to provide a button to do the same.


//cc @kaspth @gsamokovarov 