### PR TITLE
Define the `url_options` needed for SytemTest inside the route proxy:

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -120,7 +120,13 @@ module ActionDispatch
       super
       self.class.driver.use
       @proxy_route = if ActionDispatch.test_app
-        Class.new { include ActionDispatch.test_app.routes.url_helpers }.new
+        Class.new do
+          include ActionDispatch.test_app.routes.url_helpers
+
+          def url_options
+            default_url_options.merge(host: Capybara.app_host)
+          end
+        end.new
       else
         nil
       end
@@ -163,10 +169,6 @@ module ActionDispatch
     end
 
     driven_by :selenium
-
-    def url_options # :nodoc:
-      default_url_options.merge(host: Capybara.app_host)
-    end
 
     def method_missing(method, *args, &block)
       if @proxy_route.respond_to?(method)

--- a/railties/test/application/system_test_case_test.rb
+++ b/railties/test/application/system_test_case_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+class SystemTestCaseTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def setup
+    build_app
+  end
+
+  def teardown
+    teardown_app
+  end
+
+  test "url helpers are delegated to a proxy class" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get 'foo', to: 'foo#index', as: 'test_foo'
+      end
+    RUBY
+
+    app("test")
+
+    assert_not_includes(ActionDispatch::SystemTestCase.runnable_methods, :test_foo_url)
+  end
+
+  test "system tests set the Capybara host in the url_options by default" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get 'foo', to: 'foo#index', as: 'test_foo'
+      end
+    RUBY
+
+    app("test")
+    system_test = ActionDispatch::SystemTestCase.new("my_test")
+    previous_app_host = ::Capybara.app_host
+    ::Capybara.app_host = "https://my_test_example.com"
+
+    assert_equal("https://my_test_example.com/foo", system_test.test_foo_url)
+  ensure
+    ::Capybara.app_host = previous_app_host
+  end
+end


### PR DESCRIPTION
Define the `url_options` needed for SytemTest inside the route proxy:

- I made a change in https://github.com/rails/rails/pull/36691 to
  delegate route helper to a proxy class.
  This didn't take into account that the `url_options` we redefine
  in SystemTest would be ignored.

  This PR fixes that by definin the url_options inside the proxy

cc/ @rafaelfranca @georgeclaghorn 