### PR TITLE
Address test_statement_cache_with_in_clause failure

### DIFF
--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -93,7 +93,7 @@ if ActiveRecord::Base.connection.prepared_statements
       def test_statement_cache_with_in_clause
         @connection.clear_cache!
 
-        topics = Topic.where(id: [1, 3])
+        topics = Topic.where(id: [1, 3]).order(:id)
         assert_equal [1, 3], topics.map(&:id)
         assert_not_includes statement_cache, to_sql_key(topics.arel)
       end


### PR DESCRIPTION
### Summary

This pull request addresses test_statement_cache_with_in_clause failure due to nondeterministic sort order.

```ruby
$ cd activerecord
$ bundle exec rake test_postgresql
... snip ...

....F

Failure:
ActiveRecord::BindParameterTest#test_statement_cache_with_in_clause [/home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:97]:
Expected: [1, 3]
  Actual: [3, 1]

rails test home/yahonda/git/rails/activerecord/test/cases/bind_parameter_test.rb:93

```

This failure is occasional, does not always reproduce.