### PR TITLE
Infer migrations_paths from database name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Infer `migrations_paths` based on the database configuration name.
+
+    Applications don't need to set a `migrations_paths` if they want the directory name
+    to match the configuration name. The directory will automatically be created when
+    the first migration is generated for that database.
+
+    *John Crepezzi*, *Eileen M. Uchitelle*
+
 *   Do not mark Postgresql MAC address and UUID attributes as changed when the assigned value only varies by case.
 
     *Peter Fry*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -120,7 +120,7 @@ module ActiveRecord
       end
 
       def migrations_paths # :nodoc:
-        @config[:migrations_paths] || Migrator.migrations_paths
+        pool.db_config.migrations_paths
       end
 
       def migration_context # :nodoc:

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -75,6 +75,10 @@ module ActiveRecord
       def schema_cache_path
         raise NotImplementedError
       end
+
+      def default_migrations_paths
+        [name == "primary" ? "db/migrate" : "db/#{name}_migrate"]
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -76,8 +76,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      DEFAULT_MIGRATION_PATH = "db/migrate"
+
       def default_migrations_paths
-        [name == "primary" ? "db/migrate" : "db/#{name}_migrate"]
+        [name == "primary" ? DEFAULT_MIGRATION_PATH : "db/#{name}_migrate"]
       end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -47,7 +47,7 @@ module ActiveRecord
       # +migrations_paths+ key is present in the config, +migrations_paths+
       # will return its value.
       def migrations_paths
-        configuration_hash[:migrations_paths]
+        configuration_hash.fetch(:migrations_paths) { default_migrations_paths }
       end
 
       def host

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1188,15 +1188,17 @@ module ActiveRecord
 
   class Migrator # :nodoc:
     class << self
-      attr_accessor :migrations_paths
+      attr_writer :migrations_paths
+
+      def migrations_paths
+        @migrations_paths || ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+      end
 
       # For cases where a table doesn't exist like loading from schema cache
       def current_version
         MigrationContext.new(migrations_paths, SchemaMigration).current_version
       end
     end
-
-    self.migrations_paths = ["db/migrate"]
 
     def initialize(direction, migrations, schema_migration, target_version = nil)
       @direction         = direction

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -19,7 +19,6 @@ db_namespace = namespace :db do
 
   task load_config: :environment do
     ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
-    ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
   end
 
   namespace :create do

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -669,8 +669,9 @@ namespace :railties do
         puts "Copied migration #{migration.basename} from #{name}"
       end
 
-      ActiveRecord::Migration.copy(ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first, railties,
-                                    on_skip: on_skip, on_copy: on_copy)
+      destination = Rails.application.paths[ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first].first
+
+      ActiveRecord::Migration.copy(destination, railties, on_skip: on_skip, on_copy: on_copy)
     end
   end
 end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -84,7 +84,8 @@ module ActiveRecord
       end
 
       def migrations_paths
-        current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
+        paths = current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
+        @migrations_paths ||= Rails.application.paths[paths.first].to_a
       end
 
       def fixtures_path
@@ -527,7 +528,6 @@ module ActiveRecord
         end
 
         def current_db_config
-          p ActiveRecord::Base.configurations
           ActiveRecord::Base.configurations.configs_for(env_name: env, name: name)
         end
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -84,8 +84,15 @@ module ActiveRecord
       end
 
       def migrations_paths
-        paths = current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
-        @migrations_paths ||= Rails.application.paths[paths.first].to_a
+        return @migrations_paths if @migrations_paths
+
+        @migrations_paths = current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
+
+        if defined?(Rails) && Rails.application
+          @migrations_paths = Rails.application.paths[@migrations_paths.first].to_a
+        end
+
+        @migrations_paths
       end
 
       def fixtures_path

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -84,15 +84,7 @@ module ActiveRecord
       end
 
       def migrations_paths
-        return @migrations_paths if @migrations_paths
-
-        @migrations_paths = current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
-
-        #if defined?(Rails) && Rails.application
-        #  @migrations_paths = Rails.application.paths[@migrations_paths.first].to_a
-        #end
-
-        @migrations_paths
+        @migrations_paths ||= current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
       end
 
       def fixtures_path

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -88,9 +88,9 @@ module ActiveRecord
 
         @migrations_paths = current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
 
-        if defined?(Rails) && Rails.application
-          @migrations_paths = Rails.application.paths[@migrations_paths.first].to_a
-        end
+        #if defined?(Rails) && Rails.application
+        #  @migrations_paths = Rails.application.paths[@migrations_paths.first].to_a
+        #end
 
         @migrations_paths
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       end
 
       def migrations_paths
-        current_db_config.migrations_paths
+        current_db_config&.migrations_paths || [DatabaseConfigurations::DatabaseConfig::DEFAULT_MIGRATION_PATH]
       end
 
       def fixtures_path
@@ -527,7 +527,8 @@ module ActiveRecord
         end
 
         def current_db_config
-          ActiveRecord::Base.configurations.configs_for(env_name: env, spec_name: spec)
+          p ActiveRecord::Base.configurations
+          ActiveRecord::Base.configurations.configs_for(env_name: env, name: name)
         end
     end
   end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -84,7 +84,7 @@ module ActiveRecord
       end
 
       def migrations_paths
-        @migrations_paths ||= Rails.application.paths["db/migrate"].to_a
+        current_db_config.migrations_paths
       end
 
       def fixtures_path
@@ -524,6 +524,10 @@ module ActiveRecord
 
         def schema_sha1(file)
           Digest::SHA1.hexdigest(File.read(file))
+        end
+
+        def current_db_config
+          ActiveRecord::Base.configurations.configs_for(env_name: env, spec_name: spec)
         end
     end
   end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -69,6 +69,40 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
       assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements"], ActiveRecord::Base.configurations.to_h.keys.sort
     end
   end
+
+  def test_infers_migrations_paths
+    config = {
+      "default_env" => {
+        "primary" => { "pool" => 5 },
+        "animals" => { "pool" => 5 }
+      }
+    }
+
+    configs = ActiveRecord::DatabaseConfigurations.new(config)
+
+    actual = configs.configs_for(env_name: "default_env", name: "primary")
+    assert_equal ["db/migrate"], actual.migrations_paths
+
+    actual = configs.configs_for(env_name: "default_env", name: "animals")
+    assert_equal ["db/animals_migrate"], actual.migrations_paths
+  end
+
+  def test_allows_overriding_migrations_paths
+    config = {
+      "default_env" => {
+        "primary" => { "pool" => 5, "migrations_paths": ["foo"] },
+        "animals" => { "pool" => 5, "migrations_paths": ["bar"] }
+      }
+    }
+
+    configs = ActiveRecord::DatabaseConfigurations.new(config)
+
+    actual = configs.configs_for(env_name: "default_env", name: "primary")
+    assert_equal ["foo"], actual.migrations_paths
+
+    actual = configs.configs_for(env_name: "default_env", name: "animals")
+    assert_equal ["bar"], actual.migrations_paths
+  end
 end
 
 class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -182,24 +182,6 @@ class MigratorTest < ActiveRecord::TestCase
     ], ActiveRecord::MigrationContext.new(path, schema_migration).migrations_status
   end
 
-  def test_migrations_status_with_schema_define_in_subdirectories
-    path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
-    prev_paths = ActiveRecord::Migrator.migrations_paths
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    ActiveRecord::Migrator.migrations_paths = path
-
-    ActiveRecord::Schema.define(version: 3) do
-    end
-
-    assert_equal [
-      ["up", "001", "Valid people have last names"],
-      ["up", "002", "We need reminders"],
-      ["up", "003", "Innocent jointable"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration).migrations_status
-  ensure
-    ActiveRecord::Migrator.migrations_paths = prev_paths
-  end
-
   def test_migrations_status_from_two_directories
     paths = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
     schema_migration = ActiveRecord::Base.connection.schema_migration

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -71,7 +71,6 @@ production:
     database: my_animals_database
     user: animals_root
     adapter: mysql
-    migrations_paths: db/animals_migrate
   animals_replica:
     database: my_animals_database
     user: animals_readonly
@@ -88,10 +87,6 @@ replica user's permissions should be to read and not write.
 When using a replica database you need to add a `replica: true` entry to the replica in the
 `database.yml`. This is because Rails otherwise has no way of knowing which one is a replica
 and which one is the primary.
-
-Lastly, for new primary databases you need to set the `migrations_paths` to the directory
-where you will store migrations for that database. We'll look more at `migrations_paths`
-later on in this guide.
 
 Now that we have a new database, let's set up the model. In order to use the new database we
 need to create a new abstract class and connect to the animals databases.
@@ -176,8 +171,9 @@ database you can run `bin/rails db:create:animals`.
 Migrations for multiple databases should live in their own folders prefixed with the
 name of the database key in the configuration.
 
-You also need to set the `migrations_paths` in the database configurations to tell Rails
-where to find the migrations.
+You may also choose to set the `migrations_paths` in the database configurations
+to tell Rails where to find the migrations. If you don't, the path will be inferred
+for you.
 
 For example the `animals` database would look for migrations in the `db/animals_migrate` directory and
 `primary` would look in `db/migrate`. Rails generators now take a `--database` option

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -153,14 +153,10 @@ module ApplicationTests
 
       app "development"
 
-      ActiveRecord::Migrator.migrations_paths = ["#{app_path}/db/migrate"]
-
-      begin
+      Dir.chdir(app_path) do
         get "/foo"
         assert_equal 500, last_response.status
         assert_match "ActiveRecord::PendingMigrationError", last_response.body
-      ensure
-        ActiveRecord::Migrator.migrations_paths = nil
       end
     end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -138,11 +138,9 @@ module TestHelpers
             animals:
               <<: *default
               database: db/development_animals.sqlite3
-              migrations_paths: db/animals_migrate
             animals_readonly:
               <<: *default
               database: db/development_animals.sqlite3
-              migrations_paths: db/animals_migrate
               replica: true
           test:
             primary:
@@ -155,11 +153,9 @@ module TestHelpers
             animals:
               <<: *default
               database: db/test_animals.sqlite3
-              migrations_paths: db/animals_migrate
             animals_readonly:
               <<: *default
               database: db/test_animals.sqlite3
-              migrations_paths: db/animals_migrate
               replica: true
           production:
             primary:
@@ -172,11 +168,9 @@ module TestHelpers
             animals:
               <<: *default
               database: db/production_animals.sqlite3
-              migrations_paths: db/animals_migrate
             animals_readonly:
               <<: *default
               database: db/production_animals.sqlite3
-              migrations_paths: db/animals_migrate
               replica: true
           YAML
         end
@@ -462,7 +456,6 @@ module TestHelpers
             animals:
               <<: *default
               database: railties_animals_test
-              migrations_paths: db/animals_migrate
           YAML
         end
       else

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -34,6 +34,7 @@ module RailtiesTest
 
     def migrations
       migration_root = File.expand_path(ActiveRecord::Migrator.migrations_paths.first, app_path)
+      p migration_root
       ActiveRecord::MigrationContext.new(migration_root, ActiveRecord::SchemaMigration).migrations
     end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -34,7 +34,6 @@ module RailtiesTest
 
     def migrations
       migration_root = File.expand_path(ActiveRecord::Migrator.migrations_paths.first, app_path)
-      p migration_root
       ActiveRecord::MigrationContext.new(migration_root, ActiveRecord::SchemaMigration).migrations
     end
 


### PR DESCRIPTION
### Summary

Similar to what we do for schema files, we now infer the default
`migrations_paths` for a database configuration using the database
specification name.

We still allow overriding these defaults with a `migrations_paths` key
in the database configuration file.

Additionally, we've updated some documentation accordingly in the guides.

We've also removed `Migrator.migrations_paths` since we should be taking
the `migrations_paths` off of the config instead.

cc / @eileencodes 