### PR TITLE
Log active_job potential matches when asserting

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Log potential matches in `assert_enqueued_with` and `assert_performed_with`
+
+    *Gareth du Plooy*
+
 *   Add `at` argument to the `perform_enqueued_jobs` test helper.
 
     *John Crepezzi*, *Eileen Uchitelle*

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -382,6 +382,7 @@ module ActiveJob
     def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
       expected = { job: job, args: args, at: at, queue: queue }.compact
       expected_args = prepare_args_for_assertion(expected)
+      potential_matches = []
 
       if block_given?
         original_enqueued_jobs_count = enqueued_jobs.count
@@ -395,6 +396,7 @@ module ActiveJob
 
       matching_job = jobs.find do |enqueued_job|
         deserialized_job = deserialize_args_for_assertion(enqueued_job)
+        potential_matches << deserialized_job
 
         expected_args.all? do |key, value|
           if value.respond_to?(:call)
@@ -405,7 +407,9 @@ module ActiveJob
         end
       end
 
-      assert matching_job, "No enqueued job found with #{expected}"
+      message = +"No enqueued job found with #{expected}"
+      message << "\n\nPotential matches: #{potential_matches.join("\n")}" if potential_matches.present?
+      assert matching_job, message
       instantiate_job(matching_job)
     end
 
@@ -457,6 +461,7 @@ module ActiveJob
     def assert_performed_with(job: nil, args: nil, at: nil, queue: nil, &block)
       expected = { job: job, args: args, at: at, queue: queue }.compact
       expected_args = prepare_args_for_assertion(expected)
+      potential_matches = []
 
       if block_given?
         original_performed_jobs_count = performed_jobs.count
@@ -470,6 +475,7 @@ module ActiveJob
 
       matching_job = jobs.find do |enqueued_job|
         deserialized_job = deserialize_args_for_assertion(enqueued_job)
+        potential_matches << deserialized_job
 
         expected_args.all? do |key, value|
           if value.respond_to?(:call)
@@ -480,7 +486,10 @@ module ActiveJob
         end
       end
 
-      assert matching_job, "No performed job found with #{expected}"
+      message = +"No performed job found with #{expected}"
+      message << "\n\nPotential matches: #{potential_matches.join("\n")}" if potential_matches.present?
+      assert matching_job, message
+
       instantiate_job(matching_job)
     end
 

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -533,7 +533,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
       end
     end
 
-    assert_equal 'No enqueued job found with {:job=>NestedJob, :queue=>"low"}', error.message
+    assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
   end
 
   def test_assert_enqueued_with_with_no_block_failure
@@ -547,7 +547,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
       assert_enqueued_with(job: NestedJob, queue: "low")
     end
 
-    assert_equal 'No enqueued job found with {:job=>NestedJob, :queue=>"low"}', error.message
+    assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
   end
 
   def test_assert_enqueued_with_args
@@ -659,8 +659,8 @@ class EnqueuedJobsTest < ActiveJob::TestCase
         HelloJob.perform_later(ricardo)
       end
     end
-
-    assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+    assert_match(/Potential matches: {:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
   end
 
   def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
@@ -671,7 +671,8 @@ class EnqueuedJobsTest < ActiveJob::TestCase
       assert_enqueued_with(job: HelloJob, args: [wilma])
     end
 
-    assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+    assert_match(/Potential matches: {:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
   end
 
   def test_assert_enqueued_with_does_not_change_jobs_count
@@ -1823,8 +1824,8 @@ class PerformedJobsTest < ActiveJob::TestCase
         HelloJob.perform_later(ricardo)
       end
     end
-
-    assert_equal "No performed job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+    assert_match(/Potential matches: {:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
   end
 
   def test_assert_performed_with_without_block_failure_with_global_id_args
@@ -1836,7 +1837,8 @@ class PerformedJobsTest < ActiveJob::TestCase
       assert_performed_with(job: HelloJob, args: [wilma])
     end
 
-    assert_equal "No performed job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+    assert_match(/Potential matches: {:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
   end
 
   def test_assert_performed_with_does_not_change_jobs_count


### PR DESCRIPTION
Adds logging of potential matches when calling `assert_enqueued_with` and `assert_performed_with` to provide more information on test failures.

### Summary

When testing ActiveJob, it's quite helpful to view the jobs that were performed (or enqueued) when these assertions fail.

Before:
```
# Running:

...........F

Failure:
PerformedJobsTest#test_assert_performed_with_selective_args [/Users/garethduplooy/src/github.com/rails/activejob/test/cases/test_helper_test.rb:1761]:
No performed job found with {:job=>MultipleKwargsJob, :args=>{:argument2=>{:b=>3, :a=>4}, :argument1=>1}}
```

After:
```
# Running:

...........F

Failure:
PerformedJobsTest#test_assert_performed_with_selective_args [/Users/garethduplooy/src/github.com/rails/activejob/test/cases/test_helper_test.rb:1761]:
No performed job found with {:job=>MultipleKwargsJob, :args=>{:argument2=>{:b=>3, :a=>4}, :argument1=>1}}
Potential matches: {:job=>MultipleKwargsJob, :args=>[{:argument2=>{:b=>2, :a=>1}, :argument1=>1}], :queue=>"default"}
```

The added context makes it much easier to determine the source of failure (wrong job, jobs, wrong params, wrong queue, etc).

cc @gmcgibbon @rafaelfranca 