### PR TITLE
[skip ci] The default value of config.active_record.collection_cache_versioning without loading Railtie is false

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -387,7 +387,7 @@ All these configuration options are delegated to the `I18n` library.
   to be reused when the object being cached of type `ActiveRecord::Relation`
   changes by moving the volatile information (max updated at and count) of
   the relation's cache key into the cache version to support recycling cache key.
-  Defaults to `true`.
+  Defaults to `false`.
 
 The MySQL adapter adds one additional configuration option:
 


### PR DESCRIPTION
Please check https://github.com/rails/rails/pull/36260#discussion_r283266942 for reference.

[Vishal Telangre, bogdanvlviv]

@bogdanvlviv This fixes the docs as per your feedback in https://github.com/rails/rails/pull/36260. Also, as a token of appreciation, I gave you credit. 🎁