### PR TITLE
Do not clear deprecated initializer dependencies if using classic autoloader

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -39,8 +39,14 @@ module Rails
         example       = autoloaded.first
         example_klass = example.constantize.class
 
-        ActiveSupport::DescendantsTracker.clear
-        ActiveSupport::Dependencies.clear
+        if config.autoloader == :zeitwerk
+          ActiveSupport::DescendantsTracker.clear
+          ActiveSupport::Dependencies.clear
+
+          unload_message = "#{these} autoloaded #{constants} #{have} been unloaded."
+        else
+          unload_message = "`config.autoloader` is set to `#{config.autoloader}`. #{these} autoloaded #{constants} would have been unloaded if `config.autoloader` had been set to `:zeitwerk`."
+        end
 
         ActiveSupport::Deprecation.warn(<<~WARNING)
           Initialization autoloaded the #{constants} #{enum}.
@@ -52,7 +58,7 @@ module Rails
           initialization does not run again. So, if you reload #{example}, for example,
           the expected changes won't be reflected in that stale #{example_klass} object.
 
-          #{these} autoloaded #{constants} #{have} been unloaded.
+          #{unload_message}
 
           Please, check the "Autoloading and Reloading Constants" guide for solutions.
         WARNING


### PR DESCRIPTION
At GitHub we're seeing some issues related to the clearing of constants that have been autoloaded during initialization.

`Rails::Application::Finisher` defines a `:let_zeitwerk_take_over` initializer. This initializer is always run but it's statements are wrapped in a guard: `if config.autoloader == :zeitwerk`.

`Finisher` also defines a `initializer :warn_if_autoloaded` initializer with a `before: :let_zeitwerk_take_over` option which also always runs. This initializer unloads any constants which were autoloaded during initialization and displays a deprecation warning. This initializer does not account for `config.autoloader` being set to `:classic`.

This initializer changes the behavior of the classic autoloader. Constant autoloading from initializers is deprecated but the deprecation should not break existing applications which currently depend on these autoloaded constants in initializers.

This PR prevents the dependencies from being unloaded if the autoloader is not Zeitwerk (i.e. is `:classic`). It also updates the deprecation warning, if the classic autoloader is enabled, to indicate that the constants would have been unloaded if Zeitwerk had been used.

cc: @fxn, @eileencodes 