### PR TITLE
[WIP] Permanent URLs for ActiveStorage blobs

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -132,6 +132,15 @@ class ActiveStorage::Blob < ActiveRecord::Base
     content_type.start_with?("text")
   end
 
+  # Returns a public, permanent URL of the blob on the service. See the
+  # documentation of this method for the service you are using for
+  # additional instructions and comments.
+  def public_url(disposition: :inline, filename: nil)
+    filename = ActiveStorage::Filename.wrap(filename || self.filename)
+
+    service.public_url key, filename: filename, content_type: content_type_for_service_url,
+      disposition: forced_disposition_for_service_url || disposition
+  end
 
   # Returns the URL of the blob on the service. This URL is intended to be short-lived for security and not used directly
   # with users. Instead, the +service_url+ should only be exposed as a redirect from a stable, possibly authenticated URL.

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -101,6 +101,13 @@ module ActiveStorage
       raise NotImplementedError
     end
 
+    # Returns a public, permanent URL of the file at the +key+. See the
+    # documentation of this method for the service you are using for
+    # additional instructions and comments.
+    def public_url(key, *args)
+      raise NotImplementedError
+    end
+
     # Returns a signed, temporary URL for the file at the +key+. The URL will be valid for the amount
     # of seconds specified in +expires_in+. You must also provide the +disposition+ (+:inline+ or +:attachment+),
     # +filename+, and +content_type+ that you wish the file to be served with on request.

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -82,6 +82,19 @@ module ActiveStorage
       end
     end
 
+    # Container must allow public read access for blobs. See
+    # {https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources#grant-anonymous-users-permissions-to-containers-and-blobs here}
+    # for details.
+    def public_url(key, *_args)
+      instrument :url, key: key do |payload|
+        generated_url = blobs.send(:blob_uri, container, key).to_s
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def url(key, expires_in:, filename:, disposition:, content_type:)
       instrument :url, key: key do |payload|
         generated_url = signer.signed_uri(

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -9,6 +9,8 @@ module ActiveStorage
   # Wraps a local disk path as an Active Storage service. See ActiveStorage::Service for the generic API
   # documentation that applies to all services.
   class Service::DiskService < Service
+    EXPIRY_FOR_PUBLIC_URL = 100.years
+
     attr_reader :root
 
     def initialize(root:)
@@ -69,6 +71,15 @@ module ActiveStorage
         payload[:exist] = answer
         answer
       end
+    end
+
+    def public_url(key, filename:, disposition:, content_type:)
+      url(key,
+        expires_in: EXPIRY_FOR_PUBLIC_URL,
+        filename: filename,
+        disposition: disposition,
+        content_type: content_type
+      )
     end
 
     def url(key, expires_in:, filename:, disposition:, content_type:)

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -81,6 +81,21 @@ module ActiveStorage
       end
     end
 
+    # This operation will have the side effect of making this file public.
+    def public_url(key)
+      instrument :url, key: key do |payload|
+        file = file_for(key)
+
+        # Make the file public
+        file.acl.public!
+        generated_url = file.public_url
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def url(key, expires_in:, filename:, content_type:, disposition:)
       instrument :url, key: key do |payload|
         generated_url = file_for(key).signed_url expires: expires_in, query: {

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -13,7 +13,7 @@ module ActiveStorage
   class Service::MirrorService < Service
     attr_reader :primary, :mirrors
 
-    delegate :download, :download_chunk, :exist?, :url,
+    delegate :download, :download_chunk, :exist?, :public_url, :url,
       :url_for_direct_upload, :headers_for_direct_upload, :path_for, to: :primary
 
     # Stitch together from named services.

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -72,6 +72,16 @@ module ActiveStorage
       end
     end
 
+    def public_url(key, *_args)
+      instrument :url, key: key do |payload|
+        generated_url = object_for(key).public_url
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
     def url(key, expires_in:, filename:, disposition:, content_type:)
       instrument :url, key: key do |payload|
         generated_url = object_for(key).presigned_url :get, expires_in: expires_in.to_i,

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -114,6 +114,12 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "public URL" do
+    blob = create_blob
+
+    assert_equal expected_url_for(blob, expires_in: ActiveStorage::Service::DiskService::EXPIRY_FOR_PUBLIC_URL), blob.public_url
+  end
+
   test "URLs expiring in 5 minutes" do
     blob = create_blob
 
@@ -194,13 +200,13 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   end
 
   private
-    def expected_url_for(blob, disposition: :attachment, filename: nil, content_type: nil)
+    def expected_url_for(blob, expires_in: 5.minutes, disposition: :attachment, filename: nil, content_type: nil)
       filename ||= blob.filename
       content_type ||= blob.content_type
 
       query = { disposition: ActionDispatch::Http::ContentDisposition.format(disposition: disposition, filename: filename.sanitized), content_type: content_type }
       key_params = { key: blob.key }.merge(query)
 
-      "https://example.com/rails/active_storage/disk/#{ActiveStorage.verifier.generate(key_params, expires_in: 5.minutes, purpose: :blob_key)}/#{filename}?#{query.to_param}"
+      "https://example.com/rails/active_storage/disk/#{ActiveStorage.verifier.generate(key_params, expires_in: expires_in, purpose: :blob_key)}/#{filename}?#{query.to_param}"
     end
 end

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -31,6 +31,16 @@ if SERVICE_CONFIGURATIONS[:azure]
     ensure
       @service.delete(key)
     end
+
+    test "public URL generation" do
+      url = @service.public_url(@key)
+
+      assert_match(/.*\.blob\.core\.windows\.net\/.*\/#{@key}/,
+        url)
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "200", response.code
+    end
   end
 else
   puts "Skipping Azure Storage Service tests because no Azure configuration was supplied"

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -76,6 +76,16 @@ if SERVICE_CONFIGURATIONS[:gcs]
       assert_match(/storage\.googleapis\.com\/.*response-content-disposition=inline.*test\.txt.*response-content-type=text%2Fplain/,
         @service.url(@key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
     end
+
+    test "public URL generation" do
+      url = @service.public_url(@key)
+
+      assert_match(/storage\.googleapis\.com\/.*\/#{@key}/,
+        url)
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "200", response.code
+    end
   end
 else
   puts "Skipping GCS Service tests because no GCS configuration was supplied"

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -91,6 +91,16 @@ if SERVICE_CONFIGURATIONS[:s3]
       end
     end
 
+    test "public URL generation" do
+      url = @service.public_url(@key)
+
+      assert_match(/.*\.s3\.amazonaws\.com\/.*\/#{@key}/,
+        url)
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "200", response.code
+    end
+
     private
       def build_service(configuration)
         ActiveStorage::Service.configure :s3, SERVICE_CONFIGURATIONS.deep_merge(s3: configuration)


### PR DESCRIPTION
### Summary

Addresses issue #31419. Allows access to permanent URL to the blob.

### Other Information

I've tested with GCP and Azure, I could not get my AWS account set up (said my credit card number was invalid).