### PR TITLE
Optimize DescendantsArray insertions

### DIFF
--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -77,15 +77,17 @@ module ActiveSupport
       end
 
       def <<(klass)
-        cleanup!
         @refs << WeakRef.new(klass)
       end
 
       def each
-        @refs.each do |ref|
+        @refs.reject! do |ref|
           yield ref.__getobj__
+          false
         rescue WeakRef::RefError
+          true
         end
+        self
       end
 
       def refs_size


### PR DESCRIPTION
While profiling our application boot, I noticed a surprising amount of calls to check weak refs:

```
==================================
  Mode: wall(1000)
  Samples: 56891 (25.95% miss rate)
  GC: 17459 (30.69%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       464   (0.8%)         464   (0.8%)     WeakRef#weakref_alive?
```

After investigating the profile, it turns out that it's all triggered by `DescendantTracker::DescendantArray#<<`.

So every time you append a new descendant, you also do a `O(n)` operation on the existing list, IMO it doesn't make much sense because in most scenarios, classes being dereferences is rare. 

IMO it makes much more sense to cleanup the array lazily when we iterate over it.

@rafaelfranca @Edouard-chin 
