### PR TITLE
Add some examples for getting current_user

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -120,13 +120,9 @@ by this same current user, you're also ensuring that you can later retrieve all 
 connections by a given user (and potentially disconnect them all if the user is deleted
 or unauthorized).
 
-If you use Devise for authenticaion, you can get `current_user` from warden:
-
-```ruby
-  verified_user = env['warden'].user
-```
-
-In any other authentication approach you can access the session cookie. If you use cookie store for the session, your session cookie is named "\_session" and the user ID key is "user_id" you can use this approach:
+If your authentication approach includes using a session, you use cookie store for the
+session, your session cookie is named `_session` and the user ID key is `user_id` you
+can use this approach:
 ```ruby
   verified_user = User.find_by(id: cookies.encrypted['_session']['user_id'])
 ```

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -111,7 +111,7 @@ specific connection later. Note that anything marked as an identifier will autom
 create a delegate by the same name on any channel instances created off the connection.
 
 This example relies on the fact that you will already have handled authentication of the user
-somewhere else in your application, and that a successful authentication sets a signed
+somewhere else in your application, and that a successful authentication sets an encrypted
 cookie with the user ID.
 
 The cookie is then automatically sent to the connection instance when a new connection
@@ -119,6 +119,17 @@ is attempted, and you use that to set the `current_user`. By identifying the con
 by this same current user, you're also ensuring that you can later retrieve all open
 connections by a given user (and potentially disconnect them all if the user is deleted
 or unauthorized).
+
+If you use Device for authenticaion, you can get `current_user` from warden:
+
+```ruby
+  verified_user = env['warden'].user
+```
+
+In any other authentication approach you can access the session cookie. If you use cookie store for the session, your session cookie is named "\_session" and the user ID key is "user_id" you can use this approach:
+```ruby
+  verified_user = User.find_by(id: cookies.encrypted['_session']['user_id'])
+```
 
 ### Channels
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -120,7 +120,7 @@ by this same current user, you're also ensuring that you can later retrieve all 
 connections by a given user (and potentially disconnect them all if the user is deleted
 or unauthorized).
 
-If you use Device for authenticaion, you can get `current_user` from warden:
+If you use Devise for authenticaion, you can get `current_user` from warden:
 
 ```ruby
   verified_user = env['warden'].user


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Add some examples for getting current_user in ActionCable::Connection.

It is somehow common for Rails to use a session in order to keep current user user_id. The most common authentication approach is with Devise.

This PR suggest some more info on how to obtain current_user with Devise and how to obtain current_user in a more general situation when we have a session cookie.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

The in the text a "signed" cookie is mentioned but in the code above is using an "encrypted" cookie.
