### PR TITLE
Prevent error on transliterate with frozen strings

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -60,6 +60,7 @@ module ActiveSupport
     # Transliteration is restricted to UTF-8, US-ASCII and GB18030 strings
     # Other encodings will raise an ArgumentError.
     def transliterate(string, replacement = "?", locale: nil)
+      string = string.dup if string.frozen?
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
 
       allowed_encodings = [Encoding::UTF_8, Encoding::US_ASCII, Encoding::GB18030]

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -59,19 +59,19 @@ class TransliterateTest < ActiveSupport::TestCase
   end
 
   def test_transliterate_handles_strings_with_valid_utf8_encodings
-    string = String.new("A", encoding: Encoding::UTF_8)
+    string = String.new("A", encoding: Encoding::UTF_8).freeze
     assert_equal "A", ActiveSupport::Inflector.transliterate(string)
   end
 
   def test_transliterate_handles_strings_with_valid_us_ascii_encodings
-    string = String.new("A", encoding: Encoding::US_ASCII)
+    string = String.new("A", encoding: Encoding::US_ASCII).freeze
     transcoded = ActiveSupport::Inflector.transliterate(string)
     assert_equal "A", transcoded
     assert_equal Encoding::US_ASCII, transcoded.encoding
   end
 
   def test_transliterate_handles_strings_with_valid_gb18030_encodings
-    string = String.new("A", encoding: Encoding::GB18030)
+    string = String.new("A", encoding: Encoding::GB18030).freeze
     transcoded = ActiveSupport::Inflector.transliterate(string)
     assert_equal "A", transcoded
     assert_equal Encoding::GB18030, transcoded.encoding
@@ -84,7 +84,7 @@ class TransliterateTest < ActiveSupport::TestCase
       Encoding::GB18030
     ]
     incompatible_encodings.each do |encoding|
-      string = String.new("", encoding: encoding)
+      string = String.new("", encoding: encoding).freeze
       exception = assert_raises ArgumentError do
         ActiveSupport::Inflector.transliterate(string)
       end
@@ -93,17 +93,17 @@ class TransliterateTest < ActiveSupport::TestCase
   end
 
   def test_transliterate_handles_strings_with_invalid_utf8_bytes
-    string = String.new("\255", encoding: Encoding::UTF_8)
+    string = String.new("\255", encoding: Encoding::UTF_8).freeze
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 
   def test_transliterate_handles_strings_with_invalid_us_ascii_bytes
-    string = String.new("\255", encoding: Encoding::US_ASCII)
+    string = String.new("\255", encoding: Encoding::US_ASCII).freeze
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 
   def test_transliterate_handles_strings_with_invalid_gb18030_bytes
-    string = String.new("\255", encoding: Encoding::GB18030)
+    string = String.new("\255", encoding: Encoding::GB18030).freeze
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
 end


### PR DESCRIPTION
`ActiveSupport::Inflector.transliterate` mutates strings by changing encodings. After https://github.com/rails/rails/pull/36702 and prior to this commit, passing a frozen string would raise a `FrozenError`. This change duplicates the internal string, if frozen, before transliterating.

Tests are updated to freeze strings created using `String.new` before transliterating.

cc @eileencodes 