### PR TITLE
Add a warning for enum elements with 'not_' prefix.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add a warning for enum elements with 'not_' prefix.
+
+        class Foo
+          enum status: [:sent, :not_sent]
+        end
+
+    *Edu Depetris*
+
 *   Loading the schema for a model that has no `table_name` raises a `TableNotSpecified` error.
 
     *Guilherme Mansur*, *Eugene Kenny*

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -200,6 +200,8 @@ module ActiveRecord
             # scope :active, -> { where(status: 0) }
             # scope :not_active, -> { where.not(status: 0) }
             if enum_scopes != false
+              klass.send(:detect_negative_condition!, value_method_name)
+
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
               klass.scope value_method_name, -> { where(attr => value) }
 
@@ -260,6 +262,13 @@ module ActiveRecord
           method: method_name,
           source: source
         }
+      end
+
+      def detect_negative_condition!(method_name)
+        if method_name.start_with?("not_") && logger
+          logger.warn "An enum element in #{self.name} uses the prefix 'not_'." \
+            " This will cause a conflict with auto generated negative scopes."
+        end
       end
   end
 end


### PR DESCRIPTION
### Summary
Addresses #36272

I added a new warning when an user creates enum elements with **not_** prefix

Example
```rb
class Foo < ActiveRecord::Base
  enum status: [:sent, :not_sent]
end
```

```sh-session
$ bin/rails c 
Loading development environment (Rails 6.1.0.alpha)
 :001 > Foo
An enum element in Foo uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.
```

The enum element **not_sent** trigger the new warning

### Other Information
CHANGELOG updated.
