### PR TITLE
form.label :content changed to form.label :title

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -64,7 +64,7 @@ Then refer to this field in the form for the model:
 <%# app/views/messages/_form.html.erb %>
 <%= form_with(model: message) do |form| %>
   <div class="field">
-    <%= form.label :content %>
+    <%= form.label :title %>
     <%= form.rich_text_area :content %>
   </div>
 <% end %>


### PR DESCRIPTION
I'm very new to Rails, but I believe this should be :title since it is referenced as a permitted attribute. Otherwise, I'm not sure where the :title param is ever used in the documentation.

### Summary

Simple typo change.

### Other Information

Again, very new to Rails, so I hope my mental model is correct ☺️

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
