### PR TITLE
Add missing file to require digest/uuid on active_support core ext

### DIFF
--- a/activesupport/lib/active_support/core_ext/digest.rb
+++ b/activesupport/lib/active_support/core_ext/digest.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/digest/uuid"


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I noticed I had to `require "active_support/core_ext/digest/uuid"` to be able to use `Digest::UUID` so I dig into active support and I found that all the core extensions have a file to include their respective files, but `digest` so I added it.


### Other Information

I think the expected behaviour is to have `Digest::UUID` available for use so I don't think I should change changelogs or docs.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Thanks