### PR TITLE
Fall back to type casting from the connection adapter

### DIFF
--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -8,21 +8,27 @@ module ActiveRecord
         @table_name = table_name
       end
 
-      def type_cast_for_database(attribute_name, value)
+      def type_cast_for_database(attr_name, value)
         return value if value.is_a?(Arel::Nodes::BindParam)
-        column = column_for(attribute_name)
-        connection.type_cast_from_column(column, value)
+        type = type_for_attribute(attr_name)
+        type.serialize(value)
       end
+
+      def type_for_attribute(attr_name)
+        schema_cache = connection.schema_cache
+
+        if schema_cache.data_source_exists?(table_name)
+          column = schema_cache.columns_hash(table_name)[attr_name.to_s]
+          type = connection.lookup_cast_type_from_column(column) if column
+        end
+
+        type || Type.default_value
+      end
+
+      delegate :connection, to: :@klass, private: true
 
       private
         attr_reader :table_name
-        delegate :connection, to: :@klass
-
-        def column_for(attribute_name)
-          if connection.schema_cache.data_source_exists?(table_name)
-            connection.schema_cache.columns_hash(table_name)[attribute_name.to_s]
-          end
-        end
     end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -18,13 +18,18 @@ require "support/stubs/strong_parameters"
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors, :author_addresses, :binaries, :essays, :cars, :treasures, :price_estimates, :topics
+    fixtures :posts, :comments, :edges, :authors, :author_addresses, :binaries, :essays, :cars, :treasures, :price_estimates, :topics
 
     def test_in_clause_is_correctly_sliced
       assert_called(Author.connection, :in_clause_length, returns: 1) do
         david = authors(:david)
         assert_equal [david], Author.where(name: "David", id: [1, 2])
       end
+    end
+
+    def test_type_casting_nested_joins
+      comment = comments(:eager_other_comment1)
+      assert_equal [comment], Comment.joins(post: :author).where(authors: { id: "2-foo" })
     end
 
     def test_where_copies_bind_params


### PR DESCRIPTION
Unfortunately, a11a8ff had no effect as long as using bind param, and
was not tested.

This ensures making the intent of a11a8ff, which fall back to type
casting from the connection adapter.

Fixes #35205.

```
% ARCONN=postgresql bundle exec ruby -w -Itest test/cases/relation/where_test.rb -n test_type_casting_nested_joins
Using postgresql
Run options: -n test_type_casting_nested_joins --seed 55730

# Running:

E

Error:
ActiveRecord::WhereTest#test_type_casting_nested_joins:
ActiveRecord::StatementInvalid: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for integer: "2-foo"

rails test test/cases/relation/where_test.rb:30

Finished in 0.245778s, 4.0687 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```