### PR TITLE
Add ActiveSupport::MessageVerifier.split_message

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -122,7 +122,7 @@ module ActiveSupport
     def valid_message?(signed_message)
       return if signed_message.nil? || !signed_message.valid_encoding? || signed_message.blank?
 
-      data, digest = signed_message.split("--")
+      data, digest = split_signed_message(signed_message)
       data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))
     end
 
@@ -150,7 +150,7 @@ module ActiveSupport
     def verified(signed_message, purpose: nil, **)
       if valid_message?(signed_message)
         begin
-          data = signed_message.split("--")[0]
+          data = split_signed_message(signed_message)[0]
           message = Messages::Metadata.verify(decode(data), purpose)
           @serializer.load(message) if message
         rescue ArgumentError => argument_error
@@ -195,6 +195,10 @@ module ActiveSupport
 
       def decode(data)
         ::Base64.strict_decode64(data)
+      end
+
+      def split_signed_message(signed_message)
+        signed_message.split("--")
       end
 
       def generate_digest(data)


### PR DESCRIPTION
### Summary

Add `ActiveSupport::MessageVerifier.split_message` to support urlsafe base64 en/de-coding

There already are overridable encode and decode methods but in `verified` and `valid_message?` the message is split with `.split("--")` but e.g. `Base64.urlsafe_encode64 Marshal.dump 48655` results in `BAhpAg--` which gives a signed message like `BAhpAg----#{digest}` which will then get split at the wrong place `.rpartition("--")` could be used instead which shouldn't result in changed behaviour but this pull request tries to keep maximum compatibility and so keeps the use of `split`
