### PR TITLE
Add warning about using UUIDs with activestorage

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -43,6 +43,8 @@ tables. Use `rails db:migrate` to run the migration.
 
 WARNING: `active_storage_attachments` is a polymorphic join table that stores your model's class name. If your model's class name changes, you will need to run a migration on this table to update the underlying `record_type` to your model's new class name.
 
+WARNING: If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of `record_id` for the `active_storage_attachments` table in the generated migration accordingly.
+
 Declare Active Storage services in `config/storage.yml`. For each service your
 application uses, provide a name and the requisite configuration. The example
 below declares three services named `local`, `test`, and `amazon`:


### PR DESCRIPTION
### Summary

When using ActiveStorage against models that have a UUID as their primary key the underlying attachment references are broken and random files get returned when fetching the attachment.

A question on stackoverflow that describes this problem in more detail can be found for example at https://stackoverflow.com/questions/51531441/rails-5-2-activestorage-with-uuids-on-postgresql

This PR just adds a warning / headsup comment on the corresponding guide.

Additionally I think it should be considered to file this as a bug, activestorage should never return seemingly random files potentially uploaded by other users due to this - instead I think it would make sense to raise an exception when trying to make the attachment against a model that has a different column type.

However, I think this tiny addition can already be helpful to users so I'd like to propose this addition, if I should also prepare a bug report for the more general issue please let me know.

Thanks!