### PR TITLE
Fix `save!` returns nil when has_one association throws abort

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -444,7 +444,7 @@ module ActiveRecord
               end
 
               saved = record.save(validate: !autosave)
-              raise ActiveRecord::Rollback if !saved && autosave
+              raise RecordInvalid.new(association.owner) if !saved && autosave
               saved
             end
           end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1290,6 +1290,18 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_save_and_raise_an_exception_if_a_callback_cancelled_saving
+    pirate = Pirate.new(catchphrase: "Arr")
+    ship = pirate.build_ship(name: "The Vile Insanity")
+    ship.cancel_save_from_callback = true
+
+    assert_no_difference "Pirate.count" do
+      assert_no_difference "Ship.count" do
+        assert_raises(ActiveRecord::RecordInvalid) { pirate.save! }
+      end
+    end
+  end
+
   def test_should_rollback_any_changes_if_an_exception_occurred_while_saving
     before = [@pirate.catchphrase, @pirate.ship.name]
 


### PR DESCRIPTION
### Summary
Fix `save!` returns nil when has_one association throws abort

`save!` returns nil when has_one association throws abort, because
`ActiveRecord::Rollback` exception is rescued by transaction and just
returns nil.
So, change an exception from `ActiveRecord::Rollback` to `RecordInvalid`.

Fixes #36833.

### Other Information
I referred to https://github.com/rails/rails/pull/36210.
