### PR TITLE
Extend ActiveRecord::Enum for add more helpful methods.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -26,5 +26,50 @@
 
     *Michael Duchemin*
 
+*   Add more helpful methods for ActiveRecord::Enum.
+
+    *Jason Lee*
+
+    ```rb
+    class Book
+      enum status: %i[draft published archived]
+    end
+
+    Book.status_options # => [["Drafting", "draft"], ["Published", "published"], ["Archived", "archived"]]
+
+    @book = Book.new(status: :draft)
+    @book.status # => "draft"
+    @book.status_name # => "Drafting"
+    @book.status_color # => "#999999"
+    @book.status_value # => 0
+
+    @book.status = :published
+    @book.status_name # => "Published"
+    @book.status_color # => "green"
+    @book.status_value # => 1
+    ```
+
+    Custom name, color in I18n config:
+
+    ```yml
+    en:
+      activerecord:
+        enums:
+          book:
+            status:
+              draft: Drafting
+              published: Published
+              archived: Archived
+            status_color:
+              draft: "#999999"
+              published: "green"
+              archived: "red"
+    ```
+
+    `status_options` for select tag in Views:
+
+    ```erb
+    <%= f.select :status, Book.status_options %>
+    ```
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -14,11 +14,17 @@ module ActiveRecord
   #   conversation.active!
   #   conversation.active? # => true
   #   conversation.status  # => "active"
+  #   conversation.status_name # => "In active"
+  #   conversation.status_color # => "green"
+  #   conversation.status_value # => 0
   #
   #   # conversation.update! status: 1
   #   conversation.archived!
   #   conversation.archived? # => true
   #   conversation.status    # => "archived"
+  #   conversation.status_name # => "Archived"
+  #   conversation.status_color # => "gray"
+  #   conversation.status_value # => 1
   #
   #   # conversation.status = 1
   #   conversation.status = "archived"
@@ -73,6 +79,13 @@ module ActiveRecord
   #   Conversation.statuses[:active]    # => 0
   #   Conversation.statuses["archived"] # => 1
   #
+  # Or you can get value by use:
+  #
+  #   conversation = Conversation.new(status: :active)
+  #   conversation.status_value # => 0
+  #   conversation.status = :archived
+  #   conversation.status_value # => 1
+  #
   # Use that class method when you need to know the ordinal value of an enum.
   # For example, you can use that when manually building SQL strings:
   #
@@ -96,7 +109,33 @@ module ActiveRecord
   #
   #   conversation.comments_inactive!
   #   conversation.comments_active? # => false
-
+  #
+  # I18n for enum field names and colors:
+  #
+  # config/locales/en.yml
+  #
+  #   en:
+  #     activerecord:
+  #       enums:
+  #         conversation:
+  #           status:
+  #             active: In active
+  #             archived: Archived
+  #           status_color:
+  #             active: green
+  #             archived: "#999999"
+  #
+  #   conversation.status_name # => "In active"
+  #   conversation.status_color # => "green"
+  #   # conversation.update! status: 1
+  #   conversation.status_name # => "Archived"
+  #   conversation.status_color # => "gray"
+  #
+  # Get all options for select tag:
+  #
+  #    Conversation.status_options # => [["In active", "active"], ["Archived", "archived"]]
+  #    <%= f.select :status, Conversation.status_options %>
+  #
   module Enum
     def self.extended(base) # :nodoc:
       base.class_attribute(:defined_enums, instance_writer: false, default: {})
@@ -152,6 +191,8 @@ module ActiveRecord
       enum_prefix = definitions.delete(:_prefix)
       enum_suffix = definitions.delete(:_suffix)
       enum_scopes = definitions.delete(:_scopes)
+      locale_prefix = "activerecord.enums.#{klass.name&.singularize&.underscore}"
+
       definitions.each do |name, values|
         assert_valid_enum_definition_values(values)
         # statuses = { }
@@ -165,6 +206,42 @@ module ActiveRecord
 
         detect_enum_conflict!(name, name)
         detect_enum_conflict!(name, "#{name}=")
+
+        # def self.status_options; end
+        detect_enum_conflict!(name, "#{name}_options", true)
+        singleton_class.define_method("#{name}_options") do
+          self.send(name.pluralize).map do |k, _|
+            begin
+              label = I18n.t("#{locale_prefix}.#{name}.#{k}", raise: true)
+            rescue I18n::MissingTranslationData
+              label = k.titleize
+            end
+
+            [label, k]
+          end
+        end
+
+        # def status_name; I18n.t("conversation.status.#{status}"); end
+        detect_enum_conflict!(name, "#{name}_name")
+        define_method("#{name}_name") do
+          return "" if self[name].nil?
+          I18n.t("#{locale_prefix}.#{name}.#{self[name]}", raise: true)
+        rescue I18n::MissingTranslationData
+          self[name].titleize
+        end
+
+        # def status_color; I18n.t("conversation.status)_color.#{status}"); end
+        detect_enum_conflict!(name, "#{name}_color")
+        define_method("#{name}_color") do
+          return "black" if self[name].nil?
+          I18n.t("#{locale_prefix}.#{name}_color.#{self[name]}", raise: true)
+        rescue I18n::MissingTranslationData
+          "black"
+        end
+
+        # def status_value; Conversation.statuses[self.status]; end
+        detect_enum_conflict!(name, "#{name}_value")
+        define_method("#{name}_value") { klass.send(name.pluralize)[self[name]] }
 
         attr = attribute_alias?(name) ? attribute_alias(name) : name
         decorate_attribute_type(attr, :enum) do |subtype|

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -8,6 +8,29 @@ class EnumTest < ActiveRecord::TestCase
   fixtures :books, :authors, :author_addresses
 
   setup do
+    I18n.backend.store_translations(:en, activerecord: {
+      enums: {
+        book: {
+          status: {
+            proposed: "Proposed",
+            written: "In writing",
+          },
+          status_color: {
+            written: "blue",
+            published: "green"
+          },
+          difficulty: {
+            easy: "Easy"
+          },
+          difficulty_color: {
+            easy: "green",
+            medium: "#555555",
+            hard: "red"
+          }
+        }
+      }
+    })
+
     @book = books(:awdr)
   end
 
@@ -31,6 +54,43 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.author_visibility
     assert_equal "visible", @book.illustrator_visibility
     assert_equal "medium", @book.difficulty
+  end
+
+  test "enum name, value and color" do
+    @book.status = :proposed
+    assert_equal "Proposed", @book.status_name
+    assert_equal "black", @book.status_color
+    assert_equal 0, @book.status_value
+
+    @book.status = :written
+    assert_equal "In writing", @book.status_name
+    assert_equal "blue", @book.status_color
+    assert_equal 1, @book.status_value
+
+    @book.status = :published
+    assert_equal "Published", @book.status_name
+    assert_equal "green", @book.status_color
+    assert_equal 2, @book.status_value
+
+    @book.difficulty = :easy
+    assert_equal "Easy", @book.difficulty_name
+    assert_equal "green", @book.difficulty_color
+    assert_equal 0, @book.difficulty_value
+
+    @book.difficulty = :medium
+    assert_equal "Medium", @book.difficulty_name
+    assert_equal "#555555", @book.difficulty_color
+    assert_equal 1, @book.difficulty_value
+
+    @book.difficulty = :hard
+    assert_equal "Hard", @book.difficulty_name
+    assert_equal "red", @book.difficulty_color
+    assert_equal 2, @book.difficulty_value
+  end
+
+  test "enum options" do
+    assert_equal [["Proposed", "proposed"], ["In writing", "written"], ["Published", "published"]], Book.status_options
+    assert_equal [["Easy", "easy"], ["Medium", "medium"], ["Hard", "hard"]], Book.difficulty_options
   end
 
   test "find via scope" do
@@ -122,6 +182,7 @@ class EnumTest < ActiveRecord::TestCase
     @book.status = "written"
     assert_predicate @book, :written?
   end
+
 
   test "enum changed attributes" do
     old_status = @book.status


### PR DESCRIPTION
```rb
class Book
  enum status: %i[draft published archived]
end
```

Now we have `status_name`, `status_color`, `status_value` and `Book.status_options` methods:

- `#{attribute}_name` - return I18n name for display.
- `#{attribute}_color` - return color for enum value from I18n file.
- `#{attribute}_value` - return raw value for enum, Now we don't need use `Book.statuses[@book.status]`.
- `Book.#{attribute}_options` - return a array list for select tag options, `<%= f.select :status, Book.status_options %>`.

Write I18n:

```yml
en:
  activerecord:
    enums:
      book:
        status:
          draft: Drafting
          published: Published
          archived: Archived
        status_color:
          draft: "#999999"
          published: "green"
          archived: "red"

zh-CN:
  activerecord:
    enums:
      book:
        status:
          draft: "草稿"
          published: "已发布"
          archived: "归档"
```
