### PR TITLE
Use reserved domain for example configuration

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -15,7 +15,7 @@
       f.microphone  :none
       f.usb         :none
       f.fullscreen  :self
-      f.payment     :self, "https://secure-example.com"
+      f.payment     :self, "https://secure.example.com"
     end
     ```
 

--- a/actionpack/lib/action_controller/metal/feature_policy.rb
+++ b/actionpack/lib/action_controller/metal/feature_policy.rb
@@ -19,7 +19,7 @@ module ActionController #:nodoc:
   #     f.microphone  :none
   #     f.usb         :none
   #     f.fullscreen  :self
-  #     f.payment     :self, "https://secure-example.com"
+  #     f.payment     :self, "https://secure.example.com"
   #   end
   #
   #   # Controller level policy

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/feature_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/feature_policy.rb.tt
@@ -7,5 +7,5 @@
 #   f.microphone  :none
 #   f.usb         :none
 #   f.fullscreen  :self
-#   f.payment     :self, "https://secure-example.com"
+#   f.payment     :self, "https://secure.example.com"
 # end


### PR DESCRIPTION
Updates the generator output to use a [reserved domain](https://tools.ietf.org/html/rfc2606#section-3) instead of a
potentially real world domain.

Fixes https://github.com/rails/rails/pull/33439#discussion_r303222574