### PR TITLE
FIX: create a newline before group, github and source

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -57,7 +57,7 @@ module Rails
         log :gemfile, "group #{str}"
 
         in_root do
-          append_file_with_newline "Gemfile", "group #{str} do", force: true
+          append_file_with_newline "Gemfile", "\ngroup #{str} do", force: true
           with_indentation(&block)
           append_file_with_newline "Gemfile", "end", force: true
         end
@@ -70,7 +70,11 @@ module Rails
         log :github, "github #{str}"
 
         in_root do
-          append_file_with_newline "Gemfile", "#{indentation}github #{str} do", force: true
+          if @indentation.zero?
+            append_file_with_newline "Gemfile", "\ngithub #{str} do", force: true
+          else
+            append_file_with_newline "Gemfile", "#{indentation}github #{str} do", force: true
+          end
           with_indentation(&block)
           append_file_with_newline "Gemfile", "#{indentation}end", force: true
         end
@@ -90,7 +94,7 @@ module Rails
 
         in_root do
           if block
-            append_file_with_newline "Gemfile", "source #{quote(source)} do", force: true
+            append_file_with_newline "Gemfile", "\nsource #{quote(source)} do", force: true
             with_indentation(&block)
             append_file_with_newline "Gemfile", "end", force: true
           else

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -51,7 +51,7 @@ class ActionsTest < Rails::Generators::TestCase
     action :add_source, "http://gems.github.com" do
       gem "rspec-rails"
     end
-    assert_file "Gemfile", /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend\n\z/
+    assert_file "Gemfile", /\n\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend\n\z/
   end
 
   def test_add_source_with_block_adds_source_to_gemfile_after_gem
@@ -60,7 +60,19 @@ class ActionsTest < Rails::Generators::TestCase
     action :add_source, "http://gems.github.com" do
       gem "rspec-rails"
     end
-    assert_file "Gemfile", /gem 'will-paginate'\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend\n\z/
+    assert_file "Gemfile", /\ngem 'will-paginate'\n\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend\n\z/
+  end
+
+  def test_add_source_should_create_newline_between_blocks
+    run_generator
+    action :add_source, "http://gems.github.com" do
+      gem "rspec-rails"
+    end
+
+    action :add_source, "http://gems2.github.com" do
+      gem "fakeweb"
+    end
+    assert_file "Gemfile", /\n\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend\n\nsource 'http:\/\/gems2\.github\.com' do\n  gem 'fakeweb'\nend\n\z/
   end
 
   def test_gem_should_put_gem_dependency_in_gemfile
@@ -141,7 +153,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "fakeweb"
     end
 
-    assert_file "Gemfile", /^group :development, :test do\n  gem 'rspec-rails'\nend\ngroup :test do\n  gem 'fakeweb'\nend\n\z/
+    assert_file "Gemfile", /\n\ngroup :development, :test do\n  gem 'rspec-rails'\nend\n\ngroup :test do\n  gem 'fakeweb'\nend\n\z/
   end
 
   def test_github_should_create_an_indented_block
@@ -153,7 +165,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "baz"
     end
 
-    assert_file "Gemfile", /^github 'user\/repo' do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\z/
+    assert_file "Gemfile", /\n\ngithub 'user\/repo' do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\z/
   end
 
   def test_github_should_create_an_indented_block_with_options
@@ -165,7 +177,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "baz"
     end
 
-    assert_file "Gemfile", /^github 'user\/repo', a: 'correct', other: true do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\z/
+    assert_file "Gemfile", /\n\ngithub 'user\/repo', a: 'correct', other: true do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\z/
   end
 
   def test_github_should_create_an_indented_block_within_a_group
@@ -177,9 +189,32 @@ class ActionsTest < Rails::Generators::TestCase
         gem "bar"
         gem "baz"
       end
+      github "user/repo2", a: "correct", other: true do
+        gem "foo"
+        gem "bar"
+        gem "baz"
+      end
     end
 
-    assert_file "Gemfile", /^group :magic do\n  github 'user\/repo', a: 'correct', other: true do\n    gem 'foo'\n    gem 'bar'\n    gem 'baz'\n  end\nend\n\z/
+    assert_file "Gemfile", /\n\ngroup :magic do\n  github 'user\/repo', a: 'correct', other: true do\n    gem 'foo'\n    gem 'bar'\n    gem 'baz'\n  end\n  github 'user\/repo2', a: 'correct', other: true do\n    gem 'foo'\n    gem 'bar'\n    gem 'baz'\n  end\nend\n\z/
+  end
+
+  def test_github_should_create_newline_between_blocks
+    run_generator
+
+    action :github, "user/repo", a: "correct", other: true do
+      gem "foo"
+      gem "bar"
+      gem "baz"
+    end
+
+    action :github, "user/repo2", a: "correct", other: true do
+      gem "foo"
+      gem "bar"
+      gem "baz"
+    end
+
+    assert_file "Gemfile", /\n\ngithub 'user\/repo', a: 'correct', other: true do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\ngithub 'user\/repo2', a: 'correct', other: true do\n  gem 'foo'\n  gem 'bar'\n  gem 'baz'\nend\n\z/
   end
 
   def test_gem_with_gemfile_without_newline_at_the_end
@@ -198,7 +233,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "fakeweb"
     end
 
-    assert_file "Gemfile", /gem 'rspec-rails'\ngroup :test do\n  gem 'fakeweb'\nend\n\z/
+    assert_file "Gemfile", /gem 'rspec-rails'\n\ngroup :test do\n  gem 'fakeweb'\nend\n\z/
   end
 
   def test_add_source_with_gemfile_without_newline_at_the_end
@@ -209,7 +244,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "fakeweb"
     end
 
-    assert_file "Gemfile", /gem 'rspec-rails'\nsource 'http:\/\/gems\.github\.com' do\n  gem 'fakeweb'\nend\n\z/
+    assert_file "Gemfile", /gem 'rspec-rails'\n\nsource 'http:\/\/gems\.github\.com' do\n  gem 'fakeweb'\nend\n\z/
   end
 
   def test_github_with_gemfile_without_newline_at_the_end
@@ -220,7 +255,7 @@ class ActionsTest < Rails::Generators::TestCase
       gem "fakeweb"
     end
 
-    assert_file "Gemfile", /gem 'rspec-rails'\ngithub 'user\/repo' do\n  gem 'fakeweb'\nend\n\z/
+    assert_file "Gemfile", /gem 'rspec-rails'\n\ngithub 'user\/repo' do\n  gem 'fakeweb'\nend\n\z/
   end
 
   def test_environment_should_include_data_in_environment_initializer_block


### PR DESCRIPTION
### Summary
Add newlines before `group`, `source`(with block) and `github`(outside block)

fix #35285 

__master__
```ruby
gem 'fake'
source 'http://gems.github.com' do
  gem 'rspec-rails'
end
github 'user/repo' do
  gem 'foo'
end
group :development do
  gem 'fuga'
end
group :magic do
  github 'user/repo' do
    gem 'foo'
  end
  github 'user/repo2' do
    gem 'foo2'
  end
end
```

__this branch__
```ruby
gem 'fake'

source 'http://gems.github.com' do
  gem 'rspec-rails'
end

github 'user/repo' do
    gem 'foo'
end

group :development do
  gem 'fuga'
end

group :magic do
  github 'user/repo' do
    gem 'foo'
  end
  github 'user/repo2' do
    gem 'foo2'
  end
end
```

### reference
https://github.com/rails/rails/pull/35285#discussion_r305602852