### PR TITLE
Fix indentation for config.eager_load nil warning message

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -20,13 +20,13 @@ module Rails
       initializer :set_eager_load, group: :all do
         if config.eager_load.nil?
           warn <<-INFO
-config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:
+            config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:
 
-  * development - set it to false
-  * test - set it to false (unless you use a tool that preloads your test environment)
-  * production - set it to true
+              * development - set it to false
+              * test - set it to false (unless you use a tool that preloads your test environment)
+              * production - set it to true
 
-INFO
+          INFO
           config.eager_load = config.cache_classes
         end
       end


### PR DESCRIPTION
While checking #36211, I found the warning message had an inconsistent indentation. This PR just fixes the indentation. 