### PR TITLE
Make active storage model classes configurable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `config.active_storage.blob_class` and `config.active_storage.attachment_class` to make Active Storage models configurable.
+
+    *Gannon McGibbon*
+
 *   Image analysis is skipped if ImageMagick returns an error.
 
     `ActiveStorage::Analyzer::ImageAnalyzer#metadata` would previously raise a

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -5,7 +5,7 @@
 # the blob that was created up front.
 class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
   def create
-    blob = ActiveStorage::Blob.create_before_direct_upload!(blob_args)
+    blob = ActiveStorage.blob_class.create_before_direct_upload!(blob_args)
     render json: direct_upload_json(blob)
   end
 

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -33,7 +33,7 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
 
   private
     def disk_service
-      ActiveStorage::Blob.service
+      ActiveStorage.blob_class.service
     end
 
 

--- a/activestorage/app/controllers/concerns/active_storage/set_blob.rb
+++ b/activestorage/app/controllers/concerns/active_storage/set_blob.rb
@@ -9,7 +9,7 @@ module ActiveStorage::SetBlob #:nodoc:
 
   private
     def set_blob
-      @blob = ActiveStorage::Blob.find_signed(params[:signed_blob_id] || params[:signed_id])
+      @blob = ActiveStorage.blob_class.find_signed(params[:signed_blob_id] || params[:signed_id])
     rescue ActiveSupport::MessageVerifier::InvalidSignature
       head :not_found
     end

--- a/activestorage/app/jobs/active_storage/mirror_job.rb
+++ b/activestorage/app/jobs/active_storage/mirror_job.rb
@@ -8,6 +8,6 @@ class ActiveStorage::MirrorJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
 
   def perform(key, checksum:)
-    ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum)
+    ActiveStorage.blob_class.service.try(:mirror, key, checksum: checksum)
   end
 end

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -9,7 +9,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
   self.table_name = "active_storage_attachments"
 
   belongs_to :record, polymorphic: true, touch: true
-  belongs_to :blob, class_name: "ActiveStorage::Blob"
+  belongs_to :blob, class_name: ActiveStorage.blob_class_name
 
   delegate_missing_to :blob
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -33,7 +33,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   has_many :attachments
 
-  scope :unattached, -> { left_joins(:attachments).where(ActiveStorage::Attachment.table_name => { blob_id: nil }) }
+  scope :unattached, -> { left_joins(:attachments).where(ActiveStorage.attachment_class.table_name => { blob_id: nil }) }
 
   before_destroy(prepend: true) do
     raise ActiveRecord::InvalidForeignKey if attachments.exists?

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -27,6 +27,6 @@ Rails.application.routes.draw do
     route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
   end
 
-  resolve("ActiveStorage::Blob")       { |blob, options| route_for(:rails_blob, blob, options) }
-  resolve("ActiveStorage::Attachment") { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
+  resolve(ActiveStorage.blob_class_name)       { |blob, options| route_for(:rails_blob, blob, options) }
+  resolve(ActiveStorage.attachment_class_name) { |attachment, options| route_for(:rails_blob, attachment.blob, options) }
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -55,6 +55,26 @@ module ActiveStorage
   mattr_accessor :service_urls_expire_in, default: 5.minutes
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
 
+  mattr_accessor :blob_class, default: "ActiveStorage::Blob"
+
+  class << self
+    alias_method :blob_class_name, :blob_class
+
+    def blob_class
+      @constantized_blob_class ||= blob_class_name.constantize
+    end
+  end
+
+  mattr_accessor :attachment_class, default: "ActiveStorage::Attachment"
+
+  class << self
+    alias_method :attachment_class_name, :attachment_class
+
+    def attachment_class
+      @constnatized_attachment_class ||= attachment_class_name.constantize
+    end
+  end
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -45,22 +45,22 @@ module ActiveStorage
       end
 
       def build_attachment
-        ActiveStorage::Attachment.new(record: record, name: name, blob: blob)
+        ActiveStorage.attachment_class.new(record: record, name: name, blob: blob)
       end
 
       def find_or_build_blob
         case attachable
-        when ActiveStorage::Blob
+        when ActiveStorage.blob_class
           attachable
         when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
-          ActiveStorage::Blob.build_after_unfurling \
+          ActiveStorage.blob_class.build_after_unfurling \
             io: attachable.open,
             filename: attachable.original_filename,
             content_type: attachable.content_type
         when Hash
-          ActiveStorage::Blob.build_after_unfurling(attachable)
+          ActiveStorage.blob_class.build_after_unfurling(attachable)
         when String
-          ActiveStorage::Blob.find_signed(attachable)
+          ActiveStorage.blob_class.find_signed(attachable)
         else
           raise ArgumentError, "Could not find or build blob: expected attachable, got #{attachable.inspect}"
         end

--- a/activestorage/lib/active_storage/attached/changes/delete_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/delete_many.rb
@@ -9,11 +9,11 @@ module ActiveStorage
     end
 
     def attachments
-      ActiveStorage::Attachment.none
+      ActiveStorage.attachment_class.none
     end
 
     def blobs
-      ActiveStorage::Blob.none
+      ActiveStorage.blob_class.none
     end
 
     def save

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -20,8 +20,8 @@ module ActiveStorage
       #   User.with_attached_avatar
       #
       # Under the covers, this relationship is implemented as a +has_one+ association to a
-      # ActiveStorage::Attachment record and a +has_one-through+ association to a
-      # ActiveStorage::Blob record. These associations are available as +avatar_attachment+
+      # ActiveStorage.attachment_class record and a +has_one-through+ association to a
+      # ActiveStorage.blob_class record. These associations are available as +avatar_attachment+
       # and +avatar_blob+. But you shouldn't need to work with these associations directly in
       # most circumstances.
       #
@@ -46,8 +46,8 @@ module ActiveStorage
           end
         CODE
 
-        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy
-        has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob
+        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: ActiveStorage.attachment_class_name, as: :record, inverse_of: :record, dependent: :destroy
+        has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: ActiveStorage.blob_class_name, source: :blob
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
 
@@ -76,8 +76,8 @@ module ActiveStorage
       #   Gallery.where(user: Current.user).with_attached_photos
       #
       # Under the covers, this relationship is implemented as a +has_many+ association to a
-      # ActiveStorage::Attachment record and a +has_many-through+ association to a
-      # ActiveStorage::Blob record. These associations are available as +photos_attachments+
+      # ActiveStorage.attachment_class record and a +has_many-through+ association to a
+      # ActiveStorage.blob_class record. These associations are available as +photos_attachments+
       # and +photos_blobs+. But you shouldn't need to work with these associations directly in
       # most circumstances.
       #
@@ -102,7 +102,7 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy do
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: ActiveStorage.attachment_class_name, inverse_of: :record, dependent: :destroy do
           def purge
             each(&:purge)
             reset
@@ -113,7 +113,7 @@ module ActiveStorage
             reset
           end
         end
-        has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob
+        has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: ActiveStorage.blob_class_name, source: :blob
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachments": :blob) }
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -73,6 +73,8 @@ module ActiveStorage
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
         ActiveStorage.paths             = app.config.active_storage.paths || {}
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
+        ActiveStorage.blob_class        = app.config.active_storage.blob_class || "ActiveStorage::Blob"
+        ActiveStorage.attachment_class  = app.config.active_storage.attachment_class || "ActiveStorage::Attachment"
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -883,6 +883,22 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
   The default is `/rails/active_storage`
 
+* `config.active_storage.blob_class` can be used to set the class for Active Storage blobs.
+
+  ```ruby
+  config.active_storage.blob_class = "MyBlobSubclass"
+  ```
+
+  The default is `"ActiveStorage::Blob"`.
+
+* `config.active_storage.attachment_class` can be used to set the class for Active Storage attachments.
+
+  ```ruby
+  config.active_storage.attachment_class = "MyAttachmentSubclass"
+  ```
+
+  The default is `"ActiveStorage::Attachment"`.
+
 ### Results of `load_defaults`
 
 #### With '5.0':

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2593,6 +2593,42 @@ module ApplicationTests
       MESSAGE
     end
 
+    test "ActiveStorage.blob_class is ActiveStorage::Blob by default" do
+      app "development"
+
+      assert_equal ActiveStorage::Blob, ActiveStorage.blob_class
+    end
+
+    test "ActiveStorage.blob_class can be changed" do
+      app_file "app/models/my_blob.rb", <<-RUBY
+        MyBlob = Class.new(ActiveStorage::Blob)
+      RUBY
+      app_file "config/initializers/active_storage.rb", <<-RUBY
+        Rails.application.config.active_storage.blob_class = "MyBlob"
+      RUBY
+      app "development"
+
+      assert_equal MyBlob, ActiveStorage.blob_class
+    end
+
+    test "ActiveStorage.attachment_class is ActiveStorage::Attachment by default" do
+      app "development"
+
+      assert_equal ActiveStorage::Attachment, ActiveStorage.attachment_class
+    end
+
+    test "ActiveStorage.attachment_class can be changed" do
+      app_file "app/models/my_attachment.rb", <<-RUBY
+        MyAttachment = Class.new(ActiveStorage::Attachment)
+      RUBY
+      app_file "config/initializers/active_storage.rb", <<-RUBY
+        Rails.application.config.active_storage.attachment_class = "MyAttachment"
+      RUBY
+      app "development"
+
+      assert_equal MyAttachment, ActiveStorage.attachment_class
+    end
+
     test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"


### PR DESCRIPTION
### Summary

Make Active Storage model classes configurable.

While implementing Active Storage on a rather complicated Rails app, I found it necessary to subclass models to add concerns specific to the application. This made it difficult to use Active Storage due to all the hardcoded references to model classes.

Instead of subclassing or patching internals to make things work, I think it would be easier to allow apps to point to different storage models (subclassed or otherwise) through configuration options.

cc @georgeclaghorn 