### PR TITLE
Returns `nil` when `AM::Errors#delete` doesn't delete anything:

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -199,7 +199,7 @@ module ActiveModel
       matches.each do |error|
         @errors.delete(error)
       end
-      matches.map(&:message)
+      matches.map(&:message).presence
     end
 
     # When passed a symbol or a name of a method, returns an array of errors

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -573,6 +573,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not_equal errors_dup.details, errors.details
   end
 
+  test "delete returns nil when no errors were deleted" do
+    errors = ActiveModel::Errors.new(Person.new)
+
+    assert_nil(errors.delete(:name))
+  end
+
   test "delete removes details on given attribute" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)


### PR DESCRIPTION
Returns `nil` when `AM::Errors#delete` doesn't delete anything:

- `AM::Errors#delete` currently returns an empty array when trying
  to delete an error that doesn't exist.

  This behaviour is surprising and I think it would be better
  to no return a truthy value but instead return nil like
  `Hash#delete` does.

cc/ @rafaelfranca @casperisfine
