### PR TITLE
Extract default log file open operation to method

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -34,20 +34,12 @@ module Rails
       # Initialize the logger early in the stack in case we need to log some deprecation.
       initializer :initialize_logger, group: :all do
         Rails.logger ||= config.logger || begin
-          path = config.paths["log"].first
-          unless File.exist? File.dirname path
-            FileUtils.mkdir_p File.dirname path
-          end
-
-          f = File.open path, "a"
-          f.binmode
-          f.sync = config.autoflush_log # if true make sure every write flushes
-
-          logger = ActiveSupport::Logger.new f
+          logger = ActiveSupport::Logger.new(config.default_log_file)
           logger.formatter = config.log_formatter
           logger = ActiveSupport::TaggedLogging.new(logger)
           logger
         rescue StandardError
+          path = config.paths["log"].first
           logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDERR))
           logger.level = ActiveSupport::Logger::WARN
           logger.warn(

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -311,6 +311,18 @@ module Rails
         end
       end
 
+      def default_log_file
+        path = paths["log"].first
+        unless File.exist? File.dirname path
+          FileUtils.mkdir_p File.dirname path
+        end
+
+        f = File.open path, "a"
+        f.binmode
+        f.sync = autoflush_log # if true make sure every write flushes
+        f
+      end
+
       class Custom #:nodoc:
         def initialize
           @configurations = Hash.new

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1607,6 +1607,13 @@ module ApplicationTests
       assert_not_nil Rails::SourceAnnotationExtractor::Annotation.extensions[/\.(coffee)$/]
     end
 
+    test "config.default_log_file returns a File instance" do
+      app "development"
+
+      assert_instance_of File, app.config.default_log_file
+      assert_equal Rails.application.config.paths["log"].first, app.config.default_log_file.path
+    end
+
     test "rake_tasks block works at instance level" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
This allows customizing a default log file(e.g. `reopen`) by an application.

Fixes #32211.
