### PR TITLE
[CI skip] Put :nodoc: on method that raises NoMethodError

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1029,7 +1029,7 @@ module ActiveRecord
       alias_method :append, :<<
       alias_method :concat, :<<
 
-      def prepend(*args)
+      def prepend(*args) # :nodoc:
         raise NoMethodError, "prepend on association is not defined. Please use <<, push or append"
       end
 


### PR DESCRIPTION
This method is not intended to be used so I think we should
remove it from the docs.
