### PR TITLE
Add support for multiple databases to `rails db:abort_if_pending_migrations`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for multiple databases to `rails db:abort_if_pending_migrations`.
+
+    *Mark Lee*
+
 *   Fix sqlite3 collation parsing when using decimal columns.
 
     *Martin R. Schuster*

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -299,6 +299,32 @@ module ApplicationTests
         db_migrate_and_schema_cache_dump_and_schema_cache_clear
       end
 
+      test "db:abort_if_pending_migrations works on all databases" do
+        require "#{app_path}/config/environment"
+
+        app_file "db/animals_migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        output = rails("db:abort_if_pending_migrations", allow_failure: true)
+        assert_match(/You have 1 pending migration/, output)
+      end
+
+      test "db:abort_if_pending_migrations:namespace works" do
+        require "#{app_path}/config/environment"
+
+        app_file "db/animals_migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        output = rails("db:abort_if_pending_migrations:primary")
+        assert_no_match(/You have \d+ pending migration/, output)
+        output = rails("db:abort_if_pending_migrations:animals", allow_failure: true)
+        assert_match(/You have 1 pending migration/, output)
+      end
+
       test "db:prepare works on all databases" do
         require "#{app_path}/config/environment"
         db_prepare


### PR DESCRIPTION
### Summary

Currently, the `db:abort_if_pending_migrations` only operates on the primary database configured. If you have a pending migration for a different database, it will not be detected by this task.

This pull request has the task look through all of the databases, and also generates separate tasks for each database, both based off of the pattern of other multi-DB aware tasks.