### PR TITLE
Don't validate non dirty association targets

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -302,7 +302,7 @@ module ActiveRecord
       def validate_single_association(reflection)
         association = association_instance_get(reflection.name)
         record      = association && association.reader
-        association_valid?(reflection, record) if record
+        association_valid?(reflection, record) if record && record.changed_for_autosave?
       end
 
       # Validate the associated records if <tt>:validate</tt> or

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -13,12 +13,14 @@ require "models/developer"
 require "models/computer"
 require "models/invoice"
 require "models/line_item"
+require "models/mouse"
 require "models/order"
 require "models/parrot"
 require "models/pirate"
 require "models/project"
 require "models/ship"
 require "models/ship_part"
+require "models/squeak"
 require "models/tag"
 require "models/tagging"
 require "models/treasure"
@@ -385,6 +387,20 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     auditlog.developer_id = valid_developer.id
 
     assert_predicate auditlog, :valid?
+  end
+
+  def test_validation_does_not_validate_non_dirty_association_target
+    mouse = Mouse.create!(name: "Will")
+    Squeak.create!(mouse: mouse)
+
+    mouse.name = nil
+    mouse.save! validate: false
+
+    squeak = Squeak.last
+
+    assert_equal true, squeak.valid?
+    assert_equal true, squeak.mouse.present?
+    assert_equal true, squeak.valid?
   end
 end
 

--- a/activerecord/test/models/mouse.rb
+++ b/activerecord/test/models/mouse.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Mouse < ActiveRecord::Base
+  has_many :squeaks, autosave: true
+  validates :name, presence: true
+end

--- a/activerecord/test/models/squeak.rb
+++ b/activerecord/test/models/squeak.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Squeak < ActiveRecord::Base
+  belongs_to :mouse
+  accepts_nested_attributes_for :mouse
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -563,6 +563,10 @@ ActiveRecord::Schema.define do
     t.string   :type
   end
 
+  create_table :mice, force: true do |t|
+    t.string   :name
+  end
+
   create_table :movies, force: true, id: false do |t|
     t.primary_key :movieid
     t.string      :name
@@ -841,6 +845,10 @@ ActiveRecord::Schema.define do
     else
       t.datetime :updated_at
     end
+  end
+
+  create_table :squeaks, force: true do |t|
+    t.integer :mouse_id
   end
 
   create_table :prisoners, force: true do |t|


### PR DESCRIPTION
Fixes #36581.

### Summary

This fixes an issue where validations would return differently after a previously saved invalid association was loaded. Here the relationship between Mouse and Squeak is:

```ruby
class Mouse < ActiveRecord::Base
  has_many :squeaks, autosave: true
  validates :name, presence: true
end

class Squeak < ActiveRecord::Base
  belongs_to :mouse
  accepts_nested_attributes_for :mouse
end
```

Currently, if we have an invalid mouse association that was previously saved at some point in the past (eg. with `mouse.save! validate: false`) then loading the association will cause the change in return value for the parent object's `valid?` method, here `squeak.valid?`):

```ruby
squeak.valid? # => true
squeak.mouse.present? # invalid mouse association is loaded
squeak.valid?  # => false
```

Limiting validations to associations that will be saved (using autosave: true) due to being changed means that loading invalid associated relations will not change the return value of the parent relation's `valid?` method, after this patch:

```ruby
squeak.valid? # => true
squeak.mouse.present? # invalid mouse association is loaded, but not changed
squeak.valid?  # => true
```

This change also updates the way save/save! works when the association is unchanged, I think for the better. Before the change:

```ruby
squeak = Squeak.first
squeak.valid? # => true
squeak.save # => true
squeak.mouse.present? # invalid mouse association is loaded, but unchanged
squeak.valid?  # => false # valid? method behaviour has changed even though we never altered the mouse association
squeak.save # => false
```

After the change:

```ruby
squeak = Squeak.first
squeak.valid? # => true
squeak.save # => true
squeak.mouse.present? # invalid mouse association is loaded
squeak.valid?  # => true # valid? method behaviour is the same because we never altered the association and it would not be saved
squeak.save # => true
```

This seems reasonable, as we are only operating on the squeak parent object. With the new code if we change the mouse association we still get the expected behaviour:

```ruby
squeak = Squeak.first
squeak.valid? # => true
squeak.mouse.present? # invalid mouse association is loaded
squeak.save # => true
squeak.mouse.name = "Jerry" # Make the mouse object valid again
squeak.save # => true
squeak.mouse.name =  nil # Re-invalidate the mouse object
squeak.save # => false
```