### PR TITLE
Only merge DATABASE_URL settings into the current env

### DIFF
--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -347,6 +347,22 @@ module ActiveRecord
           assert_equal expected, actual
         end
       end
+
+      def test_does_not_change_other_environments
+        ENV["DATABASE_URL"] = "postgres://localhost/foo"
+        config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
+
+        actual = resolve_spec(:production, config)
+        assert_equal config["production"].merge("name" => "production"), actual
+
+        actual = resolve_spec(:default_env, config)
+        assert_equal({
+          "host" => "localhost",
+          "database" => "foo",
+          "adapter" => "postgresql",
+          "name" => "default_env"
+        }, actual)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR fixes a regression where when the `DATABASE_URL` environment variable was set and the current Rails environment had a valid configuration defined in the database config, settings from the environment variable would affect _all_ environments (not just the current one).

### Other Information

Note: This behavior was also checked against `5-2-stable` where the test contained in this PR passes. 🎉 

cc / @eileencodes 