### PR TITLE
Remove redundant test setups in log_subscriber_test

### DIFF
--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -98,6 +98,7 @@ class ACLogSubscriberTest < ActionController::TestCase
 
     @cache_path = Dir.mktmpdir(%w[tmp cache])
     @controller.cache_store = :file_store, @cache_path
+    @controller.config.perform_caching = true
     ActionController::LogSubscriber.attach_to :action_controller
   end
 
@@ -249,19 +250,15 @@ class ACLogSubscriberTest < ActionController::TestCase
   end
 
   def test_with_fragment_cache
-    @controller.config.perform_caching = true
     get :with_fragment_cache
     wait
 
     assert_equal 4, logs.size
     assert_match(/Read fragment views\/foo/, logs[1])
     assert_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_with_fragment_cache_when_log_disabled
-    @controller.config.perform_caching = true
     ActionController::Base.enable_fragment_cache_logging = false
     get :with_fragment_cache
     wait
@@ -269,69 +266,52 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal 2, logs.size
     assert_equal "Processing by Another::LogSubscribersController#with_fragment_cache as HTML", logs[0]
     assert_match(/Completed 200 OK in \d+ms/, logs[1])
-  ensure
-    @controller.config.perform_caching = true
     ActionController::Base.enable_fragment_cache_logging = true
   end
 
   def test_with_fragment_cache_if_with_true
-    @controller.config.perform_caching = true
     get :with_fragment_cache_if_with_true_condition
     wait
 
     assert_equal 4, logs.size
     assert_match(/Read fragment views\/foo/, logs[1])
     assert_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_with_fragment_cache_if_with_false
-    @controller.config.perform_caching = true
     get :with_fragment_cache_if_with_false_condition
     wait
 
     assert_equal 2, logs.size
     assert_no_match(/Read fragment views\/foo/, logs[1])
     assert_no_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_with_fragment_cache_unless_with_true
-    @controller.config.perform_caching = true
     get :with_fragment_cache_unless_with_true_condition
     wait
 
     assert_equal 2, logs.size
     assert_no_match(/Read fragment views\/foo/, logs[1])
     assert_no_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_with_fragment_cache_unless_with_false
-    @controller.config.perform_caching = true
     get :with_fragment_cache_unless_with_false_condition
     wait
 
     assert_equal 4, logs.size
     assert_match(/Read fragment views\/foo/, logs[1])
     assert_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_with_fragment_cache_and_percent_in_key
-    @controller.config.perform_caching = true
     get :with_fragment_cache_and_percent_in_key
     wait
 
     assert_equal 4, logs.size
     assert_match(/Read fragment views\/foo/, logs[1])
     assert_match(/Write fragment views\/foo/, logs[2])
-  ensure
-    @controller.config.perform_caching = true
   end
 
   def test_process_action_with_exception_includes_http_status_code


### PR DESCRIPTION
Because controller's `perform_caching` config is `true` by default, it means we actually enable the caching in all those tests implicitly (and it works). Which also means we can avoid repeatedly declaring that and just specify it once in the setup method (just for declaration).