### PR TITLE
[ci skip] Update the guide's model generator output.

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -238,14 +238,17 @@ Usage:
 
 ...
 
-Active Record options:
-      [--migration]            # Indicates when to generate migration
-                               # Default: true
+ActiveRecord options:
+      [--migration], [--no-migration]        # Indicates when to generate migration
+                                             # Default: true
 
 ...
 
 Description:
-    Create rails files for model generator.
+    Stubs out a new model. Pass the model name, either CamelCased or
+    under_scored, and an optional list of attribute pairs as arguments.
+
+...
 ```
 
 NOTE: For a list of available field types for the `type` parameter, refer to the [API documentation](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column) for the add_column method for the `SchemaStatements` module. The `index` parameter generates a corresponding index for the column.


### PR DESCRIPTION
### Summary

The model generator code sample used in the command line guides
was displaying an outdated output for the generator's usage.
This change updates the sample to mirror what's currently output
when running `$rails generate model`.