### PR TITLE
Replace the www.robotstxt.org URL with https one [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1541,7 +1541,7 @@ Disallow: /
 ```
 
 To block just specific pages, it's necessary to use a more complex syntax. Learn
-it on the [official documentation](http://www.robotstxt.org/robotstxt.html).
+it on the [official documentation](https://www.robotstxt.org/robotstxt.html).
 
 Evented File System Monitor
 ---------------------------

--- a/railties/lib/rails/generators/rails/app/templates/public/robots.txt
+++ b/railties/lib/rails/generators/rails/app/templates/public/robots.txt
@@ -1,1 +1,1 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file


### PR DESCRIPTION
### Summary

The URL of  `robots.txt` documentation is moved permanently to https one as below.

```
$ curl -I http://www.robotstxt.org/robotstxt.html
HTTP/1.1 301 Moved Permanently
Date: Tue, 25 Jun 2019 14:33:25 GMT
Server: Apache/2.4.18 (Ubuntu)
Strict-Transport-Security: max-age=63072000; includeSubdomains;
Location: https://www.robotstxt.org/robotstxt.html
Cache-Control: max-age=1296000
Expires: Wed, 10 Jul 2019 14:33:25 GMT
Content-Type: text/html; charset=iso-8859-1
$
```

This patch replaces the URL with https one. 
