### PR TITLE
Quote migration versions when running db:schema:dump

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1458,11 +1458,11 @@ module ActiveRecord
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-            sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
+            sql << versions.map { |v| "(#{quote(v.to_s)})" }.join(",\n")
             sql << ";\n\n"
             sql
           else
-            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"
+            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions.to_s)});"
           end
         end
 


### PR DESCRIPTION
As of https://github.com/rails/rails/pull/36439/, migration versions are no longer output as quoted strings in the insert statement when running `bin/rails db:schema:dump`. This causes some failures on schema GitHub's schema tests when switching between Rails 5.2 and 6.0.

Internally it looks like we generally treat versions as integers, but the database column is a `varchar`. In order to keep consistency in the schema dumps between versions, it might be best to just explicitly treat the versions as strings on output.

cc @eileencodes for thoughts