### PR TITLE
Update link to owasp XSS cheat sheet

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1211,4 +1211,4 @@ The security landscape shifts and it is important to keep up to date, because mi
 * Subscribe to the Rails security [mailing list](https://groups.google.com/forum/#!forum/rubyonrails-security).
 * [Brakeman - Rails Security Scanner](https://brakemanscanner.org/) - To perform static security analysis for Rails applications.
 * [Keep up to date on the other application layers](http://secunia.com/) (they have a weekly newsletter, too).
-* A [good security blog](https://www.owasp.org) including the [Cross-Site scripting Cheat Sheet](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet).
+* A [good security blog](https://www.owasp.org) including the [Cross-Site scripting Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md).


### PR DESCRIPTION
### Summary

The OWASP Cheat Sheets project has moved to GitHub, and it's more helpful to link directly to the latest Cheat Sheet rather than the legacy page that links back to GitHub. This way, developers can get the best, latest information right away.

### Other Information

N/A