### PR TITLE
Removed webpacker:compile step from scaffold test as it is not required

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -162,7 +162,6 @@ module ApplicationTests
       rails "generate", "scaffold", "user", "username:string", "password:string"
       with_rails_env("test") do
         rails("db:migrate")
-        rails("webpacker:compile")
       end
       output = rails("test")
 
@@ -194,7 +193,6 @@ module ApplicationTests
       rails "generate", "scaffold", "LineItems", "product:references", "cart:belongs_to"
       with_rails_env("test") do
         rails("db:migrate")
-        rails("webpacker:compile")
       end
       output = rails("test")
 


### PR DESCRIPTION
When I was working on adding webpacker to the Rails engines, my test cases were consistently failing and I had no idea what was wrong. So I checked how Rails app with webpacker solves the scaffold test scenario. 

I found that when the Rails app is build using `build_app` it compiles the assets here(https://github.com/rails/rails/blob/master/railties/test/isolation/abstract_unit.rb#L519-L526)

This `webpacker:compile` was an unnecessary step but since these are test case I was not sure If I should raise PR for change. On my local test cases ran 2sec faster 😊 . Please close this PR if the change is not needed. 



