### PR TITLE
Optimize Journey::Route#glob?

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -148,7 +148,7 @@ module ActionDispatch
       end
 
       def glob?
-        !path.spec.grep(Nodes::Star).empty?
+        path.spec.any?(Nodes::Star)
       end
 
       def dispatcher?


### PR DESCRIPTION
Our application's boot profile show a very sizable amount of time is spent creating URL helpers:

```
==================================
  Mode: cpu(1000)
  Samples: 56525 (24.91% miss rate)
  GC: 15470 (27.37%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7456  (13.2%)        7164  (12.7%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

If we dig deeper we can see that about half of that time is spent in `Route#glob?`

```
$ stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method 'ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper'
ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper (/tmp/bundle/ruby/2.5.0/bundler/gems/rails-31105c81cc82/actionpack/lib/action_dispatch/routing/route_set.rb:315)
  samples:  7164 self (12.7%)  /   7456 total (13.2%)
  callers:
    7456  (  100.0%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection#add
  callees (292 total):
     292  (  100.0%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.create

$ stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method 'ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.create'
ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.create (/tmp/bundle/ruby/2.5.0/bundler/gems/rails-31105c81cc82/actionpack/lib/action_dispatch/routing/route_set.rb:172)
  samples:     1 self (0.0%)  /    292 total (0.5%)
  callers:
     292  (  100.0%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
  callees (291 total):
     159  (   54.6%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.optimize_helper?
      95  (   32.6%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper::OptimizedUrlHelper#initialize
      37  (   12.7%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper#initialize


$ stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method 'ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.optimize_helper?'
ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.optimize_helper? (/tmp/bundle/ruby/2.5.0/bundler/gems/rails-31105c81cc82/actionpack/lib/action_dispatch/routing/route_set.rb:180)
  samples:     1 self (0.0%)  /    159 total (0.3%)
  callers:
     159  (  100.0%)  ActionDispatch::Routing::RouteSet::NamedRouteCollection::UrlHelper.create
  callees (158 total):
     158  (  100.0%)  ActionDispatch::Journey::Route#glob?
```

### Optimization

Clearly `!grep.empty?` isn't the fastest to check for one of the elements satisfying the condition, with `any?` we both save an array allocation, and return immediately once we found one matching element.

I ran the profile again after applying the following monkey patch:

```ruby
# frozen_string_literal: true
require 'action_dispatch/journey/nodes/node'
require 'action_dispatch/journey/route'

module JourneyRouteGlobPatch
  Nodes = ::ActionDispatch::Journey::Nodes
  def glob?
    path.spec.any?(Nodes::Star)
  end
end

ActionDispatch::Journey::Route.prepend(JourneyRouteGlobPatch)
```

And it does improves things by about 13%:

```
==================================
  Mode: cpu(1000)
  Samples: 68901 (29.72% miss rate)
  GC: 21837 (31.69%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7889  (11.4%)        7480  (10.9%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

@rafaelfranca @Edouard-chin 