### PR TITLE
Include BCC in the mail that sent from the development page

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -21,6 +21,7 @@ module Rails
     private
       def new_mail
         Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
+          mail[:bcc]&.include_in_headers = true
           params[:mail][:attachments].to_a.each do |attachment|
             mail.add_file(filename: attachment.path, content: attachment.read)
           end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -10,6 +10,7 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
           mail: {
             from: "Jason Fried <jason@37signals.com>",
             to: "Replies <replies@example.com>",
+            bcc: "Bcc <bcc@example.com>",
             in_reply_to: "<4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>",
             subject: "Hey there",
             body: "How's it going?"
@@ -20,6 +21,7 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
       mail = ActionMailbox::InboundEmail.last.mail
       assert_equal %w[ jason@37signals.com ], mail.from
       assert_equal %w[ replies@example.com ], mail.to
+      assert_equal %w[ bcc@example.com ], mail.bcc
       assert_equal "4e6e35f5a38b4_479f13bb90078178@small-app-01.mail", mail.in_reply_to
       assert_equal "Hey there", mail.subject
       assert_equal "How's it going?", mail.body.decoded


### PR DESCRIPTION
The BCC should be included as we show input field for BCC in view.
https://github.com/rails/rails/blob/bf625f7fecabbcda22b388e088ad5c29016b2385/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/new.html.erb#L21-L24
