### PR TITLE
Support multiple arguments in `HashWithIndifferentAccess` for `merge` and update methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support multiple arguments in `HashWithIndifferentAccess` for `merge` and `update` methods, to
+    follow Ruby 2.6 addition.
+
+    *Wojciech Wnętrzak*
+
 *   Allow initializing `thread_mattr_*` attributes via `:default` option
 
         class Scraper

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -249,6 +249,14 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert [updated_with_strings, updated_with_symbols, updated_with_mixed].all? { |h| h.keys.size == 2 }
   end
 
+  def test_update_with_multiple_arguments
+    hash = HashWithIndifferentAccess.new
+    hash.update({ "a" => 1 }, { "b" => 2 })
+
+    assert_equal 1, hash["a"]
+    assert_equal 2, hash["b"]
+  end
+
   def test_update_with_to_hash_conversion
     hash = HashWithIndifferentAccess.new
     hash.update HashByConversion.new(a: 1)
@@ -272,6 +280,14 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
 
     assert_equal 1, hash[:a]
     assert_equal 2, hash["b"]
+  end
+
+  def test_merging_with_multiple_arguments
+    hash = HashWithIndifferentAccess.new
+    merged = hash.merge({ "a" => 1 }, { "b" => 2 })
+
+    assert_equal 1, merged["a"]
+    assert_equal 2, merged["b"]
   end
 
   def test_merge_with_to_hash_conversion


### PR DESCRIPTION
It follows Ruby 2.6 addition https://github.com/ruby/ruby/pull/1951

I used this benchmark:

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  gem 'activesupport'
  gem 'benchmark-ips'
end

require 'active_support/all'

class ModifiedHashWithIndifferentAccess < ActiveSupport::HashWithIndifferentAccess
  def update(*other_hashes)
    other_hashes.each do |other_hash|
      if other_hash.is_a? HashWithIndifferentAccess
        super(other_hash)
      else
        other_hash.to_hash.each_pair do |key, value|
          if block_given? && key?(key)
            value = yield(convert_key(key), self[key], value)
          end
          regular_writer(convert_key(key), convert_value(value))
        end
      end
    end
    self
  end

  def merge(*hashes, &block)
    dup.update(*hashes, &block)
  end
end

Benchmark.ips do |x|
  x.report("original") { ActiveSupport::HashWithIndifferentAccess.new.merge({ "hash" => 1 }) }
  x.report("modified") { ModifiedHashWithIndifferentAccess.new.merge({ "hash" => 1 }) }
  x.compare!
end
```
Results in:
```
Warming up --------------------------------------
            original    23.268k i/100ms
            modified    21.457k i/100ms
Calculating -------------------------------------
            original    280.601k (± 4.9%) i/s -      1.419M in   5.070479s
            modified    239.935k (± 7.9%) i/s -      1.202M in   5.040658s

Comparison:
            original:   280601.1 i/s
            modified:   239934.8 i/s - 1.17x  slower
```