### PR TITLE
Support invoking mysqldump/pg_dump in a Docker container

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -46,6 +46,24 @@ module ActiveRecord
       # Extra flags passed to database CLI tool when calling db:structure:load
       mattr_accessor :structure_load_flags, instance_accessor: false
 
+      ##
+      # :singleton-method:
+      # The CLI tool (mysqldump/pg_dump) to invoke when calling db:structure:dump
+      #
+      # Override to run an alternative command, such as invoking the dump
+      # within a Docker container:
+      #   DatabaseTasks.structure_dump_command = "docker-compose run db mysqldump"
+      mattr_accessor :structure_dump_command, instance_accessor: false
+
+      ##
+      # :singleton-method:
+      # The CLI tool (mysql/psql) to invoke when calling db:structure:load
+      #
+      # Override to run an alternative command, such as invoking the load
+      # within a Docker container:
+      #   DatabaseTasks.structure_load_command = "docker-compose run db mysql"
+      mattr_accessor :structure_load_command, instance_accessor: false
+
       extend self
 
       attr_writer :current_config, :db_dir, :migrations_paths, :fixtures_path, :root, :env, :seed_loader

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -55,7 +55,8 @@ module ActiveRecord
         args.concat([db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysqldump", args, "dumping")
+        command = DatabaseTasks.structure_dump_command || "mysqldump"
+        run_cmd(command, args, "dumping")
       end
 
       def structure_load(filename, extra_flags)
@@ -64,7 +65,8 @@ module ActiveRecord
         args.concat(["--database", db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysql", args, "loading")
+        command = DatabaseTasks.structure_load_command || "mysql"
+        run_cmd(command, args, "loading")
       end
 
       private

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -73,17 +73,23 @@ module ActiveRecord
         end
 
         args << db_config.database
-        run_cmd("pg_dump", args, "dumping")
+
+        command = DatabaseTasks.structure_dump_command || "pg_dump"
+        run_cmd(command, args, "dumping")
+
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
 
       def structure_load(filename, extra_flags)
         set_psql_env
+
         args = ["-v", ON_ERROR_STOP_1, "-q", "-X", "-f", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
-        run_cmd("psql", args, "loading")
+
+        command = DatabaseTasks.structure_load_command || "psql"
+        run_cmd(command, args, "loading")
       end
 
       private

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -54,12 +54,16 @@ module ActiveRecord
         else
           args << ".schema"
         end
-        run_cmd("sqlite3", args, filename)
+
+        command = DatabaseTasks.structure_dump_command || "sqlite3"
+        run_cmd(command, args, filename)
       end
 
       def structure_load(filename, extra_flags)
         flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
+
+        command = DatabaseTasks.structure_load_command || "sqlite3"
+        `#{command} #{flags} #{db_config.database} < "#{filename}"`
       end
 
       private

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -196,6 +196,17 @@ if current_adapter?(:SQLite3Adapter)
         FileUtils.rm_f(dbfile)
       end
 
+      def test_structure_dump_command
+        filename = "awesome-file.sql"
+        expected_command = "docker-compose run db sqlite3 #{@database} < #{filename}"
+
+        assert_called_with(Kernel, :`, [expected_command], returns: true) do
+          with_structure_dump_command("docker-compose run db sqlite3") do
+            ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, "/rails/root"
+          end
+        end
+      end
+
       def test_structure_dump_with_ignore_tables
         dbfile   = @database
         filename = "awesome-file.sql"
@@ -233,6 +244,14 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       private
+        def with_structure_dump_command(command)
+          old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_command
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_command = command
+          yield
+        ensure
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_command = old
+        end
+
         def with_structure_dump_flags(flags)
           old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
           ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
@@ -262,6 +281,34 @@ if current_adapter?(:SQLite3Adapter)
         FileUtils.rm_f(filename)
         FileUtils.rm_f(dbfile)
       end
+
+      def test_structure_load_command
+        filename = "awesome-file.sql"
+        expected_command = "docker-compose run db sqlite3 #{@database} < #{filename}"
+
+        assert_called_with(Kernel, :`, [expected_command], returns: true) do
+          with_structure_load_command("docker-compose run db sqlite3") do
+            ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, "/rails/root"
+          end
+        end
+      end
+
+      private
+        def with_structure_load_command(command)
+          old = ActiveRecord::Tasks::DatabaseTasks.structure_load_command
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_command = command
+          yield
+        ensure
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_command = old
+        end
+
+        def with_structure_load_flags(flags)
+          old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+          yield
+        ensure
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        end
     end
   end
 end


### PR DESCRIPTION
We rely on invoking whatever mysqldump/pg_dump/sqlite3 is available in `$PATH`. Sometimes we'd like to rely on a specific version, alternate install, or a Docker container. Quick override here to match the dump/load flags setup.

(Actually getting this working with Docker is a bit of a pain since load/dump rely on filenames rather than stdin/stdout. Gotta mount a volume with the same path that AR passes to dump/load.)