### PR TITLE
fix finding with value object containing mapping to association

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -10,6 +10,7 @@ require "models/company"
 require "models/tagging"
 require "models/topic"
 require "models/reply"
+require "models/receipt"
 require "models/rating"
 require "models/entrant"
 require "models/project"
@@ -25,7 +26,7 @@ require "models/subscriber"
 require "support/stubs/strong_parameters"
 
 class FinderTest < ActiveRecord::TestCase
-  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :author_addresses, :customers, :categories, :categorizations, :cars
+  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :author_addresses, :customers, :categories, :categorizations, :cars, :receipts
 
   def test_find_by_id_with_hash
     assert_nothing_raised do
@@ -1017,6 +1018,14 @@ class FinderTest < ActiveRecord::TestCase
     address = customers(:david).address
     assert_kind_of Address, address
     found_customer = Customer.where(address: address, name: customers(:david).name).first
+    assert_equal customers(:david), found_customer
+  end
+
+  def test_hash_condition_find_with_aggregate_attribution_having_association
+    customer_invoice = CustomerInvoice.new
+    customer_invoice.id = receipts(:receipt).id
+
+    found_customer = Customer.joins(:receipts).where(customer_invoice: customer_invoice).first
     assert_equal customers(:david), found_customer
   end
 

--- a/activerecord/test/fixtures/receipts.yml
+++ b/activerecord/test/fixtures/receipts.yml
@@ -1,0 +1,4 @@
+receipt:
+  id: 1
+  title: "My receipt"
+  customer_id: 1

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -3,6 +3,9 @@
 class Customer < ActiveRecord::Base
   cattr_accessor :gps_conversion_was_run
 
+  has_many :receipts
+  composed_of :customer_invoice, mapping: [ %w(receipts.id id) ]
+
   composed_of :address, mapping: [ %w(address_street street), %w(address_city city), %w(address_country country) ], allow_nil: true
   composed_of :balance, class_name: "Money", mapping: %w(balance amount)
   composed_of :gps_location, allow_nil: true
@@ -82,4 +85,8 @@ class Fullname
   def to_s
     "#{first} #{last.upcase}"
   end
+end
+
+class CustomerInvoice
+  attr_accessor :id
 end

--- a/activerecord/test/models/receipt.rb
+++ b/activerecord/test/models/receipt.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Receipt < ActiveRecord::Base
+  belongs_to :customer
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -788,6 +788,11 @@ ActiveRecord::Schema.define do
     t.integer :first_post_id
   end
 
+  create_table :receipts, force: true do |t|
+    t.references :customer
+    t.string :title, null: false
+  end
+
   create_table :references, force: true do |t|
     t.integer :person_id
     t.integer :job_id


### PR DESCRIPTION
### Summary

On rails 5.2.0+, find with value object whose mapping contains association causes ActiveRecord::StatementInvalid error. 

```ruby
class Customer < ActiveRecord::Base
  has_many :receipts

  composed_of :invoice, mapping: [ %w(receipts.id id) ]
end

class Invoice
  attr_accessor :id
end

Cusotmer.joins(:receipts).where(invoice: invoice) #=> ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: customers.receipts.id
```

Before 5.2.0 (e.g. 5.1.7), it works.

This PR fixes the problem.

### Other Information

I guess this comimt(https://github.com/rails/rails/commit/159b21b59dba120e58eeb8bff89b9d322e720c44#diff-5eed40af24f8d1632cf58d021e82e5b9) causes the problem.

It uesd to call `expand_hash_conditions_for_aggregates` before coming to `build_from_hash`.
After the commit, the equivalent process is done in `build_from_hash`, and `convert_dot_notation_to_hash` is never called.

#### why adding no tests

I tried to adding tests by expanding `Customer` having association above and a case below. (Of course, also added fixtures and schema)

```ruby
  def test_hash_condition_find_with_aggregate_attribution_having_association
    invoice = receipts(:receipt)

    found_customer = Customer.joins(:receipts).where(invoice: invoice).first
    assert_equal customers(:david), found_customer
  end
```

But after adding the case successfully, I found some other cases(e.g. test/cases/touch_later_test.rb) started to fail, and I resigned to add.

Regards...
