### PR TITLE
Use 6.0 version of ActiveRecord::Migration for Active Storage

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,4 +1,4 @@
-class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+class CreateActiveStorageTables < ActiveRecord::Migration[6.0]
   def change
     create_table :active_storage_blobs do |t|
       t.string   :key,        null: false

--- a/activestorage/test/database/create_users_migration.rb
+++ b/activestorage/test/database/create_users_migration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActiveStorageCreateUsers < ActiveRecord::Migration[5.2]
+class ActiveStorageCreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
       t.string :name


### PR DESCRIPTION
### Summary

Changed version of ActiveRecord::Migration for Active Storage from 5.2 to 6.0

### Other Information

When I run

`$ rails action_mailbox:install` , 

migration for Action Mailbox was created in 6.0 but  migration for Active Storage was created in 5.2.

#### System configuration

`rails version: 6.0.0.rc1`
`ruby version: 2.5.5`