### PR TITLE
Consistent double quotes in application.rb template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -1,7 +1,7 @@
-require_relative 'boot'
+require_relative "boot"
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:


### PR DESCRIPTION
This file seems to mix quote styles unnecessarily.

I made them all double quotes since that was the dominating style in this file. Do the Rails core maintainers have a preferred style – prefer double, prefer single, or anything goes? (I know every Rails dev will have a preference, but perhaps debating that here would be a distraction.)

EDIT: Rubocop in this project says double quotes: https://github.com/rails/rails/blob/master/.rubocop.yml

I haven't looked at the larger codebase, but depending on how the maintainers feel about this commit, I may be open to making a bigger PR later.

I saw #35061 which was closed due to being cosmetic changes that Rubycop can take care of on the next edit, but arguably template files are different – they're generated into user projects. I opened this PR because I went to edit a file in my project and the inconsistency bothered me a little.