### PR TITLE
Helper method to create an sms link

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -571,6 +571,54 @@ module ActionView
         end
       end
 
+      # Creates an sms anchor link tag to the specified +phone_number+, which is
+      # also used as the name of the link unless +name+ is specified. Additional
+      # HTML attributes for the link can be passed in +html_options+.
+      #
+      # When clicked, an sms message is prepopulated with the passed phone number
+      #  and optional +body+ value.
+      #
+      # +sms_to+ has a +body+ option for customizing the sms message itself by
+      # passing special keys to +html_options+.
+      #
+      # ==== Options
+      # * <tt>:body</tt> - Preset the body of the email.
+      #
+      # ==== Examples
+      #   sms_to "5155555785"
+      #   # => <a href="sms:5155555785;">5155555785</a>
+      #
+      #   sms_to "5155555785", "Text me"
+      #   # => <a href="sms:5155555785;">Text me</a>
+      #
+      #   sms_to "5155555785", "Text me",
+      #            subject: "Hello Jim I have a question about your product."
+      #   # => <a href="sms:5155555785;?body=Hello%20Jim%20I%20have%20a%20question%20about%20your%20product">Text me</a>
+      #
+      # You can use a block as well if your link target is hard to fit into the name parameter. ERB example:
+      #
+      #   <%= sms_to "5155555785" do %>
+      #     <strong>Text me:</strong>
+      #   <% end %>
+      #   # => <a href="sms:5155555785;">
+      #          <strong>Text me:</strong>
+      #        </a>
+      def sms_to(phone_number, name = nil, html_options = {}, &block)
+        html_options, name = name, nil if block_given?
+        html_options = (html_options || {}).stringify_keys
+
+        extras = %w{ body }.map! { |item|
+          option = html_options.delete(item).presence || next
+          "#{item.dasherize}=#{ERB::Util.url_encode(option)}"
+        }.compact
+        extras = extras.empty? ? "" : "?&" + extras.join("&")
+
+        encoded_phone_number = ERB::Util.url_encode(phone_number)
+        html_options["href"] = "sms:#{encoded_phone_number};#{extras}"
+
+        content_tag("a", name || phone_number, html_options, &block)
+      end
+
       private
         def convert_options_to_data_attributes(options, html_options)
           if html_options

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -571,18 +571,18 @@ module ActionView
         end
       end
 
-      # Creates an sms anchor link tag to the specified +phone_number+, which is
+      # Creates an SMS anchor link tag to the specified +phone_number+, which is
       # also used as the name of the link unless +name+ is specified. Additional
       # HTML attributes for the link can be passed in +html_options+.
       #
-      # When clicked, an sms message is prepopulated with the passed phone number
+      # When clicked, an SMS message is prepopulated with the passed phone number
       #  and optional +body+ value.
       #
-      # +sms_to+ has a +body+ option for customizing the sms message itself by
+      # +sms_to+ has a +body+ option for customizing the SMS message itself by
       # passing special keys to +html_options+.
       #
       # ==== Options
-      # * <tt>:body</tt> - Preset the body of the email.
+      # * <tt>:body</tt> - Preset the body of the message.
       #
       # ==== Examples
       #   sms_to "5155555785"

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -708,6 +708,68 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal({ class: "special" }, options)
   end
 
+  def test_sms_to
+    assert_dom_equal %{<a href="sms:15155555785;">15155555785</a>}, sms_to("15155555785")
+    assert_dom_equal %{<a href="sms:15155555785;">Jim Jones</a>}, sms_to("15155555785", "Jim Jones")
+    assert_dom_equal(
+      %{<a class="admin" href="sms:15155555785;">Jim Jones</a>},
+      sms_to("15155555785", "Jim Jones", "class" => "admin")
+    )
+    assert_equal sms_to("15155555785", "Jim Jones", "class" => "admin"),
+                 sms_to("15155555785", "Jim Jones", class: "admin")
+  end
+
+  def test_sms_to_with_options
+    assert_dom_equal(
+      %{<a class="simple-class" href="sms:15155555785;?&body=Hello%20from%20Jim">Text me</a>},
+      sms_to("15155555785", "Text me", class: "simple-class", body: "Hello from Jim")
+    )
+
+    assert_dom_equal(
+      %{<a href="sms:15155555785;?&body=This%20is%20the%20body%20of%20the%20message.">Text me</a>},
+      sms_to("15155555785", "Text me", body: "This is the body of the message.")
+    )
+  end
+
+  def test_sms_with_img
+    assert_dom_equal %{<a href="sms:15155555785;"><img src="/feedback.png" /></a>},
+      sms_to("15155555785", raw('<img src="/feedback.png" />'))
+  end
+
+  def test_sms_with_html_safe_string
+    assert_dom_equal(
+      %{<a href="sms:1%2B5155555785;">1+5155555785</a>},
+      sms_to(raw("1+5155555785"))
+    )
+  end
+
+  def test_sms_with_nil
+    assert_dom_equal(
+      %{<a href="sms:;"></a>},
+      sms_to(nil)
+    )
+  end
+
+  def test_sms_returns_html_safe_string
+    assert_predicate sms_to("15155555785"), :html_safe?
+  end
+
+  def test_sms_with_block
+    assert_dom_equal %{<a href="sms:15155555785;"><span>Text me</span></a>},
+      sms_to("15155555785") { content_tag(:span, "Text me") }
+  end
+
+  def test_sms_with_block_and_options
+    assert_dom_equal %{<a class="special" href="sms:15155555785;?&body=Hello%20from%20Jim"><span>Text me</span></a>},
+      sms_to("15155555785", body: "Hello from Jim", class: "special") { content_tag(:span, "Text me") }
+  end
+
+  def test_sms_does_not_modify_html_options_hash
+    options = { class: "special" }
+    sms_to "15155555785", "ME!", options
+    assert_equal({ class: "special" }, options)
+  end
+
   def protect_against_forgery?
     request_forgery
   end


### PR DESCRIPTION
When the user clicks the sms link, the user's messaging software is opened with the passed in phone number and optional body value prepopulated. 

Test page :
https://sms-to-rails-test.herokuapp.com/

```
<%= sms_to "15155555785", "Text me", body: "I have a question.." %>
```

### Summary

OSX Chrome/Safari
![image](https://user-images.githubusercontent.com/4600/59712729-64655400-91d3-11e9-8eed-b46e632ad288.png)

Android
![image](https://user-images.githubusercontent.com/4600/59712616-3253f200-91d3-11e9-9829-d3fdea1b0519.png)

iOS Safari
![image](https://user-images.githubusercontent.com/4600/59713078-26b4fb00-91d4-11e9-8e61-2d0eac2435c7.png)
