### PR TITLE
Add ActionController::Parameters#except!

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -630,6 +630,16 @@ module ActionController
       self
     end
 
+    # Removes the given keys from <tt>ActionController::Parameters</tt> and
+    # returns it.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
+    #   params.except!(:a, :b) # => <ActionController::Parameters {"c"=>3} permitted: false>
+    #   params                 # => <ActionController::Parameters {"c"=>3} permitted: false>
+    def except!(*keys)
+      new_instance_with_inherited_permitted_status(@parameters.except!(*keys))
+    end
+
     # Returns a new <tt>ActionController::Parameters</tt> instance that
     # filters out the given +keys+.
     #

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -117,6 +117,20 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params[:person].except(:name), :permitted?
   end
 
+  test "except! removes keys" do
+    assert_equal @params, @params.except!(:person)
+    assert_not @params.key?(:person)
+  end
+
+  test "except! retains permitted status" do
+    @params.permit!
+    assert_predicate @params.except!(:person), :permitted?
+  end
+
+  test "except! retains unpermitted status" do
+    assert_not_predicate @params.except!(:person), :permitted?
+  end
+
   test "fetch retains permitted status" do
     @params.permit!
     assert_predicate @params.fetch(:person), :permitted?


### PR DESCRIPTION
### Summary

The Hash extensions have `except` and `except!`.  `ActionController::Parameters` re-implements many of these methods but not `except!`.  Seems like an oversight.