### PR TITLE
[ci skip] ActionView -> Action View

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -298,7 +298,7 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Notable changes
 
-*   Clear ActionView cache in development only on file changes, speeding up
+*   Clear Action View cache in development only on file changes, speeding up
     development mode.
     ([Pull Request](https://github.com/rails/rails/pull/35629))
 


### PR DESCRIPTION
As per the documentation guides, we use `Action View` instead of `ActionView` in the general language.

Reference: https://github.com/rails/rails/commit/27138386ad8dbda2eb44e622515626f352fd3b22
