### PR TITLE
Make currency symbols optional for money column type in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make currency symbols optional for money column type in PostgreSQL
+
+    *Joel Schneider*
+
 *   Add database_exists? method to connection adapters to check if a database exists.
 
     *Guilherme Mansur*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -26,9 +26,9 @@ module ActiveRecord
 
             value = value.sub(/^\((.+)\)$/, '-\1') # (4)
             case value
-            when /^-?\D+[\d,]+\.\d{2}$/  # (1)
+            when /^-?\D*[\d,]+\.\d{2}$/  # (1)
               value.gsub!(/[^-\d.]/, "")
-            when /^-?\D+[\d.]+,\d{2}$/  # (2)
+            when /^-?\D*[\d.]+,\d{2}$/  # (2)
               value.gsub!(/[^-\d,]/, "").sub!(/,/, ".")
             end
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -54,8 +54,12 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     type = PostgresqlMoney.type_for_attribute("wealth")
     assert_equal(12345678.12, type.cast(+"$12,345,678.12"))
     assert_equal(12345678.12, type.cast(+"$12.345.678,12"))
+    assert_equal(12345678.12, type.cast(+"12,345,678.12"))
+    assert_equal(12345678.12, type.cast(+"12.345.678,12"))
     assert_equal(-1.15, type.cast(+"-$1.15"))
     assert_equal(-2.25, type.cast(+"($2.25)"))
+    assert_equal(-1.15, type.cast(+"-1.15"))
+    assert_equal(-2.25, type.cast(+"(2.25)"))
   end
 
   def test_schema_dumping


### PR DESCRIPTION
### Summary

I made a small change to the `cast_value` regex for `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Money` class which makes the currency symbol optional when casting the value. The existing code supported "$12,345.67", "$12.345,67", "-$12.34" and "($12.34)". This would add support for "12,345.67" or "12.345,67".

### Other Information

There are currently some odd inconsistencies around the `cast_value` method that this will fix. For example, "(7,700,200.35)" and "-7,700,200.35" currently both cast to "-7700200.35". However, "7,700,200.35" cast to "7.0". With these changes, "7,700,200.35" would cast to "7700200.35" as you expect.