### PR TITLE
Add mention about `active_record.collection_cache_versioning` to the `new_framework_defaults.rb`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -38,3 +38,8 @@
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
 # Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+
+# Enable the same cache key to be reused when the object being cached of type
+# `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
+# of the relation's cache key into the cache version to support recycling cache key.
+# Rails.application.config.active_record.collection_cache_versioning = true


### PR DESCRIPTION
All other recommended new configurations that set in `load_defaults` are already mentioned in `new_framework_defaults.rb`. So `active_record.collection_cache_versioning` should also be mentioned.
