### PR TITLE
Prevent double save of has_one association when saving child

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -233,6 +233,18 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert_not_predicate client.firm, :persisted?
   end
 
+  def test_child_is_saved_only_once_if_child_is_inverse_of_parent
+    ship_reflection = Ship.reflect_on_association(:pirate)
+    pirate_reflection = Pirate.reflect_on_association(:ship)
+    assert_equal ship_reflection, pirate_reflection.inverse_of, "The pirate reflection's inverse should be the ship reflection"
+
+    ship = Ship.new(name: "Nights Dirty Lightning")
+    pirate = ship.build_pirate(catchphrase: "Aye")
+    ship.save!
+    assert_equal([nil, ship.id], ship.previous_changes["id"])
+    assert_equal([nil, pirate.id], ship.previous_changes["pirate_id"])
+  end
+
   def test_save_fails_for_invalid_belongs_to
     # Oracle saves empty string as NULL therefore :message changed to one space
     assert log = AuditLog.create(developer_id: 0, message: " ")


### PR DESCRIPTION
### Summary

Autosave double saves a has_one association when saving the child first.
The second save would clear the mutation tracker resulting in an incorrect
dirty state. This was introduced with commit c7adc610f0233b9afd5

```
    # pirate has_one ship
    ship = Ship.new(name: "Nights Dirty Lightning")
    pirate = ship.build_pirate(catchphrase: "Aye")
    ship.save!
    ship.previous_changes # => returns {} but this should contain the changes.
```

When saving ship the following happens:
1. the `before_save` callbacks of the ship are called
2. the callbacks call `autosave_associated_records_for_pirate`
3. `autosave_associated_records_for_pirate` saves the pirate
4. the `after_save` callbacks of the pirate are called
5. the callbacks call `autosave_associated_records_for_ship`
6. `autosave_associated_records_for_ship` saves the ship
7. the ship is saved again by the original save

`autosave_associated_records_for_ship` saves the ship because the
ship association is set by inverse_of in a `has_one` on the pirate. This does not happen
with a `has_many` because the inverse is not set.

With this commit the following happens:
1. the `before_save` callbacks of the ship are called
2. the callbacks call `autosave_associated_records_for_pirate`
3. set `@_already_called` on pirate for
  `autosave_associated_records_for_ship` to true
4. `autosave_associated_records_for_pirate` saves the pirate
5. the `after_save` callbacks of the pirate are called
6. the callbacks skip `autosave_associated_records_for_ship`
7. the ship is saved.

### Other Information
Preventing the double save by misusing `@_already_saved` is not the cleanest implementation but I didn't want to add new variables for tracking state.

Setting the instance variable with `instance_eval` is a hack but I wanted to make minimal changes. I could create a setter method. 

This probably fixes: #35597 but I'll have to test that first.