### PR TITLE
Use capture_sql helper method in tests

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -60,10 +60,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_does_not_use_order_by
-    ActiveRecord::SQLCounter.clear_log
-    Client.find(3).firm
-  ensure
-    sql_log = ActiveRecord::SQLCounter.log
+    sql_log = capture_sql { Client.find(3).firm }
     assert sql_log.all? { |sql| !/order by/i.match?(sql) }, "ORDER BY was used in the query: #{sql_log}"
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -37,10 +37,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_does_not_use_order_by
-    ActiveRecord::SQLCounter.clear_log
-    companies(:first_firm).account
-  ensure
-    sql_log = ActiveRecord::SQLCounter.log
+    sql_log = capture_sql { companies(:first_firm).account }
     assert sql_log.all? { |sql| !/order by/i.match?(sql) }, "ORDER BY was used in the query: #{sql_log}"
   end
 


### PR DESCRIPTION
Since we now have the `capture_sql` helper in `AR::TestCase`, we don't need to collect logs from `SQLCounter` manually.