### PR TITLE
Fix typo in autoloading constants guide

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -270,7 +270,7 @@ end
 Rails.autoloaders
 -----------------
 
-The Zeitwerk instances managing your application are availabe at
+The Zeitwerk instances managing your application are available at
 
 ```ruby
 Rails.autoloaders.main


### PR DESCRIPTION
Fixes typo autoloading constants guide. 

If this is considered in violation of the [cosmetic changes](https://github.com/rails/rails/blob/master/CONTRIBUTING.md#did-you-fix-whitespace-format-code-or-make-a-purely-cosmetic-patch) policy, feel free to close. Just noticed it while reading the (quite excellent) explanation of Zeitwerk & autoloading.

 [ci skip]

