### PR TITLE
Add hash method to ActionController::Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -259,6 +259,11 @@ module ActionController
         @parameters == other
       end
     end
+    alias eql? ==
+
+    def hash
+      [@parameters.hash, @permitted].hash
+    end
 
     # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
     # representation of the parameters with all unpermitted keys removed.

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -284,12 +284,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params1 = ActionController::Parameters.new(a: 1, b: 2)
     params2 = ActionController::Parameters.new(a: 1, b: 2)
     assert(params1 == params2)
+    assert(params1.hash == params2.hash)
   end
 
   test "is equal to Parameters instance with same permitted params" do
     params1 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
     params2 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
     assert(params1 == params2)
+    assert(params1.hash == params2.hash)
   end
 
   test "is equal to Parameters instance with same different source params, but same permitted params" do
@@ -297,6 +299,8 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params2 = ActionController::Parameters.new(a: 1, c: 3).permit(:a)
     assert(params1 == params2)
     assert(params2 == params1)
+    assert(params1.hash == params2.hash)
+    assert(params2.hash == params1.hash)
   end
 
   test "is not equal to an unpermitted Parameters instance with same params" do
@@ -304,6 +308,8 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params2 = ActionController::Parameters.new(a: 1)
     assert(params1 != params2)
     assert(params2 != params1)
+    assert(params1.hash != params2.hash)
+    assert(params2.hash != params1.hash)
   end
 
   test "is not equal to Parameters instance with different permitted params" do
@@ -311,6 +317,8 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params2 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
     assert(params1 != params2)
     assert(params2 != params1)
+    assert(params1.hash != params2.hash)
+    assert(params2.hash != params1.hash)
   end
 
   test "equality with simple types works" do


### PR DESCRIPTION
### Summary

Fix issue with strong params equality check for cases when you use `Array#uniq` or adding params objects into `Set`. 

Before change:
```ruby
params1 = ActionController::Parameters.new(a: 1)
params2 = ActionController::Parameters.new(a: 1)

[params1, params2].uniq
# => [<ActionController::Parameters {"a"=>1} permitted: false>, <ActionController::Parameters {"a"=>1} permitted: false>]

set = Set.new()
set.add(params1)
set.add(params2)

# => #<Set: {<ActionController::Parameters {"a"=>1} permitted: false>, <ActionController::Parameters {"a"=>1} permitted: false>}>
``` 

After change:
```ruby
params1 = ActionController::Parameters.new(a: 1)
params2 = ActionController::Parameters.new(a: 1)

[params1, params2].uniq
# => [<ActionController::Parameters {"a"=>1} permitted: false>

set = Set.new()
set.add(params1)
set.add(params2)

# => #<Set: {<ActionController::Parameters {"a"=>1} permitted: false>}>
``` 