### PR TITLE
Make ActiveSupport::Logger Fiber-safe

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Make ActiveSupport::Logger Fiber-safe. Fixes #36752.
+
+    Use `Fiber.current.__id__` in `ActiveSupport::Logger#local_level=` in order
+    to make log level local to Ruby Fibers in addition to Threads.
+
+    Example:
+
+        logger = ActiveSupport::Logger.new(STDOUT)
+        logger.level = 1
+        p "Main is debug? #{logger.debug?}"
+
+        Fiber.new {
+          logger.local_level = 0
+          p "Thread is debug? #{logger.debug?}"
+        }.resume
+
+        p "Main is debug? #{logger.debug?}"
+
+    Before:
+
+        Main is debug? false
+        Thread is debug? true
+        Main is debug? true
+
+    After:
+
+        Main is debug? false
+        Thread is debug? true
+        Main is debug? false
+
+    *Alexander Varnin*
+
 *   Allow the `on_rotation` proc used when decrypting/verifying a message to be
     passed at the constructor level.
 

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -3,6 +3,7 @@
 require "active_support/concern"
 require "active_support/core_ext/module/attribute_accessors"
 require "concurrent"
+require "fiber"
 
 module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:
@@ -28,7 +29,7 @@ module ActiveSupport
     end
 
     def local_log_id
-      Thread.current.__id__
+      Fiber.current.__id__
     end
 
     def local_level

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -258,6 +258,50 @@ class LoggerTest < ActiveSupport::TestCase
     assert_level(Logger::INFO)
   end
 
+  def test_logger_level_main_fiber_safety
+    @logger.level = Logger::INFO
+    assert_level(Logger::INFO)
+
+    fiber = Fiber.new do
+      assert_level(Logger::INFO)
+    end
+
+    @logger.silence(Logger::ERROR) do
+      assert_level(Logger::ERROR)
+      fiber.resume
+    end
+  end
+
+  def test_logger_level_local_fiber_safety
+    @logger.level = Logger::INFO
+    assert_level(Logger::INFO)
+
+    another_fiber = Fiber.new do
+      @logger.silence(Logger::ERROR) do
+        assert_level(Logger::ERROR)
+        @logger.silence(Logger::DEBUG) do
+          assert_level(Logger::DEBUG)
+        end
+      end
+
+      assert_level(Logger::INFO)
+    end
+
+    Fiber.new do
+      @logger.silence(Logger::ERROR) do
+        assert_level(Logger::ERROR)
+        @logger.silence(Logger::DEBUG) do
+          another_fiber.resume
+          assert_level(Logger::DEBUG)
+        end
+      end
+
+      assert_level(Logger::INFO)
+    end.resume
+
+    assert_level(Logger::INFO)
+  end
+
   private
     def level_name(level)
       ::Logger::Severity.constants.find do |severity|


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Use Fiber.current.__id__ in ActiveSupport::Logger#local_level= in order to make log level local to Ruby Fibers in addition to Threads.

Fixes #36752

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
