### PR TITLE
Correct human file size examples [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -251,7 +251,7 @@ module ActionView
       end
 
       # Formats the bytes in +number+ into a more understandable
-      # representation (e.g., giving it 1500 yields 1.5 KB). This
+      # representation (e.g., giving it 1500 yields 1.46 KB). This
       # method is useful for reporting file sizes to users. You can
       # customize the format in the +options+ hash.
       #

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -228,7 +228,7 @@ module ActiveSupport
     end
 
     # Formats the bytes in +number+ into a more understandable
-    # representation (e.g., giving it 1500 yields 1.5 KB). This
+    # representation (e.g., giving it 1500 yields 1.46 KB). This
     # method is useful for reporting file sizes to users. You can
     # customize the format in the +options+ hash.
     #


### PR DESCRIPTION
### Summary

The `number_to_human_size` helpers in Action View and Active Support
calculate the "human size" with a base of 1024. The examples should
reflect that so they don't confuse the reader.

The updated documentations use the values from:

    helper.number_to_human_size(1500)