### PR TITLE
Autoload SyntaxErrorInTemplate

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add autoload for SyntaxErrorInTemplate so syntax errors are correctly raised by DebugExceptions.
+
+    *Guilherme Mansur*, *Gannon McGibbon*
+
 *   `RenderingHelper` supports rendering objects that `respond_to?` `:render_in`
 
     *Joel Hawksley*, *Natasha Umer*, *Aaron Patterson*, *Shawn Allen*, *Emily Plummer*, *Diana Mounter*, *John Hawthorn*, *Nathan Herald*, *Zaid Zawaideh*, *Zach Ahn*

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -77,6 +77,7 @@ module ActionView
       autoload :ActionViewError
       autoload :EncodingError
       autoload :TemplateError
+      autoload :SyntaxErrorInTemplate
       autoload :WrongEncodingError
     end
   end


### PR DESCRIPTION
### Summary
Came out of looking into this: https://github.com/rails/rails/issues/36341

When a SyntaxError is detected in a template we raise this exception: `SyntaxErrorInTemplate`. On
a first request to the server the exception we get a NameError since the
exception is not required from `active_view/template/error.rb` yet.
However later on it gets required and a second request will succeed.
On the first request we see the rails "Something Wen Wrong" page and not
the expected syntax error in template error page with the webconsole and
stacktrace. By autoloading the constant we fix this issue.

Before the patch the first request looks like: 

<img width="755" alt="Screen Shot 2019-06-19 at 1 53 12 PM" src="https://user-images.githubusercontent.com/6386302/59788513-e4ee8800-9299-11e9-8986-45c22725cf2b.png">

And the log information is silenced by the `DebugExceptions` middleware. 

After the patch this looks like: 

<img width="1335" alt="Screen Shot 2019-06-19 at 1 52 51 PM" src="https://user-images.githubusercontent.com/6386302/59788547-f3d53a80-9299-11e9-87ab-74e23dcccb93.png">

cc: @gmcgibbon 

