### PR TITLE
Fix Counter Cache Bug

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -259,17 +259,13 @@ module ActiveRecord
       #   * Thus, in memory, there are MULTIPLE inverses which update the counter cache.
       #
       # If the inverse is among the possible relationships with the column, it should be used. Otherwise, use the first.
-      def counter_cache_inverse_relations
-        @counter_cache_inverse_relations ||= klass.reflect_on_all_associations(:belongs_to).select do |inverse|
-          inverse.counter_cache_column == counter_cache_column
-        end
-      end
-
       def inverse_which_updates_counter_cache
-        @inverse_which_updates_counter_cache ||= if inverse_of && counter_cache_inverse_relations.include?(inverse_of)
+        @inverse_which_updates_counter_cache ||= if inverse_of.try(:counter_cache_column) == counter_cache_column
           inverse_of
         else
-          counter_cache_inverse_relations.first
+          klass.reflect_on_all_associations(:belongs_to).find do |inverse|
+            inverse.counter_cache_column == counter_cache_column
+          end
         end
       end
       alias inverse_updates_counter_cache? inverse_which_updates_counter_cache

--- a/activerecord/test/models/hangar.rb
+++ b/activerecord/test/models/hangar.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Hangar < ActiveRecord::Base
+  belongs_to :pilot
+
+  has_many :starfighters
+end

--- a/activerecord/test/models/pilot.rb
+++ b/activerecord/test/models/pilot.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Pilot < ActiveRecord::Base
+  has_one :hangar
+
+  has_many :starfighters
+end

--- a/activerecord/test/models/starfighter.rb
+++ b/activerecord/test/models/starfighter.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Starfighter < ActiveRecord::Base
+  belongs_to :pilot, counter_cache: true, touch: true
+  belongs_to :hangar, counter_cache: true, touch: true, optional: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -642,10 +642,6 @@ ActiveRecord::Schema.define do
       end
     end
 
-    create_table :pilots, force: true do |t|
-      t.integer :starfighters_count
-    end
-
     create_table :pirates, force: :cascade do |t|
       t.string :catchphrase
       t.integer :parrot_id
@@ -714,6 +710,10 @@ ActiveRecord::Schema.define do
     t.column :treasure_id, :integer
     t.column :pet_id, :integer
     t.column :rainbow_color, :string
+  end
+
+  create_table :pilots, force: true do |t|
+    t.integer :starfighters_count
   end
 
   create_table :posts, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -387,6 +387,11 @@ ActiveRecord::Schema.define do
     t.string :info
   end
 
+  create_table :hangars, force: true do |t|
+    t.references :pilot
+    t.integer :starfighters_count
+  end
+
   create_table :having, force: true do |t|
     t.string :where
   end
@@ -637,6 +642,10 @@ ActiveRecord::Schema.define do
       end
     end
 
+    create_table :pilots, force: true do |t|
+      t.integer :starfighters_count
+    end
+
     create_table :pirates, force: :cascade do |t|
       t.string :catchphrase
       t.integer :parrot_id
@@ -865,6 +874,11 @@ ActiveRecord::Schema.define do
     t.integer :club_id
     t.references :sponsorable, polymorphic: true, index: false
     t.references :sponsor, polymorphic: true, index: false
+  end
+
+  create_table :starfighters, force: true do |t|
+    t.references :pilot
+    t.references :hangar
   end
 
   create_table :string_key_objects, id: false, force: true do |t|


### PR DESCRIPTION
This fixes #36108

### Summary

In Rails 6 the defect described in #36108 exists but in a different form. In Rails 5 version (which has a fix PR here as #36110), the issue appeared to be a semaphore unset too early. 

Now however, the problem appears to originate from `ActiveRecord::Reflection`:

```ruby
luke = Pilot.create!
xwing = luke.starfighters.create!

lando = Pilot.create!
landos_hangar = lando.build_hangar
landos_hangar.save!

landos_hangar.starfighters << xwing
```

In this case, `xwing` has two `belongs_to` relationships, and therefore two corresponding `has_many` reflections. 

One of the reflections thinks it's inverse `belongs_to` is the object responsible for updating the cache.
The other reflections thinks it's inverse does not, and so it's `has_many` causes the double increment.

The fix here selects *all* inverse relations which have the potential to manage the counter cache, then give preference to it's own `inverse_of` assignment if present. Otherwise it defers to a modified form of the original implementation (`.first { cond }` has become `.select { cond }.first`).

### Other Information

This defect appears to be isolated only to an in-memory defect. Clearing or loading directly from the database works properly.