### PR TITLE
Add ActiveRecord::Base.current_environment method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove `DEFAULT_ENV` and `RAILS_ENV` constant
+    ActiveRecord::ConnectionHandling. Introduce `current_env` method to get the
+    environment within active record.
+
+    *Guilherme Mansur*
+
 *   Add support for `strict_loading` mode on association declarations.
 
     Raise an error if attempting to load a record from an association that has been marked as `strict_loading` unless it was explicitly eager loaded.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -2,6 +2,14 @@
 
 module ActiveRecord
   module ConnectionHandling
+    RAILS_ENV = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence },
+      "RAILS_ENV is deprecated, to find out the current environment please use ActiveRecord::Base.current_environment"
+    )
+    DEFAULT_ENV = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      -> { RAILS_ENV.call || "default_env" },
+      "DEFAULT_ENV is deprecated, to find out the current environemnt please use ActiveRecord::Base.current_environment"
+    )
     # Establishes the connection to the database. Accepts a hash as input where
     # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
     # example for regular databases (MySQL, PostgreSQL, etc):

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -2,9 +2,6 @@
 
 module ActiveRecord
   module ConnectionHandling
-    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence }
-    DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
-
     # Establishes the connection to the database. Accepts a hash as input where
     # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
     # example for regular databases (MySQL, PostgreSQL, etc):
@@ -148,6 +145,10 @@ module ActiveRecord
       connection_handlers.key(connection_handler)
     end
 
+    def current_environment # :nodoc:
+      (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "default_env"
+    end
+
     def lookup_connection_handler(handler_key) # :nodoc:
       handler_key ||= ActiveRecord::Base.writing_role
       connection_handlers[handler_key] ||= ActiveRecord::ConnectionAdapters::ConnectionHandler.new
@@ -246,7 +247,7 @@ module ActiveRecord
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name
 
-        config_or_env ||= DEFAULT_ENV.call.to_sym
+        config_or_env ||= ActiveRecord::Base.current_environment.to_sym
         pool_name = primary_class? ? Base.name : name
         self.connection_specification_name = pool_name
 

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -143,7 +143,7 @@ module ActiveRecord
 
     private
       def default_env
-        ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s
+        ActiveRecord::Base.current_environment
       end
 
       def env_with_configs(env = nil)

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -63,7 +63,7 @@ module ActiveRecord
       end
 
       def for_current_env?
-        env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+        env_name == ActiveRecord::Base.current_environment
       end
 
       def schema_cache_path

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1134,10 +1134,6 @@ module ActiveRecord
       (db_list + file_list).sort_by { |_, version, _| version }
     end
 
-    def current_environment
-      ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-    end
-
     def protected_environment?
       ActiveRecord::Base.protected_environments.include?(last_stored_environment) if last_stored_environment
     end
@@ -1287,7 +1283,7 @@ module ActiveRecord
       # Stores the current environment in the database.
       def record_environment
         return if down?
-        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
+        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.current_environment
       end
 
       def ran?(migration)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -9,7 +9,7 @@ db_namespace = namespace :db do
   desc "Set the environment value for the database"
   task "environment:set" => :load_config do
     ActiveRecord::InternalMetadata.create_table
-    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
+    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.current_environment
   end
 
   task check_protected_environments: :load_config do

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -55,7 +55,7 @@ module ActiveRecord
       end
 
       ActiveRecord::InternalMetadata.create_table
-      ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+      ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.current_environment
     end
   end
 end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -56,7 +56,7 @@ module ActiveRecord
 
       def check_protected_environments!
         unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]
-          current = ActiveRecord::Base.connection.migration_context.current_environment
+          current = ActiveRecord::Base.current_environment
           stored  = ActiveRecord::Base.connection.migration_context.last_stored_environment
 
           if ActiveRecord::Base.connection.migration_context.protected_environment?

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -5,7 +5,7 @@ require "active_support/testing/parallelization"
 module ActiveRecord
   module TestDatabases # :nodoc:
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
-      create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+      create_and_load_schema(i, env_name: ActiveRecord::Base.current_environment)
     end
 
     def self.create_and_load_schema(i, env_name:)

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -36,7 +36,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       assert connection.column_exists?(table_name, :key, :string)
     end
   ensure
-    ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.current_environment
   end
 
   private

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         original_rack_env  = ENV["RACK_ENV"]
         ENV["RAILS_ENV"]   = ENV["RACK_ENV"] = ""
 
-        assert_equal "default_env", ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+        assert_equal "default_env", ActiveRecord::Base.current_environment
       ensure
         ENV["RAILS_ENV"] = original_rails_env
         ENV["RACK_ENV"]  = original_rack_env

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = @previous_rails_env
       end
 
-      def resolve_config(config, env_name = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+      def resolve_config(config, env_name = ActiveRecord::Base.current_environment)
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         configs.configs_for(env_name: env_name, spec_name: "primary")&.configuration_hash
       end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -587,7 +587,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env     = ActiveRecord::Base.current_environment
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
 
@@ -597,7 +597,7 @@ class MigrationTest < ActiveRecord::TestCase
     original_rails_env  = ENV["RAILS_ENV"]
     original_rack_env   = ENV["RACK_ENV"]
     ENV["RAILS_ENV"]    = ENV["RACK_ENV"] = "foofoo"
-    new_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    new_env = ActiveRecord::Base.current_environment
 
     assert_not_equal current_env, new_env
 
@@ -614,7 +614,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::InternalMetadata.delete_all
     ActiveRecord::InternalMetadata[:foo] = "bar"
 
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env     = ActiveRecord::Base.current_environment
     migrations_path = MIGRATIONS_ROOT + "/valid"
 
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -50,7 +50,7 @@ module ActiveRecord
   class DatabaseTasksUtilsTask < ActiveRecord::TestCase
     def test_raises_an_error_when_called_with_protected_environment
       protected_environments = ActiveRecord::Base.protected_environments
-      current_env            = ActiveRecord::Base.connection.migration_context.current_environment
+      current_env            = ActiveRecord::Base.current_environment
 
       InternalMetadata[:environment] = current_env
 
@@ -76,7 +76,7 @@ module ActiveRecord
 
     def test_raises_an_error_when_called_with_protected_environment_which_name_is_a_symbol
       protected_environments = ActiveRecord::Base.protected_environments
-      current_env            = ActiveRecord::Base.connection.migration_context.current_environment
+      current_env            = ActiveRecord::Base.current_environment
 
       InternalMetadata[:environment] = current_env
 


### PR DESCRIPTION
### Summary

The current way for determining the environment internally is by doing
`ActiveRecord::ConnectionHandling::DEFAULT_ENV.call` this method is
unclear  and is a handful to type.

This patch introduces `ActiveRecord::Base.current_environment` this
method better expresses the intent and allows us to remove the
`current_environment` method from `MigrationContext` because we can call
this directly.

Instead of having a couple of different places to get the current
environment from (connection_handler, migration_context) we can now
directly call this method internally within ActiveRecord.

