### PR TITLE
Exit before assets:precompile task if yarn:install fails

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -9,6 +9,7 @@ namespace :yarn do
       valid_node_envs.include?(Rails.env) ? Rails.env : "production"
     end
     system({ "NODE_ENV" => node_env }, "#{Rails.root}/bin/yarn install --no-progress --frozen-lockfile")
+    exit(1) unless $?.success?
   end
 end
 


### PR DESCRIPTION
### Summary

I made this change to Webpacker and was recommended by @gauravtiwari to make it to Rails itself:
https://github.com/rails/webpacker/pull/2192

Reason for change: When doing `yarn:install` if it failed the `assets:precompile` task would still be invoked. This PR ensures that on failure with `yarn:install` that `assets:precompile` will not be invoked.

### Other Information

Link to original issue for person who spotted this: https://github.com/rails/webpacker/issues/2185
