### PR TITLE
Use media_type instead of content_type internally

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -163,18 +163,18 @@ module ActionController
 
         "/**/#{options[:callback]}(#{json})"
       else
-        self.content_type ||= Mime[:json]
+        self.content_type = Mime[:json] if media_type.nil?
         json
       end
     end
 
     add :js do |js, options|
-      self.content_type ||= Mime[:js]
+      self.content_type = Mime[:js] if media_type.nil?
       js.respond_to?(:to_js) ? js.to_js(options) : js
     end
 
     add :xml do |xml, options|
-      self.content_type ||= Mime[:xml]
+      self.content_type = Mime[:xml] if media_type.nil?
       xml.respond_to?(:to_xml) ? xml.to_xml(options) : xml
     end
   end

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -280,7 +280,7 @@ module ActionController #:nodoc:
 
       # Check for cross-origin JavaScript responses.
       def non_xhr_javascript_response? # :doc:
-        %r(\A(?:text|application)/javascript).match?(content_type) && !request.xhr?
+        %r(\A(?:text|application)/javascript).match?(media_type) && !request.xhr?
       end
 
       AUTHENTICITY_TOKEN_LENGTH = 32

--- a/actionpack/test/controller/render_js_test.rb
+++ b/actionpack/test/controller/render_js_test.rb
@@ -32,4 +32,13 @@ class RenderJSTest < ActionController::TestCase
     get :show_partial, format: "js", xhr: true
     assert_equal "partial js", @response.body
   end
+
+  def test_should_not_trigger_content_type_deprecation
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    assert_not_deprecated { get :render_vanilla_js_hello, xhr: true }
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
 end

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -133,4 +133,22 @@ class RenderJsonTest < ActionController::TestCase
     get :render_json_without_options
     assert_equal '{"a":"b"}', @response.body
   end
+
+  def test_should_not_trigger_content_type_deprecation
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    assert_not_deprecated { get :render_json_hello_world }
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
+
+  def test_should_not_trigger_content_type_deprecation_with_callback
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    assert_not_deprecated { get :render_json_hello_world_with_callback, xhr: true }
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
 end

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -98,4 +98,13 @@ class RenderXmlTest < ActionController::TestCase
     get :implicit_content_type, format: "atom"
     assert_equal Mime[:atom], @response.media_type
   end
+
+  def test_should_not_trigger_content_type_deprecation
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    assert_not_deprecated { get :render_with_to_xml }
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
 end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -591,6 +591,15 @@ module RequestForgeryProtectionTests
     end
   end
 
+  def test_should_not_trigger_content_type_deprecation
+    original = ActionDispatch::Response.return_only_media_type_on_content_type
+    ActionDispatch::Response.return_only_media_type_on_content_type = true
+
+    assert_not_deprecated { get :same_origin_js, xhr: true }
+  ensure
+    ActionDispatch::Response.return_only_media_type_on_content_type = original
+  end
+
   def test_should_not_raise_error_if_token_is_not_a_string
     assert_blocked do
       patch :index, params: { custom_authenticity_token: { foo: "bar" } }


### PR DESCRIPTION
These `content_type` calls were triggering the deprecation from https://github.com/rails/rails/pull/36490 in upgraded applications.

This problem was reported as a comment on the original pull request: https://github.com/rails/rails/pull/36490#commitcomment-34472622

We can use `media_type` in all of these cases to avoid the deprecation.