### PR TITLE
Fix unexpected select_tag delete behavior when include_blank is present

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Fix `select_tag` so that it doesn't change `options` when `include_blank` is present.
+
+    *Younes SERRAJ*
 
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -137,7 +137,8 @@ module ActionView
         html_name = (options[:multiple] == true && !name.to_s.ends_with?("[]")) ? "#{name}[]" : name
 
         if options.include?(:include_blank)
-          include_blank = options.delete(:include_blank)
+          include_blank = options[:include_blank]
+          options = options.except(:include_blank)
           options_for_blank_options_tag = { value: "" }
 
           if include_blank == true

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -301,6 +301,13 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_select_tag_with_include_blank_doesnt_change_options
+    options = { include_blank: true, prompt: "string" }
+    expected_options = options.dup
+    select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), options
+    expected_options.each { |k, v| assert_equal v, options[k] }
+  end
+
   def test_select_tag_with_include_blank_false
     actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), include_blank: false
     expected = %(<select id="places" name="places"><option>Home</option><option>Work</option><option>Pub</option></select>)


### PR DESCRIPTION
### Summary

Fixes `select_tag` so that is doesn't change `options` when `include_blank` is present.

### Other Information

Fixes https://github.com/rails/rails/issues/36295
