### PR TITLE
Avoid race condition with unprepared_statement

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -258,10 +258,12 @@ module ActiveRecord
       end
 
       def unprepared_statement
-        old_prepared_statements, @prepared_statements = @prepared_statements, false
-        yield
-      ensure
-        @prepared_statements = old_prepared_statements
+        @lock.synchronize do
+          old_prepared_statements, @prepared_statements = @prepared_statements, false
+          yield
+        ensure
+          @prepared_statements = old_prepared_statements
+        end
       end
 
       # Returns the human-readable name of the adapter. Use mixed case - one

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -6,10 +6,12 @@ module ActiveRecord
       module DatabaseStatements
         # Returns an ActiveRecord::Result instance.
         def select_all(*) # :nodoc:
-          result = if ExplainRegistry.collect? && prepared_statements
-            unprepared_statement { super }
-          else
-            super
+          result = @lock.synchronize do
+            if ExplainRegistry.collect? && prepared_statements
+              unprepared_statement { super }
+            else
+              super
+            end
           end
           @connection.abandon_results!
           result


### PR DESCRIPTION
In system tests, a single database connection is shared among all
the server threads. A call to unprepared_statement temporarily
modifies an instance variable on the connection object, which is
then visible to other concurrently running threads. This leads to
a situation where prepared statements may end up with the wrong
binds.

Addresses #36763