### PR TITLE
Sync parallel test DBs to schema using SHA

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -347,6 +347,24 @@ module ActiveRecord
         ActiveRecord::InternalMetadata[:schema_sha1] == schema_sha1(file)
       end
 
+      def reconstruct_from_schema(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = env, spec_name = "primary") # :nodoc:
+        file ||= dump_filename(spec_name, format)
+
+        check_schema_file(file)
+
+        ActiveRecord::Base.establish_connection(configuration)
+
+        if schema_up_to_date?(configuration, format, file, environment, spec_name)
+          truncate_tables(configuration)
+        else
+          purge(configuration)
+          load_schema(configuration, format, file, environment, spec_name)
+        end
+      rescue ActiveRecord::NoDatabaseError
+        create(configuration)
+        load_schema(configuration, format, file, environment, spec_name)
+      end
+
       def dump_schema(configuration, format = ActiveRecord::Base.schema_format, spec_name = "primary") # :nodoc:
         require "active_record/schema_dumper"
         filename = dump_filename(spec_name, format)

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -8,30 +8,15 @@ module ActiveRecord
       create_and_load_schema(i, env_name: Rails.env)
     end
 
-    ActiveSupport::Testing::Parallelization.run_cleanup_hook do
-      drop(env_name: Rails.env)
-    end
-
     def self.create_and_load_schema(i, env_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
         db_config.config["database"] += "-#{i}"
-        ActiveRecord::Tasks::DatabaseTasks.create(db_config.config)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config.config, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
       end
     ensure
       ActiveRecord::Base.establish_connection(Rails.env.to_sym)
-      ENV["VERBOSE"] = old
-    end
-
-    def self.drop(env_name:)
-      old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
-
-      ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
-        ActiveRecord::Tasks::DatabaseTasks.drop(db_config.config)
-      end
-    ensure
       ENV["VERBOSE"] = old
     end
   end


### PR DESCRIPTION
Previously, every time we ran tests in parallel we would load the schema for all _N_ databases, and then drop them at the end of testing.

Now that we have the ability to sync DBs with the schema file exactly using metadata and a SHA, we can instead only load the schemas when they change. In order for this to work we no longer drop the databases at the end of the tests. If the schema is in sync, we truncate the tables to ensure we start with an empty DB.

I believe this will make setup fast enough to close https://github.com/rails/rails/issues/36807

Builds on #36870, obsoletes #36826