### PR TITLE
Support :any variants for ActionView::FixtureResolver

### DIFF
--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -7,10 +7,15 @@ module ActionView #:nodoc:
   # file system. This is used internally by Rails' own test suite, and is
   # useful for testing extensions that have no way of knowing what the file
   # system will look like at runtime.
-  class FixtureResolver < PathResolver
+  class FixtureResolver < OptimizedFileSystemResolver
     def initialize(hash = {}, pattern = nil)
-      super(pattern)
+      super("")
+      if pattern
+        ActiveSupport::Deprecation.warn "Specifying a custom path for #{self.class} is deprecated. Implement a custom Resolver subclass instead."
+        @pattern = pattern
+      end
       @hash = hash
+      @path = ""
     end
 
     def data
@@ -23,25 +28,32 @@ module ActionView #:nodoc:
 
     private
       def query(path, exts, _, locals, cache:)
-        query = +""
-        EXTENSIONS.each do |ext, prefix|
-          query << "(" << exts[ext].map { |e| e && Regexp.escape("#{prefix}#{e}") }.join("|") << "|)"
-        end
-        query = /^(#{Regexp.escape(path)})#{query}$/
+        regex = build_regex(path, exts)
 
-        templates = []
-        @hash.each do |_path, source|
-          next unless query.match?(_path)
+        @hash.select do |_path, _|
+          ("/" + _path).match?(regex)
+        end.map do |_path, source|
           handler, format, variant = extract_handler_and_format_and_variant(_path)
-          templates << Template.new(source, _path, handler,
+
+          Template.new(source, _path, handler,
             virtual_path: path.virtual,
             format: format,
             variant: variant,
             locals: locals
           )
+        end.sort_by do |t|
+          match = ("/" + t.identifier).match(regex)
+          EXTENSIONS.keys.reverse.map do |ext|
+            if ext == :variants && exts[ext] == :any
+              match[ext].nil? ? 0 : 1
+            elsif match[ext].nil?
+              exts[ext].length
+            else
+              found = match[ext].to_sym
+              exts[ext].index(found)
+            end
+          end
         end
-
-        templates.sort_by { |t| -t.identifier.match(/^#{query}$/).captures.reject(&:blank?).size }
       end
   end
 

--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -27,4 +27,26 @@ class FixtureResolverTest < ActiveSupport::TestCase
     assert_equal :html,           templates.first.format
     assert_equal "variant",       templates.first.variant
   end
+
+  def test_should_match_locales
+    resolver = ActionView::FixtureResolver.new("arbitrary/path.erb" => "this text", "arbitrary/path.fr.erb" => "ce texte")
+    en = resolver.find_all("path", "arbitrary", false, locale: [:en], formats: [:html], variants: [], handlers: [:erb])
+    fr = resolver.find_all("path", "arbitrary", false, locale: [:fr], formats: [:html], variants: [], handlers: [:erb])
+
+    assert_equal 1, en.size
+    assert_equal 2, fr.size
+
+    assert_equal "this text", en[0].source
+    assert_equal "ce texte",  fr[0].source
+    assert_equal "this text", fr[1].source
+  end
+
+  def test_should_return_all_variants_for_any
+    resolver = ActionView::FixtureResolver.new("arbitrary/path.html.erb" => "this html", "arbitrary/path.html+varient.erb" => "this text")
+    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    assert_equal 1, templates.size, "expected one template"
+    assert_equal "this html", templates.first.source
+    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: :any, handlers: [:erb])
+    assert_equal 2, templates.size, "expected all templates"
+  end
 end


### PR DESCRIPTION
### Summary

Currently, `ActionView::FixtureResolver` doesn't support `:any` variants.
As a result, we can't use `ActionView::FixtureResolver` in some tests which raise an exception like `ActionController::UnknownFormat`

https://github.com/rails/rails/blob/89afd816bdf8e5625237891c2ff0ac2db71ea5d6/actionpack/test/controller/render_test.rb#L711-L713

```
Failure:
ImplicitRenderTest#test_implicit_unknown_format_response [/app/actionpack/test/controller/render_test.rb:726]:
[ActionController::UnknownFormat] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `map' for :any:Symbol\nDid you mean?  tap">
```

### Other Information

This change is needed to fix flaky test `ActionControllerBaseRenderTest#test_direct_render_to_string`.

https://github.com/rails/rails/pull/36504