### PR TITLE
Fix thread safety of prevent_writes

### DIFF
--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -143,18 +143,55 @@ module ActiveRecord
       write = false
       resolver.read do
         assert ActiveRecord::Base.connected_to?(role: :writing)
-        assert ActiveRecord::Base.connection_handler.prevent_writes
+        assert_predicate ActiveRecord::Base.connection, :preventing_writes?
         read = true
 
         resolver.write do
           assert ActiveRecord::Base.connected_to?(role: :writing)
-          assert_not ActiveRecord::Base.connection_handler.prevent_writes
+          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           write = true
         end
       end
 
       assert write
       assert read
+    end
+
+    def test_preventing_writes_works_in_a_threaded_environment
+      resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session, delay: 5.seconds)
+      inside_preventing = Concurrent::Event.new
+      finished_checking = Concurrent::Event.new
+
+      @session.update_last_write_timestamp
+
+      t1 = Thread.new do
+        resolver.read do
+          inside_preventing.wait
+          assert ActiveRecord::Base.connected_to?(role: :writing)
+          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          finished_checking.set
+        end
+      end
+
+      t2 = Thread.new do
+        resolver.write do
+          assert ActiveRecord::Base.connected_to?(role: :writing)
+          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+          inside_preventing.set
+          finished_checking.wait
+        end
+      end
+
+      t3 = Thread.new do
+        resolver.read do
+          assert ActiveRecord::Base.connected_to?(role: :writing)
+          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+        end
+      end
+
+      t1.join
+      t2.join
+      t3.join
     end
 
     def test_read_from_replica_with_no_delay


### PR DESCRIPTION
As demonstrated in the test added and in #36830 the code that prevents
writes wasn't thread safe. If one thread does a read, then another does
a write, and then another does a read the second read will cause the
first write to be unwriteable.

This change removes the instance variable and instead uses a
getter/setter on Thread.current[:prevent_writes] for the connection
handler to set whether writes are allowed.

Fixes #36830

---

Thanks to @matthewd for helping me with writing this test.

cc/ @matthewd @tenderlove @jhawthorn 
Thanks to @kiyot for the original report