### PR TITLE
Add #changed_any? to ActiveModel::Dirty

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -165,6 +165,19 @@ module ActiveModel
       mutations_from_database.changed_attribute_names
     end
 
+    # Returns +true+ if any of the given attributes has unsaved changes, +false+ otherwise.
+    #
+    #   person.changed_any?(:name, :gender)   # => false
+    #   person.name = 'bob'
+    #   person.changed_any?(:name, :gender)   # => true
+    #   person.changed_any?('name', 'gender') # => true
+    def changed_any?(*attr_names)
+      return changed? if attr_names.empty?
+
+      attr_names = attr_names.flatten.map(&:to_s)
+      (attr_names & changed).present?
+    end
+
     # Dispatch target for <tt>*_changed?</tt> attribute methods.
     def attribute_changed?(attr_name, **options) # :nodoc:
       mutations_from_database.changed?(attr_name.to_s, options)

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -57,6 +57,14 @@ class DirtyTest < ActiveModel::TestCase
     assert_predicate @model, :name_changed?
   end
 
+  test "changed_any? returns whether one of the attributes changed" do
+    assert_not_predicate @model, :changed_any?
+    assert_not @model.changed_any?(:name, :color)
+    @model.name = "Ringo"
+    assert_predicate @model, :changed_any?
+    assert @model.changed_any?(:name, :color)
+  end
+
   test "list of changed attribute keys" do
     assert_equal [], @model.changed
     @model.name = "Paul"


### PR DESCRIPTION
Add `changed_any?` method to to determine if any attribute of a set of attributes was changed.

This is an addition to #36651 where I added `saved_changes_to_any?`. To keep functionality in `before_save`, and `after_save` states consistent, I implemented this method as well.

Because this affects `ActiveModel` and not `ActiveRecord` alone, I made a separate PR. But let me know what you think.

### Summary

Assume the case where one wants to check if any of a number of attributes have changed in an `before_save` callback.

For example

```ruby
class Search < ActiveRecord::Base
  before_save :delete_unnecessary_results
  
  private
  def delete_unnecessary_results
    watchlist = [:start_date, :last_start_date, :additional_days, :duration]
    return unless changed_any?(watchlist)

    # ...
  end
end
```

The method can take an array, multiple symbols, or strings.

```ruby
person = Person.new(first_name: 'Sean')
person.changed_any?(:first_name, :gender)   # => true
person.changed_any?('first_name', 'gender') # => true
person.changed_any?(:last_name, :gender)    # => false
```

### Other Information

I'm not sure about the name of the method. `changes_to_any?` came into my mind too. I'm happy to hear your thoughts on this.