### PR TITLE
Revert "Merge pull request #36676 from wjessop/change_activestorage_metadata_duration_to_bound"

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -13,7 +13,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 640, metadata[:width]
     assert_equal 480, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal true, metadata[:duration].between?(4, 6)
+    assert_equal 5.166648, metadata[:duration]
     assert_not_includes metadata, :angle
   end
 


### PR DESCRIPTION
This reverts commit a307c697b28e3c8b2860d2274c23e4d95dc164ae, reversing
changes made to f30f76af747858826d3618866676cd5a4979e64a.

Reason: This assertion is not failed even without this PR since both
ffprobe versions (3.2.14 and 4.1.3) return the same duration 5.166648
for `video.mp4`.
So there is no need to touch this assertion at this point.
