### PR TITLE
Prevent reading inline attachments after `mail` was called from raising an inaccurate exception

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -738,7 +738,7 @@ module ActionMailer
     end
 
     class LateAttachmentsProxy < SimpleDelegator
-      def inline; _raise_error end
+      def inline; self end
       def []=(_name, _content); _raise_error end
 
       private

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -267,6 +267,17 @@ class BaseTest < ActiveSupport::TestCase
     assert_match(/Can't add attachments after `mail` was called./, e.message)
   end
 
+  test "accessing inline attachments after mail was called works" do
+    class LateInlineAttachmentMailer < ActionMailer::Base
+      def welcome
+        mail body: "yay", from: "welcome@example.com", to: "to@example.com"
+        attachments.inline["invoice.pdf"]
+      end
+    end
+
+    assert_nothing_raised { LateInlineAttachmentMailer.welcome.message }
+  end
+
   test "adding inline attachments while rendering mail works" do
     class LateInlineAttachmentMailer < ActionMailer::Base
       def on_render


### PR DESCRIPTION
### Summary

Without this change, `attachments.inline['my_attachment'].present?`, for example, would raise the exception `Can't add attachments after mail was called`.

I first brought this issue up at https://github.com/rails/rails/issues/16163#issuecomment-437378347.

Note that this commit addresses only one of the 2 problems I described in that comment.  The other problem is that using `attachments.inline['my_attachment']` for reading an attachment is unnecessary--it's the same as `attachments['my_attachment']` even before `mail` is called (see https://github.com/mikel/mail/blob/2.7.1/lib/mail/attachments_list.rb#L20).  We could add a warning about the unnecessary use of `inline` but I'm saving that for a later PR since my comment has not received any feedback yet.