### PR TITLE
Share the Arel dispatch cache between connections

### DIFF
--- a/activerecord/lib/arel/visitors/visitor.rb
+++ b/activerecord/lib/arel/visitors/visitor.rb
@@ -15,7 +15,7 @@ module Arel # :nodoc: all
         attr_reader :dispatch
 
         def self.dispatch_cache
-          Hash.new do |hash, klass|
+          @dispatch_cache ||= Hash.new do |hash, klass|
             hash[klass] = "visit_#{(klass.name || '').gsub('::', '_')}"
           end
         end


### PR DESCRIPTION
It's very similar in principle to https://github.com/rails/rails/pull/36637

In short, since that cache is on a per instance basis, if the application connects to multiple database, it will keep one copy of that cache per database.

Just like in https://github.com/rails/rails/pull/36637, I don't think it needs to be protected against race conditions.

cc @rafaelfranca @Edouard-chin @kaspth @kamipo 