### PR TITLE
Also deduplicate schema cache data when using the init_with interface

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -35,11 +35,11 @@ module ActiveRecord
       end
 
       def init_with(coder)
-        @columns          = coder["columns"]
-        @columns_hash     = {}
-        @primary_keys     = coder["primary_keys"]
-        @data_sources     = coder["data_sources"]
-        @indexes          = coder["indexes"] || {}
+        @columns          = deep_deduplicate(coder["columns"])
+        @columns_hash     = @columns.transform_values { |columns| columns.index_by(&:name) }
+        @primary_keys     = deep_deduplicate(coder["primary_keys"])
+        @data_sources     = deep_deduplicate(coder["data_sources"])
+        @indexes          = deep_deduplicate(coder["indexes"] || {})
         @version          = coder["version"]
         @database_version = coder["database_version"]
       end
@@ -127,9 +127,9 @@ module ActiveRecord
       def marshal_load(array)
         @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version = array
         @indexes ||= {}
-        @columns_hash = {}
 
         @columns = deep_deduplicate(@columns)
+        @columns_hash = @columns.transform_values { |columns| columns.index_by(&:name) }
         @primary_keys = deep_deduplicate(@primary_keys)
         @data_sources = deep_deduplicate(@data_sources)
         @indexes = deep_deduplicate(@indexes)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/35891

I forgot to also apply the deduplication in `init_with`, which is actually the most likely one to be used.

Another small improvement is that `@columns_hash` is now eagerly indexed so that it's not done on the fly on the first request that access it.

Sorry both overlooking this in the previous PRs.

@kaspth @Edouard-chin @rafaelfranca 