### PR TITLE
Schema Dumper raises an exception when it fails

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When schema dumping encounters an error it raises an exception instead of
+    leaving a comment on the schema.rb file.
+
+     Fixes: #36359
+
+     *Guilherme Mansur*
+
 *   Loading the schema for a model that has no `table_name` raises a `TableNotSpecified` error.
 
     *Guilherme Mansur*, *Eugene Kenny*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -380,15 +380,8 @@ db_namespace = namespace :db do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        temp_file = Tempfile.new("temp_schema_dump.rb")
         ActiveRecord::Base.establish_connection(db_config.config)
-        ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, temp_file)
-
-        temp_file.rewind
-        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
-        File.open(filename, "w:utf-8") { |file| IO.copy_stream(temp_file, file) }
-      ensure
-        temp_file.close!
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, :ruby, db_config.spec_name)
       end
 
       db_namespace["schema:dump"].reenable

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -380,8 +380,15 @@ db_namespace = namespace :db do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
+        temp_file = Tempfile.new("temp_schema_dump.rb")
         ActiveRecord::Base.establish_connection(db_config.config)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, :ruby, db_config.spec_name)
+        ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, temp_file)
+
+        temp_file.rewind
+        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
+        File.open(filename, "w:utf-8") { |file| IO.copy_stream(temp_file, file) }
+      ensure
+        temp_file.close!
       end
 
       db_namespace["schema:dump"].reenable

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -143,7 +143,11 @@ HEADER
 
           # then dump all non-primary key columns
           columns.each do |column|
-            raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
+            unless @connection.valid_type?(column.type)
+              raise "Unknown type #{column.sql_type} for column #{column.name}. " \
+                "To fix this set config.active_record.schema_format = :sql " \
+                "the schema will then be dumped to a structure.sql file instead of schema.rb"
+            end
             next if column.name == pk
             type, colspec = column_spec(column)
             tbl.print "    t.#{type} #{column.name.inspect}"
@@ -158,10 +162,6 @@ HEADER
 
           tbl.rewind
           stream.print tbl.read
-        rescue => e
-          stream.puts "# Could not dump table #{table.inspect} because of following #{e.class}"
-          stream.puts "#   #{e.message}"
-          stream.puts
         ensure
           self.table_name = nil
         end


### PR DESCRIPTION
### Summary

Previoulsy the schema dumper when it encountered a failure it would
rescue the exception and leave a comment on the schema.rb. Now we raise
an exception and let the developer be aware that the schema was not
dumped successfully.

This behaviour was added in 87535f5 to handle unknown column types. 
This is problematic because it fails silently, and someone wouldn't know 
until they ran a command like `db:test:prepare` or `db:schema:load` until
much much later.

We now let exceptions bubble up and display a helpful message for the 
unknown column types. 

Fixes: #36359

cc: @searls, @rafaelfranca 
