### PR TITLE
Fix installation on guides/source/action_text_overview.md

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -46,6 +46,8 @@ happens after every keystroke, and avoids the need to use execCommand at all.
 ## Installation
 
 Run `rails action_text:install` to add the Yarn package and copy over the necessary migration.
+Also, you need to set up Active Storage for embedded images and other attachments.
+Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
 
 ## Examples
 


### PR DESCRIPTION
 [Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html#transforming-images)
gem 'image_proccessing' is required.

### Summary
I used ActionText with reference to [Action Text Overview](https://edgeguides.rubyonrails.org/action_text_overview.html).
I received the following error when I attached an image by drag and drop.

```
Started GET "/rails/active_storage/representations/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--15600b0b846815065144f9d5898134e62ac79eaf/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9VY21WemFYcGxYM1J2WDJ4cGJXbDBXd2RwQWdBRWFRSUFBdz09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--bdd56a50d888ef5d9416578248b1b579125cfce1/Screen%20Shot%202019-04-26%20at%2020.04.50.png" for ::1 at 2019-04-27 14:41:50 +0900
Processing by ActiveStorage::RepresentationsController#show as PNG
  Parameters: {"signed_blob_id"=>"eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--15600b0b846815065144f9d5898134e62ac79eaf", "variation_key"=>"eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9VY21WemFYcGxYM1J2WDJ4cGJXbDBXd2RwQWdBRWFRSUFBdz09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--bdd56a50d888ef5d9416578248b1b579125cfce1", "filename"=>"Screen Shot 2019-04-26 at 20.04.50"}
  ActiveStorage::Blob Load (0.2ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Disk Storage (0.2ms) Checked if file exists at key: variants/irz0bykwoiwpg2rq94ks6e45hjpz/a2845b7f0f3bf59332871c37aa09358e5c3516a2ad65fc279472c39200d7e664 (no)
  Disk Storage (1.4ms) Downloaded file from key: irz0bykwoiwpg2rq94ks6e45hjpz
DEPRECATION WARNING: Generating image variants will require the image_processing gem in Rails 6.1. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile. (called from transformer at /Users/misakishioi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activestorage-6.0.0.rc1/app/models/active_storage/variation.rb:64)
Completed 500 Internal Server Error in 26ms (ActiveRecord: 0.2ms | Allocations: 6044)

LoadError (cannot load such file -- mini_magick):
```
I wasn't aware that gem 'image_processing' was required until this error appeared.

---

Referring to this https://github.com/rails/rails/pull/36117#discussion_r291427669  and https://github.com/rails/rails/pull/36117#discussion_r291798436, I added the link to [Action Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html#transforming-images) in Action Text Overview.