### PR TITLE
Guides 6.0 release notes: fix typo

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -686,7 +686,7 @@ Please refer to the [Changelog][active-storage] for detailed changes.
 
 *   Use the `image_processing` gem for Active Storage variants. This replaces using
     `mini_magick` directly.
-    ([Pull Request](https://github.com/rails/rails/pull/32471)
+    ([Pull Request](https://github.com/rails/rails/pull/32471))
 
 *   Replace existing images instead of adding to them when updating an
     attached model via `update` or `update!` with, say, `@user.update!(images: [ … ])`.


### PR DESCRIPTION
An unfinished parenthetical.

<img width="654" alt="image" src="https://user-images.githubusercontent.com/14123/58944107-36e0d980-87d5-11e9-83be-992dc3827808.png">
