### PR TITLE
Allow include_blank: false on required select #31083

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -145,8 +145,8 @@ module ActionView
             add_default_name_and_id(html_options)
 
             if placeholder_required?(html_options)
-              raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
-              options[:include_blank] ||= true unless options[:prompt]
+              raise ArgumentError, "include_blank cannot be false for a required field with empty options." if option_tags.empty? && options[:include_blank] == false
+              options[:include_blank] ||= true unless options[:prompt] || options[:include_blank] == false
             end
 
             value = options.fetch(:selected) { value() }

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -730,11 +730,29 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
-  def test_select_with_include_blank_false_and_required
+  def test_select_from_empty_with_include_blank_false_and_required
     @post = Post.new
     @post.category = "<mus>"
-    e = assert_raises(ArgumentError) { select("post", "category", %w( abe <mus> hest), { include_blank: false }, { required: "required" }) }
-    assert_match(/include_blank cannot be false for a required field./, e.message)
+    e = assert_raises(ArgumentError) { select("post", "category", "", { include_blank: false }, { required: "required" }) }
+    assert_match(/include_blank cannot be false for a required field with empty options./, e.message)
+  end
+
+  def test_select_from_non_empty_with_include_blank_true_and_required
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select required=\"required\" id=\"post_category\" name=\"post[category]\"><option value=\"\"></option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest), { include_blank: true }, { required: "required" })
+    )
+  end
+
+  def test_select_from_non_empty_with_include_blank_false_and_required
+    @post = Post.new
+    @post.category = "<mus>"
+    assert_dom_equal(
+      "<select required=\"required\" id=\"post_category\" name=\"post[category]\"><option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\" selected=\"selected\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
+      select("post", "category", %w( abe <mus> hest), { include_blank: false }, { required: "required" })
+    )
   end
 
   def test_select_with_blank_as_string


### PR DESCRIPTION
### Summary

As it was noted in #31083 using `select` form helper with `required: true` will add blank option
```
 ActionController::Base.helpers.select 'my_select', 'my_value', ['option1']
 => "<select name=\"my_select[my_value]\" id=\"my_select_my_value\"><option value=\"option1\">option1</option></select>" 

 ActionController::Base.helpers.select 'my_select', 'my_value', ['option1'], {}, required: true
 => "<select required=\"required\" name=\"my_select[my_value]\" id=\"my_select_my_value\"><option value=\"\"></option>\n<option value=\"option1\">option1</option></select>" 
```
and when we try to disable that blank option with `include_blank: false` we got an exception
```
  ActionController::Base.helpers.select 'my_select', 'my_value', ['option1'], { include_blank: false }, required: true
Traceback (most recent call last):
        1: from (irb):13
ArgumentError (include_blank cannot be false for a required field.)
```

This pull requests is about skipping this exception when we provided some options.
Real practical example is when you do not want to allow user to be able select empty value
Example code is here https://github.com/trkin/move-index/blob/master/app/views/pages/home.html.erb#L15
![select empty value](https://user-images.githubusercontent.com/1426092/59030791-3f332600-8862-11e9-901b-aed3b7655055.png)

Thanks @octavpo for pointing this issue
