### PR TITLE
[ci skip] Clarity about embed metadata in signed and encrypted cookie

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -245,7 +245,7 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 *   Expose `ActionController::Parameters#each_key`.
     ([Pull Request](https://github.com/rails/rails/pull/33758))
 
-*   Add purpose metadata to signed/encrypted cookies to prevent copying the value of
+*   Add purpose and expiry metadata inside signed/encrypted cookies to prevent copying the value of
     cookies into one another.
     ([Pull Request](https://github.com/rails/rails/pull/32937))
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -85,13 +85,14 @@ Rails 6.1. You are encouraged to enable `config.force_ssl` to enforce HTTPS
 connections throughout your application. If you need to exempt certain endpoints
 from redirection, you can use `config.ssl_options` to configure that behavior.
 
-### Purpose in signed or encrypted cookie is now embedded within cookies
+### Purpose and expiry metadata is now embedded inside signed and encrypted cookies for increased security
 
-To improve security, Rails embeds the purpose information in encrypted or signed cookies value.
+To improve security, Rails embeds the purpose and expiry metadata inside encrypted or signed cookies value.
+
 Rails can then thwart attacks that attempt to copy the signed/encrypted value
 of a cookie and use it as the value of another cookie.
 
-This new embed information make those cookies incompatible with versions of Rails older than 6.0.
+This new embed metadata make those cookies incompatible with versions of Rails older than 6.0.
 
 If you require your cookies to be read by Rails 5.2 and older, or you are still validating your 6.0 deploy and want
 to be able to rollback set


### PR DESCRIPTION
`purpose` is not a known entity, `purpose metadata` is.