### PR TITLE
Add ActiveRecord::AttributeMethods::ClassMethods#alias_attributes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -261,6 +261,21 @@ module ActiveRecord
       @attributes.to_hash
     end
 
+    # Returns a hash of all the alias names of the attributes as keys and the values of the attributes as values.
+    #
+    #   class Person < ActiveRecord::Base
+    #     alias_attribute :first_name, :FirstName
+    #     alias_attribute :last_name, :LastName
+    #   end
+    #
+    #   person = Person.create(FirstName: 'Francesco', LastName: 'Church')
+    #   person.alias_attributes
+    #   # => {"first_name"=>"Francesco", "last_name"=>"Church"}
+    def alias_attributes
+      attrs = attributes
+      attribute_aliases.transform_values { |v| attrs[v] }
+    end
+
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated up to 50
     # characters, Date and Time attributes are returned in the

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -110,6 +110,29 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_predicate Topic.find(2), :approved?
   end
 
+  test "alias_attributes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+
+      alias_attribute :heading, :title
+      alias_attribute :author, :author_name
+    end
+    topic = klass.new(title: "Ruby", author_name: "Jon")
+
+    assert_equal(topic.alias_attributes["heading"], "Ruby")
+    assert_equal(topic.alias_attributes["author"], "Jon")
+  end
+
+  test "alias_attributes with no alias defined for attributes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+    end
+    topic = klass.new(title: "Ruby", author_name: "Jon")
+
+    assert topic.alias_attributes.is_a?(Hash)
+    assert topic.alias_attributes.blank?
+  end
+
   test "set attributes" do
     topic = Topic.find(1)
     topic.attributes = { title: "Budget", author_name: "Jason" }


### PR DESCRIPTION
### Summary

When I built a Rails app on an existing database, I defined `alias_attribute` to pretty much every fields in models because column names in tables were out of Rails's naming convention.

So when I wanted to return hashes as json for API that have all the aliases as keys and the values of the attributes as values from models, I needed to manually create them.

This method automates that process:

```ruby
class Person < ActiveRecord::Base
  alias_attribute :first_name, :FirstName
  alias_attribute :last_name, :LastName
 end

person = Person.create(FirstName: 'Francesco', LastName: 'Church')
person.alias_attributes
# => {"first_name"=>"Francesco", "last_name"=>"Church"}
```

### Other Information
__why don't you use tools like `activemodel_serializer` and `jbuilder`?__
All I want to do is just return hashes as json that have `alias_attributes` as keys for API.
I don't think I should need to use those serializers and json builders just to do it.

__potentially better solution__
I feel it is probably more practical to add an option to `ActiveModel::Serialization#as_json` to output a hash with `alias_attribute` as keys.

```ruby
Person.as_json
# => {"id"=>1, "FirstName"=>"Francesco", "LastName"=>"Church", "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:03}

Person.as_json(alias_attribute: true)
# => {"id"=>1, "first_name"=>"Francesco", "last_name"=>"Church", "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:03}
```

__structure of hash__
I feel it is probably more helpful if the returned hash has all the attributes with their names as keys and the values of the attributes as values but alias names are used instead for keys if they are defined.

```ruby
class Person < ActiveRecord::Base
  alias_attribute :first_name, :FirstName
  alias_attribute :last_name, :LastName
 end

person = Person.create(FirstName: 'Francesco', LastName: 'Church')
person.alias_attributes
# => {"id"=>1, "first_name"=>"Francesco", "last_name"=>"Church", "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:03}
```