### PR TITLE
Add CHANGELOG entry for ActiveJob change

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `at` argument to the `perform_enqueued_jobs` test helper.
+
+    *John Crepezzi*, *Eileen Uchitelle*
+
 *   `assert_enqueued_with` and `assert_performed_with` can now test jobs with relative delay.
 
     *Vlado Cingel*

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -117,7 +117,7 @@ module ActiveJob
     #       HelloJob.perform_later('elfassy')
     #     end
     #   end
-    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil, at: at)
+    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
       if block_given?
         original_count = enqueued_jobs_with(only: only, except: except, queue: queue)
 


### PR DESCRIPTION
### Summary

In #36864 we made a change to an ActiveJob test helper to add a new
parameter for testing jobs delayed into the future.

This PR adds a CHANGELOG entry for that change as well as fixing a
circular argument error mentioned in a review.

### Other Information

cc / @eileencodes 