### PR TITLE
Enabled matches_regex for MySql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow matches_regex on MySQL 
+
+    *James Pearson*
+    
 *   Allow specifying fixtures to be ignored by setting `ignore` in YAML file's '_fixture' section.
 
     *Tongfei Gao*

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -48,6 +48,14 @@ module Arel # :nodoc: all
           visit_Arel_Nodes_IsNotDistinctFrom o, collector
         end
 
+        def visit_Arel_Nodes_Regexp(o, collector)
+          infix_value o, collector, " REGEXP "
+        end
+
+        def visit_Arel_Nodes_NotRegexp(o, collector)
+          infix_value o, collector, " NOT REGEXP "
+        end
+
         # In the simple case, MySQL allows us to place JOINs directly into the UPDATE
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.


### PR DESCRIPTION
Previously matches_regex was only available on PostgreSQL, this will enable it for MySql

Usage example:

```
    users = User.arel_table;

    # Find all gmail users
    users = User.arel_table; User.where(users[:email].matches_regexp('(.*)\@gmail.com'))

    # Find all none gmail users
    users = User.arel_table; User.where(users[:email].does_not_match_regexp('(.*)\@gmail.com'))
```



