### PR TITLE
Make UTF-8 string requirement explicit for `ActiveSupport::Inflector.transliterate`

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -5,8 +5,9 @@ require "active_support/i18n"
 
 module ActiveSupport
   module Inflector
-    # Replaces non-ASCII characters with an ASCII approximation, or if none
-    # exists, a replacement character which defaults to "?".
+    # Replaces non-ASCII characters in a UTF-8 encoded string with an ASCII
+    # approximation, or if none exists, a replacement character which
+    # defaults to "?".
     #
     #    transliterate('Ærøskøbing')
     #    # => "AEroskobing"
@@ -56,8 +57,12 @@ module ActiveSupport
     #
     #   transliterate('Jürgen', locale: :de)
     #   # => "Juergen"
+    #
+    # This method requires that `string` be UTF-8 encoded. Passing an argument
+    # with a different string encoding will raise an ArgumentError.
     def transliterate(string, replacement = "?", locale: nil)
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
+      raise ArgumentError, "Can only transliterate UTF-8 strings. Received string with encoding #{string.encoding}" unless string.encoding == ::Encoding::UTF_8
 
       I18n.transliterate(
         ActiveSupport::Multibyte::Unicode.tidy_bytes(string).unicode_normalize(:nfc),

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -57,4 +57,12 @@ class TransliterateTest < ActiveSupport::TestCase
     end
     assert_equal "Can only transliterate strings. Received Object", exception.message
   end
+
+  def test_transliterate_handles_non_unicode_strings
+    ascii_8bit_string = "A".b
+    exception = assert_raises ArgumentError do
+      assert_equal "A", ActiveSupport::Inflector.transliterate(ascii_8bit_string)
+    end
+    assert_equal "Can only transliterate UTF-8 strings. Received string with encoding ASCII-8BIT", exception.message
+  end
 end


### PR DESCRIPTION
It's noted in https://github.com/rails/rails/issues/34062 that `String#parameterize` will raise an `Encoding::CompatibilityError` if the string is not UTF-8 encoded which is a result of `ActiveSupport::Inflector.transliterate` calling `.unicode_normalize` on the string.

This PR raises a higher level `ArgumentError` if the provided string is not UTF-8 and updates documentation to note the encoding requirement.