### PR TITLE
[ActiveRecord] Deduplicate optimizer hints

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -952,7 +952,7 @@ module ActiveRecord
     def optimizer_hints!(*args) # :nodoc:
       args.flatten!
 
-      self.optimizer_hints_values += args
+      self.optimizer_hints_values |= args
       self
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -363,6 +363,13 @@ module ActiveRecord
       assert_match %r{/\*\+ BADHINT \*/}, post_with_hint.to_sql
     end
 
+    def test_does_not_duplicate_optimizer_hints_on_merge
+      escaped_table = Post.connection.quote_table_name("posts")
+      expected = "SELECT /*+ OMGHINT */ #{escaped_table}.* FROM #{escaped_table}"
+      query = Post.optimizer_hints("OMGHINT").merge(Post.optimizer_hints("OMGHINT")).to_sql
+      assert_equal expected, query
+    end
+
     class EnsureRoundTripTypeCasting < ActiveRecord::Type::Value
       def type
         :string


### PR DESCRIPTION
When you merge two relations both having the same optimizer hint (it could come from a default_scope, for instance), you'll end up with duplicated hints in the result query.

This patch fixed that by applying `uniq` to hints.

cc @kamipo @rafaelfranca 