### PR TITLE
Raise TypeError instead of infinite loop in resolve_connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -221,7 +221,7 @@ module ActiveRecord
             when Hash
               resolve_hash_connection config_or_env
             else
-              resolve_connection config_or_env
+              raise TypeError, "Invalid type for configuration. Expected Symbol, String, or Hash. Got #{config_or_env.inspect}"
             end
           end
 

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -135,6 +135,12 @@ module ActiveRecord
           spec = spec("adapter" => "sqlite3")
           assert_equal "primary", spec.name, "should default to primary id"
         end
+
+        def test_spec_with_invalid_type
+          assert_raises TypeError do
+            spec(Object.new)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I think this line was previously untested, which did no harm until I made a mistake and passed it the wrong type 😅.