### PR TITLE
Upload with filename and disposition for S3

### DIFF
--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -77,6 +77,23 @@ if SERVICE_CONFIGURATIONS[:s3]
       @service.delete key
     end
 
+    test "upload with content disposition" do
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
+
+      @service.upload(
+        key,
+        StringIO.new(data),
+        checksum: Digest::MD5.base64digest(data),
+        filename: ActiveStorage::Filename.new("cool_data.txt"),
+        disposition: :attachment
+      )
+
+      assert_equal("attachment; filename=\"cool_data.txt\"; filename*=UTF-8''cool_data.txt", @service.bucket.object(key).content_disposition)
+    ensure
+      @service.delete key
+    end
+
     test "uploading a large object in multiple parts" do
       service = build_service(upload: { multipart_threshold: 5.megabytes })
 


### PR DESCRIPTION
### Summary

GCS service allows you to upload a file with disposition and filename (which is used to generate the `Content-Disposition` header), but S3 service does not. This PR adds that functionality to the S3 service.

### Other Information

cc. @gmcgibbon 