### PR TITLE
Added methods for number comparison to Numeric

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow to compare numbers with `less?`, `less_or_equal?`, `greater?` and
+    `greater_or_equal?`.
+    
+    *Alexander Spitsyn*
+
 *   Allow the `on_rotation` proc used when decrypting/verifying a message to be
     passed at the constructor level.
 

--- a/activesupport/lib/active_support/core_ext/numeric.rb
+++ b/activesupport/lib/active_support/core_ext/numeric.rb
@@ -3,3 +3,4 @@
 require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/numeric/conversions"
+require "active_support/core_ext/numeric/comparison"

--- a/activesupport/lib/active_support/core_ext/numeric/comparison.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/comparison.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Numeric
+  # 2.less?(3) # => true
+  def less?(other)
+    self < other
+  end
+
+  # 5.less_or_equal?(5) # => true
+  def less_or_equal?(other)
+    self <= other
+  end
+
+  # 3.greater?(2) #=> true
+  def greater?(other)
+    self > other
+  end
+
+  # 3.greater_or_equal?(3) # => true
+  def greater_or_equal?(other)
+    self >= other
+  end
+end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -412,3 +412,28 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     end
   end
 end
+
+class NumericExtComparisonTest < ActiveSupport::TestCase
+  def test_less
+    assert 2.less?(3)
+    assert_not 5.less?(4)
+    assert_not 5.less?(5)
+  end
+
+  def test_less_or_equal
+    assert 5.less_or_equal?(5)
+    assert 5.less_or_equal?(6)
+    assert_not 5.less_or_equal?(4)
+  end
+
+  def test_greater
+    assert 3.greater?(2)
+    assert_not 4.greater?(5)
+  end
+
+  def greater_or_equal?
+    assert 3.greater_or_equal?(3)
+    assert 3.greater_or_equal?(2)
+    assert_not 4.greater_or_equal?(5)
+  end
+end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1896,6 +1896,17 @@ Produce a string representation of a number in human-readable words:
 
 NOTE: Defined in `active_support/core_ext/numeric/conversions.rb`.
 
+### Comparison
+
+Enables the number comparison.
+
+```ruby
+2.less?(3) # => true
+5.less_or_equal?(5) # => true
+3.greater?(2) #=> true
+3.greater_or_equal?(3) # => true
+```
+
 Extensions to `Integer`
 -----------------------
 


### PR DESCRIPTION
### Added number comparison methods to `Numeric`
Some weeks ago I found out, that Rails 6 added `#before?` and `#after?` to `Date` and `Time`. This made me think that it is also very hard to use usual operators `<` and `>` with `Numeric` and I decided to add specific methods to make code more readable.

Now we can use the following methods for comparison instead of `<`, `<=`, `>`, `>=`:
```ruby
2.less?(3) # => true
5.less_or_equal?(5) # => true
3.greater?(2) #=> true
3.greater_or_equal?(3) # => true
```