### PR TITLE
Fix database loading when ERB is single line ternary

### DIFF
--- a/railties/lib/rails/application/dummy_erb_compiler.rb
+++ b/railties/lib/rails/application/dummy_erb_compiler.rb
@@ -13,7 +13,12 @@ class DummyCompiler < ERB::Compiler # :nodoc:
   def compile_content(stag, out)
     case stag
     when "<%="
-      out.push "_erbout << 'dummy_compiler'"
+      content = out.instance_variable_get(:@compiler).instance_variable_get(:@content)
+      if content.include?("?") && content.include?(":")
+        out.push "_erbout << 'dummy_key: dummy_value'"
+      else
+        out.push "_erbout << 'dummy_value'"
+      end
     end
   end
 end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -122,6 +122,22 @@ module ApplicationTests
         db_create_and_drop("db/development.sqlite3", environment_loaded: false)
       end
 
+      test "db:create and db:drop dont raise errors when loading YAML with FIXME ERB" do
+        app_file "config/database.yml", <<-YAML
+          development:
+            <%= Rails.application.config.database ? 'database: db/development.sqlite3' : 'database: db/development.sqlite3' %>
+            adapter: sqlite3
+        YAML
+
+        app_file "config/environments/development.rb", <<-RUBY
+          Rails.application.configure do
+            config.database = "db/development.sqlite3"
+          end
+        RUBY
+
+        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+      end
+
       def with_database_existing
         Dir.chdir(app_path) do
           set_database_url


### PR DESCRIPTION
*sigh* this seems like the never ending bug. I don't love or even like
this fix but it does _work_.

Rafael suggested using `dummy_key: dummy_value` but unfortunately
that doesn't work. So we're left with checking whethere there might be
ternary type things in the content and then assuming that we want to
replace the line with a key value pair.

Technically fixes https://github.com/rails/rails/issues/36088

cc/ @rafaelfranca @anamba @tenderlove @matthewd 