### PR TITLE
Only build middleware proxy when instrumentating

### DIFF
--- a/actionpack/test/controller/show_exceptions_test.rb
+++ b/actionpack/test/controller/show_exceptions_test.rb
@@ -99,7 +99,7 @@ module ShowExceptions
   class ShowFailsafeExceptionsTest < ActionDispatch::IntegrationTest
     def test_render_failsafe_exception
       @app = ShowExceptionsOverriddenController.action(:boom)
-      middleware = @app.instance_variable_get(:@middleware)
+      middleware = @app
       @exceptions_app = middleware.instance_variable_get(:@exceptions_app)
       middleware.instance_variable_set(:@exceptions_app, nil)
       $stderr = StringIO.new

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -121,9 +121,6 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   end
 
   test "instruments the execution of middlewares" do
-    app = @stack.build(proc { |env| [200, {}, []] })
-    env = {}
-
     events = []
 
     subscriber = proc do |*args|
@@ -131,6 +128,9 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
 
     ActiveSupport::Notifications.subscribed(subscriber, "process_middleware.action_dispatch") do
+      app = @stack.build(proc { |env| [200, {}, []] })
+
+      env = {}
       app.call(env)
     end
 


### PR DESCRIPTION
The instrumentation proxy introduced in #34305 adds three stack frames per-middleware, even when nothing is listening.

With this commit, when the middleware stack is built, instrumentation is only added when the `process_middleware.action_dispatch` event has already been subscribed to.

The advantage to this is that we don't have any extra stack frames in apps which don't need middleware instrumentation.

The disadvantage is that the subscriptions need to be in place when the middleware stack is built (ie. during app boot). I think this might be okay because temporary AS::Notifications subscriptions are strongly discouraged.

cc @dasch @jeremy @SamSaffron @tenderlove  