### PR TITLE
Upload filename and disposition for Azure

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -17,10 +17,12 @@ module ActiveStorage
       @container = container
     end
 
-    def upload(key, io, checksum: nil, content_type: nil, **)
+    def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, **)
       instrument :upload, key: key, checksum: checksum do
         handle_errors do
-          blobs.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum, content_type: content_type)
+          content_disposition = content_disposition_with(filename: filename, type: disposition) if disposition && filename
+
+          blobs.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum, content_type: content_type, content_disposition: content_disposition)
         end
       end
     end

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -23,6 +23,21 @@ if SERVICE_CONFIGURATIONS[:azure]
       @service.delete key
     end
 
+    test "upload with content disposition" do
+      key  = SecureRandom.base58(24)
+      data = "Foobar"
+
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
+
+      assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.blobs.get_blob_properties(@service.container, key).properties[:content_disposition])
+
+      url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: nil, filename: ActiveStorage::Filename.new("test.html"))
+      response = Net::HTTP.get_response(URI(url))
+      assert_match(/attachment;.*test\.html/, response["Content-Disposition"])
+    ensure
+      @service.delete key
+    end
+
     test "signed URL generation" do
       url = @service.url(@key, expires_in: 5.minutes,
         disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")


### PR DESCRIPTION
### Summary

GCS service allows you to upload a file with disposition and filename (which is used to generate the `Content-Disposition` header), but Azure service does not. This PR adds that functionality to the Azure service.

### Other Information

cc. @gmcgibbon 