### PR TITLE
Prettify diff generated by git for encrypted file:

### DIFF
--- a/railties/lib/rails/command/helpers/pretty_credentials.rb
+++ b/railties/lib/rails/command/helpers/pretty_credentials.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Rails
+  module Command
+    module Helpers
+      module PrettyCredentials
+        Error = Class.new(StandardError)
+
+        def opt_in_pretty_credentials
+          unless already_answered? || already_opted_in?
+            answer = yes?("Would you like to make the credentials diff from git more readable in the future? [Y/n]")
+          end
+
+          opt_in! if answer
+          FileUtils.touch(tracker) unless answer.nil?
+        rescue Error
+          say("Couldn't setup git to prettify the credentials diff")
+        end
+
+        private
+          def already_answered?
+            tracker.exist?
+          end
+
+          def already_opted_in?
+            system_call("git config --get 'diff.rails_credentials.textconv'", accepted_codes: [0, 1])
+          end
+
+          def opt_in!
+            system_call("git config diff.rails_credentials.textconv 'bin/rails credentials:show'", accepted_codes: [0])
+
+            git_attributes = Rails.root.join(".gitattributes")
+            File.open(git_attributes, "a+") do |file|
+              file.write(<<~EOM)
+                config/credentials/*.yml.enc diff=rails_credentials
+                config/credentials.yml.enc diff=rails_credentials
+              EOM
+            end
+          end
+
+          def tracker
+            Rails.root.join("tmp", "rails_pretty_credentials")
+          end
+
+          def system_call(command_line, accepted_codes:)
+            result = system(command_line)
+            raise(Error) if accepted_codes.exclude?($?.exitstatus)
+            result
+          end
+      end
+    end
+  end
+end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -301,7 +301,7 @@ module TestHelpers
     # stderr:: true to pass STDERR output straight to the "real" STDERR.
     #   By default, the STDERR and STDOUT of the process will be
     #   combined in the returned string.
-    def rails(*args, allow_failure: false, stderr: false)
+    def rails(*args, allow_failure: false, stderr: false, stdin: File::NULL)
       args = args.flatten
       fork = true
 
@@ -328,7 +328,7 @@ module TestHelpers
           out_read.close
           err_read.close if err_read
 
-          $stdin.reopen(File::NULL, "r")
+          $stdin.reopen(stdin, "r")
           $stdout.reopen(out_write)
           $stderr.reopen(err_write)
 


### PR DESCRIPTION
Prettify diff generated by git for encrypted file:

- @sinsoku had the idea and started implementing it few months ago
  but sadly didn't finish it.
  This PR is taking over his work.

  The credentials feature has changed a lot since @sinsoku opened hi
  PR, it was easier to just restart from scratch instead of checking
  out his branch.
  Sinsoku will get all the credit he deserves for this idea :)

  TL;DR on that that feature is to make the `git diff` or `git log`
  of encrypted files to be readable.

  The previous implementation was only setting up the git required
  configuration for the first time Rails was bootstraped, so I decided
  to instead provide the user a choice to opt-in for readable diff
  credential whenever a user types the `bin/rails credentials:edit`
  command.
  The question won't be asked in the future the user has already
  answered or if the user already opted in.

  Co-authored-by: Takumi Shotoku <insoku.listy@gmail.com>

cc/ @rafaelfranca @casperisfine

Screen recording https://terminalizer.com/view/a77d4aad1509

