### PR TITLE
ActionText on specific database column

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Adds `has_rich_text_field` method to use ActionText with a specific database column instead of the general table.
+    ```ruby
+    class Message < ActiveRecord::Base
+      has_rich_text_field :content
+    end
+    ```
+    *William Johnston*
+
 *   The `fill_in_rich_text_area` system test helper locates a Trix editor and fills it in with the given HTML:
 
     ```ruby

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -49,6 +49,7 @@ module ActionView::Helpers
     end
 
     def editable_value
+      return value.to_trix_html if value.is_a?(ActionText::Content)
       value&.body.try(:to_trix_html)
     end
   end

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -8,15 +8,10 @@ module ActionText
   class RichText < ActiveRecord::Base
     self.table_name = "action_text_rich_texts"
 
-    serialize :body, ActionText::Content
+    has_rich_text_field :body, attachment_field_name: :embeds
     delegate :to_s, :nil?, to: :body
 
     belongs_to :record, polymorphic: true, touch: true
-    has_many_attached :embeds
-
-    before_save do
-      self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?
-    end
 
     def to_plain_text
       body&.to_plain_text.to_s

--- a/actiontext/test/dummy/app/controllers/posts_controller.rb
+++ b/actiontext/test/dummy/app/controllers/posts_controller.rb
@@ -1,0 +1,58 @@
+class PostsController < ApplicationController
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
+
+  # GET /posts
+  def index
+    @posts = Post.all
+  end
+
+  # GET /posts/1
+  def show
+  end
+
+  # GET /posts/new
+  def new
+    @post = Post.new
+  end
+
+  # GET /posts/1/edit
+  def edit
+  end
+
+  # POST /posts
+  def create
+    @post = Post.new(post_params)
+
+    if @post.save
+      redirect_to @post, notice: 'Post was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PATCH/PUT /posts/1
+  def update
+    if @post.update(post_params)
+      redirect_to @post, notice: 'Post was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE /posts/1
+  def destroy
+    @post.destroy
+    redirect_to posts_url, notice: 'Post was successfully destroyed.'
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_post
+      @post = Post.find(params[:id])
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def post_params
+      params.require(:post).permit(:title, :body)
+    end
+end

--- a/actiontext/test/dummy/app/models/comment.rb
+++ b/actiontext/test/dummy/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ApplicationRecord
+  belongs_to :post
+
+  has_rich_text_field :comment_contents
+end

--- a/actiontext/test/dummy/app/models/post.rb
+++ b/actiontext/test/dummy/app/models/post.rb
@@ -1,0 +1,6 @@
+class Post < ApplicationRecord
+  has_many :comments
+  accepts_nested_attributes_for :comments
+
+  has_rich_text_field :custom_body
+end

--- a/actiontext/test/dummy/config/routes.rb
+++ b/actiontext/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :messages
+  resources :posts
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/actiontext/test/dummy/db/migrate/20190629134851_create_posts.rb
+++ b/actiontext/test/dummy/db/migrate/20190629134851_create_posts.rb
@@ -1,0 +1,9 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :custom_body, size: :long
+      t.timestamps
+    end
+  end
+end

--- a/actiontext/test/dummy/db/migrate/20190629134852_create_comments.rb
+++ b/actiontext/test/dummy/db/migrate/20190629134852_create_comments.rb
@@ -1,0 +1,9 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.belongs_to :post, null: false
+      t.string :author_name, null: false
+      t.text :comment_contents, size: :long
+    end
+  end
+end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_17_200724) do
+ActiveRecord::Schema.define(version: 2019_06_29_134852) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,13 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.string "author_name", null: false
+    t.text "comment_contents"
+    t.index ["post_id"], name: "index_comments_on_post_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.string "subject"
     t.datetime "created_at", precision: 6, null: false
@@ -57,6 +64,13 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
 
   create_table "people", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.text "custom_body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -39,6 +39,20 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
+  test "form with rich text area field" do
+    form_with model: Post.new(custom_body: "hello"), scope: :post do |form|
+      form.rich_text_area :custom_body
+    end
+
+    assert_dom_equal \
+      '<form action="/posts" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="post[custom_body]" id="post_custom_body_trix_input_post" value="hello" />' \
+        '<trix-editor id="post_custom_body" input="post_custom_body_trix_input_post" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
   test "form with rich text area having class" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_text_area :content, class: "custom-class"

--- a/actiontext/test/unit/attribute_test.rb
+++ b/actiontext/test/unit/attribute_test.rb
@@ -43,6 +43,15 @@ class ActionText::AttributeTest < ActiveSupport::TestCase
     assert_equal [ActiveStorage::Attachment], post.custom_body_attachments.map(&:class)
   end
 
+  test "embed extraction deduplicates file attachments" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    content = ActionText::Content.new("Hello world").append_attachables([ blob, blob ])
+
+    assert_nothing_raised do
+      Post.create!(title: "Greetings", custom_body: content)
+    end
+  end
+
   test "saving custom_body" do
     post = Post.create(title: "Greetings", custom_body: "<h1>Hello world</h1>")
     assert_equal "Hello world", post.custom_body.to_plain_text

--- a/actiontext/test/unit/attribute_test.rb
+++ b/actiontext/test/unit/attribute_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::AttributeTest < ActiveSupport::TestCase
+  test "html conversion" do
+    post = Post.new(title: "Greetings", custom_body: "<h1>Hello world</h1>")
+    assert_equal %Q(<div class="trix-content">\n  <h1>Hello world</h1>\n</div>\n), "#{post.custom_body}"
+  end
+
+  test "plain text conversion" do
+    post = Post.new(title: "Greetings", custom_body: "<h1>Hello world</h1>")
+    assert_equal "Hello world", post.custom_body.to_plain_text
+  end
+
+  test "without content" do
+    post = Post.create!(title: "Greetings")
+    assert post.custom_body.nil?
+    assert post.custom_body.blank?
+    assert_not post.custom_body.present?
+  end
+
+  test "with blank content" do
+    post = Post.create!(title: "Greetings", custom_body: "")
+    assert_not post.custom_body.nil?
+    assert post.custom_body.blank?
+    assert post.custom_body.empty?
+    assert_not post.custom_body.present?
+  end
+
+  test "embed extraction" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    post = Post.create!(title: "Greetings", custom_body: ActionText::Content.new("Hello world").append_attachables(blob))
+    assert_equal "racecar.jpg", post.custom_body_attachments.first.filename.to_s
+  end
+
+  test "embed extraction only extracts file attachments" do
+    remote_image_html = '<action-text-attachment content-type="image" url="http://example.com/cat.jpg"></action-text-attachment>'
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    content = ActionText::Content.new(remote_image_html).append_attachables(blob)
+    post = Post.create!(title: "Greetings", custom_body: content)
+    assert_equal [ActionText::Attachables::RemoteImage, ActiveStorage::Blob], post.custom_body.attachables.map(&:class)
+    assert_equal [ActiveStorage::Attachment], post.custom_body_attachments.map(&:class)
+  end
+
+  test "saving custom_body" do
+    post = Post.create(title: "Greetings", custom_body: "<h1>Hello world</h1>")
+    assert_equal "Hello world", post.custom_body.to_plain_text
+  end
+
+  test "saving content via nested attributes" do
+    post = Post.create! title: "Greetings", custom_body: "<h1>Hello world</h1>",
+      comments_attributes: [{ author_name: "Marcia", comment_contents: "Nice work!" }]
+    assert_equal "Nice work!", post.comments.first.comment_contents.to_plain_text
+  end
+
+  test "updating content via nested attributes" do
+    post = Post.create! title: "Greetings", custom_body: "<h1>Hello world</h1>",
+      comments_attributes: [{ author_name: "Marcia", comment_contents: "Nice work!" }]
+
+    post.update! comments_attributes: { id: post.comments.first.id, comment_contents: "Great work!" }
+    assert_equal "Great work!", post.comments.first.reload.comment_contents.to_plain_text
+  end
+end


### PR DESCRIPTION
ActionText for ease of use and implementation uses a discrete table for all content. At a point in scale, or for sake of database simplicity, this may not be preferred.

This PR adds the option of using ActionText on a specific column, rather than the discrete table. It adds a `has_rich_text_field` method to define this behavior. The `has_rich_text_field` method is also used to simplify the standard model mechanism, as the behavior of its `body` field is essentially identical.

Thanks for considering this!