### PR TITLE
Expose `mailbox_for` method

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `ApplicationMailbox.mailbox_for` to expose mailbox routing.
 
+  *James Dabbs*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/lib/action_mailbox/router.rb
+++ b/actionmailbox/lib/action_mailbox/router.rb
@@ -21,7 +21,7 @@ module ActionMailbox
     end
 
     def route(inbound_email)
-      if mailbox = match_to_mailbox(inbound_email)
+      if mailbox = mailbox_for(inbound_email)
         mailbox.receive(inbound_email)
       else
         inbound_email.bounced!
@@ -30,12 +30,12 @@ module ActionMailbox
       end
     end
 
+    def mailbox_for(inbound_email)
+      routes.detect { |route| route.match?(inbound_email) }.try(:mailbox_class)
+    end
+
     private
       attr_reader :routes
-
-      def match_to_mailbox(inbound_email)
-        routes.detect { |route| route.match?(inbound_email) }.try(:mailbox_class)
-      end
   end
 end
 

--- a/actionmailbox/lib/action_mailbox/routing.rb
+++ b/actionmailbox/lib/action_mailbox/routing.rb
@@ -17,6 +17,10 @@ module ActionMailbox
       def route(inbound_email)
         router.route(inbound_email)
       end
+
+      def mailbox_for(inbound_email)
+        router.route(inbound_email)
+      end
     end
   end
 end

--- a/actionmailbox/lib/action_mailbox/routing.rb
+++ b/actionmailbox/lib/action_mailbox/routing.rb
@@ -19,7 +19,7 @@ module ActionMailbox
       end
 
       def mailbox_for(inbound_email)
-        router.route(inbound_email)
+        router.mailbox_for(inbound_email)
       end
     end
   end

--- a/actionmailbox/test/unit/mailbox/routing_test.rb
+++ b/actionmailbox/test/unit/mailbox/routing_test.rb
@@ -28,4 +28,9 @@ class ActionMailbox::Base::RoutingTest < ActiveSupport::TestCase
       assert_equal "Discussion: Let's debate these attachments", $processed
     end
   end
+
+  test "mailbox_for" do
+    mail = create_inbound_email_from_fixture "welcome.eml", status: :pending
+    assert_equal RepliesMailbox, ApplicationMailbox.mailbox_for(mail)
+  end
 end

--- a/actionmailbox/test/unit/mailbox/routing_test.rb
+++ b/actionmailbox/test/unit/mailbox/routing_test.rb
@@ -30,7 +30,7 @@ class ActionMailbox::Base::RoutingTest < ActiveSupport::TestCase
   end
 
   test "mailbox_for" do
-    mail = create_inbound_email_from_fixture "welcome.eml", status: :pending
-    assert_equal RepliesMailbox, ApplicationMailbox.mailbox_for(mail)
+    inbound_email = create_inbound_email_from_fixture "welcome.eml", status: :pending
+    assert_equal RepliesMailbox, ApplicationMailbox.mailbox_for(inbound_email)
   end
 end

--- a/actionmailbox/test/unit/router_test.rb
+++ b/actionmailbox/test/unit/router_test.rb
@@ -135,5 +135,19 @@ module ActionMailbox
         @router.add_route Array.new, to: :first
       end
     end
+
+    test "single string mailbox_for" do
+      @router.add_routes("first@example.com" => :first)
+
+      inbound_email = create_inbound_email_from_mail(to: "first@example.com", subject: "This is a reply")
+      assert_equal FirstMailbox, @router.mailbox_for(inbound_email)
+    end
+
+    test "mailbox_for with no matches" do
+      @router.add_routes("first@example.com" => :first)
+
+      inbound_email = create_inbound_email_from_mail(to: "second@example.com", subject: "This is a reply")
+      assert_nil @router.mailbox_for(inbound_email)
+    end
   end
 end


### PR DESCRIPTION
Currently, the only exposed entry point into the ApplicationMailbox's configured
routing system is to call `route`, which performs a lot of work to fully
`process` inbound email. It'd be nice to have a way (e.g. in test) of checking
which mailbox an email would route to without necessarily processing it yet.

For what it's worth, I think it'd be helpful to add more inline documentation and indicate which methods are and aren't intended to be public and supported. I'd be happy to add those - either in this PR or in a separate one - if y'all think that would be valuable.