### PR TITLE
Do not reset current attributes when using inline queue adapter

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -20,8 +20,10 @@ module ActiveSupport
 
     initializer "active_support.reset_all_current_attributes_instances" do |app|
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
-      app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
-      app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+      unless app.config.respond_to?(:active_job) && app.config.active_job.queue_adapter == :inline
+        app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
+        app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+      end
     end
 
     initializer "active_support.deprecation_behavior" do |app|


### PR DESCRIPTION
Fixes #36298

Hi, this is my first try to contribute rails and I dont know if this is the right approach to solve this issue. Any guidance is highly appreciated :). I did not find any integration test other than [this](https://github.com/rails/rails/blob/master/railties/test/application/current_attributes_integration_test.rb
) so I didn't add tests for this change. If needed I can add tests.

Thanks.