### PR TITLE
Change default message for the double render error

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -7,7 +7,7 @@ require "set"
 
 module AbstractController
   class DoubleRenderError < Error
-    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"redirect_to(...) and return\"."
+    DEFAULT_MESSAGE = "Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like \"return redirect_to(...)\"."
 
     def initialize(message = nil)
       super(message || DEFAULT_MESSAGE)


### PR DESCRIPTION
Change default message for the double render error to account for rails code conventions

Previously the message said `redirect_to(...) and return` which conflicts with: https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
Instead, just prompt to return the redirect_to normally.