### PR TITLE
Name helper_method module and improve source location

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -61,12 +61,17 @@ module AbstractController
         meths.flatten!
         self._helper_methods += meths
 
+        location = caller_locations(1, 1).first
+        file, line = location.path, location.lineno
+
         meths.each do |meth|
-          _helpers.class_eval <<-ruby_eval, __FILE__, __LINE__ + 1
-            def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
-              controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
-            end                                                    # end
-          ruby_eval
+          method_def = [
+            "def #{meth}(*args, &blk)",
+            "  controller.send(%(#{meth}), *args, &blk)",
+            "end"
+          ].join(";")
+
+          _helpers.class_eval method_def, file, line
         end
       end
 

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -150,8 +150,8 @@ class HelperTest < ActiveSupport::TestCase
   end
 
   def test_default_helpers_only
-    assert_equal [JustMeHelper], JustMeController._helpers.ancestors.reject(&:anonymous?)
-    assert_equal [MeTooHelper, JustMeHelper], MeTooController._helpers.ancestors.reject(&:anonymous?)
+    assert_equal %w[JustMeHelper], JustMeController._helpers.ancestors.reject(&:anonymous?).map(&:to_s)
+    assert_equal %w[MeTooController::HelperMethods MeTooHelper JustMeHelper], MeTooController._helpers.ancestors.reject(&:anonymous?).map(&:to_s)
   end
 
   def test_base_helper_methods_after_clear_helpers


### PR DESCRIPTION
This PR aims to improve introspection of helper methods by naming the module which includes them, and by changing their source location to the line where `helper_method` is called. The module is named like `MyController::HelperMethods` (this is somewhat similar to #35595 - giving `GeneratedAttributeMethods` a name in activerecord).

For example, from a `binding.pry` in a view, if we were curious where `cookies` was defined ...

**Before**

```
pry> $ cookies

From: /Users/jhawthorn/src/rails/actionpack/lib/abstract_controller/helpers.rb @ line 66:
Owner: #<Module:0x00007f979aa93c40>
Visibility: public
Number of lines: 3

def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
  controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
end                                                    # end
```

... we don't learn a lot from this

**After**

```
pry> $ cookies

From: /Users/jhawthorn/src/rails/actionpack/lib/action_controller/metal/cookies.rb @ line 8:
Owner: ActionController::Base::HelperMethods
Visibility: public
Number of lines: 1

helper_method :cookies if defined?(helper_method)
```

... Oh! We can see where it's defined, and can tell that it's on `ActionController::Base`