### PR TITLE
Remove yaml file fixtures from regular fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Stop trying to read yaml file fixtures when loading Active Record fixtures.
+
+    *Gannon McGibbon*
+
 *   Deprecate `.reorder(nil)` with `.first` / `.first!` taking non-deterministic result.
 
     To continue taking non-deterministic result, use `.take` / `.take!` instead.

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -41,8 +41,9 @@ module ActiveRecord
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
           raise StandardError, "No fixture path found. Please set `#{self}.fixture_path`." if fixture_path.blank?
-          fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"].uniq
-          fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
+          fixture_set_names = Dir[::File.join(fixture_path, "{**,*}/*.{yml}")].uniq
+          fixture_set_names.reject! { |f| f.starts_with?(file_fixture_path.to_s) } if file_fixture_path
+          fixture_set_names.map! { |f| f[fixture_path.to_s.size..-5].delete_prefix("/") }
         else
           fixture_set_names = fixture_set_names.flatten.map(&:to_s)
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1371,6 +1371,19 @@ class NilFixturePathTest < ActiveRecord::TestCase
   end
 end
 
+class FileFixtureConflictTest < ActiveRecord::TestCase
+  def self.file_fixture_path
+    FIXTURES_ROOT + "/all/admin"
+  end
+
+  test "ignores file fixtures" do
+    self.class.fixture_path = FIXTURES_ROOT + "/all"
+    self.class.fixtures :all
+
+    assert_equal %w(developers namespaced/accounts people tasks), fixture_table_names.sort
+  end
+end
+
 class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
   test "enlist_fixture_connections ensures multiple databases share a connection pool" do
     with_temporary_connection_pool do


### PR DESCRIPTION
### Summary

Currently, you can't have yaml file fixtures inside of [the default fixture folder setup](https://github.com/rails/rails/blob/master/railties/lib/rails/test_help.rb#L27-L28). Active Record uses [this glob pattern](https://github.com/rails/rails/blob/d580d8c6dd35aab32692d7236dd9e70b2948f3f0/activerecord/lib/active_record/test_fixtures.rb#L44) to search subdirectories of `fixtures_path` for fixtures of namespaced models.

This simply removes detected fixture paths inside `file_fixture_path` so we don't read any non-record fixture yaml.
