### PR TITLE
Introduce support for 3rd-party component frameworks

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `RenderingHelper` supports rendering objects that `respond_to?` `:render_in`
+
+    *Joel Hawksley*, *Natasha Umer*, *Aaron Patterson*, *Shawn Allen*, *Emily Plummer*, *Diana Mounter*, *John Hawthorn*, *Nathan Herald*, *Zaid Zawaideh*, *Zach Ahn*
+
 *   Fix `select_tag` so that it doesn't change `options` when `include_blank` is present.
 
     *Younes SERRAJ*

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -35,7 +35,11 @@ module ActionView
             end
           end
         else
-          view_renderer.render_partial(self, partial: options, locals: locals, &block)
+          if options.respond_to?(:render_in)
+            options.render_in(self, &block)
+          else
+            view_renderer.render_partial(self, partial: options, locals: locals, &block)
+          end
         end
       end
 

--- a/actionview/test/lib/test_component.rb
+++ b/actionview/test/lib/test_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class TestComponent < ActionView::Base
+  include ActiveModel::Validations
+
+  validates :content, :title, presence: true
+  delegate :render, to: :view_context
+
+  def initialize(title:)
+    @title = title
+  end
+
+  # Entrypoint for rendering. Called by ActionView::RenderingHelper#render.
+  #
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context, &block)
+    self.class.compile
+    @view_context = view_context
+    @content = view_context.capture(&block) if block_given?
+    validate!
+    rendered_template
+  end
+
+  def self.template
+    <<~'erb'
+    <span title="<%= title %>"><%= content %> (<%= render(plain: "Inline render") %>)</span>
+    erb
+  end
+
+  def self.compile
+    @compiled ||= nil
+    return if @compiled
+
+    class_eval(
+      "def rendered_template; @output_buffer = ActionView::OutputBuffer.new; " +
+      ActionView::Template::Handlers::ERB.erb_implementation.new(template, trim: true).src +
+      "; end"
+    )
+
+    @compiled = true
+  end
+
+private
+
+  attr_reader :content, :title, :view_context
+end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -2,6 +2,8 @@
 
 require "abstract_unit"
 require "controller/fake_models"
+require "test_component"
+require "active_model/validations"
 
 class TestController < ActionController::Base
 end
@@ -669,6 +671,21 @@ module RenderTestCases
 
   def test_render_throws_exception_when_no_extensions_passed_to_register_template_handler_function_call
     assert_raises(ArgumentError) { ActionView::Template.register_template_handler CustomHandler }
+  end
+
+  def test_render_component
+    assert_equal(
+      %(<span title="my title">Hello, World! (Inline render)</span>),
+      @view.render(TestComponent.new(title: "my title")) { "Hello, World!" }.strip
+    )
+  end
+
+  def test_render_component_with_validation_error
+    error = assert_raises(ActiveModel::ValidationError) do
+      @view.render(TestComponent.new(title: "my title")).strip
+    end
+
+    assert_match "Content can't be blank", error.message
   end
 end
 


### PR DESCRIPTION
_Note: This PR initially was titled: `Introduce support for ActionView::Component`. I've updated the content to better reflect the changes we ended up shipping, to use the new name of GitHub's library, `ViewComponent`, and to remove mentions of validations, which we no longer use. - @joelhawksley, March 2020_

# Introduce support for 3rd-party component frameworks

This PR introduces structural support for 3rd-party component frameworks, including [ViewComponent](https://github.com/github/view_component), GitHub's framework for building view components.

Specifically, it modifies `ActionView::RenderingHelper#render` to support passing in an object to `render` that `responds_to` `render_in`, enabling us to build view components as objects in Rails.

We’ve been running a variant of this patch in production at GitHub since March, and now have about a dozen components used in over a hundred call sites.

The PR includes an example component (`TestComponent`) that closely resembles the base component we're using at GitHub.

[I spoke about our project at RailsConf](https://www.youtube.com/watch?v=y5Z5a6QdA-M), where we got lots of great feedback from the community. Several folks asked us to upstream it into Rails.

## Why

In working on views in our Rails monolith at GitHub (which has over 4,000 templates), we have run into several key pain points:

### Testing

Currently, Rails encourages testing views via integration or system tests. This discourages us from testing our views thoroughly, due to the costly overhead of exercising the routing/controller layer, instead of just the view. It also often leads to partials being tested for each view they are included in, cheapening the benefit of DRYing up our views.

### Code Coverage

Many common Ruby code coverage tools cannot properly handle coverage of views, making it difficult to audit how thorough our tests are and leading to gaps in our test suite.

### Data Flow

Unlike a method declaration on an object, views do not declare the values they are expected to receive, making it hard to figure out what context is necessary to render them. This often leads to subtle bugs when we reuse a view across different contexts.

### Standards

Our views often fail even the most basic standards of code quality we expect out of our Ruby classes: long methods, deep conditional nesting, and mystery guests abound.

## ViewComponent

`ViewComponent` is an effort to address these pain points in a way that improves the Rails view layer.

### Building Components

Components are subclasses of `ViewComponent` and live in `app/components`.

They include a sidecar template file with the same base name as the component.

### Example

Given the component `app/components/test_component.rb`: 

```ruby
class TestComponent < ViewComponent
  def initialize(title:)
    @title = title
  end
end
```

And the template `app/components/test_component.html.erb`:

```erb
<span title="<%= @title %>"><%= content %></span>
```

We can render it in a view as:

```erb
<%= render(TestComponent.new(title: "my title")) do %>
  Hello, World!
<% end %>
```

Which returns:

```html
<span title="my title">Hello, World!</span>
```

## Testing

Components are unit tested directly, based on their HTML output. The `render_inline` test helper enables the use of Capybara assertions:

```ruby
def test_render_component
  render_inline(TestComponent.new(title: "my title")) { "Hello, World!" }

  assert_text "Hello, World"
  assert_selector "span[title='my title']"
end
```

## Benefits

### Testing

`ViewComponent` allows views to be unit-tested. Our unit tests run in around 25ms/test, vs. ~6s/test for integration tests.

### Code Coverage

`ViewComponent` is at least partially compatible with code coverage tools. We’ve seen some success with SimpleCov.

### Data flow

By clearly defining the context necessary to render a component, we’ve found them to be easier to reuse than partials.

## Existing implementations

`ViewComponent` is far from a novel idea. Popular implementations of view components in Ruby include, but are not limited to:

- [trailblazer/cells](https://github.com/trailblazer/cells)
- [dry-rb/dry-view](https://github.com/dry-rb/dry-view)
- [komposable/komponent](https://github.com/komposable/komponent)
- [activeadmin/arbre](https://github.com/activeadmin/arbre)

## In action

I’ve created a [demo repository](https://github.com/joelhawksley/view-component-demo) pointing to this branch.

## Co-authored-by

A cross-functional working group of engineers and members of our Design Systems team collaborated on this work, including by not limited to: @natashau, @tenderlove, @shawnbot, @emplums, @broccolini, @jhawthorn, @myobie, and @zawaideh.

Additionally, numerous members of the community have shared their ideas for `ViewComponent`, including but not limited to: @cgriego, @xdmx, @skyksandr, @jcoyne, @dylanahsmith, @kennyadsl, @cquinones100, @erikaxel, @zachahn, and @trcarden.