### PR TITLE
Remove ignored_sql from SQLCounter by adding "TRANSACTION" to log name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
@@ -8,15 +8,15 @@ module ActiveRecord
       end
 
       def create_savepoint(name = current_savepoint_name)
-        execute("SAVEPOINT #{name}")
+        execute("SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def exec_rollback_to_savepoint(name = current_savepoint_name)
-        execute("ROLLBACK TO SAVEPOINT #{name}")
+        execute("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def release_savepoint(name = current_savepoint_name)
-        execute("RELEASE SAVEPOINT #{name}")
+        execute("RELEASE SAVEPOINT #{name}", "TRANSACTION")
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -204,7 +204,7 @@ module ActiveRecord
       end
 
       def begin_db_transaction
-        execute "BEGIN"
+        execute("BEGIN", "TRANSACTION")
       end
 
       def begin_isolated_db_transaction(isolation)
@@ -213,11 +213,11 @@ module ActiveRecord
       end
 
       def commit_db_transaction #:nodoc:
-        execute "COMMIT"
+        execute("COMMIT", "TRANSACTION")
       end
 
       def exec_rollback_db_transaction #:nodoc:
-        execute "ROLLBACK"
+        execute("ROLLBACK", "TRANSACTION")
       end
 
       def empty_insert_statement_value(primary_key = nil)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -145,7 +145,7 @@ module ActiveRecord
 
         # Begins a transaction.
         def begin_db_transaction
-          execute "BEGIN"
+          execute("BEGIN", "TRANSACTION")
         end
 
         def begin_isolated_db_transaction(isolation)
@@ -155,12 +155,12 @@ module ActiveRecord
 
         # Commits a transaction.
         def commit_db_transaction
-          execute "COMMIT"
+          execute("COMMIT", "TRANSACTION")
         end
 
         # Aborts a transaction.
         def exec_rollback_db_transaction
-          execute "ROLLBACK"
+          execute("ROLLBACK", "TRANSACTION")
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -68,15 +68,15 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         def begin_db_transaction #:nodoc:
-          log("begin transaction", nil) { @connection.transaction }
+          log("begin transaction", "TRANSACTION") { @connection.transaction }
         end
 
         def commit_db_transaction #:nodoc:
-          log("commit transaction", nil) { @connection.commit }
+          log("commit transaction", "TRANSACTION") { @connection.commit }
         end
 
         def exec_rollback_db_transaction #:nodoc:
-          log("rollback transaction", nil) { @connection.rollback }
+          log("rollback transaction", "TRANSACTION") { @connection.rollback }
         end
 
 

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -13,7 +13,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   module MissingSuperuserPrivileges
-    def execute(sql)
+    def execute(sql, name = nil)
       if IS_REFERENTIAL_INTEGRITY_SQL.call(sql)
         super "BROKEN;" rescue nil # put transaction in broken state
         raise ActiveRecord::StatementInvalid, "PG::InsufficientPrivilege"
@@ -24,7 +24,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   module ProgrammerMistake
-    def execute(sql)
+    def execute(sql, name = nil)
       if IS_REFERENTIAL_INTEGRITY_SQL.call(sql)
         raise ArgumentError, "something is not right."
       else

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -107,20 +107,12 @@ module ActiveRecord
 
     clear_log
 
-    self.ignored_sql = [/^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/]
-
-    attr_reader :ignore
-
-    def initialize(ignore = Regexp.union(self.class.ignored_sql))
-      @ignore = ignore
-    end
-
     def call(name, start, finish, message_id, values)
       return if values[:cached]
 
       sql = values[:sql]
       self.class.log_all << sql
-      self.class.log << sql unless values[:name] == "SCHEMA" || ignore.match?(sql)
+      self.class.log << sql unless ["SCHEMA", "TRANSACTION"].include? values[:name]
     end
   end
 


### PR DESCRIPTION
### Summary

Remove ignored_sql from SQLCounter by adding "TRANSACTION" to log name.

This commit adds "TRANSACTION" to savepoint and commit, rollback statements
because none of savepoint statements were removed by #36153 since they are not "SCHEMA" statements.

Although, only savepoint statements can be labeled as "TRANSACTION"
I think all of transaction related method should add this label.

Follow up #36153
