### PR TITLE
Fix endless range include

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Range#include?` to work with beginless and endless ranges.
+
+    *Allen Hsu*
+
 *   Don't use `Process#clock_gettime(CLOCK_PROCESS_CPUTIME_ID)` on Solaris
 
     *Iain Beeston*

--- a/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
@@ -9,9 +9,9 @@ module ActiveSupport
     #   (1.hour.ago..1.hour.from_now).include?(Time.current) # => true
     #
     def include?(value)
-      if first.is_a?(TimeWithZone)
+      if self.begin.is_a?(TimeWithZone)
         cover?(value)
-      elsif last.is_a?(TimeWithZone)
+      elsif self.end.is_a?(TimeWithZone)
         cover?(value)
       else
         super

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -60,6 +60,18 @@ class RangeTest < ActiveSupport::TestCase
     assert((1..10).include?(1...11))
   end
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+    def test_include_with_endless_range
+      assert(eval("1..").include?(2))
+    end
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+    def test_include_with_beginless_range
+      assert(eval("..2").include?(1))
+    end
+  end
+
   def test_should_compare_identical_inclusive
     assert((1..10) === (1..10))
   end


### PR DESCRIPTION
### Summary
#### Problem 
See https://github.com/rails/rails/issues/36451
Core extension on ranges calls `#last`.
Ruby 2.6.0 Endless ranges blow up on calling `#last`:
```
ruby -e "(1..).last"                                                                                                                                                                               2.6.2 help-plan-scoring b2c08bc ✗
Traceback (most recent call last):
        1: from -e:1:in `<main>'
-e:1:in `last': cannot get the last element of endless range (RangeError)
```

#### Solution
-`#end` seems directly substitutable, (`#last` acts like `#end` if `#last` is called without args) and does not blow up and returns nil if no end is defined, from the source of `#last`
```C
               static VALUE
range_last(int argc, VALUE *argv, VALUE range)
{
    if (NIL_P(RANGE_END(range))) {
        rb_raise(rb_eRangeError, "cannot get the last element of endless range");
    }
    if (argc == 0) return RANGE_END(range);
    return rb_ary_last(argc, argv, rb_Array(range));
}
```
Source of `#end`:
```C
               static VALUE
range_end(VALUE range)
{
    return RANGE_END(range);
}
```

