### PR TITLE
Don't fail ImageAnalyzer on unsupported types

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Don't raise when analyzing an unsupported image type by ImageMagick
+    Fixes: #36065
+
+    *Guilherme Mansur*
+
 *   Permit generating variants of BMP images.
 
     *Younes Serraj*

--- a/activestorage/lib/active_storage/analyzer/image_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer.rb
@@ -25,17 +25,24 @@ module ActiveStorage
           { width: image.width, height: image.height }
         end
       end
-    rescue LoadError
-      logger.info "Skipping image analysis because the mini_magick gem isn't installed"
-      {}
     end
 
     private
       def read_image
         download_blob_to_tempfile do |file|
           require "mini_magick"
-          yield MiniMagick::Image.new(file.path)
+          image = MiniMagick::Image.new(file.path)
+
+          if image.valid?
+            yield image
+          else
+            logger.info "Skipping image analysis because ImageMagick doesn't support the file"
+            {}
+          end
         end
+      rescue LoadError
+        logger.info "Skipping image analysis because the mini_magick gem isn't installed"
+        {}
       end
 
       def rotated_image?(image)

--- a/activestorage/test/analyzer/image_analyzer_test.rb
+++ b/activestorage/test/analyzer/image_analyzer_test.rb
@@ -29,4 +29,12 @@ class ActiveStorage::Analyzer::ImageAnalyzerTest < ActiveSupport::TestCase
     assert_equal 792, metadata[:width]
     assert_equal 584, metadata[:height]
   end
+
+  test "analyzing an unsupported image type" do
+    blob = create_blob(data: "bad", filename: "bad_file.bad", content_type: "image/bad_type")
+    metadata = extract_metadata_from(blob)
+
+    assert_nil metadata[:width]
+    assert_nil metadata[:heigh]
+  end
 end


### PR DESCRIPTION
### Summary

Fix: #36065

The ImageAnalyzer passes a image to ImageMagick without checking if the
image is supported by ImageMagick. This patch checks that image is
supported and if not logs an error and returns an empty hash instead of
raising an error. This is the same error handling we do when we
encounter a LoadError when mini_magick is not installed.

### Other Information

This is a breaking change I was hoping to get a quick feedback on the idea and see if this is an approach worth persuing. We skip the image analysis on a `LoadError` so I thought we could skip it on an unsupported type as well.

One option is to also make this behaviour configurable. 

Another option is to raise a generic `ActiveStorage::UnsupportedImage` error so clients don't have to rescue a low level `MiniMagick::Error`. 
