### PR TITLE
Add support for s3 host alias to ActiveStorage

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -142,7 +142,7 @@ module ActiveStorage
       end
 
       def apply_host_alias(url)
-        return if host_alias.nil?
+        return url if host_alias.nil?
 
         parsed_url = URI.parse(url)
         parsed_url.host = host_alias

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -45,6 +45,16 @@ if SERVICE_CONFIGURATIONS[:s3]
       assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
     end
 
+    test "signed URL generation with host alias" do
+      host_alias = 'example-alias.com'
+      service = build_service(host_alias: 'example-alias.com')
+      url = service.url(@key, expires_in: 5.minutes,
+                         disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+
+      assert_match(/response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url)
+      assert_match host_alias, url
+    end
+
     test "uploading with server-side encryption" do
       service = build_service(upload: { server_side_encryption: "AES256" })
 


### PR DESCRIPTION
### Summary

This PR adds support for S3 host aliases that mimics the `s3_host_alias` option in Paperclip. 
It replaces the host of the S3 object URL to the one provided in the configuration file. 

To use this feature, add `host_alias: example.com` to `config/storage.yml`. Requesting `blob.service_url` should return a link with the specified host, e.g. `https://example.com/objhash`.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
