### PR TITLE
Fix deprecation on `AM::Errors` when each is called indirectly:

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -220,7 +220,7 @@ module ActiveModel
     #     # then yield :name and "must be specified"
     #   end
     def each(&block)
-      if block.arity == 1
+      if block.arity <= 1
         @errors.each(&block)
       else
         ActiveSupport::Deprecation.warn(<<~MSG)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -44,6 +44,14 @@ class ErrorsTest < ActiveModel::TestCase
     assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end
 
+  def test_each_when_arity_is_negative
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:gender, :blank)
+
+    assert_equal([:name, :gender], errors.map(&:attribute))
+  end
+
   def test_any?
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name)


### PR DESCRIPTION
Fix deprecation on `AM::Errors` when each is called indirectly:

- `AM::Errors#each` is implemented for the `Enumerator` module and
  get called indirectly by a bunch of method in the ruby land
  (map, first, select ...)

  These methods have a `-1` arity as they are written in C and they
  wrongly trigger a deprecation warning.

  This commit fixes that and correctectly return a `AM::Error` object
  when `each` is called with a negative arity.

cc/ @rafaelfranca 