### PR TITLE
Add #saved_changes_to_any? to ActiveRecord::AttributeMethods::Dirty

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -84,6 +84,26 @@ module ActiveRecord
         mutations_before_last_save.changes
       end
 
+      # Did the last call to +save+ change any of these attributes?
+      #
+      # This method is useful in after callbacks to determine if any attribute
+      # of a set of attributes was changed during the save that triggered the
+      # callbacks to run.
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   person = Person.create(first_name: 'Sean')
+      #   person.saved_changes_to_any?(:first_name, :gender)   # => true
+      #   person.saved_changes_to_any?('first_name', 'gender') # => true
+      #   person.saved_changes_to_any?(:last_name, :gender)    # => false
+      def saved_changes_to_any?(*attr_names)
+        return saved_changes? if attr_names.empty?
+
+        attr_names = attr_names.flatten.map(&:to_s)
+        (attr_names & saved_changes.keys).present?
+      end
+
       # Will this attribute change the next time we save?
       #
       # This method is useful in validations and before callbacks to determine

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -815,6 +815,18 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not person.saved_change_to_first_name?(to: "Jim")
   end
 
+  test "saved_changes_to_any? returns whether the last call to save changed one of the attributes" do
+    person = Person.create!(first_name: "Sean")
+
+    assert_predicate person, :saved_changes_to_any?
+    assert person.saved_changes_to_any?(:first_name, :gender)
+
+    person.save
+
+    assert_not_predicate person, :saved_changes_to_any?
+    assert_not person.saved_changes_to_any?(:first_name, :gender)
+  end
+
   test "saved_change_to_attribute returns the change that occurred in the last save" do
     person = Person.create!(first_name: "Sean", gender: "M")
 


### PR DESCRIPTION
Add `#saved_changes_to_any?` method to to determine if any attribute of a set of attributes was changed during the last save.

### Summary

I had the case where I wanted to check if any of a number of attributes had changed in an `after_save` callback.

For example

```ruby
class Search < ActiveRecord::Base
  after_save :delete_unnecessary_results
  
  private
  def delete_unnecessary_results
    watchlist = [:start_date, :last_start_date, :additional_days, :duration]
    return unless saved_changes_to_any?(watchlist)

    # ...
  end
end
```

The method can take an array, multiple symbols, or strings.

```ruby
person = Person.create(first_name: 'Sean')
person.saved_changes_to_any?(:first_name, :gender)   # => true
person.saved_changes_to_any?('first_name', 'gender') # => true
person.saved_changes_to_any?(:last_name, :gender)    # => false
```

I'm happy to hear your thoughts on this. By the way I'm on Rails since 2.0.0 and this is my first contribution :sweat_smile:

### Other Information

I'm not sure about the name of the method. There are `saved_changes?` and `saved_change_to_attribute?` already, but `saved_changes_to_any_attribute?` seemed too long. Maybe someone has a suggestion.
