### PR TITLE
Prevent ActiveRecord::Type::Time::Value being returned by typecasting.

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -31,7 +31,7 @@ module ActiveModel
           if rounded_off_nsec > 0
             value.change(nsec: value.nsec - rounded_off_nsec)
           else
-            value
+            value.to_time
           end
         end
 

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -31,7 +31,7 @@ module ActiveModel
           if rounded_off_nsec > 0
             value.change(nsec: value.nsec - rounded_off_nsec)
           else
-            value.to_time
+            value.respond_to?(:__getobj__) ? value.__getobj__ : value
           end
         end
 

--- a/activemodel/test/cases/type/time_test.rb
+++ b/activemodel/test/cases/type/time_test.rb
@@ -19,6 +19,20 @@ module ActiveModel
         assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast(4 => 16, 5 => 45, 6 => 54)
       end
 
+      def test_type_cast_with_precision
+        type_0 = Type::Time.new(precision: 0)
+        assert_equal '16:45:54.000000000', type_0.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime('%H:%M:%S.%N')
+
+        type_6 = Type::Time.new(precision: 6)
+        assert_equal '16:45:54.000123000', type_6.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime('%H:%M:%S.%N')
+      end
+
+      def test_type_case_with_delegated_value
+        type = Type::Time.new(precision: 0)
+        delegated_value = DelegateClass(::Time).new(::Time.utc(2000, 1, 1))
+        assert_equal ::Time, type.cast(delegated_value).class
+      end
+
       def test_user_input_in_time_zone
         ::Time.use_zone("Pacific Time (US & Canada)") do
           type = Type::Time.new

--- a/activemodel/test/cases/type/time_test.rb
+++ b/activemodel/test/cases/type/time_test.rb
@@ -21,10 +21,10 @@ module ActiveModel
 
       def test_type_cast_with_precision
         type_0 = Type::Time.new(precision: 0)
-        assert_equal '16:45:54.000000000', type_0.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime('%H:%M:%S.%N')
+        assert_equal "16:45:54.000000000", type_0.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime("%H:%M:%S.%N")
 
         type_6 = Type::Time.new(precision: 6)
-        assert_equal '16:45:54.000123000', type_6.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime('%H:%M:%S.%N')
+        assert_equal "16:45:54.000123000", type_6.cast(::Time.utc(2000,  1,  1, 16, 45, 54, 123)).strftime("%H:%M:%S.%N")
       end
 
       def test_type_case_with_delegated_value


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/36910

The optimisation introduced in https://github.com/rails/rails/pull/36352 created a path through the code in which `ActiveRecord::Type::Time::Value` would be returned for a TIME attribute instead of `Time`.
