### PR TITLE
Fix db:seed

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -265,6 +265,8 @@ db_namespace = namespace :db do
       end
       abort %{Run `rails db:migrate` to update your database then try again.}
     end
+  ensure
+    ActiveRecord::Base.establish_connection(ActiveRecord::Tasks::DatabaseTasks.env.to_sym)
   end
 
   namespace :abort_if_pending_migrations do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -349,6 +349,25 @@ module ApplicationTests
           rails "db:drop" rescue nil
         end
       end
+
+      test "db:seed uses primary database connection" do
+        @old_rails_env = ENV["RAILS_ENV"]
+        @old_rack_env = ENV["RACK_ENV"]
+        ENV.delete "RAILS_ENV"
+        ENV.delete "RACK_ENV"
+
+        db_migrate_and_schema_dump_and_load "schema"
+
+        app_file "db/seeds.rb", <<-RUBY
+          print Book.connection.pool.spec.config[:database]
+        RUBY
+
+        output = rails("db:seed")
+        assert_equal output, "db/development.sqlite3"
+      ensure
+        ENV["RAILS_ENV"] = @old_rails_env
+        ENV["RACK_ENV"] = @old_rack_env
+      end
     end
   end
 end


### PR DESCRIPTION
The `rake db:seed` command was broken for the primary environment if the
application is using multiple databases. We never implemented `rake
db:seed` for other databases (coming soon), but that shouldn't break the
default case.

The reason this was broken was because `abort_if_pending_migrations`
would loop through the configs for all databases and check for
migrations but would leave the last established connection. So `db:seed`
was looking in the wrong database for the table to seed.

This PR doesn't fix the fact that `db:seed` doesn't work for multiple
databases but does fix the default case.

Fixes #36817

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>