### PR TITLE
Update testing guide to reflect changes from #36047

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -781,7 +781,7 @@ This can be helpful for viewing the browser at the point a test failed, or
 to view screenshots later for debugging.
 
 Two methods are provided: `take_screenshot` and `take_failed_screenshot`.
-`take_failed_screenshot` is automatically included in `after_teardown` inside
+`take_failed_screenshot` is automatically included in `before_teardown` inside
 Rails.
 
 The `take_screenshot` helper method can be included anywhere in your tests to


### PR DESCRIPTION
### Summary

In #36047 we moved `take_failed_screenshot` from an `after_teardown` hook to a `before_teardown` hook. However, I didn't realize the [Testing rails guide](https://guides.rubyonrails.org/testing.html#implementing-a-system-test) was explicitly mentioning that it happened inside `after_teardown`. So this updates the docs to be consistent with that change.