### PR TITLE
Avoid NoMethodError in actionview cache_expiry

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -20,7 +20,7 @@ module ActionView
 
     def clear_cache_if_necessary
       watched_dirs = dirs_to_watch
-      if watched_dirs != @watched_dirs
+      if @watcher.nil? || watched_dirs != @watched_dirs
         @watched_dirs = watched_dirs
         @watcher = @watcher_class.new([], watched_dirs) do
           clear_cache


### PR DESCRIPTION
Fixes #36093

When triggering two parallel requests it is possible for the second
request to call `@watcher.execute_if_updated` before `@watcher` has
been set. This change ensures that if `@watcher` has not been set we
take the code path that sets it.

This solution does mean that we may set `@watcher` in the first request
and then set it again in the second request. We may also call
`execute` an extra time. I think this may be OK since it
would only affect the first couple of requests in development.