### PR TITLE
Should take the record's state of first action in the transaction

### DIFF
--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -36,6 +36,8 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 
     has_many :replies, class_name: "ReplyWithCallbacks", foreign_key: "parent_id"
 
+    before_destroy { self.class.find(id).touch if persisted? }
+
     before_commit { |record| record.do_before_commit(nil) }
     after_commit { |record| record.do_after_commit(nil) }
     after_save_commit { |record| record.do_after_commit(:save) }


### PR DESCRIPTION
If the same id's records are saved and/or destroyed in the transaction,
commit callbackes will only run for the first enrolled record.

https://github.com/rails/rails/blob/a023e2180093ebc517a642aaf21f3c7241c67657/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L115-L119

The regression #36132 is caused due to #35920 changed the enrollment
order that the first action's record will be enrolled to last in the
transaction.

We could not change the the enrollment order as long as someone depends
on the enrollment order.

Fixes #36132.

Probably this will also fix #36082.