### PR TITLE
Specify log subscribers need a logger set before they can receive events

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -29,6 +29,9 @@ module ActiveSupport
   # subscriber, the line above should be called after your
   # <tt>ActiveRecord::LogSubscriber</tt> definition.
   #
+  # A logger also needs to be set with <tt>ActiveRecord::LogSubscriber.logger=</tt>.
+  # This is assigned automatically in a Rails environment.
+  #
   # After configured, whenever a <tt>"sql.active_record"</tt> notification is published,
   # it will properly dispatch the event
   # (<tt>ActiveSupport::Notifications::Event</tt>) to the sql method.


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/36657.

The current example code for `ActiveSupport::LogSubscriber` mysteriously fails if you're using it outside of Rails. This helps clarify a logger needs to be set first before log subscribers can process events.