### PR TITLE
Remove action_controller.perform_caching from api app's configs

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -15,9 +15,11 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
+    <%- unless options.api? -%>
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
+    <%- end -%>
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -12,7 +12,9 @@ Rails.application.configure do
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
+  <%- unless options.api? -%>
   config.action_controller.perform_caching = true
+  <%- end -%>
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -50,6 +50,13 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/application.rb", /config\.api_only = true/
     assert_file "app/controllers/application_controller.rb", /ActionController::API/
+
+    assert_file "config/environments/development.rb" do |content|
+      assert_no_match(/action_controller\.perform_caching = true/, content)
+    end
+    assert_file "config/environments/production.rb" do |content|
+      assert_no_match(/action_controller\.perform_caching = true/, content)
+    end
   end
 
   def test_generator_if_skip_action_cable_is_given


### PR DESCRIPTION
As suggested in https://github.com/rails/rails/issues/35602#issuecomment-485833483, because we don't provide view caching and doesn't include `ActionController::Caching` for api apps, we should also avoid generating

```ruby
config.action_controller.perform_caching = true
```

for those api apps. So it won't confuse people.

**But because `perform_caching` will be `true` if not set, the behavior of the app would still be the same without these configs.**