### PR TITLE
[skip ci] Add missing info about 'active_record.collection_cache_versioning' configuration

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -383,6 +383,12 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
+* `config.active_record.collection_cache_versioning` enables the same cache key
+  to be reused when the object being cached of type `ActiveRecord::Relation`
+  changes by moving the volatile information (max updated at and count) of
+  the relation's cache key into the cache version to support recycling cache key.
+  Defaults to `true`.
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
References:

- https://github.com/rails/rails/commit/4f2ac80d4cdb01c4d3c1765637bed76cc91c1e35
- https://github.com/rails/rails/blob/b1c917ee2fdaa452aeb52904db0d254d85285380/railties/lib/rails/application/configuration.rb#L147-L149
