### PR TITLE
Add PR link for Active Storage updating release note entry [ci skip]

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -454,6 +454,7 @@ Please refer to the [Changelog][active-storage] for detailed changes.
 ### Notable changes
 
 *   Updating an attached model via `update` or `update!` ala `@user.update!(images: [ … ])` now replaces the existing images instead of merely adding to them.
+    ([Pull Request](https://github.com/rails/rails/pull/33303))
 
 Active Model
 ------------


### PR DESCRIPTION
Adds the link of the pull-request which introduced the change in the release notes. 

Refer: https://github.com/rails/rails/commit/45a6cf3e038614cd415cbd1f09d5647c739aac23#r33273796

