### PR TITLE
Skip tzinfo-data in generated apps unless necessary

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -75,6 +75,6 @@ end
 <%- end -%>
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+# Zoneinfo files not included, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -73,6 +73,8 @@ group :test do
   gem 'webdrivers'
 end
 <%- end -%>
+<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+<%- end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -44,5 +44,6 @@ end
 <% end -%>
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
+# Zoneinfo files not included, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 <% end -%>


### PR DESCRIPTION
### Summary

Currently generated applications include the `tzinfo-data` gem unconditionally, even if it's only needed on some platforms. I consider that the number of Rails applications that need to support multiple different platforms is a minority, and normally when you expect an application to be run under some platform, you generate it under that platform. Also, Rails should give a very clear error if you need this gem:

https://github.com/rails/rails/blob/9b680e52f1ad4469d4fabe7f7f4e301bfe7bfd37/activesupport/lib/active_support/railtie.rb#L33-L44

So, because of the above reasons, I propose to only add this gem when the platform generating the application needs it. This is consistent with the way plugins are currently generated:

https://github.com/rails/rails/blob/9b680e52f1ad4469d4fabe7f7f4e301bfe7bfd37/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt#L45-L48

Also, this avoids the following bundler warning when generating applications:

> The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.