### PR TITLE
Revert schema dumper to use strings rather than integers

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1071,7 +1071,7 @@ module ActiveRecord
 
     def get_all_versions
       if schema_migration.table_exists?
-        schema_migration.all_versions
+        schema_migration.all_versions.map(&:to_i)
       else
         []
       end
@@ -1247,7 +1247,7 @@ module ActiveRecord
     end
 
     def load_migrated
-      @migrated_versions = Set.new(@schema_migration.all_versions)
+      @migrated_versions = Set.new(@schema_migration.all_versions.map(&:to_i))
     end
 
     private

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       end
 
       def all_versions
-        order(:version).pluck(:version).map(&:to_i)
+        order(:version).pluck(:version)
       end
     end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -33,6 +33,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     schema_info = ActiveRecord::Base.connection.dump_schema_information
     assert_match(/20100201010101.*20100301010101/m, schema_info)
+    assert_includes schema_info, "20100101010101"
   ensure
     ActiveRecord::SchemaMigration.delete_all
   end


### PR DESCRIPTION
I think we should change this, but not in 6-0-stable since that's
already in RC and I was trying to only make changes that won't require
any app changes.

This reverts a portion of https://github.com/rails/rails/pull/36439 that
made all schema migration version numbers get dumped as an integer.
While it doesn't _really_ matter it did change behavior. We should bring
this back in 6.1 with a deprecation.

cc/ @rafaelfranca you wanted me to make this change and our structure file is showing updates. It's not really a big deal, we could update github, but I'm more concerned about the behavior change so I'd like to roll this back and reapply in 6.1 with deprecation.