### PR TITLE
Check result of destroy action in controllers generated by scaffold

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -46,8 +46,11 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   # DELETE <%= route_url %>/1
   def destroy
-    @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
+    if @<%= orm_instance.destroy %>
+      redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
+    else
+      render :index
+    end
   end
 
   private


### PR DESCRIPTION
### Summary

When scaffolding a controller, the destroy action doesn't check the result of the `@object.destroy` call. This should be checked in order to be sure that the object got really destroyed, otherwise we call redirect back to the `index` (where the destroy button is placed when scaffolding)