### PR TITLE
Simplify save_collection_association conditionals

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -394,24 +394,22 @@ module ActiveRecord
             records.each do |record|
               next if record.destroyed?
 
-              saved = true
-
               if autosave != false && (new_record_before_save || record.new_record?)
                 if autosave
                   saved = association.insert_record(record, false)
                 elsif !reflection.nested?
-                  association_saved = association.insert_record(record)
+                  saved = association.insert_record(record)
 
-                  if reflection.validate?
-                    errors.add(reflection.name) unless association_saved
-                    saved = association_saved
+                  if reflection.validate? && !saved
+                    errors.add(reflection.name)
+                    raise ActiveRecord::Rollback
                   end
                 end
               elsif autosave
                 saved = record.save(validate: false)
               end
 
-              raise ActiveRecord::Rollback unless saved
+              raise ActiveRecord::Rollback if !saved && autosave
             end
           end
         end


### PR DESCRIPTION
### Summary

Simplifies `save_collection_association` conditionals and makes them more similar to `save_has_one_association`.

`save_has_one_association` has:
```ruby
   raise ActiveRecord::Rollback if !saved && autosave
```

`save_collection_association` has:
```ruby
   raise ActiveRecord::Rollback unless saved
```

But in `save_collection_association` `ActiveRecord::Rollback` is only raised if `autosave` is `true`, except for one special case.
This special case occurs when:
- autosave is nil
- the reflection is not nested but requires validation
- the record could not be inserted

For this special case we can raise the exception earlier and simplify the conditionals.
This makes this special case stand out more and keeps it's requirements in a single place.

Handling the special case like this allows us to use the following in `save_has_one_association` just like `save_has_one_association`:
```ruby
   raise ActiveRecord::Rollback if !saved && autosave
```

We can also remove the temporary `saved = true` assignment.
This is used to not raise the `Rollback` exception in cases where `autosave` is `false` and we don't save.
It's a bit confusing to have `saved` set to `true` even if we didn't save anything.