### PR TITLE
Add viewport meta tag to default application template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title><%= camelized %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 


### PR DESCRIPTION
### Summary

This PR adds a viewport meta tag to the default application layout template, enabling responsive web design by default.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Background: The first thing I do in a new Rails app is add the viewport meta tag. In a world where over half of web traffic is from mobile, I think Rails should start off developers with an application that doesn't look broken/outdated. Other frameworks like [Next.js already do this](https://github.com/zeit/next.js/pull/6754).

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->