### PR TITLE
Fix comment for "broken" inverse_of associations

### DIFF
--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -6,7 +6,7 @@ class Face < ActiveRecord::Base
   belongs_to :polymorphic_man, polymorphic: true, inverse_of: :polymorphic_face
   # Oracle identifier length is limited to 30 bytes or less, `polymorphic` renamed `poly`
   belongs_to :poly_man_without_inverse, polymorphic: true
-  # These is a "broken" inverse_of for the purposes of testing
+  # These are "broken" inverse_of associations for the purposes of testing
   belongs_to :horrible_man, class_name: "Man", inverse_of: :horrible_face
   belongs_to :horrible_polymorphic_man, polymorphic: true, inverse_of: :horrible_polymorphic_face
 


### PR DESCRIPTION
### Summary

The current comment is unclear if there is one or multiple "broken" associations.
ff508640e28914da2b546f6a8c9f215bab201b61 added the extra association and comment suggesting it should be multiple.