### PR TITLE
When DATABASE_URL is specified don't trample envs that use a url: key

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -153,11 +153,11 @@ module ActiveRecord
       def build_url_config(url, configs)
         env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s
 
-        if original_config = configs.find(&:for_current_env?)
-          if original_config.url_config?
-            configs
-          else
-            configs.map do |config|
+        if configs.find(&:for_current_env?)
+          configs.map do |config|
+            if config.url_config?
+              config
+            else
               ActiveRecord::DatabaseConfigurations::UrlConfig.new(config.env_name, config.spec_name, url, config.config)
             end
           end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -244,6 +244,25 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_no_url_sub_key_with_database_url_doesnt_trample_other_envs
+        ENV["DATABASE_URL"] = "postgres://localhost/baz"
+
+        config   = { "default_env" => { "database" => "foo" }, "other_env" => { "url" => "postgres://foohost/bardb" } }
+        actual   = resolve_config(config)
+        expected = { "default_env" =>
+                     { "database" => "baz",
+                      "adapter" => "postgresql",
+                      "host" => "localhost"
+                     },
+                     "other_env" =>
+                      { "adapter" => "postgresql",
+                       "database" => "bardb",
+                       "host"     => "foohost"
+                      }
+                    }
+        assert_equal expected, actual
+      end
+
       def test_merge_no_conflicts_with_database_url
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 


### PR DESCRIPTION
fixes #36610

### Summary

If the `DATABASE_URL` env var is present and the database env in database.yml matches the current environment *and* the database env for the current environment doesn't contain a `url:` key then all environments in the database.yml will have their database connection data overwritten wether they contain a `url:` key or not

### Other Information

The original reported was expecting the database URL for the `external_db` database config (copied here for ease of reference):

```yaml
default: &default
  adapter: postgresql
  encoding: unicode
  # For details on connection pooling, see Rails configuration guide
  # https://guides.rubyonrails.org/configuring.html#database-pooling
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

development:
  <<: *default
  database: external_db_url_config_development

production:
  <<: *default
  database: external_db_url_config_production
  url: <%= ENV['DATABASE_URL'] %>

external_db:
  url: <%= ENV['EXTERNAL_DB_URL'] %>
```

to be set to the value of the EXTERNAL_DB_URL env var when running the app in development mode, however it ends up being set to the DATABASE_URL env var instead, despite having a `url:` key which should prevent that. As stated in the docs:

> The only way to explicitly not use the connection information in ENV['DATABASE_URL'] is to specify an explicit URL connection using the "url" sub key:

I think the reason this happens is [`database_configurations.rb:156`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/database_configurations.rb#L156):

```ruby
      def build_url_config(url, configs)
        env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s

        if original_config = configs.find(&:for_current_env?) # <----------------- here
          if original_config.url_config?
            configs
          else
            configs.map do |config|
              ActiveRecord::DatabaseConfigurations::UrlConfig.new(config.env_name, config.spec_name, url, config.config)
            end
          end
        else
          configs + [ActiveRecord::DatabaseConfigurations::UrlConfig.new(env, "primary", url)]
        end
    end
```

On this line we *only* get the development env from the database.yml:

```
(byebug) configs.find(&:for_current_env?)
#<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fa0a565b038 @env_name="development", @spec_name="primary", @config={"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "database"=>"external_db_url_config_development"}>
```

As the development env is not a `original_config.url_config?` in this situation we fall through to the code:

```ruby
configs.map do |config|
  ActiveRecord::DatabaseConfigurations::UrlConfig.new(config.env_name, config.spec_name, url, config.config)
end
```

Where `url` is [populated earlier from ENV["DATABASE_URL"] ](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/database_configurations.rb#L111). This code doesn't have a `url_config?` condition, so even if the config has a `url:` parameter in the database.yml at this point it will be trampled by `ActiveRecord::DatabaseConfigurations::UrlConfig.new` which doesn't match the behaviour described in the docs.