### PR TITLE
Use connection.error_number in MySQLDatabaseTasks

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         connection.create_database configuration["database"], creation_options
         establish_connection configuration
       rescue ActiveRecord::StatementInvalid => error
-        if error.cause.error_number == ER_DB_CREATE_EXISTS
+        if connection.error_number(error.cause) == ER_DB_CREATE_EXISTS
           raise DatabaseAlreadyExists
         else
           raise


### PR DESCRIPTION
`MySQLDatabaseTasks`, like `AbstractMysqlAdapter`, should be able to operate on any mysql adapter, not just mysql2. Errors having a .error_number attribute is a mysql2 specific API, which we (Rails) don't control, so we should instead use `connection.error_number(err)`, which we do control.

This also updates tests to better test how this really works, previously it stubbed create_database to raise `Tasks::DatabaseAlreadyExists`, which can never happen.

Refs #36653 (which is a great change!)
cc @y-yagi @cpruitt @eileencodes 

I'd like to backport this to 6-0-stable