### PR TITLE
Execute unprepared statements atomically in system tests

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -357,7 +357,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout, :schema_cache
-      attr_reader :spec, :size, :reaper
+      attr_reader :spec, :size, :reaper, :lock_thread
 
       # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
       # object which describes database connection information (e.g. adapter,
@@ -706,6 +706,10 @@ module ActiveRecord
             checkout_timeout: checkout_timeout
           }
         end
+      end
+
+      def using_lock_thread? # :nodoc:
+        current_thread == @lock_thread
       end
 
       private


### PR DESCRIPTION
In system tests, a single database connection is shared among all
the server threads. A call to unprepared_statement temporarily
modifies an instance variable on the connection object, which is
then visible to other concurrently running threads. This leads to
a situation where prepared statements may end up with the wrong
binds.

Addresses #36763
