### PR TITLE
Avoid unnecessary hash allocation in HashWithIndifferentAccess#convert_value

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -367,7 +367,9 @@ module ActiveSupport
         key.kind_of?(Symbol) ? key.to_s : key
       end
 
-      def convert_value(value, options = {}) # :doc:
+      EMPTY_HASH = {}.freeze
+
+      def convert_value(value, options = EMPTY_HASH) # :doc:
         if value.is_a? Hash
           if options[:for] == :to_hash
             value.to_hash


### PR DESCRIPTION
### Summary

`HashWithIndifferentAccess#convert_value` allocates an empty hash whenever `options` are not provided which in MRI 2.6.3 is 232 bytes. This method is invoked for each value when constructing a new `HashWithIndifferentAccess` from a source `Hash` which can quickly add up to non-trivial amount of memory in a Rails app. This defaulting generated 128KB in extra memory allocations for a web request in app I was profiling. The fix is to use a constant for the default value to avoid allocating a hash for each method invocation.  

Here's a benchmark that demonstrates the fix:

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  gem 'activesupport'
  gem 'benchmark-ips'
  gem 'memory_profiler'
end

require 'active_support/all'

class OptimizedHashWithIndifferentAccess < ActiveSupport::HashWithIndifferentAccess
  private

  EMPTY_HASH = {}.freeze

  def convert_value(value, options = EMPTY_HASH) # :doc:
    if value.is_a? Hash
      if options[:for] == :to_hash
        value.to_hash
      else
        value.nested_under_indifferent_access
      end
    elsif value.is_a?(Array)
      if options[:for] != :assignment || value.frozen?
        value = value.dup
      end
      value.map! { |e| convert_value(e, options) }
    else
      value
    end
  end
end

num_values = 25
source = num_values.times.each_with_object({}) { |i, result| result["Key#{i}"] = i }

Benchmark.ips do |x|
  x.report("original") { ActiveSupport::HashWithIndifferentAccess.new(source) }
  x.report("optimized") { OptimizedHashWithIndifferentAccess.new(source) }
  x.compare!
end

original_memory = MemoryProfiler.report do
  ActiveSupport::HashWithIndifferentAccess.new(source)
end

optimized_memory = MemoryProfiler.report do
  OptimizedHashWithIndifferentAccess.new(source)
end

puts "Memory Change: #{(original_memory.total_allocated_memsize - optimized_memory.total_allocated_memsize)} bytes"
```
This produces the following output:
```
Warming up --------------------------------------
            original    11.144k i/100ms
           optimized    10.970k i/100ms
Calculating -------------------------------------
            original    116.554k (±10.9%) i/s -    579.488k in   5.039742s
           optimized    119.011k (±14.4%) i/s -    581.410k in   5.003063s

Comparison:
           optimized:   119010.9 i/s
            original:   116553.5 i/s - same-ish: difference falls within error

Memory Change: 5800 bytes
```

### Other Information

None