### PR TITLE
Frozen truncate

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   `truncate` would return the original string if it was too short to be truncated
+    and a frozen string if it were long enough to be truncated. Now truncate will
+    consistently return an unfrozen string regardless. This behavior is consistent
+    with `gsub` and `strip`.
 
+    Before:
+
+      'foobar'.truncate(5).frozen?
+      => true
+      'foobar'.truncate(6).frozen?
+      => false
+
+    After:
+
+      'foobar'.truncate(5).frozen?
+      => false
+      'foobar'.truncate(6).frozen?
+      => false
+
+    *Jordan Thomas*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -75,7 +75,7 @@ class String
         length_with_room_for_omission
       end
 
-    "#{self[0, stop]}#{omission}"
+    +"#{self[0, stop]}#{omission}"
   end
 
   # Truncates +text+ to at most <tt>bytesize</tt> bytes in length without

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -291,6 +291,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: /\s/)
   end
 
+  def test_truncate_returns_frozen_string
+    assert_not "Hello World!".truncate(12).frozen?
+    assert_not "Hello World!!".truncate(12).frozen?
+  end
+
   def test_truncate_bytes
     assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16)
     assert_equal "👍👍👍👍", "👍👍👍👍".truncate_bytes(16, omission: nil)


### PR DESCRIPTION
### Summary

Return from truncate is inconsistent. When the string is not long enough to be truncated an unfrozen string is returned. When it is long enough to be truncated a new frozen string is returned.

Fixes https://github.com/rails/rails/issues/36106.