### PR TITLE
Convert dates using to_time rather than to_datetime for comparison

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Fix comparison of a Time object with a Date object when the Rails process is in a positive UTC offset.
+
+    Before, if the Rails process was running in a positive UTC offset and a date was compared
+    to a time where the time had a zone within the offset the comparison would be wrong, for
+    example:
+
+        $ TZ=Europe/London irb -r 'active_support/all'
+        > current_time = Time.parse('Tue, 11 Jun 2019 00:30:00 BST +01:00')
+        => 2019-06-11 00:30:00 +0100
+        > current_date = current_time.to_date
+        => Tue, 11 Jun 2019
+        > current_date <= current_time
+        => false
+
+    This happened because `date_obj <=> time_obj` would implicitly convert the date_obj to
+    the UTC timezone before comparison.
+
+    After this change, the date object is converted to a time object for the comparison,
+    but is given the timezone of the running process:
+
+        $ TZ=Europe/London irb -r 'active_support/all'
+        > current_time = Time.parse('Tue, 11 Jun 2019 00:30:00 BST +01:00')
+        => 2019-06-11 00:30:00 +0100
+        > current_date = current_time.to_date
+        => Tue, 11 Jun 2019
+        > current_date <= current_time
+        => true
+
+    *Will Jessop*
+
 *   When an instance of `ActiveSupport::Duration` is converted to an `iso8601` duration string, if `weeks` are mixed with `date` parts, the `week` part will be converted to days.
     This keeps the parser and serializer on the same page.
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -133,10 +133,11 @@ class Date
     )
   end
 
-  # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.
+  # Allow Date to be compared with Time by converting to either a Time object or a DateTime object and relying on
+  # the <=> from there. Using beginning_of_day converts the date respecting the process's current timezone.
   def compare_with_coercion(other)
     if other.is_a?(Time)
-      to_datetime <=> other
+      beginning_of_day <=> other
     else
       compare_without_coercion(other)
     end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -72,6 +72,15 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert Date.yesterday < Time.now
   end
 
+  def test_compare_date_to_time_with_positive_utc_offset
+    Time.use_zone("London") do
+      current_time = Time.zone.parse("Tue, 11 Jun 2019 00:30:00 BST +01:00")
+      assert_equal true, current_time.to_date < current_time
+      assert_equal false, current_time.to_date == current_time
+      assert_equal false, current_time.to_date > current_time
+    end
+  end
+
   def test_to_datetime
     assert_equal DateTime.civil(2005, 2, 21), Date.new(2005, 2, 21).to_datetime
     assert_equal 0, Date.new(2005, 2, 21).to_datetime.offset # use UTC offset


### PR DESCRIPTION
Fixes #36462, replicated in Rails master, Ruby 2.6.3

`to_datetime` creates an implicit +0000 UTC offset throwing comparisons with positive UTC offset times out, whereas `to_time` respects the current TZ.

### Summary

The original issue that can be summed up by this code:

```
$ TZ=Europe/London irb -r 'active_support/all'
> current_time = Time.parse('Tue, 11 Jun 2019 00:30:00 BST +01:00')
=> 2019-06-11 00:30:00 +0100
> current_date = current_time.to_date
=> Tue, 11 Jun 2019
> current_date <= current_time
=> false
```

The user is expecting the comparison to return true:

```
> current_date <= current_time
=> true
```

but it returns false.

### Other Information

Why does it do that and why is this an issue? If we expand the variables `2019-06-11 00:30:00 +0100` unzoned is effectively the same as `2019-06-10 23:30:00 +0000` (ie. UTC) for the comparison. But the date, `Tue, 11 Jun 2019`, contains no time or zone information and so when we expand this to a time, as happens in [the comparison code](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/date/calculations.rb#L1360) we get `2019-06-11 00:00:00 +0000`. The comparison is effectively therefore:

```
2019-06-11 00:00:00 +0000 <= 2019-06-10 23:30:00 +0000
```

This is clearly going to return the unexpected false result (note day of month). So is it reasonable for the user to expect the comparison to return true here? I think so. If you accept that comparing dates and times are a thing, it should be possible to compare a date with a time with a positive timezone accurately, and currently the further you get from UTC the less reliable these get, here's Rails getting weird with a 6 hour 30 time difference:

```
> current_time = Time.parse('Tue, 11 Jun 2019 06:30:00 +0700')
=> 2019-06-11 06:30:00 +0700
> current_date = current_time.to_date
=> Tue, 11 Jun 2019
> current_date < current_time
=> false
```

So why does this happen? [Here is the code that does the comparison](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/date/calculations.rb#L1360) in Rails currently:

```ruby
class Date
  …
  def compare_with_coercion(other)
    if other.is_a?(Time)
      to_datetime <=> other
    else
      compare_without_coercion(other)
    end
  end
end
```

This code converts an instance of Date to a DateTime object using `to_datetime`, then compares that to the Time object. This is the root of the issue as I hope to explain. In Ruby the Date object doesn't contain any time or zone data (which seems reasonable):

```
> Time.now
=> 2019-06-29 12:43:20 +0100
> Date.today.strftime("%z")
=> "+0000"
```

This means that when calling `to_datetime` on it there is no time or zone data to work with in the Date object itself, so a default value is used.

```
$ irb -r 'active_support/all'
> td = Time.now.to_date
=> Sat, 29 Jun 2019
> td.strftime("%z")
=> "+0000"

> td.to_datetime
=> Sat, 29 Jun 2019 00:00:00 +0000
> td.to_datetime.strftime("%z")
=> "+0000"

> td.to_time
=> 2019-06-29 00:00:00 +0100
> td.to_time.strftime("%z")
=> "+0100"
```

This difference between to_time and to_datetime seems like a bug in Ruby, though perhaps a hard one to change given the amount of code out there that will be relying on the current behaviours :)

Anyway, what this means for Rails is that the conversion of Date to DateTime creates *implicit* 00:00:00 +0000 time and zone data, which will influence the comparison between times with an offset. When we compare a time to a date using this code we are effectively moving the *date* to UTC, but leaving the *time* in it's original timezone before doing the comparison.

We can fix this though by changing the conversion in `compare_with_coercion` to `to_time`:

```
def compare_with_coercion(other)
  if other.is_a?(Time)
    to_time <=> other
  else
    compare_without_coercion(other)
  end
end
```

This works because of that subtle difference in Ruby mentioned above. `to_datetime` defaults to no zone data (+0000), but `to_time` defaults to the current TZ:

```
$ TZ=US/Eastern irb -r 'active_support/all'
> Date.today.to_time
=> 2019-06-30 00:00:00 -0400
```

Comparisons now happen as you might expect:

```
$ TZ=Europe/London irb -r 'active_support/all'
> current_time = Time.parse('Tue, 11 Jun 2019 00:30:00 BST +01:00')
=> 2019-06-11 00:30:00 +0100
> current_date = current_time.to_date
=> Tue, 11 Jun 2019
> current_date <= current_time
=> true
```

This works just great, except date.to_time doesn't actually take `Time.zone` into account which can be set using the activesupport method `Time.use_zone`, it only takes the TZ set for the process environment. To handle this condition we need to branch, using DateTime to create a comparable object, because (as far as I can tell) it's the cleanest way of creating a time like object but pinning the conversion to a specified zone

```ruby
if Time.zone
  DateTime.new(year, month, day, 0, 0, 0, Time.zone.now.formatted_offset)
else
  to_time
end
```

It looks like this code was originaly `to_time` but was changed to `to_datetime` in commit f9c2f76bea41c4a7ad1419844c6102211787c458, so if there's a technical reason for it to be `to_datetime` DHH might know.
