### PR TITLE
Allow separate database env variables per-connection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make the DATABASE_URL env variable only affect the primary connection. Add new env variables for multiple databases.
+
+    *John Crepezzi*, *Eileen Uchitelle*
+
 *   Add a warning for enum elements with 'not_' prefix.
 
         class Foo
@@ -55,6 +59,5 @@
 *   Allow generated `create_table` migrations to include or skip timestamps.
 
     *Michael Duchemin*
-
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -168,10 +168,17 @@ module ActiveRecord
       end
 
       def environment_url_config(env, spec_name, config)
-        url = ENV["DATABASE_URL"]
+        url = environment_value_for(spec_name)
         return unless url
 
         ActiveRecord::DatabaseConfigurations::UrlConfig.new(env, spec_name, url, config)
+      end
+
+      def environment_value_for(spec_name)
+        spec_env_key = "#{spec_name.upcase}_DATABASE_URL"
+        url = ENV[spec_env_key]
+        url ||= ENV["DATABASE_URL"] if spec_name == "primary"
+        url
       end
 
       def method_missing(method, *args, &blk)


### PR DESCRIPTION
### Summary

This PR adds a feature which allows separate database ENV variables to be defined for each specification in a 3-tiered (multi-db) config. The names for these new environment variables will be `#{name.upcase}_DATABASE_URL`

Important note: This PR also introduces a breaking change in behavior around handling of `DATABASE_URL`. Instead of using `DATABASE_URL` to change _all_ specs in a multi-database configuration, it will now only affect the `primary` configuration. We could keep the current behavior (`5-2-stable`) for `DATABASE_URL` by letting it modify all of the configurations in the current environment at once, but that feels more surprising to people especially those with multiple databases on hosted environments.

cc / @eileencodes 