### PR TITLE
[documentation][ci skip] stringify_keys and symbolize_keys have stable results.

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2633,14 +2633,12 @@ The method `stringify_keys` returns a hash that has a stringified version of the
 # => {"" => nil, "1" => 1, "a" => :a}
 ```
 
-In case of key collision, one of the values will be chosen. The chosen value may not always be the same given the same hash:
+In case of key collision, the value will be the one most recently inserted into the hash.
 
 ```ruby
 {"a" => 1, a: 2}.stringify_keys
-# The result could either be
+# The result will be
 # => {"a"=>2}
-# or
-# => {"a"=>1}
 ```
 
 This method may be useful for example to easily accept both symbols and strings as options. For instance `ActionView::Helpers::FormHelper` defines:
@@ -2677,14 +2675,12 @@ The method `symbolize_keys` returns a hash that has a symbolized version of the 
 
 WARNING. Note in the previous example only one key was symbolized.
 
-In case of key collision, one of the values will be chosen. The chosen value may not always be the same given the same hash:
+In case of key collision, the value will be the one most recently inserted into the hash.
 
 ```ruby
 {"a" => 1, a: 2}.symbolize_keys
-# The result could either be
+# The result will be
 # => {:a=>2}
-# or
-# => {:a=>1}
 ```
 
 This method may be useful for example to easily accept both symbols and strings as options. For instance `ActionController::UrlRewriter` defines


### PR DESCRIPTION
Rails 6 uses the `Hash.transform_keys` found in Ruby 2.5 and later, and that method enumerates keys based on insertion order.  Calling `symbolize_keys`, `stringify_keys`, and their bang variants will result in the same hash every time -- the value for any key where a collision occurs is the last value assigned in that enumeration

In the docs for Hash --  https://ruby-doc.org/core-2.5.0/Hash.html

> Hashes enumerate their values in the order that the corresponding keys were inserted.

