### PR TITLE
Fix: ActiveRecord::RecordInvalid is not raised when an associated record fails to #save! due to uniqueness validation failure

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -411,7 +411,7 @@ module ActiveRecord
                 saved = record.save(validate: false)
               end
 
-              raise ActiveRecord::Rollback unless saved
+              raise(RecordInvalid.new(association.owner)) unless saved
             end
           end
         end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/author"
+require "models/book"
 require "models/bird"
 require "models/post"
 require "models/comment"
@@ -1685,6 +1686,10 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
     @pirate.birds.create(name: "cookoo")
+
+    @author = Author.new(name: "DHH")
+    @author.published_books.build(name: "Rework", isbn: "1234")
+    @author.published_books.build(name: "Remote", isbn: "1234")
   end
 
   test "should automatically validate associations" do
@@ -1692,6 +1697,42 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     @pirate.birds.each { |bird| bird.name = "" }
 
     assert_not_predicate @pirate, :valid?
+  end
+
+  test "rollbacks whole transaction and raises ActiveRecord::RecordInvalid when associations fail to #save! due to uniqueness validation failure" do
+    author_count_before_save = Author.count
+    book_count_before_save = Book.count
+
+    assert_no_difference "Author.count" do
+      assert_no_difference "Book.count" do
+        exception = assert_raises(ActiveRecord::RecordInvalid) do
+          @author.save!
+        end
+
+        assert_equal("Validation failed: Published books is invalid", exception.message)
+      end
+    end
+
+    assert_equal(author_count_before_save, Author.count)
+    assert_equal(book_count_before_save, Book.count)
+  end
+
+  test "rollbacks whole transaction when associations fail to #save due to uniqueness validation failure" do
+    author_count_before_save = Author.count
+    book_count_before_save = Book.count
+
+    assert_no_difference "Author.count" do
+      assert_no_difference "Book.count" do
+        assert_nothing_raised do
+          result = @author.save
+
+          assert_not(result)
+        end
+      end
+    end
+
+    assert_equal(author_count_before_save, Author.count)
+    assert_equal(book_count_before_save, Book.count)
   end
 end
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -116,6 +116,7 @@ class Author < ActiveRecord::Base
   has_many :tags_with_primary_key, through: :posts
 
   has_many :books
+  has_many :published_books, class_name: "PublishedBook"
   has_many :unpublished_books, -> { where(status: [:proposed, :written]) }, class_name: "Book"
   has_many :subscriptions,        through: :books
   has_many :subscribers, -> { order("subscribers.nick") }, through: :subscriptions

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -24,3 +24,9 @@ class Book < ActiveRecord::Base
     "do publish work..."
   end
 end
+
+class PublishedBook < ActiveRecord::Base
+  self.table_name = "books"
+
+  validates_uniqueness_of :isbn
+end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/35528.

The issue #35528 only occurs when trying to `#save!` a parent record along with associated child records which violate the uniqueness constraint.  So far, when other validations such as presence, inclusion, etc. fail, it raises `ActiveRecord::RecordInvalid`. But when the uniqueness validation fails, instead of raising `ActiveRecord::RecordInvalid`, it simply returns `nil`. 

Before this fix:

```ruby
class Book < ActiveRecord::Base
  belongs_to :author
  validates_uniqueness_of :isbn
end

author = Author.new(name: "DHH")
author.books.build(name: "Rework", isbn: "1234")
author.books.build(name: "Remote", isbn: "1234")

author.save! # returns nil
author.persisted? # false
```

After this fix:

```ruby
class Book < ActiveRecord::Base
  belongs_to :author
  validates_uniqueness_of :isbn
end

author = Author.new(name: "DHH")
author.books.build(name: "Rework", isbn: "1234")
author.books.build(name: "Remote", isbn: "1234")

author.save! # raises "ActiveRecord::RecordInvalid (Validation failed: Books is invalid)"
author.persisted? # false
```

Note that the silent transaction rollback feature stays unaffected and works as expected with this fix.