### PR TITLE
Corrected config option path in release notes for deprecation release notes of Rails 6

### DIFF
--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -430,7 +430,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
 *   Deprecate using class level querying methods if the receiver scope has leaked.
     ([Pull Request](https://github.com/rails/rails/pull/35280))
 
-*   Deprecate `config.activerecord.sqlite3.represent_boolean_as_integer`.
+*   Deprecate `config.active_record.sqlite3.represent_boolean_as_integer`.
     ([Commit](https://github.com/rails/rails/commit/f59b08119bc0c01a00561d38279b124abc82561b))
 
 *   Deprecate passing `migrations_paths` to `connection.assume_migrated_upto_version`.


### PR DESCRIPTION
### Summary

The correct path for `sqlite3.represent_boolean_as_integer` is
```ruby
config.active_record.sqlite3.represent_boolean_as_integer
```
instead of
```ruby
config.activerecord.sqlite3.represent_boolean_as_integer
```
