### PR TITLE
ActiveStorage - normalize the hash of transformations

### DIFF
--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -40,7 +40,7 @@ class ActiveStorage::Variation
   end
 
   def initialize(transformations)
-    @transformations = transformations
+    @transformations = transformations.deep_symbolize_keys
   end
 
   # Accepts a File object, performs the +transformations+ against it, and

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -4,6 +4,14 @@ require "test_helper"
 require "database/setup"
 
 class ActiveStorage::VariantTest < ActiveSupport::TestCase
+  test "variations have the same key for different types of the same transformation" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant_a = blob.variant(resize: "100x100")
+    variant_b = blob.variant("resize" => "100x100")
+
+    assert_equal variant_a.key, variant_b.key
+  end
+
   test "resized variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(resize: "100x100").processed


### PR DESCRIPTION
### Summary

For the same variation `variant(resize: '200x200')` and `variant('resize' => '200x200')` have different encoded keys. That results in duplicated files. This patch makes them the same.

If I put the transformations as an argument for background job, symbol keys of the argument will be parsed as string keys. This is another potential issue can be solved.