### PR TITLE
Remove call to object_id

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -134,7 +134,6 @@ module ActiveRecord
             binds: binds,
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
-            connection_id: object_id,
             cached: true
           }
         end


### PR DESCRIPTION
Calling object_id is going to get more expensive in Ruby 2.7.  Also
we're using this for `id2ref` which is going to be deprecated
