### PR TITLE
Add ActionController::Caching into api app's document [ci skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -420,6 +420,15 @@ Some common modules you might want to add:
 - `ActionController::MimeResponds`: Support for `respond_to`.
 - `ActionController::Cookies`: Support for `cookies`, which includes
   support for signed and encrypted cookies. This requires the cookies middleware.
+- `ActionController::Caching`: Support view caching for the API controller. Please notice that
+  you will need to manually specify cache store inside the controller like:
+  ```ruby
+  class ApplicationController < ActionController::API
+    include ::ActionController::Caching
+    self.cache_store = :mem_cached_store
+  end
+  ```
+  Rails does *not* pass this configuration automatically.
 
 The best place to add a module is in your `ApplicationController`, but you can
 also add modules to individual controllers.


### PR DESCRIPTION
Rails doesn't support view caching in api controllers by default but the document didn't clearerly declare this nor the manual config needed after including the module manually. So we'll see people get confused like #35602.
This update is suggested in #36038 