### PR TITLE
Add `skip-collision-check` option to generator

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -20,6 +20,8 @@ module Rails
 
       class_option :skip_namespace, type: :boolean, default: false,
                                     desc: "Skip namespace (affects only isolated applications)"
+      class_option :skip_collision_check, type: :boolean, default: false,
+                                          desc: "Skip collision check"
 
       add_runtime_options!
       strict_args_position!
@@ -249,6 +251,7 @@ module Rails
         # application or Ruby on Rails.
         def class_collisions(*class_names)
           return unless behavior == :invoke
+          return if options.skip_collision_check?
 
           class_names.flatten.each do |class_name|
             class_name = class_name.to_s
@@ -261,8 +264,8 @@ module Rails
 
             if last && last.const_defined?(last_name.camelize, false)
               raise Error, "The name '#{class_name}' is either already used in your application " \
-                           "or reserved by Ruby on Rails. Please choose an alternative and run "  \
-                           "this generator again."
+                           "or reserved by Ruby on Rails. Please choose an alternative or use --skip-collision-check "  \
+                           "to skip this check and run this generator again."
             end
           end
         end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -198,5 +198,15 @@ module ApplicationTests
         assert_no_match "active_record:migration", output
       end
     end
+
+    test "skip collision check" do
+      rails("generate", "model", "post", "title:string")
+
+      output = rails("generate", "model", "post", "title:string", "body:string")
+      assert_match(/The name 'Post' is either already used in your application or reserved/, output)
+
+      output = rails("generate", "model", "post", "title:string", "body:string", "--skip-collision-check")
+      assert_no_match(/The name 'Post' is either already used in your application or reserved/, output)
+    end
   end
 end


### PR DESCRIPTION
Until Rails 5.2, generators can run same name multi times without destroying.
But Rails 6.0(with Zeitwerk) can't this. In Rails 6.0, an error occurs due to class name collision check.

The check uses `const_defined?`, which assumes that the autoload object
is also defined.
https://ruby-doc.org/core-2.6.3/Module.html#method-i-const_defined-3F

It did not work until Rails 5.2, but Zeitwerk seems to be able to correctly check this against the application's code.

However, this is a little inconvenient if want to run the generator again like mistake an attribute name(need to run `destoy` before).
In order to solve this, this PR adds an option to skip the collision check. With this option, can overwrite files just as did until Rails 5.2.