### PR TITLE
Introduce InvalidConfigurationError

### DIFF
--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -28,6 +28,22 @@ module ActiveRecord
         resolver.resolve(spec, spec)
       end
 
+      def test_invalid_string_config
+        config = { "foo" => "bar" }
+
+        assert_raises ActiveRecord::DatabaseConfigurations::InvalidConfigurationError do
+          resolve_config(config)
+        end
+      end
+
+      def test_invalid_symbol_config
+        config = { "foo" => :bar }
+
+        assert_raises ActiveRecord::DatabaseConfigurations::InvalidConfigurationError do
+          resolve_config(config)
+        end
+      end
+
       def test_resolver_with_database_uri_and_current_env_symbol_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }


### PR DESCRIPTION
In our app at work we had a faked config like this:

```
{ "foo" => :bar, "bar" => { "adapter" => "memory" } }
```

This config is invalid. You can't say for foo env just have a symbol,
nor would this work if you had fa foo env with just a string. A
configuration must be a url or an adapter or a database. Otherwise it's
invalid and we can't parse it.

When this was just yaml turned into hashes you could get away with
passing whatever. It wouldn't work but it wouldn't blow up either.

Now that we're using objects we were returning `nil` for these but that
just means we either blow up on `for_current_env` or compact the
`nil`'s.

I think it's a better user experience to not build the configs and raise
an appropriate error.

I also removed the try because it didn't seem to be needed.

cc/ @tenderlove @rafaelfranca @matthewd 