### PR TITLE
[ci skip] Fix grammar

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -229,7 +229,7 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 *   Allow the use of `parsed_body` in `ActionController::TestCase`.
     ([Pull Request](https://github.com/rails/rails/pull/34717))
 
-*   Raise an `ArgumentError` when multiple root routes exists in the same context
+*   Raise an `ArgumentError` when multiple root routes exist in the same context
     without `as:` naming specifications.
     ([Pull Request](https://github.com/rails/rails/pull/34494))
 


### PR DESCRIPTION
Singular: `route exists`
Plural: `routes exist`