### PR TITLE
Update azure-storage gem to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.11", require: false
-  gem "azure-storage", require: false
+  gem "azure-storage-blob", require: false
 
   gem "image_processing", "~> 1.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ PATH
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+      rails-html-sanitizer (~> 1.1, >= 1.1.0)
     activejob (6.1.0.alpha)
       activesupport (= 6.1.0.alpha)
       globalid (>= 0.3.6)
@@ -131,14 +131,16 @@ GEM
       aws-sdk-core (~> 3, >= 3.37.0)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
-    azure-core (0.1.14)
+    azure-core (0.1.15)
       faraday (~> 0.9)
       faraday_middleware (~> 0.10)
       nokogiri (~> 1.6)
-    azure-storage (0.15.0.preview)
-      azure-core (~> 0.1)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.10)
+    azure-storage-blob (1.1.0)
+      azure-core (~> 0.1.13)
+      azure-storage-common (~> 1.0)
+      nokogiri (~> 1.6, >= 1.6.8)
+    azure-storage-common (1.1.0)
+      azure-core (~> 0.1.13)
       nokogiri (~> 1.6, >= 1.6.8)
     backburner (1.5.0)
       beaneater (~> 1.0)
@@ -223,7 +225,7 @@ GEM
     execjs (2.7.0)
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
+    faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     faye (1.2.4)
       cookiejar (>= 0.3.0)
@@ -537,7 +539,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)
   aws-sdk-s3
   aws-sdk-sns
-  azure-storage
+  azure-storage-blob
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Switch from `azure-storage` gem to `azure-storage-blob` gem for Azure service.
+
+    *Peter Zhu*
+
 *   Add `config.active_storage.draw_routes` to disable Active Storage routes.
 
     *Gannon McGibbon*

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -29,7 +29,7 @@ if SERVICE_CONFIGURATIONS[:azure]
 
       @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
 
-      assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.blobs.get_blob_properties(@service.container, key).properties[:content_disposition])
+      assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(@service.container, key).properties[:content_disposition])
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: nil, filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -147,10 +147,10 @@ azure:
   container: ""
 ```
 
-Add the [`azure-storage`](https://github.com/Azure/azure-storage-ruby) gem to your `Gemfile`:
+Add the [`azure-storage-blob`](https://github.com/Azure/azure-storage-ruby) gem to your `Gemfile`:
 
 ```ruby
-gem "azure-storage", require: false
+gem "azure-storage-blob", require: false
 ```
 
 ### Google Cloud Storage Service


### PR DESCRIPTION
### Summary

The [`azure-storage` gem](https://rubygems.org/gems/azure-storage) used by the Azure service was a preview version, and later got split into several gems (like `azure-storage-blob`, `azure-storage-queue`, `azure-storage-file`, etc.). The `azure-storage` gem is no longer maintained, so this PR switches Active Storage to use the new [`azure-storage-blob` gem](https://rubygems.org/gems/azure-storage-blob).

### Other Information

N/A.