### PR TITLE
Fix: DummyCompiler embeds invalid YAML content

### DIFF
--- a/railties/lib/rails/application/dummy_erb_compiler.rb
+++ b/railties/lib/rails/application/dummy_erb_compiler.rb
@@ -11,14 +11,8 @@ end
 
 class DummyCompiler < ERB::Compiler # :nodoc:
   def compile_content(stag, out)
-    case stag
-    when "<%="
-      content = out.instance_variable_get(:@compiler).instance_variable_get(:@content)
-      if content.include?("?") && content.include?(":")
-        out.push "_erbout << 'dummy_key: dummy_value'"
-      else
-        out.push "_erbout << 'dummy_value'"
-      end
+    if stag == "<%="
+      out.push "_erbout << ''"
     end
   end
 end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -138,6 +138,23 @@ module ApplicationTests
         db_create_and_drop("db/development.sqlite3", environment_loaded: false)
       end
 
+      test "db:create and db:drop don't raise errors when loading YAML which contains a key's value as an ERB statement" do
+        app_file "config/database.yml", <<-YAML
+          development:
+            database: <%= Rails.application.config.database ? 'db/development.sqlite3' : 'db/development.sqlite3' %>
+            custom_option: <%= ENV['CUSTOM_OPTION'] %>
+            adapter: sqlite3
+        YAML
+
+        app_file "config/environments/development.rb", <<-RUBY
+          Rails.application.configure do
+            config.database = "db/development.sqlite3"
+          end
+        RUBY
+
+        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+      end
+
       def with_database_existing
         Dir.chdir(app_path) do
           set_database_url


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/36237.

###  Summary

Fixes https://github.com/rails/rails/issues/36285 in which the DummyCompiler modifies the `database.yml` contents with the invalid YAML which contains the value of a key as an ERB statement.

#### Before this fix

The DummyCompiler turns 

```yml
development:
  database: <%= Rails.application.config.database ? 'db/development.sqlite3' : 'db/development.sqlite3' %>
  adapter: sqlite3
```
into 

```yml
development:
  database: dummy_key: dummy_value
  adapter: sqlite3
```

which is not a valid YAML.

```
>> content = <<-CONTENT
development:
  database: dummy_key: dummy_value
  adapter: sqlite3
CONTENT
=> "development:\n  database: dummy_key: dummy_value\n  adapter: sqlite3\n"
>> YAML.load(content)
Traceback (most recent call last):
        1: from (irb):8
Psych::SyntaxError ((<unknown>): mapping values are not allowed in this context at line 2 column 22)
```

#### After this fix

The same YAML is being converted into 

```yml
development:
  database:
  adapter: sqlite3
```

which is a valid YAML

```
>> content = <<-CONTENT
development:
  database:
  adapter: sqlite3
CONTENT
=> "development:\n  database: \n  adapter: sqlite3\n"
>> YAML.load(content)
=> {"development"=>{"database"=>nil, "adapter"=>"sqlite3"}}
```

This patch also fixes the other cases of parsing ERB in other forms which are already covered by the existing tests.

cc/ @eileencodes