### PR TITLE
Escape email addresses with name

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Added `email_address_with_name` to properly escape addresses with names.
 
+    *Sunny Ripert*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -590,6 +590,14 @@ module ActionMailer
         end
       end
 
+      # Returns an email in the format "Name <email@example.com>".
+      def email_address_with_name(address, name)
+        Mail::Address.new.tap do |builder|
+          builder.address = address
+          builder.display_name = name
+        end.to_s
+      end
+
     private
       def set_payload_for_mail(payload, mail)
         payload[:mail]               = mail.encoded
@@ -654,6 +662,11 @@ module ActionMailer
     # Returns the name of the mailer object.
     def mailer_name
       self.class.mailer_name
+    end
+
+    # Returns an email in the format "Name <email@example.com>".
+    def email_address_with_name(address, name)
+      self.class.email_address_with_name(address, name)
     end
 
     # Allows you to pass random and unusual headers to the new <tt>Mail::Message</tt>

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -36,6 +36,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.welcome
     assert_equal(["system@test.lindsaar.net"],    email.to)
     assert_equal(["jose@test.plataformatec.com"], email.from)
+    assert_equal(["mikel@test.lindsaar.net"],     email.reply_to)
     assert_equal("The first email on new API!",   email.subject)
   end
 
@@ -80,6 +81,12 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("text/html", mail.mime_type)
     mail = BaseMailer.plain_text_only
     assert_equal("text/plain", mail.mime_type)
+  end
+
+  test "mail() using email_address_with_name" do
+    email = BaseMailer.with_name
+    assert_equal("Sunny <sunny@example.com>", email["To"].value)
+    assert_equal("Mikel <mikel@test.lindsaar.net>", email["Reply-To"].value)
   end
 
   # Custom headers
@@ -881,6 +888,11 @@ class BaseTest < ActiveSupport::TestCase
 
     assert_equal "Welcome", mailer.welcome.subject
     assert_equal "Anonymous mailer body", mailer.welcome.body.encoded.strip
+  end
+
+  test "email_address_with_name escapes" do
+    address = BaseMailer.email_address_with_name("test@example.org", 'I "<3" email')
+    assert_equal '"I \"<3\" email" <test@example.org>', address
   end
 
   test "default_from can be set" do

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -5,7 +5,7 @@ class BaseMailer < ActionMailer::Base
 
   default to: "system@test.lindsaar.net",
           from: "jose@test.plataformatec.com",
-          reply_to: "mikel@test.lindsaar.net"
+          reply_to: email_address_with_name("mikel@test.lindsaar.net", "Mikel")
 
   def welcome(hash = {})
     headers["X-SPAM"] = "Not SPAM"
@@ -24,6 +24,11 @@ class BaseMailer < ActionMailer::Base
   def welcome_without_deliveries(hash = {})
     mail({ template_name: "welcome" }.merge!(hash))
     mail.perform_deliveries = false
+  end
+
+  def with_name
+    to = email_address_with_name("sunny@example.com", "Sunny")
+    mail(template_name: "welcome", to: to)
   end
 
   def html_only(hash = {})

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -358,14 +358,16 @@ The same format can be used to set carbon copy (Cc:) and blind carbon copy
 #### Sending Email With Name
 
 Sometimes you wish to show the name of the person instead of just their email
-address when they receive the email. The trick to doing that is to format the
-email address in the format `"Full Name" <email>`.
+address when they receive the email. You can use `email_address_with_name` for
+that:
 
 ```ruby
 def welcome_email
   @user = params[:user]
-  email_with_name = %("#{@user.name}" <#{@user.email}>)
-  mail(to: email_with_name, subject: 'Welcome to My Awesome Site')
+  mail(
+    to: email_address_with_name(@user.email, @user.name),
+    subject: 'Welcome to My Awesome Site'
+  )
 end
 ```
 


### PR DESCRIPTION
### Summary

Introduce a safe way to add a name in front of an address when sending emails.

### Currently

The guides' advice to do this is to do the formatting yourself:

```rb
mail(to: %("#{@user.name}" <#{@user.email}>))
```

Sadly this breaks if the name is `Aaron "Tenderlove" Patterson` or `<3`. Worse, it can silently let you think the email was sent, when in fact it is later swallowed by an uncomprehensive mail server.

### With this change

The formatting can be handled by the `email_address_with_name` method:

```rb
mail(to: email_address_with_name(@user.email, @user.name))
```

This makes it an opt-in way to make sure that the contents are correctly escaped.