### PR TITLE
Add ability to unset preventing writes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1020,8 +1020,8 @@ module ActiveRecord
       # In some cases you may want to prevent writes to the database
       # even if you are on a database that can write. `while_preventing_writes`
       # will prevent writes to the database for the duration of the block.
-      def while_preventing_writes
-        original, @prevent_writes = @prevent_writes, true
+      def while_preventing_writes(enabled = true)
+        original, @prevent_writes = @prevent_writes, enabled
         yield
       ensure
         @prevent_writes = original


### PR DESCRIPTION
Previously if an app attempts to do a write inside a read request it will be
impossible to switch back to writing to the primary. This PR adds an
argument to the `while_preventing_writes` so that we can make sure to
turn it off if we're doing a write on a primary.

Fixes #36830

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>

cc/ @tenderlove @jhawthorn @rafaelfranca @matthewd 