### PR TITLE
Fix join middle table alias when using HABTM

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -62,7 +62,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def middle_reflection(join_model)
       middle_name = [lhs_model.name.downcase.pluralize,
-                     association_name].join("_").gsub("::", "_").to_sym
+                     association_name.to_s].sort.join("_").gsub("::", "_").to_sym
       middle_options = middle_options join_model
 
       HasMany.create_reflection(lhs_model,

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -700,10 +700,17 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal ["id"], developers(:david).projects.select(:id).first.attributes.keys
   end
 
+  def test_join_middle_table_alias
+    assert_equal(
+      2,
+      Project.includes(:developers_projects).where.not("developers_projects.joined_on": nil).to_a.size
+    )
+  end
+
   def test_join_table_alias
     assert_equal(
       3,
-      Developer.includes(projects: :developers).where.not("projects_developers_projects_join.joined_on": nil).to_a.size
+      Developer.includes(projects: :developers).where.not("developers_projects_projects_join.joined_on": nil).to_a.size
     )
   end
 
@@ -716,7 +723,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(
       3,
-      Developer.includes(projects: :developers).where.not("projects_developers_projects_join.joined_on": nil).group(group.join(",")).to_a.size
+      Developer.includes(projects: :developers).where.not("developers_projects_projects_join.joined_on": nil).group(group.join(",")).to_a.size
     )
   end
 


### PR DESCRIPTION
### Summary
Fix join middle table alias when using HABTM

In using HABTM, join middle table alias is combined with the associated
models name without sort, while middle table name is combined with those
models name with sort.

This naming for join middle table alias looks confusing compared to middle table name (refer to https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb#L93 ) . 

Fixes #36742.