### PR TITLE
 Bump Gemfile entry jbuilder version

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -322,7 +322,7 @@ module Rails
 
       def jbuilder_gemfile_entry
         comment = "Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder"
-        GemfileEntry.new "jbuilder", "~> 2.5", comment, {}, options[:api]
+        GemfileEntry.new "jbuilder", "~> 2.7", comment, {}, options[:api]
       end
 
       def javascript_gemfile_entry


### PR DESCRIPTION
### Summary

jbuilder 2.6.4 is the first version that relaxes the version constraint to allow
Rails 6. I also did some more tests in #25183, although not with 2.6.4
explicitly.

To simplify the version requirement, I went for 2.7 (instead of `["~>2.6", ">= 2.6.4"]`)

https://github.com/rails/jbuilder/blob/v2.6.4/jbuilder.gemspec
https://github.com/rails/rails/issues/25183#issuecomment-494342406