### PR TITLE
Correct the assertion argument order

### DIFF
--- a/actionmailbox/test/unit/test_helper_test.rb
+++ b/actionmailbox/test/unit/test_helper_test.rb
@@ -20,21 +20,25 @@ module ActionMailbox
 
       mail = inbound_email.mail
 
-      assert_equal 2, mail.parts.count
-      assert_equal mail.text_part.to_s, <<~TEXT.chomp
+      expected_mail_text_part = <<~TEXT.chomp
         Content-Type: text/plain;\r
          charset=UTF-8\r
         Content-Transfer-Encoding: 7bit\r
         \r
         Hello, world
       TEXT
-      assert_equal mail.html_part.to_s, <<~HTML.chomp
+
+      expected_mail_html_part = <<~HTML.chomp
         Content-Type: text/html;\r
          charset=UTF-8\r
         Content-Transfer-Encoding: 7bit\r
         \r
         <h1>Hello, world</h1>
       HTML
+
+      assert_equal 2, mail.parts.count
+      assert_equal expected_mail_text_part, mail.text_part.to_s
+      assert_equal expected_mail_html_part, mail.html_part.to_s
     end
   end
 end


### PR DESCRIPTION
Followup: #36856

PR just fixes the assertion argument order for the test added in the PR. I had added a comment for same here(https://github.com/rails/rails/pull/36856#discussion_r311591923) and George seems to have fixed the one assertion in commit https://github.com/rails/rails/commit/c2f197c775bf50e214ec5e9fde9d0f484c436830

I think the other two assertion order should have been changed too. If the test fails it would show output as follows which is not correct. 
```
--- expected
+++ actual
@@ -1,6 +1,5 @@
-# encoding: US-ASCII
 "Content-Type: text/plain;\r
  charset=UTF-8\r
 Content-Transfer-Encoding: 7bit\r
 \r
-Hello, world 1"
+Hello, world"
```