### PR TITLE
Introduce ActiveSupport::Notifications.monotonic_subscribe

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -38,6 +38,19 @@ module ActiveSupport
   #     payload # => Hash, the payload
   #   end
   #
+  # Here, the +start+ and +finish+ values represent wall-clock time. If you are
+  # concerned about accuracy, you can register a monotonic subscriber.
+  #
+  #   ActiveSupport::Notifications.monotonic_subscribe('render') do |name, start, finish, id, payload|
+  #     name    # => String, name of the event (such as 'render' from above)
+  #     start   # => Monotonic time, when the instrumented block started execution
+  #     finish  # => Monotonic time, when the instrumented block ended execution
+  #     id      # => String, unique ID for the instrumenter that fired the event
+  #     payload # => Hash, the payload
+  #   end
+  #
+  # The +start+ and +finish+ values above represent monotonic time.
+  #
   # For instance, let's store all "render" events in an array:
   #
   #   events = []
@@ -135,6 +148,16 @@ module ActiveSupport
   # during the execution of the block. The callback is unsubscribed automatically
   # after that.
   #
+  # To record +started+ and +finished+ values with monotonic time,
+  # specify the optional <tt>:monotonic</tt> option to the
+  # <tt>subscribed</tt> method. The <tt>:monotonic</tt> option is set
+  # to +false+ by default.
+  #
+  #   callback = lambda {|name, started, finished, unique_id, payload| ... }
+  #   ActiveSupport::Notifications.subscribed(callback, "sql.active_record", monotonic: true) do
+  #     ...
+  #   end
+  #
   # === Manual Unsubscription
   #
   # The +subscribe+ method returns a subscriber object:
@@ -209,11 +232,17 @@ module ActiveSupport
       #     @event = event
       #   end
       def subscribe(*args, &block)
-        notifier.subscribe(*args, &block)
+        pattern, callback = *args
+        notifier.subscribe(pattern, callback, false, &block)
       end
 
-      def subscribed(callback, *args, &block)
-        subscriber = subscribe(*args, &callback)
+      def monotonic_subscribe(*args, &block)
+        pattern, callback = *args
+        notifier.subscribe(pattern, callback, true, &block)
+      end
+
+      def subscribed(callback, pattern, monotonic: false, &block)
+        subscriber = notifier.subscribe(pattern, callback, monotonic)
         yield
       ensure
         unsubscribe(subscriber)

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -643,7 +643,16 @@ The block receives the following arguments:
 ```ruby
 ActiveSupport::Notifications.subscribe "process_action.action_controller" do |name, started, finished, unique_id, data|
   # your own custom stuff
-  Rails.logger.info "#{name} Received!"
+  Rails.logger.info "#{name} Received! (started: #{started}, finished: #{finished})" # process_action.action_controller Received (started: 2019-05-05 13:43:57 -0800, finished: 2019-05-05 13:43:58 -0800)
+end
+```
+
+If you are concerned about the accuracy of `started` and `finished` to compute a precise elapsed time then use `ActiveSupport::Notifications.monotonic_subscribe`. The given block would receive the same arguments as above but the `started` and `finished` will have values with an accurate monotonic time instead of wall-clock time.
+
+```ruby
+ActiveSupport::Notifications.monotonic_subscribe "process_action.action_controller" do |name, started, finished, unique_id, data|
+  # your own custom stuff
+  Rails.logger.info "#{name} Received! (started: #{started}, finished: #{finished})" # process_action.action_controller Received (started: 1560978.425334, finished: 1560979.429234)
 end
 ```
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/36145.

Introduces `ActiveSupport::Notifications.monotonic_subscribe` to record `started` and `finished` with monotonic time using newly introduced `ActiveSupport::Notifications::Fanout::Subscribers::MonotonicTimed` class.

Also, adds an optional `monotonic` option to `ActiveSupport::Notifications.subscribed` method.
