### PR TITLE
[ci skip] collection_radio_buttons options example

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1048,7 +1048,7 @@ To access the passed options programatically (e.g. adding a custom class if chec
 
 ```html+erb
 <%= collection_radio_buttons(:article, :author_id, Author.all, :id, :name_with_initial, {checked: Author.last, required: true} do |rb| %>
-      <%= rb.label(class: "#{'my-custom-class' if rb.instance_values['input_html_options'][:checked]}") { rb.radio_button + rb.text } %>
+      <%= rb.label(class: "#{'my-custom-class' if rb.value == Author.last.id}") { rb.radio_button + rb.text } %>
 <% end %>
 ```
 

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1025,6 +1025,34 @@ If `@article.author_id` is 1, this would return:
 <label for="article_author_id_3">M. Clark</label>
 ```
 
+Recovering some option passed (e.g. programatically checking an object from collection):
+
+```ruby
+collection_radio_buttons(:article, :author_id, Author.all, :id, :name_with_initial, {checked: Author.last})
+```
+
+In this case, the last object from the collection will be checked:
+
+```html
+<input id="article_author_id_1" name="article[author_id]" type="radio" value="1" />
+<label for="article_author_id_1">D. Heinemeier Hansson</label>
+<input id="article_author_id_2" name="article[author_id]" type="radio" value="2" />
+<label for="article_author_id_2">D. Thomas</label>
+<input id="article_author_id_3" name="article[author_id]" type="radio" value="3" checked="checked" />
+<label for="article_author_id_3">M. Clark</label>
+```
+
+To access the passed options programatically (e.g. adding a custom class if checked):
+
+**Sample html.erb**
+
+```html+erb
+<%= collection_radio_buttons(:article, :author_id, Author.all, :id, :name_with_initial, {checked: Author.last, required: true} do |rb| %>
+      <%= rb.label(class: "#{'my-custom-class' if rb.instance_values['input_html_options'][:checked]}") { rb.radio_button + rb.text } %>
+<% end %>
+```
+
+
 #### collection_check_boxes
 
 Returns `check_box` tags for the collection of existing return values of `method` for `object`'s class.


### PR DESCRIPTION
Added example of how to access an option attibute passed to builder in case the person wants to add a custom style to a programatically checked value e.g.

### Summary

Added example of how to access option passed to the builder (collection_check_boxes).

### Other Information

Spent some time figuring out how to add a custom class to a default checked value, since I couldn't find it anywhere in the guide I decided to add it to save others some trouble.

In my case, I was creating a form and wanted to set the first value checked and also add the active class for styling (I'm using bootstrap 4).
Source of code:

```html+erb
<div class='col-md-4 col-sm-12 my-auto mx-auto'>
	<p><%= t('Currency') %></p>
	<div class="btn-group btn-group-toggle" data-toggle="buttons">
		<%= collection_radio_buttons :pricing, :currency_id, @currencies, :id, :symbol, {checked: @currencies.first.id, required: true} do |rb| %>
			<%= rb.label(class: "btn btn-secondary #{'active' if rb.instance_values['input_html_options'][:checked]}") { rb.radio_button + rb.text } %>
		<% end %>
	</div>
</div>
```
