### PR TITLE
fix filenames of attachments created via the inbound email conductor

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -23,7 +23,7 @@ module Rails
         Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
           params[:mail][:attachments].to_a.each do |attachment|
-            mail.add_file(filename: attachment.path, content: attachment.read)
+            mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end
       end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -45,8 +45,10 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
       end
 
       mail = ActionMailbox::InboundEmail.last.mail
+      attachment_filenames = mail.attachments.map(&:filename)
       assert_equal "Let's talk about these images:", mail.text_part.decoded
       assert_equal 2, mail.attachments.count
+      assert_equal attachment_filenames, ["avatar1.jpeg", "avatar2.jpeg"]
     end
   end
 


### PR DESCRIPTION
### Summary

when doing some testing using the inbound email conductor for ActionMailbox, I noticed that my attachments did not retain their files names upon submission of the form. When I dug in I found that the controller passed along the file path rather than the file name. 

This commit makes a slight tweak to correct that.