### PR TITLE
Ability to test activejobs with relative delay

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   `assert_enqueued_with` and `assert_performed_with` can now test jobs with relative delay.
+
+    *Vlado Cingel*
 
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -630,7 +630,7 @@ module ActiveJob
 
       def prepare_args_for_assertion(args)
         args.dup.tap do |arguments|
-          arguments[:at] = arguments[:at].to_f if arguments[:at]
+          arguments[:at] = round_time_arguments(arguments[:at]) if arguments[:at]
           arguments[:args] = round_time_arguments(arguments[:args]) if arguments[:args]
         end
       end
@@ -650,6 +650,7 @@ module ActiveJob
 
       def deserialize_args_for_assertion(job)
         job.dup.tap do |new_job|
+          new_job[:at] = round_time_arguments(Time.at(new_job[:at])) if new_job[:at]
           new_job[:args] = ActiveJob::Arguments.deserialize(new_job[:args]) if new_job[:args]
         end
       end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -621,6 +621,12 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_with_with_relative_at_option
+    assert_enqueued_with(job: HelloJob, at: 5.minutes.from_now) do
+      HelloJob.set(wait: 5.minutes).perform_later
+    end
+  end
+
   def test_assert_enqueued_with_with_no_block_with_at_option
     HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
     assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
@@ -1659,6 +1665,18 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_performed_with(job: HelloJob, at: Date.today.noon) do
         HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+      end
+    end
+  end
+
+  def test_assert_performed_with_with_relative_at_option
+    assert_performed_with(job: HelloJob, at: 5.minutes.from_now) do
+      HelloJob.set(wait: 5.minutes).perform_later
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_with(job: HelloJob, at: 2.minutes.from_now) do
+        HelloJob.set(wait: 1.minute).perform_later
       end
     end
   end


### PR DESCRIPTION
`assert_enqueued_with` and `assert_performed_with` were not able to properly test jobs with relative delay. `:at` option was asserted for equality and test will always fail cause small fraction of time will pass between assertion and job call.

This commit fixes that by droping microseconds from `:at` argument assertions.

Before: 

``` ruby
# This will pass
assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon) do
  MyJob.set(wait_until: Date.tomorrow.noon).perform_later
end

# This will fail
assert_enqueued_with(job: MyJob, at: 5.minutes.from_now) do
  MyJob.set(wait: 5.minutes).perform_later
end

# To make it pass we need something like this
job = assert_enqueued_with(job: MyJob) do
  MyJob.set(wait: 5.minutes).perform_later
end
assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
```

After:

``` ruby
# This will pass
assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon) do
  MyJob.set(wait_until: Date.tomorrow.noon).perform_later
end

# This will also pass
assert_enqueued_with(job: MyJob, at: 5.minutes.from_now) do
  MyJob.set(wait: 5.minutes).perform_later
end
```

**Note**: Original implementation was done here https://github.com/rails/rails/pull/22043, lot has changed since then and I had trouble rebasing so I opened new PR to make it easier.