### PR TITLE
Allow binary nodes to be aliased

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow Arel::Nodes::Binary to be aliased
+
+    *Kevin Deisz*
+
 *   Fix sqlite3 collation parsing when using decimal columns.
 
     *Martin R. Schuster*

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -3,6 +3,8 @@
 module Arel # :nodoc: all
   module Nodes
     class Binary < Arel::Nodes::NodeExpression
+      include Arel::AliasPredication
+
       attr_accessor :left, :right
 
       def initialize(left, right)

--- a/activerecord/test/cases/arel/nodes/binary_test.rb
+++ b/activerecord/test/cases/arel/nodes/binary_test.rb
@@ -23,6 +23,16 @@ module Arel
             assert_not_equal eq.hash, neq.hash
           end
         end
+
+        describe "as" do
+          it "should alias the binary node" do
+            lefts = Arel::Table.new(:lefts).project(:name)
+            rights = Arel::Table.new(:rights).project(:name)
+
+            sql = Arel::Nodes::Union.new(lefts, rights).as("foo").to_sql
+            assert_match %r{(.+) AS foo}, sql
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Currently looking for this behavior as it's useful to include multiple table sources in unions and then put them into the `from` clause of an AR relation.

Before:

```ruby
def tag_names
  from =
    Arel::Nodes::As.new(
      Interest.select(:name).arel.union(Skill.select(:name).arel),
      Arel.sql('tags')
    )
  Interest.from(from).pluck(:name).to_sentence
end
```

After:

```ruby
def tag_names
  from = Interest.select(:name).arel.union(Skill.select(:name).arel).as('tags')
  Interest.from(from).pluck(:name).to_sentence
end
```