### PR TITLE
1.8x Faster Partial Caching - Faster Cache Keys

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -65,7 +65,7 @@ module AbstractController
       # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
       # followed by any controller-wide key prefix values, ending
       # with the specified +key+ value.
-      def combined_fragment_cache_key(key)
+      def combined_fragment_cache_key(key = nil)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
 

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -65,7 +65,7 @@ module AbstractController
       # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
       # followed by any controller-wide key prefix values, ending
       # with the specified +key+ value.
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -59,7 +59,7 @@ module ActionView
         seed = callable_cache_key? ? @options[:cached] : ->(i) { i }
 
         digest_path = view.digest_path_from_template(template)
-        view_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key)
+        view_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key(nil))
 
         @collection.each_with_object([{}, []]) do |item, (hash, ordered_keys)|
           key = expanded_cache_key(seed.call(item), view_key, view, template, digest_path)

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -18,8 +18,8 @@ class MultifetchCacheTest < ActiveRecordTestCase
         []
       end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.with_view_paths(view_paths, {})
   end

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -18,7 +18,7 @@ class MultifetchCacheTest < ActiveRecordTestCase
         []
       end
 
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         [ :views, key ].compact
       end
     end.with_view_paths(view_paths, {})

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -15,8 +15,8 @@ module RenderTestCases
     @view = Class.new(ActionView::Base.with_empty_template_cache) do
       def view_cache_dependencies; []; end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.with_view_paths(paths, @assigns)
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -15,7 +15,7 @@ module RenderTestCases
     @view = Class.new(ActionView::Base.with_empty_template_cache) do
       def view_cache_dependencies; []; end
 
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         [ :views, key ].compact
       end
     end.with_view_paths(paths, @assigns)

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
+require "active_support/cache/key"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -86,21 +87,11 @@ module ActiveSupport
           expanded_cache_key << "#{prefix}/"
         end
 
-        expanded_cache_key << retrieve_cache_key(key)
+        expanded_cache_key << ActiveSupport::Cache::Key.cache_key_with_version(key)
         expanded_cache_key
       end
 
       private
-        def retrieve_cache_key(key)
-          case
-          when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
-          when key.respond_to?(:cache_key)              then key.cache_key
-          when key.is_a?(Array)                         then key.map { |element| retrieve_cache_key(element) }.to_param
-          when key.respond_to?(:to_a)                   then retrieve_cache_key(key.to_a)
-          else                                               key.to_param
-          end.to_s
-        end
-
         # Obtains the specified cache store class, given the name of the +store+.
         # Raises an error when the store class cannot be found.
         def retrieve_store_class(store)
@@ -315,6 +306,7 @@ module ActiveSupport
       #   cache.fetch('foo') # => "bar"
       def fetch(name, options = nil)
         if block_given?
+          name = ActiveSupport::Cache::Key(name)
           options = merged_options(options)
           key = normalize_key(name, options)
 
@@ -350,6 +342,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def read(name, options = nil)
         options = merged_options(options)
+        name    = ActiveSupport::Cache::Key(name)
         key     = normalize_key(name, options)
         version = normalize_version(name, options)
 
@@ -460,7 +453,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def write(name, value, options = nil)
         options = merged_options(options)
-
+        name = ActiveSupport::Cache::Key(name)
         instrument(:write, name, options) do
           entry = Entry.new(value, **options.merge(version: normalize_version(name, options)))
           write_entry(normalize_key(name, options), entry, **options)
@@ -671,24 +664,8 @@ module ActiveSupport
           end
         end
 
-        # Expands key to be a consistent string value. Invokes +cache_key+ if
-        # object responds to +cache_key+. Otherwise, +to_param+ method will be
-        # called. If the key is a Hash, then keys will be sorted alphabetically.
         def expanded_key(key)
-          return key.cache_key.to_s if key.respond_to?(:cache_key)
-
-          case key
-          when Array
-            if key.size > 1
-              key = key.collect { |element| expanded_key(element) }
-            else
-              key = expanded_key(key.first)
-            end
-          when Hash
-            key = key.sort_by { |k, _| k.to_s }.collect { |k, v| "#{k}=#{v}" }
-          end
-
-          key.to_param
+          ActiveSupport::Cache::Key(key).cache_key
         end
 
         def normalize_version(key, options = nil)
@@ -696,11 +673,7 @@ module ActiveSupport
         end
 
         def expanded_version(key)
-          case
-          when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
-          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
-          end
+          ActiveSupport::Cache::Key(key).cache_version
         end
 
         def instrument(operation, key, options = nil)

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Cache
+    # Convenience method to prevent re-generating a Key
+    # instance, if the element being passed in is already
+    # instance of the `Key` class.
+    #
+    # Example:
+    #
+    #   ActiveSupport::Cache::Key("foo").cache_key
+    #    # => "foo"
+    #
+    #   k1 = Key.new("foo")
+    #   key = ActiveSupport::Cache::Key(k1)
+    #   k1.object_id == key.object_id # => true
+    def self.Key(key_or_components) # :nodoc:
+      if key_or_components.is_a?(ActiveSupport::Cache::Key)
+        key_or_components
+      else
+        Key.new(key_or_components)
+      end
+    end
+
+    # This class is responsible for coercing input into a valid
+    # key format and cache version for cache stores.
+    #
+    # The goal of this class is to provide a composable way
+    # to build keys. You can put an instance of Key
+    # into another instance of Key and it should produce
+    # the same `cache_key` and `cache_version`.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k2 = Key.new(k1)
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #
+    # In addition to passing a key into the initialize method,
+    # key fragments can be added onto an existing key through the
+    # `<<` method.
+    #
+    # Example:
+    #
+    #   key = Key.new
+    #   key << "foo"
+    #   key << "bar"
+    #   key.cache_key
+    #   # => "foo/bar"
+    #
+    # Multiple key entries generate the same key regardless of how
+    # they are added. I.e. if they're added via multiple arrays
+    # or directly via the `<<` operator.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k1 << "bar"
+    #   k2 = Key.new(["foo", "bar"])
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #   k3 = Key.new(["foo", ["bar"]])
+    #   k2.cache_key == k3.cache_key
+    #   # => true
+    #
+    # It is faster to directly add objects to the
+    # Key object via `<<` than to generate
+    # an intermediate array of objects.
+    #
+    # The class supports strings, arrays, hashes,
+    # objects with a `cache_key` method and anything
+    # that can be implicitly cast to a string:
+    #
+    # Examples:
+    #
+    #   Key.new("foo").cache_key
+    #   # => "foo"
+    #
+    #   Key.new(["foo", "bar"]).cache_key
+    #   # => "foo/bar"
+    #
+    #   Key.new({ bar: 1, foo: 2 }).cache_key
+    #   # => "bar=1/foo=2"
+    #
+    #   klass = Class.new { def cache_key; "foo"; end }
+    #   Key.new(klass.new).cache_key
+    #   # => "foo"
+    #
+    # In addition to generating a `cache_key`,
+    # a `cache_version` is also generated if the object
+    # passed in responds to `cache_version` or if it contains
+    # an element that responds to `cache_version`.
+    #
+    # The purpose of keeping this value seperate from
+    # `cache_key` is to support the use of "cache versioning"
+    # where the same key is recycled but the version of the object
+    # being stored is kept directly in the cache.
+    #
+    # Example:
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new(klass.new).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new([klass.new]).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new({foo: klass.new}).cache_version
+    #   # => "foo"
+    class Key # :nodoc:
+      attr_reader :cache_key, :cache_version
+
+      def initialize(key = nil)
+        @cache_key = +""
+        @cache_version = +""
+        @empty_key = true
+        @key_parts = []
+        self << key
+      end
+
+      def length
+        @cache_key.length
+      end
+
+      def self.cache_key_with_version(key)
+        case
+        when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
+        when key.respond_to?(:cache_key)              then key.cache_key
+        when key.is_a?(Array)                         then key.map { |element| cache_key_with_version(element) }.to_param
+        when key.respond_to?(:to_a)                   then cache_key_with_version(key.to_a)
+        else                                               key.to_param
+        end.to_s
+      end
+
+      def cache_key_with_version(key = @key_parts)
+        self.class.cache_key_with_version(key)
+      end
+
+      def update(key)
+        @key_parts << key
+        internal_update(key)
+        self
+      end
+      alias :<< :update
+
+      private
+        def internal_update(key)
+          if key.respond_to?(:cache_key)
+            update_version(key)
+            update_key(key.cache_key.to_s)
+          else
+            split_key(key)
+          end
+        end
+
+        def update_key(key)
+          @cache_key << "/" unless @empty_key
+          @cache_key << key.to_param.to_s
+          @empty_key = false
+        end
+
+        def update_version(key)
+          if key.respond_to?(:cache_version)
+            @cache_version << "/" unless @cache_version.empty?
+            @cache_version << key.cache_version.to_param.to_s
+          else
+            split_version(key)
+          end
+        end
+
+        def split_key(key)
+          case key
+          when Array
+            key.each { |k| internal_update(k) }
+          when Hash
+            key = key.to_a
+            update_version(key)
+            key.sort_by! { |k, _| k.to_s }
+            key.each { |k, v| update_key("#{k}=#{v}") }
+          else
+            if key.respond_to?(:to_a) && !key.nil?
+              internal_update(key.to_a)
+            else
+              update_version(key)
+              update_key(key)
+            end
+          end
+        end
+
+        def split_version(key)
+          if key.is_a?(Array)
+            key.each { |k| update_version(k) }
+          elsif key.respond_to?(:to_a)
+            split_version(key.to_a)
+          end
+        end
+    end
+  end
+end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -21,8 +21,9 @@ module CacheStoreBehavior
   end
 
   def test_fetch_with_cache_miss
-    assert_called_with(@cache, :write, ["foo", "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch("foo") { "baz" }
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
+      assert_equal "baz", @cache.fetch(key) { "baz" }
     end
   end
 
@@ -39,8 +40,9 @@ module CacheStoreBehavior
   def test_fetch_with_forced_cache_miss
     @cache.write("foo", "bar")
     assert_not_called(@cache, :read) do
-      assert_called_with(@cache, :write, ["foo", "bar", @cache.options.merge(force: true)]) do
-        @cache.fetch("foo", force: true) { "bar" }
+      key = ActiveSupport::Cache::Key.new("foo")
+      assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(force: true)]) do
+        @cache.fetch(key, force: true) { "bar" }
       end
     end
   end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/cache"
+
+class KeyTest < ActiveSupport::TestCase
+  def test_composability
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_key, k2.cache_key
+  end
+
+  def test_composable_elements
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k1 << "bar"
+    assert_equal "foo/bar", k1.cache_key
+
+    k2 = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal k1.cache_key, k2.cache_key
+
+    k3 = ActiveSupport::Cache::Key.new(["foo", ["bar"]])
+    assert_equal k2.cache_key, k3.cache_key
+  end
+
+  def test_cache_types
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_equal "foo", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal "foo/bar", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(bar: 1, foo: 2)
+    assert_equal "bar=1/foo=2", key.cache_key
+
+    klass = Class.new { def cache_key; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_key
+  end
+
+  def test_cache_version
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new([klass.new])
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(foo: klass.new)
+    assert_equal "foo", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "foo/foo", key.cache_version
+
+    klass = Class.new { def cache_version; nil; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "", key.cache_version
+  end
+
+  def test_cache_version_composability
+    klass = Class.new { def cache_version; "foo"; end }
+    k1 = ActiveSupport::Cache::Key.new(klass.new)
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_version, k2.cache_version
+  end
+
+  def test_nil_and_empty_keys
+    key = ActiveSupport::Cache::Key.new([ :a, nil, :b, "", :c ])
+    assert_equal "a//b//c", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(hello: nil, world: "today", nil: "rules")
+    assert_equal "hello=/nil=rules/world=today", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["", "", ""])
+    assert_equal "//", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new([ :foo, [], [], :bar ])
+    assert_equal "foo/bar", key.cache_key
+  end
+
+  def test_nested_to_a_cache_versions
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(hello: { world: klass.new })
+    assert_equal "foo", key.cache_version
+  end
+
+  def test_call_returns_original_if_key
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key(k1)
+    assert_equal k1, k2
+
+    key = ActiveSupport::Cache::Key("foo")
+    assert_equal ActiveSupport::Cache::Key, key.class
+    assert_equal "foo", key.cache_key
+  end
+
+  def test_enum
+    k1 = ActiveSupport::Cache::Key.new([1, 2, 3].to_enum)
+    assert_equal "1/2/3", k1.cache_key
+  end
+end


### PR DESCRIPTION
In rails/rails#35257 Aaron pointed out that partial caching is very slow when the partial is very
 small. When I ran the same benchmark locally (without this patch) I get around 5.97x slower than
no caching. With this PR I get 3.29x slower. This represents a **1.8x improvement in speed**.

With this PR i'm seeing a 1.09x faster performance improvement in overall CodeTriage response time
via derailed_benchmarks.

## How it works today

Currently, cache keys are generated via method calls. When a single object is retrieved the raw object that the cache key is built from must be iterated over twice. Once to build the cache key and another for the cache version. In addition to generating the cache key for interacting with the cache, it is also re-generated for logging inside of the `instrument` call. These two things make generating cache keys slow.

## How this patch works

To make this faster I moved the key generation to an object. As elements are added to the key object a cache key and cache version are built incrementally. Since we can build both at the same time we can optimize this execution. In this model we only generate cache key once, retrieving the cache key multiple times on this object is now fast.

One other cause of slowness is that when the partial is being rendered the view generates and prepends the "combined_fragment_cache_key" to each of the cache keys. Because our cache objects are now composable we can instead generate the "combined_fragment_cache_key" once and re-use the same object for generating N cache keys.

This is building off the work of rails/rails#33944. The main difference here is that this PR is backwards compatible.

## Benchmark

You can run this benchmark by following these instructions:

```
$ git clone https://github.com/codetriage/codetriage
$ cd codetriage
$ git checkout schneems/keymaster-reproduction
$ bundle install
$ bundle exec ruby perf_scripts/partial_cache.rb
-- create_table(:customers, {:force=>true})
   -> 0.0092s
/Users/rschneeman/Documents/projects/codetriage/perf_scripts/partial_cache
<#ActiveSupport::Cache::MemoryStore entries=1000, size=352893, options={}>
Warming up --------------------------------------
collection render: no cache
                        27.000  i/100ms
collection render: with cache
                         7.000  i/100ms
Calculating -------------------------------------
collection render: no cache
                        272.792  (± 2.9%) i/s -      1.377k in   5.052080s
collection render: with cache
                         82.970  (± 2.4%) i/s -    420.000  in   5.066222s

Comparison:
collection render: no cache:      272.8 i/s
collection render: with cache:       83.0 i/s - 3.29x  slower
```
> Note that while it's still slower, the prior version was `5.97x` slower.
