### PR TITLE
Update rails-html-sanitizer to 1.1.0 in actionview.gemspec

### DIFF
--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.4"
-  s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.3"
+  s.add_dependency "rails-html-sanitizer", "~> 1.1", ">= 1.1.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"
 
   s.add_development_dependency "actionpack",  version


### PR DESCRIPTION
Commit https://github.com/rails/rails/commit/52f0b050e25cac6d9571d71c9f74ea583d8aa2b0 replaces `white_list_sanitizer` with `safe_list_sanitizer`. At GitHub we found this to be a breaking change with Rails 6.0 unless the version of `rails-html-sanitizer` is upgraded to `>= 1.1.0`.

This PR updates the minimum version of `rails-html-sanitizer`  in `actionview/actionview.gemspec` to `1.1.0`.

CC: @JuanitoFatas, @kaspth, @eileencodes