### PR TITLE
Irregular inflector for "Tranche"

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -66,6 +66,7 @@ module ActiveSupport
     inflect.irregular("sex", "sexes")
     inflect.irregular("move", "moves")
     inflect.irregular("zombie", "zombies")
+    inflect.irregular("tranche", "tranches")
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end


### PR DESCRIPTION
### Summary

Now:
ActiveSupport::Inflector.singularize("tranches") **=> "tranch"**

Should be:
ActiveSupport::Inflector.singularize("tranches") **=> "tranche"**
