### PR TITLE
Fix the `require_dependency` main usage for STI workaround:

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -245,7 +245,8 @@ module ActiveRecord
 
         def type_condition(table = arel_table)
           sti_column = arel_attribute(inheritance_column, table)
-          sti_names  = ([self] + descendants).map(&:sti_name)
+          base_class.pluck(inheritance_column).compact.uniq.map(&:safe_constantize)
+          sti_names = ([self] + descendants).map(&:sti_name)
 
           predicate_builder.build(sti_column, sti_names)
         end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -11,6 +11,7 @@ require "models/subscriber"
 require "models/vegetables"
 require "models/shop"
 require "models/sponsor"
+require "models/inept_wizard"
 
 module InheritanceTestHelper
   def with_store_full_sti_class(&block)
@@ -32,7 +33,7 @@ end
 
 class InheritanceTest < ActiveRecord::TestCase
   include InheritanceTestHelper
-  fixtures :companies, :projects, :subscribers, :accounts, :vegetables, :memberships
+  fixtures :companies, :projects, :subscribers, :accounts, :vegetables, :memberships, :inept_wizards
 
   def test_class_with_store_full_sti_class_returns_full_name
     with_store_full_sti_class do
@@ -376,6 +377,18 @@ class InheritanceTest < ActiveRecord::TestCase
 
     firm = Company.new(type: "ExtraFirm")
     assert_equal ExtraFirm, firm.class
+  ensure
+    ActiveSupport::Dependencies.autoload_paths.reject! { |p| p == path }
+    ActiveSupport::Dependencies.clear
+  end
+
+  def test_retrieve_all_descendants
+    path = File.expand_path("../models/autoloadable", __dir__)
+    ActiveSupport::Dependencies.autoload_paths << path
+
+    assert_nil(defined?(Necromancer))
+    Thaumaturgist.find_by!(name: "Melisandre")
+    assert_equal("constant", defined?(Necromancer))
   ensure
     ActiveSupport::Dependencies.autoload_paths.reject! { |p| p == path }
     ActiveSupport::Dependencies.clear

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -11,22 +11,7 @@ require "models/uuid_item"
 require "models/author"
 require "models/person"
 require "models/essay"
-
-class Wizard < ActiveRecord::Base
-  self.abstract_class = true
-
-  validates_uniqueness_of :name
-end
-
-class IneptWizard < Wizard
-  validates_uniqueness_of :city
-end
-
-class Conjurer < IneptWizard
-end
-
-class Thaumaturgist < IneptWizard
-end
+require "models/inept_wizard"
 
 class ReplyTitle; end
 

--- a/activerecord/test/fixtures/inept_wizards.yml
+++ b/activerecord/test/fixtures/inept_wizards.yml
@@ -1,0 +1,9 @@
+felicia:
+  name: 'Felicia'
+  city: 'Budapest'
+  type: 'Thaumaturgist'
+
+melisandre:
+  name: 'Melisandre'
+  city: 'Westeros'
+  type: 'Necromancer'

--- a/activerecord/test/models/autoloadable/necromancer.rb
+++ b/activerecord/test/models/autoloadable/necromancer.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Necromancer < Thaumaturgist
+end

--- a/activerecord/test/models/inept_wizard.rb
+++ b/activerecord/test/models/inept_wizard.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Wizard < ActiveRecord::Base
+  self.abstract_class = true
+
+  validates_uniqueness_of :name
+end
+
+class IneptWizard < Wizard
+  validates_uniqueness_of :city
+end
+
+class Conjurer < IneptWizard
+end
+
+class Thaumaturgist < IneptWizard
+end


### PR DESCRIPTION
Fix the `require_dependency` main usage for STI workaround:

- One the main usage of the `require_dependency` inside an application
  is to workaround the STI issue described in this Rails [documentation](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-and-sti)

  This commit aims to remove this requirement by loading all the
  STI types from the database instead of the descendants.

- Zeitwerk claims that "All known use cases of require_dependency have been eliminated. you should grep the project and delete them".
  I'm not sure whether I correctly understand this affirmation,
  but removing all `require_dependency` call from an application using
  Zeitwerk doesn't solve the problem unless we do some [preloading](https://github.com/fxn/zeitwerk#preloading)

cc/ @byroot @rafaelfranca @casperisfine