### PR TITLE
Add `exclude_nil` option to `Hash#to_query`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -70,12 +70,18 @@ class Hash
   #   {name: 'David', nationality: 'Danish'}.to_query('user')
   #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
   #
+  # There's an option to exclude pairs with nil value.
+  #   {a: nil, b: "foo"}.to_query(exclude_nil: true)
+  #   # => "b=foo"
+  #
   # The string pairs "key=value" that conform the query string
   # are sorted lexicographically in ascending order.
   #
   # This method is also aliased as +to_param+.
-  def to_query(namespace = nil)
+  def to_query(namespace = nil, exclude_nil: false)
     query = collect do |key, value|
+      next if exclude_nil && value.nil?
+
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -67,6 +67,13 @@ class ToQueryTest < ActiveSupport::TestCase
       a: [], b: 3
   end
 
+  def test_hash_with_nil_value_with_exclude_option
+    assert_equal "", { a: nil, b: nil }.to_query(exclude_nil: true)
+    assert_equal "b=foo", { a: nil, b: "foo" }.to_query(exclude_nil: true)
+    assert_equal "a=&b=", { a: nil, b: nil }.to_query(exclude_nil: false)
+    assert_equal "a=&b=", { a: nil, b: nil }.to_query
+  end
+
   def test_hash_with_namespace
     hash = { name: "Nakshay", nationality: "Indian" }
     assert_equal "user%5Bname%5D=Nakshay&user%5Bnationality%5D=Indian", hash.to_query("user")


### PR DESCRIPTION
### Summary

This option makes it possible to exclude nil values.
It's useful because when a Hash some nil values the resulting string
will be ugly, for example:

```ruby
{a: nil, b: nil, c: 'foo'}.to_query
```

With `exclude_nil` option, the resulting string is cleaner:

```ruby
{a: nil, b: nil, c: 'foo'}.to_query(exclude_nil: true)
```

It's not only cleaner but also shorter and often more expressive, because
empty value rarely makes sense.