### PR TITLE
fix order() to handle complex subqueries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1148,7 +1148,15 @@ module ActiveRecord
       #   columns_for_distinct("posts.id", ["posts.created_at desc"])
       #
       def columns_for_distinct(columns, orders) # :nodoc:
-        columns
+        order_columns = orders.compact_blank.map { |s|
+            # Convert Arel node to string
+            s = s.to_sql unless s.is_a?(String)
+            # Remove any ASC/DESC modifiers
+            s.gsub(/\s+(?:ASC|DESC)\b/i, "")
+             .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
+          }.compact_blank.map.with_index { |column, i| "#{column} AS alias_#{i}" }
+
+        (order_columns << columns).join(", ")
       end
 
       # Adds timestamps (+created_at+ and +updated_at+) columns to +table_name+.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1142,8 +1142,9 @@ module ActiveRecord
       end
 
       # Given a set of columns and an ORDER BY clause, returns the columns for a SELECT DISTINCT.
-      # PostgreSQL, MySQL, and Oracle override this for custom DISTINCT syntax - they
-      # require the order columns appear in the SELECT.
+      # PostgreSQL, MySQL, and Oracle require the order columns appear in the SELECT.
+      #
+      # Sqlite3 overrides this because it does not have that requirement
       #
       #   columns_for_distinct("posts.id", ["posts.created_at desc"])
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -479,21 +479,6 @@ module ActiveRecord
       end
       private :can_perform_case_insensitive_comparison_for?
 
-      # In MySQL 5.7.5 and up, ONLY_FULL_GROUP_BY affects handling of queries that use
-      # DISTINCT and ORDER BY. It requires the ORDER BY columns in the select list for
-      # distinct queries, and requires that the ORDER BY include the distinct column.
-      # See https://dev.mysql.com/doc/refman/en/group-by-handling.html
-      def columns_for_distinct(columns, orders) # :nodoc:
-        order_columns = orders.compact_blank.map { |s|
-          # Convert Arel node to string
-          s = s.to_sql unless s.is_a?(String)
-          # Remove any ASC/DESC modifiers
-          s.gsub(/\s+(?:ASC|DESC)\b/i, "")
-        }.compact_blank.map.with_index { |column, i| "#{column} AS alias_#{i}" }
-
-        (order_columns << super).join(", ")
-      end
-
       def strict_mode?
         self.class.type_cast_config_to_boolean(@config.fetch(:strict, true))
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -557,20 +557,6 @@ module ActiveRecord
           sql
         end
 
-        # PostgreSQL requires the ORDER BY columns in the select list for distinct queries, and
-        # requires that the ORDER BY include the distinct column.
-        def columns_for_distinct(columns, orders) #:nodoc:
-          order_columns = orders.compact_blank.map { |s|
-              # Convert Arel node to string
-              s = s.to_sql unless s.is_a?(String)
-              # Remove any ASC/DESC modifiers
-              s.gsub(/\s+(?:ASC|DESC)\b/i, "")
-               .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
-            }.compact_blank.map.with_index { |column, i| "#{column} AS alias_#{i}" }
-
-          (order_columns << super).join(", ")
-        end
-
         def update_table_definition(table_name, base) # :nodoc:
           PostgreSQL::Table.new(table_name, base)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -343,6 +343,10 @@ module ActiveRecord
         end
       end
 
+      def columns_for_distinct(columns, orders) # :nodoc:
+        columns
+      end
+
       private
         # See https://www.sqlite.org/limits.html,
         # the default value is 999 when not configured.

--- a/activerecord/lib/arel/attributes/attribute.rb
+++ b/activerecord/lib/arel/attributes/attribute.rb
@@ -22,6 +22,12 @@ module Arel # :nodoc: all
       def able_to_type_cast?
         relation.able_to_type_cast?
       end
+
+      def to_sql(engine = Table.engine)
+        collector = Arel::Collectors::SQLString.new
+        collector = engine.connection.visitor.accept self, collector
+        collector.value
+      end
     end
 
     class String    < Attribute; end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -564,6 +564,59 @@ module ActiveRecord
       @connection.disable_query_cache!
     end
 
+    def test_columns_for_distinct_zero_orders
+      assert_equal "posts.id",
+        @connection.columns_for_distinct("posts.id", [])
+    end
+
+    def test_columns_for_distinct_one_order
+      assert_equal "posts.created_at AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", ["posts.created_at desc"])
+    end
+
+    def test_columns_for_distinct_few_orders
+      assert_equal "posts.created_at AS alias_0, posts.position AS alias_1, posts.id",
+        @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+    end
+
+    def test_columns_for_distinct_with_case
+      assert_equal(
+        "CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id",
+          ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
+      )
+    end
+
+    def test_columns_for_distinct_blank_not_nil_orders
+      assert_equal "posts.created_at AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
+    end
+
+    def test_columns_for_distinct_with_arel_order
+      order = Object.new
+      def order.to_sql
+        "posts.created_at desc"
+      end
+      assert_equal "posts.created_at AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", [order])
+    end
+
+    def test_columns_for_distinct_with_nulls
+      assert_equal "posts.updater_id AS alias_0, posts.title", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls first"])
+      assert_equal "posts.updater_id AS alias_0, posts.title", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls last"])
+    end
+
+    def test_columns_for_distinct_without_order_specifiers
+      assert_equal "posts.updater_id AS alias_0, posts.title",
+        @connection.columns_for_distinct("posts.title", ["posts.updater_id"])
+
+      assert_equal "posts.updater_id AS alias_0, posts.title",
+        @connection.columns_for_distinct("posts.title", ["posts.updater_id nulls last"])
+
+      assert_equal "posts.updater_id AS alias_0, posts.title",
+        @connection.columns_for_distinct("posts.title", ["posts.updater_id nulls first"])
+    end
+
     # test resetting sequences in odd tables in PostgreSQL
     if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
       require "models/movie"

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -592,13 +592,39 @@ module ActiveRecord
         @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
     end
 
-    def test_columns_for_distinct_with_arel_order
-      order = Object.new
-      def order.to_sql
-        "posts.created_at desc"
-      end
+    def test_columns_for_distinct_with_string_order
+      order = "posts.created_at desc"
       assert_equal "posts.created_at AS alias_0, posts.id",
         @connection.columns_for_distinct("posts.id", [order])
+    end
+
+    def test_columns_for_distinct_with_literal_order
+      order = Arel.sql("posts.created_at desc")
+      assert_equal "posts.created_at AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", [order])
+    end
+
+    def test_columns_for_distinct_with_descending_sql_order
+      order = Arel::Nodes::Descending.new(Arel.sql("posts.created_at"))
+      assert_equal "posts.created_at DESC", order.to_sql
+      assert_equal "posts.created_at AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", [order])
+    end
+
+    def test_columns_for_distinct_with_descending_attribute_order
+      order = Arel::Nodes::Descending.new(Post.arel_attribute(:created_at))
+      column = "#{@connection.quote_table_name("posts")}.#{@connection.quote_column_name("created_at")}"
+      assert_equal "#{column} DESC", order.to_sql
+      assert_equal "#{column} AS alias_0, posts.id",
+        @connection.columns_for_distinct("posts.id", [order])
+    end
+
+    def test_columns_for_distinct_with_subquery_order
+      column_subquery = "(select name from posts where posts.author_id = authors.id order id desc limit 1)"
+      order = Arel::Nodes::Descending.new(Arel.sql(column_subquery))
+      assert_equal "#{column_subquery} DESC", order.to_sql
+      assert_equal "#{column_subquery} AS alias_0, authors.id",
+        @connection.columns_for_distinct("authors.id", [order])
     end
 
     def test_columns_for_distinct_with_nulls

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -32,43 +32,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
      "expected database #{config[:database]} to exist"
   end
 
-  def test_columns_for_distinct_zero_orders
-    assert_equal "posts.id",
-      @conn.columns_for_distinct("posts.id", [])
-  end
-
-  def test_columns_for_distinct_one_order
-    assert_equal "posts.created_at AS alias_0, posts.id",
-      @conn.columns_for_distinct("posts.id", ["posts.created_at desc"])
-  end
-
-  def test_columns_for_distinct_few_orders
-    assert_equal "posts.created_at AS alias_0, posts.position AS alias_1, posts.id",
-      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
-  end
-
-  def test_columns_for_distinct_with_case
-    assert_equal(
-      "CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0, posts.id",
-      @conn.columns_for_distinct("posts.id",
-        ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
-    )
-  end
-
-  def test_columns_for_distinct_blank_not_nil_orders
-    assert_equal "posts.created_at AS alias_0, posts.id",
-      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
-  end
-
-  def test_columns_for_distinct_with_arel_order
-    order = Object.new
-    def order.to_sql
-      "posts.created_at desc"
-    end
-    assert_equal "posts.created_at AS alias_0, posts.id",
-      @conn.columns_for_distinct("posts.id", [order])
-  end
-
   def test_errors_for_bigint_fks_on_integer_pk_table_in_alter_table
     # table old_cars has primary key of integer
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -272,59 +272,6 @@ module ActiveRecord
         end
       end
 
-      def test_columns_for_distinct_zero_orders
-        assert_equal "posts.id",
-          @connection.columns_for_distinct("posts.id", [])
-      end
-
-      def test_columns_for_distinct_one_order
-        assert_equal "posts.created_at AS alias_0, posts.id",
-          @connection.columns_for_distinct("posts.id", ["posts.created_at desc"])
-      end
-
-      def test_columns_for_distinct_few_orders
-        assert_equal "posts.created_at AS alias_0, posts.position AS alias_1, posts.id",
-          @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
-      end
-
-      def test_columns_for_distinct_with_case
-        assert_equal(
-          "CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0, posts.id",
-          @connection.columns_for_distinct("posts.id",
-            ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
-        )
-      end
-
-      def test_columns_for_distinct_blank_not_nil_orders
-        assert_equal "posts.created_at AS alias_0, posts.id",
-          @connection.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
-      end
-
-      def test_columns_for_distinct_with_arel_order
-        order = Object.new
-        def order.to_sql
-          "posts.created_at desc"
-        end
-        assert_equal "posts.created_at AS alias_0, posts.id",
-          @connection.columns_for_distinct("posts.id", [order])
-      end
-
-      def test_columns_for_distinct_with_nulls
-        assert_equal "posts.updater_id AS alias_0, posts.title", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls first"])
-        assert_equal "posts.updater_id AS alias_0, posts.title", @connection.columns_for_distinct("posts.title", ["posts.updater_id desc nulls last"])
-      end
-
-      def test_columns_for_distinct_without_order_specifiers
-        assert_equal "posts.updater_id AS alias_0, posts.title",
-          @connection.columns_for_distinct("posts.title", ["posts.updater_id"])
-
-        assert_equal "posts.updater_id AS alias_0, posts.title",
-          @connection.columns_for_distinct("posts.title", ["posts.updater_id nulls last"])
-
-        assert_equal "posts.updater_id AS alias_0, posts.title",
-          @connection.columns_for_distinct("posts.title", ["posts.updater_id nulls first"])
-      end
-
       def test_raise_error_when_cannot_translate_exception
         assert_raise TypeError do
           @connection.send(:log, nil) { @connection.execute(nil) }

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -292,5 +292,11 @@ module ActiveRecord
       assert_equal 1, klass.new(no_type: 1).no_type
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
+
+    test "to_sql returns quoted string" do
+      quoted_name = "#{OverloadedType.connection.quote_table_name("overloaded_types")}.#{OverloadedType.connection.quote_column_name("overloaded_float")}"
+      attribute = OverloadedType.arel_attribute("overloaded_float")
+      assert_equal quoted_name, attribute.to_sql
+    end
   end
 end


### PR DESCRIPTION
**TL;DR:** remove sql string munging for `ORDER BY` and leverage Arel instead.

### Summary

If a query has a `distinct()` and an `order()`, active record generates a pre query to just fetch ids. `columns_for_distinct` converts the order clause into something usable in the sql clause.

```ruby
Author.distinct.left_joins(:posts).where(:posts => {:id => [5,6,7,8,9,10]}).order(:name)
```

```sql
SELECT DISTINCT "authors"."id" AS alias_0, "authors"."name"
LEFT OUTER JOIN "posts" ON "posts"."author_id" = "authors"."id"
FROM "authors"
WHERE "posts"."id" in (...)
ORDER BY "posts"."name";
```

The issue enters when the `order()` clause is a subquery joining to a `has_many` model. The subquery needs to return 1 value, so it will have a `LIMIT 1` and an `ORDER BY` clause.

The sql munging in `columns_for_distinct` inadvertently modifies the subquery's `ORDER BY` clause. So the `SELECT` subquery will be different from the `ORDER BY` subquery. Postgres and MySQL do not like this:

```
ActiveRecord::StatementInvalid (PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list)
LINE 1: ..."disks"."hardware_id" = "hardwares"."id" ORDER BY (SELECT  "...
```

### Before this PR

- Rails converts the `ORDER BY` clause columns to a sql string and uses regular expressions to removes  all `"ASC", "DESC"` from the sql.
- The sql in the `SELECT` no longer resembles the sql in the `ORDER BY` and the db complains.


### After

- Rails drops the `Arel::Nodes::Ordering` node and uses the actual expression (i.e.: `@expr`). Since the `Order` node is removed, the `ASC` or `DESC` are successfully removed. No String munging required.
- To support `Arel::Attributes::Attribute` nodes, the general case of `to_sql` is added.

I've observed that most of the `ORDER BY` clauses are an `Arel::Nodes::Ordering` node pointing to an `Arel::Attributes::Attribute` node. Less frequently, the `ORDER BY` clauses is an `Ordering` node pointing to a `SqlLiteral`. This supports both.

### Alternatives

- ~~I can implement `Arel::Attributes::Attribute#to_sql`, but comments suggests that `to_sql` is bad and should go away.~~ **DONE**
- ~~I can move `columns_for_distinct` into the abstract `SchemaStatements`, if you prefer.~~ **DONE**

### Thanks

Thank for all the help.

As @matthewd and @tenderlove may have guessed, this is related to [virtual attributes](https://github.com/ManageIQ/activerecord-virtual_attributes).
