### PR TITLE
Share the column and table name quote cache between connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -106,6 +106,14 @@ module ActiveRecord
         Regexp.union(*parts)
       end
 
+      def self.quoted_column_names # :nodoc:
+        @quoted_column_names ||= {}
+      end
+
+      def self.quoted_table_names # :nodoc:
+        @quoted_table_names ||= {}
+      end
+
       def initialize(connection, logger = nil, config = {}) # :nodoc:
         super()
 
@@ -116,7 +124,6 @@ module ActiveRecord
         @config              = config
         @pool                = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since          = Concurrent.monotonic_time
-        @quoted_column_names, @quoted_table_names = {}, {}
         @visitor = arel_visitor
         @statements = build_statement_pool
         @lock = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -5,11 +5,11 @@ module ActiveRecord
     module MySQL
       module Quoting # :nodoc:
         def quote_column_name(name)
-          @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"
+          self.class.quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"
         end
 
         def quote_table_name(name)
-          @quoted_table_names[name] ||= super.gsub(".", "`.`").freeze
+          self.class.quoted_table_names[name] ||= super.gsub(".", "`.`").freeze
         end
 
         def unquoted_true

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         # - "schema.name".table_name
         # - "schema.name"."table.name"
         def quote_table_name(name) # :nodoc:
-          @quoted_table_names[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted.freeze
+          self.class.quoted_table_names[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted.freeze
         end
 
         # Quotes schema names for use in SQL queries.
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Quotes column names for use in SQL queries.
         def quote_column_name(name) # :nodoc:
-          @quoted_column_names[name] ||= PG::Connection.quote_ident(super).freeze
+          self.class.quoted_column_names[name] ||= PG::Connection.quote_ident(super).freeze
         end
 
         # Quote date/time values for use in SQL input.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -13,11 +13,11 @@ module ActiveRecord
         end
 
         def quote_table_name(name)
-          @quoted_table_names[name] ||= super.gsub(".", "\".\"").freeze
+          self.class.quoted_table_names[name] ||= super.gsub(".", "\".\"").freeze
         end
 
         def quote_column_name(name)
-          @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
+          self.class.quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
         end
 
         def quoted_time(value)


### PR DESCRIPTION
For apps using multiple database connections, especially if they are shards or replicas, different connections are very likely to share parts or all their table and column names.

Because of this I believe this cache should not be stored as an instance variable of `ConnectionAdapter`, but on the adapter class itself. This way all instances of a same type will share that same cache.

#### Should it use a Concurrent::Map ? 

I believe it doesn't need it because if a race condition was to happen, both thread would generate the same value. So the locking needed would cause more harm than good.

cc @rafaelfranca @Edouard-chin @kaspth 