### PR TITLE
Fixed indentation in the plugin generator

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -76,10 +76,10 @@ module Rails
     def test
       template "test/test_helper.rb"
       template "test/%namespaced_name%_test.rb"
-      append_file "Rakefile", <<-EOF
+      append_file "Rakefile", <<~EOF
 
-#{rakefile_test_tasks}
-task default: :test
+        #{rakefile_test_tasks}
+        task default: :test
       EOF
       if engine?
         template "test/integration/navigation_test.rb"
@@ -393,14 +393,14 @@ task default: :test
       end
 
       def rakefile_test_tasks
-        <<-RUBY
-require 'rake/testtask'
+        <<~RUBY
+          require 'rake/testtask'
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
-end
+          Rake::TestTask.new(:test) do |t|
+            t.libs << 'test'
+            t.pattern = 'test/**/*_test.rb'
+            t.verbose = false
+          end
         RUBY
       end
 


### PR DESCRIPTION
While working on #36332 found some wrong indentation in the code. This PR fixes it. Please do close the PR if this is not required. 

Screenshot after change:
<img width="841" alt="Rakefile — issue-36332 2019-05-30 22-45-55" src="https://user-images.githubusercontent.com/7736232/58650630-d2350300-832c-11e9-8f7c-4e2cbc23aa8f.png">
