### PR TITLE
add note about 'require active_storage/engine'

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -36,7 +36,8 @@ files.
 ## Setup
 
 Active Storage uses two tables in your application’s database named
-`active_storage_blobs` and `active_storage_attachments`. After creating a new
+`active_storage_blobs` and `active_storage_attachments`. If you are upgrading from an earlier version of Rails, 
+make sure you have `require "active_storage/engine` in `config/application.rb`.  After creating a new
 application (or upgrading your application to Rails 5.2), run
 `rails active_storage:install` to generate a migration that creates these
 tables. Use `rails db:migrate` to run the migration.


### PR DESCRIPTION
this is not present if you're upgrading from an earlier rails version, it's only present for a new application.

### Summary

document change only

### Other Information

document change only
