### PR TITLE
MySQL: Fix schema dumping `enum` and `set` columns correctly

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -41,13 +41,15 @@ module ActiveRecord
             case column.sql_type
             when /\Atimestamp\b/
               :timestamp
+            when /\A(?:enum|set)\b/
+              column.sql_type
             else
               super
             end
           end
 
           def schema_limit(column)
-            super unless /\A(?:tiny|medium|long)?(?:text|blob)/.match?(column.sql_type)
+            super unless /\A(?:enum|set|(?:tiny|medium|long)?(?:text|blob))\b/.match?(column.sql_type)
           end
 
           def schema_precision(column)

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -146,7 +146,11 @@ HEADER
             raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
             next if column.name == pk
             type, colspec = column_spec(column)
-            tbl.print "    t.#{type} #{column.name.inspect}"
+            if type.is_a?(Symbol)
+              tbl.print "    t.#{type} #{column.name.inspect}"
+            else
+              tbl.print "    t.column #{column.name.inspect}, #{type.inspect}"
+            end
             tbl.print ", #{format_colspec(colspec)}" if colspec.present?
             tbl.puts
           end

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "support/schema_dumping_helper"
 
 class Mysql2EnumTest < ActiveRecord::Mysql2TestCase
+  include SchemaDumpingHelper
+
   class EnumTest < ActiveRecord::Base
+  end
+
+  def setup
+    EnumTest.connection.create_table :enum_tests, id: false, force: true do |t|
+      t.column :enum_column, "enum('text','blob','tiny','medium','long','unsigned','bigint')"
+    end
   end
 
   def test_enum_limit
@@ -19,5 +28,10 @@ class Mysql2EnumTest < ActiveRecord::Mysql2TestCase
   def test_should_not_be_bigint
     column = EnumTest.columns_hash["enum_column"]
     assert_not_predicate column, :bigint?
+  end
+
+  def test_schema_dumping
+    schema = dump_table_schema "enum_tests"
+    assert_match %r{t\.column "enum_column", "enum\('text','blob','tiny','medium','long','unsigned','bigint'\)"$}, schema
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/set_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/set_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+class Mysql2SetTest < ActiveRecord::Mysql2TestCase
+  include SchemaDumpingHelper
+
+  class SetTest < ActiveRecord::Base
+  end
+
+  def setup
+    SetTest.connection.create_table :set_tests, id: false, force: true do |t|
+      t.column :set_column, "set('text','blob','tiny','medium','long','unsigned','bigint')"
+    end
+  end
+
+  def test_should_not_be_unsigned
+    column = SetTest.columns_hash["set_column"]
+    assert_not_predicate column, :unsigned?
+  end
+
+  def test_should_not_be_bigint
+    column = SetTest.columns_hash["set_column"]
+    assert_not_predicate column, :bigint?
+  end
+
+  def test_schema_dumping
+    schema = dump_table_schema "set_tests"
+    assert_match %r{t\.column "set_column", "set\('text','blob','tiny','medium','long','unsigned','bigint'\)"$}, schema
+  end
+end

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -40,7 +40,7 @@ if current_adapter?(:Mysql2Adapter)
         end
 
         def test_enum_type_with_value_matching_other_type
-          assert_lookup_type :string, "ENUM('unicode', '8bit', 'none')"
+          assert_lookup_type :string, "ENUM('unicode', '8bit', 'none', 'time')"
         end
 
         def test_binary_types

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -62,10 +62,6 @@ ActiveRecord::Schema.define do
     t.binary :binary_column,    limit: 1
   end
 
-  create_table :enum_tests, id: false, force: true do |t|
-    t.column :enum_column, "ENUM('text','blob','tiny','medium','long','unsigned','bigint')"
-  end
-
   execute "DROP PROCEDURE IF EXISTS ten"
 
   execute <<~SQL


### PR DESCRIPTION
`enum` and `set` are typed cast as `:string`, but currently the
`:string` type is incorrectly reused for schema dumping.

A cast type on columns is not always the same with `sql_type`, this
fixes schema dumping `enum` and `set` columns to use `sql_type` instead
of `type` correctly.