### PR TITLE
Enable `Layout/EmptyLinesAroundAccessModifier` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,10 @@ Layout/EndAlignment:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
 

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -66,7 +66,6 @@ module ActionCable
       end
 
       private
-
         def logger
           ActionCable.server.logger
         end

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -591,7 +591,6 @@ module ActionMailer
       end
 
     private
-
       def set_payload_for_mail(payload, mail)
         payload[:mail]               = mail.encoded
         payload[:mailer]             = name
@@ -873,7 +872,6 @@ module ActionMailer
     end
 
     private
-
       # Used by #mail to set the content type of the message.
       #
       # It will use the given +user_content_type+, or multipart if the mail

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -55,7 +55,6 @@ module ActionMailer
       end
 
       private
-
         def interceptor_class_for(interceptor)
           case interceptor
           when String, Symbol

--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -22,7 +22,6 @@ module ActionMailer
       end
 
       private
-
         def clear_test_deliveries
           if ActionMailer::Base.delivery_method == :test
             ActionMailer::Base.deliveries.clear
@@ -76,7 +75,6 @@ module ActionMailer
       end
 
       private
-
         def initialize_test_deliveries
           set_delivery_method :test
           @old_perform_deliveries = ActionMailer::Base.perform_deliveries

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -152,7 +152,6 @@ module ActionMailer
     end
 
     private
-
       def delivery_job_filter(job)
         job_class = job.is_a?(Hash) ? job.fetch(:job) : job.class
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -939,7 +939,6 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   private
-
     # Execute the block setting the given values and restoring old values after
     # the block is executed.
     def swap(klass, new_values)

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -189,7 +189,6 @@ class FunctionalFragmentCachingTest < BaseCachingTest
   end
 
   private
-
     def template_digest(name, format)
       ActionView::Digestor.digest(name: name, format: format, finder: @mailer.lookup_context)
     end

--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -67,7 +67,6 @@ class ActionMailerI18nWithControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     def with_translation(locale, data)
       I18n.backend.store_translations(locale, data)
       yield

--- a/actionmailer/test/legacy_delivery_job_test.rb
+++ b/actionmailer/test/legacy_delivery_job_test.rb
@@ -69,7 +69,6 @@ class LegacyDeliveryJobTest < ActiveSupport::TestCase
   end
 
   private
-
     def with_delivery_job(job)
       old_params_delivery_job = ParamsMailer.delivery_job
       old_regular_delivery_job = DelayedMailer.delivery_job

--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -68,7 +68,6 @@ The second
   end
 
   private
-
     def mail_with_defaults(&block)
       mail(to: "test@localhost", from: "tester@example.com",
             subject: "using helpers", &block)

--- a/actionmailer/test/mailers/proc_mailer.rb
+++ b/actionmailer/test/mailers/proc_mailer.rb
@@ -18,7 +18,6 @@ class ProcMailer < ActionMailer::Base
   end
 
   private
-
     def give_a_greeting
       "Thanks for signing up this afternoon"
     end

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -81,7 +81,6 @@ class ParameterizedTest < ActiveSupport::TestCase
   end
 
   private
-
     def with_delivery_job(job)
       old_delivery_job = ParamsMailer.delivery_job
       ParamsMailer.delivery_job = job

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -176,7 +176,6 @@ module AbstractController
     end
 
     private
-
       # Returns true if the name can be considered an action because
       # it has a method defined in the controller.
       #

--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -22,7 +22,6 @@ module AbstractController
     end
 
   private
-
     def method_missing(symbol, &block)
       unless mime_constant = Mime[symbol]
         raise NoMethodError, "To respond to a custom format, register it as a MIME type first: " \

--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -30,7 +30,6 @@ module ActionController
     end
 
     private
-
       def instrument_payload(key)
         {
           controller: controller_name,

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -35,7 +35,6 @@ module ActionController
     end
 
     private
-
       INCLUDE = ->(list, action) { list.include? action }
       EXCLUDE = ->(list, action) { !list.include? action }
       NULL    = ->(list, action) { true }

--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -36,7 +36,6 @@ module ActionController #:nodoc:
     end
 
     private
-
       def content_security_policy?
         request.content_security_policy
       end

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -69,7 +69,6 @@ module ActionController
     end
 
   private
-
     # A hook invoked every time a before callback is halted.
     def halted_callback_hook(filter)
       ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -107,7 +107,6 @@ module ActionController
       end
 
       private
-
         def perform_write(json, options)
           current_options = @options.merge(options).stringify_keys
 
@@ -205,7 +204,6 @@ module ActionController
       end
 
       private
-
         def each_chunk(&block)
           loop do
             str = nil
@@ -220,7 +218,6 @@ module ActionController
 
     class Response < ActionDispatch::Response #:nodoc: all
       private
-
         def before_committed
           super
           jar = request.cookie_jar
@@ -286,7 +283,6 @@ module ActionController
     end
 
     private
-
       # Spawn a new thread to serve up the controller in. This is to get
       # around the fact that Rack isn't based around IOs and we need to use
       # a thread to stream data from the response bodies. Nobody should call

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -246,7 +246,6 @@ module ActionController
     end
 
     private
-
       # Returns the wrapper key which will be used to store wrapped parameters.
       def _wrapper_key
         _wrapper_options.name

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -53,7 +53,6 @@ module ActionController
     end
 
     private
-
       def _process_variant(options)
         if defined?(request) && !request.nil? && request.variant.present?
           options[:variant] = request.variant

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -151,7 +151,6 @@ module ActionController #:nodoc:
       end
 
       private
-
         def protection_method_class(name)
           ActionController::RequestForgeryProtection::ProtectionMethods.const_get(name.to_s.classify)
         rescue NameError
@@ -175,7 +174,6 @@ module ActionController #:nodoc:
         end
 
         private
-
           class NullSessionHash < Rack::Session::Abstract::SessionHash #:nodoc:
             def initialize(req)
               super(nil, req)

--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -196,7 +196,6 @@ module ActionController #:nodoc:
     extend ActiveSupport::Concern
 
     private
-
       # Set proper cache control and transfer encoding when streaming
       def _process_options(options)
         super

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -158,7 +158,6 @@ module ActionController
     end.new
 
     private
-
       def params_parsers
         super.merge @custom_param_parsers
       end
@@ -208,7 +207,6 @@ module ActionController
     end
 
     private
-
       def load!
         @id
       end
@@ -594,7 +592,6 @@ module ActionController
       end
 
       private
-
         def scrub_env!(env)
           env.delete_if { |k, v| k =~ /^(action_dispatch|rack)\.request/ }
           env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -123,7 +123,6 @@ module ActionDispatch
         end
 
       private
-
         DATE          = "Date"
         LAST_MODIFIED = "Last-Modified"
         SPECIAL_KEYS  = Set.new(%w[extras no-cache max-age public private must-revalidate])

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -30,7 +30,6 @@ module ActionDispatch #:nodoc:
       end
 
       private
-
         def html_response?(headers)
           if content_type = headers[CONTENT_TYPE]
             content_type =~ /html/
@@ -91,7 +90,6 @@ module ActionDispatch #:nodoc:
       end
 
       private
-
         def generate_content_security_policy_nonce
           content_security_policy_nonce_generator.call(self)
         end

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -56,7 +56,6 @@ module ActionDispatch
       end
 
     private
-
       def parameter_filter # :doc:
         parameter_filter_for fetch_header("action_dispatch.parameter_filter") {
           return NULL_PARAM_FILTER

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -14,7 +14,6 @@ module ActionDispatch
       end
 
     private
-
       def location_filters
         if request
           request.get_header("action_dispatch.redirect_filter") || []

--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -116,7 +116,6 @@ module ActionDispatch
       def env; @req.env.dup; end
 
       private
-
         # Converts an HTTP header name to an environment variable name if it is
         # not contained within the headers hash.
         def env_name(key)

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -154,7 +154,6 @@ module ActionDispatch
       end
 
       private
-
         BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
 
         def valid_accept_header # :doc:

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -290,11 +290,9 @@ module Mime
     def all?; false; end
 
     protected
-
       attr_reader :string, :synonyms
 
     private
-
       def to_ary; end
       def to_a; end
 

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -85,7 +85,6 @@ module ActionDispatch
       end
 
       private
-
         def set_binary_encoding(params, controller, action)
           return params unless controller && controller.valid_encoding?
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -143,7 +143,6 @@ module ActionDispatch # :nodoc:
       end
 
       private
-
         def each_chunk(&block)
           @buf.each(&block)
         end
@@ -409,7 +408,6 @@ module ActionDispatch # :nodoc:
     end
 
   private
-
     ContentTypeHeader = Struct.new :mime_type, :charset
     NullContentTypeHeader = ContentTypeHeader.new nil, nil
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -78,7 +78,6 @@ module ActionDispatch
         end
 
         private
-
           def add_params(path, params)
             params = { params: params } unless params.is_a?(Hash)
             params.reject! { |_, v| v.to_param.nil? }

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -62,7 +62,6 @@ module ActionDispatch
       end
 
       private
-
         def extract_parameterized_parts(route, options, recall, parameterize = nil)
           parameterized_parts = recall.merge(options)
 

--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -128,7 +128,6 @@ module ActionDispatch
         end
 
         private
-
           def followpos_table
             @followpos ||= build_followpos
           end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -141,7 +141,6 @@ module ActionDispatch
         end
 
         private
-
           def states_hash_for(sym)
             case sym
             when String

--- a/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/transition_table.rb
@@ -94,7 +94,6 @@ module ActionDispatch
         end
 
         private
-
           def inverted
             return @inverted if @inverted
 

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -174,7 +174,6 @@ module ActionDispatch
         end
 
         private
-
           def regexp_visitor
             @anchored ? AnchoredRegexp : UnanchoredRegexp
           end

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -81,7 +81,6 @@ module ActionDispatch
       end
 
       private
-
         def partitioned_routes
           routes.partition { |r|
             r.path.anchored && r.ast.grep(Nodes::Symbol).all? { |n| n.default_regexp?  }

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -71,7 +71,6 @@ module ActionDispatch
       end
 
       private
-
         def clear_cache!
           @ast                = nil
           @simulator          = nil

--- a/actionpack/lib/action_dispatch/journey/scanner.rb
+++ b/actionpack/lib/action_dispatch/journey/scanner.rb
@@ -33,7 +33,6 @@ module ActionDispatch
       end
 
       private
-
         # takes advantage of String @- deduping capabilities in Ruby 2.5 upwards
         # see: https://bugs.ruby-lang.org/issues/13077
         def dedup_scan(regex)

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -59,7 +59,6 @@ module ActionDispatch
         end
 
         private
-
           def visit(node)
             send(DISPATCH_CACHE[node.type], node)
           end
@@ -168,7 +167,6 @@ module ActionDispatch
 
       class String < FunctionalVisitor # :nodoc:
         private
-
           def binary(node, seed)
             visit(node.right, visit(node.left, seed))
           end
@@ -214,7 +212,6 @@ module ActionDispatch
         end
 
         private
-
           def binary(node, seed)
             seed.last.concat node.children.map { |c|
               "#{node.object_id} -> #{c.object_id};"

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -252,7 +252,6 @@ module ActionDispatch
       end
 
       private
-
         def upgrade_legacy_hmac_aes_cbc_cookies?
           request.secret_key_base.present? &&
             request.encrypted_signed_cookie_salt.present? &&
@@ -428,7 +427,6 @@ module ActionDispatch
       mattr_accessor :always_write_cookie, default: false
 
       private
-
         def escape(string)
           ::Rack::Utils.escape(string)
         end

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -42,7 +42,6 @@ module ActionDispatch
     end
 
     private
-
       def invoke_interceptors(request, exception)
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
         wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -130,7 +130,6 @@ module ActionDispatch
     end
 
     private
-
       def backtrace
         Array(@exception.backtrace)
       end

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -30,7 +30,6 @@ module ActionDispatch
       end
 
       private
-
         def sanitize_hosts(hosts)
           Array(hosts).map do |host|
             case host
@@ -87,7 +86,6 @@ module ActionDispatch
     end
 
     private
-
       def authorized?(request)
         origin_host = request.get_header("HTTP_HOST").to_s.sub(/:\d+\z/, "")
         forwarded_host = request.x_forwarded_host.to_s.split(/,\s?/).last.to_s.sub(/:\d+\z/, "")

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -32,7 +32,6 @@ module ActionDispatch
     end
 
     private
-
       def render(status, content_type, body)
         format = "to_#{content_type.to_sym}" if content_type
         if format && body.respond_to?(format)

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -156,7 +156,6 @@ module ActionDispatch
       end
 
     private
-
       def ips_from(header) # :doc:
         return [] unless header
         # Split the comma-separated list into an array of strings.

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -30,7 +30,6 @@ module ActionDispatch
       end
 
     private
-
       def initialize_sid # :doc:
         @default_options.delete(:sidbits)
         @default_options.delete(:secure_random)
@@ -83,7 +82,6 @@ module ActionDispatch
       include SessionObject
 
       private
-
         def set_cookie(request, session_id, cookie)
           request.cookie_jar[key] = cookie
         end

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -67,7 +67,6 @@ module ActionDispatch
       end
 
       private
-
         def extract_session_id(req)
           stale_session_check! do
             unpacked_cookie_data(req)["session_id"]

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -40,7 +40,6 @@ module ActionDispatch
     end
 
     private
-
       def render_exception(request, exception)
         backtrace_cleaner = request.get_header "action_dispatch.backtrace_cleaner"
         wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -134,7 +134,6 @@ module ActionDispatch
     end
 
     private
-
       def assert_index(index, where)
         i = index.is_a?(Integer) ? index : middlewares.index { |m| m.klass == index }
         raise "No such middleware to insert #{where}: #{index.inspect}" unless i

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -216,7 +216,6 @@ module ActionDispatch
       end
 
       private
-
         def load_for_read!
           load! if !loaded? && exists?
         end

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -177,7 +177,6 @@ module ActionDispatch
         end
 
         private
-
           def draw_section(routes)
             header_lengths = ["Prefix", "Verb", "URI Pattern"].map(&:length)
             name_width, verb_width, path_width = widths(routes).zip(header_lengths).map(&:max)
@@ -210,7 +209,6 @@ module ActionDispatch
         end
 
         private
-
           def draw_expanded_section(routes)
             routes.map.each_with_index do |r, i|
               <<~MESSAGE.chomp

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1673,7 +1673,6 @@ module ActionDispatch
         end
 
         private
-
           def parent_resource
             @scope[:scope_level_resource]
           end

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -156,7 +156,6 @@ module ActionDispatch
       end
 
       private
-
         def polymorphic_url_for_action(action, record_or_hash, options)
           polymorphic_url(record_or_hash, options.merge(action: action))
         end
@@ -323,7 +322,6 @@ module ActionDispatch
           end
 
           private
-
             def polymorphic_mapping(target, record)
               if record.respond_to?(:to_model)
                 target._routes.polymorphic_mappings[record.to_model.model_name.name]

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -40,7 +40,6 @@ module ActionDispatch
         end
 
       private
-
         def controller(req)
           req.controller_class
         rescue NameError => e
@@ -59,7 +58,6 @@ module ActionDispatch
         end
 
         private
-
           def controller(_); @controller_class; end
       end
 
@@ -215,7 +213,6 @@ module ActionDispatch
             end
 
             private
-
               def optimized_helper(args)
                 params = parameterize_args(args) do
                   raise_generation_error(args)

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -215,13 +215,11 @@ module ActionDispatch
       end
 
       protected
-
         def optimize_routes_generation?
           _routes.optimize_routes_generation? && default_url_options.empty?
         end
 
       private
-
         def _with_routes(routes) # :doc:
           old_routes, @_routes = @_routes, routes
           yield

--- a/actionpack/lib/action_dispatch/testing/assertion_response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertion_response.rb
@@ -35,7 +35,6 @@ module ActionDispatch
     end
 
     private
-
       def code_from_name(name)
         GENERIC_RESPONSE_CODES[name] || Rack::Utils::SYMBOL_TO_STATUS_CODE[name]
       end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -335,7 +335,6 @@ module RoutingTestHelpers
     end
 
     private
-
       def make_request(env)
         Request.new super, url_helpers, @block, strict
       end

--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -18,7 +18,6 @@ class ConditionalGetApiController < ActionController::API
   end
 
   private
-
     def handle_last_modified_and_etags
       fresh_when(last_modified: Time.now.utc.beginning_of_day, etag: [ :foo, 123 ])
     end

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -132,7 +132,6 @@ class ContentTypeTest < ActionController::TestCase
   end
 
   private
-
     def with_default_charset(charset)
       old_default_charset = ActionDispatch::Response.default_charset
       ActionDispatch::Response.default_charset = charset

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -310,7 +310,6 @@ class FilterTest < ActionController::TestCase
     after_action  :conditional_in_parent_after, only: [:show, :another_action]
 
     private
-
       def conditional_in_parent_before
         @ran_filter ||= []
         @ran_filter << "conditional_in_parent_before"
@@ -508,7 +507,6 @@ class FilterTest < ActionController::TestCase
     end
 
     private
-
       def filter_one
         @filters ||= []
         @filters << "filter_one"
@@ -532,7 +530,6 @@ class FilterTest < ActionController::TestCase
     before_action :find_except, except: :edit
 
     private
-
       def find_only
         @only = "Only"
       end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -361,7 +361,6 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     # Overwrite get to send SessionSecret in env hash
     def get(path, *args)
       args[0] ||= {}

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -32,7 +32,6 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     end
 
     private
-
       def authenticate
         authenticate_or_request_with_http_basic do |username, password|
           username == "lifo" && password == "world"
@@ -172,7 +171,6 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
   end
 
   private
-
     def encode_credentials(username, password)
       "Basic #{::Base64.encode64("#{username}:#{password}")}"
     end

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -20,7 +20,6 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
     end
 
     private
-
       def authenticate
         authenticate_or_request_with_http_digest("SuperSecret") do |username|
           # Returns the password
@@ -254,7 +253,6 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
   end
 
   private
-
     def encode_credentials(options)
       options.reverse_merge!(nc: "00000001", cnonce: "0a4f113b", password_is_ha1: false)
       password = options.delete(:password)

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -21,7 +21,6 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     end
 
     private
-
       def authenticate
         authenticate_or_request_with_http_token do |token, _|
           token == "lifo"
@@ -190,7 +189,6 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
   end
 
   private
-
     def sample_request(token, options = { nonce: "def" })
       authorization = options.inject([%{Token token="#{token}"}]) do |arr, (k, v)|
         arr << "#{k}=\"#{v}\""

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -43,7 +43,6 @@ class PostController < AbstractPostController
   end
 
 private
-
   def with_iphone
     request.format = "iphone" if request.env["HTTP_ACCEPT"] == "text/iphone"
     yield

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -67,7 +67,6 @@ module RenderTemplate
     end
 
     private
-
       def show_detailed_exceptions?
         request.local?
       end

--- a/actionpack/test/controller/new_base/render_test.rb
+++ b/actionpack/test/controller/new_base/render_test.rb
@@ -37,7 +37,6 @@ module Render
     end
 
     private
-
       def secretz
         render plain: "FAIL WHALE!"
       end

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -52,7 +52,6 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   private
-
     def assert_logged(message)
       old_logger = ActionController::Base.logger
       log = StringIO.new

--- a/actionpack/test/controller/params_parse_test.rb
+++ b/actionpack/test/controller/params_parse_test.rb
@@ -24,7 +24,6 @@ class ParamsParseTest < ActionController::TestCase
   end
 
   private
-
     def capture_log_output
       output = StringIO.new
       request.set_header "action_dispatch.logger", ActiveSupport::Logger.new(output)

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -411,7 +411,6 @@ class IrregularInflectionParamsWrapperTest < ActionController::TestCase
   end
 
   private
-
     def with_dup
       original = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)[:en]
       ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: original.dup)

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -265,7 +265,6 @@ class TestController < ActionController::Base
   end
 
   private
-
     def set_variable_for_layout
       @variable_for_layout = nil
     end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -112,7 +112,6 @@ class PrependProtectForgeryBaseController < ActionController::Base
   end
 
   private
-
     def add_called_callback(name)
       @called_callbacks ||= []
       @called_callbacks << name

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -304,7 +304,6 @@ class RescueControllerTest < ActionController::TestCase
   end
 
   private
-
     def capture_log_output
       output = StringIO.new
       request.set_header "action_dispatch.logger", ActiveSupport::Logger.new(output)
@@ -351,7 +350,6 @@ class RescueTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     def with_test_routing
       with_routing do |set|
         set.draw do

--- a/actionpack/test/controller/show_exceptions_test.rb
+++ b/actionpack/test/controller/show_exceptions_test.rb
@@ -51,7 +51,6 @@ module ShowExceptions
 
   class ShowExceptionsOverriddenController < ShowExceptionsController
     private
-
       def show_detailed_exceptions?
         params["detailed"] == "1"
       end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -165,7 +165,6 @@ XML
     end
 
     private
-
       def generate_url(opts)
         url_for(opts.merge(action: "test_uri"))
       end

--- a/actionpack/test/dispatch/callbacks_test.rb
+++ b/actionpack/test/dispatch/callbacks_test.rb
@@ -38,7 +38,6 @@ class DispatcherTest < ActiveSupport::TestCase
   end
 
   private
-
     def dispatch(&block)
       ActionDispatch::Callbacks.new(block || DummyApp.new).call(
         "rack.input" => StringIO.new("")

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -307,7 +307,6 @@ class DefaultContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationT
   end
 
   private
-
     def assert_policy(expected, report_only: false)
       if report_only
         expected_header = "Content-Security-Policy-Report-Only"
@@ -470,7 +469,6 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     def assert_policy(expected, report_only: false)
       assert_response :success
 

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -29,7 +29,6 @@ class RequestIdTest < ActiveSupport::TestCase
   end
 
   private
-
     def stub_request(env = {})
       ActionDispatch::RequestId.new(lambda { |environment| [ 200, environment, [] ] }).call(env)
       ActionDispatch::Request.new(env)
@@ -58,7 +57,6 @@ class RequestIdResponseTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     def with_test_route_set
       with_routing do |set|
         set.draw do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3810,7 +3810,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
 private
-
   def draw(&block)
     self.class.stub_controllers do |routes|
       routes.default_url_options = { host: "www.example.com" }
@@ -4953,7 +4952,6 @@ class TestPartialDynamicPathSegments < ActionDispatch::IntegrationTest
   end
 
   private
-
     def assert_params(params)
       assert_equal(params, request.path_parameters)
     end
@@ -5184,7 +5182,6 @@ class TestRecognizePath < ActionDispatch::IntegrationTest
   end
 
   private
-
     def recognize_path(*args)
       Routes.recognize_path(*args)
     end

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -379,7 +379,6 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   end
 
   private
-
     # Overwrite get to send SessionSecret in env hash
     def get(path, *args)
       args[0] ||= {}

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -232,7 +232,6 @@ module StaticTests
   end
 
   private
-
     def assert_gzip(file_name, response)
       expected = File.read("#{FIXTURE_LOAD_PATH}/#{public_path}" + file_name)
       actual   = ActiveSupport::Gzip.decompress(response.body)

--- a/actionpack/test/journey/route/definition/scanner_test.rb
+++ b/actionpack/test/journey/route/definition/scanner_test.rb
@@ -66,7 +66,6 @@ module ActionDispatch
         end
 
         private
-
           def assert_tokens(expected_tokens, scanner, pattern)
             actual_tokens = []
             while token = scanner.next_token

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -503,7 +503,6 @@ module ActionDispatch
       end
 
       private
-
         def get(*args)
           ActiveSupport::Deprecation.silence do
             mapper.get(*args)

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -41,7 +41,6 @@ module ActionView
     end
 
     private
-
       def dirs_to_watch
         fs_paths = all_view_paths.grep(FileSystemResolver)
         fs_paths.map(&:path).sort.uniq

--- a/actionview/lib/action_view/flows.rb
+++ b/actionview/lib/action_view/flows.rb
@@ -68,7 +68,6 @@ module ActionView
     end
 
     private
-
       def inside_fiber?
         Fiber.current.object_id != @root
       end

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -38,7 +38,6 @@ module ActionView
       end
 
       private
-
         def object_has_errors?
           object.respond_to?(:errors) && object.errors.respond_to?(:[]) && error_message.present?
         end

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -227,7 +227,6 @@ module ActionView
       end
 
     private
-
       def fragment_name_with_digest(name, virtual_path, digest_path)
         virtual_path ||= @virtual_path
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -688,7 +688,6 @@ module ActionView
       end
 
       private
-
         def normalize_distance_of_time_argument_to_time(value)
           if value.is_a?(Numeric)
             Time.at(value)

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -403,7 +403,6 @@ module ActionView
       end
 
       private
-
         def delegate_number_helper_method(method, number, options)
           return unless number
           options = escape_unsafe_options(options.symbolize_keys)

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -34,7 +34,6 @@ module ActionView
         end
 
         private
-
           def value
             if @allow_method_names_outside_object
               object.public_send @method_name if object && object.respond_to?(@method_name)

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -39,7 +39,6 @@ module ActionView
         end
 
         private
-
           def checked?(value)
             case value
             when TrueClass, FalseClass

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -22,7 +22,6 @@ module ActionView
         end
 
         private
-
           def render_component(builder)
             builder.check_box + builder.label
           end

--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -37,7 +37,6 @@ module ActionView
         end
 
         private
-
           def instantiate_builder(builder_class, item, value, text, html_options)
             builder_class.new(@template_object, @object_name, @method_name, item,
                               sanitize_attribute_name(value), text, value, html_options)

--- a/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
@@ -21,7 +21,6 @@ module ActionView
         end
 
         private
-
           def render_component(builder)
             builder.radio_button + builder.label
           end

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -12,7 +12,6 @@ module ActionView
         end
 
         private
-
           def validate_color_string(string)
             regex = /#[0-9a-fA-F]{6}/
             if regex.match?(string)

--- a/actionview/lib/action_view/helpers/tags/date_field.rb
+++ b/actionview/lib/action_view/helpers/tags/date_field.rb
@@ -5,7 +5,6 @@ module ActionView
     module Tags # :nodoc:
       class DateField < DatetimeField # :nodoc:
         private
-
           def format_date(value)
             value.try(:strftime, "%Y-%m-%d")
           end

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -23,7 +23,6 @@ module ActionView
         end
 
         private
-
           def select_type
             self.class.select_type
           end

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -14,7 +14,6 @@ module ActionView
         end
 
         private
-
           def format_date(value)
             raise NotImplementedError
           end

--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -11,7 +11,6 @@ module ActionView
         end
 
         private
-
           def format_date(value)
             value.try(:strftime, "%Y-%m-%dT%T")
           end

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -71,7 +71,6 @@ module ActionView
         end
 
         private
-
           def render_component(builder)
             builder.translation
           end

--- a/actionview/lib/action_view/helpers/tags/month_field.rb
+++ b/actionview/lib/action_view/helpers/tags/month_field.rb
@@ -5,7 +5,6 @@ module ActionView
     module Tags # :nodoc:
       class MonthField < DatetimeField # :nodoc:
         private
-
           def format_date(value)
             value.try(:strftime, "%Y-%m")
           end

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -23,7 +23,6 @@ module ActionView
         end
 
         private
-
           def checked?(value)
             value.to_s == @tag_value.to_s
           end

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -29,7 +29,6 @@ module ActionView
         end
 
         private
-
           # Grouped choices look like this:
           #
           #   [nil, []]

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -24,7 +24,6 @@ module ActionView
         end
 
         private
-
           def field_type
             self.class.field_type
           end

--- a/actionview/lib/action_view/helpers/tags/time_field.rb
+++ b/actionview/lib/action_view/helpers/tags/time_field.rb
@@ -5,7 +5,6 @@ module ActionView
     module Tags # :nodoc:
       class TimeField < DatetimeField # :nodoc:
         private
-
           def format_date(value)
             value.try(:strftime, "%T.%L")
           end

--- a/actionview/lib/action_view/helpers/tags/week_field.rb
+++ b/actionview/lib/action_view/helpers/tags/week_field.rb
@@ -5,7 +5,6 @@ module ActionView
     module Tags # :nodoc:
       class WeekField < DatetimeField # :nodoc:
         private
-
           def format_date(value)
             value.try(:strftime, "%Y-W%V")
           end

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -426,7 +426,6 @@ module ActionView
         end
 
         private
-
           def next_index
             step_index(1)
           end

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -224,7 +224,6 @@ module ActionView
       # that if no layout conditions are used, this method is not used
       module LayoutConditions # :nodoc:
         private
-
           # Determines whether the current action has a layout definition by
           # checking the action name against the :only and :except conditions
           # set by the <tt>layout</tt> method.
@@ -334,7 +333,6 @@ module ActionView
       end
 
       private
-
         # If no layout is supplied, look for a template named the return
         # value of this method.
         #
@@ -372,7 +370,6 @@ module ActionView
     end
 
   private
-
     def _conditional_layout?
       true
     end

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -54,7 +54,6 @@ module ActionView
     end
 
   private
-
     EMPTY = ""
     def from_rails_root(string) # :doc:
       string = string.sub(rails_root, EMPTY)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -112,7 +112,6 @@ module ActionView
       end
 
     private
-
       def _set_detail(key, value) # :doc:
         @details = @details.dup if @digest_cache || @details_key
         @digest_cache = nil
@@ -171,7 +170,6 @@ module ActionView
       end
 
     private
-
       # Whenever setting view paths, makes a copy so that we can manipulate them in
       # instance objects as we wish.
       def build_view_paths(paths)

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -69,7 +69,6 @@ module ActionView #:nodoc:
     end
 
     private
-
       def _find_all(path, prefixes, args)
         prefixes = [prefixes] if String === prefixes
         prefixes.each do |prefix|

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -95,7 +95,6 @@ module ActionView
     end
 
   private
-
     # Returns a string representation of the key attribute(s) that is suitable for use in an HTML DOM id.
     # This can be overwritten to customize the default generated string representation if desired.
     # If you need to read back a key from a dom_id in order to query for the underlying database record,

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -74,7 +74,6 @@ module ActionView
     end
 
     private
-
       def extract_details(options) # :doc:
         @lookup_context.registered_details.each_with_object({}) do |key, details|
           value = options[key]

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -322,7 +322,6 @@ module ActionView
     end
 
     private
-
       def render_collection(view, template)
         identifier = (template && template.identifier) || @path
         instrument(:collection, identifier: identifier, count: @collection.size) do |payload|

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -27,7 +27,6 @@ module ActionView
       end
 
       private
-
         # This is the same logging logic as in ShowExceptions middleware.
         def log_error(exception)
           logger = ActionView::Base.logger
@@ -55,7 +54,6 @@ module ActionView
     end
 
     private
-
       def delayed_render(buffer, template, layout, view, locals)
         # Wrap the given buffer in the StreamingBuffer and pass it to the
         # underlying template handler. Now, every time something is concatenated

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -14,7 +14,6 @@ module ActionView
     end
 
     private
-
       # Determine the template to be rendered using the given options.
       def determine_template(options)
         keys = options.has_key?(:locals) ? options[:locals].keys : []

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -104,7 +104,6 @@ module ActionView
     end
 
     private
-
       # Find and render a template based on the options given.
       def _render_template(options)
         variant = options.delete(:variant)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -264,7 +264,6 @@ module ActionView
     end
 
     private
-
       # Compile a template. This method ensures a template is compiled
       # just once and removes the source after it is compiled.
       def compile!(view)

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -114,7 +114,6 @@ module ActionView
       end
 
       private
-
         def source_location
           if line_number
             "on line ##{line_number} of "

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -63,7 +63,6 @@ module ActionView
         end
 
       private
-
         def valid_encoding(string, encoding)
           # If a magic encoding comment was found, tag the
           # String with this encoding. This is for a case

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -93,7 +93,6 @@ module ActionView
       end
 
       private
-
         def canonical_no_templates(templates)
           templates.empty? ? NO_TEMPLATES : templates
         end
@@ -130,7 +129,6 @@ module ActionView
     end
 
   private
-
     def _find_all(name, prefix, partial, details, key, locals)
       find_templates(name, prefix, partial, details, locals)
     end
@@ -183,7 +181,6 @@ module ActionView
     end
 
     private
-
       def _find_all(name, prefix, partial, details, key, locals)
         path = Path.build(name, prefix, partial)
         query(path, details, details[:formats], locals, cache: !!key)
@@ -323,7 +320,6 @@ module ActionView
     end
 
     private
-
       def find_template_paths_from_details(path, details)
         # Instead of checking for every possible path, as our other globs would
         # do, scan the directory for files with the right prefix.

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -93,7 +93,6 @@ module ActionView
         end
 
       private
-
         def include_helper_modules!
           helper(helper_class) if helper_class
           include _helpers
@@ -163,7 +162,6 @@ module ActionView
       end
 
     private
-
       # Need to experiment if this priority is the best one: rendered => output_buffer
       def document_root_element
         Nokogiri::HTML::Document.parse(@rendered.blank? ? @output_buffer : @rendered).root

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -22,7 +22,6 @@ module ActionView #:nodoc:
     end
 
     private
-
       def query(path, exts, _, locals, cache:)
         query = +""
         EXTENSIONS.each do |ext, prefix|

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -18,7 +18,6 @@ module ActionView
     end
 
     private
-
       def build_template(locals)
         options = @options.merge(locals: locals)
         Template.new(

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -29,7 +29,6 @@ module ActionView
       end
 
       private
-
         # Override this method in your controller if you want to change paths prefixes for finding views.
         # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.
         def local_prefixes

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -230,6 +230,7 @@ module AbstractController
 
     class ActionMissingRespondToActionController < AbstractController::Base
       # No actions
+
       private
         def action_missing(action_name)
           self.response_body = "success"
@@ -242,7 +243,6 @@ module AbstractController
       def fail()  self.response_body = "fail"    end
 
     private
-
       def method_for_action(action_name)
         action_name.to_s != "fail" && action_name
       end

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -140,6 +140,7 @@ module AbstractControllerTests
       def index
         render template: ActionView::Template::Text.new("Hello symbol!")
       end
+
     private
       def hello
         "overwrite"

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -607,7 +607,6 @@ class TestController < ActionController::Base
   end
 
   private
-
     def set_variable_for_layout
       @variable_for_layout = nil
     end

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -58,7 +58,6 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   end
 
   private
-
     def hidden_fields(method = nil)
       txt = +%{<input name="utf8" type="hidden" value="&#x2713;" />}
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1897,7 +1897,6 @@ class FormHelperTest < ActionView::TestCase
   def test_form_tags_do_not_call_private_properties_on_form_object
     obj = Class.new do
       private
-
         def private_property
           raise "This method should not be called."
         end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1472,7 +1472,6 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   private
-
     def dummy_posts
       [ Post.new("<Abe> went home", "<Abe>", "To a little house", "shh!"),
         Post.new("Babe went home", "Babe", "To a little house", "shh!"),

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -803,7 +803,6 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   private
-
     def root_elem(rendered_content)
       Nokogiri::HTML::DocumentFragment.parse(rendered_content).children.first # extract from nodeset
     end

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -45,7 +45,6 @@ module ActiveJob
     end
 
     private
-
       # :nodoc:
       PERMITTED_TYPES = [ NilClass, String, Integer, Float, BigDecimal, TrueClass, FalseClass ]
       # :nodoc:

--- a/activejob/lib/active_job/serializers/date_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_serializer.rb
@@ -12,7 +12,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           Date
         end

--- a/activejob/lib/active_job/serializers/date_time_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_time_serializer.rb
@@ -12,7 +12,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           DateTime
         end

--- a/activejob/lib/active_job/serializers/duration_serializer.rb
+++ b/activejob/lib/active_job/serializers/duration_serializer.rb
@@ -15,7 +15,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           ActiveSupport::Duration
         end

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -44,7 +44,6 @@ module ActiveJob
       end
 
       private
-
         # The class of the object that will be serialized.
         def klass # :doc:
           raise NotImplementedError

--- a/activejob/lib/active_job/serializers/symbol_serializer.rb
+++ b/activejob/lib/active_job/serializers/symbol_serializer.rb
@@ -12,7 +12,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           Symbol
         end

--- a/activejob/lib/active_job/serializers/time_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_serializer.rb
@@ -12,7 +12,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           Time
         end

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -12,7 +12,6 @@ module ActiveJob
       end
 
       private
-
         def klass
           ActiveSupport::TimeWithZone
         end

--- a/activejob/test/cases/serializers_test.rb
+++ b/activejob/test/cases/serializers_test.rb
@@ -26,7 +26,6 @@ class SerializersTest < ActiveSupport::TestCase
     end
 
     private
-
       def klass
         DummyValueObject
       end

--- a/activejob/test/jobs/timezone_dependent_job.rb
+++ b/activejob/test/jobs/timezone_dependent_job.rb
@@ -15,7 +15,6 @@ class TimezoneDependentJob < ActiveJob::Base
   end
 
   private
-
     def localtime(*args)
       Time.zone ? Time.zone.local(*args) : Time.utc(*args)
     end

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -19,7 +19,6 @@ module TestCaseHelpers
   end
 
   private
-
     def jobs_manager
       JobsManager.current_manager
     end

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -38,7 +38,6 @@ module ActiveModel
     alias attributes= assign_attributes
 
     private
-
       def _assign_attributes(attributes)
         attributes.each do |k, v|
           _assign_attribute(k, v)

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -94,11 +94,9 @@ module ActiveModel
     end
 
     protected
-
       attr_reader :attributes
 
     private
-
       def initialized_attributes
         attributes.select { |_, attr| attr.initialized? }
       end

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -42,7 +42,6 @@ module ActiveModel
       end
 
       private
-
         def define_method_attribute=(name)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
             generated_attribute_methods, name, writer: true,
@@ -114,7 +113,6 @@ module ActiveModel
     end
 
     private
-
       def write_attribute(attr_name, value)
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -126,7 +126,6 @@ module ActiveModel
     end
 
     private
-
       def _define_before_model_callback(klass, callback)
         klass.define_singleton_method("before_#{callback}") do |*args, **options, &block|
           options.assert_valid_keys(:if, :unless, :prepend)

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -73,7 +73,6 @@ module ActiveModel
     end
 
     protected
-
       def attributes_for_hash
         [@base, @attribute, @raw_type, @options]
       end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -594,7 +594,6 @@ module ActiveModel
     end
 
     private
-
       def normalize_arguments(attribute, type, **options)
         # Evaluate proc first
         if type.respond_to?(:call)
@@ -640,7 +639,6 @@ module ActiveModel
     end
 
     private
-
       def prepare_content
         content = @errors.to_hash
         content.each do |attribute, value|

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -207,7 +207,6 @@ module ActiveModel
     end
 
     private
-
       def _singularize(string)
         ActiveSupport::Inflector.underscore(string).tr("/", "_")
       end

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -150,7 +150,6 @@ module ActiveModel
     end
 
     private
-
       # Hook method defining how an attribute value should be retrieved for
       # serialization. By default this is assumed to be an instance named after
       # the attribute. Override this method in subclasses should you need to

--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -6,7 +6,6 @@ module ActiveModel
   module Type
     class BigInteger < Integer # :nodoc:
       private
-
         def max_value
           ::Float::INFINITY
         end

--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -34,7 +34,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           if value == ""
             nil

--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -15,7 +15,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           if value.is_a?(::String)
             return if value.empty?

--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -14,7 +14,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           return apply_seconds_precision(value) unless value.is_a?(::String)
           return if value.empty?

--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -17,7 +17,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           casted_value = \
             case value

--- a/activemodel/lib/active_model/type/float.rb
+++ b/activemodel/lib/active_model/type/float.rb
@@ -19,7 +19,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           case value
           when ::Float then value

--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -24,7 +24,6 @@ module ActiveModel
         end
 
         private
-
           def number_to_non_number?(old_value, new_value_before_type_cast)
             old_value != nil && non_numeric_string?(new_value_before_type_cast.to_s)
           end

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -44,7 +44,6 @@ module ActiveModel
         end
 
         private
-
           def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
             # Treat 0000-00-00 00:00:00 as nil.
             return if year.nil? || (year == 0 && mon == 0 && mday == 0)

--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -17,7 +17,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           result = \
             case value

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -12,7 +12,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           case value
           when ::String then ::String.new(value)

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -29,7 +29,6 @@ module ActiveModel
       end
 
       private
-
         def cast_value(value)
           return apply_seconds_precision(value) unless value.is_a?(::String)
           return if value.empty?

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -114,7 +114,6 @@ module ActiveModel
       end
 
       private
-
         # Convenience method for types which do not need separate type casting
         # behavior for user and database inputs. Called by Value#cast for
         # values except +nil+.

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -402,7 +402,6 @@ module ActiveModel
     alias :read_attribute_for_validation :send
 
   private
-
     def run_validations!
       _run_validate_callbacks
       errors.empty?

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -15,7 +15,6 @@ module ActiveModel
       end
 
       private
-
         def setup!(klass)
           klass.include(LazilyDefineAttributes.new(AttributeDefinition.new(attributes)))
         end

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -112,7 +112,6 @@ module ActiveModel
       end
 
     private
-
       # Overwrite run validations to include callbacks.
       def run_validations!
         _run_validation_callbacks { super }

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -15,7 +15,6 @@ module ActiveModel
       end
 
     private
-
       def include?(record, value)
         members = if delimiter.respond_to?(:call)
           delimiter.call(record)

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -23,7 +23,6 @@ module ActiveModel
       end
 
       private
-
         def option_call(record, name)
           option = options[name]
           option.respond_to?(:call) ? option.call(record) : option

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -79,7 +79,6 @@ module ActiveModel
       end
 
     private
-
       def is_number?(raw_value)
         !parse_as_number(raw_value).nil?
       rescue ArgumentError, TypeError

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -150,7 +150,6 @@ module ActiveModel
       end
 
     private
-
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
       def _validates_default_keys

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -175,7 +175,6 @@ module ActiveModel
     end
 
     private
-
       def validate_each(record, attribute, value)
         @block.call(record, attribute, value)
       end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -40,7 +40,6 @@ private
   end
 
 protected
-
   def protected_method
     "O_o O_o"
   end

--- a/activemodel/test/cases/type/date_time_test.rb
+++ b/activemodel/test/cases/type/date_time_test.rb
@@ -37,7 +37,6 @@ module ActiveModel
       end
 
       private
-
         def with_timezone_config(default:)
           old_zone_default = ::Time.zone_default
           ::Time.zone_default = ::Time.find_zone(default)

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -92,7 +92,6 @@ class AcceptanceValidationTest < ActiveModel::TestCase
   end
 
   private
-
     # Acceptance validator includes anonymous module into class, which cannot
     # be cleared, so to avoid multiple inclusions we use a named subclass which
     # we can remove in teardown.

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -310,7 +310,6 @@ class NumericalityValidationTest < ActiveModel::TestCase
   end
 
   private
-
     def invalid!(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|
         assert topic.invalid?, "#{value.inspect} not rejected as a number"

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -14,7 +14,6 @@ module ActiveRecord
     end
 
     private
-
       def clear_aggregation_cache
         @aggregation_cache.clear if persisted?
       end

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -29,7 +29,6 @@ module ActiveRecord
     end
 
     private
-
       def exec_queries
         super do |record|
           @association.set_inverse_instance_from_queries(record)

--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -72,7 +72,6 @@ module ActiveRecord
       attr_reader :aliases
 
       private
-
         def truncate(name)
           name.slice(0, @connection.table_alias_length - 2)
         end

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -46,7 +46,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
         end
 
         private
-
           def self.suppress_composite_primary_key(pk)
             pk unless pk.is_a?(Array)
           end
@@ -73,7 +72,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     private
-
       def middle_options(join_model)
         middle_options = {}
         middle_options[:class_name] = "#{lhs_model.name}::#{join_model.name}"

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1101,7 +1101,6 @@ module ActiveRecord
       delegate(*delegate_methods, to: :scope)
 
       private
-
         def find_nth_with_limit(index, limit)
           load_target if find_from_target?
           super

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -37,7 +37,6 @@ module ActiveRecord
       end
 
       private
-
         # Returns the number of records in this collection.
         #
         # If the association has a counter cache it gets that value. Otherwise

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -95,7 +95,6 @@ module ActiveRecord
       end
 
       private
-
         # Loads all the given data into +records+ for the +association+.
         def preloaders_on(association, records, scope, polymorphic_parent = false)
           case association

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -7,7 +7,6 @@ module ActiveRecord
     include ActiveModel::AttributeAssignment
 
     private
-
       def _assign_attributes(attributes)
         multi_parameter_attributes  = {}
         nested_parameter_attributes = {}

--- a/activerecord/lib/active_record/attribute_decorators.rb
+++ b/activerecord/lib/active_record/attribute_decorators.rb
@@ -46,7 +46,6 @@ module ActiveRecord
       end
 
       private
-
         def load_schema!
           super
           attribute_types.each do |name, type|
@@ -75,7 +74,6 @@ module ActiveRecord
       end
 
       private
-
         def decorators_for(name, type)
           matching(name, type).map(&:last)
         end

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -66,7 +66,6 @@ module ActiveRecord
       end
 
       private
-
         # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
         def attribute_before_type_cast(attribute_name)
           read_attribute_before_type_cast(attribute_name)

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -45,7 +45,6 @@ module ActiveRecord
       end
 
       private
-
         def attribute_method?(attr_name)
           attr_name == "id" || super
         end
@@ -120,7 +119,6 @@ module ActiveRecord
           end
 
           private
-
             def suppress_composite_primary_key(pk)
               return pk unless pk.is_a?(Array)
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -7,7 +7,6 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-
           def define_method_attribute(name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
               generated_attribute_methods, name

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -79,7 +79,6 @@ module ActiveRecord
         end
 
         private
-
           def type_incompatible_with_serialize?(type, class_name)
             type.is_a?(ActiveRecord::Type::Json) && class_name == ::JSON ||
               type.respond_to?(:type_cast_array, true) && class_name == ::Array

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -25,7 +25,6 @@ module ActiveRecord
         end
 
         private
-
           def convert_time_to_time_zone(value)
             return if value.nil?
 
@@ -64,7 +63,6 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-
           def inherited(subclass)
             super
             # We need to apply this decorator here, rather than on module inclusion. The closure

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -11,7 +11,6 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-
           def define_method_attribute=(name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
               generated_attribute_methods, name, writer: true,

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -255,7 +255,6 @@ module ActiveRecord
       end
 
       private
-
         NO_DEFAULT_PROVIDED = Object.new # :nodoc:
         private_constant :NO_DEFAULT_PROVIDED
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -147,7 +147,6 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       private
-
         def define_non_cyclic_method(name, &block)
           return if instance_methods(false).include?(name)
           define_method(name) do |*args|
@@ -267,7 +266,6 @@ module ActiveRecord
     end
 
     private
-
       # Returns the record for an association collection that should be validated
       # or saved. If +autosave+ is +false+ only new records will be returned,
       # unless the parent is/was a new record itself.

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -323,7 +323,6 @@ module ActiveRecord
     end
 
   private
-
     def create_or_update(**)
       _run_save_callbacks { super }
     end

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -39,7 +39,6 @@ module ActiveRecord
       end
 
       private
-
         def check_arity_of_constructor
           load(nil)
         rescue ArgumentError

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -167,7 +167,6 @@ module ActiveRecord
         end
 
         private
-
           def internal_poll(timeout)
             no_wait_poll || (timeout && wait_poll(timeout))
           end
@@ -330,7 +329,6 @@ module ActiveRecord
           end
 
           private
-
             def spawn_thread(frequency)
               Thread.new(frequency) do |t|
                 loop do
@@ -1112,7 +1110,6 @@ module ActiveRecord
       end
 
       private
-
         def owner_to_pool
           @owner_to_pool[Process.pid]
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -109,7 +109,6 @@ module ActiveRecord
       end
 
       private
-
         def cache_sql(sql, name, binds)
           @lock.synchronize do
             result =

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -19,7 +19,6 @@ module ActiveRecord
           to: :@conn, private: true
 
         private
-
           def visit_AlterTable(o)
             sql = +"ALTER TABLE #{quote_table_name(o.name)} "
             sql << o.adds.map { |col| accept col }.join(" ")

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -309,7 +309,6 @@ module ActiveRecord
       end
 
       private
-
         NULL_TRANSACTION = NullTransaction.new
 
         # Deallocate invalidated prepared statements outside of the transaction

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -593,7 +593,6 @@ module ActiveRecord
       end
 
       private
-
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|
             initialize_type_map(mapping)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -45,7 +45,6 @@ module ActiveRecord
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         private
-
           def dealloc(stmt)
             stmt.close
           end
@@ -513,7 +512,6 @@ module ActiveRecord
       end
 
       private
-
         def initialize_type_map(m = type_map)
           super
 
@@ -795,7 +793,6 @@ module ActiveRecord
           end
 
           private
-
             def cast_value(value)
               case value
               when true then "1"

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -56,7 +56,6 @@ module ActiveRecord
         end
 
         private
-
           attr_reader :uri
 
           def uri_parser

--- a/activerecord/lib/active_record/connection_adapters/mysql/explain_pretty_printer.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/explain_pretty_printer.rb
@@ -37,7 +37,6 @@ module ActiveRecord
         end
 
         private
-
           def compute_column_widths(result)
             [].tap do |widths|
               result.columns.each_with_index do |column, i|

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -7,7 +7,6 @@ module ActiveRecord
         delegate :add_sql_comment!, :mariadb?, to: :@conn, private: true
 
         private
-
           def visit_DropForeignKey(name)
             "DROP FOREIGN KEY #{name}"
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -115,7 +115,6 @@ module ActiveRecord
       end
 
       private
-
         def connect
           @connection = Mysql2::Client.new(@config)
           configure_connection

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -77,7 +77,6 @@ module ActiveRecord
           end
 
           private
-
             def type_cast_array(value, method)
               if value.is_a?(::Array)
                 value.map { |item| type_cast_array(item, method) }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/enum.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/enum.rb
@@ -10,7 +10,6 @@ module ActiveRecord
           end
 
           private
-
             def cast_value(value)
               value.to_s
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -46,7 +46,6 @@ module ActiveRecord
           end
 
           private
-
             HstorePair = begin
               quoted_string = /"[^"\\]*(?:\\.[^"\\]*)*"/
               unquoted_string = /(?:\\.|[^\s,])[^\s=,\\]*(?:\\.[^\s=,\\]*|=[^,>])*/

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/legacy_point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/legacy_point.rb
@@ -34,7 +34,6 @@ module ActiveRecord
           end
 
           private
-
             def number_for_point(number)
               number.to_s.gsub(/\.0$/, "")
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
@@ -50,7 +50,6 @@ module ActiveRecord
           end
 
           private
-
             def number_for_point(number)
               number.to_s.gsub(/\.0$/, "")
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -58,7 +58,6 @@ module ActiveRecord
           end
 
           private
-
             def type_cast_single(value)
               infinity?(value) ? value : @subtype.deserialize(value)
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -14,7 +14,6 @@ module ActiveRecord
           end
 
           private
-
             def cast_value(value)
               casted = value.to_s
               casted if casted.match?(ACCEPTABLE_UUID)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module PostgreSQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
-
           def extensions(stream)
             extensions = @connection.extensions
             if extensions.any?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -37,7 +37,6 @@ module ActiveRecord
         end
 
         protected
-
           def parts
             @parts ||= [@schema, @identifier].compact
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -453,7 +453,6 @@ module ActiveRecord
       end
 
       private
-
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"
         NUMERIC_VALUE_OUT_OF_RANGE = "22003"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -82,7 +82,6 @@ module ActiveRecord
         private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
 
         private
-
           def _type_cast(value)
             case value
             when BigDecimal

--- a/activerecord/lib/active_record/connection_adapters/statement_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/statement_pool.rb
@@ -48,7 +48,6 @@ module ActiveRecord
       end
 
       private
-
         def cache
           @cache[Process.pid]
         end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -256,7 +256,6 @@ module ActiveRecord
       :clear_all_connections!, :flush_idle_connections!, to: :connection_handler
 
     private
-
       def swap_connection_handler(handler, &blk) # :nodoc:
         old_handler, ActiveRecord::Base.connection_handler = ActiveRecord::Base.connection_handler, handler
         yield

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -286,7 +286,6 @@ module ActiveRecord
       end
 
       private
-
         def cached_find_by_statement(key, &block)
           cache = @find_by_statement_cache[connection.prepared_statements]
           cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
@@ -554,7 +553,6 @@ module ActiveRecord
     end
 
     private
-
       # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of
       # the array, and then rescues from the possible +NoMethodError+. If those elements are
       # +ActiveRecord::Base+'s, then this triggers the various +method_missing+'s that we have,

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -56,7 +56,6 @@ module ActiveRecord
       end
 
       private
-
         def build_url_hash(url)
           if url.nil? || /^jdbc:/.match?(url)
             { "url" => url }

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -69,7 +69,6 @@ module ActiveRecord
         end
 
         private
-
           def body
             "#{finder}(#{attributes_hash})"
           end

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -36,7 +36,6 @@ module ActiveRecord
     end
 
     private
-
       def render_bind(attr)
         value = if attr.type.binary? && attr.value
           "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -48,7 +48,6 @@ module ActiveRecord
       end
 
       private
-
         def model_metadata
           @table_rows.model_metadata
         end

--- a/activerecord/lib/active_record/fixture_set/table_rows.rb
+++ b/activerecord/lib/active_record/fixture_set/table_rows.rb
@@ -29,7 +29,6 @@ module ActiveRecord
       end
 
       private
-
         def build_table_rows_from(table_name, fixtures, config)
           now = config.default_timezone == :utc ? Time.now.utc : Time.now
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -464,7 +464,6 @@ module ActiveRecord
       end
 
       private
-
         def insert_class(class_names, name, klass)
           # We only want to deal with AR objects.
           if klass && klass < ActiveRecord::Base
@@ -570,7 +569,6 @@ module ActiveRecord
       end
 
       private
-
         def read_and_insert(fixtures_directory, fixture_files, class_names, connection) # :nodoc:
           fixtures_map = {}
           fixture_sets = fixture_files.map do |fixture_set_name|
@@ -661,7 +659,6 @@ module ActiveRecord
     end
 
     private
-
       def model_class=(class_name)
         if class_name.is_a?(Class) # TODO: Should be an AR::Base type class, or any?
           @model_class = class_name

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -176,7 +176,6 @@ module ActiveRecord
       end
 
       protected
-
         # Returns the class type of the record using the current module as a prefix. So descendants of
         # MyApp::Business::Account would appear as MyApp::Business::AccountSubclass.
         def compute_type(type_name)
@@ -208,7 +207,6 @@ module ActiveRecord
         end
 
       private
-
         # Called by +instantiate+ to decide which class to use for a new
         # record instance. For single-table inheritance, we check the record
         # for a +type+ column and return the corresponding class.
@@ -272,7 +270,6 @@ module ActiveRecord
     end
 
     private
-
       def initialize_internals_callback
         super
         ensure_proper_type

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -156,7 +156,6 @@ module ActiveRecord
           end
 
           private
-
             # We need to apply this decorator here, rather than on module inclusion. The closure
             # created by the matcher would otherwise evaluate for `ActiveRecord::Base`, not the
             # sub class being decorated. As such, changes to `lock_optimistically`, or

--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -55,7 +55,6 @@ module ActiveRecord
       end
 
       private
-
         def select_database(request, &blk)
           context = context_klass.call(request)
           resolver = resolver_klass.call(context, options)

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -44,7 +44,6 @@ module ActiveRecord
         end
 
         private
-
           def read_from_primary(&blk)
             ActiveRecord::Base.connection.while_preventing_writes do
               ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -568,7 +568,6 @@ module ActiveRecord
       end
 
       private
-
         def connection
           ActiveRecord::Base.connection
         end
@@ -992,7 +991,6 @@ module ActiveRecord
     delegate :migrate, :announce, :write, :disable_ddl_transaction, to: :migration
 
     private
-
       def migration
         @migration ||= load_migration
       end
@@ -1250,7 +1248,6 @@ module ActiveRecord
     end
 
     private
-
       # Used for running a specific migration.
       def run_without_lock
         migration = migrations.detect { |m| m.version == @target_version }

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -118,7 +118,6 @@ module ActiveRecord
       end
 
       private
-
         module StraightReversions # :nodoc:
           private
             {

--- a/activerecord/lib/active_record/migration/join_table.rb
+++ b/activerecord/lib/active_record/migration/join_table.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   class Migration
     module JoinTable #:nodoc:
       private
-
         def find_join_table_name(table_1, table_2, options = {})
           options.delete(:table_name) || join_table_name(table_1, table_2)
         end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -456,13 +456,11 @@ module ActiveRecord
       end
 
       protected
-
         def initialize_load_schema_monitor
           @load_schema_monitor = Monitor.new
         end
 
       private
-
         def inherited(child_class)
           super
           child_class.initialize_load_schema_monitor

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -354,7 +354,6 @@ module ActiveRecord
       end
 
       private
-
         # Generates a writer method for this association. Serves as a point for
         # accessing the objects in the association. For example, this method
         # could generate the following:
@@ -386,7 +385,6 @@ module ActiveRecord
     end
 
     private
-
       # Attribute hash keys that should not be assigned as normal attributes.
       # These hash keys are nested attributes implementation details.
       UNASSIGNABLE_KEYS = %w( id _destroy )

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -60,7 +60,6 @@ module ActiveRecord
     end
 
     private
-
       def exec_queries
         @records = [].freeze
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -865,7 +865,6 @@ module ActiveRecord
     end
 
   private
-
     # A hook to be overridden by association modules.
     def destroy_associations
     end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -590,7 +590,6 @@ module ActiveRecord
       end
 
       private
-
         def calculate_constructable(macro, options)
           true
         end
@@ -704,7 +703,6 @@ module ActiveRecord
       end
 
       private
-
         def calculate_constructable(macro, options)
           !options[:through]
         end

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -258,7 +258,6 @@ module ActiveRecord
     end
 
     private
-
       def apply_limits(relation, start, finish)
         relation = apply_start_limit(relation, start) if start
         relation = apply_finish_limit(relation, finish) if finish

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -99,7 +99,6 @@ module ActiveRecord
       end
 
       private
-
         def method_missing(method, *args, &block)
           if @klass.respond_to?(method)
             @klass.generate_relation_method(method)
@@ -116,7 +115,6 @@ module ActiveRecord
       end
 
       private
-
         def relation_class_for(klass)
           klass.relation_delegate_class(self)
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -346,7 +346,6 @@ module ActiveRecord
     end
 
     private
-
       def offset_index
         offset_value || 0
       end

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -89,7 +89,6 @@ module ActiveRecord
       end
 
       private
-
         def merge_preloads
           return if other.preload_values.empty? && other.includes_values.empty?
 

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -67,7 +67,6 @@ module ActiveRecord
     end
 
     private
-
       def relation_with(values)
         result = Relation.create(klass, values: values)
         result.extend(*extending_values) if extending_values.any?

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -87,7 +87,6 @@ module ActiveRecord
       end
 
       protected
-
         attr_reader :predicates
 
         def referenced_columns

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -132,7 +132,6 @@ module ActiveRecord
     end
 
     private
-
       def column_type(name, type_overrides = {})
         type_overrides.fetch(name) do
           column_types.fetch(name, Type.default_value)

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -95,7 +95,6 @@ module ActiveRecord
       end
 
       private
-
         def raise_invalid_scope_type!(scope_type)
           if !VALID_SCOPE_TYPES.include?(scope_type)
             raise ArgumentError, "Invalid scope type '#{scope_type}' sent to the registry. Scope types must be included in VALID_SCOPE_TYPES"

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -44,7 +44,6 @@ module ActiveRecord
         end
 
         private
-
           # Use this macro in your model to set a default scope for all operations on
           # the model.
           #

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -204,7 +204,6 @@ module ActiveRecord
         end
 
         private
-
           def valid_scope_name?(name)
             if respond_to?(name, true) && logger
               logger.warn "Creating scope :#{name}. " \

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -67,7 +67,6 @@ module ActiveRecord
       end
 
       private
-
         attr_reader :configuration
 
         def configuration_without_database

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -89,7 +89,6 @@ module ActiveRecord
       end
 
       private
-
         attr_reader :configuration
 
         def encoding

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -59,7 +59,6 @@ module ActiveRecord
       end
 
       private
-
         attr_reader :configuration, :root
 
         def run_cmd(cmd, args, out)

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -179,7 +179,6 @@ module ActiveRecord
     end
 
     private
-
       # Shares the writing connection pool with connections on
       # other handlers.
       #

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -96,7 +96,6 @@ module ActiveRecord
     end
 
   private
-
     def _create_record
       if record_timestamps
         current_time = current_time_from_proper_timezone

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -36,7 +36,6 @@ module ActiveRecord
     end
 
     private
-
       def surreptitiously_touch(attrs)
         attrs.each { |attr| write_attribute attr, @_touch_time }
         clear_attribute_changes attrs

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -282,7 +282,6 @@ module ActiveRecord
       end
 
       private
-
         def set_options_for_callbacks!(args, enforced_options = {})
           options = args.extract_options!.merge!(enforced_options)
           args << options

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -47,7 +47,6 @@ module ActiveRecord
       end
 
       private
-
         def current_adapter_name
           ActiveRecord::Base.connection.adapter_name.downcase.to_sym
         end

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -11,7 +11,6 @@ module ActiveRecord
       end
 
       private
-
         def registration_klass
           Registration
         end
@@ -53,7 +52,6 @@ module ActiveRecord
       end
 
       protected
-
         attr_reader :name, :block, :adapter, :override
 
         def priority
@@ -72,7 +70,6 @@ module ActiveRecord
         end
 
       private
-
         def matches_adapter?(adapter: nil, **)
           (self.adapter.nil? || adapter == self.adapter)
         end

--- a/activerecord/lib/active_record/type/hash_lookup_type_map.rb
+++ b/activerecord/lib/active_record/type/hash_lookup_type_map.rb
@@ -16,7 +16,6 @@ module ActiveRecord
       end
 
       private
-
         def perform_fetch(type, *args, &block)
           @mapping.fetch(type, block).call(type, *args)
         end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -56,7 +56,6 @@ module ActiveRecord
       end
 
       private
-
         def default_value?(value)
           value == coder.load(nil)
         end

--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -45,7 +45,6 @@ module ActiveRecord
       end
 
       private
-
         def perform_fetch(lookup_key, *args)
           matching_pair = @mapping.reverse_each.detect do |key, _|
             key === lookup_key

--- a/activerecord/lib/active_record/type/unsigned_integer.rb
+++ b/activerecord/lib/active_record/type/unsigned_integer.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module Type
     class UnsignedInteger < ActiveModel::Type::Integer # :nodoc:
       private
-
         def max_value
           super * 2
         end

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -71,7 +71,6 @@ module ActiveRecord
     alias_method :validate, :valid?
 
   private
-
     def default_validation_context
       new_record? ? :create : :update
     end

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -10,7 +10,6 @@ module ActiveRecord
       end
 
       private
-
         def valid_object?(record)
           (record.respond_to?(:marked_for_destruction?) && record.marked_for_destruction?) || record.valid?
         end

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -221,7 +221,6 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
     end
 
     private
-
       def grouping_any(method_id, others, *extras)
         nodes = others.map { |expr| send(method_id, expr, *extras) }
         Nodes::Grouping.new nodes.inject { |memo, node|

--- a/activerecord/lib/arel/visitors/depth_first.rb
+++ b/activerecord/lib/arel/visitors/depth_first.rb
@@ -9,7 +9,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         def visit(o)
           super
           @block.call o

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -31,7 +31,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         def visit_Arel_Nodes_Ordering(o)
           visit_edge o, "expr"
         end

--- a/activerecord/lib/arel/visitors/mssql.rb
+++ b/activerecord/lib/arel/visitors/mssql.rb
@@ -11,7 +11,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         def visit_Arel_Nodes_IsNotDistinctFrom(o, collector)
           right = o.right
 

--- a/activerecord/lib/arel/visitors/oracle.rb
+++ b/activerecord/lib/arel/visitors/oracle.rb
@@ -4,7 +4,6 @@ module Arel # :nodoc: all
   module Visitors
     class Oracle < Arel::Visitors::ToSql
       private
-
         def visit_Arel_Nodes_SelectStatement(o, collector)
           o = order_hacks(o)
 

--- a/activerecord/lib/arel/visitors/oracle12.rb
+++ b/activerecord/lib/arel/visitors/oracle12.rb
@@ -4,7 +4,6 @@ module Arel # :nodoc: all
   module Visitors
     class Oracle12 < Arel::Visitors::ToSql
       private
-
         def visit_Arel_Nodes_SelectStatement(o, collector)
           # Oracle does not allow LIMIT clause with select for update
           if o.limit && o.lock

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -4,7 +4,6 @@ module Arel # :nodoc: all
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
       private
-
         def visit_Arel_Nodes_Matches(o, collector)
           op = o.case_sensitive ? " LIKE " : " ILIKE "
           collector = infix_value o, collector, op

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -4,7 +4,6 @@ module Arel # :nodoc: all
   module Visitors
     class SQLite < Arel::Visitors::ToSql
       private
-
         # Locks are not supported in SQLite
         def visit_Arel_Nodes_Lock(o, collector)
           collector

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -19,7 +19,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         def visit_Arel_Nodes_DeleteStatement(o, collector)
           o = prepare_delete_statement(o)
 

--- a/activerecord/lib/arel/visitors/visitor.rb
+++ b/activerecord/lib/arel/visitors/visitor.rb
@@ -12,7 +12,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         attr_reader :dispatch
 
         def self.dispatch_cache

--- a/activerecord/lib/arel/visitors/where_sql.rb
+++ b/activerecord/lib/arel/visitors/where_sql.rb
@@ -9,7 +9,6 @@ module Arel # :nodoc: all
       end
 
       private
-
         def visit_Arel_Nodes_SelectCore(o, collector)
           collector << "WHERE "
           wheres = o.wheres.map do |where|

--- a/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
@@ -13,7 +13,6 @@ module ActiveRecord
       end
 
       private
-
         def application_record_file_name
           @application_record_file_name ||=
             if namespaced?

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -17,7 +17,6 @@ module ActiveRecord
       end
 
       private
-
         def primary_key_type
           key_type = options[:primary_key_type]
           ", id: :#{key_type}" if key_type

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -35,7 +35,6 @@ module ActiveRecord
       hook_for :test_framework
 
       private
-
         def attributes_with_index
           attributes.select { |a| !a.reference? && a.has_index? }
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -559,7 +559,6 @@ module ActiveRecord
     end
 
     private
-
       def reset_fixtures(*fixture_names)
         ActiveRecord::FixtureSet.reset_cache
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -197,7 +197,6 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   private
-
     def test_lock_free(lock_name)
       @connection.select_value("SELECT IS_FREE_LOCK(#{@connection.quote(lock_name)})") == 1
     end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -213,7 +213,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   private
-
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)
       super(@conn, "ex", definition, &block)
     end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -40,7 +40,6 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   end
 
   private
-
     def with_encoding_utf8mb4
       database_name = connection.current_database
       database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -239,7 +239,6 @@ module ActiveRecord
     end
 
     private
-
       def with_warning_suppression
         log_level = @connection.client_min_messages
         @connection.client_min_messages = "error"

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -361,7 +361,6 @@ class PostgreSQLGeometricTypesTest < ActiveRecord::PostgreSQLTestCase
   end
 
   private
-
     def assert_column_exists(column_name)
       assert connection.column_exists?(table_name, column_name)
     end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -443,7 +443,6 @@ module ActiveRecord
       end
 
       private
-
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)
           super(@connection, "ex", definition, &block)
         end

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -106,7 +106,6 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   private
-
     def assert_transaction_is_not_broken
       assert_equal 1, @connection.select_value("SELECT 1")
     end

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -25,7 +25,6 @@ class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
   end
 
   private
-
     def num_indices_named(name)
       @connection.execute(<<~SQL).values.length
         SELECT 1 FROM "pg_index"

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -177,7 +177,6 @@ module ActiveRecord
     end
 
     private
-
       def with_warning_suppression
         log_level = ActiveRecord::Base.connection.client_min_messages
         ActiveRecord::Base.connection.client_min_messages = "error"

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -636,7 +636,6 @@ module ActiveRecord
       end
 
       private
-
         def assert_logged(logs)
           subscriber = SQLSubscriber.new
           subscription = ActiveSupport::Notifications.subscribe("sql.active_record", subscriber)

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -14,6 +14,7 @@ module Remembered
 
   included do
     after_create :remember
+
   private
     def remember; self.class.remembered << self; end
   end

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -87,7 +87,6 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
   end
 
   private
-
     def extend!(model)
       ActiveRecord::Associations::Builder::HasMany.send(:define_extensions, model, :association_name) { }
     end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2938,7 +2938,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   private
-
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target
     end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -626,7 +626,6 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   private
-
     def assert_includes_and_joins_equal(query, expected, association)
       actual = assert_queries(1) { query.joins(association).to_a.uniq }
       assert_equal expected, actual

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -117,7 +117,6 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   private
-
     def subclass_of(klass, &block)
       subclass = Class.new(klass, &block)
       def subclass.name

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1087,7 +1087,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   private
-
     def new_topic_like_ar_class(&block)
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "topics"

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -39,7 +39,6 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
       def self.name; "Person"; end
 
       private
-
         def should_be_cool
           unless first_name == "cool"
             errors.add :first_name, "not cool"
@@ -82,7 +81,6 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   end
 
   private
-
     def assert_no_difference_when_adding_callbacks_twice_for(model, association_name)
       reflection = model.reflect_on_association(association_name)
       assert_no_difference "callbacks_for_model(#{model.name}).length" do

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -58,7 +58,6 @@ if current_adapter?(:Mysql2Adapter)
         end
 
         private
-
           def assert_lookup_type(type, lookup)
             cast_type = @connection.send(:type_map).lookup(lookup)
             assert_equal type, cast_type.type

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -109,7 +109,6 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
         end
 
         private
-
           def assert_lookup_type(type, lookup)
             cast_type = @connection.send(:type_map).lookup(lookup)
             assert_equal type, cast_type.type

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -23,7 +23,6 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
   end
 
   private
-
     def return_the_inserted_id(method:)
       # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
       if current_adapter?(:OracleAdapter)

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -72,7 +72,6 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     private
-
       def stub_explain_for_query_plans(query_plans = ["query plan foo", "query plan bar"])
         explain_called = 0
 

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -54,7 +54,6 @@ class FinderRespondToTest < ActiveRecord::TestCase
   end
 
   private
-
     def ensure_topic_method_is_not_cached(method_id)
       Topic.singleton_class.remove_method method_id if Topic.public_methods.include? method_id
     end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -948,7 +948,6 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
   end
 
   private
-
     def fire_connection_notification(connection)
       assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book"], returns: connection) do
         message_bus = ActiveSupport::Notifications.instrumenter
@@ -1367,7 +1366,6 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
   end
 
   private
-
     def with_temporary_connection_pool
       old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -189,7 +189,6 @@ end
 
 module InTimeZone
   private
-
     def in_time_zone(zone)
       old_zone  = Time.zone
       old_tz    = ActiveRecord::Base.time_zone_aware_attributes

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -115,7 +115,6 @@ class HotCompatibilityTest < ActiveRecord::TestCase
   end
 
   private
-
     def get_prepared_statement_cache(connection)
       connection.instance_variable_get(:@statements)
         .instance_variable_get(:@cache)[Process.pid]

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -262,7 +262,6 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   private
-
     def capture_log_output
       output = StringIO.new
       old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(output)

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -10,7 +10,6 @@ require "models/comment"
 
 module JsonSerializationHelpers
   private
-
     def set_include_root_in_json(value)
       original_root_in_json = ActiveRecord::Base.include_root_in_json
       ActiveRecord::Base.include_root_in_json = value

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -593,7 +593,6 @@ class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase
   end
 
   private
-
     def add_counter_column_to(model, col = "test_count")
       model.connection.add_column model.table_name, col, :integer, null: false, default: 0
       model.reset_column_information

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -151,7 +151,6 @@ module ActiveRecord
       end
 
       private
-
         def with_table_cleanup
           tables_before = connection.data_sources
 

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -34,7 +34,6 @@ module ActiveRecord
       end
 
       private
-
         delegate(*CONNECTION_METHODS, to: :connection)
     end
   end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -126,7 +126,6 @@ module ActiveRecord
       end
 
       private
-
         def with_polymorphic_column
           add_column table_name, :supplier_type, :string
           add_index table_name, [:supplier_id, :supplier_type]

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -935,7 +935,6 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     private
-
       def with_bulk_change_table
         # Reset columns/indexes cache as we're changing the table
         @columns = @indexes = nil

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -851,7 +851,6 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   private
-
     def association_setter
       @association_setter ||= "#{@association_name}_attributes=".to_sym
     end

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -72,7 +72,6 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   end
 
   private
-
     def add_record(name)
       ActiveRecord::Base.connection_pool.with_connection { Project.create! name: name }
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -537,7 +537,6 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   private
-
     def with_temporary_connection_pool
       old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -233,7 +233,6 @@ class ActiveRecord::Relation
     end
 
     private
-
       def table
         Arel::Table.new("table")
       end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -405,7 +405,6 @@ module ActiveRecord
     end
 
     private
-
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?
           skip <<-ERROR.squish

--- a/activerecord/test/cases/schema_loading_test.rb
+++ b/activerecord/test/cases/schema_loading_test.rb
@@ -43,7 +43,6 @@ class SchemaLoadingTest < ActiveRecord::TestCase
   end
 
   private
-
     def define_model
       Class.new(ActiveRecord::Base) do
         include SchemaLoadCounter

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -835,7 +835,6 @@ module ActiveRecord
       end
 
       private
-
         def capture_migration_status
           capture(:stdout) do
             ActiveRecord::Tasks::DatabaseTasks.migrate_status

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -100,7 +100,6 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       private
-
         def with_stubbed_connection_establish_connection
           ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do
@@ -180,7 +179,6 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       private
-
         def with_stubbed_connection_establish_connection
           ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do
@@ -233,7 +231,6 @@ if current_adapter?(:Mysql2Adapter)
       end
 
       private
-
         def with_stubbed_connection_establish_connection
           ActiveRecord::Base.stub(:establish_connection, nil) do
             ActiveRecord::Base.stub(:connection, @connection) do

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -139,7 +139,6 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       private
-
         def with_stubbed_connection_establish_connection
           ActiveRecord::Base.stub(:connection, @connection) do
             ActiveRecord::Base.stub(:establish_connection, nil) do
@@ -201,7 +200,6 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       private
-
         def with_stubbed_connection_establish_connection
           ActiveRecord::Base.stub(:connection, @connection) do
             ActiveRecord::Base.stub(:establish_connection, nil) do
@@ -301,7 +299,6 @@ if current_adapter?(:PostgreSQLAdapter)
       end
 
       private
-
         def with_stubbed_connection
           ActiveRecord::Base.stub(:connection, @connection) do
             yield

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -460,7 +460,6 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   end
 
   private
-
     def add_transaction_execution_blocks(record)
       record.after_commit_block(:create) { |r| r.history << :commit_on_create }
       record.after_commit_block(:update) { |r| r.history << :commit_on_update }

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1077,7 +1077,6 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   private
-
     %w(validation save destroy).each do |filter|
       define_method("add_cancelling_before_#{filter}_with_db_side_effect_to_topic") do |topic|
         meta = class << topic; self; end

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -130,7 +130,6 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   private
-
     def yaml_fixture(file_name)
       path = File.expand_path(
         "../support/yaml_compatibility_fixtures/#{file_name}.yml",

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -15,7 +15,6 @@ class Club < ActiveRecord::Base
   accepts_nested_attributes_for :membership
 
   private
-
     def private_method
       "I'm sorry sir, this is a *private* club, not a *pirate* club"
     end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -25,7 +25,6 @@ class Company < AbstractCompany
   end
 
   private
-
     def private_method
       "I am Jack's innermost fears and aspirations"
     end

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -91,7 +91,6 @@ module MyApplication
       validate :check_empty_credit_limit
 
       private
-
         def check_empty_credit_limit
           errors.add("credit_card", :blank) if credit_card.blank?
         end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -101,7 +101,6 @@ class RichPerson < ActiveRecord::Base
   before_validation :run_before_validation
 
   private
-
     def run_before_create
       self.first_name = first_name.to_s + "run_before_create"
     end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -93,7 +93,6 @@ class Topic < ActiveRecord::Base
   end
 
   private
-
     def default_written_on
       self.written_on = Time.now unless attribute_present?("written_on")
     end

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -12,7 +12,6 @@ module ARTest
     end
 
     private
-
       def config_file
         Pathname.new(ENV["ARCONFIG"] || TEST_ROOT + "/config.yml")
       end

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -85,7 +85,6 @@ module ActiveSupport
     end
 
     private
-
       FORMATTED_GEMS_PATTERN = /\A[^\/]+ \([\w.]+\) /
 
       def add_gem_filter

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -72,7 +72,6 @@ module ActiveSupport
       end
 
       private
-
         def read_entry(key, options)
           if File.exist?(key)
             File.open(key) { |f| Marshal.load(f) }

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -114,7 +114,6 @@ module ActiveSupport
       end
 
       private
-
         PER_ENTRY_OVERHEAD = 240
 
         def cached_size(key, entry)

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -142,7 +142,6 @@ module ActiveSupport
     end
 
     private
-
       # A hook invoked every time a before callback is halted.
       # This can be overridden in ActiveSupport::Callbacks implementors in order
       # to provide better debugging/logging.
@@ -582,7 +581,6 @@ module ActiveSupport
           attr_reader :chain
 
         private
-
           def append_one(callback)
             @callbacks = nil
             remove_duplicates(callback)
@@ -843,7 +841,6 @@ module ActiveSupport
         end
 
         protected
-
           def get_callbacks(name) # :nodoc:
             __callbacks[name.to_sym]
           end

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -200,7 +200,6 @@ module ActiveSupport
       end
 
       private
-
         # Must be called within synchronize
         def busy_for_exclusive?(purpose)
           busy_for_sharing?(purpose) ||

--- a/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
@@ -29,7 +29,6 @@ module DateAndTime
     end
 
     private
-
       def time_with_zone(time, zone)
         if time
           ActiveSupport::TimeWithZone.new(time.utc? ? time : time.getutc, zone)

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -96,7 +96,6 @@ class DateTime
   end
 
   private
-
     def offset_in_seconds
       (offset * 86400).to_i
     end

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -15,7 +15,6 @@ module ActiveSupport
     end
 
     private
-
       def ensure_iteration_allowed
         raise TypeError, "can't iterate from #{first.class}" if first.is_a?(TimeWithZone)
       end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -291,7 +291,6 @@ module ActiveSupport #:nodoc:
     end
 
     private
-
       def html_escape_interpolated_argument(arg)
         (!html_safe? || arg.html_safe?) ? arg : CGI.escapeHTML(arg.to_s)
       end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -290,7 +290,6 @@ module ActiveSupport #:nodoc:
       end
 
       private
-
         def load(file, wrap = false)
           result = false
           load_dependency(file) { result = super }

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -56,7 +56,6 @@ module ActiveSupport
         end
 
         private
-
           def setup_autoloaders(enable_reloading)
             Dependencies.autoload_paths.each do |autoload_path|
               # Zeitwerk only accepts existing directories in `push_dir` to

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -41,7 +41,6 @@ module ActiveSupport
       end
 
       private
-
         def accumulate_descendants(klass, acc)
           if direct_descendants = @@direct_descendants[klass]
             direct_descendants.each do |direct_descendant|

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -198,7 +198,6 @@ module ActiveSupport
       end
 
       private
-
         def calculate_total_seconds(parts)
           parts.inject(0) do |total, (part, value)|
             total + value * PARTS_IN_SECONDS[part]
@@ -399,7 +398,6 @@ module ActiveSupport
     end
 
     private
-
       def sum(sign, time = ::Time.current)
         parts.inject(time) do |t, (type, number)|
           if t.acts_like?(:time) || t.acts_like?(:date)

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -80,7 +80,6 @@ module ActiveSupport
       end
 
       private
-
         def finished?
           scanner.eos?
         end

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -32,7 +32,6 @@ module ActiveSupport
       end
 
       private
-
         # Return pair of duration's parts and whole duration sign.
         # Parts are summarized (as they can become repetitive due to addition, etc).
         # Zero parts are removed as not significant.

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -217,7 +217,6 @@ module ActiveSupport
         end
 
         private
-
           def ascendant_of?(base, other)
             base != other && other.ascend do |ascendant|
               break true if base == ascendant

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -98,7 +98,6 @@ module ActiveSupport
     end
 
     private
-
       def watched
         @watched || begin
           all = @files.select { |f| File.exist?(f) }

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -230,7 +230,6 @@ module ActiveSupport
       end
 
       private
-
         def define_acronym_regex_patterns
           @acronym_regex             = @acronyms.empty? ? /(?=a)b/ : /#{@acronyms.values.join("|")}/
           @acronyms_camelize_regex   = /^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -359,7 +359,6 @@ module ActiveSupport
     end
 
     private
-
       # Mounts a regular expression, returned as a string to ease interpolation,
       # that will match part by part the given constant.
       #

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -44,7 +44,6 @@ module ActiveSupport
       end
 
       private
-
         def convert_dates_from(data)
           case data
           when nil

--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -54,7 +54,6 @@ module ActiveSupport
     end
 
     private
-
       def with_execution_control(name, block, once)
         unless @run_once[name].include?(block)
           @run_once[name] << block if once

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -112,7 +112,6 @@ module ActiveSupport
     end
 
   private
-
     %w(info debug warn error fatal unknown).each do |level|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{level}(progname = nil, &block)

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -207,7 +207,6 @@ module ActiveSupport #:nodoc:
       end
 
       private
-
         def chars(string)
           self.class.new(string)
         end

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -148,7 +148,6 @@ module ActiveSupport
       end
 
       private
-
         def recode_windows1252_chars(string)
           string.encode(Encoding::UTF_8, Encoding::Windows_1252, invalid: :replace, undef: :replace)
         end

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -46,7 +46,6 @@ module ActiveSupport
       end
 
       private
-
         def unique_id
           SecureRandom.hex(10)
         end

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -136,7 +136,6 @@ module ActiveSupport
       end
 
       private
-
         def options
           @options ||= format_options.merge(opts)
         end

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -21,7 +21,6 @@ module ActiveSupport
       end
 
       private
-
         def absolute_value(number)
           number.respond_to?(:abs) ? number.abs : number.sub(/\A-/, "")
         end

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -14,7 +14,6 @@ module ActiveSupport
       end
 
       private
-
         def parts
           left, right = number.to_s.split(".")
           left.gsub!(delimiter_pattern) do |digit_to_delimit|

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -31,7 +31,6 @@ module ActiveSupport
       end
 
       private
-
         def format
           options[:format] || translate_in_locale("human.decimal_units.format")
         end

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -28,7 +28,6 @@ module ActiveSupport
       end
 
       private
-
         def conversion_format
           translate_number_value_with_default("human.storage_units.format", locale: options[:locale], raise: true)
         end

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -12,7 +12,6 @@ module ActiveSupport
       end
 
       private
-
         def convert_to_phone_number(number)
           if opts[:area_code]
             convert_with_area_code(number)

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -38,7 +38,6 @@ module ActiveSupport
       end
 
       private
-
         def strip_insignificant_zeros
           options[:strip_insignificant_zeros]
         end

--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -51,7 +51,6 @@ module ActiveSupport
     end
 
   private
-
     def compiled_filter
       @compiled_filter ||= CompiledFilter.compile(@filters, mask: @mask)
     end

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -18,7 +18,6 @@ module ActiveSupport
   #   vehicle.bike?  # => false
   class StringInquirer < String
     private
-
       def respond_to_missing?(method_name, include_private = false)
         (method_name[-1] == "?") || super
       end

--- a/activesupport/lib/active_support/testing/stream.rb
+++ b/activesupport/lib/active_support/testing/stream.rb
@@ -4,7 +4,6 @@ module ActiveSupport
   module Testing
     module Stream #:nodoc:
       private
-
         def silence_stream(stream)
           old_stream = stream.dup
           stream.reopen(IO::NULL)

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -40,7 +40,6 @@ module ActiveSupport
       end
 
       private
-
         def unstub_object(stub)
           singleton_class = stub.object.singleton_class
           singleton_class.silence_redefinition_of_method stub.method_name
@@ -191,7 +190,6 @@ module ActiveSupport
       end
 
       private
-
         def simple_stubs
           @simple_stubs ||= SimpleStubs.new
         end

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -155,7 +155,6 @@ module ActiveSupport
     end
 
     private
-
       def _dasherize(key)
         # $2 must be a non-greedy regex for this to work
         left, middle, right = /\A(_*)(.*?)(_*)\Z/.match(key.strip)[1, 3]

--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -53,7 +53,6 @@ module ActiveSupport
     end
 
     private
-
       # Convert an XML element and merge into the hash
       #
       # hash::

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -507,7 +507,6 @@ module CacheStoreBehavior
   end
 
   private
-
     def assert_compressed(value, **options)
       assert_compression(true, value, **options)
     end

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -79,7 +79,6 @@ class CacheKeyTest < ActiveSupport::TestCase
   end
 
   private
-
     def with_env(kv)
       old_values = {}
       kv.each { |key, value| old_values[key], ENV[key] = ENV[key], value }

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -113,7 +113,6 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   private
-
     def store
       [:mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"]
     end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -191,7 +191,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include ConnectionPoolBehavior
 
     private
-
       def store
         [:redis_cache_store]
       end
@@ -238,7 +237,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include FailureSafetyBehavior
 
     private
-
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, UnavailableRedisClient)

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -397,7 +397,6 @@ module CallbacksTest
     end
 
     private
-
       def record1
         @recorder << 1
       end
@@ -989,6 +988,7 @@ module CallbacksTest
         define_callbacks :foo, scope: [:name]
         set_callback :foo, :before, :foo, if: callback
         def run; run_callbacks :foo; end
+
         private
           def foo; end
       }

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -25,7 +25,6 @@ Someone = Struct.new(:name, :place) do
   delegate :bar, to: :place, allow_nil: true
 
   private
-
     def private_name
       "Private"
     end

--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -10,12 +10,10 @@ class MethodWrappersTest < ActiveSupport::TestCase
       alias_method :old_method, :new_method
 
       protected
-
         def new_protected_method; "abc" end
         alias_method :old_protected_method, :new_protected_method
 
       private
-
         def new_private_method; "abc" end
         alias_method :old_private_method, :new_private_method
     end

--- a/activesupport/test/descendants_tracker_test_cases.rb
+++ b/activesupport/test/descendants_tracker_test_cases.rb
@@ -52,7 +52,6 @@ module DescendantsTrackerTestCases
   end
 
   private
-
     def assert_equal_sets(expected, actual)
       assert_equal Set.new(expected), Set.new(actual)
     end

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -113,7 +113,6 @@ class TestJSONDecoding < ActiveSupport::TestCase
   end
 
   private
-
     def with_parse_json_times(value)
       old_value = ActiveSupport.parse_json_times
       ActiveSupport.parse_json_times = value

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -466,7 +466,6 @@ EXPECTED
   end
 
   private
-
     def object_keys(json_object)
       json_object[1..-2].scan(/([^{}:,\s]+):/).flatten.sort
     end

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -175,7 +175,6 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
   end
 
 private
-
   def incr_amt
     5
   end

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -783,7 +783,6 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
   end
 
   private
-
     def string_from_classes(classes)
       # Characters from the character classes as described in UAX #29
       character_from_class = {

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -20,7 +20,6 @@ module Notifications
     end
 
   private
-
     def event(*args)
       ActiveSupport::Notifications::Event.new(*args)
     end

--- a/activesupport/test/share_lock_test.rb
+++ b/activesupport/test/share_lock_test.rb
@@ -488,12 +488,10 @@ class ShareLockTest < ActiveSupport::TestCase
   end
 
   private
-
     module CustomAssertions
       SUFFICIENT_TIMEOUT = 0.2
 
       private
-
         def assert_threads_stuck_but_releasable_by_latch(threads, latch)
           assert_threads_stuck threads
           latch.count_down

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -17,7 +17,6 @@ class TestSubscriber < ActiveSupport::Subscriber
   end
 
   private
-
     def private_party(event)
       events << event
     end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -315,7 +315,6 @@ class SetupAndTeardownTest < ActiveSupport::TestCase
   end
 
   private
-
     def reset_callback_record
       @called_back = []
     end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -43,7 +43,6 @@ module RailsGuides
     end
 
     private
-
       def register_kindle_mime_types
         Mime::Type.register_alias("application/xml", :opf, %w(opf))
         Mime::Type.register_alias("application/xml", :ncx, %w(ncx))

--- a/guides/rails_guides/indexer.rb
+++ b/guides/rails_guides/indexer.rb
@@ -18,7 +18,6 @@ module RailsGuides
     end
 
     private
-
       def process(string, current_level = 3, counters = [1])
         s = StringScanner.new(string)
 

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -30,7 +30,6 @@ module RailsGuides
     end
 
     private
-
       def dom_id(nodes)
         dom_id = dom_id_text(nodes.last.text)
 

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -53,7 +53,6 @@ HTML
       end
 
       private
-
         def convert_footnotes(text)
           text.gsub(/\[<sup>(\d+)\]<\/sup>/i) do
             %(<sup class="footnote" id="footnote-#{$1}-ref">) +

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -501,7 +501,6 @@ module Rails
     end
 
   protected
-
     alias :build_middleware_stack :app
 
     def run_tasks_blocks(app) #:nodoc:
@@ -581,7 +580,6 @@ module Rails
     end
 
     private
-
       def generate_development_secret
         if secrets.secret_key_base.nil?
           key_file = Rails.root.join("tmp/development_secret.txt")
@@ -623,7 +621,6 @@ module Rails
         end
 
         private
-
           def convert_key(key)
             unless key.kind_of?(Symbol)
               ActiveSupport::Deprecation.warn(<<~MESSAGE.squish)

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -79,7 +79,6 @@ module Rails
       end
 
       private
-
         def load_rack_cache
           rack_cache = config.action_dispatch.rack_cache
           return unless rack_cache

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -25,7 +25,6 @@ module Rails
       end
 
     private
-
       def updater
         @updater ||= ActiveSupport::FileUpdateChecker.new(paths) { reload! }
       end

--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -12,7 +12,6 @@ class Rails::ApplicationController < ActionController::Base # :nodoc:
   end
 
   private
-
     def require_local!
       unless local_request?
         render html: "<p>For security purposes, this information is only available to local requests.</p>".html_safe, status: :forbidden

--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -13,7 +13,6 @@ module Rails
         end
 
         private
-
           # This code is based directly on the Text gem implementation.
           # Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
           #

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -654,14 +654,12 @@ module Rails
     end
 
     protected
-
       def run_tasks_blocks(*) #:nodoc:
         super
         paths["lib/tasks"].existent.sort.each { |ext| load(ext) }
       end
 
     private
-
       def load_config_initializer(initializer) # :doc:
         ActiveSupport::Notifications.instrument("load_config_initializer.railties", initializer: initializer) do
           load(initializer)

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -287,7 +287,6 @@ module Rails
       end
 
       private
-
         def print_list(base, namespaces) # :doc:
           namespaces = namespaces.reject { |n| hidden_namespaces.include?(n) }
           super

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -268,7 +268,6 @@ module Rails
       end
 
       private
-
         # Define log for backwards compatibility. If just one argument is sent,
         # invoke say, otherwise invoke say_status. Differently from say and
         # similarly to say_status, this method respects the quiet? option given.

--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -40,7 +40,6 @@ module Rails
         alias :exists? :existing_migration
 
         private
-
           def on_conflict_behavior # :doc:
             options = base.options.merge(config)
             if identical?

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -108,7 +108,6 @@ module Rails
       end
 
     private
-
       def gemfile_entry(name, *args) # :doc:
         options = args.extract_options!
         version = args.first

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -245,7 +245,6 @@ module Rails
       end
 
       private
-
         # Check whether the given class names are already taken by user
         # application or Ruby on Rails.
         def class_collisions(*class_names)

--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -6,7 +6,6 @@ module Erb # :nodoc:
   module Generators # :nodoc:
     class Base < Rails::Generators::NamedBase #:nodoc:
       private
-
         def formats
           [format]
         end

--- a/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
@@ -29,7 +29,6 @@ module Erb # :nodoc:
       end
 
       private
-
         def formats
           [:text, :html]
         end

--- a/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
@@ -24,7 +24,6 @@ module Erb # :nodoc:
       end
 
     private
-
       def available_views
         %w(index edit show new _form)
       end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -39,7 +39,6 @@ module Rails
         end
 
         private
-
           # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
           # when declaring options curly brackets should be used
           def parse_type_and_options(type)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -497,7 +497,6 @@ module Rails
     # :startdoc:
 
     private
-
       # Define file as an alias to create_file for backwards compatibility.
       def file(*args, &block)
         create_file(*args, &block)
@@ -542,7 +541,6 @@ module Rails
       end
 
       private
-
         def handle_version_request!(argument)
           if ["--version", "-v"].include?(argument)
             require "rails/version"

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -25,7 +25,6 @@ module Rails
       end
 
       private
-
         def file_name
           @_file_name ||= remove_possible_suffix(super)
         end

--- a/railties/lib/rails/generators/rails/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/rails/generator/generator_generator.rb
@@ -15,7 +15,6 @@ module Rails
       hook_for :test_framework
 
       private
-
         def generator_dir
           if options[:namespace]
             File.join("lib", "generators", regular_class_path, file_name)

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -269,7 +269,6 @@ task default: :test
       end
 
     private
-
       def create_dummy_app(path = nil)
         dummy_path(path) if path
 

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -34,7 +34,6 @@ module Rails
       end
 
       private
-
         def permitted_params
           attachments, others = attributes_names.partition { |name| attachments?(name) }
           params = others.map { |name| ":#{name}" }

--- a/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
@@ -15,7 +15,6 @@ module TestUnit # :nodoc:
       end
 
     private
-
       def generator_path
         if options[:namespace]
           File.join("generators", regular_class_path, file_name, "#{file_name}_generator")

--- a/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
+++ b/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
@@ -12,7 +12,6 @@ module TestUnit # :nodoc:
       end
 
       private
-
         def file_name
           @_file_name ||= super.sub(/_test\z/i, "")
         end

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -38,7 +38,6 @@ module TestUnit # :nodoc:
       end
 
       private
-
         def attributes_string
           attributes_hash.map { |k, v| "#{k}: #{v}" }.join(", ")
         end

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -88,7 +88,6 @@ module Rails
         end
 
         private
-
           def destination_root_is_set?
             raise "You need to configure your Rails::Generators::TestCase destination root." unless destination_root
           end

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -33,7 +33,6 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
   end
 
   private
-
     def match_route
       _routes.routes.select { |route|
         yield route.path

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -98,7 +98,6 @@ module Rails
       end
 
     private
-
       def filter_by(&block)
         all_paths.find_all(&block).flat_map { |path|
           paths = path.existent
@@ -223,7 +222,6 @@ module Rails
       alias to_a expanded
 
       private
-
         def files_in(path)
           Dir.chdir(path) do
             files = Dir.glob(@glob)

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -30,7 +30,6 @@ module Rails
       end
 
       private
-
         def call_app(request, env) # :doc:
           instrumenter = ActiveSupport::Notifications.instrumenter
           instrumenter.start "request.action_dispatch", request: request

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -228,7 +228,6 @@ module Rails
     end
 
     protected
-
       def run_console_blocks(app) #:nodoc:
         each_registered_block(:console) { |block| block.call(app) }
       end
@@ -247,7 +246,6 @@ module Rails
       end
 
     private
-
       # run `&block` in every registered block in `#register_block_for`
       def each_registered_block(type, &block)
         klass = self.class

--- a/railties/lib/rails/railtie/configurable.rb
+++ b/railties/lib/rails/railtie/configurable.rb
@@ -27,7 +27,6 @@ module Rails
         end
 
         private
-
           def method_missing(*args, &block)
             instance.send(*args, &block)
           end

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -87,7 +87,6 @@ module Rails
       end
 
     private
-
       def method_missing(name, *args, &blk)
         if name.to_s =~ /=$/
           @@options[$`.to_sym] = args.first

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -491,7 +491,6 @@ module ApplicationTests
     end
 
     private
-
       def app_with_assets_in_view
         app_file "app/assets/javascripts/application.js", "//= require_tree ."
         app_file "app/assets/javascripts/xmlhr.js", "function f1() { alert(); }"

--- a/railties/test/application/content_security_policy_test.rb
+++ b/railties/test/application/content_security_policy_test.rb
@@ -204,7 +204,6 @@ module ApplicationTests
     end
 
     private
-
       def assert_policy(expected, report_only: false)
         assert_equal 200, last_response.status
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -454,7 +454,6 @@ class LoadingTest < ActiveSupport::TestCase
   end
 
   private
-
     def setup_ar!
       ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       ActiveRecord::Migration.verbose = false

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -309,7 +309,6 @@ module ApplicationTests
     end
 
     private
-
       def boot!
         require "#{app_path}/config/environment"
       end

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -159,7 +159,6 @@ module ApplicationTests
       end
 
       private
-
         def run_rake_notes(command = "bin/rake notes")
           Dir.chdir(app_path) do
             output = `#{command}`

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -116,7 +116,6 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   private :output
 
   private
-
     def start(argv = [])
       rails_console = Rails::Console.new(app, parse_arguments(argv))
       @output = capture(:stdout) { rails_console.start }

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -275,7 +275,6 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   private :aborted, :output
 
   private
-
     def app_db_config(results)
       Rails.application.config.stub(:database_configuration, results || {}) do
         yield

--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -51,7 +51,6 @@ module Rails
       end
 
       private
-
         def assert_playback(msg_name, args)
           mock = Minitest::Mock.new
           mock.expect :send, nil, [msg_name, args]

--- a/railties/test/env_helpers.rb
+++ b/railties/test/env_helpers.rb
@@ -4,7 +4,6 @@ require "rails"
 
 module EnvHelpers
   private
-
     def with_rails_env(env)
       Rails.instance_variable_set :@_env, nil
       switch_env "RAILS_ENV", env do

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -505,7 +505,6 @@ F
   end
 
   private
-
     def action(*args, &block)
       capture(:stdout) { generator.send(*args, &block) }
     end

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -109,7 +109,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
   end
 
   private
-
     def default_files
       %w(.gitignore
         .ruby-version

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -445,7 +445,6 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   end
 
   private
-
     def with_singular_table_name
       old_state = ActiveRecord::Base.pluralize_table_names
       ActiveRecord::Base.pluralize_table_names = false

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -169,7 +169,6 @@ class NamedBaseTest < Rails::Generators::TestCase
   end
 
   private
-
     def assert_name(generator, value, method)
       assert_equal value, generator.send(method)
     end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -713,7 +713,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   private
-
     def action(*args, &block)
       silence(:stdout) { generator.send(*args, &block) }
     end

--- a/tools/profile
+++ b/tools/profile
@@ -68,7 +68,6 @@ module CodeTools
     end
 
     private
-
       def assert_ruby_file_exists(path)
         fail Error.new("No such file") unless File.exist?(path)
         fail Error.new("#{path} is a directory") if File.directory?(path)


### PR DESCRIPTION
We sometimes say "✂️ newline after `private`" in a code review (e.g.
https://github.com/rails/rails/pull/18546#discussion_r23188776, https://github.com/rails/rails/pull/34832#discussion_r244847195).

Now `Layout/EmptyLinesAroundAccessModifier` cop have new enforced style
`EnforcedStyle: only_before` (https://github.com/rubocop-hq/rubocop/pull/7059).

That cop and enforced style will reduce the our code review cost.