### PR TITLE
Fix Inconsistent behaviour on db:prepare task

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1029,7 +1029,6 @@ module ActiveRecord
       alias :connection_pools :connection_pool_list
 
       def establish_connection(config)
-        resolver = ConnectionSpecification::Resolver.new(Base.configurations)
         spec = resolver.spec(config)
 
         remove_connection(spec.name)
@@ -1048,6 +1047,12 @@ module ActiveRecord
         end
 
         owner_to_pool[spec.name]
+      end
+
+      def database_exists?(config)
+        spec = resolver.spec(config)
+        adapter = Base.send(spec.adapter)
+        adapter.database_exists?(config)
       end
 
       # Returns true if there are any active connections among the connection
@@ -1147,6 +1152,10 @@ module ActiveRecord
         def pool_from_any_process_for(spec_name)
           owner_to_pool = @owner_to_pool.values.reverse.find { |v| v[spec_name] }
           owner_to_pool && owner_to_pool[spec_name]
+        end
+
+        def resolver
+          ConnectionSpecification::Resolver.new(Base.configurations)
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -5,10 +5,10 @@ require "uri"
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecification #:nodoc:
-      attr_reader :name, :config, :adapter_method
+      attr_reader :name, :config, :adapter, :adapter_method
 
-      def initialize(name, config, adapter_method)
-        @name, @config, @adapter_method = name, config, adapter_method
+      def initialize(name, config, adapter, adapter_method)
+        @name, @config, @adapter, @adapter_method = name, config, adapter, adapter_method
       end
 
       def initialize_dup(original)
@@ -149,6 +149,8 @@ module ActiveRecord
         #
         #   config = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
         #   spec = Resolver.new(config).spec(:production)
+        #   spec.adapter
+        #   # => "sqlite3"
         #   spec.adapter_method
         #   # => "sqlite3_connection"
         #   spec.config
@@ -183,12 +185,13 @@ module ActiveRecord
           end
 
           adapter_method = "#{spec[:adapter]}_connection"
+          adapter = "#{spec[:adapter]}_adapter"
 
-          unless ActiveRecord::Base.respond_to?(adapter_method)
+          if !ActiveRecord::Base.respond_to?(adapter) || !ActiveRecord::Base.respond_to?(adapter_method)
             raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
           end
 
-          ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method)
+          ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter, adapter_method)
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -150,7 +150,7 @@ module ActiveRecord
         #   config = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
         #   spec = Resolver.new(config).spec(:production)
         #   spec.adapter
-        #   # => "sqlite3"
+        #   # => "sqlite3_adapter"
         #   spec.adapter_method
         #   # => "sqlite3_connection"
         #   spec.config

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -187,7 +187,7 @@ module ActiveRecord
           adapter_method = "#{spec[:adapter]}_connection"
           adapter = "#{spec[:adapter]}_adapter"
 
-          if !ActiveRecord::Base.respond_to?(adapter) || !ActiveRecord::Base.respond_to?(adapter_method)
+          unless ActiveRecord::Base.respond_to?(adapter_method)
             raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
           end
 

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -7,8 +7,8 @@ module ActiveRecord
     class ConnectionSpecification #:nodoc:
       attr_reader :name, :config, :adapter, :adapter_method
 
-      def initialize(name, config, adapter, adapter_method)
-        @name, @config, @adapter, @adapter_method = name, config, adapter, adapter_method
+      def initialize(name, config, adapter_method, adapter = nil)
+        @name, @config, @adapter_method, @adapter = name, config, adapter_method, adapter
       end
 
       def initialize_dup(original)
@@ -191,7 +191,7 @@ module ActiveRecord
             raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
           end
 
-          ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter, adapter_method)
+          ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method, adapter)
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -28,6 +28,10 @@ module ActiveRecord
         raise
       end
     end
+
+    def mysql2_adapter
+      ConnectionAdapters::Mysql2Adapter
+    end
   end
 
   module ConnectionAdapters

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -52,6 +52,10 @@ module ActiveRecord
         raise
       end
     end
+
+    def postgresql_adapter
+      ConnectionAdapters::PostgreSQLAdapter
+    end
   end
 
   module ConnectionAdapters

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -45,6 +45,10 @@ module ActiveRecord
         raise
       end
     end
+
+    def sqlite3_adapter
+      ConnectionAdapters::SQLite3Adapter
+    end
   end
 
   module ConnectionAdapters #:nodoc:

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -51,6 +51,11 @@ module ActiveRecord
       connection_handler.establish_connection(config_hash)
     end
 
+    def database_exists?(config_or_env = nil)
+      config_hash = resolve_config_for_connection(config_or_env)
+      connection_handler.database_exists?(config_hash)
+    end
+
     # Connects a model to the databases specified. The +database+ keyword
     # takes a hash consisting of a +role+ and a +database_key+.
     #

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -297,10 +297,7 @@ db_namespace = namespace :db do
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       if ActiveRecord::Base.database_exists?(db_config.config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
-
-        # Skipped when no database
         ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
-
       else
         ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)
         ActiveRecord::Tasks::DatabaseTasks.load_schema(

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -300,6 +300,7 @@ db_namespace = namespace :db do
         ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
       else
         ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
         ActiveRecord::Tasks::DatabaseTasks.load_schema(
           db_config.config,
           ActiveRecord::Base.schema_format,
@@ -307,6 +308,7 @@ db_namespace = namespace :db do
           db_config.env_name,
           db_config.spec_name
         )
+        ActiveRecord::Tasks::DatabaseTasks.migrate
 
         seed = true
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -295,7 +295,7 @@ db_namespace = namespace :db do
     seed = false
 
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-      if ActiveRecord::Base.database_exists?(db_config)
+      if ActiveRecord::Base.database_exists?(db_config.config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
 
         # Skipped when no database

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -619,6 +619,7 @@ module ApplicationTests
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           output = rails("db:prepare")
+          assert_match(/Created database/, output)
           assert_match(/CreateBooks: migrated/, output)
 
           output = rails("db:drop")


### PR DESCRIPTION
## Summary

Now that `database_exists?`  has been added to connection adapters #36471 we can use this method in order to prevent inconsistencies described on #36383. Basically, SQLite never raise an `ActiveRecord::NoDatabaseError` exception since it creates the files or stores the information on memory every time that tries to establish a connection 

closes #36383 

cc @guilleiguaran @eileencodes 