### PR TITLE
Add at option to perform_enqueued_jobs test helper

### DIFF
--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
@@ -54,7 +54,11 @@ module ActiveJob
         end
 
         def filtered?(job)
-          filtered_queue?(job) || filtered_job_class?(job)
+          filtered_queue?(job) || filtered_job_class?(job) || filtered_time?(job)
+        end
+
+        def filtered_time?(job)
+          job.scheduled_at > at.to_f if at && job.scheduled_at
         end
 
         def filtered_queue?(job)

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -117,7 +117,7 @@ module ActiveJob
     #       HelloJob.perform_later('elfassy')
     #     end
     #   end
-    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
+    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil, at: at)
       if block_given?
         original_count = enqueued_jobs_with(only: only, except: except, queue: queue)
 
@@ -539,8 +539,10 @@ module ActiveJob
     #     assert_performed_jobs 1
     #   end
     #
-    def perform_enqueued_jobs(only: nil, except: nil, queue: nil)
-      return flush_enqueued_jobs(only: only, except: except, queue: queue) unless block_given?
+    # If the +:at+ option is specified, then only run jobs enqueued to run
+    # immediately or before the given time
+    def perform_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil)
+      return flush_enqueued_jobs(only: only, except: except, queue: queue, at: at) unless block_given?
 
       validate_option(only: only, except: except)
 
@@ -549,6 +551,7 @@ module ActiveJob
       old_filter = queue_adapter.filter
       old_reject = queue_adapter.reject
       old_queue = queue_adapter.queue
+      old_at = queue_adapter.at
 
       begin
         queue_adapter.perform_enqueued_jobs = true
@@ -556,6 +559,7 @@ module ActiveJob
         queue_adapter.filter = only
         queue_adapter.reject = except
         queue_adapter.queue = queue
+        queue_adapter.at = at
 
         yield
       ensure
@@ -564,6 +568,7 @@ module ActiveJob
         queue_adapter.filter = old_filter
         queue_adapter.reject = old_reject
         queue_adapter.queue = old_queue
+        queue_adapter.at = old_at
       end
     end
 
@@ -585,7 +590,7 @@ module ActiveJob
         performed_jobs.clear
       end
 
-      def jobs_with(jobs, only: nil, except: nil, queue: nil)
+      def jobs_with(jobs, only: nil, except: nil, queue: nil, at: nil)
         validate_option(only: only, except: except)
 
         jobs.count do |job|
@@ -601,6 +606,10 @@ module ActiveJob
             next false unless queue.to_s == job.fetch(:queue, job_class.queue_name)
           end
 
+          if at && job[:at]
+            next false if job[:at] > at.to_f
+          end
+
           yield job if block_given?
 
           true
@@ -613,16 +622,16 @@ module ActiveJob
         ->(job) { Array(filter).include?(job.fetch(:job)) }
       end
 
-      def enqueued_jobs_with(only: nil, except: nil, queue: nil, &block)
-        jobs_with(enqueued_jobs, only: only, except: except, queue: queue, &block)
+      def enqueued_jobs_with(only: nil, except: nil, queue: nil, at: nil, &block)
+        jobs_with(enqueued_jobs, only: only, except: except, queue: queue, at: at, &block)
       end
 
       def performed_jobs_with(only: nil, except: nil, queue: nil, &block)
         jobs_with(performed_jobs, only: only, except: except, queue: queue, &block)
       end
 
-      def flush_enqueued_jobs(only: nil, except: nil, queue: nil)
-        enqueued_jobs_with(only: only, except: except, queue: queue) do |payload|
+      def flush_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil)
+        enqueued_jobs_with(only: only, except: except, queue: queue, at: at) do |payload|
           instantiate_job(payload).perform_now
           queue_adapter.performed_jobs << payload
         end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -859,6 +859,54 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_performed_jobs 1, only: LoggingJob, queue: :other_queue
   end
 
+  def test_perform_enqueued_jobs_with_at_with_job_performed_now
+    HelloJob.perform_later("kevin")
+
+    perform_enqueued_jobs(at: Time.now)
+
+    assert_performed_jobs 1
+  end
+
+  def test_perform_enqueued_jobs_with_at_with_job_wait_in_past
+    HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
+
+    perform_enqueued_jobs(at: Time.now)
+
+    assert_performed_jobs 1
+  end
+
+  def test_perform_enqueued_jobs_with_at_with_job_wait_in_future
+    HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
+
+    perform_enqueued_jobs(at: Time.now)
+
+    assert_performed_jobs 0
+  end
+
+  def test_perform_enqueued_jobs_block_with_at_with_job_performed_now
+    perform_enqueued_jobs(at: Time.now) do
+      HelloJob.perform_later("kevin")
+    end
+
+    assert_performed_jobs 1
+  end
+
+  def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_past
+    perform_enqueued_jobs(at: Time.now) do
+      HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
+    end
+
+    assert_performed_jobs 1
+  end
+
+  def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_future
+    perform_enqueued_jobs(at: Time.now) do
+      HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
+    end
+
+    assert_performed_jobs 0
+  end
+
   def test_assert_performed_jobs
     assert_nothing_raised do
       assert_performed_jobs 1 do


### PR DESCRIPTION
### Summary

Currently, the `perform_enqueued_jobs` helper will also immediately
perform jobs that are scheduled via `set(wait:)` to run in the future.
This PR adds a new argument to `perform_enqueued_jobs` to make it
only run jobs scheduled at or before the passed in `Time`. This allows
testing the side effects of immediate job execution separate of jobs
delayed in the future.