### PR TITLE
Include handy migration-related rake tasks in rake -T output

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -112,7 +112,7 @@ db_namespace = namespace :db do
       end
     end
 
-    # desc  'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
+    desc "Rolls back the database one migration and re-migrates up (options: STEP=x, VERSION=x)."
     task redo: :load_config do
       raise "Empty VERSION provided" if ENV["VERSION"] && ENV["VERSION"].empty?
 
@@ -128,7 +128,7 @@ db_namespace = namespace :db do
     # desc 'Resets your database using your migrations for the current environment'
     task reset: ["db:drop", "db:create", "db:migrate"]
 
-    # desc 'Runs the "up" for a given migration VERSION.'
+    desc 'Runs the "up" for a given migration VERSION.'
     task up: :load_config do
       ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:migrate:up")
 
@@ -162,7 +162,7 @@ db_namespace = namespace :db do
       end
     end
 
-    # desc 'Runs the "down" for a given migration VERSION.'
+    desc 'Runs the "down" for a given migration VERSION.'
     task down: :load_config do
       ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:migrate:down")
 


### PR DESCRIPTION
This adds the `migrate:up`, `migrate:down`, and `migrate:redo` commands to the output of `rake -T`.

With their descriptions commented out these commands were not appearing in the commands listed by `rake -T`, which is a shame as they are useful, particularly during the development of more complex migrations.

Looking back at the history, it looks like they were commented out to "Cut down even further on rake -T noise" back in 2010 (see 983815632cc1d316c7c803a47be28f1abe6698fb). I think the value of exposing these potentially useful rake tasks to developers is greater than the noise of three extra lines in the output of the command.