### PR TITLE
Able to initalize default value for `thread_mattr_*` methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add capability to initialize a `thread_mattr_*` method with a default
+    value through the `default:` keyword argument
+
+    class MyClass
+      thread_attr_reader :foo, default: :foo
+    end
+
+    *Guilherme Mansur*
+
 *   `delegate_missing_to` would raise a `DelegationError` if the object
     delegated to was `nil`. Now the `allow_nil` option has been added to enable
     the user to specify they want `nil` returned in this case.

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -33,7 +33,7 @@ class Module
   #   end
   #
   #   Current.new.user # => NoMethodError
-  def thread_mattr_reader(*syms, instance_reader: true, instance_accessor: true) # :nodoc:
+  def thread_mattr_reader(*syms, instance_reader: true, instance_accessor: true, default: nil) # :nodoc:
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /^[_A-Za-z]\w*$/.match?(sym)
 
@@ -52,6 +52,9 @@ class Module
           end
         EOS
       end
+
+      default_val = (block_given? && default.nil?) ? yield : default
+      Thread.current["attr_" + name + "_#{sym}"] = default_val unless default_val.nil?
     end
   end
   alias :thread_cattr_reader :thread_mattr_reader
@@ -74,7 +77,7 @@ class Module
   #   end
   #
   #   Current.new.user = "DHH" # => NoMethodError
-  def thread_mattr_writer(*syms, instance_writer: true, instance_accessor: true) # :nodoc:
+  def thread_mattr_writer(*syms, instance_writer: true, instance_accessor: true, default: nil) # :nodoc:
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /^[_A-Za-z]\w*$/.match?(sym)
 
@@ -93,6 +96,9 @@ class Module
           end
         EOS
       end
+
+      default_val = (block_given? && default.nil?) ? yield : default
+      Thread.current["attr_" + name + "_#{sym}"] = default_val unless default_val.nil?
     end
   end
   alias :thread_cattr_writer :thread_mattr_writer
@@ -136,9 +142,9 @@ class Module
   #
   #   Current.new.user = "DHH"  # => NoMethodError
   #   Current.new.user          # => NoMethodError
-  def thread_mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true)
-    thread_mattr_reader(*syms, instance_reader: instance_reader, instance_accessor: instance_accessor)
-    thread_mattr_writer(*syms, instance_writer: instance_writer, instance_accessor: instance_accessor)
+  def thread_mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil, &blk)
+    thread_mattr_reader(*syms, instance_reader: instance_reader, instance_accessor: instance_accessor, default: default, &blk)
+    thread_mattr_writer(*syms, instance_writer: instance_writer, instance_accessor: instance_accessor, default: default)
   end
   alias :thread_cattr_accessor :thread_mattr_accessor
 end

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -53,8 +53,7 @@ class Module
         EOS
       end
 
-      default_val = (block_given? && default.nil?) ? yield : default
-      Thread.current["attr_" + name + "_#{sym}"] = default_val unless default_val.nil?
+      Thread.current["attr_" + name + "_#{sym}"] = default unless default.nil?
     end
   end
   alias :thread_cattr_reader :thread_mattr_reader
@@ -97,8 +96,7 @@ class Module
         EOS
       end
 
-      default_val = (block_given? && default.nil?) ? yield : default
-      Thread.current["attr_" + name + "_#{sym}"] = default_val unless default_val.nil?
+      public_send("#{sym}=", default) unless default.nil?
     end
   end
   alias :thread_cattr_writer :thread_mattr_writer
@@ -142,8 +140,8 @@ class Module
   #
   #   Current.new.user = "DHH"  # => NoMethodError
   #   Current.new.user          # => NoMethodError
-  def thread_mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil, &blk)
-    thread_mattr_reader(*syms, instance_reader: instance_reader, instance_accessor: instance_accessor, default: default, &blk)
+  def thread_mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil)
+    thread_mattr_reader(*syms, instance_reader: instance_reader, instance_accessor: instance_accessor, default: default)
     thread_mattr_writer(*syms, instance_writer: instance_writer, instance_accessor: instance_accessor, default: default)
   end
   alias :thread_cattr_accessor :thread_mattr_accessor

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -23,18 +23,11 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
   def test_can_initialize_with_default_value
     Thread.new do
       @class.thread_mattr_accessor :baz, default: "default_value"
-      assert_equal "default_value", @class.baz
-    end.join
-  end
-
-  def test_can_initialize_with_a_block_as_default_value
-    Thread.new do
-      @class.thread_mattr_accessor :baz do
-        "default_value"
-      end
 
       assert_equal "default_value", @class.baz
     end.join
+
+    assert_nil @class.baz
   end
 
   def test_should_use_mattr_default
@@ -82,19 +75,19 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
     threads = []
     threads << Thread.new do
       @class.foo = "things"
-      sleep 1
+      Thread.pass
       assert_equal "things", @class.foo
     end
 
     threads << Thread.new do
       @class.foo = "other things"
-      sleep 1
+      Thread.pass
       assert_equal "other things", @class.foo
     end
 
     threads << Thread.new do
       @class.foo = "really other things"
-      sleep 1
+      Thread.pass
       assert_equal "really other things", @class.foo
     end
 


### PR DESCRIPTION
### Summary
While working on https://github.com/rails/rails/pull/36220 I considered doing something like: 

`thread_mattr_accessor :timings, default: {}`

but saw that passing in the default was not supported, which is also inconsistent with the api from `mattr_accessor`.  This adds the bility to initialize `thread_mattr_*` methods with default
values like so:

``` ruby
  class MyClass
    thread_attr_reader :foo, default: :foo
    thread_attr_writer :bar, default: :bar
    thread_attr_accessor: baz do
      "baz"
    end
  end
```

This is consistent with the api exposed by `mattr_accessor`.

### Other Information

This actually breaks the usage of this method in anonymous classes where the `self.name` method is defined after the `thread_matrr_*` methods:

``` ruby
Class.new do
  thread_mattr_accessor :foo 
 
  def self.name
    "MyClass"
  end
```

This will break since when `thread_mattr_accessor` is executed the `name` is `nil`. 

I don't think this edge case is worth supporting imo, seems to be used only in testing, and can be easily fixed by declaring a class vs an anonymous class. 

