### PR TITLE
ActionCable: don't allowlist keys passed to the Redis initializer

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -14,7 +14,7 @@ module ActionCable
       # This is needed, for example, when using Makara proxies for distributed Redis.
       cattr_accessor :redis_connector, default: ->(config) do
         config[:id] ||= "ActionCable-PID-#{$$}"
-        ::Redis.new(config.slice(:url, :host, :port, :db, :password, :id))
+        ::Redis.new(config.except(:adapter, :channel_prefix))
       end
 
       def initialize(*)

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -5,6 +5,8 @@ require "thread"
 gem "redis", ">= 3", "< 5"
 require "redis"
 
+require "active_support/core_ext/hash/except"
+
 module ActionCable
   module SubscriptionAdapter
     class Redis < Base # :nodoc:

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -34,11 +34,11 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
 end
 
 class RedisAdapterTest::Connector < ActionCable::TestCase
-  test "slices url, host, port, db, password and id from config" do
+  test "excludes adapter and channel prefix" do
     config = { url: 1, host: 2, port: 3, db: 4, password: 5, id: "Some custom ID" }
 
     assert_called_with ::Redis, :new, [ config ] do
-      connect config.merge(other: "unrelated", stuff: "here")
+      connect config.merge(adapter: "redis", channel_prefix: "custom")
     end
   end
 


### PR DESCRIPTION
### Summary

Rather than allowlisting keys that are able to be passed to the Redis adapter initalizer, pass all keys except for the ones that we explicitly know do not need to be passed to Redis. This prevents having to monitor for config changes to the `redis-rb` gem and having to update this line of code to match them, while also adding Redis Sentinel support to ActionCable (<- the real reason this came about).

cc @georgeclaghorn 