### PR TITLE
Remove unused requires from debug_exceptions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -4,8 +4,6 @@ require "action_dispatch/http/request"
 require "action_dispatch/middleware/exception_wrapper"
 require "action_dispatch/routing/inspector"
 
-require "active_support/actionable_error"
-
 require "action_view"
 require "action_view/base"
 


### PR DESCRIPTION
### Summary

Just a simple removal of a require that is unused in `DebugExceptions` after the refactor to `ActionableExceptions` middleware @gsamokovarov 