### PR TITLE
Add attribute_names to ActiveModel::Attributes

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -26,6 +26,21 @@ module ActiveModel
         define_attribute_method(name)
       end
 
+      # Returns an array of attribute names as strings
+      #
+      #   class Person
+      #     include ActiveModel::Attributes
+      #
+      #     attribute :name, :string
+      #     attribute :age, :integer
+      #   end
+      #
+      #   Person.attribute_names
+      #   # => ["name", "age"]
+      def attribute_names
+        attribute_types.keys
+      end
+
       private
 
         def define_method_attribute=(name)
@@ -65,8 +80,37 @@ module ActiveModel
       super
     end
 
+    # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
+    #
+    #   class Person
+    #     include ActiveModel::Model
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #   person = Person.new(name: 'Francesco', age: 22)
+    #   person.attributes
+    #   # => {"name"=>"Francesco", "age"=>22}
     def attributes
       @attributes.to_hash
+    end
+
+    # Returns an array of attribute names as strings
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #   person = Person.new
+    #   person.attribute_names
+    #   # => ["name", "age"]
+    def attribute_names
+      @attributes.keys
     end
 
     private

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -67,6 +67,20 @@ module ActiveModel
       assert_equal expected_attributes, data.attributes
     end
 
+    test "reading attribute names" do
+      names = [
+        "integer_field",
+        "string_field",
+        "decimal_field",
+        "string_with_default",
+        "date_field",
+        "boolean_field"
+      ]
+
+      assert_equal names, ModelForAttributesTest.attribute_names
+      assert_equal names, ModelForAttributesTest.new.attribute_names
+    end
+
     test "nonexistent attribute" do
       assert_raise ActiveModel::UnknownAttributeError do
         ModelForAttributesTest.new(nonexistent: "nonexistent")


### PR DESCRIPTION
**No rush on reviewing this PR. This can definitely wait until after the next release**

This adds `.attribute_names` and `#attribute_names` to `ActiveModel::Attributes` along the same lines as the corresponding methods in `ActiveRecord::AttributeMethods` (see [`.attribute_names`][class_method] and [`#attribute_names`][instance_method]).

While I was here I also added documentation for `#attributes`, which I added in 043ce35b186. The whole module is still `#:nodoc:` so I don't think this will have any effect for now.

[class_method]: https://github.com/rails/rails/blob/cc834db1d0815744cfa173813c05d928e008e167/activerecord/lib/active_record/attribute_methods.rb#L154-L160
[instance_method]: https://github.com/rails/rails/blob/cc834db1d0815744cfa173813c05d928e008e167/activerecord/lib/active_record/attribute_methods.rb#L299-L301

I do have questions about future plans for `ActiveModel::Attributes`. Is there something in particular that is holding us back documenting this publicly  (https://github.com/rails/rails/commit/7e9ded512dd58a923a3be038843708dbba4215f6 mentions that it was not ready yet, but I don't know exactly what is missing)? I have used it successfully on a few projects, not quite realizing is wasn't documented. If there are specific things that we need to work on I would be happy to take that on.