### PR TITLE
Fix cookie modification during rotation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -532,9 +532,13 @@ module ActionDispatch
           if value
             case
             when needs_migration?(value)
-              self[name] = Marshal.load(value)
+              Marshal.load(value).tap do |v|
+                self[name] = { value: v }
+              end
             when rotate
-              self[name] = serializer.load(value)
+              serializer.load(value).tap do |v|
+                self[name] = { value: v }
+              end
             else
               serializer.load(value)
             end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -893,6 +893,19 @@ class CookiesTest < ActionController::TestCase
     assert_equal 45, encryptor.decrypt_and_verify(@response.cookies["foo"])
   end
 
+  def test_cookie_with_hash_value_not_modified_by_rotation
+    @request.env["action_dispatch.signed_cookie_digest"] = "SHA256"
+    @request.env["action_dispatch.cookies_rotations"].rotate :signed, digest: "SHA1"
+
+    key_generator = @request.env["action_dispatch.key_generator"]
+    old_secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
+    old_value = ActiveSupport::MessageVerifier.new(old_secret).generate(bar: "baz")
+
+    @request.headers["Cookie"] = "foo=#{old_value}"
+    get :get_signed_cookie
+    assert_equal({ bar: "baz" }, @controller.send(:cookies).signed[:foo])
+  end
+
   def test_cookie_with_all_domain_option
     get :set_cookie_with_domain
     assert_response :success


### PR DESCRIPTION
During cookie rotation, a Hash used as a value in a signed/encrypted cookie jar gets interpreted as the cookie options and then modified. This adds extra data to any signed or encrypted cookies (including the session) whenever a cookie is upgraded:
```diff
CookiesTest#test_cookie_with_hash_value_not_modified_by_rotation [test/dispatch/cookies_test.rb:906]:
--- expected
+++ actual
@@ -1 +1 @@
-{:bar=>"baz"}
+{:bar=>"baz", :value=>"BAgw--19e63e2f070077fd7e1c97fed32ded6adae26a0f560a8a33e4ba02c414e50199", :path=>"/"}
```

This seems to have regressed in 5.2 with https://github.com/rails/rails/commit/8b0af54bbe5ab8b598e980013dd53a50d819b636#diff-69714203ccef60fcead8d4eff741a883R538.
