### PR TITLE
Add :primary_key option for nested attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:primary_key` option to `accepts_nested_attributes_for` to support
+    scenarios where public-facing identifiers (e.g. UUID) can be used in place
+    of database primary keys.
+
+    *Nick Rivadeneira*
+
 *   Preserve user supplied joins order as much as possible.
 
     Fixes #36761, #34328, #24281, #12953.


### PR DESCRIPTION
### Summary

A common pattern for APIs is to have an external identifier, such as a UUID, separate from an internal primary key. This change adds support for that pattern to `accepts_nested_attributes_for` by way of a new `:primary_key` option.

The author and book relationship in the fixtures is a good example, with `isbn` being a natural candidate for record identification. This change would support a simple pass-through of params to `ActiveRecord` update methods without requiring a change in `Book.primary_key`.

```ruby
{
  author: {
    name: "Billy Shakespeare",
    books_attributes: [
      {
        id: "9781420922530",
        title: "Hamlet, Remastered"
      }
    ]
  }
}
```

### Other Information

In the case of polymorphic one-to-one relationships, `klass` may be `nil` for the association. In those cases, `primary_key` defaults to `:id`, with help by the safe navigation operator. Is this a reasonable default?