### PR TITLE
Remove dead code in duplicable.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 #--
@@ -28,96 +29,6 @@ class Object
   end
 end
 
-class NilClass
-  begin
-    nil.dup
-  rescue TypeError
-
-    # +nil+ is not duplicable:
-    #
-    #   nil.duplicable? # => false
-    #   nil.dup         # => TypeError: can't dup NilClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class FalseClass
-  begin
-    false.dup
-  rescue TypeError
-
-    # +false+ is not duplicable:
-    #
-    #   false.duplicable? # => false
-    #   false.dup         # => TypeError: can't dup FalseClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class TrueClass
-  begin
-    true.dup
-  rescue TypeError
-
-    # +true+ is not duplicable:
-    #
-    #   true.duplicable? # => false
-    #   true.dup         # => TypeError: can't dup TrueClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class Symbol
-  begin
-    :symbol.dup
-
-    # Some symbols couldn't be duped in Ruby 2.4.0 only, due to a bug.
-    # This feature check catches any regression.
-    "symbol_from_string".to_sym.dup
-  rescue TypeError
-
-    # Symbols are not duplicable:
-    #
-    #   :my_symbol.duplicable? # => false
-    #   :my_symbol.dup         # => TypeError: can't dup Symbol
-    def duplicable?
-      false
-    end
-  end
-end
-
-class Numeric
-  begin
-    1.dup
-  rescue TypeError
-
-    # Numbers are not duplicable:
-    #
-    #  3.duplicable? # => false
-    #  3.dup         # => TypeError: can't dup Integer
-    def duplicable?
-      false
-    end
-  end
-end
-
-require "bigdecimal"
-class BigDecimal
-  # BigDecimals are duplicable:
-  #
-  #   BigDecimal("1.2").duplicable? # => true
-  #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
-  def duplicable?
-    true
-  end
-end
-
 class Method
   # Methods are not duplicable:
   #
@@ -125,35 +36,5 @@ class Method
   #  method(:puts).dup         # => TypeError: allocator undefined for Method
   def duplicable?
     false
-  end
-end
-
-class Complex
-  begin
-    Complex(1).dup
-  rescue TypeError
-
-    # Complexes are not duplicable:
-    #
-    #   Complex(1).duplicable? # => false
-    #   Complex(1).dup         # => TypeError: can't copy Complex
-    def duplicable?
-      false
-    end
-  end
-end
-
-class Rational
-  begin
-    Rational(1).dup
-  rescue TypeError
-
-    # Rationals are not duplicable:
-    #
-    #   Rational(1).duplicable? # => false
-    #   Rational(1).dup         # => TypeError: can't copy Rational
-    def duplicable?
-      false
-    end
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 #--
@@ -34,6 +33,16 @@ class Method
   #
   #  method(:puts).duplicable? # => false
   #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?
+    false
+  end
+end
+
+class UnboundMethod
+  # Unbound methods are not duplicable:
+  #
+  #  method(:puts).unbind.duplicable? # => false
+  #  method(:puts).unbind.dup         # => TypeError: allocator undefined for UnboundMethod
   def duplicable?
     false
   end

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/object/duplicable"
 require "active_support/core_ext/numeric/time"
 
 class DuplicableTest < ActiveSupport::TestCase
-  RAISE_DUP = [method(:puts)]
+  RAISE_DUP = [method(:puts), method(:puts).unbind]
   ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
 
   def test_duplicable


### PR DESCRIPTION
Edit: https://github.com/rails/rails/pull/28544

AFAIK all these feature tests are for pre 2.5.0 MRI, now that Rails requires 2.5.0+, it's no longer useful to test it.

While I was at it I added one exception for `UnboundMethod` that was missing.

Another class that could use it is `Thread`:

```ruby
>> Thread.new{}.dup
TypeError (allocator undefined for Thread)
```

However it would mean requiring the `thread` module, which seems wrong.

cc @rafaelfranca @Edouard-chin 