### PR TITLE
[ci skip] Use default path in button_to documentation

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -253,7 +253,7 @@ module ActionView
       #   #      <input value="New" type="submit" />
       #   #    </form>"
       #
-      #   <%= button_to "New", new_articles_path %>
+      #   <%= button_to "New", new_article_path %>
       #   # => "<form method="post" action="/articles/new" class="button_to">
       #   #      <input value="New" type="submit" />
       #   #    </form>"


### PR DESCRIPTION
### Summary
This is really a nitpick I found while reading the docs, but as this is the framework's documentation I think it should follow standards as many times as possible to avoid confusion in new users.

If we were using `resources :articles` in routes, which is what scaffold adds, the generated helper would be `new_article_path` instead of `new_articles_path`.

Thanks for your review.