### PR TITLE
Remove misleading documentation

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -105,9 +105,6 @@ module ActionView
   #
   #   <%= render(partial: "ad", collection: @advertisements) || "There's no ad to be displayed" %>
   #
-  # NOTE: Due to backwards compatibility concerns, the collection can't be one of hashes. Normally you'd also
-  # just keep domain objects, like Active Records, in there.
-  #
   # == \Rendering shared partials
   #
   # Two controllers can share a set of partials and render them like this:


### PR DESCRIPTION
Fixes #36897, [ci skip].

The docs for ActionView partial renderer state:

> NOTE: Due to backwards compatibility concerns, the collection can't be one of hashes. Normally you'd also just keep domain objects, like Active Records, in there.

This note was added in 2005 in commit 703d18ea520c3def7bc677cef5fd87e2c7c3cd34. There isn't any information I can find about *why* these were a concern, but it seems to work now. I tested this in a Rails 6.0 rc2 app and hashes were passed as described.

The reporter stated:

> I can render a collection of hashes without problems:
>
> = render :partial => "info_row", :collection => my_collection, :as => :d