### PR TITLE
Restore ActiveSupport::Inflector.parameterize support for non-utf-8 strings

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -56,8 +56,14 @@ module ActiveSupport
     #
     #   transliterate('Jürgen', locale: :de)
     #   # => "Juergen"
+    #
+    # If the provided string's encoding is not UTF-8, the string will be converted
+    # to UTF-8. This means that this method will always return a UTF-8 string.
     def transliterate(string, replacement = "?", locale: nil)
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
+
+      # unicode_normalize expects a UTF-8 string. If a non-utf-8 string is given, we'll convert encodings
+      string = string.encode("utf-8", invalid: :replace, undef: :replace, replace: "") unless string.encoding == ::Encoding::UTF_8
 
       I18n.transliterate(
         ActiveSupport::Multibyte::Unicode.tidy_bytes(string).unicode_normalize(:nfc),
@@ -92,6 +98,8 @@ module ActiveSupport
     # the word will be parameterized as a word of that language.
     # By default, this parameter is set to <tt>nil</tt> and it will use
     # the configured <tt>I18n.locale<tt>.
+    #
+    # This method always returns a UTF-8 encoded string.
     def parameterize(string, separator: "-", preserve_case: false, locale: nil)
       # Replace accented chars with their ASCII equivalents.
       parameterized_string = transliterate(string, locale: locale)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -310,6 +310,24 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("fuenf-autos", ActiveSupport::Inflector.parameterize(word, locale: :de))
   end
 
+  def test_parameterize_with_non_unicode_string
+    StringToParameterizedNonUnicode.each do |some_string, parameterized_string|
+      assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
+    end
+  end
+
+  def test_parameterize_with_non_unicode_string_and_locale
+    word = "\u{ff21}".encode(Encoding::Windows_31J)
+    I18n.backend.store_translations(:ja, i18n: { transliterate: { rule: { "Ａ" => "A" } } })
+    assert_equal("a", ActiveSupport::Inflector.parameterize(word, locale: :ja))
+  end
+
+  def test_parameterize_with_unidentified_characters_in_non_unicode_string
+    some_string = String.new("\xC3\xBC unidentified chars", encoding: Encoding::ASCII_8BIT)
+    parameterized_string = "unidentified-chars"
+    assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
+  end
+
   def test_classify
     ClassNameToTableName.each do |class_name, table_name|
       assert_equal(class_name, ActiveSupport::Inflector.classify(table_name))

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -242,6 +242,11 @@ module InflectorTestCases
     "Japanese: 日本語" => "japanese"
   }
 
+  StringToParameterizedNonUnicode = {
+    String.new("an ASCII-8BIT string", encoding: Encoding::ASCII_8BIT)  => "an-ascii-8bit-string",
+    "\u{ff21}".encode(Encoding::Windows_31J)                            => ""
+  }
+
   UnderscoreToHuman = {
     "employee_salary" => "Employee salary",
     "employee_id"     => "Employee",

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -57,4 +57,20 @@ class TransliterateTest < ActiveSupport::TestCase
     end
     assert_equal "Can only transliterate strings. Received Object", exception.message
   end
+
+  def test_transliterate_handles_non_unicode_strings
+    ascii_8bit_string = String.new("A", encoding: Encoding::ASCII_8BIT)
+    assert_equal "A", ActiveSupport::Inflector.transliterate(ascii_8bit_string)
+  end
+
+  def test_transliterate_handles_non_unicode_strings_with_locale
+    I18n.backend.store_translations(:ja, i18n: { transliterate: { rule: { "Ａ" => "A" } } })
+    windows_31j_string = "\u{ff21}".encode(Encoding::Windows_31J)
+    assert_equal "A", ActiveSupport::Inflector.transliterate(windows_31j_string, locale: :ja)
+  end
+
+  def test_transliterate_handles_unidentified_characters_in_non_unicode_strings
+    ascii_8bit_string = String.new("\xC3\xBC", encoding: Encoding::ASCII_8BIT)
+    assert_equal "", ActiveSupport::Inflector.transliterate(ascii_8bit_string)
+  end
 end


### PR DESCRIPTION
## Summary

This PR suggests updating `ActiveSupport::Inflector.transliterate` and `ActiveSupport::Inflector.parameterize` to restore support for strings with encodings other than `UTF-8`.

It's noted in https://github.com/rails/rails/issues/34062 that `String#parameterize` will raise an `Encoding::CompatibilityError` if the string is not `UTF-8` encoded. https://github.com/rails/rails/issues/34062 is currently a closed issue but I wonder if it might be worth revisiting.

## Details

At GitHub we've encountered issues with `parameterize` and `ASCII-8BIT` strings a few times. We've resolved the errors by converting to `UTF-8` before calling `parameterize`. Recently we encountered the error again in a way that our main test suite didn't reveal but we were fortunate enough to catch. 

This issue was nagging at me and I thought I'd submit a PR for a few reasons:

1. `String#parameterize` is a higher level API and only being able to call the method on a UTF-8 string feels a little bit odd.

2. Prior to https://github.com/rails/rails/pull/26743, the method worked and did not raise an error for other encodings. In https://github.com/rails/rails/issues/34062 there was some discussion about wanting to maintain prior behavior but it was noted that `ActiveSupport::Multibyte::Unicode.normalize` did not previously always return the expected result anyway, so raising an error was appropriate. I can certainly see the point being made, however for an app upgrading to 6.0 I think maybe keeping the original behavior of being able to call the method on non-UTF-8 string without raising an error might be preferred.

3. It seems probable that some apps may be depending on the framework to work with non-UTF-8 encodings, and might not test behavior with other encodings. This could lead to errors that are only identified when they occur in production.

Since it's reasonable (in cases I've encountered) to deal with this error by converting the string to `UTF-8` prior to calling `parameterize`, it seems reasonable to me for the framework to perform that step automatically when needed.

This PR updates `ActiveSupport::Inflector.transliterate` to check and encode strings to `UTF-8` which also extends the behavior `ActiveSupport::Inflector.parameterize`. It's entirely possible that there are some other complexities dealing with encoding that I'm not considering here. If so, I'm happy to try to work on some other tests cases to see if this can maybe get squeezed into 6.0