### PR TITLE
ActionCable: optimise logger.debug calling

### DIFF
--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -40,7 +40,7 @@ module ActionCable
           end
 
           def broadcast(message)
-            server.logger.debug "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}"
+            server.logger.debug { "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}" }
 
             payload = { broadcasting: broadcasting, message: message, coder: coder }
             ActiveSupport::Notifications.instrument("broadcast.action_cable", payload) do


### PR DESCRIPTION
### Summary

Before call of `logger.debug` its args are always evaluated, no matter the log level, but it's not always required, because current log level can be `info` or higher. 

Rails guides also have a paragraph about it https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance

I faced with some performance degradation in my project during broadcasting big objects through ActionCable, and find fixed in this PR lines with `ruby_prof` profiler.

### Benchmark

There is a benchmark for fixed part: https://gist.github.com/holyketzer/e0ddf3313baee7470e52e754a4390a31

Results with small payload (65 bytes):
```
OptimizedBroadcaster log_level=info:     51404.7 i/s
Broadcaster          log_level=info:     40453.9 i/s - 1.27x  (± 0.03) slower
OptimizedBroadcaster log_level=debug:    32918.8 i/s - 1.56x  (± 0.05) slower
Broadcaster          log_level=debug:    32299.8 i/s - 1.59x  (± 0.07) slower
```

with large payload (about 20 KBytes):
```
OptimizedBroadcaster log_level=info:      283.7 i/s
Broadcaster          log_level=debug:     224.1 i/s - 1.27x  (± 0.03) slower
Broadcaster          log_level=info:      221.0 i/s - 1.28x  (± 0.03) slower
OptimizedBroadcaster log_level=debug:     219.1 i/s - 1.29x  (± 0.04) slower
```

it significantly improves performance for `info` and higher levels, and runs similar for `debug` level.