### PR TITLE
Rely on Kernel require instead of self require

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -122,7 +122,7 @@ module ActiveSupport
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
     class DeprecatedConstantProxy < DeprecationProxy
       def initialize(old_const, new_const, deprecator = ActiveSupport::Deprecation.instance, message: "#{old_const} is deprecated! Use #{new_const} instead.")
-        require "active_support/inflector/methods"
+        Kernel.require "active_support/inflector/methods"
 
         @old_const = old_const
         @new_const = new_const


### PR DESCRIPTION
Hello :)

We recently had failures with [derailed_benchmarks](https://github.com/schneems/derailed_benchmarks/pull/130) on Rails 6.

After digging with @schneems at EuRuKo we end up with this little patch that fix the issue on _derailed_.

With this code (extracted from derailed_benchmarks):

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", "~> 6.0.0.rc1", require: false
end

FILES = [
  "rails/engine/configuration",
  "rails/source_annotation_extractor",
  "active_support/deprecation"
]

module Kernel
  alias :original_require :require

  def require(file)
    Kernel.require(file)
  end

  class << self
    alias :original_require :require
  end
end

Kernel.define_singleton_method(:require) do |file|
  original_require(file)
end

FILES.each do |file|
  puts "requiring file: #{file}"
  require file
end
```

It fails with Rails 6 and the change introduced by #32065
```
    requiring file: rails/engine/configuration
    requiring file: rails/source_annotation_extractor
    Traceback (most recent call last):
            11: from repro_derailed.rb:33:in `<main>'
            10: from repro_derailed.rb:33:in `each'
             9: from repro_derailed.rb:35:in `block in <main>'
             8: from repro_derailed.rb:21:in `require'
             7: from repro_derailed.rb:30:in `block in <main>'
             6: from repro_derailed.rb:30:in `require'
             5: from /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/railties-6.0.0.rc1/lib/rails/source_annotation_extractor.rb:8:in `<top (required)>'
             4: from /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/activesupport-6.0.0.rc1/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
             3: from /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/activesupport-6.0.0.rc1/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
             2: from /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/activesupport-6.0.0.rc1/lib/active_support/deprecation/proxy_wrappers.rb:125:in `initialize'
             1: from /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/activesupport-6.0.0.rc1/lib/active_support/deprecation/proxy_wrappers.rb:23:in `method_missing'
    /Users/benoit.tigeot/.rvm/gems/ruby-2.5.1/gems/activesupport-6.0.0.rc1/lib/active_support/deprecation/proxy_wrappers.rb:148:in `warn': private method `warn' called for nil:NilClass (NoMethodError)
```

We don't have clear explanations of why we need to rely on `Kernel` require instead of `require`. We just know it works that way. Happy yo hear your thoughts.

👋 

Related:
- https://github.com/schneems/derailed_benchmarks/pull/130
- https://github.com/rails/rails/pull/32065