### PR TITLE
Use official database name. Change sqlite3 -> SQLite3 in changelog [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Fix sqlite3 collation parsing when using decimal columns.
+*   Fix SQLite3 collation parsing when using decimal columns.
 
     *Martin R. Schuster*
 


### PR DESCRIPTION
Similar to: https://github.com/rails/rails/commit/96f0114e082b116856e945b075abd747eff0e63e

Changed `sqlite3` -> `SQLite3`. 