### PR TITLE
Use rails versions on release announcement draft

### DIFF
--- a/tasks/release_announcement_draft.erb
+++ b/tasks/release_announcement_draft.erb
@@ -28,7 +28,7 @@ To see the full list of changes, [check out all the commits on
 GitHub](https://github.com/rails/rails/compare/v<%= "#{version.previous}...v#{version}" %>).
 <% end %>
 
-## SHA-256
+## Rails <%= versions.join(" and ") %> SHA-256
 
 If you'd like to verify that your gem is the same as the one I've uploaded,
 please use these SHA-256 hashes.


### PR DESCRIPTION
### Summary

This allow to have uniq link anchor for each version SHA256 and
fix markup errors that does not allow same id on same page

### Other Information

https://validator.nu/?doc=https%3A%2F%2Fweblog.rubyonrails.org%2F