### PR TITLE
Easier Debugging of Complex Views With Rendering Hints

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -162,6 +162,9 @@ module ActionView #:nodoc:
     # Specify whether submit_tag should automatically disable on click
     cattr_accessor :automatically_disable_submit_tag, default: true
 
+    # Specify whether the view rendering includes which partial produced the output
+    cattr_accessor :render_hints, default: true
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -163,7 +163,7 @@ module ActionView #:nodoc:
     cattr_accessor :automatically_disable_submit_tag, default: true
 
     # Specify whether the view rendering includes which partial produced the output
-    cattr_accessor :render_hints, default: true
+    cattr_accessor :render_hints, default: false
 
     class_attribute :_routes
     class_attribute :logger

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -99,7 +99,7 @@ module ActionView
 
     initializer "action_view.render_hints" do |app|
       ActiveSupport.on_load(:action_view) do
-        PartialRenderer.render_hints = app.config.render_hints
+        PartialRenderer.render_hints = app.config.action_view.render_hints
       end
     end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -13,6 +13,7 @@ module ActionView
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
     config.action_view.finalize_compiled_template_methods = NULL_OPTION
+    config.action_view.render_hints = nil
 
     config.eager_load_namespaces << ActionView
 
@@ -94,6 +95,12 @@ module ActionView
 
     initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
       PartialRenderer.collection_cache = app.config.action_controller.cache_store
+    end
+
+    initializer "action_view.render_hints" do |app|
+      ActiveSupport.on_load(:action_view) do
+        PartialRenderer.render_hints = app.config.render_hints
+      end
     end
 
     rake_tasks do |app|

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -460,7 +460,7 @@ module ActionView
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
 
-          partial_hints(template, content, locals) if render_hints
+          partial_hints(template, content, locals.except(counter, iteration)) if render_hints
           build_rendered_template(content, template)
         end
       end
@@ -484,7 +484,7 @@ module ActionView
           content = template.render(view, locals)
           partial_iteration.iterate!
 
-          partial_hints(template, content, locals) if render_hints
+          partial_hints(template, content, locals.except(counter, iteration)) if render_hints
           build_rendered_template(content, template)
         end
       end

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -12,6 +12,9 @@ module ActionView
   # each time +render+ is called.
   class Renderer
     attr_accessor :lookup_context
+    cattr_accessor :nested_level
+
+    @@nested_level = -1
 
     def initialize(lookup_context)
       @lookup_context = lookup_context
@@ -62,7 +65,14 @@ module ActionView
     end
 
     def render_partial_to_object(context, options, &block) #:nodoc:
-      PartialRenderer.new(@lookup_context).render(context, options, block)
+      @@nested_level += 1
+
+      renderer = PartialRenderer.new(@lookup_context)
+      renderer.nested_level = nested_level
+
+      renderer.render(context, options, block)
+    ensure
+      @@nested_level -= 1
     end
   end
 end

--- a/actionview/test/fixtures/test/template_with_partial_collection.erb
+++ b/actionview/test/fixtures/test/template_with_partial_collection.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'test/customer', collection: [Customer.new, Customer.new] %>

--- a/actionview/test/fixtures/test/template_with_partial_locals.erb
+++ b/actionview/test/fixtures/test/template_with_partial_locals.erb
@@ -1,0 +1,2 @@
+<%= render partial: "test/partial", locals: {first_name: "Jim", last_name: "Jones"} %>
+template with partial and locals

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -692,14 +692,11 @@ module RenderTestCases
     old_config = ActionView::PartialRenderer.render_hints
     ActionView::PartialRenderer.render_hints = true
 
-    SecureRandom.stub(:uuid, "xyz-123") do
-      content = @view.render template: "test/template_with_partial_locals"
+    content = @view.render template: "test/template_with_partial_locals"
 
-      assert_match "start render:", content
-      assert_match "end render:", content
-      assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
-      assert_match "uuid: xyz-123", content
-    end
+    assert_match "begin", content
+    assert_match "end", content
+    assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
   ensure
     ActionView::PartialRenderer.render_hints = old_config
   end
@@ -708,19 +705,14 @@ module RenderTestCases
     old_config = ActionView::PartialRenderer.render_hints
     ActionView::PartialRenderer.render_hints = true
 
-    content = @view.render template: "test/template_with_partial_collection"
+    content = @view.render template: "test/template_with_partial_locals"
 
-    SecureRandom.stub(:uuid, "xyz-123") do
-      content = @view.render template: "test/template_with_partial_locals"
+    assert_no_match "iteration", content
+    assert_no_match "counter", content
 
-      assert_no_match "iteration", content
-      assert_no_match "counter", content
-
-      assert_match "start render:", content
-      assert_match "end render:", content
-      assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
-      assert_match "uuid: xyz-123", content
-    end
+    assert_match "begin", content
+    assert_match "end", content
+    assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
   ensure
     ActionView::PartialRenderer.render_hints = old_config
   end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -687,6 +687,43 @@ module RenderTestCases
 
     assert_match "Content can't be blank", error.message
   end
+
+  def test_render_template_with_partial_hints
+    old_config = ActionView::PartialRenderer.render_hints
+    ActionView::PartialRenderer.render_hints = true
+
+    SecureRandom.stub(:uuid, "xyz-123") do
+      content = @view.render template: "test/template_with_partial_locals"
+
+      assert_match "start render:", content
+      assert_match "end render:", content
+      assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
+      assert_match "uuid: xyz-123", content
+    end
+  ensure
+    ActionView::PartialRenderer.render_hints = old_config
+  end
+
+  def test_render_template_with_partial_hints_excludes_local_internals
+    old_config = ActionView::PartialRenderer.render_hints
+    ActionView::PartialRenderer.render_hints = true
+
+    content = @view.render template: "test/template_with_partial_collection"
+
+    SecureRandom.stub(:uuid, "xyz-123") do
+      content = @view.render template: "test/template_with_partial_locals"
+
+      assert_no_match "iteration", content
+      assert_no_match "counter", content
+
+      assert_match "start render:", content
+      assert_match "end render:", content
+      assert_match "{:first_name=>\"Jim\", :last_name=>\"Jones\"}", content
+      assert_match "uuid: xyz-123", content
+    end
+  ensure
+    ActionView::PartialRenderer.render_hints = old_config
+  end
 end
 
 class CachedViewRenderTest < ActiveSupport::TestCase

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -157,6 +157,8 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 
 * `config.time_zone` sets the default time zone for the application and enables time zone awareness for Active Record.
 
+* `config.render_hints` determines whether to output debug html comments denoting the beginning/end rendering of a partial.
+
 * `config.autoloader` sets the autoloading mode. This option defaults to `:zeitwerk` if `6.0` is specified in `config.load_defaults`. Applications can still use the classic autoloader by setting this value to `:classic` after loading the framework defaults:
 
     ```ruby

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -157,7 +157,7 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 
 * `config.time_zone` sets the default time zone for the application and enables time zone awareness for Active Record.
 
-* `config.render_hints` determines whether to output debug html comments denoting the beginning/end rendering of a partial.
+* `config.action_view.render_hints` determines whether to output debug html comments denoting the beginning/end rendering of a partial.
 
 * `config.autoloader` sets the autoloading mode. This option defaults to `:zeitwerk` if `6.0` is specified in `config.load_defaults`. Applications can still use the classic autoloader by setting this value to `:classic` after loading the framework defaults:
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -19,7 +19,8 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
-                    :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path
+                    :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
+                    :render_hints
 
       attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
 
@@ -70,6 +71,7 @@ module Rails
         @disable_sandbox                         = false
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil
+        @render_hints                            = false
       end
 
       def load_defaults(target_version)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -19,8 +19,7 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
-                    :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :render_hints
+                    :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path
 
       attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
 
@@ -71,7 +70,6 @@ module Rails
         @disable_sandbox                         = false
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil
-        @render_hints                            = false
       end
 
       def load_defaults(target_version)

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -69,4 +69,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Display inline html comments marking the begining/end rendering
+  #  of a partial.
+  config.render_hints = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -70,7 +70,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Display inline html comments marking the begining/end rendering
-  #  of a partial.
-  config.render_hints = true
+  # Display inline html comments marking the begining/end rendering of a partial.
+  config.action_view.render_hints = true
 end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -34,7 +34,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
     app_file "app/controllers/customers_controller.rb", <<-RUBY
       class CustomersController < ApplicationController
         self.perform_caching = true
-        Rails.application.config.action_view.render_hints = true            
+        Rails.application.config.action_view.render_hints = true
 
         def index
           render [ Customer.new('david', 1), Customer.new('dingus', 2) ]
@@ -54,7 +54,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
   teardown :teardown_app
 
   test "digests are reused when rendering the same template twice" do
-    SecureRandom.stub(:uuid, 'xyz-123') do
+    SecureRandom.stub(:uuid, "xyz-123") do
       get "/customers"
       assert_equal 200, last_response.status
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1208,6 +1208,7 @@ YAML
 
       add_to_config("config.railties_order = [:all, :main_app, Blog::Engine]")
       add_to_env_config "development", "config.assets.digest = false"
+      add_to_env_config "development", "config.action_view.render_hints = false"
 
       boot_rails
 
@@ -1259,6 +1260,7 @@ YAML
       RUBY
 
       add_to_config("config.railties_order = [Bukkits::Engine]")
+      add_to_env_config "development", "config.action_view.render_hints = false"
 
       boot_rails
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4600/63070108-7287d600-bedf-11e9-978e-8a96f607409a.png)

![image](https://user-images.githubusercontent.com/4600/63070104-6e5bb880-bedf-11e9-827a-83f369e3e399.png)

### Issue

For large codebases with many nested partials, it can be particularly hard to discern which partials were utilized in the generation of the final view.

### Summary of Resolution

Now for every partial rendered, the HTML output is encapsulated within a set of start/end HTML comment tags along with the associated local values used to generate the snippet.  

### Other Information

The rendering annotation hints can be toggled on/off with the `config.action_view.render_hints` option.  It's turned on for development mode in this PR.