### PR TITLE
read webpacker config to populate autoload paths

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -6,14 +6,15 @@ module Rails
   class Engine
     class Configuration < ::Rails::Railtie::Configuration
       attr_reader :root
-      attr_accessor :middleware
-      attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths, :webpacker_path
+      attr_accessor :middleware, :javascript_path
+      attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths
 
       def initialize(root = nil)
         super()
         @root = root
         @generators = app_generators.dup
         @middleware = Rails::Configuration::MiddlewareStackProxy.new
+        @javascript_path = "javascript"
       end
 
       # Holds generators configuration:
@@ -40,7 +41,7 @@ module Rails
 
           paths.add "app",                 eager_load: true,
                                            glob: "{*,*/concerns}",
-                                           exclude: ["assets", webpacker_path]
+                                           exclude: ["assets", javascript_path]
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
@@ -84,10 +85,6 @@ module Rails
 
       def autoload_paths
         @autoload_paths ||= paths.autoload_paths
-      end
-
-      def webpacker_path
-        @webpacker_path ||= "javascript"
       end
     end
   end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require "rails/railtie/configuration"
-require "yaml"
 
 module Rails
   class Engine
     class Configuration < ::Rails::Railtie::Configuration
       attr_reader :root
       attr_accessor :middleware
-      attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths
+      attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths, :webpacker_path
 
       def initialize(root = nil)
         super()
@@ -88,11 +87,7 @@ module Rails
       end
 
       def webpacker_path
-        if File.file?("#{Rails.root}/config/webpacker.yml")
-          YAML.load_file("#{Rails.root}/config/webpacker.yml")[Rails.env]["source_path"]&.gsub("app/", "")
-        else
-          "javascript"
-        end
+        @webpacker_path ||= "javascript"
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1708,7 +1708,7 @@ module ApplicationTests
       app "development"
       ActiveSupport::Dependencies.autoload_paths.each do |path|
         assert_not_operator path, :ends_with?, "app/assets"
-        assert_not_operator path, :ends_with?, "app/#{Rails.configuration.webpacker_path}"
+        assert_not_operator path, :ends_with?, "app/javascript"
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1712,18 +1712,9 @@ module ApplicationTests
       end
     end
 
-    test "autoload paths will exclude changed path" do
-      app_file "config/webpacker.yml", <<-YAML
-        default: &default
-          source_path: app/webpack
-          check_yarn_integrity: false
-        development:
-          <<: *default
-        test:
-          <<: *default
-        production:
-          <<: *default
-      YAML
+    test "autoload paths will exclude the configured javascript_path" do
+      add_to_config "config.javascript_path = 'webpack'"
+      app_dir("app/webpack")
 
       app "development"
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1712,6 +1712,27 @@ module ApplicationTests
       end
     end
 
+    test "autoload paths will exclude changed path" do
+      app_file "config/webpacker.yml", <<-YAML
+        default: &default
+          source_path: app/webpack
+          check_yarn_integrity: false
+        development:
+          <<: *default
+        test:
+          <<: *default
+        production:
+          <<: *default
+      YAML
+
+      app "development"
+
+      ActiveSupport::Dependencies.autoload_paths.each do |path|
+        assert_not_operator path, :ends_with?, "app/assets"
+        assert_not_operator path, :ends_with?, "app/webpack"
+      end
+    end
+
     test "autoload paths are added to $LOAD_PATH by default" do
       app "development"
 

--- a/railties/test/isolation/assets/config/webpacker.yml
+++ b/railties/test/isolation/assets/config/webpacker.yml
@@ -1,4 +1,5 @@
 default: &default
+  source_path: app/javascript
   check_yarn_integrity: false
 development:
   <<: *default


### PR DESCRIPTION
### Summary

this change fixes the issue reported in #36799 when an environment is not in webpacker.yml.  It will default to look in the production configuration.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
