### PR TITLE
Allow `on_rotation` in MessageEncryptor to be passed in constructor:

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Allow the on_rotation proc used when decrypting/verifying a message to be
+    be passed at the constructor level.
+
+    Before:
+
+	crypt = ActiveSupport::MessageEncryptor.new('long_secret')
+	crypt.decrypt_and_verify(encrypted_message, on_rotation: proc { ... })
+	crypt.decrypt_and_verify(another_encrypted_message, on_rotation: proc { ... })
+
+    After:
+
+	crypt = ActiveSupport::MessageEncryptor.new('long_secret', on_rotation: proc { ... })
+	crypt.decrypt_and_verify(encrypted_message)
+	crypt.decrypt_and_verify(another_encrypted_message)
+
+    *Edouard Chin*
+
 *   `delegate_missing_to` would raise a `DelegationError` if the object
     delegated to was `nil`. Now the `allow_nil` option has been added to enable
     the user to specify they want `nil` returned in this case.


### PR DESCRIPTION
Allow `on_rotation` in MessageEncryptor to be passed in constructor:

- Use case:

  I'm writing a wrapper around MessageEncryptor to make things easier
  to rotate a secret in our app.

  It currently works something like
  ```ruby
  crypt = RotatableSecret.new(['old_secret', 'new_secret'])
  crypt.decrypt_and_verify(message, on_rotation: -> { ... })
  ```

  I'd like the caller to not have to care about passing the
  `on_rotation` option and have the wrapper deal with it when
  instantiating the MessageEncryptor object.

  Also, almost all of the time the on_rotation should be the same when
  rotating a secret (logging something or StatsD event) so I think
  it's not worth having to repeat ourselves each time we decrypt a message.

