### PR TITLE
Add server timing middleware

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -66,6 +66,7 @@ module ActionDispatch
     autoload :ShowExceptions
     autoload :SSL
     autoload :Static
+    autoload :ServerTiming
   end
 
   autoload :Journey

--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "action_dispatch/middleware/server_timing_subscriber"
+
+module ActionDispatch
+  class ServerTiming
+    SERVER_TIMING_HEADER = "Server-Timing"
+
+    class << self
+      def add_timing(key:, dur: nil, desc: nil)
+        timings[key] = { dur: dur, desc: desc }
+      end
+
+      def to_header
+        metrics = []
+        timings.each_pair do |key, data|
+          metric = +key.to_s
+          metric << ";desc=\"#{data[:desc]}\"" if data[:desc]
+          metric << ";dur=#{data[:dur]}" if data[:dur]
+          metrics << metric
+        end
+        metrics.join(", ")
+      end
+
+      def measure(key, desc: nil, &blk)
+        ActiveSupport::Notifications.instrument("measure.server_timing", desc: desc, key: key) do
+          yield
+        end
+      end
+
+      def timings
+        Thread.current[:server_timing] ||= {}
+      end
+
+      def clear_timings!
+        Thread.current[:server_timing] = {}
+      end
+    end
+
+    def initialize(app, events: [], all_events: false)
+      @app = app
+      if all_events
+        subscribe_to_all_events
+      else
+        subscribe_to_events(events)
+      end
+    end
+
+    def call(env)
+      @app.call(env).tap do |_, headers, _|
+        add_timing_headers(headers)
+      end
+    ensure
+      self.class.clear_timings!
+    end
+
+    private
+
+      def add_timing_headers(headers)
+        headers[SERVER_TIMING_HEADER] = self.class.to_header
+      end
+
+      def subscribe_to_all_events
+        ActiveSupport::Notifications.subscribe(/.*/) do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+
+          ServerTiming.add_timing(
+            key: event.payload.dig(:server_timing, :key) || event.name,
+            dur: event.duration,
+            desc: event.payload.dig(:server_timing, :desc)
+          )
+        end
+      end
+
+      def subscribe_to_events(events_config)
+        events_config.each do |event_config|
+          if event_config.is_a?(String)
+            ActiveSupport::Notifications.subscribe(event_config) do |*args|
+              event = ActiveSupport::Notifications::Event.new(*args)
+
+              ServerTiming.add_timing(
+                key: event.payload.dig(:server_timing, :key) || event.name,
+                dur: event.duration,
+                desc: event.payload.dig(:server_timing, :desc)
+              )
+            end
+          else
+            event_name, keys = event_config.first
+            keys.each do |key|
+              ActiveSupport::Notifications.subscribe(event_name) do |*args|
+                event = ActiveSupport::Notifications::Event.new(*args)
+
+                ServerTiming.add_timing(
+                  key: key,
+                  dur: event.payload.fetch(key),
+                  desc: event.payload.dig(:server_timing, :desc)
+                )
+              end
+            end
+          end
+        end
+      end
+  end
+end

--- a/actionpack/lib/action_dispatch/middleware/server_timing_subscriber.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing_subscriber.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "active_support/subscriber"
+
+module ActionDispatch
+  class ServerTimingSubscriber < ActiveSupport::Subscriber
+    def measure(event)
+      ServerTiming.add_timing(
+        key: event.payload[:key],
+        desc: event.payload[:desc],
+        dur: event.duration
+      )
+    end
+  end
+
+  ServerTimingSubscriber.attach_to :server_timing
+end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -58,5 +58,15 @@ module ActionDispatch
         include app.routes.url_helpers
       end
     end
+
+    initializer "action_dispatch.server_timing" do
+      if events = config.action_dispatch.delete(:server_timing)
+        if events == true
+          config.app_middleware.insert_after ActionDispatch::Executor, ActionDispatch::ServerTiming, all_events: true
+        else
+          config.app_middleware.insert_after ActionDispatch::Executor, ActionDispatch::ServerTiming, events: events
+        end
+      end
+    end
   end
 end

--- a/actionpack/test/dispatch/server_timing_test.rb
+++ b/actionpack/test/dispatch/server_timing_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module ActionDispatch
+  class ServerTimingTest < ActiveSupport::TestCase
+    def teardown
+      ServerTiming.clear_timings!
+    end
+
+    def test_to_header_with_only_a_key
+      ServerTiming.add_timing(key: :test)
+      assert_equal "test", ServerTiming.to_header
+    end
+
+    def test_to_header_with_key_duration_and_description
+      ServerTiming.add_timing(key: :test, dur: 3, desc: "desc")
+      assert_equal 'test;desc="desc";dur=3', ServerTiming.to_header
+    end
+
+    def test_to_header_with_key_and_duration
+      ServerTiming.add_timing(key: :test, dur: 3)
+      assert_equal "test;dur=3", ServerTiming.to_header
+    end
+
+    def test_to_header_with_key_and_description
+      ServerTiming.add_timing(key: :test, desc: "test")
+      assert_equal 'test;desc="test"', ServerTiming.to_header
+    end
+
+    def test_to_header_with_multiple_timings
+      expected_header = 'test;desc="test";dur=1, test2;desc="test2";dur=2'
+      ServerTiming.add_timing(key: :test,  desc: "test", dur: 1)
+      ServerTiming.add_timing(key: :test2, desc: "test2", dur: 2)
+      assert_equal expected_header, ServerTiming.to_header
+    end
+
+    def test_measure
+      ServerTiming.measure(:test, desc: "desc") do
+        "do a thing"
+      end
+
+      assert_not_nil ServerTiming.timings[:test]
+      assert_not_nil ServerTiming.timings[:test][:dur]
+      assert_equal "desc", ServerTiming.timings[:test][:desc]
+    end
+
+    def test_middleware_adds_server_timing_headers
+      app = -> env do
+        ServerTiming.add_timing(key: :test, dur: 1, desc: "desc")
+
+        [ 200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app).call({})
+
+      assert_equal 'test;desc="desc";dur=1', response[1]["Server-Timing"]
+    end
+
+    def test_timings_are_cleared_even_if_there_is_an_exception_during_the_request
+      app = -> env do
+        ServerTiming.add_timing(key: :test, dur: 1, desc: "desc")
+        raise
+      end
+
+      assert_raises do
+        ServertTiming.new(app).call({})
+      end
+
+      assert_empty ServerTiming.timings
+    end
+
+    def test_subscribes_to_all_events_when_subscribe_all_is_set_to_true
+      app = -> env do
+        ActiveSupport::Notifications.instrument("my_test") { "do a thing" }
+        ActiveSupport::Notifications.instrument("my_other_test") { "do another thing" }
+
+        [ 200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app, all_events: true).call({})
+
+      assert_match(/my_test;dur=.*, my_other_test;dur=.*/, response[1]["Server-Timing"])
+    end
+
+    def test_subscribe_to_custom_events
+      app = -> env do
+        ActiveSupport::Notifications.instrument("custom_event") { "do a thing" }
+        ActiveSupport::Notifications.instrument("do_not_susbcribe") { "do another thing" }
+
+        [ 200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app, events: ["custom_event"]).call({})
+
+      assert_match(/custom_event;dur=.*/, response[1]["Server-Timing"])
+    end
+
+    def test_extract_duration_from_custom_keys_for_events
+      app = -> env do
+        ActiveSupport::Notifications.instrument("event_with_keys", foo: 1, bar: 2)
+
+        [ 200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app, events: [{ "event_with_keys" => [:foo, :bar] }]).call({})
+
+      assert_equal "foo;dur=1, bar;dur=2", response[1]["Server-Timing"]
+    end
+
+    def test_providing_key_and_description_through_server_timing_key_in_event_payload
+      app = -> env do
+        ActiveSupport::Notifications.instrument("test_event", server_timing: { key: "my_key", desc: "my_desc" }) do
+          "do the thing"
+        end
+
+        [200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app, events: [ "test_event" ]).call({})
+
+      assert_match(/my_key;desc="my_desc";dur=.*/, response[1]["Server-Timing"])
+    end
+
+    def test_measure_returns_correct_headers
+      app = -> env do
+        ActionDispatch::ServerTiming.measure("measure_test") do
+          "do the thing"
+        end
+
+        [200, {}, [""]]
+      end
+
+      response = ServerTiming.new(app, all_events: false).call({})
+
+      assert_match(/test;dur=.*/, response[1]["Server-Timing"])
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This is a proposal for adding a server timing middleware to rails: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing

This is an implementation based on `ActiveSupport::Notifications`.

This is what the headers look like in the chrome dev tools: 

![server_timing](https://user-images.githubusercontent.com/6386302/57709217-a4677300-7638-11e9-963d-66bada018fc1.png)

The `list_item` is a custom field and `View` and `DB` are default fields provided by the rails controller. 

The proposed API for this is: 
#### In an environment config file

``` ruby
# to enable server timing with the selected defaults
config.action_dispatch.server_timing = [:view_runtime, :db_runtime]

# to enable server timing with no defauts
config.action_dispatch.server_timing = []
```

#### Within application code

``` ruby
class MyController < ApplicationController
  def index
    # desc is optional
    # #measure times the block of code and adds the timing to the response headers with the right key and desc
    ActionDispatch::ServerTiming.measure(key: :things_list, desc: :things) do
      @things = Thing.all
    end
    
    # register a value directly in the headers.
    ActionDispatch::ServerTiming.add_timing(key: :other_thing, desc: :other_things, dur: 80)
  end
end
```

Manually creating a subscriber and instrumenting 

``` ruby
class RedisRead < ActionDispatch::ServerTimingSubscriber
end

RedisRead.attach_to :redis_read

# somewhere else
ActiveSupport::Notifications.instrument("measure.redis_read", key: :redis_read) do
 val =  Redis.get("some_key")
end
```

If we are happy with this approach I can start adding some documentation. 

cc: @gsamokovarov 