### PR TITLE
Allow primary key comment on create table statement

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for primary key column comment with `primary_key_comment` option to `create_table`
+
+    *Guilherme Goettems Schneider*
+
 *   Fix invalid schema when primary key column has a comment
 
     Fixes #29966

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -13,9 +13,9 @@ module ActiveRecord
         end
 
         def column_spec_for_primary_key(column)
-          return {} if default_primary_key?(column)
-          spec = { id: schema_type(column).inspect }
-          spec.merge!(prepare_column_options(column).except!(:null, :comment))
+          spec = {}
+          spec[:id] = schema_type(column).inspect unless default_primary_key?(column)
+          spec.merge!(prepare_primary_key_options(column))
           spec[:default] ||= "nil" if explicit_primary_key_default?(column)
           spec
         end
@@ -31,6 +31,13 @@ module ActiveRecord
           spec[:comment] = column.comment.inspect if column.comment.present?
           spec.compact!
           spec
+        end
+
+        def prepare_primary_key_options(column)
+          options = prepare_column_options(column).except!(:null)
+          comment = options.delete(:comment)
+          options[:primary_key_comment] = comment if comment
+          options
         end
 
         def default_primary_key?(column)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -291,7 +291,7 @@ module ActiveRecord
       #     SELECT * FROM orders INNER JOIN line_items ON order_id=orders.id
       #
       # See also TableDefinition#column for details on how to create columns.
-      def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
+      def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, primary_key_comment: nil, **options)
         td = create_table_definition(
           table_name, options.extract!(:temporary, :if_not_exists, :options, :as, :comment)
         )
@@ -302,6 +302,7 @@ module ActiveRecord
           if pk.is_a?(Array)
             td.primary_keys pk
           else
+            options[:comment] = primary_key_comment if primary_key_comment
             td.primary_key pk, id, options
           end
         end

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -38,9 +38,7 @@ if ActiveRecord::Base.connection.supports_comments?
         t.index :absent_comment
       end
 
-      @connection.create_table("pk_commenteds", comment: "Table comment", id: false, force: true) do |t|
-        t.integer :id, comment: "Primary key comment", primary_key: true
-      end
+      @connection.create_table("pk_commenteds", comment: "Table comment", primary_key_comment: "Primary key comment", force: true)
 
       Commented.reset_column_information
       BlankComment.reset_column_information
@@ -187,7 +185,7 @@ if ActiveRecord::Base.connection.supports_comments?
     def test_schema_dump_with_primary_key_comment
       output = dump_table_schema "pk_commenteds"
       assert_match %r[create_table "pk_commenteds",.*\s+comment: "Table comment"], output
-      assert_no_match %r[create_table "pk_commenteds",.*\s+comment: "Primary key comment"], output
+      assert_match %r[create_table "pk_commenteds",.*\s+primary_key_comment: "Primary key comment"], output
     end
   end
 end


### PR DESCRIPTION
This PR adds support for primary key column comment with `primary_key_comment` option to `create_table`.

Before this schema dump/load was not able to keep a comment that was added to a primary key column.

This PR complements #36384.