### PR TITLE
Delete evented_file_update_checker existing_parent

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -187,13 +187,6 @@ module ActiveSupport
           lcsp
         end
 
-        # Returns the deepest existing ascendant, which could be the argument itself.
-        def existing_parent(dir)
-          dir.ascend do |ascendant|
-            break ascendant if ascendant.directory?
-          end
-        end
-
         # Filters out directories which are descendants of others in the collection (stable).
         def filter_out_descendants(dirs)
           return dirs if dirs.length < 2

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -156,14 +156,6 @@ class EventedFileUpdateCheckerPathHelperTest < ActiveSupport::TestCase
     assert_nil @ph.longest_common_subpath([])
   end
 
-  test "#existing_parent returns the most specific existing ascendant" do
-    wd = Pathname.getwd
-
-    assert_equal wd, @ph.existing_parent(wd)
-    assert_equal wd, @ph.existing_parent(wd.join("non-existing/directory"))
-    assert_equal pn("/"), @ph.existing_parent(pn("/non-existing/directory"))
-  end
-
   test "#filter_out_descendants returns the same collection if there are no descendants (empty)" do
     assert_equal [], @ph.filter_out_descendants([])
   end


### PR DESCRIPTION
This is no longer used as of caa3cc8868206f8109e0d633efb09d31e94ef635 (which is a really great change ❤️)

This whole class is `:nodoc:` so this should be safe to remove.