### PR TITLE
Fallback to spawn instead of fork in jruby

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -95,9 +95,7 @@ namespace :test do
       ])
       puts fake_command
 
-      if defined?(JRUBY_VERSION)
-        Process.wait spawn(fake_command)
-      else
+      if Process.respond_to?(:fork)
         # We could run these in parallel, but pretty much all of the
         # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
         Process.waitpid fork {
@@ -106,6 +104,8 @@ namespace :test do
 
           load file
         }
+      else
+        Process.wait spawn(fake_command)
       end
 
       unless $?.success?

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -95,14 +95,18 @@ namespace :test do
       ])
       puts fake_command
 
-      # We could run these in parallel, but pretty much all of the
-      # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
-      Process.waitpid fork {
-        ARGV.clear.concat test_options
-        Rake.application = nil
+      if defined?(JRUBY_VERSION)
+        Process.wait spawn(fake_command)
+      else
+        # We could run these in parallel, but pretty much all of the
+        # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
+        Process.waitpid fork {
+          ARGV.clear.concat test_options
+          Rake.application = nil
 
-        load file
-      }
+          load file
+        }
+      end
 
       unless $?.success?
         failing_files << file


### PR DESCRIPTION
### Summary

This commit: b342db6 introduced a `fork` fork when running the railties
tests since this is not supported in jruby we fallback to using spawn.
Fixes: https://github.com/rails/rails/issues/35900

