### PR TITLE
Allows logged redirect URls filtering based on parameter_filters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added ability to filter specific parameters in redirect URL logs
+    
+    *Mike Yue*
+
 *   Add DSL for configuring HTTP Feature Policy
 
     This new DSL provides a way to configure a HTTP Feature Policy at a

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -32,6 +32,10 @@ module Another
       redirect_to "http://secret.foo.bar/"
     end
 
+    def parameter_filterable_redirector
+      redirect_to "http://secret.foo.bar/?token=test"
+    end
+
     def data_sender
       send_data "cool data", filename: "file.txt"
     end


### PR DESCRIPTION
Added ability to filter specific parameters in redirect URL logs

*Mike Yue*

If Rails.application.config.filter_redirect is not specified, Rails will now look at
Rails.application.config.filter_parameters and filter out any parameters in the URL
present to be logged

### Summary

Previously, filtering out URLs to be logged meant the entire URL would be filtered out. This PR does not change any original functionality of the existing `filter_redirect` functions. Rather, in the absence of any keywords specified for `filter_redirect`, Rails will take keywords specified for `filter_parameters` and filter out any parameters in the logged URL that match those keywords. For example, if `:token` is specified as a parameter to be filtered, the original URL `https://example.come/?token=example&redirect=/` will become `https://example.come/?token=[FILTERED]&redirect=/` in the logs.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
