### PR TITLE
[skip ci] Add undefined STI acronym to the heading which is referred under its section

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2451,8 +2451,8 @@ Extensions can refer to the internals of the association proxy using these three
 * `proxy_association.reflection` returns the reflection object that describes the association.
 * `proxy_association.target` returns the associated object for `belongs_to` or `has_one`, or the collection of associated objects for `has_many` or `has_and_belongs_to_many`.
 
-Single Table Inheritance
-------------------------
+Single Table Inheritance (STI)
+------------------------------
 
 Sometimes, you may want to share fields and behavior between different models.
 Let's say we have Car, Motorcycle, and Bicycle models. We will want to share


### PR DESCRIPTION
The section `Single Table Inheritance` in the `Active Record Associations` guide uses `STI` acronym as follows which readers of the guide must be seeing for the first time.

```
[...] STI won't work without a "type" field in the table. [...]
```

It can be hard for a first-time reader to correlate between `STI` and `Single Table Inheritance`.

This PR adds the acronym to the heading itself to reduce the confusion and save readers' time.