### PR TITLE
Serialize symbols to strings in ImmutableString serialize method

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -9,7 +9,7 @@ module ActiveModel
 
       def serialize(value)
         case value
-        when ::Numeric, ActiveSupport::Duration then value.to_s
+        when ::Numeric, ::Symbol, ActiveSupport::Duration then value.to_s
         when true then "t"
         when false then "f"
         else super

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -326,6 +326,13 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not_predicate topic, :approved_changed?
   end
 
+  def test_string_attribute_should_compare_with_typecast_symbol_after_update
+    pirate = Pirate.create!(catchphrase: :foo)
+    pirate.update_column :catchphrase, :foo
+    pirate.catchphrase
+    assert_not_predicate pirate, :catchphrase_changed?
+  end
+
   def test_partial_update
     pirate = Pirate.new(catchphrase: "foo")
     old_updated_on = 1.hour.ago.beginning_of_day


### PR DESCRIPTION
### Summary

Symbols serialize to strings when persisted:

```ruby
model.some_string = :foo
model.save! # "foo" is persisted
```

This PR updates the immutable string class to serialize symbols to strings to mirror this behavior as ActiveModel::Attribute calls this serialize method to determine the return value for changed_in_place? Prior to this change this code would report that "something" had changed:

```ruby
comment = Comment.create! # (has a string "something" field)
comment.update_column :something, :anything # persists "anything" to the "something" field of the comments table
comment.something  # or comment.attributes
comment.something_change # will be ["anything", "anything"], note these are `to` and `from` values, but are identical
```

After this PR the comment.something_change will return nil for this situation.

Fixes #36463

### Other Information

I bisected and it looks like c342d58446defad94f26c067b19003c9941f2470 introduced the change in behavior.