### PR TITLE
Add `rails initializers` and `rails middleware` to miscellaneous section in Rails Command Line guide [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -601,6 +601,8 @@ The `tmp:` namespaced commands will help you clear and create the `Rails.root/tm
 
 ### Miscellaneous
 
+* `rails initializers` prints out all defined initializers in the order they are invoked by Rails.
+* `rails middleware` lists Rack middleware stack enabled for your app.
 * `rails stats` is great for looking at statistics on your code, displaying things like KLOCs (thousands of lines of code) and your code to test ratio.
 * `rails secret` will give you a pseudo-random key to use for your session secret.
 * `rails time:zones:all` lists all the timezones Rails knows about.


### PR DESCRIPTION
`The Rails Command Line` guide lacks a description of some commands such as `rails initializers` and `rails middleware` command.
There's a similar command `rails about` described, but `rails initializers` and `rails middleware` and are more useful in some cases such as debugging gems, so I think these commands are worth adding.