### PR TITLE
Remove unnecessary require pathname from actionpack controller specs

### DIFF
--- a/actionpack/test/controller/render_js_test.rb
+++ b/actionpack/test/controller/render_js_test.rb
@@ -2,7 +2,6 @@
 
 require "abstract_unit"
 require "controller/fake_models"
-require "pathname"
 
 class RenderJSTest < ActionController::TestCase
   class TestController < ActionController::Base

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -3,7 +3,6 @@
 require "abstract_unit"
 require "controller/fake_models"
 require "active_support/logger"
-require "pathname"
 
 class RenderJsonTest < ActionController::TestCase
   class JsonRenderable

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -2,7 +2,6 @@
 
 require "abstract_unit"
 require "controller/fake_models"
-require "pathname"
 
 class RenderXmlTest < ActionController::TestCase
   class XmlRenderable


### PR DESCRIPTION
Found the `require "pathname"` is not necessary in the following specs so I have removed them. Test passed on my local after removing them. 

Also, I did find some `require "pathname"` which didn't look like needed in the code. I did not remove it because I am not aware of the impact. Please let me know if I should mention those files here.

I came across this when I was working on https://github.com/rails/rails/pull/36034#discussion_r289644734 comment 

Please feel free to close the PR if this is not needed. Thanks 😊 