### PR TITLE
Fix ActionText::RichText #blank? and #present? methods

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   `ActionText::RichText#blank?` and `ActionText::RichText#present?` methods fixed to account for cases where the text is blank but embeds are present.
+
 *   The `fill_in_rich_text_area` system test helper locates a Trix editor and fills it in with the given HTML:
 
     ```ruby

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -22,7 +22,15 @@ module ActionText
       body&.to_plain_text.to_s
     end
 
-    delegate :blank?, :empty?, :present?, to: :to_plain_text
+    def blank?
+      to_plain_text.blank? && embeds.none?
+    end
+
+    def present?
+      !blank?
+    end
+
+    delegate :empty?, to: :to_plain_text
   end
 end
 


### PR DESCRIPTION
### Summary

#36607. Currently, `ActionText::RichText#blank?` is delegated to the `:to_plain_text` method, causing it to return `true` even if there are attached `:embeds`. This PR changes this behavior so that `ActionText::RichText#blank?` will return false on objects with attachments, even if the text is blank.

I am submitting this as a bugfix, but I have not heard from any maintainers whether the current behavior is intentional, so please merge with caution.