### PR TITLE
[quik changes] shorten find_by method at active record

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -200,11 +200,10 @@ module ActiveRecord
           }
           where(wheres).limit(1)
         }
-        begin
-          statement.execute(hash.values, connection)&.first
-        rescue TypeError
-          raise ActiveRecord::StatementInvalid
-        end
+
+        statement.execute(hash.values, connection)&.first
+      rescue TypeError
+        raise ActiveRecord::StatementInvalid
       end
 
       def find_by!(*args) # :nodoc:


### PR DESCRIPTION
### Summary
No `begin`  are required here, even compared to other methods.

Before:

```
begin
  statement.execute(hash.values, connection)&.first
rescue TypeError
  raise ActiveRecord::StatementInvalid
end
```

After:

```
  statement.execute(hash.values, connection)&.first
rescue TypeError
  raise ActiveRecord::StatementInvalid
```

`After` is Simpler than `Before`.

Specially here, i think that there is no need to clarify where exceptions raise.