### PR TITLE
[ci skip] Mention `context` option of save in documentation

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -40,6 +40,7 @@ module ActiveRecord
     include ActiveModel::Validations
 
     # The validation process on save can be skipped by passing <tt>validate: false</tt>.
+    # The validation context can be changed by passing <tt>context: context</tt>.
     # The regular {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] method is replaced
     # with this when the validations module is mixed in, which it is by default.
     def save(options = {})


### PR DESCRIPTION
### Summary

`ActiveRecord::Validations#save` takes `context` option which can change validation context.
This fact should be mentioned in the documentation.