### PR TITLE
Fixed db:prepare task for multiple databases.

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -169,8 +169,8 @@ module ActiveRecord
         end
       end
 
-      def create_current(environment = env)
-        each_current_configuration(environment) { |configuration|
+      def create_current(environment = env, spec_name = nil)
+        each_current_configuration(environment, spec_name) { |configuration|
           create configuration
         }
         ActiveRecord::Base.establish_connection(environment.to_sym)
@@ -325,6 +325,26 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
+      def dump_schema(configuration, format = ActiveRecord::Base.schema_format, spec_name = "primary")
+        require "active_record/schema_dumper"
+        filename = dump_filename(spec_name, format)
+
+        case format
+        when :ruby
+          File.open(filename, "w:utf-8") do |file|
+            ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+          end
+        when :sql
+          structure_dump(configuration, filename)
+          if ActiveRecord::SchemaMigration.table_exists?
+            File.open(filename, "a") do |f|
+              f.puts ActiveRecord::Base.connection.dump_schema_information
+              f.print "\n"
+            end
+          end
+        end
+      end
+
       def schema_file(format = ActiveRecord::Base.schema_format)
         File.join(db_dir, schema_file_type(format))
       end
@@ -406,12 +426,14 @@ module ActiveRecord
           task.is_a?(String) ? task.constantize : task
         end
 
-        def each_current_configuration(environment)
+        def each_current_configuration(environment, spec_name = nil)
           environments = [environment]
           environments << "test" if environment == "development"
 
           environments.each do |env|
             ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|
+              next if spec_name && spec_name != db_config.spec_name
+
               yield db_config.config, db_config.spec_name, env
             end
           end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -448,18 +448,36 @@ module TestHelpers
       $:.reject! { |path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
 
-    def use_postgresql
-      File.open("#{app_path}/config/database.yml", "w") do |f|
-        f.puts <<-YAML
-        default: &default
-          adapter: postgresql
-          pool: 5
-          database: railties_test
-        development:
-          <<: *default
-        test:
-          <<: *default
-        YAML
+    def use_postgresql(multi_db: false)
+      if multi_db
+        File.open("#{app_path}/config/database.yml", "w") do |f|
+          f.puts <<-YAML
+          default: &default
+            adapter: postgresql
+            pool: 5
+          development:
+            primary:
+              <<: *default
+              database: railties_test
+            animals:
+              <<: *default
+              database: railties_animals_test
+              migrations_paths: db/animals_migrate
+          YAML
+        end
+      else
+        File.open("#{app_path}/config/database.yml", "w") do |f|
+          f.puts <<-YAML
+          default: &default
+            adapter: postgresql
+            pool: 5
+            database: railties_test
+          development:
+            <<: *default
+          test:
+            <<: *default
+          YAML
+        end
       end
     end
   end


### PR DESCRIPTION
When one database existed already, but not the other,
during setup of missing one, existing database was wiped out.

Other issue caused by this - when using `structure.sql` , on existing database it was loaded again, resulting in error.

Issue was that when invoking rake task `migrate` and `setup` they were not scoped to the current connection, but repeated for all databases.

/cc @robertomiranda @eileencodes 