### PR TITLE
any? should be delegated to the errors list

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -64,7 +64,7 @@ module ActiveModel
     include Enumerable
 
     extend Forwardable
-    def_delegators :@errors, :size, :clear, :blank?, :empty?, :uniq!
+    def_delegators :@errors, :size, :clear, :blank?, :empty?, :uniq!, :any?
     # TODO: forward all enumerable methods after `each` deprecation is removed.
     def_delegators :@errors, :count
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -44,6 +44,17 @@ class ErrorsTest < ActiveModel::TestCase
     assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end
 
+  def test_any?
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name)
+    assert_not_deprecated {
+      assert errors.any?, "any? should return true"
+    }
+    assert_not_deprecated {
+      assert errors.any? { |_| true }, "any? should return true"
+    }
+  end
+
   def test_dup
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name)


### PR DESCRIPTION
Otherwise we get deprecation warnings in the generated scaffold template files
