### PR TITLE
Add content_type to upload method for Azure

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -17,10 +17,10 @@ module ActiveStorage
       @container = container
     end
 
-    def upload(key, io, checksum: nil, **)
+    def upload(key, io, checksum: nil, content_type: nil, **)
       instrument :upload, key: key, checksum: checksum do
         handle_errors do
-          blobs.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum)
+          blobs.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum, content_type: content_type)
         end
       end
     end


### PR DESCRIPTION
### Summary

Azure blob storage supports uploading with content type (see [here](https://www.rubydoc.info/github/yaxia/azure-storage-ruby/Azure%2FStorage%2FBlob%2FBlobService:create_block_blob)). Both S3 and GCS services all have this feature in Active Storage except Azure, so this PR will make it more consistent between providers.

### Other Information

N/A.
