### PR TITLE
Raise specific exception on Mysql2::Error::TimeoutError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -619,7 +619,11 @@ module ActiveRecord
           when ER_QUERY_INTERRUPTED
             QueryCanceled.new(message, sql: sql, binds: binds)
           else
-            super
+            if exception.is_a?(Mysql2::Error::TimeoutError)
+              ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
+            else
+              super
+            end
           end
         end
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -365,6 +365,10 @@ module ActiveRecord
   class QueryCanceled < StatementInvalid
   end
 
+  # AdapterTimeout will be raised when database clients times out while waiting from the server
+  class AdapterTimeout < StatementInvalid
+  end
+
   # UnknownAttributeReference is raised when an unknown and potentially unsafe
   # value is passed to a query method when allow_unsafe_raw_sql is set to
   # :disabled. For example, passing a non column name value to a relation's

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -225,6 +225,20 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_read_timeout_exception
+    ActiveRecord::Base.establish_connection(
+      ActiveRecord::Base.configurations[:arunit].merge("read_timeout" => 1)
+    )
+
+    error = assert_raises(ActiveRecord::AdapterTimeout) do
+      ActiveRecord::Base.connection.execute("SELECT SLEEP(2)")
+    end
+
+    assert_equal Mysql2::Error::TimeoutError, error.cause.class
+  ensure
+    ActiveRecord::Base.establish_connection :arunit
+  end
+
   private
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)
       super(@conn, "ex", definition, &block)


### PR DESCRIPTION
This is a backport of a Shopify patch.

When mysql2 client fails on a read timeout, it raises [Mysql2::Error::TimeoutError](https://github.com/brianmario/mysql2/pull/911/files#diff-634fc29a00423da17966525049aa8877R10) - which is currently wrapped into `ActiveRecord::StatementInvalid`. Based on our experience that's not a very descriptive exception class (the statement that times out is usually valid, so it's misleading) so we prefer to wrap it into its own (descriptive) exception.

This PR makes `translate_exception` to wrap  `Mysql2::Error::TimeoutError` into `ActiveRecord::AdapterTimeout` which indicates that the timeout is coming from adapter, not from MySQL server.

I'm open to hear alternative suggestions on the naming. I'm also aware that this is MySQL-only thing, but I think it's still worth doing. I looked for adapter timeouts for PG, but I couldn't find any specific exception for it.

cc @casperisfine @rafaelfranca @Edouard-chin 