### PR TITLE
Able to add Symbol parameter(alias column name) with where clause

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -19,6 +19,15 @@ module ActiveRecord
           parts = predicate_builder.build_from_hash(attributes)
         when Arel::Nodes::Node
           parts = [opts]
+        when Symbol
+          raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})" if other.blank?
+
+          if klass.attribute_alias?(opts)
+            original_column = klass.attribute_alias(opts)
+          else
+            original_column = opts.to_s
+          end
+          parts = [ original_column + klass.sanitize_sql(other.size == 1 ? other.first : ([other.first] + other.from(1))) ]
         else
           raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
         end

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         when Arel::Nodes::Node
           parts = [opts]
         when Symbol
-          raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})" if other.blank?
+          raise ArgumentError, "do not allow only symbol parameter" if other.blank?
 
           if klass.attribute_alias?(opts)
             original_column = klass.attribute_alias(opts)

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         when Arel::Nodes::Node
           parts = [opts]
         when Symbol
-          raise ArgumentError, "do not allow only symbol parameter" if other.blank?
+          raise ArgumentError, "do not allow only symbol parameter: #{opts} (#{opts.class}" if other.blank?
 
           if klass.attribute_alias?(opts)
             original_column = klass.attribute_alias(opts)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -286,13 +286,13 @@ module ActiveRecord
     def test_inequality_condition_with_alias_name
       current_time = Time.current
       expected = Topic.where("created_at > ?", current_time)
-      actual   = Topic.where(:published_at, " > ?", current_time)
+      actual   = Topic.where(:alias_created_at, " > ?", current_time)
 
       assert_equal expected.to_sql, actual.to_sql
     end
 
     def test_inequality_condition_with_unsupported_arguments
-      assert_raises(ArgumentError) { Topic.where(:published_at) }
+      assert_raises(ArgumentError) { Topic.where(:alias_created_at) }
     end
 
     def test_where_error

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -283,6 +283,18 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_inequality_condition_with_alias_name
+      current_time = Time.current
+      expected = Topic.where("created_at > ?", current_time)
+      actual   = Topic.where(:published_at, " > ?", current_time)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_inequality_condition_with_unsupported_arguments
+      assert_raises(ArgumentError) { Topic.where(:published_at) }
+    end
+
     def test_where_error
       assert_nothing_raised do
         Post.where(id: { "posts.author_id" => 10 }).first

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -55,6 +55,7 @@ class Topic < ActiveRecord::Base
   end
 
   alias_attribute :heading, :title
+  alias_attribute :published_at, :created_at
 
   before_validation :before_validation_for_transaction
   before_save :before_save_for_transaction

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -55,7 +55,7 @@ class Topic < ActiveRecord::Base
   end
 
   alias_attribute :heading, :title
-  alias_attribute :published_at, :created_at
+  alias_attribute :alias_created_at, :created_at
 
   before_validation :before_validation_for_transaction
   before_save :before_save_for_transaction


### PR DESCRIPTION
Hi!, Everyone.
this is my first PR. please review.
I want to add the Symbol parameter to the Where function and use the Where function with a column alias.

If legacy column names did not be created  Rails's naming rule, you may wish to use only alias.
We are developing  with legacy tables that could not be created according to Rails  naming rules.

Legacy Table
```
CREATE TABLE TArticle (
  taId int,
  taTitle varchar(40),
  taContent varchar(100),
  taCreated date time,
)
```
The column names of all the tables are defined as aliases.
Rails Model
```
class Legacy::Article < ApplicationRecord
  self.table_name = 'TArticle'
  self.primary_key = 'taId'

  alias_attribute :title, :taTitle
  alias_attribute :content, :taContent
  alias_attribute :published_at, :taCreated
end
```

I can select data with using origin column name
`Legacy::Article.where('taCreated> ?', 10.days.ago)`

But I can’t select data with using alias column name. 
I want to use alias column name.

I edited `where_clause_factory.rb` 
If you  just write an alias ​column ​name  in the first parameter of the where function.
please review and merge.

After change.
```
Legacy::Article.where(:published_at, ’ > ? ', 10.days.ago)
```
SQL
```
SELECT [TArticle].* FROM [TArticle] WHERE  (taCreated > '07-04-2019 19:40:25.29’);
```