### PR TITLE
Fix invalid schema dump when primary key column has a comment

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix invalid schema when primary key column has a comment
+
+    Fixes #29966
+
+    *Guilherme Goettems Schneider*
+
 *   Fix table comment also being applied to the primary key column
 
     *Guilherme Goettems Schneider*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         def column_spec_for_primary_key(column)
           return {} if default_primary_key?(column)
           spec = { id: schema_type(column).inspect }
-          spec.merge!(prepare_column_options(column).except!(:null))
+          spec.merge!(prepare_column_options(column).except!(:null, :comment))
           spec[:default] ||= "nil" if explicit_primary_key_default?(column)
           spec
         end


### PR DESCRIPTION
Before this fix it would either generate an invalid schema, passing `comment` option twice to `create_table`, or it move the comment from primary key column to the table if table had no comment when the dump was generated.

The situation now is that a comment on primary key will be ignored (not present on schema). I've submitted a proposal to fix this on #36385.

Fixes #29966