### PR TITLE
Dump schema when running migrations from actionable errors

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -133,6 +133,9 @@ module ActiveRecord
 
     action "Run pending migrations" do
       ActiveRecord::Tasks::DatabaseTasks.migrate
+      if ActiveRecord::Base.dump_schema_after_migration
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(ActiveRecord::Tasks::DatabaseTasks.current_config)
+      end
     end
 
     def initialize(message = nil)


### PR DESCRIPTION
This makes running migrations from error page behave more like `db:migrate` task.
