### PR TITLE
Don't call listen with empty directory list

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -108,7 +108,10 @@ module ActiveSupport
     private
       def boot!
         normalize_dirs!
-        Listen.to(*@dtw, &method(:changed)).start
+
+        unless @dtw.empty?
+          Listen.to(*@dtw, &method(:changed)).start
+        end
       end
 
       def shutdown!


### PR DESCRIPTION
Listen interprets an empty list of directories as "watch the current directory". Since EventedFileUpdateChecker doesn't share these semantics, we should not initialize listen if we end up with an empty directory list.

Refs #36397 #36377

cc @y-yagi