### PR TITLE
Rails HTML sanitizer update changes to Gemfile lock on bundle install.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ PATH
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
     actiontext (6.1.0.alpha)
       actionpack (= 6.1.0.alpha)
       activerecord (= 6.1.0.alpha)


### PR DESCRIPTION
### Summary

> 12001611d6355cb81360973e93020b7426aad896 : Require and support rails-html-sanitzer 1.2.0
- Reference commit ☝️ 
- `bundle install` resulted in `Gemfile.lock` changes in the pull request.

// @kaspth 