### PR TITLE
Use a better requirement for sass-rails 6 prereleases

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -307,7 +307,7 @@ module Rails
       def assets_gemfile_entry
         return [] if options[:skip_sprockets]
 
-        GemfileEntry.version("sass-rails", "~> 5", "Use SCSS for stylesheets")
+        GemfileEntry.version("sass-rails", ">= 5", "Use SCSS for stylesheets")
       end
 
       def webpacker_gemfile_entry


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/commit/2e4c65e3afb18fc9a84d4d3ae893209efce27592 introduced the `~> 5` dependency for sass-rails in generators, to allow sass-rails 6 prereleases.

Although this is the behavior I naively expect for the operator when used with a single digit, it's
definitely an edge case for it, and it doesn't seem to work as expected for including prereleases.

Using >= works fine and makes the intention more clear anyways.

Closes #36112.

### Other Information

On a related note, shouldn't we use `sassc-rails` here? Making `sass-rails` a thin wrapper for `sassc-rails` is great for existing applications transitioning, but since no further development will be performed in `sass-rails`, I think generators should point directly to `sassc-rails`?