### PR TITLE
Don't eager load when plucking with includes/limit

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -184,7 +184,7 @@ module ActiveRecord
       end
 
       if has_include?(column_names.first)
-        relation = apply_join_dependency
+        relation = apply_join_dependency(eager_loading: false)
         relation.pluck(*column_names)
       else
         klass.disallow_raw_sql!(column_names)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -770,6 +770,18 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [], Topic.includes(:replies).order(:id).offset(5).pluck(:id)
   end
 
+  def test_pluck_with_includes_limit
+    c = Company.create!(name: "test", contracts: [Contract.new(developer_id: 7), Contract.new(developer_id: 8)])
+    assert_equal [c.id], Company.where(id: c.id).includes(:contracts).limit(1).pluck(:id)
+    assert_equal [7], Company.where(id: c.id).includes(:contracts).limit(1).pluck(:'contracts.developer_id')
+  end
+
+  def test_pluck_same_as_outer_join
+    c = Company.create!(name: "test", contracts: [Contract.new(developer_id: 7), Contract.new(developer_id: 8)])
+    assert_equal Company.where(id: c.id).includes(:contracts).limit(1).pluck(:'contracts.developer_id'),
+      Company.where(id: c.id).left_outer_joins(:contracts).limit(1).pluck(:'contracts.developer_id')
+  end
+
   def test_pluck_with_join
     assert_equal [[2, 2], [4, 4]], Reply.includes(:topic).pluck(:id, :"topics.id")
   end


### PR DESCRIPTION
### Summary

 Consider a `Company` `c` that has many `Contract`s, and the following statement:

```ruby
Company.where(id: c.id).includes(:contracts).limit(1).pluck('contracts.id')
```

The `pluck` runs two queries, one to get distinct values of the main record primary key, which has the `LIMIT` applied, and a second to get the pluck values, with is filtered by the IDs retrieved in the first query:
 
```sql
SELECT DISTINCT "companies"."id" FROM "companies" LEFT OUTER JOIN "contracts" ON "contracts"."company_id" = "companies"."id" WHERE "companies"."id" = ? LIMIT ?  [["id", 12], ["LIMIT", 1]]
SELECT "contracts"."developer_id" FROM "companies" LEFT OUTER JOIN "contracts" ON "contracts"."company_id" = "companies"."id" WHERE "companies"."id" = ? AND "companies"."id" = ?  [["id", 12], ["id", 12]]
```

The limit is applied only to the number of records retrieved only from the first query, which means that in the `pluck` above, multiple results are returned, despite asking for 1.

As well, running a second query has a performance impact, especially if the query isn't hitting an appropriate index (as I found in my production app). In the best case scenario, it's still a second query for no benefit. Since a `pluck` statement isn't going to instantiate any AR objects, nothing will be preloaded anyways.

This change makes `includes.limit.pluck` behave identically to `left_joins.limit.pluck` (same queries, same results).

Fixes #36217.
