### PR TITLE
Different versions of ffprobe can return subtly different video lengths

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -13,7 +13,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 640, metadata[:width]
     assert_equal 480, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal 5.166648, metadata[:duration]
+    assert_equal true, metadata[:duration].between?(4, 6)
     assert_not_includes metadata, :angle
   end
 


### PR DESCRIPTION
340667243c12b7ba879e0e2db71b3f8843f75379 removes an assertion that failed due to a change in the output of ffprobe. This PR is a is a proposal to retain the check, but specify a range so we can take this into account, but not get caught out by 0, nil or way too large values.

/cc @kamipo
