### PR TITLE
[CI skip] Update how to apply override pattern

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1124,6 +1124,8 @@ module Blorgh
   class Engine < ::Rails::Engine
     isolate_namespace Blorgh
 
+    Rails.autoloaders.main.ignore("#{Rails.root}/app/overrides")
+    
     config.to_prepare do
       Dir.glob(Rails.root + "app/overrides/**/*_override*.rb").each do |c|
         require_dependency(c)


### PR DESCRIPTION
### Summary

See #36100, Rails 6.0.0.rc1 breaks override pattern, this PR update the code that made it works again as @fxn suggests.

### Other Information

Personally, I would prefer let users adding the override pattern explicitly in their App if needed, not on the engine side. what core team say?