### PR TITLE
Remove SQLite version support caveats [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -205,8 +205,6 @@ module ActiveRecord
       # In order to get around this problem, #transaction will emulate the effect
       # of nested transactions, by using savepoints:
       # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
-      # Savepoints are supported by MySQL and PostgreSQL. SQLite3 version >= '3.6.8'
-      # supports savepoints.
       #
       # It is safe to call this method if a database transaction is already open,
       # i.e. if #transaction is called within another #transaction block. In case

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -735,7 +735,7 @@ module ActiveRecord
       #
       #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id) WHERE active
       #
-      # Note: Partial indexes are only supported for PostgreSQL and SQLite 3.8.0+.
+      # Note: Partial indexes are only supported for PostgreSQL and SQLite.
       #
       # ====== Creating an index with a specific method
       #

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -48,8 +48,8 @@ module ActiveRecord
   end
 
   module ConnectionAdapters #:nodoc:
-    # The SQLite3 adapter works SQLite 3.6.16 or newer
-    # with the sqlite3-ruby drivers (available as gem from https://rubygems.org/gems/sqlite3).
+    # The SQLite3 adapter works with the sqlite3-ruby drivers
+    # (available as gem from https://rubygems.org/gems/sqlite3).
     #
     # Options:
     #

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -164,12 +164,12 @@ module ActiveRecord
     #     end
     #   end
     #
-    # only "Kotori" is created. This works on MySQL and PostgreSQL. SQLite3 version >= '3.6.8' also supports it.
+    # only "Kotori" is created.
     #
     # Most databases don't support true nested transactions. At the time of
     # writing, the only database that we're aware of that supports true nested
     # transactions, is MS-SQL. Because of this, Active Record emulates nested
-    # transactions by using savepoints on MySQL and PostgreSQL. See
+    # transactions by using savepoints. See
     # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
     # for more information about savepoints.
     #


### PR DESCRIPTION
Spotted when reviewing https://github.com/rails/rails/pull/36240.

Since https://github.com/rails/rails/pull/32923, Active Record requires SQLite version 3.8.0 or greater, so savepoints and partial indexes are always available.

That commit also added a runtime version check, so we can remove the minimum version requirement from the internal adapter documentation.