### PR TITLE
Implement ActiveSupport::Notifications.subscribe symbol pattern support

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -3,6 +3,7 @@
 require "mutex_m"
 require "concurrent/map"
 require "set"
+require "active_support/hash_with_indifferent_access.rb"
 
 module ActiveSupport
   module Notifications
@@ -14,7 +15,7 @@ module ActiveSupport
       include Mutex_m
 
       def initialize
-        @string_subscribers = Hash.new { |h, k| h[k] = [] }
+        @string_subscribers = HashWithIndifferentAccess.new { |h, k| h[k] = [] }
         @other_subscribers = []
         @listeners_for = Concurrent::Map.new
         super
@@ -23,7 +24,7 @@ module ActiveSupport
       def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
         subscriber = Subscribers.new(pattern, callable || block, monotonic)
         synchronize do
-          if String === pattern
+          if String === pattern || Symbol === pattern
             @string_subscribers[pattern] << subscriber
             @listeners_for.delete(pattern)
           else

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -102,6 +102,32 @@ module ActiveSupport
         ], listener.events
       end
 
+      def test_listen_to_symbol
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe(:hello, listener)
+        notifier.start("hello", 1, {})
+        notifier.finish("hello", 2, {})
+
+        assert_equal [
+          [:start, "hello", 1, {}],
+          [:finish, "hello", 2, {}]
+        ], listener.events
+      end
+
+      def test_subscribe_to_symbol
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe("hello", listener)
+        notifier.start(:hello, 1, {})
+        notifier.finish(:hello, 2, {})
+
+        assert_equal [
+          [:start, :hello, 1, {}],
+          [:finish, :hello, 2, {}],
+        ], listener.events
+      end
+
       def test_listen_to_regexp_with_exclusions
         notifier = Fanout.new
         listener = Listener.new


### PR DESCRIPTION
### Summary
This commit implements `ActiveSupport::Notifications.subscribe` via a symbol:

```ruby
ActiveSupport::Notifications.subscribe :render do |*args|
  # do something
end
```

```ruby
ActiveSupport::Notifications.subscribe 'render' do |*args|
  # do something
end
```

### Other Information
I recently found it quite confusing that 

```ruby
ActiveSupport::Notifications.subscribe :render do |*args|
  # do something
end
```

does actually not subscribe to `render` and one has to use a String instead.
