### PR TITLE
Merge payload for EventObject subscribers

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -218,6 +218,7 @@ module ActiveSupport
           def finish(name, id, payload)
             stack = Thread.current[:_event_stack]
             event = stack.pop
+            event.payload = payload
             event.finish!
             @delegate.call event
           end

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -53,7 +53,8 @@ module ActiveSupport
     end
 
     class Event
-      attr_reader :name, :time, :end, :transaction_id, :payload, :children
+      attr_reader :name, :time, :end, :transaction_id, :children
+      attr_accessor :payload
 
       def self.clock_gettime_supported? # :nodoc:
         defined?(Process::CLOCK_PROCESS_CPUTIME_ID) &&

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -42,6 +42,27 @@ module Notifications
       assert_operator event.duration, :>, 0
     end
 
+    def test_subscribe_to_events_where_payload_is_changed_during_instrumentation
+      @notifier.subscribe do |event|
+        assert_equal "success!", event.payload[:my_key]
+      end
+
+      ActiveSupport::Notifications.instrument("foo") do |payload|
+        payload[:my_key] = "success!"
+      end
+    end
+
+    def test_subscribe_to_events_can_handle_nested_hashes_in_the_paylaod
+      @notifier.subscribe do |event|
+        assert_equal "success!", event.payload[:some_key][:key_one]
+        assert_equal "great_success!", event.payload[:some_key][:key_two]
+      end
+
+      ActiveSupport::Notifications.instrument("foo", some_key: { key_one: "success!" }) do |payload|
+        payload[:some_key][:key_two] = "great_success!"
+      end
+    end
+
     def test_subscribe_via_top_level_api
       old_notifier = ActiveSupport::Notifications.notifier
       ActiveSupport::Notifications.notifier = ActiveSupport::Notifications::Fanout.new


### PR DESCRIPTION
### Summary

Merge payload for EventObject subscribers  …
When instrumenting a block of code like:

```ruby
ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
 payload[:view_runtime] = render_view
end
```
If we use an evented subscriber like so:

``` ruby
ActiveSupport::Notifications.subscribe("process_action.action_controller", raw_payload) do |event|
 assert event.payload[:view_runtime]
end
```

The code breaks because the underlying EventObject's payload does not have the
`:view_runtime` key added during instrumentation.

This PR makes it so that the the payload with its modifications is available to the `EventedObject` subscriber. 
