### PR TITLE
Fix action pack and railties changelog typo[ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -89,7 +89,7 @@
     This is a new middleware that guards against DNS rebinding attacks by
     explicitly permitting the hosts a request can be made to.
 
-    Each host is checked with the case operator (`#===`) to support `RegExp`,
+    Each host is checked with the case operator (`#===`) to support `Regexp`,
     `Proc`, `IPAddr` and custom objects as host allowances.
 
     *Genadi Samokovarov*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -188,7 +188,7 @@
         Rails.application.config.hosts << "product.com"
 
     The host of a request is checked against the `hosts` entries with the case
-    operator (`#===`), which lets `hosts` support entries of type `RegExp`,
+    operator (`#===`), which lets `hosts` support entries of type `Regexp`,
     `Proc` and `IPAddr` to name a few. Here is an example with a regexp.
 
         # Allow requests from subdomains like `www.product.com` and


### PR DESCRIPTION
### Summary

The class RegExp does not exist in Ruby.
I think Regexp is correct.