### PR TITLE
Avoid coercing all SELECTs with the same column name to the same value

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -743,8 +743,8 @@ module ActiveRecord
         #
         # This is an internal hook to make possible connection adapters to build
         # custom result objects with connection-specific data.
-        def build_result(columns:, rows:, column_types: {})
-          ActiveRecord::Result.new(columns, rows, column_types)
+        def build_result(columns:, rows:, types: [])
+          ActiveRecord::Result.new(columns, rows, types)
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -103,7 +103,7 @@ module ActiveRecord
               fmod  = result.fmod i
               types << get_oid_type(ftype, fmod, fname)
             end
-            build_result(columns: fields, rows: result.values, column_types: types)
+            build_result(columns: fields, rows: result.values, types: types)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -96,12 +96,12 @@ module ActiveRecord
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false)
           execute_and_clear(sql, name, binds, prepare: prepare) do |result|
-            types = {}
+            types = []
             fields = result.fields
             fields.each_with_index do |fname, i|
               ftype = result.ftype i
               fmod  = result.fmod i
-              types[fname] = get_oid_type(ftype, fmod, fname)
+              types << get_oid_type(ftype, fmod, fname)
             end
             build_result(columns: fields, rows: result.values, column_types: types)
           end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -34,13 +34,19 @@ module ActiveRecord
   class Result
     include Enumerable
 
-    attr_reader :columns, :rows, :types
+    attr_reader :columns, :rows, :types, :column_types
 
     def initialize(columns, rows, types = [])
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
-      @types        = types
+      @types        = types || []
+      @column_types =
+        if types.empty?
+          {}
+        else
+          Hash[@columns.zip(@types)]
+        end
     end
 
     # Returns true if this result set includes the column named +name+
@@ -131,14 +137,7 @@ module ActiveRecord
       @rows         = rows.dup
       @hash_rows    = nil
       @types        = types.dup
-    end
-
-    def column_types
-      if @types.present?
-        Hash[@columns.zip(@types)]
-      else
-        {}
-      end
+      @column_types = column_types.dup
     end
 
     private

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -865,6 +865,17 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal expected, actual
   end
 
+  def test_pluck_columns_with_same_name_but_different_types
+    assert_equal [
+      ["Domain-Driven Design", "hardcover", 0],
+      ["Thoughtleadering", "unspecified", 0]
+    ], Book.where(id: 3..4).order(:id).pluck(
+      :name,
+      Arel.sql("COALESCE(format, 'unspecified')"),
+      Arel.sql("COALESCE(nullable_status, 0)")
+    )
+  end
+
   def test_calculation_with_polymorphic_relation
     part = ShipPart.create!(name: "has trinket")
     part.trinkets.create!

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -268,7 +268,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
       authors = [@david, @mary]
       encoded = ActiveSupport::JSON.encode(authors, except: [
         :name, :author_address_id, :author_address_extra_id,
-        :organization_id, :owned_essay_id
+        :organization_id, :owned_essay_id, :status
       ])
       assert_equal %([{"id":1},{"id":2}]), encoded
     end

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -69,7 +69,7 @@ module ActiveRecord
     test "cast_values returns rows after type casting" do
       values = [["1.1", "2.2"], ["3.3", "4.4"]]
       columns = ["col1", "col2"]
-      types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+      types = [Type::Integer.new, Type::Float.new]
       result = Result.new(columns, values, types)
 
       assert_equal [[1, 2.2], [3, 4.4]], result.cast_values
@@ -78,7 +78,7 @@ module ActiveRecord
     test "cast_values uses identity type for unknown types" do
       values = [["1.1", "2.2"], ["3.3", "4.4"]]
       columns = ["col1", "col2"]
-      types = { "col1" => Type::Integer.new }
+      types = [Type::Integer.new]
       result = Result.new(columns, values, types)
 
       assert_equal [[1, "2.2"], [3, "4.4"]], result.cast_values
@@ -87,7 +87,7 @@ module ActiveRecord
     test "cast_values returns single dimensional array if single column" do
       values = [["1.1"], ["3.3"]]
       columns = ["col1"]
-      types = { "col1" => Type::Integer.new }
+      types = [Type::Integer.new]
       result = Result.new(columns, values, types)
 
       assert_equal [1, 3], result.cast_values
@@ -96,7 +96,7 @@ module ActiveRecord
     test "cast_values can receive types to use instead" do
       values = [["1.1", "2.2"], ["3.3", "4.4"]]
       columns = ["col1", "col2"]
-      types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+      types = [Type::Integer.new, Type::Float.new]
       result = Result.new(columns, values, types)
 
       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values("col1" => Type::Float.new)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define do
     t.references :author_address_extra
     t.string :organization_id
     t.string :owned_essay_id
+    t.string :status
   end
 
   create_table :author_addresses, force: true do |t|


### PR DESCRIPTION
### Overview of Issue

Rails had been mapping types to columns in a Result Set by indexing types on columns' names. When two values in a Result Set have the same column name, they are forced to share a type.

There are several scenarios where multiple values may share the same column name.

One involves 
1. One scenario (where two tables happen to have columns with the same name but the column's values differ) is explained in #36042. **This PR does not resolve the issue in #36042 but proved _part_ of a solution to _that_ issue.**

2. Another is when using functions in a `.select` or `.pluck`. In the absence of an Alias clause, Postgres names values with the last function called, so if two values in the same query happen to use `COALESCE`, they'll both be named `"coalesce"`.

   ```
   psql> SELECT COALESCE(NULL, 'four'), COALESCE(NULL, 4);
    coalesce | coalesce
   ----------+----------
    four     |        4
   (1 row)
   ```

   ```ruby
   ActiveRecord::Base.pluck(
     Arel.sql("COALESCE(NULL, 'four')"),
     Arel.sql("COALESCE(NULL, 4)")
   ) # => [[0, 4]]
   ```

I was able to reproduce this on Rails 4.2.11.1, 5.0.7.2, 5.1.7, 5.2.3, and master.

### Solution

This commit matches `types` with `columns` and `values` (in a row) by array position (which is an assumption already made in `PostgreSQL::DatabaseStatements#exec_query`). It adds `column_types` as a public method on `ActiveRecord::Result` to preserve the class's public API.

### Concerns

Does Rails expect client code to be constructing `ActiveRecord::Result` objects? Do we need to check whether its third argument is a `Hash`, give — maybe — a deprecation warning and convert it to an `Array`?
