### PR TITLE
Fixed db:prepare task to not touch schema when it is disabled

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -297,10 +297,11 @@ db_namespace = namespace :db do
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config.config)
 
-      ActiveRecord::Tasks::DatabaseTasks.migrate
-
       # Skipped when no database
-      ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
+      if ActiveRecord::Base.dump_schema_after_migration
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
+      end
 
     rescue ActiveRecord::NoDatabaseError
       ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -630,6 +630,22 @@ module ApplicationTests
           assert_match(/CreateRecipes: migrated/, output)
         end
       end
+
+      test "db:prepare does not touch schema when dumping is disabled" do
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          rails "db:create", "db:migrate"
+
+          app_file "db/schema.rb", "Not touched"
+          app_file "config/initializers/disable_dumping_schema.rb", <<-RUBY
+            Rails.application.config.active_record.dump_schema_after_migration = false
+          RUBY
+
+          rails "db:prepare"
+
+          assert_equal("Not touched", File.read("db/schema.rb").strip)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
During https://github.com/rails/rails/pull/36416 I forgot to move the conditional for dumping schema, that
is present in https://github.com/rails/rails/blob/0e149abbd5affc43f80a5c9bf8b7a7c2a5905d53/activerecord/lib/active_record/railties/databases.rake#L92

This is causing issues in environments with limited file permissions that are preparing database.

@eileencodes can we have it backported to 6-0-stable branch as well?