### PR TITLE
Only create parallel test databases on schema changes

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -348,8 +348,7 @@ module ActiveRecord
             ActiveRecord::InternalMetadata[:schema_sha1] == schema_sha1(file)
           truncate_tables(configuration)
         else
-          drop(configuration)
-          create(configuration)
+          purge(configuration)
           load_schema(configuration, format, file, environment, spec_name)
         end
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -322,6 +322,8 @@ module ActiveRecord
         check_schema_file(file)
         ActiveRecord::Base.establish_connection(configuration)
 
+        schema_sha1 = Digest::SHA1.hexdigest(File.read(file))
+
         case format
         when :ruby
           load(file)
@@ -332,6 +334,7 @@ module ActiveRecord
         end
         ActiveRecord::InternalMetadata.create_table
         ActiveRecord::InternalMetadata[:environment] = environment
+        ActiveRecord::InternalMetadata[:schema_sha1] = schema_sha1
       ensure
         Migration.verbose = verbose_was
       end

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -8,30 +8,15 @@ module ActiveRecord
       create_and_load_schema(i, env_name: Rails.env)
     end
 
-    ActiveSupport::Testing::Parallelization.run_cleanup_hook do
-      drop(env_name: Rails.env)
-    end
-
     def self.create_and_load_schema(i, env_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
         db_config.config["database"] += "-#{i}"
-        ActiveRecord::Tasks::DatabaseTasks.create(db_config.config)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.reset_to_schema(db_config.config, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
       end
     ensure
       ActiveRecord::Base.establish_connection(Rails.env.to_sym)
-      ENV["VERBOSE"] = old
-    end
-
-    def self.drop(env_name:)
-      old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
-
-      ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
-        ActiveRecord::Tasks::DatabaseTasks.drop(db_config.config)
-      end
-    ensure
       ENV["VERBOSE"] = old
     end
   end

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -232,10 +232,7 @@ module ApplicationTests
       assert_successful_test_run("models/user_test.rb")
     end
 
-    # TODO: would be nice if we could detect the schema change automatically.
-    # For now, the user has to synchronize the schema manually.
-    # This test case serves as a reminder for this use case.
-    test "manually synchronize test schema after rollback" do
+    test "automatically synchronizes test schema after rollback" do
       output  = rails("generate", "model", "user", "name:string")
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
@@ -267,10 +264,6 @@ module ApplicationTests
           end
         end
       RUBY
-
-      assert_successful_test_run "models/user_test.rb"
-
-      rails "db:test:prepare"
 
       assert_unsuccessful_run "models/user_test.rb", <<-ASSERTION
 Expected: ["id", "name"]


### PR DESCRIPTION
This introduces a new key in the `ar_internal_metadata` table, `:schema_sha1`, which tracks the SHA1 of the schema file being loaded into the database.

This can be used to keep a test database exactly in sync with a schema file. This is similar to the [maintain_test_schema](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L589-L608) functionality non-parallel tests currently use, but is more accurate (migrations can be changed or rolled back). I plan to update `maintain_test_schema` to use this instead in a future PR.

This adjusts parallelization test databases hook to only reload the schema when it has changed, and to no longer drop the database at exit.

Refs #36807