### PR TITLE
Return a copy of the cache entry when local_cache exists:

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -75,7 +75,10 @@ module ActiveSupport
           end
 
           def fetch_entry(key, options = nil) # :nodoc:
-            @data.fetch(key) { @data[key] = yield }
+            entry = @data.fetch(key) { @data[key] = yield }
+            dup_entry = entry.dup
+            dup_entry&.dup_value!
+            dup_entry
           end
         end
 

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -46,6 +46,15 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_read_returns_a_copy_of_the_entry
+    @cache.with_local_cache do
+      @cache.write(:foo, type: "bar")
+      value = @cache.read(:foo)
+      assert_equal("bar", value.delete(:type))
+      assert_equal({ type: "bar" }, @cache.read(:foo))
+    end
+  end
+
   def test_local_cache_of_read
     @cache.write("foo", "bar")
     @cache.with_local_cache do


### PR DESCRIPTION
Return a copy of the cache entry when local_cache exists:

- When the local cache exists (during the request lifecycle), the
  entry returned from the LocalStore is passed as a reference which
  means mutable object can accidentaly get modified.

  This behaviour seems unnecessarily unsafe and is prone to
  issues like it happened in our application.

  This patch dup the `Entry` returned from the cache and dup it's
  internal value.

cc/ @rafaelfranca @casperisfine