### PR TITLE
Style actionable errors buttons

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -32,7 +32,7 @@
 
     header {
       color: #F0F0F0;
-      background: #C52F24;
+      background: #C00;
       padding: 0.5em 1.5em;
     }
 
@@ -43,7 +43,7 @@
     }
 
     h2 {
-      color: #C52F24;
+      color: #C00;
       line-height: 25px;
     }
 
@@ -116,24 +116,46 @@
     }
 
     .line.active {
-      background-color: #FFCCCC;
+      background-color: #FCC;
     }
 
     .button_to {
       display: inline-block;
-      margin-top: 0.5em;
-      margin-bottom: 0.5em;
+      margin-top: 0.75em;
+      margin-bottom: 0.75em;
     }
 
     .hidden {
       display: none;
     }
 
+    input[type="submit"] {
+      color: white;
+      background-color: #C00;
+      border: none;
+      border-radius: 12px;
+      box-shadow: 0 3px #F99;
+      font-size: 13px;
+      font-weight: bold;
+      margin: 0;
+      padding: 10px 18px;
+      -webkit-appearance: none;
+    }
+    input[type="submit"]:focus,
+    input[type="submit"]:hover {
+      opacity: 0.8;
+    }
+    input[type="submit"]:active {
+      box-shadow: 0 2px #F99;
+      transform: translateY(1px)
+    }
+
+
     a { color: #980905; }
     a:visited { color: #666; }
     a.trace-frames { color: #666; }
-    a:hover { color: #C52F24; }
-    a.trace-frames.selected { color: #C52F24 }
+    a:hover { color: #C00; }
+    a.trace-frames.selected { color: #C00 }
 
     @media (prefers-color-scheme: dark) {
       body {
@@ -168,22 +190,17 @@
       }
 
       .line.active {
-        background-color: #977;
+        background-color: #900;
       }
 
       input[type="submit"] {
-        color: #EEE;
-        background-color: #535353;
-        border: none;
-        border-radius: 3px;
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0,0,0,0.15), 0 1px 1px rgba(0,0,0,0.15);
-        padding: 2px 7px;
+        box-shadow: 0 3px #800;
       }
       input[type="submit"]:active {
-        background-color: #777;
+        box-shadow: 0 2px #800;
       }
 
-      a { color: #C52F24; }
+      a { color: #C00; }
       a.trace-frames { color: #999; }
       a:hover { color: #E9382B; }
       a.trace-frames.selected { color: #E9382B; }


### PR DESCRIPTION
### Summary

While I worked on https://github.com/rails/rails/pull/36122 (support for dark mode for the rescues layout), @matthewd suggested to use the button style from [rubyonrails.org](https://rubyonrails.org) for the actionable errors buttons.

<img width="1116" alt="Screen Shot 2019-05-20 at 07 15 20" src="https://user-images.githubusercontent.com/3188392/57997837-1293b600-7acf-11e9-988d-aac31204e96f.png">

### Other Information

This PR also changes the primary red color used in the rescues layout from #C52F24 to #C00, to be consistent with what is used on [rubyonrails.org](https://rubyonrails.org).

Before:
<img width="40" alt="Screen Shot 2019-05-20 at 06 17 01" src="https://user-images.githubusercontent.com/3188392/57996308-e2e0b000-7ac6-11e9-9c38-38527b632afe.png">

After:
<img width="40" alt="Screen Shot 2019-05-20 at 06 16 02" src="https://user-images.githubusercontent.com/3188392/57996285-c0e72d80-7ac6-11e9-8d3c-21f51520a290.png">

The line-highlight for the dark mode was also darkened, as Matthew suggested.