### PR TITLE
Support beginless ranges in hash conditions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for beginless ranges, introduced in Ruby 2.7.
+
+    *Josh Goodall*
+
 *   Add database_exists? method to connection adapters to check if a database exists.
 
     *Guilherme Mansur*

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -37,7 +37,7 @@ module Arel # :nodoc: all
     def between(other)
       if unboundable?(other.begin) == 1 || unboundable?(other.end) == -1
         self.in([])
-      elsif open_ended?(other.begin)
+      elsif other.begin.nil? || open_ended?(other.begin)
         if other.end.nil? || open_ended?(other.end)
           not_in([])
         elsif other.exclude_end?
@@ -85,7 +85,7 @@ Passing a range to `#in` is deprecated. Call `#between`, instead.
     def not_between(other)
       if unboundable?(other.begin) == 1 || unboundable?(other.end) == -1
         not_in([])
-      elsif open_ended?(other.begin)
+      elsif other.begin.nil? || open_ended?(other.begin)
         if other.end.nil? || open_ended?(other.end)
           self.in([])
         elsif other.exclude_end?

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -638,6 +638,18 @@ module Arel
           )
         end
 
+        if Gem::Version.new("2.7.0") <= Gem::Version.new(RUBY_VERSION)
+          it "can be constructed with a range implicitly starting at Infinity" do
+            attribute = Attribute.new nil, nil
+            node = attribute.between(eval("..0")) # eval for backwards compatibility
+
+            node.must_equal Nodes::LessThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            )
+          end
+        end
+
         if Gem::Version.new("2.6.0") <= Gem::Version.new(RUBY_VERSION)
           it "can be constructed with a range implicitly ending at Infinity" do
             attribute = Attribute.new nil, nil
@@ -837,6 +849,18 @@ module Arel
             attribute,
             Nodes::Casted.new(0, attribute)
           )
+        end
+
+        if Gem::Version.new("2.7.0") <= Gem::Version.new(RUBY_VERSION)
+          it "can be constructed with a range implicitly starting at Infinity" do
+            attribute = Attribute.new nil, nil
+            node = attribute.not_between(eval("..0")) # eval for backwards compatibility
+
+            node.must_equal Nodes::GreaterThan.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            )
+          end
         end
 
         if Gem::Version.new("2.6.0") <= Gem::Version.new(RUBY_VERSION)


### PR DESCRIPTION
### Summary

Ruby 2.7 introduces beginless ranges (`..value` and `...value`) and as with endless ranges we can turn these into inequalities, enabling expressions such as

    Order.where(created_at: ..1.year.ago)

    class Users < ApplicationRecord
      scope :unruly, -> { where(karma: ...0) }

### Other Information

Ruby 2.7 may not be released yet, but It is Coming.

