### PR TITLE
Allow __FILE__ in config/database.yml

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,3 @@
-
+* You can now refer to `__FILE__` when parsing ERB in `config/database.yml`
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -222,7 +222,9 @@ module Rails
         config = if yaml && yaml.exist?
           require "yaml"
           require "erb"
-          loaded_yaml = YAML.load(ERB.new(yaml.read).result) || {}
+          erb = ERB.new(yaml.read)
+          erb.filename = yaml.to_s
+          loaded_yaml = YAML.load(erb.result) || {}
           shared = loaded_yaml.delete("shared")
           if shared
             loaded_yaml.each do |_k, values|


### PR DESCRIPTION

### Summary

Fixes #36441

We have a monorepo with multiple rails apps that are tightly coupled. In one of the apps (app 1), we have a slightly convoluted configuration that takes advantage of the fact that `config/database.yml` is parsed by ERB first. App 1 loads some of it's database configuration from another YAML file.  App 2 in the monorepo needs to be able to parse App 1's `config/database.yml` correctly. This PR tweaks the ERB processing for that file so it can correctly refer to `__FILE__` when it's including the second config file so the path resolves correctly whether it's being read by App 1 or App 2.
