### PR TITLE
Fix activestorage CI failure due to ffprove version differece

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -24,7 +24,6 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 480, metadata[:width]
     assert_equal 640, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal 5.227975, metadata[:duration]
     assert_equal 90, metadata[:angle]
   end
 


### PR DESCRIPTION
Our CI environment is upgraded from stretch to buster then ffprove
version is also upgraded from 3.2.14 to 4.1.3.

https://packages.debian.org/stretch/ffmpeg
https://packages.debian.org/buster/ffmpeg

Somehow those ffprove returns different metadata for
`rotated_video.mp4`.

```
$ ffprobe -print_format json -show_streams -v error rotated_video.mp4 > ffprobe41.json
$ diff -ub ffprobe32.json ffprobe41.json
--- ffprobe32.json      2019-07-14 20:02:13.000000000 +0900
+++ ffprobe41.json      2019-07-14 19:59:08.000000000 +0900
@@ -27,8 +27,8 @@
             "time_base": "1/17594",
             "start_pts": 3976,
             "start_time": "0.225986",
-            "duration_ts": 91981,
-            "duration": "5.227975",
+            "duration_ts": 88000,
+            "duration": "5.001705",
             "bit_rate": "321546",
             "bits_per_raw_sample": "8",
             "nb_frames": "44",
@@ -78,8 +78,8 @@
             "time_base": "1/44100",
             "start_pts": 0,
             "start_time": "0.000000",
-            "duration_ts": 227865,
-            "duration": "5.167007",
+            "duration_ts": 227850,
+            "duration": "5.166667",
             "bit_rate": "109732",
             "max_bit_rate": "109732",
             "nb_frames": "223",
```

In the case on the `test "analyzing a rotated video"`, most important
part is `assert_equal 90, metadata[:angle]`, the accidental difference
of duration for ffprove version is out of scope for the test.