### PR TITLE
[skip ci] use 'template' instead of 'create_file' for erb templates in generators guide

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -252,7 +252,7 @@ Add the method below, so our generator looks like the following:
 # lib/generators/rails/my_helper/my_helper_generator.rb
 class Rails::MyHelperGenerator < Rails::Generators::NamedBase
   def create_helper_file
-    create_file "app/helpers/#{file_name}_helper.rb", <<-FILE
+    template "app/helpers/#{file_name}_helper.rb", <<-FILE
 module #{class_name}Helper
   attr_reader :#{plural_name}, :#{plural_name.singularize}
 end
@@ -307,7 +307,7 @@ To do that, we can change the generator this way:
 # lib/generators/rails/my_helper/my_helper_generator.rb
 class Rails::MyHelperGenerator < Rails::Generators::NamedBase
   def create_helper_file
-    create_file "app/helpers/#{file_name}_helper.rb", <<-FILE
+    template "app/helpers/#{file_name}_helper.rb", <<-FILE
 module #{class_name}Helper
   attr_reader :#{plural_name}, :#{plural_name.singularize}
 end


### PR DESCRIPTION
### Summary

In sections [5](https://guides.rubyonrails.org/generators.html#customizing-your-workflow) and [6](https://guides.rubyonrails.org/generators.html#customizing-your-workflow-by-changing-generators-templates) of the currently published Generators guide, examples are given for how to use ERB in templates.

Unfortunately, the `create_file` method invoked inside a generator appears to no longer support ERB substitution. Using `template` instead of `create_file` allows ERB substitution to work.

This PR changes the two examples with ERB compilation to use `template` instead of `create_file`.


