### PR TITLE
Make configuration on connect optional for mysql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a auto_configure key to database configuration of connections done by
+    active record optional.
+
+    *Guilherme Mansur*
+
 *   Allow specifying fixtures to be ignored by setting `ignore` in YAML file's '_fixture' section.
 
     *Tongfei Gao*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -692,6 +692,8 @@ module ActiveRecord
         end
 
         def configure_connection
+          return unless  @config.fetch(:auto_configure, true)
+
           variables = @config.fetch(:variables, {}).stringify_keys
 
           # By default, MySQL 'where id is null' selects the last inserted id; Turn this off.


### PR DESCRIPTION
### Summary

The configure_connection method in the abstract mysql adapter sets some
session variables that can cause proxys like proxysql to hold on to the
connection indefinetely. Furthermore there is a waitimeout set during
the configure_connection method as well, which can conflict with wait
timeouts set outside the config. Since someone can set these values in
their DB server we should have the option of being able to opt out of
this configuration entirely. This patch introduces a auto_configure key
in the mysql database config which when set to false will skip the auto
configure for that particular mysql database.

### Other Information

The reason I added this key in the `db/config.yml` is that we can easily specify which databases not to configure in a world with multiple databases. An alternative is to have something like: 

`active_record.config.mysql.skip_configure_connection_for = [:db_1, :db_2]`

In the `production.rb, development.rb, etc..` files. 
