### PR TITLE
Only load test railtie in test environment

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -16,7 +16,7 @@ require "action_controller/railtie"
 require "action_view/railtie"
 <%= comment_if :skip_action_cable %>require "action_cable/engine"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
-<%= comment_if :skip_test %>require "rails/test_unit/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie" if Rails.env.test?
 <% end -%>
 
 # Require the gems listed in Gemfile, including any gems

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
@@ -14,7 +14,7 @@ require "action_controller/railtie"
 require "action_view/railtie"
 <%= comment_if :skip_action_cable %>require "action_cable/engine"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
-<%= comment_if :skip_test %>require "rails/test_unit/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie" if Rails.env.test?
 <% end -%>
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
This cuts down on a bit of memory being allocated in production and a little bit on boot speed.