### PR TITLE
Postgres: allow enabling prepared statements for specific queries when globally disabled.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -642,13 +642,14 @@ module ActiveRecord
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
 
-          if without_prepared_statement?(binds)
-            result = exec_no_cache(sql, name, [])
-          elsif !prepare
-            result = exec_no_cache(sql, name, binds)
-          else
+          if prepare
             result = exec_cache(sql, name, binds)
+          elsif without_prepared_statement?(binds)
+            result = exec_no_cache(sql, name, [])
+          else
+            result = exec_no_cache(sql, name, binds)
           end
+
           ret = yield result
           result.clear
           ret

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -138,6 +138,17 @@ module ActiveRecord
       end
     end
 
+    def test_force_prepare_statement
+      @connection.unprepared_statement do
+        @connection.exec_query("SELECT 1::integer", "SQL", [], prepare: true)
+        name = @subscriber.payloads.last[:statement_name]
+        assert name
+        res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(1)")
+        plan = res.column_types["QUERY PLAN"].deserialize res.rows.first.first
+        assert_operator plan.length, :>, 0
+      end
+    end
+
     def test_reconnection_after_actual_disconnection_with_verify
       original_connection_pid = @connection.query("select pg_backend_pid()")
 


### PR DESCRIPTION
### Summary

When prepared statements are disabled globally for postgres, the `prepare` argument to `exec_query` (and any others) is now respected to enable them to be selectively enabled.
I don't believe there is a way to do this otherwise. I believe this is a bug in the current method, given the expectations implied by its method signature.

Per discussion in #24893 this is a private API, so I didn't want to add
extra test coverage for it to imply otherwise. (Separate to this PR, I would probably make an argument that this API is _effectively_ public given widespread usage of `exec_query`.)

### Other Information

We are currently using a monkey patch to apply this in our code base. To provide more context on this PR, and also for the benefit of anyone who finds this issue, I've include below our justification and specific patch for 5.2.3:

```
# AFAICT, the only way to use prepared statements directly is to use what is
# technically a private API. That API accepts a `prepare` argument to disabled
# prepared statements when enabled globally, but does _not_ enable them when
# disabled globally. We want to have it disabled globally because in general it
# doesn't give much benefit for our use cases but causes issues on deploy/migrate.
# 
# Below I've monkey patched the offending method to fix the bug and enable us
# to opt-in to prepared statements. Since this method is private, we can't
# subclass PostgreSQLAdapter to override it, which may hvae been a nicer
# approach. To mitigate future risk, I've explicitly locked it to our current
# version of Rails. Upgraders will need to verify it is still valid for future
# versions.
# 
# We could also run off our own fork of Rails, but that seems bad.
# 
# An alternative solution could possibly be to retry any transaction that fails
# with ActiveRecord::PreparedStatementCacheExpired. If we were building from
# scratch I would advocate for this, but given our existing code base I fear
# that we may be doing non-database things inside database transactions, so
# auto-retrying may cause unexpected side effects. A more rigorous audit would
# be required.
# 
# Another alternative solution would be to use direct interpolation rather than
# binds. Putting aside the security concerns of doing it this way, when I tried
# it it did not result in identical behaviour (particularly around date times).

if Rails::VERSION::STRING != "5.2.3"
  raise "Rails version was upgraded, need to verify that our monkey patch still applies."
end

# lib/active_record/connection_adapters/postgresql_adapter.rb
class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter < ActiveRecord::ConnectionAdapters::AbstractAdapter
  private

  def execute_and_clear(sql, name, binds, prepare: false)
    # Next two lines are new
    if prepare
      result = exec_cache(sql, name, binds)
    elsif without_prepared_statement?(binds)
      result = exec_no_cache(sql, name, [])
    elsif !prepare
      result = exec_no_cache(sql, name, binds)
    else
      result = exec_cache(sql, name, binds)
    end
    ret = yield result
    result.clear
    ret
  end
end
```
