### PR TITLE
Fix problem with accessing deprecated constant proxy's subclass

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -120,7 +120,14 @@ module ActiveSupport
     #   # => DEPRECATION WARNING: PLANETS is deprecated! Use PLANETS_POST_2006 instead.
     #        (Backtrace information…)
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
-    class DeprecatedConstantProxy < DeprecationProxy
+    class DeprecatedConstantProxy < Module
+      def self.new(*args, &block)
+        object = args.first
+
+        return object unless object
+        super
+      end
+
       def initialize(old_const, new_const, deprecator = ActiveSupport::Deprecation.instance, message: "#{old_const} is deprecated! Use #{new_const} instead.")
         require "active_support/inflector/methods"
 
@@ -128,6 +135,14 @@ module ActiveSupport
         @new_const = new_const
         @deprecator = deprecator
         @message = message
+      end
+
+      instance_methods.each { |m| undef_method m unless /^__|^object_id$/.match?(m) }
+
+      # Don't give a deprecation warning on inspect since test/unit and error
+      # logs rely on it for diagnostics.
+      def inspect
+        target.inspect
       end
 
       # Returns the class of the new constant.
@@ -144,8 +159,14 @@ module ActiveSupport
           ActiveSupport::Inflector.constantize(@new_const.to_s)
         end
 
-        def warn(callstack, called, args)
-          @deprecator.warn(@message, callstack)
+        def const_missing(name)
+          @deprecator.warn(@message, caller_locations)
+          target.const_get(name)
+        end
+
+        def method_missing(called, *args, &block)
+          @deprecator.warn(@message, caller_locations)
+          target.__send__(called, *args, &block)
         end
     end
   end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -38,6 +38,11 @@ class Deprecatee
     C = 1
   end
   A = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Deprecatee::A", "Deprecatee::B::C")
+
+  module New
+    class Descendant; end
+  end
+  Old = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Deprecatee::Old", "Deprecatee::New")
 end
 
 class DeprecateeWithAccessor
@@ -208,6 +213,18 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_not_deprecated { Deprecatee::B::C }
     assert_deprecated("Deprecatee::A") { assert_equal Deprecatee::B::C, Deprecatee::A }
     assert_not_deprecated { assert_equal Deprecatee::B::C.class, Deprecatee::A.class }
+  end
+
+  def test_deprecated_constant_descendant
+    assert_not_deprecated { Deprecatee::New::Descendant }
+
+    assert_deprecated("Deprecatee::Old") do
+      assert_equal Deprecatee::Old::Descendant, Deprecatee::New::Descendant
+    end
+
+    assert_raises(NameError) do
+      assert_deprecated("Deprecatee::Old") { Deprecatee::Old::NON_EXISTENCE }
+    end
   end
 
   def test_deprecated_constant_accessor


### PR DESCRIPTION
This commit fixes #36313.

After #32065 moved `SourceAnnotationExtractor` into `Rails` module, it broke the ability to access `SourceAnnotationExtractor::Annotate` directly as user would get this error:

    TypeError: Rails::SourceAnnotationExtractor is not a class/module

This commit fixes the issue by making `DeprecatedConstantProxy` to inherit from `Module` and then defines `method_missing` and `const_missing` to retain the previous functionality.

Thank you @matthewd for the [idea](https://github.com/rails/rails/pull/32065#issuecomment-378794102) of how to fix the issue!
