### PR TITLE
Update ActionView::Helpers::SanitizeHelper for upcoming rails-html-sanitizer release

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -4,7 +4,7 @@ require "rails-html-sanitizer"
 
 module ActionText
   module ContentHelper
-    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.white_list_sanitizer.new }
+    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.safe_list_sanitizer.new }
     mattr_accessor(:allowed_tags) { sanitizer.class.allowed_tags + [ ActionText::Attachment::TAG_NAME, "figure", "figcaption" ] }
     mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
     mattr_accessor(:scrubber)

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   [ActionView::Helpers::SanitizeHelper] Deprecate `#white_list_sanitizer`,
+    please use `#safe_list_sanitizer` instead.
 
+    *Juanito Fatas*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/actionview/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Prepare when https://github.com/rails/rails-html-sanitizer/commit/2191bfe73220070cb9c18d607973399af36fbaf9 released.

Tests are failing because abovementioned commit not released yet.

### Summary

- Update the sanitizer to `safe_list_sanitizer` that changed in https://github.com/rails/rails-html-sanitizer/pull/87
- deprecate `white_list_sanitizer`

### Other Information

- [x] CHANGELOG added
- [x] Checked that we do not need to update [Securing Rails Applications guide](https://guides.rubyonrails.org/security.html)
- [x] Checked that we do not need to update [Action View Overview guide](https://guides.rubyonrails.org/action_view_overview.html)

----

cc @kaspth @rafaelfranca 