### PR TITLE
Don't include routes helpers inside System test class:

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -54,11 +54,5 @@ module ActionDispatch
 
       ActionDispatch.test_app = app
     end
-
-    initializer "action_dispatch.system_tests" do |app|
-      ActiveSupport.on_load(:action_dispatch_system_test_case) do
-        include app.routes.url_helpers
-      end
-    end
   end
 end


### PR DESCRIPTION
Don't include routes helpers inside System test class:

- https://github.com/rails/rails/pull/36283 made a change to
  make SystemTest inherits from ActiveSupport::TestCase instead
  of ActionDispatch::IntegrationTest.

  With this change, the route helpers are now directly included inside
  the SystemTest class. This causes an edge case in case you have a
  routes whos name starts with `test_`, minitest will consider it as a
  test and will try to run it https://github.com/seattlerb/minitest/blob/ab39d35fb4e84eb866ed9c4ecb707cbf3889de42/lib/minitest/test.rb#L66

  This PR uses a proxy and deleted missing method to a dummy class
  that has all the route helpers.

cc/ @rafaelfranca 