### PR TITLE
Add support for foreign key constraint comments in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -92,6 +92,10 @@ module ActiveRecord
         options[:on_update]
       end
 
+      def comment
+        options[:comment]
+      end
+
       def custom_primary_key?
         options[:primary_key] != default_primary_key
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -370,6 +370,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support comments on constraints?
+      def supports_comments_on_constraints?
+        false
+      end
+
       # Does this adapter support multi-value insert?
       def supports_multi_insert?
         true

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -197,6 +197,10 @@ module ActiveRecord
         true
       end
 
+      def supports_comments_on_constraints?
+        true
+      end
+
       def supports_savepoints?
         true
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -232,6 +232,8 @@ HEADER
             parts << "on_update: #{foreign_key.on_update.inspect}" if foreign_key.on_update
             parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
 
+            parts << "comment: #{foreign_key.comment.inspect}" if foreign_key.comment
+
             "  #{parts.join(', ')}"
           end
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -309,6 +309,33 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           assert_equal :nullify, fk.on_update
         end
 
+        if ActiveRecord::Base.connection.supports_comments_on_constraints?
+          def test_add_foreign_key_with_comment
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", comment: "comment"
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_equal "comment", fk.comment
+          end
+
+          def test_create_table_with_foreign_key_comment
+            @connection.create_table "boosters", force: true do |t|
+              t.string :name
+              t.references :rocket, foreign_key: { comment: "comment" }
+            end
+
+            foreign_keys = @connection.foreign_keys("boosters")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_equal "comment", fk.comment
+
+            @connection.drop_table "boosters"
+          end
+        end
+
         def test_foreign_key_exists
           @connection.add_foreign_key :astronauts, :rockets
 


### PR DESCRIPTION
### Summary

Adds support for comments on foreign key constraints in PostgreSQL. The comment can be referenced from an instance of `ForeignKey` within the app and is dumped to the Ruby schema.
