### PR TITLE
Added missing comment notation for the example of form_with in form_helpers.md documentation. [ci skip]

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -307,7 +307,7 @@ When dealing with RESTful resources, calls to `form_with` can get significantly 
 ## Creating a new article
 # long-style:
 form_with(model: @article, url: articles_path)
-short-style:
+# short-style:
 form_with(model: @article)
 
 ## Editing an existing article


### PR DESCRIPTION
### Summary

- Comment notation was missing for `short-style` text explaining usage of `form_with` in form helpers documentation