### PR TITLE
Fix indentation of the config.eager_load nil warning

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -19,7 +19,7 @@ module Rails
 
       initializer :set_eager_load, group: :all do
         if config.eager_load.nil?
-          warn <<-INFO
+          warn <<~INFO
             config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:
 
               * development - set it to false


### PR DESCRIPTION
Before #36214:
```
vagrant@rails-dev-box:/vagrant/rails/my-test-app$ bin/rails c
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

Loading development environment (Rails 6.1.0.alpha)
irb(main):001:0>
```

After #36214:
```
vagrant@rails-dev-box:/vagrant/rails/my-test-app$ bin/rails c
            config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

              * development - set it to false
              * test - set it to false (unless you use a tool that preloads your test environment)
              * production - set it to true

Loading development environment (Rails 6.1.0.alpha)
irb(main):001:0>
```

This PR changes the behavior to what it was before #36214.

I think the indentation "feels" wrong when reading the code because some places in code are using `<<-` for heredocs whereas some places are using `<<~` which allows text inside it to be indented. 
If you agree, I would like to change all places to use `<<~` so the text inside it would appear well formatted when reading the source in a separate pull request.
