### PR TITLE
document update_counters on relation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -468,7 +468,19 @@ module ActiveRecord
       end
     end
 
-    def update_counters(counters) # :nodoc:
+    # Updates the counters of the records in the current relation.
+    #
+    # === Parameters
+    #
+    # * +counter+ - A Hash containing the names of the fields to update as keys and the amount to update as values.
+    # * <tt>:touch</tt> option - Touch the timestamp columns when updating.
+    # * If attributes names are passed, they are updated along with update_at/on attributes.
+    #
+    # === Examples
+    #
+    #  # For Posts by a given author increment the comment_count by 1.
+    #  Post.where(author_id: author.id).update_counters(comment_count: 1)
+    def update_counters(counters)
       touch = counters.delete(:touch)
 
       updates = {}


### PR DESCRIPTION
### Summary

This is related to: https://github.com/rails/rails/issues/36055 where someone would have benefitted from this method. 

Since this commit by @kamipo the `update_counters` is defined on the `ActiveRecord::Relation`: https://github.com/rails/rails/commit/975fa15b47e4ef47a3b46f0e946860a076167149

It seems that this is a useful feature outside of the internals as well, so having it documented in our public api seems like a good idea to me. 

### Other Information

Does the new `update_counters` on the relation have to be added to the `CHANGELOG`? 
