### PR TITLE
Remove reminiscences from previous documentation

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -495,11 +495,3 @@ end
 >> @user.save
 => User was saved to database
 ```
-
-To register callbacks for both create and destroy actions, use `after_commit` instead.
-
-```ruby
-class User < ApplicationRecord
-  after_commit :log_user_saved_to_db, on: [:create, :destroy]
-end
-```


### PR DESCRIPTION
### Summary
In #35861 documentation for `after_save_commit` was added, but also old documentation was adapted. I think adapting the old documentation is not necessary because there are already examples for `after_commit` on `:destroy` above. On top of that the action invoked by the callback on `:destroy` (`:log_user_saved_to_db`) talks about saving when the object is destroyed, which can be misleading.

As I believe the documentation added by #35861 is already enough, this patch removes the modified part, which made sense before adding docs for `after_save_commit` but is now already covered by other parts of this guide.