### PR TITLE
[ci skip] Refer actionmailbox and actiontext in the guide

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -108,6 +108,8 @@ A standard Rails application depends on several gems, specifically:
 * activerecord
 * activestorage
 * activesupport
+* actionmailbox
+* actiontext
 * arel
 * builder
 * bundler
@@ -538,6 +540,8 @@ require "rails"
   action_mailer/railtie
   active_job/railtie
   action_cable/engine
+  action_mailbox/engine
+  action_text/engine
   rails/test_unit/railtie
   sprockets/railtie
 ).each do |railtie|


### PR DESCRIPTION
Added actionmailbox and actiontext reference in the initialization guide