### PR TITLE
Fix table comment also being applied to the primary key column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix table comment also being applied to the primary key column
+
+    *Guilherme Goettems Schneider*
+
 *   Allow generated `create_table` migrations to include or skip timestamps.
 
      *Michael Duchemin*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -302,7 +302,7 @@ module ActiveRecord
           if pk.is_a?(Array)
             td.primary_keys pk
           else
-            td.primary_key pk, options.fetch(:id, :primary_key), options
+            td.primary_key pk, options.fetch(:id, :primary_key), options.except(:comment)
           end
         end
 

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -44,6 +44,11 @@ if ActiveRecord::Base.connection.supports_comments?
       @connection.drop_table "blank_comments", if_exists: true
     end
 
+    def test_primary_key_comment
+      column = Commented.columns_hash["id"]
+      assert_nil column.comment
+    end
+
     def test_column_created_in_block
       column = Commented.columns_hash["name"]
       assert_equal :string, column.type


### PR DESCRIPTION
### Summary

While investigating #29966 I found this related bug that a table created with a comment in a `create_table` call like this 

```ruby
create_table :foo, comment: 'A table comment'
```

Will also add the same comment to the primary key column in the database.

### Detailed analysis

I traced back the origin of this bug. In the initial PR that added the database comments support, the comment option on the create table was not being passed to the primary key options, as [can be seen here](https://github.com/rails/rails/pull/22911/files#diff-a0775e1ec64264dc76a8ee71a5211ae3R273).

But then, after these 2 subsequent refactors 485e7f25f29ca1ca23bb214b802cf68840dabbb6 and b04c6339640d87b680f1975f3686fed0d885b1bc, the comment option was not being excluded from primary key options anymore and thus the bug.

