### PR TITLE
Preserve attributes assigned on initialize using becomes

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -565,12 +565,13 @@ module ActiveRecord
     # If you want to change the sti column as well, use #becomes! instead.
     def becomes(klass)
       became = klass.allocate
-      became.send(:initialize)
-      became.instance_variable_set("@attributes", @attributes)
-      became.instance_variable_set("@mutations_from_database", @mutations_from_database ||= nil)
-      became.instance_variable_set("@new_record", new_record?)
-      became.instance_variable_set("@destroyed", destroyed?)
-      became.errors.copy!(errors)
+      became.send(:initialize) do |record|
+        record.instance_variable_set("@attributes", @attributes)
+        record.instance_variable_set("@mutations_from_database", @mutations_from_database ||= nil)
+        record.instance_variable_set("@new_record", new_record?)
+        record.instance_variable_set("@destroyed", destroyed?)
+        record.errors.copy!(errors)
+      end
       became
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -228,6 +228,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal %w{name}, client.changed
   end
 
+  def test_becomes_preserves_initialized_callback_values
+    model_with_defaults = Class.new(Company) do
+      after_initialize { |c| c.name ||= "aha" }
+    end
+    company = Company.new.becomes(model_with_defaults)
+    assert_equal "aha", company.name
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])


### PR DESCRIPTION
### Summary

Attributes set through an `after_initialize` callback were being overwritten by the attributes from the original instance. The callback is now applied after the new record is instantiated with the attributes.