### PR TITLE
Fix TranslationHelper#translate handling of Hash defaults

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -60,7 +60,7 @@ module ActionView
       def translate(key, options = {})
         options = options.dup
         if options.has_key?(:default)
-          remaining_defaults = Array(options.delete(:default)).compact
+          remaining_defaults = Array.wrap(options.delete(:default)).compact
           options[:default] = remaining_defaults unless remaining_defaults.first.kind_of?(Symbol)
         end
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -121,6 +121,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
     I18n.exception_handler = old_exception_handler
   end
 
+  def test_hash_default
+    default = { separator: ".", delimiter: "," }
+    assert_equal default, translate(:'special.number.format', default: default)
+  end
+
   def test_translation_returning_an_array
     expected = %w(foo bar)
     assert_equal expected, translate(:"translations.array")


### PR DESCRIPTION
It is sometimes expected of the `translate` methods to return a Hash,
for instance it's the case of the `number.format` key.

As such users might need to specify a Hash default, e.g.

`translate(:'some.format', default: { separator: '.', delimiter: ',' })`.

This works as expected with the `I18n.translate` methods,
however `TranslationHelper#translate` apply `Array()` on the default value.

As a result the default value end up as `[:separator, '.', :delimiter, ',']`.

cc @rafaelfranca @Edouard-chin 