### PR TITLE
Fixed cache_store name used in adding other modules section of api app documentation guide. [ci skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -425,7 +425,7 @@ Some common modules you might want to add:
   ```ruby
   class ApplicationController < ActionController::API
     include ::ActionController::Caching
-    self.cache_store = :mem_cached_store
+    self.cache_store = :mem_cache_store
   end
   ```
   Rails does *not* pass this configuration automatically.


### PR DESCRIPTION
### Summary

- Using `mem_cached_store` results in an exception as,
```
lib/active_support/cache.rb:106:in `rescue in retrieve_store_class':
Could not find cache store adapter for mem_cached_store (cannot load such file -- active_support/cache/mem_cached_store) (RuntimeError)
```
- Changed the name of cache_store as `mem_cache_store` instead of `mem_cached_store`
