### PR TITLE
read configuration to determine excluded eager loaded directory

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -89,7 +89,7 @@ module Rails
 
       private
         def webpacker_path
-          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"].gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
+          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
         end
     end
   end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -87,10 +87,9 @@ module Rails
         @autoload_paths ||= paths.autoload_paths
       end
 
-      private
-        def webpacker_path
-          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
-        end
+      def webpacker_path
+        YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
+      end
     end
   end
 end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/railtie/configuration"
+require "yaml"
 
 module Rails
   class Engine
@@ -40,7 +41,7 @@ module Rails
 
           paths.add "app",                 eager_load: true,
                                            glob: "{*,*/concerns}",
-                                           exclude: %w(assets javascript)
+                                           exclude: ["assets", webpacker_path]
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
@@ -85,6 +86,11 @@ module Rails
       def autoload_paths
         @autoload_paths ||= paths.autoload_paths
       end
+
+      private
+        def webpacker_path
+          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"].gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
+        end
     end
   end
 end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -88,7 +88,11 @@ module Rails
       end
 
       def webpacker_path
-        YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "") if File.file?("#{Rails.root}/config/webpacker.yml")
+        if File.file?("#{Rails.root}/config/webpacker.yml")
+          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "")
+        else
+          "javascript"
+        end
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1701,7 +1701,7 @@ module ApplicationTests
       app "development"
       ActiveSupport::Dependencies.autoload_paths.each do |path|
         assert_not_operator path, :ends_with?, "app/assets"
-        assert_not_operator path, :ends_with?, "app/javascript"
+        assert_not_operator path, :ends_with?, "app/#{Rails.configuration.webpacker_path}"
       end
     end
 


### PR DESCRIPTION
### Summary

When upgrading an application from a previous version that uses webpacker, the `rails zeitwerk:check` command will throw an error if you have customized the default directory for webpacker (for example renamed from javascript to webpack).  This is documented in issue #36339.  This change reads the config/webpacker.yml file to read the directory to exclude instead of hard coding it.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
