### PR TITLE
Fix programmatic clicks with data-remote

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/features/remote.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/features/remote.coffee
@@ -88,6 +88,6 @@ Rails.preventInsignificantClick = (e) ->
   data = link.getAttribute('data-params')
   metaClick = e.metaKey or e.ctrlKey
   insignificantMetaClick = metaClick and method is 'GET' and not data
-  primaryMouseKey = e.button is 0
-  e.stopImmediatePropagation() if not primaryMouseKey or insignificantMetaClick
+  nonPrimaryMouseClick = e.button? and e.button isnt 0
+  e.stopImmediatePropagation() if nonPrimaryMouseClick or insignificantMetaClick
 

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -82,6 +82,20 @@ asyncTest('right/mouse-wheel-clicking on a link does not fire ajaxyness', 0, fun
   setTimeout(function() { start() }, 13)
 })
 
+asyncTest('clicking on a link via a non-mouse Event (such as from js) works', 1, function() {
+  var link = $('a[data-remote]')
+
+  link
+    .removeAttr('data-params')
+    .bindNative('ajax:beforeSend', function() {
+      ok(true, 'ajax should be triggered')
+    })
+
+  Rails.fire(link[0], 'click')
+
+  setTimeout(function() { start() }, 13)
+})
+
 asyncTest('ctrl-clicking on a link still fires ajax for non-GET links and for links with "data-params"', 2, function() {
   var link = $('a[data-remote]')
 


### PR DESCRIPTION
### Summary

#34573 made sure errant right clicks & scroll wheel clicks weren't handled like a primary click by data-remote and friends. 

It did so by ensuring `event.button` was equal to `0`, otherwise stopping the event — unfortunately, this has a side effect of also blocking programmatic events called from javascript (such as those made from `Rails.fire()`. This is a change in behavior from Rails 5.x and (I believe) an unintentional bug.

This PR fixes that side effect and restores the ability to click a `data-remote` link with javascript.

### Testing

Includes a test that fails on master. 

The existing test harness helped mask this issue. All click events in tests sent by `triggerNative` are of the class `_MouseEvent` and would have the default `button` value of `0`. Events that fire programmatically (such as `Rails.fire()`) do not have a `button` value.

/cc @WoH