### PR TITLE
Fixed the typo in the deprecation error messages. `Erors` -> `Errors`

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -307,7 +307,7 @@ module ActiveModel
       ActiveSupport::Deprecation.warn(<<~EOM)
         ActiveModel::Errors#to_h is deprecated and will be removed in Rails 6.2
         Please use `ActiveModel::Errors.to_hash` instead. The values in the hash
-        returned by `ActiveModel::Erors.to_hash` is an array of error messages.
+        returned by `ActiveModel::Errors.to_hash` is an array of error messages.
       EOM
 
       to_hash.transform_values { |values| values.last }


### PR DESCRIPTION
`Erors` -> `Errors`