### PR TITLE
Fix multiple database support for DATABASE_URL env variable

### DIFF
--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -323,6 +323,30 @@ module ActiveRecord
 
         assert_equal expected, actual
       end
+
+      def test_tiered_configs_with_database_url
+        ENV["DATABASE_URL"] = "postgres://localhost/foo"
+
+        config = {
+          "default_env" => {
+            "primary" => { "pool" => 5 },
+            "animals" => { "pool" => 5 }
+          }
+        }
+
+        expected = {
+          "adapter"  => "postgresql",
+          "database" => "foo",
+          "host"     => "localhost",
+          "pool"     => 5
+        }
+
+        ["primary", "animals"].each do |spec_name|
+          configs = ActiveRecord::DatabaseConfigurations.new(config)
+          actual = configs.configs_for(env_name: "default_env", spec_name: spec_name).config
+          assert_equal expected, actual
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR fixes an issue where multi-database configurations were incompatible with setting a `DATABASE_URL` environment variable.  We had been using `config["database"] || config["adapter"] || ENV["DATABASE_URL"]` to determine if a multi-tier config was in place, which made the assumption that if `DATABASE_URL` was present, we were in a single-database configuration.

As part of this work, this PR also includes a light refactor to make both multi and single database configurations lead into the same code path so they behave the same.

### Other information

As mentioned in #36736, this regression was introduced as part of f2ad69fe7a605b01bb7c37eeac6a9b4e7deb488e

Thank you for the great bug report and reproduction!

---

Closes #36736

/cc @morgoth @eileencodes