### PR TITLE
Improve error message of ActiveSupport delegate

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -170,7 +170,7 @@ class Module
   # The target method must be public, otherwise it will raise +NoMethodError+.
   def delegate(*methods, to: nil, prefix: nil, allow_nil: nil, private: nil)
     unless to
-      raise ArgumentError, "Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter)."
+      raise ArgumentError, "Delegation needs a target. Supply a keyword argument 'to' (e.g. delegate :hello, to: :greeter)."
     end
 
     if prefix == true && /^[^a-z_]/.match?(to)


### PR DESCRIPTION
### Summary

ActiveSupport `delegate` has `to` option, but it's not an option hash anymore and now it's a keyword argument.
When `to` argument is not given, it raises an ArgumentError but the message suggests supplying "options hash", which is now wrong.
Now it's fixed to provide correct suggestion to supply a keyword argument.
