### PR TITLE
Empty array instead of nil for source_extract

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   annotated_source_code returns an empty array so TemplateErrors without a
+    template in the backtrace are surfaced properly by DebugExceptions.
+
+    *Guilherme Mansur*, *Kasper Timm Hansen*
+
 *   Add autoload for SyntaxErrorInTemplate so syntax errors are correctly raised by DebugExceptions.
 
     *Guilherme Mansur*, *Gannon McGibbon*

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -81,8 +81,8 @@ module ActionView
         end
       end
 
-      def source_extract(indentation = 0, output = :console)
-        return unless num = line_number
+      def source_extract(indentation = 0)
+        return [] unless num = line_number
         num = num.to_i
 
         source_code = @template.source.split("\n")
@@ -91,9 +91,9 @@ module ActionView
         end_on_line   = [ num + SOURCE_CODE_RADIUS - 1, source_code.length].min
 
         indent = end_on_line.to_s.size + indentation
-        return unless source_code = source_code[start_on_line..end_on_line]
+        return [] unless source_code = source_code[start_on_line..end_on_line]
 
-        formatted_code_for(source_code, start_on_line, indent, output)
+        formatted_code_for(source_code, start_on_line, indent)
       end
 
       def sub_template_of(template_path)
@@ -122,15 +122,11 @@ module ActionView
           end + file_name
         end
 
-        def formatted_code_for(source_code, line_counter, indent, output)
-          start_value = (output == :html) ? {} : []
-          source_code.inject(start_value) do |result, line|
+        def formatted_code_for(source_code, line_counter, indent)
+          indent_template = "%#{indent}s: %s"
+          source_code.map do |line|
             line_counter += 1
-            if output == :html
-              result.update(line_counter.to_s => "%#{indent}s %s\n" % ["", line])
-            else
-              result << "%#{indent}s: %s" % [line_counter, line]
-            end
+            indent_template % [line_counter, line]
           end
         end
     end

--- a/actionview/test/template/template_error_test.rb
+++ b/actionview/test/template/template_error_test.rb
@@ -34,4 +34,20 @@ class TemplateErrorTest < ActiveSupport::TestCase
 
     assert_equal "#<ActionView::Template::Error: original>", error.inspect
   end
+
+  def test_annotated_source_code_returns_empty_array_if_source_cant_be_found
+    template = Class.new do
+      def identifier
+        "something"
+      end
+    end.new
+
+    error = begin
+      raise
+    rescue
+      raise ActionView::Template::Error.new(template) rescue $!
+    end
+
+    assert_equal [], error.annotated_source_code
+  end
 end


### PR DESCRIPTION
### Summary

The source_extract method will return nil when it can't find the file name in
the backtrace, methods that consume this method expect an array and the nil ends
up causing type errors down the road like it happened here: #36341. This patch
introduces a to_a call that converts the nil into an empty array this makes it so
client classes can correctly handle a empty list of source code lines and not
trigger a type error.

### Other Information

Note this is a bit defensive and preventative imo, this occured for the edge case described here: https://github.com/rails/rails/issues/36341#issuecomment-503673532 and potentially other unknown code paths could still cause this behaviour to occur, but I don't know of any. 

At any rate I do like having the method return a `[]` instead of a nil and thing that is a better interface for this class in general since the method will be returning consistent types. 

discussed this with @rafaelfranca and @gmcgibbon 