### PR TITLE
Implement a preload_descendant interface for DescendantTracker

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -9,6 +9,10 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
+    initializer "active_support.descendants_tracker_preloading" do |app|
+      DescendantsTracker.preloading_required = !app.config.eager_load
+    end
+
     initializer "active_support.set_authenticated_message_encryption" do |app|
       config.after_initialize do
         unless app.config.active_support.use_authenticated_message_encryption.nil?

--- a/activesupport/test/descendants_tracker_with_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_with_autoloading_test.rb
@@ -8,6 +8,10 @@ require "descendants_tracker_test_cases"
 class DescendantsTrackerWithAutoloadingTest < ActiveSupport::TestCase
   include DescendantsTrackerTestCases
 
+  def setup
+    ActiveSupport::DescendantsTracker.preloading_required = true
+  end
+
   def test_clear_with_autoloaded_parent_children_and_grandchildren
     mark_as_autoloaded(*ALL) do
       ActiveSupport::DescendantsTracker.clear
@@ -32,5 +36,27 @@ class DescendantsTrackerWithAutoloadingTest < ActiveSupport::TestCase
       assert_equal_sets [], Child1.descendants
       assert_equal_sets [], Child2.descendants
     end
+  end
+
+  def test_preload_descendants_is_called_once_if_autoloading_is_enabled
+    refute_predicate Parent, :preload_descendants_called
+    Parent.descendants
+    assert_predicate Parent, :preload_descendants_called
+
+    Parent.preload_descendants_called = false
+    Parent.descendants
+    refute_predicate Parent, :preload_descendants_called
+  end
+
+  def test_clear_reset_preload_descendants_memorization
+    refute_predicate Parent, :preload_descendants_called
+    Parent.descendants
+    assert_predicate Parent, :preload_descendants_called
+
+    Parent.preload_descendants_called = false
+    ActiveSupport::DescendantsTracker.clear
+
+    Parent.descendants
+    assert_predicate Parent, :preload_descendants_called
   end
 end

--- a/activesupport/test/descendants_tracker_without_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_without_autoloading_test.rb
@@ -16,4 +16,10 @@ class DescendantsTrackerWithoutAutoloadingTest < ActiveSupport::TestCase
       assert_not ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants).key?(parent_instance.singleton_class)
     end
   end
+
+  def test_preload_descendants_is_not_called_if_autoloading_is_disabled
+    refute_predicate Parent, :preload_descendants_called
+    Parent.descendants
+    refute_predicate Parent, :preload_descendants_called
+  end
 end


### PR DESCRIPTION
This allow classes including DesendantTracker to define a hook
to be called when `descendants` is called in an environment that
doesn't fully eager load the application.

e.g.

```ruby
class MyBase
  class << self
    def preload_descendants
      Dir[Rails.root.join('app/models/my_base/*.rb')].each do |path|
        require path
      end
    end
  end
end
```

While totally optional, this allows to ensure that `MyBase.descendant`
will have the same behavior in development and production.


@fxn @Edouard-chin @rafaelfranca here's the first draft of what we discussed in https://github.com/rails/rails/pull/36487 feedback welcome.