### PR TITLE
Regard operating system color scheme for rescues

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -7,6 +7,8 @@
     body {
       background-color: #FAFAFA;
       color: #333;
+      color-scheme: light dark;
+      supported-color-schemes: light dark;
       margin: 0px;
     }
 
@@ -119,6 +121,8 @@
 
     .button_to {
       display: inline-block;
+      margin-top: 0.5em;
+      margin-bottom: 0.5em;
     }
 
     .hidden {
@@ -130,6 +134,60 @@
     a.trace-frames { color: #666; }
     a:hover { color: #C52F24; }
     a.trace-frames.selected { color: #C52F24 }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #222;
+        color: #ECECEC;
+      }
+
+      .details {
+        border-color: #666;
+      }
+
+      .summary {
+        border-color: #666;
+      }
+
+      .source {
+        border-color: #555;
+        background-color: #333;
+      }
+
+      .source .data {
+        background: #444;
+      }
+
+      .source .data .line_numbers {
+        background: #333;
+        border-color: #222;
+      }
+
+      .line:hover {
+        background: #666;
+      }
+
+      .line.active {
+        background-color: #977;
+      }
+
+      input[type="submit"] {
+        color: #EEE;
+        background-color: #535353;
+        border: none;
+        border-radius: 3px;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0,0,0,0.15), 0 1px 1px rgba(0,0,0,0.15);
+        padding: 2px 7px;
+      }
+      input[type="submit"]:active {
+        background-color: #777;
+      }
+
+      a { color: #C52F24; }
+      a.trace-frames { color: #999; }
+      a:hover { color: #E9382B; }
+      a.trace-frames.selected { color: #E9382B; }
+    }
 
     <%= yield :style %>
   </style>

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -49,6 +49,17 @@
     width: 80%;
     font-size: inherit;
   }
+
+  @media (prefers-color-scheme: dark) {
+    #route_table tbody tr:nth-child(odd) {
+      background: #333;
+    }
+
+    #route_table tbody.exact_matches,
+    #route_table tbody.fuzzy_matches {
+      color: #333;
+    }
+  }
 <% end %>
 
 <table id='route_table' class='route_table'>


### PR DESCRIPTION
### Summary

Small PR that enables Rails to regard the OS setting for dark/light appearance when displaying errors.

It uses the `prefers-color-scheme` CSS media query which is [currently supported by Firefox and Safari](https://caniuse.com/#search=prefers-color-scheme) and [in development for Chrome](https://www.chromestatus.com/feature/5109758977638400).

Essentially when you crunch it deep at night and don't want to burn your retinas, thus have enabled dark mode for your OS, it changes this …

<img width="1392" alt="Screen Shot 2019-04-27 at 17 57 36" src="https://user-images.githubusercontent.com/3188392/56852030-f3fa2f00-6915-11e9-9b63-5d86f085a3c6.png">

… into this

<img width="1392" alt="Screen Shot 2019-04-27 at 17 57 09" src="https://user-images.githubusercontent.com/3188392/56852020-e3e24f80-6915-11e9-959a-d95f02d60d88.png">