### PR TITLE
Fix unexpected behavior for dependent: :purge

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Correct unexpected behavior resulting from dependent: :purge when using
+    has_one_attached or has_many_attached. Fixes #36423.
+
+    *Mark Oveson*
+
 *   Allow configuring Active Storage base controller parent class
 
     This enables users to change the parent class for

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -48,7 +48,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   delegate :signed_id, to: :blob
 
   after_create_commit :run_upload_callbacks, unless: :pending_upload
-  after_destroy_commit :purge_dependent_blob_later
+  after_destroy_commit :purge_dependent_blob
 
   ##
   # :singleton-method:
@@ -222,8 +222,12 @@ class ActiveStorage::Attachment < ActiveStorage::Record
       ActiveStorage::CreateVariantsJob.perform_later(blob, variants: later_variants, process: :later) if later_variants.any?
     end
 
-    def purge_dependent_blob_later
-      blob&.purge_later if dependent == :purge_later
+    def purge_dependent_blob
+      if dependent == :purge_later
+        blob&.purge_later
+      elsif dependent == :purge
+        blob&.purge
+      end
     end
 
     def dependent

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -75,7 +75,7 @@ module ActiveStorage
       # The +:dependent+ option defaults to +:purge_later+. This means the attachment will be
       # purged (i.e. destroyed) in the background whenever the record is destroyed.
       # If an ActiveJob::Backend queue adapter is not set in the application set it to
-      # +purge+ instead.
+      # +:purge+ instead.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For example:
@@ -192,7 +192,7 @@ module ActiveStorage
       # The +:dependent+ option defaults to +:purge_later+. This means the attachments will be
       # purged (i.e. destroyed) in the background whenever the record is destroyed.
       # If an ActiveJob::Backend queue adapter is not set in the application set it to
-      # +purge+ instead.
+      # +:purge+ instead.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For example:

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -619,6 +619,19 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_nil user.attachment_changes["highlights"]
   end
 
+  test "purge attached blobs now when the record is destroyed" do
+    @user.favorites.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")
+    favorite_keys = @user.favorites.collect(&:key)
+
+    @user.reload.destroy
+
+    assert_nil ActiveStorage::Blob.find_by(key: favorite_keys.first)
+    assert_not ActiveStorage::Blob.service.exist?(favorite_keys.first)
+
+    assert_nil ActiveStorage::Blob.find_by(key: favorite_keys.second)
+    assert_not ActiveStorage::Blob.service.exist?(favorite_keys.second)
+  end
+
   test "purging later" do
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       @user.highlights.attach blobs

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -618,6 +618,16 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_nil user.attachment_changes["avatar"]
   end
 
+  test "purge attached blob now when the record is destroyed" do
+    @user.icon.attach create_blob(filename: "funky.jpg")
+    icon_key = @user.icon.key
+
+    @user.reload.destroy
+
+    assert_nil ActiveStorage::Blob.find_by(key: icon_key)
+    assert_not ActiveStorage::Blob.service.exist?(icon_key)
+  end
+
   test "purging later" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -42,8 +42,80 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal [ :avatar, :avatar_with_conditional_preprocessed, :avatar_with_immediate_analysis, :avatar_with_immediate_variants, :avatar_with_later_analysis, :avatar_with_later_variants, :avatar_with_lazy_analysis, :avatar_with_lazy_variants, :avatar_with_preprocessed, :avatar_with_variants, :cover_photo, :highlights, :highlights_with_conditional_preprocessed, :highlights_with_immediate_variants, :highlights_with_preprocessed, :highlights_with_variants, :intro_video, :name_pronunciation_audio, :resume, :resume_with_preprocessing, :vlogs ], reflections.collect(&:name)
-    assert_equal [ :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal([
+      :avatar,
+      :avatar_with_conditional_preprocessed,
+      :avatar_with_immediate_analysis,
+      :avatar_with_immediate_variants,
+      :avatar_with_later_analysis,
+      :avatar_with_later_variants,
+      :avatar_with_lazy_analysis,
+      :avatar_with_lazy_variants,
+      :avatar_with_preprocessed,
+      :avatar_with_variants,
+      :cover_photo,
+      :favorites,
+      :highlights,
+      :highlights_with_conditional_preprocessed,
+      :highlights_with_immediate_variants,
+      :highlights_with_preprocessed,
+      :highlights_with_variants,
+      :icon,
+      :intro_video,
+      :name_pronunciation_audio,
+      :resume,
+      :resume_with_preprocessing,
+      :vlogs
+    ], reflections.collect(&:name))
+    assert_equal([
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_many_attached,
+      :has_many_attached,
+      :has_many_attached,
+      :has_many_attached,
+      :has_many_attached,
+      :has_many_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_one_attached,
+      :has_many_attached
+    ], reflections.collect(&:macro))
+    assert_equal([
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      false,
+      :purge,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      :purge_later,
+      false
+    ], reflections.collect { |reflection| reflection.options[:dependent] })
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -128,6 +128,7 @@ class User < ActiveRecord::Base
   validates :name, presence: true
 
   has_one_attached :avatar
+  has_one_attached :icon, dependent: :purge
   has_one_attached :cover_photo, dependent: false, service: :local
   has_one_attached :avatar_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
@@ -160,6 +161,7 @@ class User < ActiveRecord::Base
   has_one_attached :avatar_with_lazy_analysis, analyze: :lazily
 
   has_many_attached :highlights
+  has_many_attached :favorites, dependent: :purge
   has_many_attached :vlogs, dependent: false, service: :local
   has_many_attached :highlights_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]


### PR DESCRIPTION
*   Correct unexpected behavior resulting from dependent: :purge when using
    has_one_attached or has_many_attached. Fixes #36423. 
    
    *Mark Oveson*

### Summary

Given the following model:

    class User < ApplicationRecord
      has_one_attached :photo, dependent: :purge
    end

Behavior before this fix is that the dependent attachment would be
**detached, not purged** when the user record is destroyed.

After this fix, the dependent attachment will be purged when the user
record is destroyed. Now `dependent: :purge`, `dependent: :purge_later`, 
and `dependent: :detach` all function as expected.
