### PR TITLE
Ruby convention for class names is PascalCase

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -79,7 +79,7 @@ a class `Book`, you should have a database table called **books**. The Rails
 pluralization mechanisms are very powerful, being capable of pluralizing (and
 singularizing) both regular and irregular words. When using class names composed
 of two or more words, the model class name should follow the Ruby conventions,
-using the CamelCase form, while the table name must contain the words separated
+using the PascalCase form, while the table name must contain the words separated
 by underscores. Examples:
 
 * Model Class - Singular with the first letter of each word capitalized (e.g.,


### PR DESCRIPTION
The documentation mistakenly listed "CamelCase" as the naming convention for Ruby classes / models, but the correct naming convention is "PascalCase". This was an isolated error, as PascalCase is used in all other places in the documentation.