### PR TITLE
Preload browser driver_path to fix system testing under parallelism

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -4,6 +4,7 @@ gem "capybara", ">= 2.15"
 
 require "capybara/dsl"
 require "capybara/minitest"
+require "selenium/webdriver"
 require "action_controller"
 require "action_dispatch/system_testing/driver"
 require "action_dispatch/system_testing/browser"

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -39,6 +39,19 @@ module ActionDispatch
           end
       end
 
+      # driver_path can be configured as a proc. The webdrivers gem uses this
+      # proc to update web drivers. Running this proc early allows us to only
+      # update the webdriver once and avoid race conditions when using
+      # parallel tests.
+      def preload
+        case type
+        when :chrome
+          ::Selenium::WebDriver::Chrome::Service.driver_path.try(:call)
+        when :firefox
+          ::Selenium::WebDriver::Firefox::Service.driver_path.try(:call)
+        end
+      end
+
       private
         def headless_chrome_browser_options
           capabilities.args << "--headless"

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -9,6 +9,8 @@ module ActionDispatch
         @screen_size = options[:screen_size]
         @options = options[:options]
         @capabilities = capabilities
+
+        @browser.preload
       end
 
       def use

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -120,4 +120,17 @@ class DriverTest < ActiveSupport::TestCase
       driver.use
     end
   end
+
+  test "preloads browser's driver_path" do
+    called = false
+
+    original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
+    ::Selenium::WebDriver::Chrome::Service.driver_path = -> { called = true }
+
+    ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
+
+    assert called
+  ensure
+    ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
+  end
 end


### PR DESCRIPTION
The `webdrivers` gem configures `Selenium::WebDriver::Service.driver_path` as a proc which updates the web drivers and returns their path.

This commit introduces `SystemTesting::Browser#preload`, which runs this proc early. This ensures that webdrivers update is run before forking for parallel testing, but doesn't explicitly tie us to that gem (and I think anything configured as driver_path probably makes sense to eager-load).

cc @rmacklin @eileencodes

Fixes #36288
Closes #36292