### PR TITLE
Fail parallel tests if workers exit early

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -27,6 +27,10 @@ module ActiveSupport
           @queue << o
         end
 
+        def length
+          @queue.length
+        end
+
         def pop; @queue.pop; end
       end
 
@@ -109,6 +113,10 @@ module ActiveSupport
       def shutdown
         @queue_size.times { @queue << nil }
         @pool.each { |pid| Process.waitpid pid }
+
+        if @queue.length > 0
+          raise "Queue not empty, but all workers have finished. This probably means that a worker crashed and #{@queue.length} tests were missed."
+        end
       end
 
       private

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -564,6 +564,24 @@ module ApplicationTests
       assert_no_match "create_table(:users)", output
     end
 
+    def test_run_in_parallel_with_process_worker_crash
+      exercise_parallelization_regardless_of_machine_core_count(with: :processes)
+
+      file_name = app_file("test/models/parallel_test.rb", <<-RUBY)
+        require 'test_helper'
+
+        class ParallelTest < ActiveSupport::TestCase
+          def test_crash
+            Kernel.exit 1
+          end
+        end
+      RUBY
+
+      output = run_test_command(file_name)
+
+      assert_match %r{Queue not empty, but all workers have finished. This probably means that a worker crashed and 1 tests were missed.}, output
+    end
+
     def test_run_in_parallel_with_threads
       exercise_parallelization_regardless_of_machine_core_count(with: :threads)
 


### PR DESCRIPTION
Previously, if a test worker exited early, the in-flight test it was supposed to run wasn't reported as a failure.

If all workers exited immediately, this would previously be reported as (for example)

    Finished in 1.708349s, 39.2192 runs/s, 79.0237 assertions/s.
    67 runs, 135 assertions, 0 failures, 0 errors, 2 skips

This commit validates that all workers finish running their tests by ensuring that the queue is empty after they exit. This works because we signal the workers to exit by pushing one `nil` each onto the queue, so the number of items left in the queue should matching the number of missed tests (technically off by one if the worker runs no tests, but 🤷‍♂).