### PR TITLE
Minor API doc fix

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1002,7 +1002,7 @@ module ActiveRecord
       end
 
       # Adds one or more +records+ to the collection by setting their foreign keys
-      # to the association's primary key. Since +<<+ flattens its argument list and
+      # to the association's primary key. Since <tt><<</tt> flattens its argument list and
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+
       # so several appends may be chained together.
       #


### PR DESCRIPTION
`<<` method in API doc is rendered as `+<<+`. I find it uneasy read this on API doc. Thank you :) 


![Screenshot 2019-04-23 at 11 41 15 PM](https://user-images.githubusercontent.com/3127583/56605317-7be3ee80-6621-11e9-85bf-7d006c9f826a.png)

