### PR TITLE
Make `ActionDispatch::Response#content_type` behavior configurable

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -86,6 +86,7 @@ module ActionDispatch # :nodoc:
 
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers
+    cattr_accessor :return_only_media_type_on_content_type, default: false
 
     include Rack::Response::Helpers
     # Aliasing these off because AD::Http::Cache::Response defines them.
@@ -243,7 +244,17 @@ module ActionDispatch # :nodoc:
 
     # Content type of response.
     def content_type
-      super.presence
+      if self.class.return_only_media_type_on_content_type
+        ActiveSupport::Deprecation.warn(
+          "Rails 6.1 will return Content-Type header without modification." \
+          " If you want just the MIME type, please use `#media_type` instead."
+        )
+
+        content_type = super
+        content_type ? content_type.split(/;\s*charset=/)[0].presence : content_type
+      else
+        super.presence
+      end
     end
 
     # Media type of response.

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -23,6 +23,7 @@ module ActionDispatch
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.use_cookies_with_metadata = false
     config.action_dispatch.perform_deep_munge = true
+    config.action_dispatch.return_only_media_type_on_content_type = true
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -43,6 +44,7 @@ module ActionDispatch
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
       ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
+      ActionDispatch::Response.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_media_type_on_content_type
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -593,4 +593,33 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal("text/csv", @response.media_type)
     assert_equal("utf-16", @response.charset)
   end
+
+  test "`content type` returns header that excludes `charset` when specified `return_only_media_type_on_content_type`" do
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    @app = lambda { |env|
+      if env["PATH_INFO"] == "/with_parameters"
+        [200, { "Content-Type" => "text/csv; header=present; charset=utf-16" }, [""]]
+      else
+        [200, { "Content-Type" => "text/csv; charset=utf-16" }, [""]]
+      end
+    }
+
+    get "/"
+    assert_response :success
+
+    assert_deprecated do
+      assert_equal("text/csv", @response.content_type)
+    end
+
+    get "/with_parameters"
+    assert_response :success
+
+    assert_deprecated do
+      assert_equal("text/csv; header=present", @response.content_type)
+    end
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -553,6 +553,10 @@ Defaults to `'signed cookie'`.
 
   Any exceptions that are not configured will be mapped to 500 Internal Server Error.
 
+* `config.action_dispatch.return_only_media_type_on_content_type` change the
+  return value of `ActionDispatch::Response#content_type` to the Content-Type
+  header without modification. Defaults to `false`.
+
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.
@@ -908,6 +912,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.autoloader`: `:zeitwerk`
 - `config.action_view.default_enforce_utf8`: `false`
 - `config.action_dispatch.use_cookies_with_metadata`: `true`
+- `config.action_dispatch.return_only_media_type_on_content_type`: `false`
 - `config.action_mailer.delivery_job`: `"ActionMailer::MailDeliveryJob"`
 - `config.active_job.return_false_on_aborted_enqueue`: `true`
 - `config.active_storage.queues.analysis`: `:active_storage_analysis`

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -129,6 +129,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.use_cookies_with_metadata = true
+            action_dispatch.return_only_media_type_on_content_type = false
           end
 
           if respond_to?(:action_mailer)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -16,6 +16,9 @@
 # It's best enabled when your entire app is migrated and stable on 6.0.
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
+# Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
+# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = true
+
 # Return false instead of self when enqueuing is aborted from a callback.
 # Rails.application.config.active_job.return_false_on_aborted_enqueue = true
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2436,6 +2436,33 @@ module ApplicationTests
       assert_nil ActiveStorage.queues[:purge]
     end
 
+    test "ActionDispatch::Response.return_only_media_type_on_content_type is false by default" do
+      app "development"
+
+      assert_equal false, ActionDispatch::Response.return_only_media_type_on_content_type
+    end
+
+    test "ActionDispatch::Response.return_only_media_type_on_content_type is true in the 5.x defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "5.2"'
+
+      app "development"
+
+      assert_equal true, ActionDispatch::Response.return_only_media_type_on_content_type
+    end
+
+    test "ActionDispatch::Response.return_only_media_type_on_content_type can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_6_0.rb", <<-RUBY
+        Rails.application.config.action_dispatch.return_only_media_type_on_content_type = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActionDispatch::Response.return_only_media_type_on_content_type
+    end
+
     test "ActionMailbox.logger is Rails.logger by default" do
       app "development"
 


### PR DESCRIPTION
I changed return value of `ActionDispatch::Response#content_type` in #36034.
But this change seems to an obstacle to upgrading. https://github.com/rails/rails/pull/36034#issuecomment-498795893

Therefore, I restored the behavior of `ActionDispatch::Response#content_type` to 5.2 and deprecated old behavior. Also, made it possible to control the behavior with the config.

