### PR TITLE
Raise an error when the not available option in :only and :except options for resource routing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1163,6 +1163,19 @@ module ActionDispatch
             @options    = options
             @shallow    = shallow
             @api_only   = api_only
+
+            if (Array(options[:only]).map(&:to_sym) - default_actions).present?
+              raise ArgumentError,
+                ":only option contain #{(Array(options[:only]).map(&:to_sym) - default_actions)}"\
+                " not available action, available actions: #{default_actions}"
+            end
+
+            if (Array(options[:except]).map(&:to_sym) - default_actions).present?
+              raise ArgumentError,
+                ":except option contain #{(Array(options[:except]).map(&:to_sym) - default_actions)} not "\
+                "available action, available actions: #{default_actions}"
+            end
+
             @only       = options.delete :only
             @except     = options.delete :except
           end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1166,14 +1166,14 @@ module ActionDispatch
 
             if (Array(options[:only]).map(&:to_sym) - default_actions).present?
               raise ArgumentError,
-                ":only option contain #{(Array(options[:only]).map(&:to_sym) - default_actions)}"\
-                " not available action, available actions: #{default_actions}"
+                ":only option contains #{(Array(options[:only]).map(&:to_sym) - default_actions)} "\
+                "that are not valid. The available valid are: #{default_actions}"
             end
 
             if (Array(options[:except]).map(&:to_sym) - default_actions).present?
               raise ArgumentError,
-                ":except option contain #{(Array(options[:except]).map(&:to_sym) - default_actions)} not "\
-                "available action, available actions: #{default_actions}"
+                ":except option contains #{(Array(options[:except]).map(&:to_sym) - default_actions)} "\
+                "that are not valid. The available valid are: #{default_actions}"
             end
 
             @only       = options.delete :only

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -205,6 +205,26 @@ module ActionDispatch
           end
         end
       end
+
+      def test_raising_error_when_only_option_contains_not_available_action
+        assert_raises ArgumentError do
+          Mapper::Resources::Resource.new(:test_route, false, false, only: [:wrong_action])
+        end
+
+        assert_raises ArgumentError do
+          Mapper::Resources::SingletonResource.new(:test_route, false, false, only: [:index])
+        end
+      end
+
+      def test_raising_error_when_except_option_contains_not_available_action
+        assert_raises ArgumentError do
+          Mapper::Resources::Resource.new(:test_route, false, false, except: [:wrong_action])
+        end
+
+        assert_raises ArgumentError do
+          Mapper::Resources::SingletonResource.new(:test_route, false, false, except: [:index])
+        end
+      end
     end
   end
 end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -206,23 +206,31 @@ module ActionDispatch
         end
       end
 
-      def test_raising_error_when_only_option_contains_not_available_action
-        assert_raises ArgumentError do
-          Mapper::Resources::Resource.new(:test_route, false, false, only: [:wrong_action])
+      def test_raising_error_when_only_option_contains_not_valid_action
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        assert_raise(ArgumentError) do
+          mapper.resources(:test_route, only: [:wrong_action]) do
+          end
         end
 
-        assert_raises ArgumentError do
-          Mapper::Resources::SingletonResource.new(:test_route, false, false, only: [:index])
+        assert_raise(ArgumentError) do
+          mapper.resource(:test_route, only: [:index]) do
+          end
         end
       end
 
-      def test_raising_error_when_except_option_contains_not_available_action
-        assert_raises ArgumentError do
-          Mapper::Resources::Resource.new(:test_route, false, false, except: [:wrong_action])
+      def test_raising_error_when_except_option_contains_not_valid_action
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        assert_raise(ArgumentError) do
+          mapper.resources(:test_route, except: [:wrong_action]) do
+          end
         end
 
-        assert_raises ArgumentError do
-          Mapper::Resources::SingletonResource.new(:test_route, false, false, except: [:index])
+        assert_raise(ArgumentError) do
+          mapper.resource(:test_route, except: [:index]) do
+          end
         end
       end
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2795,10 +2795,12 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_except_option_should_not_inherit
     draw do
-      namespace :except do
-        resources :sectors, except: [:show, :update, :destroy] do
-          resources :companies
-          resource  :leader
+      scope except: :destroy do
+        namespace :except do
+          resources :sectors, except: [:show, :update, :destroy] do
+            resources :companies
+            resource  :leader
+          end
         end
       end
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2664,39 +2664,39 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_only_should_be_read_from_scope
     draw do
-      scope only: [:index, :show] do
+      scope only: [:edit, :show] do
         namespace :only do
           resources :clubs do
             resources :players
-            resource  :chairman, only: [:show]
+            resource  :chairman
           end
         end
       end
     end
 
     get "/only/clubs"
-    assert_equal "only/clubs#index", @response.body
-    assert_equal "/only/clubs", only_clubs_path
+    assert_equal "Not Found", @response.body
+    assert_raise(NoMethodError) { only_clubs_path }
 
     get "/only/clubs/1/edit"
-    assert_equal "Not Found", @response.body
-    assert_raise(NoMethodError) { edit_only_club_path(id: "1") }
+    assert_equal "only/clubs#edit", @response.body
+    assert_equal "/only/clubs/1/edit", edit_only_club_path(id: "1")
 
     get "/only/clubs/1/players"
-    assert_equal "only/players#index", @response.body
-    assert_equal "/only/clubs/1/players", only_club_players_path(club_id: "1")
+    assert_equal "Not Found", @response.body
+    assert_raise(NoMethodError) { only_club_players_path(club_id: "1") }
 
     get "/only/clubs/1/players/2/edit"
-    assert_equal "Not Found", @response.body
-    assert_raise(NoMethodError) { edit_only_club_player_path(club_id: "1", id: "2") }
+    assert_equal "only/players#edit", @response.body
+    assert_equal "/only/clubs/1/players/2/edit", edit_only_club_player_path(club_id: "1", id: "2")
 
     get "/only/clubs/1/chairman"
     assert_equal "only/chairmen#show", @response.body
     assert_equal "/only/clubs/1/chairman", only_club_chairman_path(club_id: "1")
 
     get "/only/clubs/1/chairman/edit"
-    assert_equal "Not Found", @response.body
-    assert_raise(NoMethodError) { edit_only_club_chairman_path(club_id: "1") }
+    assert_equal "only/chairmen#edit", @response.body
+    assert_equal "/only/clubs/1/chairman/edit", edit_only_club_chairman_path(club_id: "1")
   end
 
   def test_except_should_be_read_from_scope

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2668,7 +2668,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         namespace :only do
           resources :clubs do
             resources :players
-            resource  :chairman
+            resource  :chairman, only: [:show]
           end
         end
       end
@@ -2795,12 +2795,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_except_option_should_not_inherit
     draw do
-      scope except: :index do
-        namespace :except do
-          resources :sectors, except: [:show, :update, :destroy] do
-            resources :companies
-            resource  :leader
-          end
+      namespace :except do
+        resources :sectors, except: [:show, :update, :destroy] do
+          resources :companies
+          resource  :leader
         end
       end
     end


### PR DESCRIPTION
### Summary

Added error for not available options in :except and :only options for resource routing. It fixes annoying typos in action names. For example index action for resource routing. If I can drop a warning in logs here, I will prefer adding this solution.