### PR TITLE
Fix scoped uniqueness validation if inheritance used.

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -46,12 +46,16 @@ module ActiveRecord
       # their subclasses, we have to build the hierarchy between self and
       # the record's class.
       def find_finder_class_for(record)
-        class_hierarchy = [record.class]
+        record_class = record.class
 
+        if @klass.table_name != record_class.table_name && !record_class.abstract_class? && !@klass.abstract_class?
+          return record_class
+        end
+
+        class_hierarchy = [record_class]
         while class_hierarchy.first != @klass
           class_hierarchy.unshift(class_hierarchy.first.superclass)
         end
-
         class_hierarchy.detect { |klass| !klass.abstract_class? }
       end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -66,6 +66,18 @@ class TopicWithAfterCreate < Topic
   end
 end
 
+class Party < ActiveRecord::Base
+end
+
+class Participant < ActiveRecord::Base
+  belongs_to :party
+  validates_uniqueness_of :name, scope: :party
+end
+
+class Performer < Participant
+  self.table_name = "performers"
+end
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   INT_MAX_VALUE = 2147483647
 
@@ -483,6 +495,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_not w6.valid?, "w6 shouldn't be valid"
     assert w6.errors[:city].any?, "Should have errors for city"
     assert_equal ["has already been taken"], w6.errors[:city], "Should have uniqueness message for city"
+
+    party = Party.create(name: "BD party")
+    Participant.create(name: "Jo", party: party)
+    performer = Performer.new(name: "Jo", party: party)
+    assert performer.valid?, "performer should be valid"
   end
 
   def test_validate_uniqueness_with_conditions

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1106,6 +1106,20 @@ ActiveRecord::Schema.define do
   create_table :non_primary_keys, force: true, id: false do |t|
     t.integer :id
   end
+
+  create_table :parties, force: true do |t|
+    t.string :name
+  end
+
+  create_table :participants, force: true do |t|
+    t.string :name
+    t.integer :party_id
+  end
+
+  create_table :performers, force: true do |t|
+    t.string :name
+    t.integer :party_id
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
In my application I have
```
class Participant < ApplicationRecord
  validates_uniqueness_of :email, scope: :account_id
end

module ParticipantImporter
  class Participant < ::Participant
    self.table_name = "stg_participants"
  end
end
```
I can't save `ParticipantImporter::Participant` if `Participant` with the same `account_id` and `name` exists and `stg_participants` table is empty. 

For some reason when inheriting from another model with a uniqueness validation it is scoped to the original model even though the table name is set in the other class.

It's not supposed to be a single-table inheritance. I this particular case I'm trying to use  "super-class" logic in its child. And use different tables for both classes.

This pr should fix it