### PR TITLE
Rename LookupContext#prefixes to #partial_prefixes

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,7 +15,7 @@ module ActionView
   # view paths, used in the resolver cache lookup. Since this key is generated
   # only once during the request, it speeds up all cache accesses.
   class LookupContext #:nodoc:
-    attr_accessor :prefixes, :rendered_format
+    attr_accessor :partial_prefixes, :rendered_format
     deprecate :rendered_format
     deprecate :rendered_format=
 
@@ -166,7 +166,7 @@ module ActionView
             @view_paths = _view_paths
           end
         else
-          ActionView::LookupContext.new(view_paths, @details, @prefixes)
+          ActionView::LookupContext.new(view_paths, @details, @partial_prefixes)
         end
       end
 
@@ -246,11 +246,11 @@ module ActionView
     include DetailsCache
     include ViewPaths
 
-    def initialize(view_paths, details = {}, prefixes = [])
+    def initialize(view_paths, details = {}, partial_prefixes = [])
       @details_key = nil
       @digest_cache = nil
       @cache = true
-      @prefixes = prefixes
+      @partial_prefixes = partial_prefixes
 
       @details = initialize_details({}, details)
       @view_paths = build_view_paths(view_paths)
@@ -264,7 +264,7 @@ module ActionView
       details = @details.dup
       details[:formats] = formats
 
-      self.class.new(@view_paths, details, @prefixes)
+      self.class.new(@view_paths, details, @partial_prefixes)
     end
 
     def initialize_details(target, details)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -291,7 +291,7 @@ module ActionView
 
     def initialize(*)
       super
-      @context_prefix = @lookup_context.prefixes.first
+      @context_prefix = @lookup_context.partial_prefixes.first
     end
 
     def render(context, options, block)
@@ -429,7 +429,7 @@ module ActionView
       end
 
       def find_template(path, locals)
-        prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
+        prefixes = path.include?(?/) ? [] : @lookup_context.partial_prefixes
         @lookup_context.find_template(path, prefixes, true, locals, @details)
       end
 

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -180,6 +180,6 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def test_lookup_context_accessor
-    assert_equal ["test"], TestController.new.lookup_context.prefixes
+    assert_equal ["test"], TestController.new.lookup_context.partial_prefixes
   end
 end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -236,10 +236,10 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_not_equal template, old_template
   end
 
-  test "responds to #prefixes" do
-    assert_equal [], @lookup_context.prefixes
-    @lookup_context.prefixes = ["foo"]
-    assert_equal ["foo"], @lookup_context.prefixes
+  test "responds to #partial_prefixes" do
+    assert_equal [], @lookup_context.partial_prefixes
+    @lookup_context.partial_prefixes = ["foo"]
+    assert_equal ["foo"], @lookup_context.partial_prefixes
   end
 end
 


### PR DESCRIPTION
This is related to https://github.com/rails/rails/issues/30131
The purpose of `LookupContext`'s `prefixes` attribute is actually different than the prefixes we pass in template finding methods like `find_template` or `find_all`...etc. Current usages of the `prefixes` method is only to provide default prefix info for `PartialRenderer`. So I think it'll avoid confusion and help future refactoring if we can name it differently.