### PR TITLE
Don't break configurations.each, .first before the deprecation period

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -91,6 +91,19 @@ module ActiveRecord
     end
     alias :blank? :empty?
 
+    def each
+      throw_getter_deprecation(:each)
+      configurations.each { |config|
+        yield [config.env_name, config.config]
+      }
+    end
+
+    def first
+      throw_getter_deprecation(:first)
+      config = configurations.first
+      [config.env_name, config.config]
+    end
+
     private
       def env_with_configs(env = nil)
         if env
@@ -174,9 +187,6 @@ module ActiveRecord
 
       def method_missing(method, *args, &blk)
         case method
-        when :each, :first
-          throw_getter_deprecation(method)
-          configurations.send(method, *args, &blk)
         when :fetch
           throw_getter_deprecation(method)
           configs_for(env_name: args.first)

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -80,17 +80,20 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
 
   def test_each_is_deprecated
     assert_deprecated do
-      ActiveRecord::Base.configurations.each do |db_config|
-        assert_equal "primary", db_config.spec_name
+      all_configs = ActiveRecord::Base.configurations.values
+      ActiveRecord::Base.configurations.each do |env_name, config|
+        assert_includes ["arunit", "arunit2", "arunit_without_prepared_statements"], env_name
+        assert_includes all_configs, config
       end
     end
   end
 
   def test_first_is_deprecated
+    first_config = ActiveRecord::Base.configurations.values.first
     assert_deprecated do
-      db_config = ActiveRecord::Base.configurations.first
-      assert_equal "arunit", db_config.env_name
-      assert_equal "primary", db_config.spec_name
+      env_name, config = ActiveRecord::Base.configurations.first
+      assert_equal "arunit", env_name
+      assert_equal first_config, config
     end
   end
 


### PR DESCRIPTION
### Summary

I was working on a library (switchman) that uses configuration.each and realized that it was broken (despite being listed as just deprecated) relative to Rails 5. I whipped up this change to fix it but I'm not sure if this is desired at this point in the release cycle. This is a first draft meant mostly as a chance for the maintainers to say "we're too frozen for this right now"; let me know if that isn't the case and you would like me to add tests or change anything.