### PR TITLE
Add note about human_attribute_name symbol/string

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Calls to `human_attribute_name` on an `ActiveModel` now pass attributes as strings instead of symbols in some cases.
+    
+    This is in line with examples in Rails docs and puts the code in line with the intention -
+    the potential use of strings or symbols.
+    It is recommended to cast the attribute input to your desired type as it may be a string or symbol
+
 *   Add *_previously_was attribute methods when dirty tracking. Example:
 
         pirate.update(catchphrase: "Ahoy!")


### PR DESCRIPTION
### Summary

This was always the intended API as per discussion in https://github.com/rails/rails/issues/36916, however versions before Rails 6 always passed a symbol. This means that some apps relied on symbols to be passed, this change is intended to note the change in behaviour so that apps can respond in kind.

This is simply a CHANGELOG change.

Thanks for contributing to Rails!
