### PR TITLE
Return parameters enumerator from transform_keys/!

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Calling `ActionController::Parameters#transform_keys/!` without a block now returns
+    an enumerator for the parameters instead of the underlying hash.
+
+    *Eugene Kenny*
+
 * Fix strong parameters blocks all attributes even when only some keys are invalid (non-numerical). It should only block invalid key's values instead.
 
     *Stan Lo*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -679,18 +679,16 @@ module ActionController
     # Returns a new <tt>ActionController::Parameters</tt> instance with the
     # results of running +block+ once for every key. The values are unchanged.
     def transform_keys(&block)
-      if block
-        new_instance_with_inherited_permitted_status(
-          @parameters.transform_keys(&block)
-        )
-      else
-        @parameters.transform_keys
-      end
+      return to_enum(:transform_keys) unless block_given?
+      new_instance_with_inherited_permitted_status(
+        @parameters.transform_keys(&block)
+      )
     end
 
     # Performs keys transformation and returns the altered
     # <tt>ActionController::Parameters</tt> instance.
     def transform_keys!(&block)
+      return to_enum(:transform_keys!) unless block_given?
       @parameters.transform_keys!(&block)
       self
     end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -203,6 +203,16 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.transform_keys { |k| k }, :permitted?
   end
 
+  test "transform_keys without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.transform_keys
+    assert_kind_of ActionController::Parameters, @params.transform_keys.each { |k| k }
+  end
+
+  test "transform_keys! without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.transform_keys!
+    assert_kind_of ActionController::Parameters, @params.transform_keys!.each { |k| k }
+  end
+
   test "transform_values retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_values { |v| v }, :permitted?
@@ -219,8 +229,9 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
-  test "transform_values without block yieds an enumerator" do
+  test "transform_values without a block returns an enumerator" do
     assert_kind_of Enumerator, @params.transform_values
+    assert_kind_of ActionController::Parameters, @params.transform_values.each { |k| k }
   end
 
   test "transform_values! converts hashes to parameters" do
@@ -229,8 +240,9 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
-  test "transform_values! without block yields an enumerator" do
+  test "transform_values! without a block returns an enumerator" do
     assert_kind_of Enumerator, @params.transform_values!
+    assert_kind_of ActionController::Parameters, @params.transform_values!.each { |k| k }
   end
 
   test "value? returns true if the given value is present in the params" do


### PR DESCRIPTION
Spotted when reviewing https://github.com/rails/rails/pull/36294.

Previously calling `ActionController::Parameters#transform_keys/!` without passing a block would return an enumerator for the underlying hash, which was inconsistent with the behaviour when a block was passed:

```ruby
ActionController::Parameters.new(foo: "bar").transform_keys { |k| k }
=> <ActionController::Parameters {"foo"=>"bar"} permitted: false>
ActionController::Parameters.new(foo: "bar").transform_keys.each { |k| k }
=> {"foo"=>"bar"}
```

An enumerator for the parameters is now returned instead, ensuring that evaluating it produces another parameters object instead of a hash:

```ruby
ActionController::Parameters.new(foo: "bar").transform_keys.each { |k| k }
=> <ActionController::Parameters {"foo"=>"bar"} permitted: false>
```