### PR TITLE
Namespace association extension modules under the owner model

### DIFF
--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -22,9 +22,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.define_extensions(model, name, &block)
       if block_given?
-        extension_module_name = "#{model.name.demodulize}#{name.to_s.camelize}AssociationExtension"
+        extension_module_name = "#{name.to_s.camelize}AssociationExtension"
         extension = Module.new(&block)
-        model.module_parent.const_set(extension_module_name, extension)
+        model.const_set(extension_module_name, extension)
       end
     end
 

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -70,8 +70,8 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
     extend!(Developer)
     extend!(MyApplication::Business::Developer)
 
-    assert Object.const_get "DeveloperAssociationNameAssociationExtension"
-    assert MyApplication::Business.const_get "DeveloperAssociationNameAssociationExtension"
+    assert Developer.const_get "AssociationNameAssociationExtension"
+    assert MyApplication::Business::Developer.const_get "AssociationNameAssociationExtension"
   end
 
   def test_proxy_association_after_scoped

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -2,13 +2,13 @@
 
 require "ostruct"
 
-module DeveloperProjectsAssociationExtension2
-  def find_least_recent
-    order("id ASC").first
-  end
-end
-
 class Developer < ActiveRecord::Base
+  module ProjectsAssociationExtension2
+    def find_least_recent
+      order("id ASC").first
+    end
+  end
+
   self.ignored_columns = %w(first_name last_name)
 
   has_and_belongs_to_many :projects do
@@ -24,19 +24,19 @@ class Developer < ActiveRecord::Base
   has_and_belongs_to_many :shared_computers, class_name: "Computer"
 
   has_and_belongs_to_many :projects_extended_by_name,
-      -> { extending(DeveloperProjectsAssociationExtension) },
+      -> { extending(ProjectsAssociationExtension) },
       class_name: "Project",
       join_table: "developers_projects",
       association_foreign_key: "project_id"
 
   has_and_belongs_to_many :projects_extended_by_name_twice,
-      -> { extending(DeveloperProjectsAssociationExtension, DeveloperProjectsAssociationExtension2) },
+      -> { extending(ProjectsAssociationExtension, ProjectsAssociationExtension2) },
       class_name: "Project",
       join_table: "developers_projects",
       association_foreign_key: "project_id"
 
   has_and_belongs_to_many :projects_extended_by_name_and_block,
-      -> { extending(DeveloperProjectsAssociationExtension) },
+      -> { extending(ProjectsAssociationExtension) },
       class_name: "Project",
       join_table: "developers_projects",
       association_foreign_key: "project_id" do


### PR DESCRIPTION
Some minor bug I noticed while ironing Zeitwerk out in autoloaded environment:

```ruby
~gems/rails-d1107f4d1e25/activerecord/lib/active_record/associations/builder/collection_association.rb:27: warning: already initialized constant PostCommentsAssociationExtension
~gems/rails-d1107f4d1e25/activerecord/lib/active_record/associations/builder/collection_association.rb:27: warning: previous definition of PostCommentsAssociationExtension was here
```

What is happening is that previously `ActiveSupport::Dependencies` was watching which constants were defined by the loaded files, and would remove them before reloading the file.

However Zeitwerk won't do that, which cause this warning.

I did some spelunking as to understand why that module would be defined on the parent module, but I got quite far (11 years ago!!) without any proper answer: https://github.com/rails/rails/commit/de96a8666d8edc9be57f6146e587a71d23dbeb41

I don't see any argument for defining the module on the parent, whereas defining it on the association owner has several advantages:

  - First it plays well with Zeitwerk
  - Second if you reference `PostCommentsAssociationExtension` before `Post` was referenced you'll end up with a `LoadError`, whereas `Post::CommentsAssociationExtension`, it will autoload properly.

Since there was tests about that behavior, I decided to add a deprecation.

@fxn because Zeitwerk

cc @rafaelfranca @Edouard-chin 