### PR TITLE
test for associated model validation when not dirty but invalid

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1221,6 +1221,14 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     assert_predicate @pirate.errors[:"ship.name"], :any?
   end
 
+  def test_should_automatically_validate_the_associated_non_dirty_model
+    Ship.web_request_result = true
+    assert_predicate @pirate, :invalid?
+    assert_predicate @pirate.errors[:"ship.base"], :any?
+  ensure
+    Ship.web_request_result = false
+  end
+
   def test_should_merge_errors_on_the_associated_models_onto_the_parent_even_if_it_is_not_valid
     @pirate.ship.name   = nil
     @pirate.catchphrase = nil

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -15,6 +15,9 @@ class Ship < ActiveRecord::Base
 
   validates_presence_of :name
 
+  cattr_accessor :web_request_result
+  validate { errors.add(:base, 'External service deemed us invalid') if Ship.web_request_result }
+
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, if: :cancel_save_from_callback
   def cancel_save_callback_method


### PR DESCRIPTION
Split the associated models test between associated objects that are dirty vs not dirty. In reference to #36822 where it was noticed that non-dirty associated models are no longer validated.

There is a broad range of cases where a record that was valid when put in to the database is now invalid. There could be a change in the model validations over time, but also external state changes such as from web APIs, file system changes, and asymmetrical database relationship changes.

This test will pass in v5.2.3 but not after https://github.com/rails/rails/commit/0206d9cb7c823fefbf3dfc1d1672be4628986c4e