### PR TITLE
[ci skip] Correct the stylesheet name used in the guide.

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -91,7 +91,7 @@ end
 
 By default, the Action Text editor and content is styled by the Trix defaults.
 If you want to change these defaults, you'll want to remove
-the `app/assets/stylesheets/actiontext.css` linker and base your stylings on
+the `app/assets/stylesheets/actiontext.scss` linker and base your stylings on
 the [contents of that file](https://raw.githubusercontent.com/basecamp/trix/master/dist/trix.css).
 
 You can also style the HTML used for embedded images and other attachments (known as blobs).


### PR DESCRIPTION
### Summary

In the [Action Text guides](https://edgeguides.rubyonrails.org/action_text_overview.html#custom-styling), `app/assets/stylesheets/actiontext.css`
is specified as the file used to style the Action Text editor and
content but the actual file generated from `rails action_text:install`
is `app/assets/stylesheets/actiontext.scss`.

This change simply corrects the file extension shown in the guide.