### PR TITLE
Sync test DB from schema using its SHA1

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -587,18 +587,22 @@ module ActiveRecord
       end
 
       def load_schema_if_pending!
-        if Base.connection.migration_context.needs_migration? || !Base.connection.migration_context.any_migrations?
+        current_config = Base.connection_config
+        all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
+
+        unless all_configs.all? { |config| Tasks::DatabaseTasks.schema_up_to_date?(config.config) }
           # Roundtrip to Rake to allow plugins to hook into database initialization.
           root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
           FileUtils.cd(root) do
-            current_config = Base.connection_config
             Base.clear_all_connections!
             system("bin/rails db:test:prepare")
-            # Establish a new connection, the old database may be gone (db:test:prepare uses purge)
-            Base.establish_connection(current_config)
           end
-          check_pending!
         end
+
+        # Establish a new connection, the old database may be gone (db:test:prepare uses purge)
+        Base.establish_connection(current_config)
+
+        check_pending!
       end
 
       def maintain_test_schema! #:nodoc:

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -232,10 +232,7 @@ module ApplicationTests
       assert_successful_test_run("models/user_test.rb")
     end
 
-    # TODO: would be nice if we could detect the schema change automatically.
-    # For now, the user has to synchronize the schema manually.
-    # This test case serves as a reminder for this use case.
-    test "manually synchronize test schema after rollback" do
+    test "automatically synchronizes test schema after rollback" do
       output  = rails("generate", "model", "user", "name:string")
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
@@ -267,10 +264,6 @@ module ApplicationTests
           end
         end
       RUBY
-
-      assert_successful_test_run "models/user_test.rb"
-
-      rails "db:test:prepare"
 
       assert_unsuccessful_run "models/user_test.rb", <<-ASSERTION
 Expected: ["id", "name"]


### PR DESCRIPTION
Previously, we used the migration status to determine whether the test database(s) needed to be reloaded from the schema. This worked in most cases, but if a `schema.rb` was modified outside of migrations or if a migration was rolled back, it would require a manual `db:test:prepare`.

This commit updates load_schema to record the SHA1 of the loaded schema file inside the `ar_internal_metadata` table under a new `schema_sha` key. We can then use this SHA to determine whether we should reload the schema.

This ensures that the test DB stays exactly in sync with the schema file, including rollbacks which fixes a test marked TODO.

This came from #36826 where the motivation was to speed up parallel test DB creation, but I think we should make this change first and there's enough motivation to want it for non-parallel DB creation 😄