### PR TITLE
Fix EventedFileUpdateChecker through a symlink 

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -107,11 +107,18 @@ module ActiveSupport
 
     private
       def boot!
+        normalize_dirs!
         Listen.to(*@dtw, &method(:changed)).start
       end
 
       def shutdown!
         Listen.stop
+      end
+
+      def normalize_dirs!
+        @dirs.transform_keys! do |dir|
+          dir.exist? ? dir.realpath : dir
+        end
       end
 
       def changed(modified, added, removed)

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -77,6 +77,24 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     Process.wait(pid)
   end
 
+  test "should detect changes through symlink" do
+    actual_dir = File.join(tmpdir, "actual")
+    linked_dir = File.join(tmpdir, "linked")
+
+    Dir.mkdir(actual_dir)
+    FileUtils.ln_s(actual_dir, linked_dir)
+
+    checker = new_checker([], linked_dir => ".rb") { }
+
+    assert_not_predicate checker, :updated?
+
+    FileUtils.touch(File.join(actual_dir, "a.rb"))
+    wait
+
+    assert_predicate checker, :updated?
+    assert checker.execute_if_updated
+  end
+
   test "updated should become true when nonexistent directory is added later" do
     watched_dir = File.join(tmpdir, "app")
     unwatched_dir = File.join(tmpdir, "node_modules")

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -78,31 +78,29 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   test "updated should become true when nonexistent directory is added later" do
-    Dir.mktmpdir do |dir|
-      watched_dir = File.join(dir, "app")
-      unwatched_dir = File.join(dir, "node_modules")
-      not_exist_watched_dir = File.join(dir, "test")
+    watched_dir = File.join(tmpdir, "app")
+    unwatched_dir = File.join(tmpdir, "node_modules")
+    not_exist_watched_dir = File.join(tmpdir, "test")
 
-      Dir.mkdir(watched_dir)
-      Dir.mkdir(unwatched_dir)
+    Dir.mkdir(watched_dir)
+    Dir.mkdir(unwatched_dir)
 
-      checker = new_checker([], watched_dir => ".rb", not_exist_watched_dir => ".rb") { }
+    checker = new_checker([], watched_dir => ".rb", not_exist_watched_dir => ".rb") { }
 
-      FileUtils.touch(File.join(watched_dir, "a.rb"))
-      wait
-      assert_predicate checker, :updated?
-      assert checker.execute_if_updated
+    FileUtils.touch(File.join(watched_dir, "a.rb"))
+    wait
+    assert_predicate checker, :updated?
+    assert checker.execute_if_updated
 
-      Dir.mkdir(not_exist_watched_dir)
-      wait
-      assert_predicate checker, :updated?
-      assert checker.execute_if_updated
+    Dir.mkdir(not_exist_watched_dir)
+    wait
+    assert_predicate checker, :updated?
+    assert checker.execute_if_updated
 
-      FileUtils.touch(File.join(unwatched_dir, "a.rb"))
-      wait
-      assert_not_predicate checker, :updated?
-      assert_not checker.execute_if_updated
-    end
+    FileUtils.touch(File.join(unwatched_dir, "a.rb"))
+    wait
+    assert_not_predicate checker, :updated?
+    assert_not checker.execute_if_updated
   end
 end
 


### PR DESCRIPTION
Locally, on MacOS when I ran `evented_file_update_checker_test.rb`, the "updated should become true when nonexistent directory is added later" test would fail. This is failing because on MacOS `/var` is a symlink to `/private/var`, and this specific test was using `Dir.mktmpdir` explicitly - other tests were making a tmpdir inside `test/` (which maybe we should also change 🤔).

When watching through a symlink, Listen seems to return the absolute path to the modified file. Because `@dirs` references the path of the symlink, its `realpath`, `watching?(f)` returns false.

This PR fixes the issue by replacing each `@dirs` key with its `realpath` if it exists. This done on `boot!`, so it will work with newly created directories through a symlink.