### PR TITLE
Update comment in attribute_method_matchers_matching

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -352,8 +352,9 @@ module ActiveModel
 
         def attribute_method_matchers_matching(method_name)
           attribute_method_matchers_cache.compute_if_absent(method_name) do
-            # Must try to match prefixes/suffixes first, or else the matcher with no prefix/suffix
-            # will match every time.
+            # Bump plain matcher to last place so that only methods that do not
+            # match any other pattern match the actual attribute name.
+            # This is currently only needed to support legacy usage.
             matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
             matchers.map { |matcher| matcher.match(method_name) }.compact
           end


### PR DESCRIPTION
The current comment here is from 2011 and its original context (8b8b714) has changed completely. The plain matcher will not "match every time" anymore since the code now filters all matchers, and only selects those for which the captured attribute is valid.

There is a debate about whether we should remove the code below the comment in #36005.

In the meantime, the comment is very misleading and will lead to confusion, so I'd like to update it.