### PR TITLE
Fix method redefined warning

### DIFF
--- a/activemodel/test/cases/nested_error_test.rb
+++ b/activemodel/test/cases/nested_error_test.rb
@@ -5,7 +5,7 @@ require "active_model/nested_error"
 require "models/topic"
 require "models/reply"
 
-class ErrorTest < ActiveModel::TestCase
+class NestedErrorTest < ActiveModel::TestCase
   def test_initialize
     topic = Topic.new
     inner_error = ActiveModel::Error.new(topic, :title, :not_enough, count: 2)


### PR DESCRIPTION
This fixes "warning: method redefined; discarding old test_initialize".  The ErrorTest class defined by nested_error_test.rb was in conflict with the ErrorTest class defined by error_test.rb, and was likely the result of a copy / paste oversight.
