### PR TITLE
Update directory name in example commands [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -340,7 +340,7 @@ $ TEST_DIR=generators bundle exec rake test
 You can run the tests for a particular file by using:
 
 ```bash
-$ cd actionpack
+$ cd actionview
 $ bundle exec ruby -w -Itest test/template/form_helper_test.rb
 ```
 


### PR DESCRIPTION
This is just a small fix: the file is actually located in `actionview` instead of `actionpack`