### PR TITLE
Respect Content-Type header passed in head method

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -38,7 +38,10 @@ module ActionController
       self.response_body = ""
 
       if include_content?(response_code)
-        self.content_type = content_type || (Mime[formats.first] if formats) || Mime[:html]
+        unless self.media_type
+          self.content_type = content_type || (Mime[formats.first] if formats) || Mime[:html]
+        end
+
         response.charset = false
       end
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -338,6 +338,10 @@ module Mime
       true
     end
 
+    def to_s
+      ""
+    end
+
     def ref; end
 
     private

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -223,6 +223,10 @@ class TestController < ActionController::Base
     head :ok, content_type: "image/png"
   end
 
+  def head_ok_with_string_key_content_type
+    head :ok, "Content-Type" => "application/pdf"
+  end
+
   def head_with_location_header
     head :ok, location: "/foo"
   end
@@ -755,6 +759,11 @@ class HeadRenderTest < ActionController::TestCase
     assert_predicate @response.body, :blank?
     assert_equal "image/png", @response.header["Content-Type"]
     assert_response :ok
+  end
+
+  def test_head_respect_string_content_type
+    get :head_ok_with_string_key_content_type
+    assert_equal "application/pdf", @response.header["Content-Type"]
   end
 
   def test_head_with_location_header


### PR DESCRIPTION
This fixes the issue that `head` doesn't respect content type passed in string format, like:

```ruby
head 200, 'Content-Type' => 'application/pdf'
# this will be override later to be "text/html"
```

So this PR checks if there's a previously existed content type before assigning the callback options. (Actually I use `media_type` instead of `content_type` for checking to avoid charset only content type value, like `; charset=utf-8`)

I also found weird case when working on this PR: Before we process newly assigned content_type value, we call `#to_s` at the passed mime type objects.

https://github.com/rails/rails/blob/dbf3e4882f9da95e34ed9086f182cf424aaac224/actionpack/lib/action_dispatch/http/response.rb#L236-L238

 Generally this works well, like 

```ruby
Mime[:html].to_s #=> "text/html"
```

But for `Mime::NullType`, it doesn't work like this

```ruby
Mime::NullType.instance.to_s #=> "#<Mime::NullType:0xXXXXXX>"
# I think it should return an empty string instead so it'll be easier for later identification.
```

And in later method calls, `"#<Mime::NullType:0xXXXXXX>"` will actually become the content type of the response.  Currently we don't see any errors because we always override the content_type when calling head method. But this won't be the case after this PR, so I changed this behavior as well.

This fixes #28858 