### PR TITLE
Move SchemaMigration to migration_context

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1064,8 +1064,8 @@ module ActiveRecord
         options
       end
 
-      def dump_schema_information #:nodoc:
-        versions = ActiveRecord::SchemaMigration.all_versions
+      def dump_schema_information # :nodoc:
+        versions = schema_migration.all_versions
         insert_versions_sql(versions) if versions.any?
       end
 
@@ -1081,7 +1081,7 @@ module ActiveRecord
         end
 
         version = version.to_i
-        sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
+        sm_table = quote_table_name(schema_migration.table_name)
 
         migrated = migration_context.get_all_versions
         versions = migration_context.migrations.map(&:version)
@@ -1454,7 +1454,7 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions)
-          sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
+          sm_table = quote_table_name(schema_migration.table_name)
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -163,7 +163,22 @@ module ActiveRecord
       end
 
       def migration_context # :nodoc:
-        MigrationContext.new(migrations_paths)
+        MigrationContext.new(migrations_paths, schema_migration)
+      end
+
+      def schema_migration # :nodoc:
+        @schema_migration ||= begin
+                                conn = self
+                                spec_name = conn.pool.spec.name
+                                name = "#{spec_name}::SchemaMigration"
+
+                                Class.new(ActiveRecord::SchemaMigration) do
+                                  define_singleton_method(:name) { name }
+                                  define_singleton_method(:to_s) { name }
+
+                                  self.connection_specification_name = spec_name
+                                end
+                              end
       end
 
       class Version

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -884,13 +884,14 @@ module ActiveRecord
 
     def copy(destination, sources, options = {})
       copied = []
+      schema_migration = options[:schema_migration] || ActiveRecord::SchemaMigration
 
       FileUtils.mkdir_p(destination) unless File.exist?(destination)
 
-      destination_migrations = ActiveRecord::MigrationContext.new(destination).migrations
+      destination_migrations = ActiveRecord::MigrationContext.new(destination, schema_migration).migrations
       last = destination_migrations.last
       sources.each do |scope, path|
-        source_migrations = ActiveRecord::MigrationContext.new(path).migrations
+        source_migrations = ActiveRecord::MigrationContext.new(path, schema_migration).migrations
 
         source_migrations.each do |migration|
           source = File.binread(migration.filename)
@@ -1012,10 +1013,11 @@ module ActiveRecord
   end
 
   class MigrationContext #:nodoc:
-    attr_reader :migrations_paths
+    attr_reader :migrations_paths, :schema_migration
 
-    def initialize(migrations_paths)
+    def initialize(migrations_paths, schema_migration)
       @migrations_paths = migrations_paths
+      @schema_migration = schema_migration
     end
 
     def migrate(target_version = nil, &block)
@@ -1046,7 +1048,7 @@ module ActiveRecord
         migrations
       end
 
-      Migrator.new(:up, selected_migrations, target_version).migrate
+      Migrator.new(:up, selected_migrations, schema_migration, target_version).migrate
     end
 
     def down(target_version = nil)
@@ -1056,20 +1058,20 @@ module ActiveRecord
         migrations
       end
 
-      Migrator.new(:down, selected_migrations, target_version).migrate
+      Migrator.new(:down, selected_migrations, schema_migration, target_version).migrate
     end
 
     def run(direction, target_version)
-      Migrator.new(direction, migrations, target_version).run
+      Migrator.new(direction, migrations, schema_migration, target_version).run
     end
 
     def open
-      Migrator.new(:up, migrations, nil)
+      Migrator.new(:up, migrations, schema_migration)
     end
 
     def get_all_versions
-      if SchemaMigration.table_exists?
-        SchemaMigration.all_versions.map(&:to_i)
+      if schema_migration.table_exists?
+        schema_migration.all_versions
       else
         []
       end
@@ -1106,12 +1108,12 @@ module ActiveRecord
     end
 
     def migrations_status
-      db_list = ActiveRecord::SchemaMigration.normalized_versions
+      db_list = schema_migration.normalized_versions
 
       file_list = migration_files.map do |file|
         version, name, scope = parse_migration_filename(file)
         raise IllegalMigrationNameError.new(file) unless version
-        version = ActiveRecord::SchemaMigration.normalize_migration_number(version)
+        version = schema_migration.normalize_migration_number(version)
         status = db_list.delete(version) ? "up" : "down"
         [status, version, (name + scope).humanize]
       end.compact
@@ -1151,7 +1153,7 @@ module ActiveRecord
       end
 
       def move(direction, steps)
-        migrator = Migrator.new(direction, migrations)
+        migrator = Migrator.new(direction, migrations, schema_migration)
 
         if current_version != 0 && !migrator.current_migration
           raise UnknownMigrationVersionError.new(current_version)
@@ -1170,27 +1172,28 @@ module ActiveRecord
       end
   end
 
-  class Migrator #:nodoc:
+  class Migrator # :nodoc:
     class << self
       attr_accessor :migrations_paths
 
       # For cases where a table doesn't exist like loading from schema cache
       def current_version
-        MigrationContext.new(migrations_paths).current_version
+        MigrationContext.new(migrations_paths, SchemaMigration).current_version
       end
     end
 
     self.migrations_paths = ["db/migrate"]
 
-    def initialize(direction, migrations, target_version = nil)
+    def initialize(direction, migrations, schema_migration, target_version = nil)
       @direction         = direction
       @target_version    = target_version
       @migrated_versions = nil
       @migrations        = migrations
+      @schema_migration  = schema_migration
 
       validate(@migrations)
 
-      ActiveRecord::SchemaMigration.create_table
+      @schema_migration.create_table
       ActiveRecord::InternalMetadata.create_table
     end
 
@@ -1244,7 +1247,7 @@ module ActiveRecord
     end
 
     def load_migrated
-      @migrated_versions = Set.new(Base.connection.migration_context.get_all_versions)
+      @migrated_versions = Set.new(@schema_migration.all_versions)
     end
 
     private
@@ -1327,10 +1330,10 @@ module ActiveRecord
       def record_version_state_after_migrating(version)
         if down?
           migrated.delete(version)
-          ActiveRecord::SchemaMigration.delete_by(version: version.to_s)
+          @schema_migration.delete_by(version: version.to_s)
         else
           migrated << version
-          ActiveRecord::SchemaMigration.create!(version: version.to_s)
+          @schema_migration.create!(version: version.to_s)
         end
       end
 

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       instance_eval(&block)
 
       if info[:version].present?
-        ActiveRecord::SchemaMigration.create_table
+        connection.schema_migration.create_table
         connection.assume_migrated_upto_version(info[:version])
       end
 

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       end
 
       def all_versions
-        order(:version).pluck(:version)
+        order(:version).pluck(:version).map(&:to_i)
       end
     end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -73,7 +73,7 @@ class Mysql2DefaultEngineOptionSchemaDumpTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    ActiveRecord::Migrator.new(:up, [migration]).migrate
+    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
 
     output  = dump_table_schema("mysql_table_options")
     options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
@@ -112,7 +112,7 @@ class Mysql2DefaultEngineOptionSqlOutputTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    ActiveRecord::Migrator.new(:up, [migration]).migrate
+    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
 
     assert_match %r{ENGINE=InnoDB}, @log.string
   end

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -50,7 +50,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.disable_extension("hstore")
 
     migrations = [EnableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations).migrate
+    ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::Base.connection.schema_migration).migrate
     assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
   end
 
@@ -58,7 +58,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.enable_extension("hstore")
 
     migrations = [DisableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations).migrate
+    ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::Base.connection.schema_migration).migrate
     assert_not @connection.extension_enabled?("hstore"), "extension hstore should not be enabled"
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -293,14 +293,14 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
         create_table("pg_uuids_4", id: :uuid)
       end
     end.new
-    ActiveRecord::Migrator.new(:up, [migration]).migrate
+    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::SchemaMigration.delete_all
+    ActiveRecord::Base.connection.schema_migration.delete_all
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
 end
@@ -343,14 +343,14 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
         create_table("pg_uuids_4", id: :uuid, default: nil)
       end
     end.new
-    ActiveRecord::Migrator.new(:up, [migration]).migrate
+    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: nil/, schema)
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::SchemaMigration.delete_all
+    ActiveRecord::Base.connection.schema_migration.delete_all
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_with_default_nil_in_legacy_migration
 end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -12,6 +12,7 @@ module ActiveRecord
       def setup
         super
         @connection = ActiveRecord::Base.connection
+        @schema_migration = @connection.schema_migration
         @verbose_was = ActiveRecord::Migration.verbose
         ActiveRecord::Migration.verbose = false
 
@@ -38,7 +39,7 @@ module ActiveRecord
         }.new
 
         assert connection.index_exists?(:testings, :foo, name: "custom_index_name")
-        assert_raise(StandardError) { ActiveRecord::Migrator.new(:up, [migration]).migrate }
+        assert_raise(StandardError) { ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate }
         assert connection.index_exists?(:testings, :foo, name: "custom_index_name")
       end
 
@@ -53,7 +54,7 @@ module ActiveRecord
         }.new
 
         assert connection.index_exists?(:testings, :bar)
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
         assert_not connection.index_exists?(:testings, :bar)
       end
 
@@ -67,7 +68,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert_not connection.index_exists?(:more_testings, :foo_id)
         assert_not connection.index_exists?(:more_testings, :bar_id)
@@ -84,7 +85,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:more_testings, :created_at, null: true)
         assert connection.column_exists?(:more_testings, :updated_at, null: true)
@@ -101,7 +102,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:testings, :created_at, null: true)
         assert connection.column_exists?(:testings, :updated_at, null: true)
@@ -117,7 +118,7 @@ module ActiveRecord
             end
           }.new
 
-          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
           assert connection.column_exists?(:testings, :created_at, null: true)
           assert connection.column_exists?(:testings, :updated_at, null: true)
@@ -131,7 +132,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:testings, :created_at, null: true)
         assert connection.column_exists?(:testings, :updated_at, null: true)
@@ -146,7 +147,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:more_testings, :created_at, null: false, **precision_implicit_default)
         assert connection.column_exists?(:more_testings, :updated_at, null: false, **precision_implicit_default)
@@ -163,7 +164,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:testings, :created_at, null: false, **precision_implicit_default)
         assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
@@ -179,7 +180,7 @@ module ActiveRecord
             end
           }.new
 
-          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
           assert connection.column_exists?(:testings, :created_at, null: false, **precision_implicit_default)
           assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
@@ -193,7 +194,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration]).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:testings, :created_at, null: false, **precision_implicit_default)
         assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
@@ -230,7 +231,7 @@ module ActiveRecord
             end
           }.new
 
-          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
           assert connection.column_exists?(:testings, :foo, comment: "comment")
         end
 
@@ -243,7 +244,7 @@ module ActiveRecord
             end
           }.new
 
-          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
           assert_equal "comment", connection.table_comment("testings")
         end
@@ -261,7 +262,7 @@ module ActiveRecord
           }.new
 
           Testing.create!
-          ActiveRecord::Migrator.new(:up, [migration]).migrate
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
           assert_equal ["foobar"], Testing.all.map(&:foo)
         ensure
           ActiveRecord::Base.clear_cache!

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -17,19 +17,20 @@ module ActiveRecord
 
       def setup
         super
-        ActiveRecord::SchemaMigration.create_table
-        ActiveRecord::SchemaMigration.delete_all
+        @schema_migration = ActiveRecord::Base.connection.schema_migration
+        @schema_migration.create_table
+        @schema_migration.delete_all
       end
 
       teardown do
-        ActiveRecord::SchemaMigration.drop_table
+        @schema_migration.drop_table
       end
 
       def test_migration_should_be_run_without_logger
         previous_logger = ActiveRecord::Base.logger
         ActiveRecord::Base.logger = nil
         migrations = [Migration.new("a", 1), Migration.new("b", 2), Migration.new("c", 3)]
-        ActiveRecord::Migrator.new(:up, migrations).migrate
+        ActiveRecord::Migrator.new(:up, migrations, @schema_migration).migrate
       ensure
         ActiveRecord::Base.logger = previous_logger
       end

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -23,8 +23,9 @@ class MigratorTest < ActiveRecord::TestCase
 
   def setup
     super
-    ActiveRecord::SchemaMigration.create_table
-    ActiveRecord::SchemaMigration.delete_all rescue nil
+    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @schema_migration.create_table
+    @schema_migration.delete_all rescue nil
     @verbose_was = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.message_count = 0
     ActiveRecord::Migration.class_eval do
@@ -36,7 +37,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   teardown do
-    ActiveRecord::SchemaMigration.delete_all rescue nil
+    @schema_migration.delete_all rescue nil
     ActiveRecord::Migration.verbose = @verbose_was
     ActiveRecord::Migration.class_eval do
       undef :puts
@@ -49,7 +50,7 @@ class MigratorTest < ActiveRecord::TestCase
   def test_migrator_with_duplicate_names
     e = assert_raises(ActiveRecord::DuplicateMigrationNameError) do
       list = [ActiveRecord::Migration.new("Chunky"), ActiveRecord::Migration.new("Chunky")]
-      ActiveRecord::Migrator.new(:up, list)
+      ActiveRecord::Migrator.new(:up, list, @schema_migration)
     end
     assert_match(/Multiple migrations have the name Chunky/, e.message)
   end
@@ -57,39 +58,40 @@ class MigratorTest < ActiveRecord::TestCase
   def test_migrator_with_duplicate_versions
     assert_raises(ActiveRecord::DuplicateMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 1)]
-      ActiveRecord::Migrator.new(:up, list)
+      ActiveRecord::Migrator.new(:up, list, @schema_migration)
     end
   end
 
   def test_migrator_with_missing_version_numbers
     assert_raises(ActiveRecord::UnknownMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 2)]
-      ActiveRecord::Migrator.new(:up, list, 3).run
+      ActiveRecord::Migrator.new(:up, list, @schema_migration, 3).run
     end
 
     assert_raises(ActiveRecord::UnknownMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 2)]
-      ActiveRecord::Migrator.new(:up, list, -1).run
+      ActiveRecord::Migrator.new(:up, list, @schema_migration, -1).run
     end
 
     assert_raises(ActiveRecord::UnknownMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 2)]
-      ActiveRecord::Migrator.new(:up, list, 0).run
+      ActiveRecord::Migrator.new(:up, list, @schema_migration, 0).run
     end
 
     assert_raises(ActiveRecord::UnknownMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 2)]
-      ActiveRecord::Migrator.new(:up, list, 3).migrate
+      ActiveRecord::Migrator.new(:up, list, @schema_migration, 3).migrate
     end
 
     assert_raises(ActiveRecord::UnknownMigrationVersionError) do
       list = [ActiveRecord::Migration.new("Foo", 1), ActiveRecord::Migration.new("Bar", 2)]
-      ActiveRecord::Migrator.new(:up, list, -1).migrate
+      ActiveRecord::Migrator.new(:up, list, @schema_migration, -1).migrate
     end
   end
 
   def test_finds_migrations
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid").migrations
+    schema_migration = ActiveRecord::Base.connection.schema_migration
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", schema_migration).migrations
 
     [[1, "ValidPeopleHaveLastNames"], [2, "WeNeedReminders"], [3, "InnocentJointable"]].each_with_index do |pair, i|
       assert_equal migrations[i].version, pair.first
@@ -98,7 +100,8 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_in_subdirectories
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid_with_subdirectories").migrations
+    schema_migration = ActiveRecord::Base.connection.schema_migration
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid_with_subdirectories", schema_migration).migrations
 
     [[1, "ValidPeopleHaveLastNames"], [2, "WeNeedReminders"], [3, "InnocentJointable"]].each_with_index do |pair, i|
       assert_equal migrations[i].version, pair.first
@@ -107,8 +110,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_from_two_directories
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     directories = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
-    migrations = ActiveRecord::MigrationContext.new(directories).migrations
+    migrations = ActiveRecord::MigrationContext.new(directories, schema_migration).migrations
 
     [[20090101010101, "PeopleHaveHobbies"],
      [20090101010202, "PeopleHaveDescriptions"],
@@ -121,14 +125,16 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_in_numbered_directory
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/10_urban").migrations
+    schema_migration = ActiveRecord::Base.connection.schema_migration
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/10_urban", schema_migration).migrations
     assert_equal 9, migrations[0].version
     assert_equal "AddExpressions", migrations[0].name
   end
 
   def test_relative_migrations
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     list = Dir.chdir(MIGRATIONS_ROOT) do
-      ActiveRecord::MigrationContext.new("valid").migrations
+      ActiveRecord::MigrationContext.new("valid", schema_migration).migrations
     end
 
     migration_proxy = list.find { |item|
@@ -138,9 +144,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_pending_migrations
-    ActiveRecord::SchemaMigration.create!(version: "1")
+    @schema_migration.create!(version: "1")
     migration_list = [ActiveRecord::Migration.new("foo", 1), ActiveRecord::Migration.new("bar", 3)]
-    migrations = ActiveRecord::Migrator.new(:up, migration_list).pending_migrations
+    migrations = ActiveRecord::Migrator.new(:up, migration_list, @schema_migration).pending_migrations
 
     assert_equal 1, migrations.size
     assert_equal migration_list.last, migrations.first
@@ -148,35 +154,38 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_migrations_status
     path = MIGRATIONS_ROOT + "/valid"
+    schema_migration = ActiveRecord::Base.connection.schema_migration
 
-    ActiveRecord::SchemaMigration.create(version: 2)
-    ActiveRecord::SchemaMigration.create(version: 10)
+    @schema_migration.create(version: 2)
+    @schema_migration.create(version: 10)
 
     assert_equal [
       ["down", "001", "Valid people have last names"],
       ["up",   "002", "We need reminders"],
       ["down", "003", "Innocent jointable"],
       ["up",   "010", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(path).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, schema_migration).migrations_status
   end
 
   def test_migrations_status_in_subdirectories
     path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
+    schema_migration = ActiveRecord::Base.connection.schema_migration
 
-    ActiveRecord::SchemaMigration.create(version: 2)
-    ActiveRecord::SchemaMigration.create(version: 10)
+    @schema_migration.create(version: 2)
+    @schema_migration.create(version: 10)
 
     assert_equal [
       ["down", "001", "Valid people have last names"],
       ["up",   "002", "We need reminders"],
       ["down", "003", "Innocent jointable"],
       ["up",   "010", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(path).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, schema_migration).migrations_status
   end
 
   def test_migrations_status_with_schema_define_in_subdirectories
     path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
     prev_paths = ActiveRecord::Migrator.migrations_paths
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     ActiveRecord::Migrator.migrations_paths = path
 
     ActiveRecord::Schema.define(version: 3) do
@@ -186,16 +195,17 @@ class MigratorTest < ActiveRecord::TestCase
       ["up", "001", "Valid people have last names"],
       ["up", "002", "We need reminders"],
       ["up", "003", "Innocent jointable"],
-    ], ActiveRecord::MigrationContext.new(path).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, schema_migration).migrations_status
   ensure
     ActiveRecord::Migrator.migrations_paths = prev_paths
   end
 
   def test_migrations_status_from_two_directories
     paths = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
+    schema_migration = ActiveRecord::Base.connection.schema_migration
 
-    ActiveRecord::SchemaMigration.create(version: "20100101010101")
-    ActiveRecord::SchemaMigration.create(version: "20160528010101")
+    @schema_migration.create(version: "20100101010101")
+    @schema_migration.create(version: "20160528010101")
 
     assert_equal [
       ["down", "20090101010101", "People have hobbies"],
@@ -204,18 +214,18 @@ class MigratorTest < ActiveRecord::TestCase
       ["down", "20100201010101", "Valid with timestamps we need reminders"],
       ["down", "20100301010101", "Valid with timestamps innocent jointable"],
       ["up",   "20160528010101", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(paths).migrations_status
+    ], ActiveRecord::MigrationContext.new(paths, schema_migration).migrations_status
   end
 
   def test_migrator_interleaved_migrations
     pass_one = [Sensor.new("One", 1)]
 
-    ActiveRecord::Migrator.new(:up, pass_one).migrate
+    ActiveRecord::Migrator.new(:up, pass_one, @schema_migration).migrate
     assert pass_one.first.went_up
     assert_not pass_one.first.went_down
 
     pass_two = [Sensor.new("One", 1), Sensor.new("Three", 3)]
-    ActiveRecord::Migrator.new(:up, pass_two).migrate
+    ActiveRecord::Migrator.new(:up, pass_two, @schema_migration).migrate
     assert_not pass_two[0].went_up
     assert pass_two[1].went_up
     assert pass_two.all? { |x| !x.went_down }
@@ -224,7 +234,7 @@ class MigratorTest < ActiveRecord::TestCase
                   Sensor.new("Two", 2),
                   Sensor.new("Three", 3)]
 
-    ActiveRecord::Migrator.new(:down, pass_three).migrate
+    ActiveRecord::Migrator.new(:down, pass_three, @schema_migration).migrate
     assert pass_three[0].went_down
     assert_not pass_three[1].went_down
     assert pass_three[2].went_down
@@ -232,7 +242,7 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_up_calls_up
     migrations = [Sensor.new(nil, 0), Sensor.new(nil, 1), Sensor.new(nil, 2)]
-    migrator = ActiveRecord::Migrator.new(:up, migrations)
+    migrator = ActiveRecord::Migrator.new(:up, migrations, @schema_migration)
     migrator.migrate
     assert migrations.all?(&:went_up)
     assert migrations.all? { |m| !m.went_down }
@@ -243,7 +253,7 @@ class MigratorTest < ActiveRecord::TestCase
     test_up_calls_up
 
     migrations = [Sensor.new(nil, 0), Sensor.new(nil, 1), Sensor.new(nil, 2)]
-    migrator = ActiveRecord::Migrator.new(:down, migrations)
+    migrator = ActiveRecord::Migrator.new(:down, migrations, @schema_migration)
     migrator.migrate
     assert migrations.all? { |m| !m.went_up }
     assert migrations.all?(&:went_down)
@@ -251,30 +261,31 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_current_version
-    ActiveRecord::SchemaMigration.create!(version: "1000")
-    migrator = ActiveRecord::MigrationContext.new("db/migrate")
+    @schema_migration.create!(version: "1000")
+    schema_migration = ActiveRecord::Base.connection.schema_migration
+    migrator = ActiveRecord::MigrationContext.new("db/migrate", schema_migration)
     assert_equal 1000, migrator.current_version
   end
 
   def test_migrator_one_up
     calls, migrations = sensors(3)
 
-    ActiveRecord::Migrator.new(:up, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1).migrate
     assert_equal [[:up, 1]], calls
     calls.clear
 
-    ActiveRecord::Migrator.new(:up, migrations, 2).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 2).migrate
     assert_equal [[:up, 2]], calls
   end
 
   def test_migrator_one_down
     calls, migrations = sensors(3)
 
-    ActiveRecord::Migrator.new(:up, migrations).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration).migrate
     assert_equal [[:up, 1], [:up, 2], [:up, 3]], calls
     calls.clear
 
-    ActiveRecord::Migrator.new(:down, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 1).migrate
 
     assert_equal [[:down, 3], [:down, 2]], calls
   end
@@ -282,17 +293,17 @@ class MigratorTest < ActiveRecord::TestCase
   def test_migrator_one_up_one_down
     calls, migrations = sensors(3)
 
-    ActiveRecord::Migrator.new(:up, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1).migrate
     assert_equal [[:up, 1]], calls
     calls.clear
 
-    ActiveRecord::Migrator.new(:down, migrations, 0).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 0).migrate
     assert_equal [[:down, 1]], calls
   end
 
   def test_migrator_double_up
     calls, migrations = sensors(3)
-    migrator = ActiveRecord::Migrator.new(:up, migrations, 1)
+    migrator = ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1)
     assert_equal(0, migrator.current_version)
 
     migrator.migrate
@@ -305,7 +316,7 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_migrator_double_down
     calls, migrations = sensors(3)
-    migrator = ActiveRecord::Migrator.new(:up, migrations, 1)
+    migrator = ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1)
 
     assert_equal 0, migrator.current_version
 
@@ -313,7 +324,7 @@ class MigratorTest < ActiveRecord::TestCase
     assert_equal [[:up, 1]], calls
     calls.clear
 
-    migrator = ActiveRecord::Migrator.new(:down, migrations, 1)
+    migrator = ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 1)
     migrator.run
     assert_equal [[:down, 1]], calls
     calls.clear
@@ -328,12 +339,12 @@ class MigratorTest < ActiveRecord::TestCase
     _, migrations = sensors(3)
 
     ActiveRecord::Migration.verbose = true
-    ActiveRecord::Migrator.new(:up, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1).migrate
     assert_not_equal 0, ActiveRecord::Migration.message_count
 
     ActiveRecord::Migration.message_count = 0
 
-    ActiveRecord::Migrator.new(:down, migrations, 0).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 0).migrate
     assert_not_equal 0, ActiveRecord::Migration.message_count
   end
 
@@ -341,9 +352,9 @@ class MigratorTest < ActiveRecord::TestCase
     _, migrations = sensors(3)
 
     ActiveRecord::Migration.verbose = false
-    ActiveRecord::Migrator.new(:up, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1).migrate
     assert_equal 0, ActiveRecord::Migration.message_count
-    ActiveRecord::Migrator.new(:down, migrations, 0).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 0).migrate
     assert_equal 0, ActiveRecord::Migration.message_count
   end
 
@@ -351,23 +362,24 @@ class MigratorTest < ActiveRecord::TestCase
     calls, migrations = sensors(3)
 
     # migrate up to 1
-    ActiveRecord::Migrator.new(:up, migrations, 1).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @schema_migration, 1).migrate
     assert_equal [[:up, 1]], calls
     calls.clear
 
     # migrate down to 0
-    ActiveRecord::Migrator.new(:down, migrations, 0).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 0).migrate
     assert_equal [[:down, 1]], calls
     calls.clear
 
     # migrate down to 0 again
-    ActiveRecord::Migrator.new(:down, migrations, 0).migrate
+    ActiveRecord::Migrator.new(:down, migrations, @schema_migration, 0).migrate
     assert_equal [], calls
   end
 
   def test_migrator_going_down_due_to_version_target
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     calls, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     migrator.up(1)
     assert_equal [[:up, 1]], calls
@@ -382,8 +394,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_output_when_running_multiple_migrations
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     result = migrator.migrate
     assert_equal(3, result.count)
@@ -397,8 +410,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_output_when_running_single_migration
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(1)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     result = migrator.run(:up, 1)
 
@@ -406,8 +420,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_rollback
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     migrator.migrate
     assert_equal(3, migrator.current_version)
@@ -426,8 +441,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_db_has_no_schema_migrations_table
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     ActiveRecord::SchemaMigration.drop_table
     assert_not_predicate ActiveRecord::SchemaMigration, :table_exists?
@@ -436,8 +452,9 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_forward
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(3)
-    migrator = migrator.new("/valid")
+    migrator = migrator.new("/valid", schema_migration)
     migrator.migrate(1)
     assert_equal(1, migrator.current_version)
 
@@ -450,18 +467,20 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_only_loads_pending_migrations
     # migrate up to 1
-    ActiveRecord::SchemaMigration.create!(version: "1")
+    @schema_migration.create!(version: "1")
 
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     calls, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
     migrator.migrate
 
     assert_equal [[:up, 2], [:up, 3]], calls
   end
 
   def test_get_all_versions
+    schema_migration = ActiveRecord::Base.connection.schema_migration
     _, migrator = migrator_class(3)
-    migrator = migrator.new("valid")
+    migrator = migrator.new("valid", schema_migration)
 
     migrator.migrate
     assert_equal([1, 2, 3], migrator.get_all_versions)

--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "cases/migration/helper"
+
+class MultiDbMigratorTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  # Use this class to sense if migrations have gone
+  # up or down.
+  class Sensor < ActiveRecord::Migration::Current
+    attr_reader :went_up, :went_down
+
+    def initialize(name = self.class.name, version = nil)
+      super
+      @went_up = false
+      @went_down = false
+    end
+
+    def up; @went_up = true; end
+    def down; @went_down = true; end
+  end
+
+  def setup
+    super
+    @connection_a = ActiveRecord::Base.connection
+    @connection_b = ARUnit2Model.connection
+
+    @connection_a.schema_migration.create_table
+    @connection_b.schema_migration.create_table
+
+    @connection_a.schema_migration.delete_all rescue nil
+    @connection_b.schema_migration.delete_all rescue nil
+
+    @path_a = MIGRATIONS_ROOT + "/valid"
+    @path_b = MIGRATIONS_ROOT + "/to_copy"
+
+    @schema_migration_a = @connection_a.schema_migration
+    @migrations_a = ActiveRecord::MigrationContext.new(@path_a, @schema_migration_a).migrations
+    @schema_migration_b = @connection_b.schema_migration
+    @migrations_b = ActiveRecord::MigrationContext.new(@path_b, @schema_migration_b).migrations
+
+    @migrations_a_list = [[1, "ValidPeopleHaveLastNames"], [2, "WeNeedReminders"], [3, "InnocentJointable"]]
+    @migrations_b_list = [[1, "PeopleHaveHobbies"], [2, "PeopleHaveDescriptions"]]
+
+    @verbose_was = ActiveRecord::Migration.verbose
+
+    ActiveRecord::Migration.message_count = 0
+    ActiveRecord::Migration.class_eval do
+      undef :puts
+      def puts(*)
+        ActiveRecord::Migration.message_count += 1
+      end
+    end
+  end
+
+  teardown do
+    @connection_a.schema_migration.delete_all rescue nil
+    @connection_b.schema_migration.delete_all rescue nil
+
+    ActiveRecord::Migration.verbose = @verbose_was
+    ActiveRecord::Migration.class_eval do
+      undef :puts
+      def puts(*)
+        super
+      end
+    end
+  end
+
+  def test_finds_migrations
+    @migrations_a_list.each_with_index do |pair, i|
+      assert_equal @migrations_a[i].version, pair.first
+      assert_equal @migrations_a[i].name, pair.last
+    end
+
+    @migrations_b_list.each_with_index do |pair, i|
+      assert_equal @migrations_b[i].version, pair.first
+      assert_equal @migrations_b[i].name, pair.last
+    end
+  end
+
+  def test_migrations_status
+    @schema_migration_a.create(version: 2)
+    @schema_migration_a.create(version: 10)
+
+    assert_equal [
+      ["down", "001", "Valid people have last names"],
+      ["up",   "002", "We need reminders"],
+      ["down", "003", "Innocent jointable"],
+      ["up",   "010", "********** NO FILE **********"],
+    ], ActiveRecord::MigrationContext.new(@path_a, @schema_migration_a).migrations_status
+
+    @schema_migration_b.create(version: 4)
+
+    assert_equal [
+      ["down", "001", "People have hobbies"],
+      ["down", "002", "People have descriptions"],
+      ["up", "004", "********** NO FILE **********"]
+    ], ActiveRecord::MigrationContext.new(@path_b, @schema_migration_b).migrations_status
+  end
+
+  def test_get_all_versions
+    _, migrator_a = migrator_class(3)
+    migrator_a = migrator_a.new(@path_a, @schema_migration_a)
+
+    migrator_a.migrate
+    assert_equal([1, 2, 3], migrator_a.get_all_versions)
+
+    migrator_a.rollback
+    assert_equal([1, 2], migrator_a.get_all_versions)
+
+    migrator_a.rollback
+    assert_equal([1], migrator_a.get_all_versions)
+
+    migrator_a.rollback
+    assert_equal([], migrator_a.get_all_versions)
+
+    _, migrator_b = migrator_class(2)
+    migrator_b = migrator_b.new(@path_b, @schema_migration_b)
+
+    migrator_b.migrate
+    assert_equal([1, 2], migrator_b.get_all_versions)
+
+    migrator_b.rollback
+    assert_equal([1], migrator_b.get_all_versions)
+
+    migrator_b.rollback
+    assert_equal([], migrator_b.get_all_versions)
+  end
+
+  def test_finds_pending_migrations
+    @schema_migration_a.create!(version: "1")
+    migration_list_a = [ActiveRecord::Migration.new("foo", 1), ActiveRecord::Migration.new("bar", 3)]
+    migrations_a = ActiveRecord::Migrator.new(:up, migration_list_a, @schema_migration_a).pending_migrations
+
+    assert_equal 1, migrations_a.size
+    assert_equal migration_list_a.last, migrations_a.first
+
+    @schema_migration_b.create!(version: "1")
+    migration_list_b = [ActiveRecord::Migration.new("foo", 1), ActiveRecord::Migration.new("bar", 3)]
+    migrations_b = ActiveRecord::Migrator.new(:up, migration_list_b, @schema_migration_b).pending_migrations
+
+    assert_equal 1, migrations_b.size
+    assert_equal migration_list_b.last, migrations_b.first
+  end
+
+  def test_migrator_db_has_no_schema_migrations_table
+    _, migrator = migrator_class(3)
+    migrator = migrator.new(@path_a, @schema_migration_a)
+
+    @schema_migration_a.drop_table
+    assert_not @connection_a.table_exists?("schema_migrations")
+    migrator.migrate(1)
+    assert @connection_a.table_exists?("schema_migrations")
+
+    _, migrator = migrator_class(3)
+    migrator = migrator.new(@path_b, @schema_migration_b)
+
+    @schema_migration_b.drop_table
+    assert_not @connection_b.table_exists?("schema_migrations")
+    migrator.migrate(1)
+    assert @connection_b.table_exists?("schema_migrations")
+  end
+
+  def test_migrator_forward
+    _, migrator = migrator_class(3)
+    migrator = migrator.new(@path_a, @schema_migration_a)
+    migrator.migrate(1)
+    assert_equal(1, migrator.current_version)
+
+    migrator.forward(2)
+    assert_equal(3, migrator.current_version)
+
+    migrator.forward
+    assert_equal(3, migrator.current_version)
+
+    _, migrator_b = migrator_class(3)
+    migrator_b = migrator_b.new(@path_b, @schema_migration_b)
+    migrator_b.migrate(1)
+    assert_equal(1, migrator_b.current_version)
+
+    migrator_b.forward(2)
+    assert_equal(3, migrator_b.current_version)
+
+    migrator_b.forward
+    assert_equal(3, migrator_b.current_version)
+  end
+
+  private
+    def m(name, version)
+      x = Sensor.new name, version
+      x.extend(Module.new {
+        define_method(:up) { yield(:up, x); super() }
+        define_method(:down) { yield(:down, x); super() }
+      }) if block_given?
+    end
+
+    def sensors(count)
+      calls = []
+      migrations = count.times.map { |i|
+        m(nil, i + 1) { |c, migration|
+          calls << [c, migration.version]
+        }
+      }
+      [calls, migrations]
+    end
+
+    def migrator_class(count)
+      calls, migrations = sensors(count)
+
+      migrator = Class.new(ActiveRecord::MigrationContext) {
+        define_method(:migrations) { |*|
+          migrations
+        }
+      }
+      [calls, migrator]
+    end
+end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -133,11 +133,12 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    assert_equal [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort
+    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord, "primary::SchemaMigration"].collect(&:to_s).sort
+    assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort
     get "/load"
-    assert_equal [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord, Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort
+    assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial
     get "/unload"
-    assert_equal [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort
+    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration", "primary::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -34,7 +34,7 @@ module RailtiesTest
 
     def migrations
       migration_root = File.expand_path(ActiveRecord::Migrator.migrations_paths.first, app_path)
-      ActiveRecord::MigrationContext.new(migration_root).migrations
+      ActiveRecord::MigrationContext.new(migration_root, ActiveRecord::SchemaMigration).migrations
     end
 
     test "serving sprocket's assets" do


### PR DESCRIPTION
This PR moves the `schema_migration` to `migration_context` so that we
can access the `schema_migration` per connection.

This does not change behavior of the SchemaMigration if you are using
one database. This also does not change behavior of any public APIs.
`Migrator` is private as is `MigrationContext` so we can change these as
needed.

We now need to pass a `schema_migration` to `Migrator` so that we can
run migrations on the right connection outside the context of a rake
task.

The bugs this fixes were discovered while debugging the issues around
the SchemaCache on initialization with multiple database. It was clear
that `get_all_versions` wouldn't work without these changes outside the
context of a rake task (because in the rake task we establish a
connection and change AR::Base.connection to the db we're running on).

Because the `SchemaCache` relies on the `SchemaMigration` information we
need to make sure we store it per-connection rather than on
ActiveRecord::Base.

cc/ @tenderlove, @rafaelfranca, @jhawthorn, @matthewd 