### PR TITLE
Fix --skip-webpacker-install

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -311,7 +311,7 @@ module Rails
       end
 
       def webpacker_gemfile_entry
-        return [] if options[:skip_javascript]
+        return [] unless webpack_install?
 
         if options.dev? || options.edge?
           GemfileEntry.github "webpacker", "rails/webpacker", nil, "Use development version of Webpacker"


### PR DESCRIPTION
### Summary

Use the same condition to check whether webpacker is to be added to Gemfile and to check whether or not to run `webpacker:install`

### Other Information

Fixes https://github.com/rails/rails/issues/36280 / https://github.com/rails/rails/issues/35484
