### PR TITLE
Remove `spring-watcher-listen` from default Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -58,9 +58,6 @@ group :development do
 <% if spring_install? -%>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-<% if depend_on_listen? -%>
-  gem 'spring-watcher-listen', '~> 2.0.0'
-<% end -%>
 <% end -%>
 end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1124,7 +1124,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     def assert_listen_related_configuration
       assert_gem "listen"
-      assert_gem "spring-watcher-listen"
 
       assert_file "config/environments/development.rb" do |content|
         assert_match(/^\s*config\.file_watcher = ActiveSupport::EventedFileUpdateChecker/, content)


### PR DESCRIPTION
`spring-watcher-listen` watch application root by default.
https://github.com/jonleighton/spring-watcher-listen/blob/c4bfe15805867e229588e4b776a7b87438137094/lib/spring/watcher/listen.rb#L58

This is necessary to watch the file (e.g. `.ruby-version`) in the application root.

By this `node_modules` also be watched, and it is a possibility to be
shown a warning by `listen`.
Related to #32700, #34912, https://github.com/rails/webpacker/issues/1990.

`listen` watches directory recursive by default, and it cannot avoid it.
https://github.com/guard/listen/issues/111
So If this warning happens, the only workaround the user can do is remove the gem.

The issue is likely to occur more frequently in Rails 6 because `rails new` runs `webpacker:install` by default. Because of such a state, I think that we should not recommend to use `spring-watcher-listen`.

Spring has polling watcher, restart process works without this
`spring-watcher-listen`. Because of polling base, CPU load may be higher than listen base. Still I think that it is better than the warning comes out.
