### PR TITLE
Check for Client only variables during require, Fix #36601

### DIFF
--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -24,8 +24,10 @@ export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_
 }
 
 export function getConfig(name) {
-  const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
-  if (element) {
-    return element.getAttribute("content")
+  if (document) {
+    const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
+    if (element) {
+      return element.getAttribute("content")
+    }
   }
 }


### PR DESCRIPTION
Fix #36601

### Summary

By not accessing `document` in the export, this can be safely `required`/`imported` by environments without them.
Specific use-case is React-Rails where components will be built with both client and server-side `import "actioncable"`; where the only client-side use will be in `componentDidMount` which is the client-only hook.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
