### PR TITLE
Use Dir.glob(base: ...) to avoid chdir

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -223,12 +223,10 @@ module Rails
 
       private
         def files_in(path)
-          Dir.chdir(path) do
-            files = Dir.glob(@glob)
-            files -= @exclude if @exclude
-            files.map! { |file| File.join(path, file) }
-            files.sort
-          end
+          files = Dir.glob(@glob, base: path)
+          files -= @exclude if @exclude
+          files.map! { |file| File.join(path, file) }
+          files.sort
         end
     end
   end


### PR DESCRIPTION
`chdir` is global, so we might as well avoid it if we can. I think it's simpler to anyways now that all our supported Ruby versions have `Dir.glob(..., base:)`