### PR TITLE
Allow specifying fixtures to be ignored in "_fixture" section

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow specifying fixtures to be ignored by setting `ignore` in YAML file's '_fixture' section.
+
+    *Tongfei Gao*
+
 *   Make the DATABASE_URL env variable only affect the primary connection. Add new env variables for multiple databases.
 
     *John Crepezzi*, *Eileen Uchitelle*

--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -29,6 +29,10 @@ module ActiveRecord
         config_row["model_class"]
       end
 
+      def ignored_fixtures
+        config_row["ignore"]
+      end
+
       private
         def rows
           @rows ||= raw_rows.reject { |fixture_name, _| fixture_name == "_fixture" }
@@ -40,7 +44,7 @@ module ActiveRecord
             if row
               row.last
             else
-              { 'model_class': nil }
+              { 'model_class': nil, 'ignore': nil }
             end
           end
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1279,6 +1279,33 @@ class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
   end
 end
 
+class IgnoreFixturesTest < ActiveRecord::TestCase
+  fixtures :other_books, :parrots
+
+  test "ignores books fixtures" do
+    assert_raise(StandardError) { other_books(:published) }
+    assert_raise(StandardError) { other_books(:published_paperback) }
+    assert_raise(StandardError) { other_books(:published_ebook) }
+
+    assert_equal 2, Book.count
+    assert_equal "Agile Web Development with Rails", other_books(:awdr).name
+    assert_equal "published", other_books(:awdr).status
+    assert_equal "paperback", other_books(:awdr).format
+    assert_equal "english", other_books(:awdr).language
+
+    assert_equal "Ruby for Rails", other_books(:rfr).name
+    assert_equal "ebook", other_books(:rfr).format
+    assert_equal "published", other_books(:rfr).status
+  end
+
+  test "ignores parrots fixtures" do
+    assert_raise(StandardError) { parrots(:DEFAULT) }
+    assert_raise(StandardError) { parrots(:DEAD_PARROT) }
+
+    assert_equal "DeadParrot", parrots(:polly).parrot_sti_class
+  end
+end
+
 class FixturesWithDefaultScopeTest < ActiveRecord::TestCase
   fixtures :bulbs
 

--- a/activerecord/test/fixtures/other_books.yml
+++ b/activerecord/test/fixtures/other_books.yml
@@ -1,0 +1,26 @@
+_fixture:
+  model_class: Book
+  ignore:
+    - PUBLISHED
+    - PUBLISHED_PAPERBACK
+    - PUBLISHED_EBOOK
+
+PUBLISHED: &PUBLISHED
+  status: :published
+
+PUBLISHED_PAPERBACK: &PUBLISHED_PAPERBACK
+  <<: *PUBLISHED
+  format: "paperback"
+  language: :english
+
+PUBLISHED_EBOOK: &PUBLISHED_EBOOK
+  <<: *PUBLISHED
+  format: "ebook"
+
+awdr:
+  <<: *PUBLISHED_PAPERBACK
+  name: "Agile Web Development with Rails"
+
+rfr:
+  <<: *PUBLISHED_EBOOK
+  name: "Ruby for Rails"

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -1,3 +1,9 @@
+_fixture:
+  ignore: DEAD_PARROT
+
+DEAD_PARROT: &DEAD_PARROT
+  parrot_sti_class: DeadParrot
+
 george:
   name: "Curious George"
   treasures: diamond, sapphire
@@ -17,7 +23,7 @@ polly:
   name: $LABEL
   killer: blackbeard
   treasures: sapphire, ruby
-  parrot_sti_class: DeadParrot
+  <<: *DEAD_PARROT
 
 DEFAULTS: &DEFAULTS
   treasures: sapphire, ruby


### PR DESCRIPTION
### Summary

Currently, there is a "DEFAULTS" key we can use in fixtures file for attributes inheriting and fixture named DEFAULTS will not be created.

This PR introduces a new configuration option in `_fixture` section: `ignore`.

It allows us to specify what fixtures can be ignored. For example:

    # users.yml
    _fixture:
      ignore:
        - base
      # or use `ignore: base` when there is only one fixture needs to be ignored.

    base: &base
      admin: false
      introduction: "This is a default description"

    admin:
      <<: *base
      admin: true

    visitor:
      <<: *base

In the above example, "base" fixture will not be created. This is helpful when you want to use some base fixtures for attributes inheriting without actually creating them. 