### PR TITLE
Make ActionCable compatible with React Native

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -3,8 +3,8 @@
 })(this, function(exports) {
   "use strict";
   var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
+    logger: typeof module === "undefined" ? self.console : console,
+    WebSocket: typeof module === "undefined" ? self.WebSocket : WebSocket
   };
   var logger = {
     log: function log() {
@@ -65,7 +65,9 @@
         this.startedAt = now();
         delete this.stoppedAt;
         this.startPolling();
-        addEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof addEventListener !== "undefined") {
+          addEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log("ConnectionMonitor started. pollInterval = " + this.getPollInterval() + " ms");
       }
     };
@@ -73,7 +75,9 @@
       if (this.isRunning()) {
         this.stoppedAt = now();
         this.stopPolling();
-        removeEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof removeEventListener !== "undefined") {
+          removeEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log("ConnectionMonitor stopped");
       }
     };
@@ -132,7 +136,7 @@
     };
     ConnectionMonitor.prototype.visibilityDidChange = function visibilityDidChange() {
       var _this2 = this;
-      if (document.visibilityState === "visible") {
+      if (typeof document !== "undefined" && document.visibilityState === "visible") {
         setTimeout(function() {
           if (_this2.connectionIsStale() || !_this2.connection.isOpen()) {
             logger.log("ConnectionMonitor reopening stale connection on visibilitychange. visbilityState = " + document.visibilityState);
@@ -480,7 +484,7 @@
     if (typeof url === "function") {
       url = url();
     }
-    if (url && !/^wss?:/i.test(url)) {
+    if (url && typeof document !== "undefined" && !/^wss?:/i.test(url)) {
       var a = document.createElement("a");
       a.href = url;
       a.href = a.href;
@@ -495,7 +499,7 @@
     return new Consumer(url);
   }
   function getConfig(name) {
-    var element = document.head.querySelector("meta[name='action-cable-" + name + "']");
+    var element = typeof document !== "undefined" && document.head.querySelector("meta[name='action-cable-" + name + "']");
     if (element) {
       return element.getAttribute("content");
     }

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,4 @@
 export default {
-  logger: self.console,
-  WebSocket: self.WebSocket
+  logger: typeof module === "undefined" ? self.console : console,
+  WebSocket: typeof module === "undefined" ? self.WebSocket : WebSocket
 }

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -21,7 +21,9 @@ class ConnectionMonitor {
       this.startedAt = now()
       delete this.stoppedAt
       this.startPolling()
-      addEventListener("visibilitychange", this.visibilityDidChange)
+      if(typeof addEventListener !== "undefined") {
+        addEventListener("visibilitychange", this.visibilityDidChange)
+      }
       logger.log(`ConnectionMonitor started. pollInterval = ${this.getPollInterval()} ms`)
     }
   }
@@ -30,7 +32,9 @@ class ConnectionMonitor {
     if (this.isRunning()) {
       this.stoppedAt = now()
       this.stopPolling()
-      removeEventListener("visibilitychange", this.visibilityDidChange)
+      if(typeof removeEventListener !== "undefined") {
+        removeEventListener("visibilitychange", this.visibilityDidChange)
+      }
       logger.log("ConnectionMonitor stopped")
     }
   }
@@ -102,7 +106,7 @@ class ConnectionMonitor {
   }
 
   visibilityDidChange() {
-    if (document.visibilityState === "visible") {
+    if (typeof document !== "undefined" && document.visibilityState === "visible") {
       setTimeout(() => {
         if (this.connectionIsStale() || !this.connection.isOpen()) {
           logger.log(`ConnectionMonitor reopening stale connection on visibilitychange. visbilityState = ${document.visibilityState}`)

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -62,7 +62,7 @@ export function createWebSocketURL(url) {
     url = url()
   }
 
-  if (url && !/^wss?:/i.test(url)) {
+  if (url && typeof document!== "undefined" && !/^wss?:/i.test(url)) {
     const a = document.createElement("a")
     a.href = url
     // Fix populating Location properties in IE. Otherwise, protocol will be blank.

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -24,7 +24,7 @@ export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_
 }
 
 export function getConfig(name) {
-  const element = document.head.querySelector(`meta[name='action-cable-${name}']`)
+  const element = typeof document !== "undefined" && document.head.querySelector(`meta[name='action-cable-${name}']`)
   if (element) {
     return element.getAttribute("content")
   }


### PR DESCRIPTION
[The API for WebSockets on React Native](https://facebook.github.io/react-native/docs/network#websocket-support) it's similar to the [Web API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) but actionable is not supported given it makes some references to the DOM.

I noticed its possible to make it compatible with React Native by ignoring those DOM references in order to don't get errors like https://github.com/rails/rails/issues/35674