### PR TITLE
[Guides] Remove dynamic_form gem reference in guides

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -992,27 +992,6 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 | numericality | :odd                      | :odd                      | -             |
 | numericality | :even                     | :even                     | -             |
 
-#### Translations for the Active Record `error_messages_for` Helper
-
-If you are using the Active Record `error_messages_for` helper, you will want to add
-translations for it.
-
-Rails ships with the following translations:
-
-```yaml
-en:
-  activerecord:
-    errors:
-      template:
-        header:
-          one:   "1 error prohibited this %{model} from being saved"
-          other: "%{count} errors prohibited this %{model} from being saved"
-        body:    "There were problems with the following fields:"
-```
-
-NOTE: In order to use this helper, you need to install [DynamicForm](https://github.com/joelmoss/dynamic_form)
-gem by adding this line to your `Gemfile`: `gem 'dynamic_form'`.
-
 ### Translations for Action Mailer E-Mail Subjects
 
 If you don't pass a subject to the `mail` method, Action Mailer will try to find


### PR DESCRIPTION
This gem has not been updated since April 2014, still uses Rails 3 as its testing reference, and 2 of the 4 methods it introduces have been broken since Rails 4.

I think that referencing it in the guides leads to broken expectations.
