### PR TITLE
Revert "Include Caching module for ActionController::API"

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -117,7 +117,6 @@ module ActionController
       ApiRendering,
       Renderers::All,
       ConditionalGet,
-      Caching,
       BasicImplicitRender,
       StrongParameters,
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2216,19 +2216,6 @@ module ApplicationTests
       assert_equal :default, Rails.configuration.debug_exception_response_format
     end
 
-    test "action_controller.cache_store works for api_only app as well" do
-      add_to_config <<-RUBY
-        config.api_only = true
-        config.action_controller.cache_store = :memory_store
-      RUBY
-
-      app "development"
-
-      api_controller = Class.new(ActionController::API)
-
-      assert_equal(api_controller.cache_store.class, ActiveSupport::Cache::MemoryStore)
-    end
-
     test "controller force_ssl declaration can be used even if session_store is disabled" do
       make_basic_app do |application|
         application.config.session_store :disabled


### PR DESCRIPTION
Reverts rails/rails#36038

It is missing the documentation changes and we should not change the default since `Caching` is about view cache and no all API controllers need that.