### PR TITLE
Update asset compression text [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -205,7 +205,7 @@ $ rails server
 TIP: If you are using Windows, you have to pass the scripts under the `bin`
 folder directly to the Ruby interpreter e.g. `ruby bin\rails server`.
 
-TIP: Compiling JavaScript asset compression requires you
+TIP: JavaScript asset compression requires you
 have a JavaScript runtime available on your system, in the absence
 of a runtime you will see an `execjs` error during asset compilation.
 Usually macOS and Windows come with a JavaScript runtime installed.


### PR DESCRIPTION
#36157 removed text related to CoffeeScript but the verb before it was missed so I've removed it.

Before #36157:
Compiling CoffeeScript **and** JavaScript asset compression

After #36157:
Compiling JavaScript asset compression

This PR:
JavaScript asset compression