### PR TITLE
Remove duplicate method definition

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -128,11 +128,6 @@ module Rails
         end
       end
 
-      # Remove the color from output.
-      def no_color!
-        Thor::Base.shell = Thor::Shell::Basic
-      end
-
       # Returns an array of generator namespaces that are hidden.
       # Generator namespaces may be hidden for a variety of reasons.
       # Some are aliased such as "rails:migration" and can be


### PR DESCRIPTION
`no_color!` is already defined in [`Rails::Command::Behavior`][behavior],
which gets [included into `Rails:Generators`][include]. This duplication
came about in 6813edc when we introduced the Thor command structure.

We have [test coverage][] to ensure this method still behaves correctly
on `Rails:Generators`.

[behavior]: https://github.com/rails/rails/blob/f7e91c7224560fbd3e95c238a0e8bb362799bcb7/railties/lib/rails/command/behavior.rb#L12-L14
[include]: https://github.com/rails/rails/blob/f7e91c7224560fbd3e95c238a0e8bb362799bcb7/railties/lib/rails/generators.rb#L18
[test coverage]: https://github.com/rails/rails/blob/f7e91c7224560fbd3e95c238a0e8bb362799bcb7/railties/test/generators_test.rb#L163-L168