### PR TITLE
Deprecate `AM::Errors#to_h`:

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -303,6 +303,12 @@ module ActiveModel
       hash
     end
 
+    def to_h
+      deprecation_rename_warning(:to_h, :to_hash)
+
+      to_hash
+    end
+
     def messages
       DeprecationHandlingMessageHash.new(self)
     end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -474,6 +474,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.to_a
   end
 
+  test "to_h is deprecated" do
+    person = Person.new
+    person.errors.add(:name, "cannot be blank")
+
+    expected_deprecation = "ActiveModel::Errors#to_h is deprecated. Please call #to_hash instead."
+    assert_deprecated(expected_deprecation) do
+      assert_equal({ name: ["cannot be blank"] }, person.errors.to_h)
+    end
+  end
+
   test "to_hash returns the error messages hash" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
Deprecated `AM::Errors#to_h`:

- In ef4d3215b1198c456780b8d18aa62be7795b9b8c I made a change to
   pass `AM::Error` object in case the arity of the block passed to
   `each` accepted less than 2 arguments.

   This is causing one issue for `to_h` as it expects the argument
   passed to the block to be an Array (and were are passing it an
   instance of `AM::Error`).

   There is no real reason to use `to_h` anymore since `to_hash` exists

   Deprecating `to_h` inf favor of `to_hash`

cc/ @rafaelfranca @casperisfine