### PR TITLE
Remove wrong default value for `cache_versioning` in documentation of `cache_version`

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -93,7 +93,7 @@ module ActiveRecord
     # cache_version, but this method can be overwritten to return something else.
     #
     # Note, this method will return nil if ActiveRecord::Base.cache_versioning is set to
-    # +false+ (which it is by default until Rails 6.0).
+    # +false+.
     def cache_version
       return unless cache_versioning
 


### PR DESCRIPTION
### Summary

`ActiveRecord::Base.cache_versioning` is `true` by default since Rails 5.2 as stated correctly in the documentation for the `ActiveRecord::Base.cache_versioning` class attribute. Remove the wrong and duplicated documentation of the default value for `cache_versioning` from `cache_version`.
