### PR TITLE
Make Active Storage routes optional

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `config.active_storage.draw_routes` to disable Active Storage routes.
+
+    *Gannon McGibbon*
+
 *   Image analysis is skipped if ImageMagick returns an error.
 
     `ActiveStorage::Analyzer::ImageAnalyzer#metadata` would previously raise a

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -29,4 +29,4 @@ Rails.application.routes.draw do
 
   resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
   resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
-end
+end if ActiveStorage.draw_routes

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -60,6 +60,7 @@ module ActiveStorage
   mattr_accessor :service_urls_expire_in, default: 5.minutes
 
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
+  mattr_accessor :draw_routes, default: true
 
   mattr_accessor :replace_on_assign_to_many, default: false
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -73,6 +73,7 @@ module ActiveStorage
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
         ActiveStorage.paths             = app.config.active_storage.paths || {}
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
+        ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -885,6 +885,8 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 * `config.active_storage.replace_on_assign_to_many` determines whether assigning to a collection of attachments declared with `has_many_attached` replaces any existing attachments or appends to them. The default is `true`.
 
+* `config.active_storage.draw_routes` can be used to toggle Active Storage route generation. The default is `true`.
+
 ### Results of `load_defaults`
 
 #### With '5.0':

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2593,6 +2593,21 @@ module ApplicationTests
       MESSAGE
     end
 
+    test "ActiveStorage.draw_routes can be configured via config.active_storage.draw_routes" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_storage.draw_routes = false
+        end
+      RUBY
+
+      output = rails("routes")
+      assert_not_includes(output, "rails_service_blob")
+      assert_not_includes(output, "rails_blob_representation")
+      assert_not_includes(output, "rails_disk_service")
+      assert_not_includes(output, "update_rails_disk_service")
+      assert_not_includes(output, "rails_direct_uploads")
+    end
+
     test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"


### PR DESCRIPTION
### Summary

Currently, I don't see a way of turning off Active Storage's default routes. They are drawn on the host application and not on the engine (due to `direct` and `resolve` being used). For applications that only want to use assets internally, or need to point to different controllers to meet their app's needs, the only way to remove routes currently is something like this:

```
initializer(:remove_activestorage_routes, after: :add_routing_paths) do |app|
  app.routes_reloader.paths.delete_if { |path| path =~ /activestorage/ }
end
```

Does it make sense to make this easier? cc @georgeclaghorn 