### PR TITLE
Add support for script-src-attr / elem and style-src-attr / elem directives

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -137,7 +137,11 @@ module ActionDispatch #:nodoc:
       object_src:      "object-src",
       prefetch_src:    "prefetch-src",
       script_src:      "script-src",
+      script_src_attr: "script-src-attr",
+      script_src_elem: "script-src-elem",
       style_src:       "style-src",
+      style_src_attr:  "style-src-attr",
+      style_src_elem:  "style-src-elem",
       worker_src:      "worker-src"
     }.freeze
 

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -128,11 +128,35 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.script_src false
     assert_no_match %r{script-src}, @policy.build
 
+    @policy.script_src_attr :self
+    assert_match %r{script-src-attr 'self'}, @policy.build
+
+    @policy.script_src_attr false
+    assert_no_match %r{script-src-attr}, @policy.build
+
+    @policy.script_src_elem :self
+    assert_match %r{script-src-elem 'self'}, @policy.build
+
+    @policy.script_src_elem false
+    assert_no_match %r{script-src-elem}, @policy.build
+
     @policy.style_src :self
     assert_match %r{style-src 'self'}, @policy.build
 
     @policy.style_src false
     assert_no_match %r{style-src}, @policy.build
+
+    @policy.style_src_attr :self
+    assert_match %r{style-src-attr 'self'}, @policy.build
+
+    @policy.style_src_attr false
+    assert_no_match %r{style-src-attr}, @policy.build
+
+    @policy.style_src_elem :self
+    assert_match %r{style-src-elem 'self'}, @policy.build
+
+    @policy.style_src_elem false
+    assert_no_match %r{style-src-elem}, @policy.build
 
     @policy.worker_src :self
     assert_match %r{worker-src 'self'}, @policy.build


### PR DESCRIPTION
These directives can be used in Chrome 75.
Ref: https://www.chromestatus.com/feature/5141352765456384