### PR TITLE
Improve Primary Key handling for upsert.

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/book"
+require "models/speedometer"
 
 class ReadonlyNameBook < Book
   attr_readonly :name
@@ -223,6 +224,23 @@ class InsertAllTest < ActiveRecord::TestCase
     new_name = "Agile Web Development with Rails, 4th Edition"
     Book.upsert_all [{ id: 1, name: new_name }]
     assert_equal new_name, Book.find(1).name
+  end
+
+  def test_upsert_all_updates_existing_record_by_primary_key
+    skip unless supports_insert_on_duplicate_update?
+
+    Book.upsert_all [{ id: 1, name: "New edition" }], unique_by: :id
+
+    assert_equal "New edition", Book.find(1).name
+  end
+
+  def test_upsert_all_updates_existing_record_by_configued_primary_key
+    skip unless supports_insert_on_duplicate_update?
+
+    error = assert_raises ArgumentError do
+      Speedometer.upsert_all [{ speedometer_id: "s1", name: "New Speedometer" }]
+    end
+    assert_match "No unique index found for speedometer_id", error.message
   end
 
   def test_upsert_all_does_not_update_readonly_attributes


### PR DESCRIPTION
### Summary

Currently when passing in the primary key to the `unique_by` option to upsert, like:

```ruby
Book.upsert_all [{ id: 1, name: new_name }], unique_by: :id
```

You get the error 

```
ArgumentError: No unique index found for id
```

If you don't pass in anything to `unique_by` it does a unique_by on the primary key - so you can work around it - but I don't think that it is clear and that passing in the primary key as a column list should be valid.

Also - the upsert_all code assumes that the `primary_key` for the model is the primary key in the database - which might not always be the case.  

If you have set `primary_key` for a model to something without a unique index and try to upsert, you get an error like:

```
ActiveRecord::StatementInvalid: PG::InvalidColumnReference: ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification
```

This change changes this error message to be the same as if it was any set of columns without a unique index - an `ArgumentError` with message like "No unique index found for ..."
