### PR TITLE
Not allowed to chain ActiveSupport::Duration part methods.

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -46,7 +46,7 @@ module ActiveJob
     #    my_job_instance.enqueue wait_until: Date.tomorrow.midnight
     #    my_job_instance.enqueue priority: 10
     def enqueue(options = {})
-      self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
+      self.scheduled_at = options[:wait].to_i.seconds.from_now.to_f if options[:wait]
       self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
       self.priority     = options[:priority].to_i if options[:priority]

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add raises `NoMethodError` when you chain some duration part methods.
+
+    Example:
+
+        1.year.year
+        1.month.weeks
+        1.hour.minutes
+
+    Before:
+
+        # => NoMethodError: undefined method `year' for ...
+        # => 18144000 days
+        # => 216000 seconds
+
+    After:
+
+        # => undefined method `year' for 1 year:ActiveSupport::Duration
+        # => undefined method `weeks' for 1 month:ActiveSupport::Duration
+        # => undefined method `minutes' for 1 hour:ActiveSupport::Duration
+
+    *Edu Depetris*
+
 *   Calling `ActiveSupport::TaggedLogging#tagged` without a block now returns a tagged logger.
 
     ```ruby

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -426,12 +426,23 @@ module ActiveSupport
         value.respond_to?(method)
       end
 
+      FULL_PARTS = PARTS + [:year, :month, :week, :day, :hour, :minute, :second]
+
       def method_missing(method, *args, &block)
-        value.public_send(method, *args, &block)
+        # Not allowed to chain part methods
+        if FULL_PARTS.include?(method)
+          raise_no_method_error_for_part(method)
+        else
+          value.public_send(method, *args, &block)
+        end
       end
 
       def raise_type_error(other)
         raise TypeError, "no implicit conversion of #{other.class} into #{self.class}"
+      end
+
+      def raise_no_method_error_for_part(method)
+        raise NoMethodError, "undefined method `#{method}' for #{self.inspect}:#{self.class}"
       end
   end
 end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -693,6 +693,20 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "can't build an ActiveSupport::Duration from a NilClass", error.message
   end
 
+  def test_does_not_allow_chaining_duration_part_methods
+    parts = %w[years months weeks days hours minutes seconds year month week day hour minute second]
+
+    parts.combination(2).each do |combination|
+      p1, p2 = combination
+
+      e = assert_raise(NoMethodError) { 1.public_send(p1).public_send(p2) }
+
+      singular_p1 = p1.end_with?("s") ? p1.chop : p1
+
+      assert_equal("undefined method `#{p2}' for 1 #{singular_p1}:ActiveSupport::Duration", e.message)
+    end
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
### Summary

Reading the issue #36644 I found a non consistent and unwanted
behavior, at least for me, when you are chaining
ActiveSupport::Duration [part methods][1].

Example:

    1.year.year # => NoMethodError: undefined method `year' for ...
    1.month.weeks # => 18144000 days
    1.hour.minutes # => 216000 seconds

In my opinion chaining these methods should not be allowed and it
should raises the exception "NoMethodError".

This PR intercept the chain call on `method_missing` and then raises
a `NoMethodError` exception.

How it works:

    1.year.year # =>
      undefined method `year' for 1 year:ActiveSupport::Duration

    1.month.weeks # =>
      undefined method `weeks' for 1 month:ActiveSupport::Duration

### Other Information

- I tested it on the last version of rails. 
```console
$ bin/rails c 
Loading development environment (Rails 6.1.0.alpha)
2.6.1 :001 > 1.month.year
Traceback (most recent call last):
        1: from (irb):1
NoMethodError (undefined method `year' for 1 month:ActiveSupport::Duration)
```
- I updated the CHANGELOG.


[1]:https://github.com/rails/rails/blob/727da1d8cdcab3ff50e399053faf7ba84e05ce03/activesupport/lib/active_support/duration.rb#L125