### PR TITLE
Allow using env var to specify pidfile

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -289,7 +289,7 @@ def default_options
     environment:        (ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development").dup,
     daemonize:          false,
     caching:            nil,
-    pid:                Options::DEFAULT_PID_PATH,
+    pid:                ENV.fetch("PIDFILE", Options::DEFAULT_PIDFILE).dup,
     restart_cmd:        restart_command)
 end
 ```

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Support using environment variable to set pidfile
 
+  *Ben Thorner*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -99,7 +99,7 @@ module Rails
       RACK_SERVERS = %w(cgi fastcgi webrick lsws scgi thin puma unicorn)
 
       DEFAULT_PORT = 3000
-      DEFAULT_PID_PATH = "tmp/pids/server.pid"
+      DEFAULT_PIDFILE = "tmp/pids/server.pid"
 
       argument :using, optional: true
 
@@ -114,8 +114,8 @@ module Rails
         desc: "Runs server as a Daemon."
       class_option :using, aliases: "-u", type: :string,
         desc: "Specifies the Rack server used to run the application (thin/puma/webrick).", banner: :name
-      class_option :pid, aliases: "-P", type: :string, default: DEFAULT_PID_PATH,
-        desc: "Specifies the PID file."
+      class_option :pid, aliases: "-P", type: :string,
+        desc: "Specifies the PID file - defaults to #{DEFAULT_PIDFILE}."
       class_option :dev_caching, aliases: "-C", type: :boolean, default: nil,
         desc: "Specifies whether to perform caching in development."
       class_option :restart, type: :boolean, default: nil, hide: true
@@ -207,6 +207,7 @@ module Rails
             end
             user_supplied_options << :Host if ENV["HOST"] || ENV["BINDING"]
             user_supplied_options << :Port if ENV["PORT"]
+            user_supplied_options << :pid if ENV["PIDFILE"]
             user_supplied_options.uniq
           end
         end
@@ -253,7 +254,7 @@ module Rails
         end
 
         def pid
-          File.expand_path(options[:pid])
+          File.expand_path(options[:pid] || ENV.fetch("PIDFILE", DEFAULT_PIDFILE))
         end
 
         def self.banner(*)
@@ -261,7 +262,7 @@ module Rails
         end
 
         def prepare_restart
-          FileUtils.rm_f(options[:pid]) if options[:restart]
+          FileUtils.rm_f(pid) if options[:restart]
         end
 
         def deprecate_positional_rack_server_and_rewrite_to_option(original_options)

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -116,6 +116,13 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
     end
   end
 
+  def test_environment_with_pidfile
+    switch_env "PIDFILE", "/tmp/rails.pid" do
+      options = parse_arguments
+      assert_equal "/tmp/rails.pid", options[:pid]
+    end
+  end
+
   def test_caching_without_option
     args = []
     options = parse_arguments(args)
@@ -234,6 +241,12 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
       options = parse_arguments(args)
       assert_equal "127.0.0.1", options[:Host]
     end
+
+    switch_env "PIDFILE", "/tmp/rails.pid" do
+      args = ["-P", "/somewhere/else.pid"]
+      options = parse_arguments(args)
+      assert_equal "/somewhere/else.pid", options[:pid]
+    end
   end
 
   def test_records_user_supplied_options
@@ -252,6 +265,16 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
     switch_env "BINDING", "1.2.3.4" do
       server_options = parse_arguments
       assert_equal [:Host], server_options[:user_supplied_options]
+    end
+
+    switch_env "PORT", "3001" do
+      server_options = parse_arguments
+      assert_equal [:Port], server_options[:user_supplied_options]
+    end
+
+    switch_env "PIDFILE", "/tmp/server.pid" do
+      server_options = parse_arguments
+      assert_equal [:pid], server_options[:user_supplied_options]
     end
   end
 


### PR DESCRIPTION
### Summary

Previously it was only possible to specify the location of the pidfile
for the 'rails server' command with the '-P' flag. This adds support for
specifying the pidfile using a PIDFILE env var, which can still be
overridden by the '-P' flag and with the default pidfile path unchanged.

The motivation for this feature comes from using Docker to run multiple
instances of the same rails app. When developing a rails app with
Docker, it's common to bind-mount the rails root directory in the
running container, so that changes to files are shared between the
container and the host. However, this doesn't work so well with the
pidfile and it's necessary to (remember to) add a '-P' flag to the
'rails server' command line; being able to specify this flag using an
env var would make developing with Rails+Docker a bit simpler.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
