### PR TITLE
Added a way to move a middleware from the stack:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Added a way to move a middleware up or down the stack
+
+    ```ruby
+      initializer :move_some_library_middleware do
+        config.middleware.move(LibraryMiddleware, :insert_before, SomeOtherMiddleware)
+        # or
+        config.middleware.move(LibraryMiddleware, :insert_after, SomeOtherMiddleware)
+      end
+    ```
+
+    *Edouard Chin*
+
 *   Fix IntegrationTest `follow_redirect!` to follow redirection using the same HTTP verb when following
     a 307 redirection.
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -122,6 +122,13 @@ module ActionDispatch
       middlewares.push(build_middleware(klass, args, block))
     end
 
+    def move(klass, where, index)
+      current_index = assert_index(klass, where)
+      desired_index = assert_index(index, where)
+      offset = where == :insert_after ? 1 : 0
+      middlewares.insert(desired_index + offset, middlewares.delete_at(current_index))
+    end
+
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)
       middlewares.freeze.reverse.inject(app || block) do |a, e|

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -93,6 +93,22 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal FooMiddleware, @stack[0].klass
   end
 
+  test "move a middleware up the stack" do
+    @stack.use(BazMiddleware, "foo", "bar")
+    assert_equal(BazMiddleware, @stack.last.klass)
+    @stack.move(BazMiddleware, :insert_before, FooMiddleware)
+    assert_equal(BazMiddleware, @stack.first.klass)
+    assert_equal(["foo", "bar"], @stack.first.args)
+  end
+
+  test "move a middleware down the stack" do
+    @stack.insert_before(FooMiddleware, BazMiddleware, "foo", "bar")
+    assert_equal(BazMiddleware, @stack.first.klass)
+    @stack.move(BazMiddleware, :insert_after, BarMiddleware)
+    assert_equal(BazMiddleware, @stack.last.klass)
+    assert_equal(["foo", "bar"], @stack.last.args)
+  end
+
   test "unshift adds a new middleware at the beginning of the stack" do
     @stack.unshift MiddlewareStackTest::BazMiddleware
     assert_equal BazMiddleware, @stack.first.klass

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -26,6 +26,11 @@ module Rails
     #
     #     config.middleware.insert_after Rack::Head, Magical::Unicorns
     #
+    # If you need to move a middleware up or down the stack, you can use the +move+ method.
+    # The second argument should be +:insert_before+ or +:insert_after+.
+    #
+    #     config.middleware.move Rack::HEAD, :insert_before, Magical::Unicorns
+    #
     # Middlewares can also be completely swapped out and replaced with others:
     #
     #     config.middleware.swap ActionDispatch::Flash, Magical::Unicorns
@@ -55,6 +60,10 @@ module Rails
       end
 
       def use(*args, &block)
+        @operations << [__method__, args, block]
+      end
+
+      def move(*args, &block)
         @operations << [__method__, args, block]
       end
 

--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -33,6 +33,11 @@ module Rails
         assert_playback :use, :foo
       end
 
+      def test_playback_move
+        @stack.move :foo
+        assert_playback :move, :foo
+      end
+
       def test_playback_delete
         @stack.delete :foo
         assert_playback :delete, :foo


### PR DESCRIPTION
Added a way to move a middleware from the stack:

- Moving a middleware from the stack isn't common but I had the use
  case couple times, and it wasn't trivial to figure out how to bypass
  the Middleware proxy implementation to allow it.

  The main reason to move a middleware from the stack is to move a
  middleware that a railtie added at some point.
  Right now, to move a middleware you need to do this:

  ```ruby
    initializer :move_up_bugsnag_middleware, after: "bugsnag.use_rack_middleware" do
      placeholder = Class.new

      config.middleware.swap(Bugsnag::Rack, placeholder)
      config.middleware.insert_before(ProfilerMiddleware, Bugsnag::Rack)
      config.middleware.delete(placeholder)
    end
  ```

  It's not possible to just delete the middleware and then re-add it
  at the right position like so
  ```ruby
    config.middleware.delete(Bugsnag::Rack)
    config.middleware.insert_before(ProfilerMiddleware, Bugsnag::Rack)
  ```
  because the `delete_operations` from the middleware proxy is called
  last, which means the `Bugsnag::Rack` middleware will get removed
  entirely. And even if it was possible it's not a good idea to do that because you might end up removing arguments passed when building the middleware

https://github.com/rails/rails/blob/91fd679710118482f718ea710710561f1cfb0b70/railties/lib/rails/configuration.rb#L70

  This patch adds a `move` method, in order to move a already built
  middleware somewhere else in the stack.

cc/ @rafaelfranca @casperisfine