### PR TITLE
Add after/on_confirm callback to ActionCable channels

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -181,8 +181,14 @@ module ActionCable
           subscribed
         end
 
-        reject_subscription if subscription_rejected?
-        ensure_confirmation_sent
+        if subscription_rejected?
+          reject_subscription
+          return
+        else
+          run_callbacks :confirm do
+            ensure_confirmation_sent
+          end
+        end
       end
 
       # Called by the cable connection when it's cut, so the channel has a chance to cleanup with callbacks.
@@ -220,7 +226,6 @@ module ActionCable
         end
 
         def ensure_confirmation_sent # :doc:
-          return if subscription_rejected?
           @defer_subscription_confirmation_counter.decrement
           transmit_subscription_confirmation unless defer_subscription_confirmation?
         end

--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -11,6 +11,7 @@ module ActionCable
       included do
         define_callbacks :subscribe
         define_callbacks :unsubscribe
+        define_callbacks :confirm
       end
 
       module ClassMethods
@@ -31,6 +32,11 @@ module ActionCable
           set_callback(:unsubscribe, :after, *methods, &block)
         end
         alias_method :on_unsubscribe, :after_unsubscribe
+
+        def after_confirm(*methods, &block)
+          set_callback(:confirm, :after, *methods, &block)
+        end
+        alias_method :on_confirm, :after_confirm
       end
     end
   end

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -25,6 +25,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
     attr_reader :room, :last_action
     after_subscribe :toggle_subscribed
     after_unsubscribe :toggle_subscribed
+    after_confirm :subscription_confirmed
 
     class SomeCustomError < StandardError; end
     rescue_from SomeCustomError, with: :error_handler
@@ -45,6 +46,10 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
 
     def toggle_subscribed
       @subscribed = !@subscribed
+    end
+
+    def subscription_confirmed
+      @last_action = [ :subscription_confirmed ]
     end
 
     def leave
@@ -99,6 +104,11 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   test "on subscribe callbacks" do
     @channel.subscribe_to_channel
     assert @channel.subscribed
+  end
+
+  test "on confirm callbacks" do
+    @channel.subscribe_to_channel
+    assert_equal [ :subscription_confirmed ], @channel.last_action
   end
 
   test "channel params" do
@@ -179,7 +189,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "actions available on Channel" do
-    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? get_latest receive chatters topic error_action).to_set
+    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? subscription_confirmed get_latest receive chatters topic error_action).to_set
     assert_equal available_actions, ChatChannel.action_methods
   end
 


### PR DESCRIPTION
### Summary

Corresponds to Issue #25333 

Current behavior of `subscribed` method in ActionCable has all callbacks fire before the subscription is confirmed and thus before it is live. As indicated in the referenced Issue, there is at least a certain amount of desire for the ability to be able to perform an action (like sending a broadcast) immediately after a subscription is successfully set up.

This PR adds a `:confirm` family of callbacks, with one available hook `after_confirm` (aliased as `on_confirm`). This family of callbacks is only called if the subscription is not rejected. It is called around the confirmation message, so the `after_confirm` hook takes place after the subscription has been confirmed and is available for broadcast.

### Other Information

In the referenced Issue, I suggested that the `run_callbacks` method could wrap the entirety of the `subscribe_to_channel` method's internals to provide the desired functionality in the `after/on_subscribe` hook. That would have been a breaking change, and upon further reflection I can see cases where one may wish to make the determination to reject a subscription after the actions of the `subscribe` method. Because of this it seems like the better option is to add an additional hook specifically focused on the confirmation phase of setting up the subscription. Since the `after_subscribe` hook already happens between the `subscribe` method and the confirmation, it did not seem that a `before_confirm` hook would be necessary and I only added the `after`.
<!-- This is a very minor change, but it's the first one I'm proposing to a repo I'm not a primary contributor for. It's exciting and I hope it is well-received.
If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
