### PR TITLE
Remove `AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId` migration

### DIFF
--- a/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
+++ b/activestorage/db/update_migrate/20180723000244_add_foreign_key_constraint_to_active_storage_attachments_for_blob_id.rb
@@ -1,9 +1,0 @@
-class AddForeignKeyConstraintToActiveStorageAttachmentsForBlobId < ActiveRecord::Migration[6.0]
-  def up
-    return if foreign_key_exists?(:active_storage_attachments, column: :blob_id)
-
-    if table_exists?(:active_storage_blobs)
-      add_foreign_key :active_storage_attachments, :active_storage_blobs, column: :blob_id
-    end
-  end
-end


### PR DESCRIPTION
In https://github.com/rails/rails/pull/33419, we added this migration to
properly upgrade Active Storage from 5.2 to 6.0

On Rails 6.1 `rails app:update` shouldn't add this migration to users' app.

Note that, I've left implementation that makes `rails app:update` to generate
migrations for users' app that are in `activestorage/db/update_migrate/`
because we are likely to need it e.g.: (~~https://github.com/rails/rails/pull/34794~~ is a typo I meant https://github.com/rails/rails/pull/34935), https://github.com/rails/rails/pull/36835.