### PR TITLE
Make "bin/setup" works when using PostgreSQL with locales other than en locale

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -46,7 +46,7 @@ module ActiveRecord
       conn = PG.connect(conn_params)
       ConnectionAdapters::PostgreSQLAdapter.new(conn, logger, conn_params, config)
     rescue ::PG::Error => error
-      if error.message.include?("does not exist")
+      if error.message.include?(conn_params[:dbname])
         raise ActiveRecord::NoDatabaseError
       else
         raise


### PR DESCRIPTION
The PostgreSQL adapter uses an error message to determine if a database exists or not.
https://github.com/rails/rails/blob/74ef67b16de67d2ae2f996e50a18a93aebf68fe6/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L49
    
However, this message is properly converted according to the locale. So this check does not work correctly for non-en locales.
    
As a result, `db:prepare` cannot correctly determine if a database exists, and `bin/setup`, which depends on the task, does not work correctly if the database does not exist.
    
It checks to exist if the "does not exist" exists, but that message is also used in other error messages(e.g. "role does not exist"). So cannot check correctly also in en locale.
https://github.com/postgres/postgres/blob/master/src/backend/po/ja.po#L10542
    
It would be fine could check the status, but in my understanding, when a connecting fails, only the status `CONNECTION_BAD` be used, and it seems that details cannot be checked.
https://www.postgresql.org/docs/11/libpq-status.html#LIBPQ-PQSTATUS
    
I fixed to check whether the error message contains a database name. This is probably not accurate but can check it better now.
