### PR TITLE
Shouldn't connected_to better be named connecting_to?

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -84,23 +84,23 @@ module ActiveRecord
     # If a role is passed, Active Record will look up the connection
     # based on the requested role:
     #
-    #   ActiveRecord::Base.connected_to(role: :writing) do
+    #   ActiveRecord::Base.connecting_to(role: :writing) do
     #     Dog.create! # creates dog using dog writing connection
     #   end
     #
-    #   ActiveRecord::Base.connected_to(role: :reading) do
+    #   ActiveRecord::Base.connecting_to(role: :reading) do
     #     Dog.create! # throws exception because we're on a replica
     #   end
     #
-    #   ActiveRecord::Base.connected_to(role: :unknown_role) do
+    #   ActiveRecord::Base.connecting_to(role: :unknown_role) do
     #     # raises exception due to non-existent role
     #   end
     #
     # For cases where you may want to connect to a database outside of the model,
-    # you can use +connected_to+ with a +database+ argument. The +database+ argument
+    # you can use +connecting_to+ with a +database+ argument. The +database+ argument
     # expects a symbol that corresponds to the database key in your config.
     #
-    #   ActiveRecord::Base.connected_to(database: :animals_slow_replica) do
+    #   ActiveRecord::Base.connecting_to(database: :animals_slow_replica) do
     #     Dog.run_a_long_query # runs a long query while connected to the +animals_slow_replica+
     #   end
     #
@@ -108,15 +108,15 @@ module ActiveRecord
     # default the `:writing` role will be used since all connections must be assigned
     # a role. If you would like to use a different role you can pass a hash to database:
     #
-    #   ActiveRecord::Base.connected_to(database: { readonly_slow: :animals_slow_replica }) do
+    #   ActiveRecord::Base.connecting_to(database: { readonly_slow: :animals_slow_replica }) do
     #     # runs a long query while connected to the +animals_slow_replica+ using the readonly_slow role.
     #     Dog.run_a_long_query
     #   end
     #
     # When using the database key a new connection will be established every time.
-    def connected_to(database: nil, role: nil, &blk)
+    def connecting_to(database: nil, role: nil, &blk)
       if database && role
-        raise ArgumentError, "connected_to can only accept a `database` or a `role` argument, but not both arguments."
+        raise ArgumentError, "connecting_to can only accept a `database` or a `role` argument, but not both arguments."
       elsif database
         if database.is_a?(Hash)
           role, database = database.first
@@ -138,21 +138,21 @@ module ActiveRecord
 
     # Returns true if role is the current connected role.
     #
-    #   ActiveRecord::Base.connected_to(role: :writing) do
-    #     ActiveRecord::Base.connected_to?(role: :writing) #=> true
-    #     ActiveRecord::Base.connected_to?(role: :reading) #=> false
+    #   ActiveRecord::Base.connecting_to(role: :writing) do
+    #     ActiveRecord::Base.connecting_to?(role: :writing) #=> true
+    #     ActiveRecord::Base.connecting_to?(role: :reading) #=> false
     #   end
-    def connected_to?(role:)
+    def connecting_to?(role:)
       current_role == role.to_sym
     end
 
     # Returns the symbol representing the current connected role.
     #
-    #   ActiveRecord::Base.connected_to(role: :writing) do
+    #   ActiveRecord::Base.connecting_to(role: :writing) do
     #     ActiveRecord::Base.current_role #=> :writing
     #   end
     #
-    #   ActiveRecord::Base.connected_to(role: :reading) do
+    #   ActiveRecord::Base.connecting_to(role: :reading) do
     #     ActiveRecord::Base.current_role #=> :reading
     #   end
     def current_role

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -47,7 +47,7 @@ module ActiveRecord
 
           def read_from_primary(&blk)
             ActiveRecord::Base.connection.while_preventing_writes do
-              ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+              ActiveRecord::Base.connecting_to(role: ActiveRecord::Base.writing_role) do
                 instrumenter.instrument("database_selector.active_record.read_from_primary") do
                   yield
                 end
@@ -56,7 +56,7 @@ module ActiveRecord
           end
 
           def read_from_replica(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord::Base.reading_role) do
+            ActiveRecord::Base.connecting_to(role: ActiveRecord::Base.reading_role) do
               instrumenter.instrument("database_selector.active_record.read_from_replica") do
                 yield
               end
@@ -64,7 +64,7 @@ module ActiveRecord
           end
 
           def write_to_primary(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+            ActiveRecord::Base.connecting_to(role: ActiveRecord::Base.writing_role) do
               instrumenter.instrument("database_selector.active_record.wrote_to_primary") do
                 yield
               ensure

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -199,7 +199,7 @@ module ActiveRecord
       end
 
       def truncate_tables(configuration)
-        ActiveRecord::Base.connected_to(database: { truncation: configuration }) do
+        ActiveRecord::Base.connecting_to(database: { truncation: configuration }) do
           table_names = ActiveRecord::Base.connection.tables
           table_names -= [
             SchemaMigration.table_name,

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       called = false
       resolver.read do
         called = true
-        assert ActiveRecord::Base.connected_to?(role: :reading)
+        assert ActiveRecord::Base.connecting_to?(role: :reading)
       end
       assert called
     end
@@ -57,7 +57,7 @@ module ActiveRecord
       called = false
       resolver.read do
         called = true
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
       end
       assert called
     end
@@ -70,7 +70,7 @@ module ActiveRecord
 
       called = false
       resolver.write do
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
         called = true
       end
       assert called
@@ -88,7 +88,7 @@ module ActiveRecord
       called = false
       assert_raises(ActiveRecord::RecordNotFound) do
         resolver.write do
-          assert ActiveRecord::Base.connected_to?(role: :writing)
+          assert ActiveRecord::Base.connecting_to?(role: :writing)
           called = true
           raise ActiveRecord::RecordNotFound
         end
@@ -107,7 +107,7 @@ module ActiveRecord
 
       called = false
       resolver.write do
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
         called = true
       end
       assert called
@@ -117,7 +117,7 @@ module ActiveRecord
 
       read = false
       resolver.read do
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
         read = true
       end
       assert read
@@ -131,7 +131,7 @@ module ActiveRecord
 
       called = false
       resolver.write do
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
         called = true
       end
       assert called
@@ -141,7 +141,7 @@ module ActiveRecord
 
       read = false
       resolver.read do
-        assert ActiveRecord::Base.connected_to?(role: :reading)
+        assert ActiveRecord::Base.connecting_to?(role: :reading)
         read = true
       end
       assert read
@@ -149,7 +149,7 @@ module ActiveRecord
 
     def test_the_middleware_chooses_writing_role_with_POST_request
       middleware = ActiveRecord::Middleware::DatabaseSelector.new(lambda { |env|
-        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert ActiveRecord::Base.connecting_to?(role: :writing)
         [200, {}, ["body"]]
       })
       assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "POST")
@@ -157,7 +157,7 @@ module ActiveRecord
 
     def test_the_middleware_chooses_reading_role_with_GET_request
       middleware = ActiveRecord::Middleware::DatabaseSelector.new(lambda { |env|
-        assert ActiveRecord::Base.connected_to?(role: :reading)
+        assert ActiveRecord::Base.connecting_to?(role: :reading)
         [200, {}, ["body"]]
       })
       assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "GET")

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -61,7 +61,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     }
 
-    ActiveRecord::Base.connected_to(role: :reading) do
+    ActiveRecord::Base.connecting_to(role: :reading) do
       ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
     end
 
@@ -510,25 +510,25 @@ class QueryCacheTest < ActiveRecord::TestCase
         reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       }
 
-      ActiveRecord::Base.connected_to(role: :reading) do
+      ActiveRecord::Base.connecting_to(role: :reading) do
         ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
       end
 
       mw = middleware { |env|
-        ActiveRecord::Base.connected_to(role: :reading) do
+        ActiveRecord::Base.connecting_to(role: :reading) do
           @topic = Topic.first
         end
 
         assert @topic
 
-        ActiveRecord::Base.connected_to(role: :writing) do
+        ActiveRecord::Base.connecting_to(role: :writing) do
           @topic.title = "It doesn't have to be crazy at work"
           @topic.save!
         end
 
         assert_equal "It doesn't have to be crazy at work", @topic.title
 
-        ActiveRecord::Base.connected_to(role: :reading) do
+        ActiveRecord::Base.connecting_to(role: :reading) do
           @topic = Topic.first
           assert_equal "It doesn't have to be crazy at work", @topic.title
         end

--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -531,7 +531,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
     and `rails db:schema:cache:clear`.
     ([Pull Request](https://github.com/rails/rails/pull/34181))
 
-*   Add support for hash and url configs in database hash of `ActiveRecord::Base.connected_to`.
+*   Add support for hash and url configs in database hash of `ActiveRecord::Base.connecting_to`.
     ([Pull Request](https://github.com/rails/rails/pull/34196))
 
 *   Add support for default expressions and expression indexes for MySQL.


### PR DESCRIPTION
Hi! Just a choice of words, but for me it feels a little bit more natural to name a method that is connecting to a DB to be `connecting_to` over `connected_to`.

before:
```ruby
ActiveRecord::Base.connected_to(role: :writing) do
  ...
end
```

after:
```ruby
ActiveRecord::Base.connecting_to(role: :writing) do
  ...
end
```

Thoughts? > @eileencodes @dhh 