### PR TITLE
Option to disable bang and predicate methods that 'ActiveRecord.enum' generates by default

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -151,6 +151,8 @@ module ActiveRecord
       klass = self
       enum_prefix = definitions.delete(:_prefix)
       enum_suffix = definitions.delete(:_suffix)
+      enum_predicate = definitions.delete(:_predicate)
+      enum_bang = definitions.delete(:_bang)
       enum_scopes = definitions.delete(:_scopes)
       definitions.each do |name, values|
         assert_valid_enum_definition_values(values)
@@ -189,13 +191,17 @@ module ActiveRecord
             enum_values[label] = value
             label = label.to_s
 
-            # def active?() status == "active" end
-            klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-            define_method("#{value_method_name}?") { self[attr] == label }
+            if enum_predicate != false
+              # def active?() status == "active" end
+              klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
+              define_method("#{value_method_name}?") { self[attr] == label }
+            end
 
-            # def active!() update!(status: 0) end
-            klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
-            define_method("#{value_method_name}!") { update!(attr => value) }
+            if enum_bang != false
+              # def active!() update!(status: 0) end
+              klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
+              define_method("#{value_method_name}!") { update!(attr => value) }
+            end
 
             # scope :active, -> { where(status: 0) }
             # scope :not_active, -> { where.not(status: 0) }

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -557,6 +557,24 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal :integer, Book.type_for_attribute("status").type
   end
 
+  test "predicate methods can be disabled" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written], _predicate: false
+    end
+
+    assert_raises(NoMethodError) { klass.proposed? }
+  end
+
+  test "bang methods can be disabled" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written], _bang: false
+    end
+
+    assert_raises(NoMethodError) { klass.proposed! }
+  end
+
   test "scopes can be disabled" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"


### PR DESCRIPTION
### Summary

 * By default ActiveRecord.enum generates bang and predicate methods that may have conflicts with methods defined by state_machine. Helps address the following issue: [issue-13](https://github.com/state-machines/state_machines-activerecord/issues/13)

### Usage Example
```ruby
enum status: {
  parked: 0,
  idling: 1
}, _predicate: false, _bang: false

state_machine :status, initial: :parked, action: :save do
  event :ignite { transition parked: :idling }
end
```
