### PR TITLE
Fix sqlite3 collation parsing when using decimal columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix sqlite3 collation parsing when using decimal columns.
+
+    *Martin R. Schuster*
+
 *   Fix invalid schema when primary key column has a comment
 
     Fixes #29966

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -477,9 +477,9 @@ module ActiveRecord
           result = exec_query(sql, "SCHEMA").first
 
           if result
-            # Splitting with left parentheses and picking up last will return all
+            # Splitting with left parentheses and discarding the first part will return all
             # columns separated with comma(,).
-            columns_string = result["sql"].split("(").last
+            columns_string = result["sql"].split("(", 2).last
 
             columns_string.split(",").each do |column_string|
               # This regex will match the column name and collation type and will save

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -11,6 +11,10 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
     @connection.create_table :collation_table_sqlite3, force: true do |t|
       t.string :string_nocase, collation: "NOCASE"
       t.text :text_rtrim, collation: "RTRIM"
+      # The decimal column might interfere with collation parsing.
+      # Thus, add this column type and some other string column afterwards.
+      t.decimal :decimal_col, precision: 6, scale: 2
+      t.string :string_after_decimal_nocase, collation: "NOCASE"
     end
   end
 
@@ -20,6 +24,11 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
 
   test "string column with collation" do
     column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "string_nocase" }
+    assert_equal :string, column.type
+    assert_equal "NOCASE", column.collation
+
+    # Verify collation of a column behind the decimal column as well.
+    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "string_after_decimal_nocase" }
     assert_equal :string, column.type
     assert_equal "NOCASE", column.collation
   end


### PR DESCRIPTION
If an sqlite3 table contains a decimal column behind columns with a collation
definition, then parsing the collation of all preceding columns will fail --
the collation will be missed without notice.

This PR fixes the issue and adds test coverage.