### PR TITLE
Run actionview tests in parallel

### DIFF
--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -192,6 +192,8 @@ module ActionDispatch
 end
 
 class ActiveSupport::TestCase
+  parallelize
+
   include ActiveSupport::Testing::MethodCallAssertions
 
   private

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -42,6 +42,12 @@ class ActiveRecordTestConnector
       self.able_to_connect = false
     end
 
+    def reconnect
+      return unless able_to_connect
+      ActiveRecord::Base.connection.reconnect!
+      load_schema
+    end
+
     private
       def setup_connection
         if Object.const_defined?(:ActiveRecord)
@@ -102,3 +108,7 @@ class ActiveRecordTestCase < ActionController::TestCase
 end
 
 ActiveRecordTestConnector.setup
+
+ActiveSupport::Testing::Parallelization.after_fork_hook do
+  ActiveRecordTestConnector.reconnect
+end

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -60,46 +60,8 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
     assert_equal "two", render(template: "test/render_file_with_locals_and_default", locals: { secret: "two" })
   end
 
-  def test_template_changes_are_not_reflected_with_cached_templates
-    assert_equal "Hello world!", render(template: "test/hello_world")
-    modify_template "test/hello_world.erb", "Goodbye world!" do
-      assert_equal "Hello world!", render(template: "test/hello_world")
-    end
-    assert_equal "Hello world!", render(template: "test/hello_world")
-  end
-
-  def test_template_changes_are_reflected_with_uncached_templates
-    assert_equal "Hello world!", render_without_cache(template: "test/hello_world")
-    modify_template "test/hello_world.erb", "Goodbye world!" do
-      assert_equal "Goodbye world!", render_without_cache(template: "test/hello_world")
-    end
-    assert_equal "Hello world!", render_without_cache(template: "test/hello_world")
-  end
-
   private
     def render(*args)
-      render_with_cache(*args)
-    end
-
-    def render_with_cache(*args)
-      view_paths = ActionController::Base.view_paths
-      view_class.with_view_paths(view_paths, {}).render(*args)
-    end
-
-    def render_without_cache(*args)
-      path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
-      view_paths = ActionView::PathSet.new([path])
-      view_class.with_view_paths(view_paths, {}).render(*args)
-    end
-
-    def modify_template(template, content)
-      filename = "#{FIXTURE_LOAD_PATH}/#{template}"
-      old_content = File.read(filename)
-      begin
-        File.open(filename, "wb+") { |f| f.write(content) }
-        yield
-      ensure
-        File.open(filename, "wb+") { |f| f.write(old_content) }
-      end
+      ActionController::Base.render(*args)
     end
 end


### PR DESCRIPTION
This changes all three of actionview's test suites to run in parallel.

On my machine:

**Before**
`test:templates`: Finished in 3.266624s, 632.7633 runs/s, 1475.5294 assertions/s.
`test:integration:action_pack`: Finished in 0.231103s, 1021.1917 runs/s, 1380.3397 assertions/s.
`test:integration:active_record`: Finished in 2.400327s, 70.8237 runs/s, 125.3996 assertions/s.
Total time (including loading):
`PARALLEL_WORKERS=0 bundle exec rake  9.67s user 0.97s system 98% cpu 10.754 total`

**After**
`test:templates`: Finished in 1.171794s, 1763.9617 runs/s, 4113.3505 assertions/s.
`test:integration:action_pack`: Finished in 0.157664s, 1496.8584 runs/s, 2023.2959 assertions/s.
`test:integration:active_record`: Finished in 0.564327s, 301.2439 runs/s, 533.3789 assertions/s.
Total time (including loading):
`bundle exec rake  13.13s user 1.83s system 220% cpu 6.769 total`