### PR TITLE
Prevent double save of inverse associations in autosave

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -572,6 +572,7 @@ module ActiveRecord
         @readonly                 = false
         @destroyed                = false
         @marked_for_destruction   = false
+        @saving                   = false
         @destroyed_by_association = nil
         @_start_transaction_state = nil
         @transaction_state        = nil

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -429,6 +429,7 @@ module ActiveRecord
               attr = attr.with_value_from_user(value) if attr.value != value
               attr
             end
+            @saving = false
             @mutations_from_database = nil
             @mutations_before_last_save = nil
             if @attributes.fetch_value(@primary_key) != restore_state[:id]

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1511,7 +1511,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     fall.sections << sections
     fall.save!
     fall.reload
-    assert_equal sections, fall.sections.sort_by(&:id)
+    assert_equal sections.sort_by(&:id), fall.sections.sort_by(&:id)
   end
 
   private


### PR DESCRIPTION
### Summary

Autosave would double save the child of a parent association with
inverse set if saving the child first. The second save of the child
would clear the mutation tracker resulting in an incorrect dirty state.

```
    # pirate has_one ship
    ship = Ship.new(name: "Nights Dirty Lightning")
    pirate = ship.build_pirate(catchphrase: "Aye")
    ship.save!
    ship.previous_changes # => returns {} but this should contain the changes.
```

This commit adds a `@saving` state which tracks if a record is currently being saved.
If `@saving` is set to true, the record won't be saved by the autosave callbacks.

When saving ship currently the following happens:
1. the `before_save` callbacks of the **ship** are called
2. the callbacks call `autosave_associated_records_for_pirate`
3. `autosave_associated_records_for_pirate` saves the **pirate**
4. the `after_save` callbacks of the **pirate** are called
5. the callbacks call `autosave_associated_records_for_ship`
6. `autosave_associated_records_for_ship` saves the **ship**
7. the **ship** is saved again by the original save

`autosave_associated_records_for_ship` saves the ship because the ship
association is set by inverse_of in a `has_one` on the pirate. This does
not happen with a `has_many` by default because the inverse is not set.
If setting the inverse on the `has_many` the problem occurs as well.

With this commit the following happens when saving a ship:
1. `@saving` is set to true on **ship**
2. the `before_save` callbacks of the **ship** are called
3. the callbacks call `autosave_associated_records_for_pirate`
5. `autosave_associated_records_for_pirate` saves the **pirate**
6. the `after_save` callbacks of the **pirate** are called
6. `autosave_associated_records_for_ship` skips saving the **ship**
8. the **ship** is saved.
9. `@saving` is set to false on \ship

### Other Information

Fixes #35597
