### PR TITLE
Make scope arity check consistent

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -477,7 +477,7 @@ module ActiveRecord
       def check_preloadable!
         return unless scope
 
-        if scope.arity > 0
+        unless scope.arity == 0
           raise ArgumentError, <<-MSG.squish
             The association scope '#{name}' is instance dependent (the scope
             block takes an argument). Preloading instance dependent scopes is

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1516,6 +1516,24 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_match message, error.message
   end
 
+  test "preloading and eager loading of optional instance dependent associations is not supported" do
+    message = "association scope 'posts_mentioning_author' is"
+    error = assert_raises(ArgumentError) do
+      Author.includes(:posts_mentioning_author).to_a
+    end
+    assert_match message, error.message
+
+    error = assert_raises(ArgumentError) do
+      Author.preload(:posts_mentioning_author).to_a
+    end
+    assert_match message, error.message
+
+    error = assert_raises(ArgumentError) do
+      Author.eager_load(:posts_mentioning_author).to_a
+    end
+    assert_match message, error.message
+  end
+
   test "preload with invalid argument" do
     exception = assert_raises(ArgumentError) do
       Author.preload(10).to_a

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -153,6 +153,7 @@ class Author < ActiveRecord::Base
   has_many :comments_on_posts_with_default_include, through: :posts_with_default_include, source: :comments
 
   has_many :posts_with_signature, ->(record) { where("posts.title LIKE ?", "%by #{record.name.downcase}%") }, class_name: "Post"
+  has_many :posts_mentioning_author, ->(record = nil) { where("posts.body LIKE ?", "%#{record&.name&.downcase}%") }, class_name: "Post"
 
   has_many :posts_with_extension, -> { order(:title) }, class_name: "Post" do
     def extension_method; end


### PR DESCRIPTION
### Summary

ActiveRecord associations are not preloadable if they have a scope with arguments (i.e. they require an instance to exist). There is an attempt to enforce this in the `check_preloadable` method in [reflection.rb:480](https://github.com/rails/rails/blob/314d66b5a14d20a84228ec0f59a897d491d43932/activerecord/lib/active_record/reflection.rb#L480). This line checks that `arity > 0`, and raises an `ArgumentError` if not. The original implementation was intended to resolve [#15024](https://github.com/rails/rails/issues/15024).

However, this does not take into account the behavior of [Proc#arity](https://ruby-doc.org/core-2.6.2/Proc.html#method-i-arity), which will return a negative value if the block allows optional arguments. Thus, `->(*args) { ... }` has an `arity` of -1, `->(an_arg, *args) { ... }` has an `arity` of -2, etc. The result is that we can "trick" this code into accepting a scope with mandatory arguments.

[`Association#build_scope`](https://github.com/rails/rails/blob/314d66b5a14d20a84228ec0f59a897d491d43932/activerecord/lib/active_record/associations/builder/association.rb#L51) handles this by checking `scope.arity == 0`, so this change uses that same strategy.

### Other Information

A test (using the provided template) is available in this gist: [test_fix_scope_arity.rb](https://gist.github.com/Redapted/a12aeb70d81fdba63e1b9b36d49ab60c). There are no tests provided in this PR; this is my first time contributing to Rails, and I couldn't find any existing tests for similar idioms. Because of this, I wasn't sure how/if I should write tests for this kind of change.

Incidentally, this "feature" can actually be used successfully (if awkwardly) by writing an association like this:

```ruby
has_many :scoped_things, ->(*args) { args.any? where(attr: args.first.o_attr) : all }
```

But that seems awful and contrary to intended usage.