### PR TITLE
Fix host for ActiveStorage DiskService

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -84,8 +84,12 @@ module ActiveStorage
           purpose: :blob_key }
         )
 
+        current_uri = URI.parse(current_host)
+
         generated_url = url_helpers.rails_disk_service_url(verified_key_with_expiration,
-          host: current_host,
+          protocol: current_uri.scheme,
+          host: current_uri.host,
+          port: current_uri.port,
           disposition: content_disposition,
           content_type: content_type,
           filename: filename

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -8,8 +8,14 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "URL generation" do
-    assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
-      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+    begin
+      assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
+        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+    ensure
+      Rails.application.routes.default_url_options = original_url_options
+    end
   end
 
   test "headers_for_direct_upload generation" do


### PR DESCRIPTION
### Summary

The previous behavior would only set host, which didn't work correctly if the default_url_options contained the protocol or the port.

We now parse the host and specify protocol, host, and port separately to ensure that they win out.

Fixes #36629 