### PR TITLE
Move the deprecation call after the new class has been defined:

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -2,11 +2,6 @@
 
 require "active_support/deprecation"
 
-# Remove this deprecated class in the next minor version
-#:nodoc:
-SourceAnnotationExtractor = ActiveSupport::Deprecation::DeprecatedConstantProxy.
-  new("SourceAnnotationExtractor", "Rails::SourceAnnotationExtractor")
-
 module Rails
   # Implements the logic behind <tt>Rails::Command::NotesCommand</tt>. See <tt>rails notes --help</tt> for usage information.
   #
@@ -160,3 +155,8 @@ module Rails
     end
   end
 end
+
+# Remove this deprecated class in the next minor version
+#:nodoc:
+SourceAnnotationExtractor = ActiveSupport::Deprecation::DeprecatedConstantProxy.
+  new("SourceAnnotationExtractor", "Rails::SourceAnnotationExtractor")


### PR DESCRIPTION
Move the deprecation call after the new class has been defined:

- If we create the deprecation before the new class is defined this
  creates an issue in case you use a `TracePoint`. The
  `Tracepoint#return_value` will try to get the new class constant
  resulting in a uninitialized constant Rails::SourceAnnotationExtractor

  The problem can be reproduced like this:

  ```ruby
  @defined = Set.new

  ANONYMOUS_CLASS_DEFINITION_TRACEPOINT = TracePoint.new(:c_return) do |tp|
    next unless @defined.add?(tp.return_value)
  end

  ANONYMOUS_CLASS_DEFINITION_TRACEPOINT.enable

  require 'rails'
  require "rails/source_annotation_extractor"
  ```

cc @rafaelfranca @casperisfine