### PR TITLE
Added deep_transform_keys to StrongParameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `deep_transform_keys` and `deep_transform_keys!` methods to ActionController::Parameters.
+
+    *Gustavo Gutierrez*
+
 *   Calling `ActionController::Parameters#transform_keys/!` without a block now returns
     an enumerator for the parameters instead of the underlying hash.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -693,6 +693,23 @@ module ActionController
       self
     end
 
+    # Returns a new <tt>ActionController::Parameters</tt> instance with the
+    # results of running +block+ once for every key. This includes the keys
+    # from the root hash and from all nested hashes and arrays. The values are unchanged.
+    def deep_transform_keys(&block)
+      new_instance_with_inherited_permitted_status(
+        @parameters.deep_transform_keys(&block)
+      )
+    end
+
+    # Returns the <tt>ActionController::Parameters</tt> instance changing its keys.
+    # This includes the keys from the root hash and from all nested hashes and arrays.
+    # The values are unchanged.
+    def deep_transform_keys!(&block)
+      @parameters.deep_transform_keys!(&block)
+      self
+    end
+
     # Deletes a key-value pair from +Parameters+ and returns the value. If
     # +key+ is not found, returns +nil+ (or, with optional code block, yields
     # +key+ and returns the result). Cf. +#extract!+, which returns the

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -213,6 +213,15 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_kind_of ActionController::Parameters, @params.transform_keys!.each { |k| k }
   end
 
+  test "deep_transform_keys retains permitted status" do
+    @params.permit!
+    assert_predicate @params.deep_transform_keys { |k| k }, :permitted?
+  end
+
+  test "deep_transform_keys retains unpermitted status" do
+    assert_not_predicate @params.deep_transform_keys { |k| k }, :permitted?
+  end
+
   test "transform_values retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_values { |v| v }, :permitted?

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -118,4 +118,13 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
   test "transform_values! retains unpermitted status" do
     assert_not_predicate @params.transform_values! { |v| v }, :permitted?
   end
+
+  test "deep_transform_keys! retains permitted status" do
+    @params.permit!
+    assert_predicate @params.deep_transform_keys! { |k| k }, :permitted?
+  end
+
+  test "deep_transform_keys! retains unpermitted status" do
+    assert_not_predicate @params.deep_transform_keys! { |k| k }, :permitted?
+  end
 end


### PR DESCRIPTION
### Summary

This PR implements the methods `deep_transform_keys` and `deep_transform_keys!` for `ActionController::Parameters`.

### Other Information

Thread in the Ruby On Rails Mailing list can be found [here](https://groups.google.com/forum/#!topic/rubyonrails-core/paiccJIC5E0).

