### PR TITLE
Move multi-parameter attributes from ActiveRecord to ActiveModel

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -42,6 +42,7 @@ module ActiveModel
   autoload :ForbiddenAttributesProtection
   autoload :Lint
   autoload :Model
+  autoload :MultiparameterAttributeAssignment
   autoload :Name, "active_model/naming"
   autoload :Naming
   autoload :SecurePassword
@@ -52,7 +53,9 @@ module ActiveModel
   autoload :Validator
 
   eager_autoload do
+    autoload :AttributeAssignmentError, "active_model/multiparameter_attribute_assignment"
     autoload :Errors
+    autoload :MultiparameterAssignmentErrors, "active_model/multiparameter_attribute_assignment"
     autoload :RangeError, "active_model/errors"
     autoload :StrictValidationFailed, "active_model/errors"
     autoload :UnknownAttributeError, "active_model/errors"

--- a/activemodel/lib/active_model/multiparameter_attribute_assignment.rb
+++ b/activemodel/lib/active_model/multiparameter_attribute_assignment.rb
@@ -38,11 +38,11 @@ module ActiveModel
           end
           send("#{name}=", values)
         rescue => ex
-          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+          errors << attribute_assignment_error_class.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
         end
         unless errors.empty?
           error_descriptions = errors.map(&:message).join(",")
-          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
+          raise multiparameter_assignment_errors_class.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
         end
       end
 
@@ -66,6 +66,14 @@ module ActiveModel
 
       def find_parameter_position(multiparameter_name)
         multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+      end
+
+      def attribute_assignment_error_class
+        ActiveModel::AttributeAssignmentError
+      end
+
+      def multiparameter_assignment_errors_class
+        ActiveModel::MultiparameterAssignmentErrors
       end
   end
 

--- a/activemodel/lib/active_model/multiparameter_attribute_assignment.rb
+++ b/activemodel/lib/active_model/multiparameter_attribute_assignment.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module MultiparameterAttributeAssignment
+    include ActiveModel::AttributeAssignment
+
+    private
+
+      def _assign_attributes(attributes)
+        multi_parameter_attributes = {}
+
+        attributes.each do |k, v|
+          multi_parameter_attributes[k] = attributes.delete(k) if k.include?("(")
+        end
+        super(attributes)
+        assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
+      end
+
+      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
+      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
+      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
+      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
+      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
+      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
+      def assign_multiparameter_attributes(pairs)
+        execute_callstack_for_multiparameter_attributes(
+          extract_callstack_for_multiparameter_attributes(pairs)
+        )
+      end
+
+      def execute_callstack_for_multiparameter_attributes(callstack)
+        errors = []
+        callstack.each do |name, values_with_empty_parameters|
+          if values_with_empty_parameters.each_value.all?(&:nil?)
+            values = nil
+          else
+            values = values_with_empty_parameters
+          end
+          send("#{name}=", values)
+        rescue => ex
+          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+        end
+        unless errors.empty?
+          error_descriptions = errors.map(&:message).join(",")
+          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
+        end
+      end
+
+      def extract_callstack_for_multiparameter_attributes(pairs)
+        attributes = {}
+
+        pairs.each do |(multiparameter_name, value)|
+          attribute_name = multiparameter_name.split("(").first
+          attributes[attribute_name] ||= {}
+
+          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
+        end
+
+        attributes
+      end
+
+      def type_cast_attribute_value(multiparameter_name, value)
+        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
+      end
+
+      def find_parameter_position(multiparameter_name)
+        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+      end
+  end
+
+  # Raised when an error occurred while doing a mass assignment to an attribute through the
+  # +attributes=+ method. The exception has an +attribute+ property that is the name of the
+  # offending attribute.
+  class AttributeAssignmentError < StandardError
+    attr_reader :exception, :attribute
+
+    def initialize(message, exception, attribute)
+      super(message)
+      @exception = exception
+      @attribute = attribute
+    end
+  end
+
+  # Raised when there are multiple errors while doing a mass assignment through the +attributes+
+  # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
+  # objects, each corresponding to the error while assigning to an attribute.
+  class MultiparameterAssignmentErrors < StandardError
+    attr_reader :errors
+
+    def initialize(errors)
+      @errors = errors
+    end
+  end
+end

--- a/activemodel/test/cases/multiparameter_attribute_assignment_test.rb
+++ b/activemodel/test/cases/multiparameter_attribute_assignment_test.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class MultiparameterAttributeAssignmentTest < ActiveModel::TestCase
+  class Address < Struct.new(:street, :city, :country) ; end
+
+  class AddressType < ActiveModel::Type::Value
+    def cast(hash_values)
+      Address.new(*hash_values.sort.map(&:last))
+    end
+  end
+
+  class Person
+    include ActiveModel::Attributes
+    include ActiveModel::MultiparameterAttributeAssignment
+    attribute :name, :string
+    attribute :date_of_birth, :date
+    attribute :last_slept, :datetime
+    attribute :address, AddressType.new
+  end
+
+  def setup
+    Time.zone = "UTC"
+  end
+
+  def test_multiparameter_attributes_on_date
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_equal Date.new(2004, 6, 24), person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_year
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day_and_year
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "6",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_day_and_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "2004",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_empty_year_and_month
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => "24"
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_date_with_all_empty
+    person = Person.new
+    person.attributes = {
+      "date_of_birth(1i)" => "",
+      "date_of_birth(2i)" => "",
+      "date_of_birth(3i)" => ""
+    }
+    assert_nil person.date_of_birth
+  end
+
+  def test_multiparameter_attributes_on_time
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "6", "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24", "last_slept(6i)" => "00"
+    }
+    assert_equal Time.zone.local(2004, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_no_date
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16",
+        "last_slept(5i)" => "24",
+        "last_slept(6i)" => "00"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_invalid_time_params
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(1i)" => "2004",
+        "last_slept(2i)" => "6",
+        "last_slept(3i)" => "24",
+        "last_slept(4i)" => "2004",
+        "last_slept(5i)" => "36",
+        "last_slept(6i)" => "64",
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_old_date
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "1850",
+      "last_slept(2i)" => "6",
+      "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16",
+      "last_slept(5i)" => "24",
+      "last_slept(6i)" => "00"
+    }
+    assert_equal Time.zone.local(1850, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_raise_on_big_time_if_missing_date_parts
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16", "last_slept(5i)" => "24"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_with_raise_on_small_time_if_missing_date_parts
+    person = Person.new
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = {
+        "last_slept(4i)" => "16",
+        "last_slept(5i)" => "12",
+        "last_slept(6i)" => "02"
+      }
+    end
+    assert_equal("last_slept", ex.errors[0].attribute)
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_hour_if_missing
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "12", "last_slept(3i)" => "12",
+      "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_equal Time.zone.local(2004, 12, 12, 0, 12, 2), person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_hour_if_blank
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "", "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_will_ignore_date_if_empty
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_seconds_will_ignore_date_if_empty
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "", "last_slept(2i)" => "", "last_slept(3i)" => "",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "12", "last_slept(6i)" => "02"
+    }
+    assert_nil person.last_slept
+  end
+
+  def test_multiparameter_attributes_on_time_with_empty_seconds
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "2004", "last_slept(2i)" => "6", "last_slept(3i)" => "24",
+      "last_slept(4i)" => "16", "last_slept(5i)" => "24", "last_slept(6i)" => ""
+    }
+    assert_equal Time.zone.local(2004, 6, 24, 16, 24, 0), person.last_slept
+  end
+
+  def test_multiparameter_attributes_setting_date_attribute
+    person = Person.new
+    person.attributes = { "last_slept(1i)" => "1952", "last_slept(2i)" => "3", "last_slept(3i)" => "11" }
+    assert_equal 1952, person.last_slept.year
+    assert_equal 3, person.last_slept.month
+    assert_equal 11, person.last_slept.day
+  end
+
+  def test_multiparameter_attributes_setting_date_and_time_attribute
+    person = Person.new
+    person.attributes = {
+      "last_slept(1i)" => "1952",
+      "last_slept(2i)" => "3",
+      "last_slept(3i)" => "11",
+      "last_slept(4i)" => "13",
+      "last_slept(5i)" => "55"
+    }
+    assert_equal 1952, person.last_slept.year
+    assert_equal 3, person.last_slept.month
+    assert_equal 11, person.last_slept.day
+    assert_equal 13, person.last_slept.hour
+    assert_equal 55, person.last_slept.min
+  end
+
+  def test_multiparameter_attributes_setting_time_but_not_date_on_date_field
+    person = Person.new
+    assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      person.attributes = { "last_slept(4i)" => "13", "last_slept(5i)" => "55" }
+    end
+  end
+
+  def test_multiparameter_assignment_of_custom_attribute_type
+    address = Address.new("The Street", "The City", "The Country")
+    person = Person.new
+    person.attributes = {
+      "address(1)" => address.street,
+      "address(2)" => address.city,
+      "address(3)" => address.country
+    }
+    assert_equal address, person.address
+  end
+end

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -1,28 +1,25 @@
 # frozen_string_literal: true
 
 require "active_model/forbidden_attributes_protection"
+require "active_model/multiparameter_attribute_assignment"
 
 module ActiveRecord
   module AttributeAssignment
-    include ActiveModel::AttributeAssignment
+    include ActiveModel::MultiparameterAttributeAssignment
 
     private
 
       def _assign_attributes(attributes)
-        multi_parameter_attributes  = {}
         nested_parameter_attributes = {}
 
         attributes.each do |k, v|
-          if k.include?("(")
-            multi_parameter_attributes[k] = attributes.delete(k)
-          elsif v.is_a?(Hash)
+          if v.is_a?(Hash)
             nested_parameter_attributes[k] = attributes.delete(k)
           end
         end
         super(attributes)
 
         assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
-        assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
       end
 
       # Assign any deferred nested attributes after the base attributes have been set.
@@ -30,56 +27,12 @@ module ActiveRecord
         pairs.each { |k, v| _assign_attribute(k, v) }
       end
 
-      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
-      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
-      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
-      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
-      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
-      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
-      def assign_multiparameter_attributes(pairs)
-        execute_callstack_for_multiparameter_attributes(
-          extract_callstack_for_multiparameter_attributes(pairs)
-        )
+      def attribute_assignment_error_class
+        ::ActiveRecord::AttributeAssignmentError
       end
 
-      def execute_callstack_for_multiparameter_attributes(callstack)
-        errors = []
-        callstack.each do |name, values_with_empty_parameters|
-          if values_with_empty_parameters.each_value.all?(&:nil?)
-            values = nil
-          else
-            values = values_with_empty_parameters
-          end
-          send("#{name}=", values)
-        rescue => ex
-          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
-        end
-        unless errors.empty?
-          error_descriptions = errors.map(&:message).join(",")
-          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
-        end
-      end
-
-      def extract_callstack_for_multiparameter_attributes(pairs)
-        attributes = {}
-
-        pairs.each do |(multiparameter_name, value)|
-          attribute_name = multiparameter_name.split("(").first
-          attributes[attribute_name] ||= {}
-
-          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
-          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
-        end
-
-        attributes
-      end
-
-      def type_cast_attribute_value(multiparameter_name, value)
-        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
-      end
-
-      def find_parameter_position(multiparameter_name)
-        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+      def multiparameter_assignment_errors_class
+        ::ActiveRecord::MultiparameterAssignmentErrors
       end
   end
 end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -262,27 +262,13 @@ module ActiveRecord
   # Raised when an error occurred while doing a mass assignment to an attribute through the
   # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
   # The exception has an +attribute+ property that is the name of the offending attribute.
-  class AttributeAssignmentError < ActiveRecordError
-    attr_reader :exception, :attribute
-
-    def initialize(message = nil, exception = nil, attribute = nil)
-      super(message)
-      @exception = exception
-      @attribute = attribute
-    end
-  end
+  AttributeAssignmentError = ActiveModel::AttributeAssignmentError
 
   # Raised when there are multiple errors while doing a mass assignment through the
   # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
   # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
   # objects, each corresponding to the error while assigning to an attribute.
-  class MultiparameterAssignmentErrors < ActiveRecordError
-    attr_reader :errors
-
-    def initialize(errors = nil)
-      @errors = errors
-    end
-  end
+  MultiparameterAssignmentErrors = ActiveModel::MultiparameterAssignmentErrors
 
   # Raised when a primary key is needed, but not specified in the schema or model.
   class UnknownPrimaryKey < ActiveRecordError


### PR DESCRIPTION
Take 3, Previously attempted in 2012 (#8189) and 2015 (#19709). 

This new version uses ActiveModel Attributes API.