### PR TITLE
Update docs with warning on ActiveStorage Content-Disposition override

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -398,6 +398,10 @@ helper allows you to set the disposition.
 rails_blob_path(user.avatar, disposition: "attachment")
 ```
 
+WARNING: To prevent XSS attacks, ActiveStorage forces the Content-Disposition header
+to "attachment" for some kind of files. To change this behaviour see the
+available configuration opions in [Configuring Rails Applications](configuring.html#configuring-active-storage).
+
 If you need to create a link from outside of controller/view context (Background
 jobs, Cronjobs, etc.), you can access the rails_blob_path like this:
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -844,6 +844,8 @@ You can find more detailed configuration options in the
 * `config.active_storage.content_types_to_serve_as_binary` accepts an array of strings indicating the content types that Active Storage will always serve as an attachment, rather than inline. The default is `%w(text/html
 text/javascript image/svg+xml application/postscript application/x-shockwave-flash text/xml application/xml application/xhtml+xml application/mathml+xml text/cache-manifest)`.
 
+* `config.active_storage.content_types_allowed_inline` accepts an array of strings indicating the content types that Active Storage allows to serve as inline. The default is `%w(image/png image/gif image/jpg image/jpeg image/vnd.adobe.photoshop image/vnd.microsoft.icon application/pdf)`.
+
 * `config.active_storage.queues.analysis` accepts a symbol indicating the Active Job queue to use for analysis jobs. When this option is `nil`, analysis jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
 
    ```ruby


### PR DESCRIPTION
### Summary

* Adding missing Active Storage `content_types_allowed_inline` config to the Configuring Rails guide.

* Adding a warning on the Active Storage guide about the Content-Disposition override that AS does when serving files with content types not white listed. 

### Context

When linking to an ActiveStorage Blob object using the following code:

```ruby
rails_blob_path(user.avatar, disposition: "inline")
```

The expected behaviour is that the response to that request is going to include the `Content-Disposition` header set to `inline`. However, to prevent from XSS attacks, AS forces the disposition  to `attachment` for certain kind of files, specified via the following configs: `config.active_storage.content_types_to_serve_as_binary` and `config.active_storage.content_types_allowed_inline`.

### Comments on the ActiveStorage Configuration API

As it stands right now, there's two configs that handle which files can be displayed as `inline`. One is a whitelist (`content_types_allowed_inline`) and the other a blacklist (`content_types_to_serve_as_binary`). At a first glance, they seemed redundant, but I found that the blacklist also affects the metadata of the file when uploaded (not affected by the whitelist). I don't fully understand the reasoning behind that differentiation, but as a user of ActiveStorage if I want to enable a type of file to be served as `inline` I need to update both options which seems redundant and it's not clear why. For example, to be able to serve SVG files inline I need to do the following:

```
    config.active_storage.content_types_allowed_inline << "image/svg+xml"
    config.active_storage.content_types_to_serve_as_binary -= ["image/svg+xml"]
```

### Proposal to improve override behaviour

I don't think it's ideal that AS silently overrides a given parameter. I propose we do the following:

* If backwards compatibility is needed, I'd log a warning message whenever we override the content-disposition of a file.
* If breaking backwards compatibility is an option, I'd raise an exception whenever this happens on development, and log a warning on production. 

I can submit a PR with those changes if they sound good to someone in the core team.

Issue where I first reported this: https://github.com/rails/rails/issues/36277

