### PR TITLE
xml_http_request? method inconsistent with docs

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -260,7 +260,7 @@ module ActionDispatch
       super.to_i
     end
 
-    # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
+    # Returns 0 if the "X-Requested-With" header contains "XMLHttpRequest"
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?


### PR DESCRIPTION
the =~ operator returns 0 for a match (in this case) and nil otherwise.

I've changed the documentation for the `xml_http_request?` method to reflect how it actually works. 

Cleaner would have been to make the method actually return `true` for a match, but this might be considered a breaking change and therefore rejected. I'm happy to fix the method to return `true` for match and `false` otherwise if reviewers prefer it. e.g.:
````ruby
#line 267
  !!(get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i)
````

IMHO the "principle of least surprise" suggests returning a bool from a method with a '?' suffix.
