### PR TITLE
Fix Browser#preload for older Selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 gem "rake", ">= 11.1"
 
 gem "capybara", ">= 2.15"
-gem "selenium-webdriver", ">= 3.5.0"
+gem "selenium-webdriver", ">= 3.141.592"
 
 gem "rack-cache", "~> 1.2"
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,7 +582,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   sdoc (~> 1.0)
-  selenium-webdriver (>= 3.5.0)
+  selenium-webdriver (>= 3.141.592)
   sequel
   sidekiq
   sneakers

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -46,9 +46,19 @@ module ActionDispatch
       def preload
         case type
         when :chrome
-          ::Selenium::WebDriver::Chrome::Service.driver_path.try(:call)
+          if ::Selenium::WebDriver::Service.respond_to? :driver_path=
+            ::Selenium::WebDriver::Chrome::Service.driver_path.try(:call)
+          else
+            # Selenium <= v3.141.0
+            ::Selenium::WebDriver::Chrome.driver_path
+          end
         when :firefox
-          ::Selenium::WebDriver::Firefox::Service.driver_path.try(:call)
+          if ::Selenium::WebDriver::Service.respond_to? :driver_path=
+            ::Selenium::WebDriver::Firefox::Service.driver_path.try(:call)
+          else
+            # Selenium <= v3.141.0
+            ::Selenium::WebDriver::Firefox.driver_path
+          end
         end
       end
 


### PR DESCRIPTION
Follow up to #36592 

Older versions of selenium had `driver_path` on `::Selenium::WebDriver::Chrome` directly, not on `...::Service`. This avoids errors on those old versions and will preload properly if webdrivers is installed.

I learned this because I broke tests on 6-0-stable when backporting the initial commit (oops! 😳). We'll probably want to also bump the selenium version on 6-0-stable to make the test added in #36592 pass.