### PR TITLE
Stop setting a default Capybara app host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gemspec
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"
 
-gem "capybara", ">= 2.15"
+gem "capybara", ">= 3.26"
 gem "selenium-webdriver", ">= 3.141.592"
 
 gem "rack-cache", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,13 +175,13 @@ GEM
     bunny (2.13.0)
       amq-protocol (~> 2.3, >= 2.3.0)
     byebug (10.0.2)
-    capybara (3.10.1)
+    capybara (3.26.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
@@ -388,7 +388,7 @@ GEM
     redis (4.1.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    regexp_parser (1.3.0)
+    regexp_parser (1.6.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -545,7 +545,7 @@ DEPENDENCIES
   blade-sauce_labs_plugin
   bootsnap (>= 1.4.4)
   byebug
-  capybara (>= 2.15)
+  capybara (>= 3.26)
   connection_pool
   dalli
   delayed_job

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   System tests require Capybara 3.26 or newer.
+
+    *George Claghorn*
+
 *   Reduced log noise handling ActionController::RoutingErrors.
 
     *Alberto Fernández-Capel*

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -4,15 +4,12 @@ module ActionDispatch
   module SystemTesting
     module TestHelpers
       module SetupAndTeardown # :nodoc:
-        DEFAULT_HOST = "http://127.0.0.1"
-
         def host!(host)
-          Capybara.app_host = host
-        end
+          ActiveSupport::Deprecation.warn \
+            "ActionDispatch::SystemTestCase#host! is deprecated with no replacement. " \
+            "Set Capybara.app_host directly or rely on Capybara's default host."
 
-        def before_setup
-          host! DEFAULT_HOST
-          super
+          Capybara.app_host = host
         end
 
         def before_teardown

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -36,12 +36,10 @@ class SetDriverToSeleniumHeadlessFirefoxTest < DrivenBySeleniumWithHeadlessFiref
 end
 
 class SetHostTest < DrivenByRackTest
-  test "sets default host" do
-    assert_equal "http://127.0.0.1", Capybara.app_host
-  end
-
   test "overrides host" do
-    host! "http://example.com"
+    assert_deprecated do
+      host! "http://example.com"
+    end
 
     assert_equal "http://example.com", Capybara.app_host
   end


### PR DESCRIPTION
It's intended not to be set if Capybara starts the app server itself. Base Rails-generated URLs off of `Capybara.current_session.server_url` instead.

Closes #36608.

/cc @twalpole 