### PR TITLE
Move the `ActiveModel:Errors#full_message` method to the `Error` class:

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -53,6 +53,7 @@ module ActiveModel
 
   eager_autoload do
     autoload :Errors
+    autoload :Error
     autoload :RangeError, "active_model/errors"
     autoload :StrictValidationFailed, "active_model/errors"
     autoload :UnknownAttributeError, "active_model/errors"

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -8,6 +8,92 @@ module ActiveModel
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
     MESSAGE_OPTIONS = [:message]
 
+    class << self
+      attr_accessor :i18n_customize_full_message # :nodoc:
+    end
+    self.i18n_customize_full_message = false
+
+    def self.full_message(attribute, message, base_class) # :nodoc:
+      return message if attribute == :base
+      attribute = attribute.to_s
+
+      if i18n_customize_full_message && base_class.respond_to?(:i18n_scope)
+        attribute = attribute.remove(/\[\d\]/)
+        parts = attribute.split(".")
+        attribute_name = parts.pop
+        namespace = parts.join("/") unless parts.empty?
+        attributes_scope = "#{base_class.i18n_scope}.errors.models"
+
+        if namespace
+          defaults = base_class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
+            ]
+          end
+        else
+          defaults = base_class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
+            ]
+          end
+        end
+
+        defaults.flatten!
+      else
+        defaults = []
+      end
+
+      defaults << :"errors.format"
+      defaults << "%{attribute} %{message}"
+
+      attr_name = attribute.tr(".", "_").humanize
+      attr_name = base_class.human_attribute_name(attribute, default: attr_name)
+
+      I18n.t(defaults.shift,
+        default:  defaults,
+        attribute: attr_name,
+        message:   message)
+    end
+
+    def self.generate_message(attribute, type, base, options) # :nodoc:
+      type = options.delete(:message) if options[:message].is_a?(Symbol)
+      value = (attribute != :base ? base.send(:read_attribute_for_validation, attribute) : nil)
+
+      options = {
+        model: base.model_name.human,
+        attribute: base.class.human_attribute_name(attribute),
+        value: value,
+        object: base
+      }.merge!(options)
+
+      if base.class.respond_to?(:i18n_scope)
+        i18n_scope = base.class.i18n_scope.to_s
+        defaults = base.class.lookup_ancestors.flat_map do |klass|
+          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+        end
+        defaults << :"#{i18n_scope}.errors.messages.#{type}"
+
+        catch(:exception) do
+          translation = I18n.translate(defaults.first, options.merge(default: defaults.drop(1), throw: true))
+          return translation unless translation.nil?
+        end unless options[:message]
+      else
+        defaults = []
+      end
+
+      defaults << :"errors.attributes.#{attribute}.#{type}"
+      defaults << :"errors.messages.#{type}"
+
+      key = defaults.shift
+      defaults = options.delete(:message) if options[:message]
+      options[:default] = defaults
+
+      I18n.translate(key, options)
+    end
+
     def initialize(base, attribute, type = :invalid, **options)
       @base = base
       @attribute = attribute
@@ -28,7 +114,7 @@ module ActiveModel
     def message
       case raw_type
       when Symbol
-        base.errors.generate_message(attribute, raw_type, options.except(*CALLBACKS_OPTIONS))
+        self.class.generate_message(attribute, raw_type, @base, options.except(*CALLBACKS_OPTIONS))
       else
         raw_type
       end
@@ -39,7 +125,7 @@ module ActiveModel
     end
 
     def full_message
-      base.errors.full_message(attribute, message)
+      self.class.full_message(attribute, message, @base.class)
     end
 
     # See if error matches provided +attribute+, +type+ and +options+.

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/class/attribute"
+
 module ActiveModel
   # == Active \Model \Error
   #
@@ -8,10 +10,7 @@ module ActiveModel
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
     MESSAGE_OPTIONS = [:message]
 
-    class << self
-      attr_accessor :i18n_customize_full_message # :nodoc:
-    end
-    self.i18n_customize_full_message = false
+    class_attribute :i18n_customize_full_message, default: false
 
     def self.full_message(attribute, message, base_class) # :nodoc:
       return message if attribute == :base

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -69,11 +69,6 @@ module ActiveModel
 
     LEGACY_ATTRIBUTES = [:messages, :details].freeze
 
-    class << self
-      attr_accessor :i18n_customize_full_message # :nodoc:
-    end
-    self.i18n_customize_full_message = false
-
     attr_reader :errors
     alias :objects :errors
 
@@ -467,47 +462,7 @@ module ActiveModel
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
     def full_message(attribute, message)
-      return message if attribute == :base
-      attribute = attribute.to_s
-
-      if self.class.i18n_customize_full_message && @base.class.respond_to?(:i18n_scope)
-        attribute = attribute.remove(/\[\d\]/)
-        parts = attribute.split(".")
-        attribute_name = parts.pop
-        namespace = parts.join("/") unless parts.empty?
-        attributes_scope = "#{@base.class.i18n_scope}.errors.models"
-
-        if namespace
-          defaults = @base.class.lookup_ancestors.map do |klass|
-            [
-              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
-              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
-            ]
-          end
-        else
-          defaults = @base.class.lookup_ancestors.map do |klass|
-            [
-              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
-              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
-            ]
-          end
-        end
-
-        defaults.flatten!
-      else
-        defaults = []
-      end
-
-      defaults << :"errors.format"
-      defaults << "%{attribute} %{message}"
-
-      attr_name = attribute.tr(".", "_").humanize
-      attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
-
-      I18n.t(defaults.shift,
-        default:  defaults,
-        attribute: attr_name,
-        message:   message)
+      Error.full_message(attribute, message, @base.class)
     end
 
     # Translates an error message in its default scope
@@ -535,40 +490,7 @@ module ActiveModel
     # * <tt>errors.attributes.title.blank</tt>
     # * <tt>errors.messages.blank</tt>
     def generate_message(attribute, type = :invalid, options = {})
-      type = options.delete(:message) if options[:message].is_a?(Symbol)
-      value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
-
-      options = {
-        model: @base.model_name.human,
-        attribute: @base.class.human_attribute_name(attribute),
-        value: value,
-        object: @base
-      }.merge!(options)
-
-      if @base.class.respond_to?(:i18n_scope)
-        i18n_scope = @base.class.i18n_scope.to_s
-        defaults = @base.class.lookup_ancestors.flat_map do |klass|
-          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
-        end
-        defaults << :"#{i18n_scope}.errors.messages.#{type}"
-
-        catch(:exception) do
-          translation = I18n.translate(defaults.first, options.merge(default: defaults.drop(1), throw: true))
-          return translation unless translation.nil?
-        end unless options[:message]
-      else
-        defaults = []
-      end
-
-      defaults << :"errors.attributes.#{attribute}.#{type}"
-      defaults << :"errors.messages.#{type}"
-
-      key = defaults.shift
-      defaults = options.delete(:message) if options[:message]
-      options[:default] = defaults
-
-      I18n.translate(key, options)
+      Error.generate_message(attribute, type, @base, options)
     end
 
     def marshal_load(array) # :nodoc:

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -14,7 +14,7 @@ module ActiveModel
     end
 
     initializer "active_model.i18n_customize_full_message" do
-      ActiveModel::Errors.i18n_customize_full_message = config.active_model.delete(:i18n_customize_full_message) || false
+      ActiveModel::Error.i18n_customize_full_message = config.active_model.delete(:i18n_customize_full_message) || false
     end
   end
 end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -482,6 +482,27 @@ class ErrorsTest < ActiveModel::TestCase
     assert_nil person.errors.as_json.default_proc
   end
 
+  test "full_messages doesn't require the base object to respond to `:errors" do
+    model = Class.new do
+      def initialize
+        @errors = ActiveModel::Errors.new(self)
+        @errors.add(:name, "bar")
+      end
+
+      def self.human_attribute_name(attr, options = {})
+        "foo"
+      end
+
+      def call
+        error_wrapper = Struct.new(:model_errors)
+
+        error_wrapper.new(@errors)
+      end
+    end
+
+    assert_equal(["foo bar"], model.new.call.model_errors.full_messages)
+  end
+
   test "full_messages creates a list of error messages with the attribute name included" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")

--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -35,20 +35,20 @@ class RailtieTest < ActiveModel::TestCase
   test "i18n customize full message defaults to false" do
     @app.initialize!
 
-    assert_equal false, ActiveModel::Errors.i18n_customize_full_message
+    assert_equal false, ActiveModel::Error.i18n_customize_full_message
   end
 
   test "i18n customize full message can be disabled" do
     @app.config.active_model.i18n_customize_full_message = false
     @app.initialize!
 
-    assert_equal false, ActiveModel::Errors.i18n_customize_full_message
+    assert_equal false, ActiveModel::Error.i18n_customize_full_message
   end
 
   test "i18n customize full message can be enabled" do
     @app.config.active_model.i18n_customize_full_message = true
     @app.initialize!
 
-    assert_equal true, ActiveModel::Errors.i18n_customize_full_message
+    assert_equal true, ActiveModel::Error.i18n_customize_full_message
   end
 end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -59,6 +59,19 @@ class I18nValidationTest < ActiveModel::TestCase
     assert_equal "Name test cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
   end
 
+  def test_errors_full_messages_on_nested_error_uses_attribute_format
+    ActiveModel::Error.i18n_customize_full_message = true
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { person: { attributes: { gender: "Gender" } } } },
+      attributes: { "person/contacts": { gender: "Gender" } }
+    })
+
+    person = person_class.new
+    error = ActiveModel::Error.new(person, :gender, "can't be blank")
+    person.errors.import(error, attribute: "person[0].contacts.gender")
+    assert_equal ["Gender can't be blank"], person.errors.full_messages
+  end
+
   def test_errors_full_messages_uses_attribute_format
     ActiveModel::Error.i18n_customize_full_message = true
 

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -51,7 +51,7 @@ class I18nValidationTest < ActiveRecord::TestCase
     test "validates_uniqueness_of on generated message #{name}" do
       Topic.validates_uniqueness_of :title, validation_options
       @topic.title = unique_topic.title
-      assert_called_with(@topic.errors, :generate_message, [:title, :taken, generate_message_options.merge(value: "unique!")]) do
+      assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, generate_message_options.merge(value: "unique!")]) do
         @topic.valid?
         @topic.errors.messages
       end
@@ -61,7 +61,7 @@ class I18nValidationTest < ActiveRecord::TestCase
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_associated on generated message #{name}" do
       Topic.validates_associated :replies, validation_options
-      assert_called_with(replied_topic.errors, :generate_message, [:replies, :invalid, generate_message_options.merge(value: replied_topic.replies)]) do
+      assert_called_with(ActiveModel::Error, :generate_message, [:replies, :invalid, replied_topic, generate_message_options.merge(value: replied_topic.replies)]) do
         replied_topic.save
         replied_topic.errors.messages
       end


### PR DESCRIPTION
Move the `ActiveModel:Errors#full_message` method to the `Error` class:

- One regression introduced by the "AM errors as object" features is
  about the `full_messages` method.

  It's currently impossible to call that method if the `base` object
  passed in the constructor of `AM::Errors` doesn't respond to the
  `errors` method.
  That's because `full_messages` now makes a weird back and forth trip

  `AM::Errors#full_messages` -> `AM::Error#full_message` -> `AM::Errors#full_message`

  Since `full_message` (singular) isn't needed by AM::Errors, I moved
  it to the `AM::Error` (singular) class. This way we don't need to
  grab the `AM::Errors` object from the base.

cc/ @casperisfine @rafaelfranca 

