### PR TITLE
Add GitHub Actions workflow to Rails

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,105 @@
+on: [push]
+
+name: Rails CI
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+        - 6379:6379
+      memcached:
+        image: memcached
+        ports:
+        - 11211:11211
+      postgres:
+        image: postgres:10.8
+        ports:
+        - 5432:5432
+        env:
+          POSTGRES_PASSWORD: ""
+      mysql:
+        image: mysql:5.7
+        ports:
+        - 99:3306
+        env:
+          MYSQL_ROOT_PASSWORD: secret
+    strategy:
+      matrix:
+        ruby_version: [2.6.x]
+        gem:
+        - activesupport
+        - actionmailer
+        - activemodel
+        - actiontext
+        - actionmailbox
+        - actionview
+        - actionpack
+        - actioncable
+        - activejob
+        - activestorage
+        - activerecord:postgresql
+        - activerecord:sqlite3
+        - activerecord:sqlite3_mem
+        - activerecord:mysql2
+        - guides
+        - railties
+    name: ${{ matrix.gem }}
+    steps:
+    - name: Install libraries
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y default-mysql-client libmysqlclient-dev postgresql-client libpq-dev sqlite3 libsqlite3-dev redis-tools ffmpeg mupdf mupdf-tools poppler-utils
+    - name: Configure databases
+      run: |
+        echo "Redis"
+        redis-cli config set stop-writes-on-bgsave-error no
+        redis-cli config set save ""
+
+        echo "Postgres"
+        psql -h localhost -c "create database activerecord_unittest;" -U postgres
+        psql -h localhost -c "create database activerecord_unittest2;" -U postgres
+
+        echo "MySQL"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "create user rails;"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "grant all privileges on activerecord_unittest.* to rails;"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "grant all privileges on activerecord_unittest2.* to rails;"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "grant all privileges on inexistent_activerecord_unittest.* to rails;"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "create database activerecord_unittest default character set utf8mb4;"
+        mysql --user=root --password=secret --host=127.0.0.1 --port=99 -e "create database activerecord_unittest2 default character set utf8mb4;"
+    - name: Install Node
+      uses: actions/setup-node@v1
+      with:
+        version: 10.x
+    - name: Install NPM
+      run: |
+        npm install
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Update Ruby and Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bison ruby ruby-dev libffi-dev libgdbm-dev libgmp-dev libjemalloc-dev libncurses5-dev libncursesw5-dev libreadline6-dev libssl-dev libyaml-dev openssl zlib1g-dev libmysqlclient-dev libpq-dev sqlite3 libsqlite3-dev redis-tools curl libxml2-dev tzdata
+        curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        sudo gem install bundler -v '1.17.3'
+    - name: Install dependencies
+      run: |
+        sudo gem install bundler -v '1.17.3'
+        bundle install -j8
+    - name: Run tests
+      run: |
+        IFS=: read -a GEM <<<"${{ matrix.gem }}"
+        DATABASE="${GEM[1]}"
+        export PGHOST=localhost PGUSER=postgres
+        cd "${GEM[0]}"
+        if [ -z "$DATABASE" ]
+        then
+          bundle exec rake
+        else
+          bundle exec rake "test:${GEM[1]}"
+        fi
+      env:
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_PORT: 99

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -200,6 +200,11 @@ module ActionDispatch
       end
 
       class Expanded < Base
+        def initialize(width: IO.console_size.second)
+          @width = width
+          super()
+        end
+
         def section_title(title)
           @buffer << "\n#{"[ #{title} ]"}"
         end
@@ -222,9 +227,8 @@ module ActionDispatch
           end
 
           def route_header(index:)
-            console_width = IO.console_size.second
             header_prefix = "--[ Route #{index} ]"
-            dash_remainder = [console_width - header_prefix.size, 0].max
+            dash_remainder = [@width - header_prefix.size, 0].max
 
             "#{header_prefix}#{'-' * dash_remainder}"
           end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -317,9 +317,6 @@ module ActionDispatch
       end
 
       def test_routes_when_expanded
-        previous_console_winsize = IO.console.winsize
-        IO.console.winsize = [0, 23]
-
         engine = Class.new(Rails::Engine) do
           def self.inspect
             "Blog::Engine"
@@ -329,7 +326,7 @@ module ActionDispatch
           get "/cart", to: "cart#show"
         end
 
-        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
+        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new(width: 23)) do
           get "/custom/assets", to: "custom_assets#show"
           get "/custom/furnitures", to: "custom_furnitures#show"
           mount engine => "/blog", :as => "blog"
@@ -357,8 +354,6 @@ module ActionDispatch
                       "Verb              | GET",
                       "URI               | /cart(.:format)",
                       "Controller#Action | cart#show"], output
-      ensure
-        IO.console.winsize = previous_console_winsize
       end
 
       def test_no_routes_matched_filter_when_expanded

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -57,12 +57,18 @@ connections:
 <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>
 <% end %>
+<% if ENV['MYSQL_PORT'] %>
+      port: <%= ENV['MYSQL_PORT'] %>
+<% end %>
     arunit2:
       username: rails
       encoding: utf8mb4
       collation: utf8mb4_general_ci
 <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>
+<% end %>
+<% if ENV['MYSQL_PORT'] %>
+      port: <%= ENV['MYSQL_PORT'] %>
 <% end %>
 
   oracle:

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -187,122 +187,126 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     MESSAGE
   end
 
+  def stub_winsize(size)
+    fake_console = Struct.new(:winsize).new(size)
+    IO.stub(:console, fake_console) do
+      yield
+    end
+  end
+
   test "rails routes with expanded option" do
-    previous_console_winsize = IO.console.winsize
-    IO.console.winsize = [0, 27]
+    stub_winsize([0, 27]) do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/cart', to: 'cart#show'
+        end
+      RUBY
 
-    app_file "config/routes.rb", <<-RUBY
-      Rails.application.routes.draw do
-        get '/cart', to: 'cart#show'
-      end
-    RUBY
-
-    # rubocop:disable Layout/TrailingWhitespace
-    assert_equal <<~MESSAGE, run_routes_command([ "--expanded" ])
-      --[ Route 1 ]--------------
-      Prefix            | cart
-      Verb              | GET
-      URI               | /cart(.:format)
-      Controller#Action | cart#show
-      --[ Route 2 ]--------------
-      Prefix            | rails_mandrill_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
-      Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
-      --[ Route 3 ]--------------
-      Prefix            | rails_postmark_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
-      Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
-      --[ Route 4 ]--------------
-      Prefix            | rails_relay_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
-      Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
-      --[ Route 5 ]--------------
-      Prefix            | rails_sendgrid_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
-      Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
-      --[ Route 6 ]--------------
-      Prefix            | rails_mailgun_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
-      Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
-      --[ Route 7 ]--------------
-      Prefix            | rails_conductor_inbound_emails
-      Verb              | GET
-      URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
-      --[ Route 8 ]--------------
-      Prefix            | 
-      Verb              | POST
-      URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
-      --[ Route 9 ]--------------
-      Prefix            | new_rails_conductor_inbound_email
-      Verb              | GET
-      URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
-      --[ Route 10 ]-------------
-      Prefix            | edit_rails_conductor_inbound_email
-      Verb              | GET
-      URI               | /rails/conductor/action_mailbox/inbound_emails/:id/edit(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#edit
-      --[ Route 11 ]-------------
-      Prefix            | rails_conductor_inbound_email
-      Verb              | GET
-      URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
-      --[ Route 12 ]-------------
-      Prefix            | 
-      Verb              | PATCH
-      URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
-      --[ Route 13 ]-------------
-      Prefix            | 
-      Verb              | PUT
-      URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
-      --[ Route 14 ]-------------
-      Prefix            | 
-      Verb              | DELETE
-      URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
-      Controller#Action | rails/conductor/action_mailbox/inbound_emails#destroy
-      --[ Route 15 ]-------------
-      Prefix            | rails_conductor_inbound_email_reroute
-      Verb              | POST
-      URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
-      Controller#Action | rails/conductor/action_mailbox/reroutes#create
-      --[ Route 16 ]-------------
-      Prefix            | rails_service_blob
-      Verb              | GET
-      URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
-      Controller#Action | active_storage/blobs#show
-      --[ Route 17 ]-------------
-      Prefix            | rails_blob_representation
-      Verb              | GET
-      URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
-      Controller#Action | active_storage/representations#show
-      --[ Route 18 ]-------------
-      Prefix            | rails_disk_service
-      Verb              | GET
-      URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
-      Controller#Action | active_storage/disk#show
-      --[ Route 19 ]-------------
-      Prefix            | update_rails_disk_service
-      Verb              | PUT
-      URI               | /rails/active_storage/disk/:encoded_token(.:format)
-      Controller#Action | active_storage/disk#update
-      --[ Route 20 ]-------------
-      Prefix            | rails_direct_uploads
-      Verb              | POST
-      URI               | /rails/active_storage/direct_uploads(.:format)
-      Controller#Action | active_storage/direct_uploads#create
-    MESSAGE
-    # rubocop:enable Layout/TrailingWhitespace
-  ensure
-    IO.console.winsize = previous_console_winsize
+      # rubocop:disable Layout/TrailingWhitespace
+      assert_equal <<~MESSAGE, run_routes_command([ "--expanded" ])
+        --[ Route 1 ]--------------
+        Prefix            | cart
+        Verb              | GET
+        URI               | /cart(.:format)
+        Controller#Action | cart#show
+        --[ Route 2 ]--------------
+        Prefix            | rails_mandrill_inbound_emails
+        Verb              | POST
+        URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
+        Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
+        --[ Route 3 ]--------------
+        Prefix            | rails_postmark_inbound_emails
+        Verb              | POST
+        URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
+        Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
+        --[ Route 4 ]--------------
+        Prefix            | rails_relay_inbound_emails
+        Verb              | POST
+        URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
+        Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
+        --[ Route 5 ]--------------
+        Prefix            | rails_sendgrid_inbound_emails
+        Verb              | POST
+        URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
+        Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
+        --[ Route 6 ]--------------
+        Prefix            | rails_mailgun_inbound_emails
+        Verb              | POST
+        URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
+        Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
+        --[ Route 7 ]--------------
+        Prefix            | rails_conductor_inbound_emails
+        Verb              | GET
+        URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
+        --[ Route 8 ]--------------
+        Prefix            | 
+        Verb              | POST
+        URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
+        --[ Route 9 ]--------------
+        Prefix            | new_rails_conductor_inbound_email
+        Verb              | GET
+        URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
+        --[ Route 10 ]-------------
+        Prefix            | edit_rails_conductor_inbound_email
+        Verb              | GET
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id/edit(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#edit
+        --[ Route 11 ]-------------
+        Prefix            | rails_conductor_inbound_email
+        Verb              | GET
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
+        --[ Route 12 ]-------------
+        Prefix            | 
+        Verb              | PATCH
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
+        --[ Route 13 ]-------------
+        Prefix            | 
+        Verb              | PUT
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
+        --[ Route 14 ]-------------
+        Prefix            | 
+        Verb              | DELETE
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
+        Controller#Action | rails/conductor/action_mailbox/inbound_emails#destroy
+        --[ Route 15 ]-------------
+        Prefix            | rails_conductor_inbound_email_reroute
+        Verb              | POST
+        URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
+        Controller#Action | rails/conductor/action_mailbox/reroutes#create
+        --[ Route 16 ]-------------
+        Prefix            | rails_service_blob
+        Verb              | GET
+        URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
+        Controller#Action | active_storage/blobs#show
+        --[ Route 17 ]-------------
+        Prefix            | rails_blob_representation
+        Verb              | GET
+        URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
+        Controller#Action | active_storage/representations#show
+        --[ Route 18 ]-------------
+        Prefix            | rails_disk_service
+        Verb              | GET
+        URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
+        Controller#Action | active_storage/disk#show
+        --[ Route 19 ]-------------
+        Prefix            | update_rails_disk_service
+        Verb              | PUT
+        URI               | /rails/active_storage/disk/:encoded_token(.:format)
+        Controller#Action | active_storage/disk#update
+        --[ Route 20 ]-------------
+        Prefix            | rails_direct_uploads
+        Verb              | POST
+        URI               | /rails/active_storage/direct_uploads(.:format)
+        Controller#Action | active_storage/direct_uploads#create
+      MESSAGE
+      # rubocop:enable Layout/TrailingWhitespace
+    end
   end
 
   private


### PR DESCRIPTION
This PR adds the necessary workflow to use GitHub Actions on the
Rails repo. There are a couple of things missing but the majority of
tests are passing for Linux. :tada:

The changes to ActionPack and Railties are due to other CI's pretending
they are a tty, but Actions doesn't act as a tty so we need to handle
these differently.

Co-Authored-By: John Hawthorn <john@hawthorn.email>
Co-Authored-By: Aaron Patterson <aaron.patterson@gmail.com>
Co-Authored-By: Edward Thomson <ethomson@edwardthomson.com>