### PR TITLE
Fix errors getting duplicated when passed validations options:

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -74,7 +74,7 @@ module ActiveModel
 
     protected
       def attributes_for_hash
-        [@base, @attribute, @raw_type, @options]
+        [@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]
       end
   end
 end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -27,7 +27,8 @@ class ShipWithoutNestedAttributes < ActiveRecord::Base
   has_many :prisoners, inverse_of: :ship, foreign_key: :ship_id
   has_many :parts, class_name: "ShipPart", foreign_key: :ship_id
 
-  validates :name, presence: true
+  validates :name, presence: true, if: -> { true }
+  validates :name, presence: true, if: -> { true }
 end
 
 class Prisoner < ActiveRecord::Base


### PR DESCRIPTION
Fix errors getting duplicated when passed validations options:

- In 86620cc3aa8e2630bc8d934b1a86453276b9eee9, a change was made
  on how we remove error duplication on a record for autosave
  association

  This fix has one caveat where validation having a `if` / `unless`
  options passed as a proc would be considered different.
  Example:

  ```ruby
  class Book < ApplicationRecord
    has_one :author

    validates :title, presence: true, if -> { true }
    validates :title, presence: true, if -> { true }
  end

  Book.new.valid? # false
  Book.errors.full_messages # ["title can't be blank", "title can't be blank"]
  ```

  While this example might sound strange, I think it's better to
  ignore `AM::Validations` options (if, unless ...) when making the
  comparison.

cc/ @rafaelfranca @casperisfine