### PR TITLE
Fix ActiveModel::Errors#added? when :taken error occur

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -8,7 +8,7 @@ module ActiveModel
   # Represents one single error
   class Error
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
-    MESSAGE_OPTIONS = [:message]
+    MESSAGE_OPTIONS = [:message, :value]
 
     class_attribute :i18n_customize_full_message, default: false
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -296,6 +296,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert person.errors.added?(:name, :too_long)
   end
 
+  test "added? ignores value option" do
+    person = Person.new
+
+    person.errors.add(:name, :taken, value: "foo")
+    assert person.errors.added?(:name, :taken)
+  end
+
   test "added? detects indifferent if a specific error was added to the object" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
### Summary

The uniqueness validation add the value to the error like the message
option, this break the comparison on [error.strict_match?](https://github.com/spk/rails/blob/1551552acab859d8096a9908c1f52ff8befb77a1/activemodel/lib/active_model/error.rb#L148)

ref https://github.com/rails/rails/issues/36573

### Other Information

First i've made a test like @y-yagi did on the [snippet](https://github.com/rails/rails/issues/36573#issuecomment-506993012) but I don't think its related with sqlite with id as a string; but I may be wrong o/