### PR TITLE
Call Webdrivers::Chromedriver.update in application_system_test_case.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## (Unreleased)
 
+*   Make generated application_system_test_case.rb files avoid
+    `ChildProcess::LaunchError` when parallel tests are enabled.
+
+    *Richard Macklin*
+
 *   The new configuration point `config.add_autoload_paths_to_load_path` allows
     users to opt-out from adding autoload paths to `$LOAD_PATH`. This flag is
     `true` by default, but it is recommended to be set to `false` in `:zeitwerk`

--- a/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
@@ -1,5 +1,7 @@
 require "test_helper"
 
+Webdrivers::Chromedriver.update
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb.tt
@@ -1,5 +1,7 @@
 require "test_helper"
 
+Webdrivers::Chromedriver.update
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 end

--- a/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb.tt
@@ -1,5 +1,7 @@
 require "test_helper"
 
+Webdrivers::Chromedriver.update
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
### Summary

Addresses #36288

This updates the templates for `application_system_test_case.rb` to explicitly trigger a chromedriver update. This is useful when system tests are run in parallel (the default mode for new Rails 6 applications), because it ensures that we only attempt to download chromedriver once before parallel processes are forked (rather than once per parallel process).

This should avoid the following error:
```
ChildProcess::LaunchError: Text file busy - /home/circleci/.webdrivers/chromedriver
```
which can happen if multiple parallel processes each try to download chromedriver.