### PR TITLE
Use adapter name from existing connection

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -247,7 +247,7 @@ module ActiveRecord
         super
         attributes_to_define_after_schema_loads.each do |name, (type, options)|
           if type.is_a?(Symbol)
-            type = ActiveRecord::Type.lookup(type, **options.except(:default))
+            type = ActiveRecord::Type.lookup(type, adapter: adapter_name(connection), **options.except(:default))
           end
 
           define_attribute(name, type, **options.slice(:default))
@@ -258,6 +258,10 @@ module ActiveRecord
 
         NO_DEFAULT_PROVIDED = Object.new # :nodoc:
         private_constant :NO_DEFAULT_PROVIDED
+
+        def adapter_name(connection)
+          connection.adapter_name.downcase.to_sym
+        end
 
         def define_default_attribute(name, value, type, from_user:)
           if value == NO_DEFAULT_PROVIDED


### PR DESCRIPTION
### Summary
Detailed explanation: https://github.com/rails/rails/issues/36139#issuecomment-489373177

When loading the schema we call the `ActiveRecord::Base.connection` to
retrieve the `adapter_name` for an attribute. In a multi-database world
this can break as the resulting connection pool may not exist.

This patch uses the existing connection object when fetching the
adapter_name instead of calling out to `ActiveRecord::Base`.

Fixes: 36139

### Other Information

Not sure if we want to write a test case for this, and in particular where would be a good place to put it. 
