### PR TITLE
Backport #36257 into 6-0-stable

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -1,4 +1,4 @@
-# SQLite version 3.x
+# SQLite. Versions 3.8.0 and up are supported.
 #   gem 'activerecord-jdbcsqlite3-adapter'
 #
 # Configure Using Gemfile

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -1,4 +1,4 @@
-# SQLite version 3.x
+# SQLite. Versions 3.8.0 and up are supported.
 #   gem install sqlite3
 #
 #   Ensure the SQLite 3 gem is defined in your Gemfile


### PR DESCRIPTION
### Summary

This pull request backports #36257 into 6-0-stable branch because Rails 6.0 bumps the minimum version of SQLite by #32923. I wanted these two template files to include #36257

### Other Information
This branch has been made as follows to cherry-pick merged commit.

```
$ git cherry-pick -m 1 317543c
```

cc @vipulnsward @kamipo 