### PR TITLE
Remove compatibility module from docs [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/template_assertions.rb
+++ b/actionpack/lib/action_controller/template_assertions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionController
-  module TemplateAssertions
+  module TemplateAssertions # :nodoc:
     def assert_template(options = {}, message = nil)
       raise NoMethodError,
         "assert_template has been extracted to a gem. To continue using it,


### PR DESCRIPTION
This module exists to warn old users. I think we should remove
it from the docs so we don't advertise it.