### PR TITLE
Fix preloading on AR::Relation where records are duplicated by a join

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -27,7 +27,9 @@ module ActiveRecord
         end
 
         def records_by_owner
-          @records_by_owner ||= preloaded_records.each_with_object({}) do |record, result|
+          # owners can be duplicated when a relation has a collection association join
+          # #compare_by_identity makes such owners different hash keys
+          @records_by_owner ||= preloaded_records.each_with_object({}.compare_by_identity) do |record, result|
             owners_by_key[convert_key(record[association_key_name])].each do |owner|
               (result[owner] ||= []) << record
             end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2932,6 +2932,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [], reference.ideal_jobs
   end
 
+  def test_has_many_preloading_with_duplicate_records
+    posts = Post.joins(:comments).preload(:comments).to_a
+    assert_equal [1, 2], posts.first.comments.map(&:id)
+  end
+
   private
 
     def force_signal37_to_load_all_clients_of_firm


### PR DESCRIPTION
## Problem

Fixes #36396 

## Solution

Using an unknown `Hash#compare_by_identity` to allow equal hash keys.
When hash has this feature enabled, cache keys become unique using `key1.object_id == key2.object_id` not `key1 == key2`.

❤️ ❤️ ❤️ RUBY ❤️ ❤️ ❤️ 

https://apidock.com/ruby/Hash/compare_by_identity 

cc @kamipo @pstare
