### PR TITLE
Update docs regarding skipping CI tests [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -139,7 +139,7 @@ changes to the master branch.
 
 When working with documentation, please take into account the [API Documentation Guidelines](api_documentation_guidelines.html) and the [Ruby on Rails Guides Guidelines](ruby_on_rails_guides_guidelines.html).
 
-NOTE: To help our CI servers you should add [ci skip] to your documentation commit message to skip build on that commit. Please remember to use it for commits containing only documentation changes.
+NOTE: For documentation changes, your commit message should include [ci skip]. This will skip the running the test suite, helping us to cut down on our server costs. Keep in mind that you should only skip CI when your change touches documentation exclusively.
 
 Translating Rails Guides
 ------------------------


### PR DESCRIPTION
### Summary

I noticed this while skimming random docs, obviously, this is subjective.

### Other Information

The phrasing of this struck me as odd, "To help our CI servers..." So I
feel it would be more useful if we explain more explicitly that ci skip
cuts down on usage by not running CI.
