### PR TITLE
Handle invalid string encodings and characters in ActiveSupport::Inflector.transliterate

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -56,8 +56,12 @@ module ActiveSupport
     #
     #   transliterate('Jürgen', locale: :de)
     #   # => "Juergen"
+    #
+    # Transliteration of ASCII-8BIT / BINARY strings is not
+    # supported and will raise an ArgumentError.
     def transliterate(string, replacement = "?", locale: nil)
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
+      raise ArgumentError, "Can not transliterate strings with ASCII-8BIT encoding" if string.encoding == ::Encoding::ASCII_8BIT
 
       I18n.transliterate(
         ActiveSupport::Multibyte::Unicode.tidy_bytes(string).unicode_normalize(:nfc),

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -58,13 +58,11 @@ class TransliterateTest < ActiveSupport::TestCase
     assert_equal "Can only transliterate strings. Received Object", exception.message
   end
 
-  # Valid UTF-8 Works
   def test_transliterate_handles_strings_with_valid_utf8_encodings
     string = String.new("A", encoding: Encoding::UTF_8)
     assert_equal "A", ActiveSupport::Inflector.transliterate(string)
   end
 
-  # Valid US-ASCII Works
   def test_transliterate_handles_strings_with_valid_us_ascii_encodings
     string = String.new("A", encoding: Encoding::US_ASCII)
     transcoded = ActiveSupport::Inflector.transliterate(string)
@@ -72,7 +70,6 @@ class TransliterateTest < ActiveSupport::TestCase
     assert_equal Encoding::US_ASCII, transcoded.encoding
   end
 
-  # Valid GB18030 Works
   def test_transliterate_handles_strings_with_valid_gb18030_encodings
     string = String.new("A", encoding: Encoding::GB18030)
     transcoded = ActiveSupport::Inflector.transliterate(string)
@@ -80,7 +77,6 @@ class TransliterateTest < ActiveSupport::TestCase
     assert_equal Encoding::GB18030, transcoded.encoding
   end
 
-  # All other encodings raise argument errors
   def test_transliterate_handles_strings_with_incompatible_encodings
     incompatible_encodings = Encoding.list - [
       Encoding::UTF_8,
@@ -96,19 +92,16 @@ class TransliterateTest < ActiveSupport::TestCase
     end
   end
 
-  # Invalid UTF-8 Works
   def test_transliterate_handles_strings_with_invalid_utf8_bytes
     string = String.new("\255", encoding: Encoding::UTF_8)
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 
-  # Invalid raises exception
   def test_transliterate_handles_strings_with_invalid_us_ascii_bytes
     string = String.new("\255", encoding: Encoding::US_ASCII)
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 
-  # Invalid GB18030 raises exception
   def test_transliterate_handles_strings_with_invalid_gb18030_bytes
     string = String.new("\255", encoding: Encoding::GB18030)
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -57,4 +57,12 @@ class TransliterateTest < ActiveSupport::TestCase
     end
     assert_equal "Can only transliterate strings. Received Object", exception.message
   end
+
+  def test_transliterate_handles_ascci_8bit_strings
+    ascii_8bit_string = "A".b
+    exception = assert_raises ArgumentError do
+      ActiveSupport::Inflector.transliterate(ascii_8bit_string)
+    end
+    assert_equal "Can not transliterate strings with ASCII-8BIT encoding", exception.message
+  end
 end

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -75,7 +75,9 @@ class TransliterateTest < ActiveSupport::TestCase
   # Valid GB18030 Works
   def test_transliterate_handles_strings_with_valid_gb18030_encodings
     string = String.new("A", encoding: Encoding::GB18030)
-    assert_equal "A", ActiveSupport::Inflector.transliterate(string)
+    transcoded = ActiveSupport::Inflector.transliterate(string)
+    assert_equal "A", transcoded
+    assert_equal Encoding::GB18030, transcoded.encoding
   end
 
   # All other encodings raise argument errors
@@ -103,17 +105,12 @@ class TransliterateTest < ActiveSupport::TestCase
   # Invalid raises exception
   def test_transliterate_handles_strings_with_invalid_us_ascii_bytes
     string = String.new("\255", encoding: Encoding::US_ASCII)
-    # exception = assert_raises Encoding::CompatibilityError do
-    #   ActiveSupport::Inflector.transliterate(string)
-    # end
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 
   # Invalid GB18030 raises exception
   def test_transliterate_handles_strings_with_invalid_gb18030_bytes
     string = String.new("\255", encoding: Encoding::GB18030)
-    exception = assert_raises Encoding::CompatibilityError do
-      ActiveSupport::Inflector.transliterate(string)
-    end
+    assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 end


### PR DESCRIPTION
Adds `ArgumentError` to `ActiveSupport::Inflector::transliterate` if a string is passed with an encoding which would raise an error in `unicode_normalize` or `I18n.transliterate`. Permitted encodings are `UTF-8`, `US-ASCII` and `GB18030`.

Prior to this change `US-ASCII` and `GB18030` would raise exceptions if invalid characters were encountered, while `UTF-8` would handle invalids by replacing them. This PR makes the behavior of `ActiveSupport::Inflector::transliterate` consistent with all permitted encodings by replacing invalid or undefined characters in `US-ASCII` and `GB18030` strings in roughly the same way that `tidy_bytes` does for `UTF-8`.

See: https://github.com/rails/rails/pull/36700

cc @eileencodes / @tenderlove