### PR TITLE
Do not use aliases in GROUP BY clause

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -340,7 +340,7 @@ module ActiveRecord
         }
 
         relation = except(:group).distinct!(false)
-        relation.group_values  = group_aliases
+        relation.group_values  = group_fields
         relation.select_values = select_values
 
         calculated_data = skip_query_cache_if_necessary { @klass.connection.select_all(relation.arel, nil) }

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -139,6 +139,13 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_use_alias_for_grouped_field
+    assert_sql(/GROUP BY #{Regexp.escape(Account.connection.quote_table_name("accounts.firm_id"))}/i) do
+      c = Account.group(:firm_id).order("accounts_firm_id").sum(:credit_limit)
+      assert_equal [1, 2, 6, 9], c.keys.compact
+    end
+  end
+
   def test_should_order_by_grouped_field
     c = Account.group(:firm_id).order("firm_id").sum(:credit_limit)
     assert_equal [1, 2, 6, 9], c.keys.compact


### PR DESCRIPTION
It appears that Oracle does not allow using aliases in GROUP BY clause
unlike ORDER BY clause.

Fixes #36613.

cc @yahonda 