### PR TITLE
Backports Rails 6 ActiveStorage's route_prefix

### DIFF
--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "/rails/active_storage/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+  scope ActiveStorage.routes_prefix do
+    get "/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
+    get "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
+    put "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
+    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+  end
 
   direct :rails_blob do |blob, options|
     route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
@@ -9,9 +15,6 @@ Rails.application.routes.draw do
 
   resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
   resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
-
-
-  get "/rails/active_storage/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations#show", as: :rails_blob_representation
 
   direct :rails_representation do |representation, options|
     signed_blob_id = representation.blob.signed_id
@@ -24,8 +27,4 @@ Rails.application.routes.draw do
   resolve("ActiveStorage::Variant") { |variant, options| route_for(:rails_representation, variant, options) }
   resolve("ActiveStorage::Preview") { |preview, options| route_for(:rails_representation, preview, options) }
 
-
-  get  "/rails/active_storage/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-  put  "/rails/active_storage/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-  post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -50,4 +50,5 @@ module ActiveStorage
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline, default: []
   mattr_accessor :binary_content_type, default: "application/octet-stream"
+  mattr_accessor :routes_prefix, default: "/rails/active_storage"
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -55,11 +55,12 @@ module ActiveStorage
 
     initializer "active_storage.configs" do
       config.after_initialize do |app|
-        ActiveStorage.logger     = app.config.active_storage.logger || Rails.logger
-        ActiveStorage.queue      = app.config.active_storage.queue
-        ActiveStorage.previewers = app.config.active_storage.previewers || []
-        ActiveStorage.analyzers  = app.config.active_storage.analyzers || []
-        ActiveStorage.paths      = app.config.active_storage.paths || {}
+        ActiveStorage.logger            = app.config.active_storage.logger || Rails.logger
+        ActiveStorage.queue             = app.config.active_storage.queue
+        ActiveStorage.previewers        = app.config.active_storage.previewers || []
+        ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
+        ActiveStorage.paths             = app.config.active_storage.paths || {}
+        ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/31228

This should be a non-breaking change that brings in the ability to configure Active Storage's `route_prefix`. This will allow Rails 5.2 applications use ActiveStorage with:
- Catchall routes
- Reverse proxies with multiple Rails apps with Active Storage while sharing a domain.