### PR TITLE
Removed unnecessary app/javascript from the plugin test dummy app. 

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -114,7 +114,6 @@ task default: :test
     end
 
     def test_dummy_assets
-      template "rails/javascripts.js",    "#{dummy_path}/app/javascript/packs/application.js", force: true
       template "rails/stylesheets.css",   "#{dummy_path}/app/assets/stylesheets/application.css", force: true
       template "rails/dummy_manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true
     end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -467,6 +467,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/dummy/README.md"
     assert_no_file "test/dummy/config/master.key"
     assert_no_file "test/dummy/config/credentials.yml.enc"
+    assert_no_file "test/dummy/app/javascript"
     assert_no_directory "test/dummy/lib/tasks"
     assert_no_directory "test/dummy/test"
     assert_no_directory "test/dummy/vendor"

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -233,8 +233,12 @@ module SharedGeneratorTests
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
-    assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
-      assert_no_match(/activestorage/, content)
+    if generator_class.name == "Rails::Generators::PluginGenerator"
+      assert_no_file "#{application_path}/app/javascript/packs/application.js"
+    else
+      assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
+        assert_no_match(/activestorage/, content)
+      end
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|
@@ -263,8 +267,12 @@ module SharedGeneratorTests
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
 
-    assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
-      assert_no_match(/^require\("@rails\/activestorage"\)\.start\(\)/, content)
+    if generator_class.name == "Rails::Generators::PluginGenerator"
+      assert_no_file "#{application_path}/app/javascript/packs/application.js"
+    else
+      assert_file "#{application_path}/app/javascript/packs/application.js" do |content|
+        assert_no_match(/^require\("@rails\/activestorage"\)\.start\(\)/, content)
+      end
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|


### PR DESCRIPTION
While working on #36364, I found that the dummy test application generated always has `app/javascript` but that is never actually needed as `--skip-javascript` flag is always set to true. `app/javascript` is also not included in the `application.html` so I think we can remove it.
