### PR TITLE
Only clear cache when view paths are specified

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -22,6 +22,8 @@ module ActionView
     def clear_cache_if_necessary
       @mutex.synchronize do
         watched_dirs = dirs_to_watch
+        return if watched_dirs.empty?
+
         if watched_dirs != @watched_dirs
           @watched_dirs = watched_dirs
           @watcher = @watcher_class.new([], watched_dirs) do


### PR DESCRIPTION
Currently, `clear_cache_if_necessary` is executed even if view paths are not set like `rails console`.

If the watcher class is `EventedFileUpdateChecker` and the watch directories are empty, the application root directory will watch. This is because listen uses the current directory as the default watch directory.
https://github.com/guard/listen/blob/8d85b4cd5788592799adea61af14a29bf2895d87/lib/listen/adapter/config.rb#L13
    
As a result, `node_modules` also watch. This cause a warning of `listen`.
Ref: https://github.com/rails/rails/pull/36377#issuecomment-498399576
