### PR TITLE
Port caching documentation fix to stable-5.2

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -295,7 +295,7 @@ Consider the following example. An application has a `Product` model with an ins
 ```ruby
 class Product < ApplicationRecord
   def competing_price
-    Rails.cache.fetch("#{cache_key}/competing_price", expires_in: 12.hours) do
+    Rails.cache.fetch("#{cache_key_with_version}/competing_price", expires_in: 12.hours) do
       Competitor::API.find_price(id)
     end
   end


### PR DESCRIPTION
There's a documentation fix that's been on master for a while and I believe it should also be in `stable-5-2`. This is the commit with the fix that I cherry-picked: https://github.com/rails/rails/pull/34525/commits/95f9af8257d85764cc2938f0b81bdd39f60de468

The error can be seen here in this screenshot taken from the current rails guides:

![Screen Shot 2019-06-28 at 2 13 18 AM](https://user-images.githubusercontent.com/278462/60318762-a2d4de80-994a-11e9-9b98-10dc69bb398b.png)

The alert at the bottom mentions using the `cache_key_with_version` method but the sample code uses `cache_key`. 