### PR TITLE
Rename `hash` to `jar` in CookieJar.build

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -287,8 +287,8 @@ module ActionDispatch
       DOMAIN_REGEXP = /[^.]*\.([^.]*|..\...|...\...)$/
 
       def self.build(req, cookies)
-        new(req).tap do |hash|
-          hash.update(cookies)
+        new(req).tap do |jar|
+          jar.update(cookies)
         end
       end
 


### PR DESCRIPTION
### Summary

In CookieJar.build, the name `hash` is used as block parameter name for tap method.
However, it is actually not hash but a CookieJar's instance.
The name `hash` was confusing, so replace with `jar`.