### PR TITLE
Avoid extra allocation in String#from and #to

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -44,7 +44,7 @@ class String
   #   str.from(0).to(-1) # => "hello"
   #   str.from(1).to(-2) # => "ell"
   def from(position)
-    self[position..-1]
+    self[position, length]
   end
 
   # Returns a substring from the beginning of the string to the given position.
@@ -61,7 +61,8 @@ class String
   #   str.from(0).to(-1) # => "hello"
   #   str.from(1).to(-2) # => "ell"
   def to(position)
-    self[0..position]
+    position = [position + length, -1].max if position < 0
+    self[0, position + 1]
   end
 
   # Returns the first character. If a limit is supplied, returns a substring


### PR DESCRIPTION
Removes unnecessary Range object allocations for a significant speed-up.

```
String#from Comparison:
  new:   3378594.0 i/s
  old:   2380129.8 i/s - 1.42x slower

String#to Comparison:
  new:   2866175.7 i/s
  old:   2304406.4 i/s - 1.24x slower
```
