### PR TITLE
Remove `report-uri` directive when arugment returns `nil`

### DIFF
--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -171,6 +171,19 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_match %r{report-uri /violations}, @policy.build
   end
 
+  def test_reporting_directives_when_nil
+    @policy.report_uri nil
+    @policy.default_src :self
+    assert_no_match %r{report-uri}, @policy.build
+  end
+
+  def test_reporting_directives_when_argument_proc_returns_nil
+    controller = ActionController::Base.new
+    @policy.report_uri proc { nil }
+    @policy.default_src :self
+    assert_no_match %r{report-uri}, @policy.build(controller)
+  end
+
   def test_other_directives
     @policy.block_all_mixed_content
     assert_match %r{block-all-mixed-content}, @policy.build


### PR DESCRIPTION
This is the continuation of #34704

It updates the CSP `report_uri` method to only include the `report-uri` directive if the value provided to it isn't `nil`.

Fixes #34703