### PR TITLE
Ensure custom PK types are casted in through reflection queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure custom PK types are casted in through reflection queries.
+
+    *Gannon McGibbon*
+
 *   Preserve user supplied joins order as much as possible.
 
     Fixes #36761, #34328, #24281, #12953.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -764,7 +764,16 @@ module ActiveRecord
       end
 
       def klass
-        @klass ||= delegate_reflection.compute_class(class_name)
+        @klass ||= delegate_reflection.compute_class(class_name).tap do |klass|
+          if !parent_reflection.is_a?(HasAndBelongsToManyReflection) &&
+             !klass.reflections.include?(options[:through].to_s) &&
+             active_record.type_for_attribute(active_record.primary_key).type != :integer
+            raise NotImplementedError, <<~MSG.squish
+              In order to correctly type cast #{active_record}.#{active_record.primary_key},
+              #{klass} needs to define a :#{options[:through]} association.
+            MSG
+          end
+        end
       end
 
       # Returns the source of the through reflection. It checks both a singularized

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -256,6 +256,14 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_kind_of ThroughReflection, Subscriber.reflect_on_association(:books)
   end
 
+  def test_uncastable_has_many_through_reflection
+    error = assert_raises(NotImplementedError) { Subscriber.new.published_books }
+    assert_equal <<~MSG.squish, error.message
+      In order to correctly type cast Subscriber.nick,
+      PublishedBook needs to define a :subscriptions association.
+    MSG
+  end
+
   def test_chain
     expected = [
       Organization.reflect_on_association(:author_essay_categories),

--- a/activerecord/test/models/dashboard.rb
+++ b/activerecord/test/models/dashboard.rb
@@ -2,4 +2,6 @@
 
 class Dashboard < ActiveRecord::Base
   self.primary_key = :dashboard_id
+
+  has_one :speedometer
 end

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -4,6 +4,7 @@ class Subscriber < ActiveRecord::Base
   self.primary_key = "nick"
   has_many :subscriptions
   has_many :books, through: :subscriptions
+  has_many :published_books, through: :subscriptions
 end
 
 class SpecialSubscriber < Subscriber

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -2,6 +2,7 @@
 
 class Subscription < ActiveRecord::Base
   belongs_to :subscriber, counter_cache: :books_count
+  belongs_to :published_book
   belongs_to :book
 
   validates_presence_of :subscriber_id, :book_id


### PR DESCRIPTION
### Summary

Make sure primary keys with non-integer types (eg. binary) can be correctly type casted in queries using through reflections.

Fixes https://github.com/rails/rails/issues/35839.

I deferred this check to happen when the through reflection computes its class and memoizes the result. Still, I'm curious if this one time runtime check is too expensive. Thoughts?
