### PR TITLE
Wrap ActionView cache expiry in a mutex

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -16,18 +16,21 @@ module ActionView
       @watched_dirs = nil
       @watcher_class = watcher
       @watcher = nil
+      @mutex = Mutex.new
     end
 
     def clear_cache_if_necessary
-      watched_dirs = dirs_to_watch
-      if watched_dirs != @watched_dirs
-        @watched_dirs = watched_dirs
-        @watcher = @watcher_class.new([], watched_dirs) do
-          clear_cache
+      @mutex.synchronize do
+        watched_dirs = dirs_to_watch
+        if watched_dirs != @watched_dirs
+          @watched_dirs = watched_dirs
+          @watcher = @watcher_class.new([], watched_dirs) do
+            clear_cache
+          end
+          @watcher.execute
+        else
+          @watcher.execute_if_updated
         end
-        @watcher.execute
-      else
-        @watcher.execute_if_updated
       end
     end
 


### PR DESCRIPTION
Alternative to #36094

I was able to confirm locally that multiple requests can enter the `clear_cache_if_necessary` method (I wasn't able to get the same error, but it makes sense that it can happen). I guess this is because we're running in `Executor#before` rather than as part of `Reloader` (maybe this is another hint to me that it should be moved there 🤷‍♂).

Because of this we should wrap `clear_cache_if_necessary` with a Mutex (this is just the check and clear before a request). This only runs in dev mode, and in my local testing there wasn't a significant performance change to adding the mutex.

cc @kaspth @composerinteralia 