### PR TITLE
Fix handling of undefined year in DateTimeSelector

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -830,7 +830,7 @@ module ActionView
       end
 
       def select_year
-        if !@datetime || @datetime == 0
+        if !year || @datetime == 0
           val = "1"
           middle_year = Date.today.year
         else

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -19,6 +19,8 @@ class DateHelperTest < ActionView::TestCase
         "123"
       end
     end
+
+    ComposedDate = Struct.new("ComposedDate", :year, :month, :day)
   end
 
   def assert_distance_of_time_in_words(from, to = nil)
@@ -466,6 +468,26 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_year(Time.mktime(2003, 8, 16), start_year: 2003, end_year: 2005)
     assert_dom_equal expected, select_year(2003, start_year: 2003, end_year: 2005)
+  end
+
+  def test_select_year_with_empty_hash_value_and_no_start_year
+    expected = +%(<select id="date_year" name="date[year]">\n)
+    expected << %(<option value="2014">2014</option>\n<option value="2015">2015</option>\n<option value="2016">2016</option>\n<option value="2017">2017</option>\n<option value="2018">2018</option>\n)
+    expected << "</select>\n"
+
+    Date.stub(:current, Date.new(2018, 12, 18)) do
+      assert_dom_equal expected, select_year({ year: nil, month: 4, day: nil }, { end_year: 2018 })
+    end
+  end
+
+  def test_select_year_with_empty_object_value_and_no_start_year
+    expected = +%(<select id="date_year" name="date[year]">\n)
+    expected << %(<option value="2014">2014</option>\n<option value="2015">2015</option>\n<option value="2016">2016</option>\n<option value="2017">2017</option>\n<option value="2018">2018</option>\n)
+    expected << "</select>\n"
+
+    Date.stub(:current, Date.new(2018, 12, 18)) do
+      assert_dom_equal expected, select_year(ComposedDate.new(nil, 4, nil), end_year: 2018)
+    end
   end
 
   def test_select_year_with_disabled


### PR DESCRIPTION
### Summary
Prevents select_year to cause error when the year is nil and is passed as part of Hash, like select_year(year: nil). Since similar helpers like select_month(month: nil) or select_day(day: nil) doesn't cause error in such condition, select_year shouldn't either.

### Description

Since `@datetime` can be an arbitrary object here that responds to :year, it should use `middle_year = Date.today.year` fallback if `@datetime.year` returned nil. Otherwise method may raise error on operations with empty middle_year.