### PR TITLE
Make getting/setting foreign_key uniform in autosave_association

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -435,7 +435,7 @@ module ActiveRecord
           if autosave && record.marked_for_destruction?
             record.destroy
           elsif autosave != false
-            key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
+            key = send(reflection.options[:primary_key] || :id)
 
             if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
               unless reflection.through_reflection
@@ -484,8 +484,8 @@ module ActiveRecord
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
-              association_id = record.send(reflection.options[:primary_key] || :id)
-              self[reflection.foreign_key] = association_id
+              key = record.send(reflection.options[:primary_key] || :id)
+              self[reflection.foreign_key] = key
               association.loaded!
             end
 


### PR DESCRIPTION
### Summary

Setting the foreign_key in the autosave records can be made more
similar.

Getting the foreign_key is done in two variants in autosave_association. The longer form:
```ruby
key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
```

...and the shorter form:
```ruby
  key = send(reflection.options[:primary_key] || :id)
```

This refactoring uses the shorter form for both.

Also in save_belongs_to_association `association_id` is used as the name of the
variable for the value of the foreign_key. But `key` is used everywhere else in
autosave_association. So `association_id` has been renamed to `key`.