### PR TITLE
Revert changes to monotonic times

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -180,13 +180,13 @@ module ActiveSupport
 
           def start(name, id, payload)
             timestack = Thread.current[:_timestack] ||= []
-            timestack.push Concurrent.monotonic_time
+            timestack.push Time.now
           end
 
           def finish(name, id, payload)
             timestack = Thread.current[:_timestack]
             started = timestack.pop
-            @delegate.call(name, started, Concurrent.monotonic_time, id, payload)
+            @delegate.call(name, started, Time.now, id, payload)
           end
         end
 

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -302,7 +302,7 @@ module Notifications
 
   class EventTest < TestCase
     def test_events_are_initialized_with_details
-      time = Concurrent.monotonic_time
+      time = Time.now
       event = event(:foo, time, time + 0.01, random_id, {})
 
       assert_equal :foo, event.name
@@ -310,12 +310,11 @@ module Notifications
       assert_in_delta 10.0, event.duration, 0.00001
     end
 
-    def test_event_cpu_time_and_idle_time_when_start_and_finish_is_not_called
-      time = Concurrent.monotonic_time
+    def test_event_cpu_time_does_not_raise_error_when_start_or_finished_not_called
+      time = Time.now
       event = event(:foo, time, time + 0.01, random_id, {})
 
       assert_equal 0, event.cpu_time
-      assert_in_delta 10.0, event.idle_time, 0.00001
     end
 
 


### PR DESCRIPTION
The change to monotonic times causes failures for applications
where the subscribed block is expecting Time objects as described
in this issue: https://github.com/rails/rails/issues/36145

The original PR (https://github.com/rails/rails/pull/35984) was
concerned with errors on the cpu_time. Test was edited to reflect
changes to initializer using 0 values instead of nil

cc/ @cpruitt @eileencodes @tenderlove 