### PR TITLE
warning: instance variable @serial not initialized

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -24,6 +24,16 @@ module ActiveRecord
           super.sub(/\[\]\z/, "")
         end
 
+        def init_with(coder)
+          @serial = coder["serial"]
+          super
+        end
+
+        def encode_with(coder)
+          coder["serial"] = @serial
+          super
+        end
+
         def ==(other)
           other.is_a?(Column) &&
             super &&


### PR DESCRIPTION
Introduced in bba7c63a663b073034f4c73f0d59655751694e5a

Before:

```
$ TESTOPTS="-n=/test_yaml_dump_and_load/" bundle exec rake
test:postgresql

:scisors: ... :scisors:

Using postgresql
Run options: -n=/test_yaml_dump_and_load/ --seed 36896

/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/column.rb:15:
warning: instance variable @serial not initialized
.

Finished in 0.195325s, 5.1197 runs/s, 35.8376 assertions/s.
1 runs, 7 assertions, 0 failures, 0 errors, 0 skips

```

