### PR TITLE
 Fix: Inclusion of DateTime in a Date range and vice versa

### DIFF
--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -3,5 +3,6 @@
 require "active_support/core_ext/range/conversions"
 require "active_support/core_ext/range/compare_range"
 require "active_support/core_ext/range/include_time_with_zone"
+require "active_support/core_ext/range/include_date_time"
 require "active_support/core_ext/range/overlaps"
 require "active_support/core_ext/range/each"

--- a/activesupport/lib/active_support/core_ext/range/include_date_time.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_date_time.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module IncludeDateTime #:nodoc:
+    # Extends the default Range#include? to support
+    # Date and DateTime range comparisons.
+    #
+    #   (Date.today.beginning_of_month..Date.today.end_of_month).include?(Date.today) # => true
+    #   (Date.today.beginning_of_month..Date.today.end_of_month).include?(DateTime.now) # => true
+    #   (DateTime.now.beginning_of_month..DateTime.now.end_of_month).include?(Date.today) # => true
+    #   (DateTime.now.beginning_of_month..DateTime.now.end_of_month).include?(DateTime.now) # => true
+    #
+    def include?(value)
+      if first.is_a?(Date) || first.is_a?(DateTime)
+        cover?(value)
+      elsif last.is_a?(Date) || last.is_a?(DateTime)
+        cover?(value)
+      else
+        super
+      end
+    end
+  end
+end
+
+Range.prepend(ActiveSupport::IncludeDateTime)

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -52,6 +52,39 @@ class RangeTest < ActiveSupport::TestCase
     assert(range.include?(DateTime.now))
   end
 
+  def test_date_range_includes_time
+    range = Date.yesterday..Date.tomorrow
+
+    assert(range.include?(Time.now))
+  end
+
+  def test_date_range_includes_time_with_zone
+    time_with_zone = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["UTC"], Time.now.utc)
+    range = Date.yesterday..Date.tomorrow
+
+    assert(range.include?(time_with_zone))
+  end
+
+  def test_date_time_range_includes_time
+    range = DateTime.yesterday..DateTime.tomorrow
+
+    assert(range.include?(Time.now))
+  end
+
+  def test_time_with_zone_range_includes_time_with_zone
+    yesterday = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["UTC"], 1.day.ago)
+    time_with_zone = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["UTC"], Time.now.utc)
+    range = (yesterday..1.minute.from_now)
+
+    assert(range.include?(time_with_zone))
+  end
+
+  def test_time_with_zone_range_includes_date
+    range = (1.week.ago..2.days.from_now)
+
+    assert(range.include?(Date.today))
+  end
+
   def test_overlaps_last_inclusive
     assert((1..5).overlaps?(5..10))
   end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -32,6 +32,26 @@ class RangeTest < ActiveSupport::TestCase
     assert_instance_of Range, DateTime.new..DateTime::Infinity.new
   end
 
+  def test_date_range_includes_date
+    range = Date.today.beginning_of_month..Date.today.end_of_month
+    assert(range.include?(Date.today))
+  end
+
+  def test_date_range_includes_date_time
+    range = Date.today.beginning_of_month..Date.today.end_of_month
+    assert(range.include?(DateTime.now))
+  end
+
+  def test_date_time_range_includes_date
+    range = DateTime.now.beginning_of_month..DateTime.now.end_of_month
+    assert(range.include?(Date.today))
+  end
+
+  def test_date_time_range_includes_date_time
+    range = DateTime.now.beginning_of_month..DateTime.now.end_of_month
+    assert(range.include?(DateTime.now))
+  end
+
   def test_overlaps_last_inclusive
     assert((1..5).overlaps?(5..10))
   end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/36175 which exists for Rails 5.2.3 and Rails 6, too.

With this fix, the range inclusion predicate method works as intended.

```ruby
(Date.today.beginning_of_month..Date.today.end_of_month).include?(Date.today) # => true
(Date.today.beginning_of_month..Date.today.end_of_month).include?(DateTime.now) # => true
(DateTime.now.beginning_of_month..DateTime.now.end_of_month).include?(Date.today) # => true
(DateTime.now.beginning_of_month..DateTime.now.end_of_month).include?(DateTime.now) # => true
```