### PR TITLE
Stop checking schema cache version before loading it

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -128,6 +128,8 @@ module ActiveRecord
 
       mattr_accessor :reading_role, instance_accessor: false, default: :reading
 
+      mattr_accessor :check_schema_cache_dump_version, instance_accessor: false
+
       class_attribute :default_connection_handler, instance_writer: false
 
       self.filter_attributes = []

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -154,6 +154,10 @@ module Rails
           end
         when "6.1"
           load_defaults "6.0"
+
+          if respond_to?(:active_record)
+            active_record.check_schema_cache_dump_version = false
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end


### PR DESCRIPTION
There isn't much value in this check, but it has several downsides.

The only point of it, is to save users from loading a severely outdated
cache, which arguably is a bug in the user deploy and migration process.

On the other side, if the application does implement 0-downtime deployments,
all migrations already need to be fully backward compatible, hence loading
a cache that is a couple migrations behind is much better than invalidating
it which will cause lots of schema queries to be issued.

Another issue is that queries during the boot process are inherently
problematic, because it create a hard dependency on a functional and healthy
database to allow web workers to boot, which in a outage recovery scenario
can makes things much harder.

e.g. you deploy a very slow query that overloads the database, you start
a rollback but the web workers with the sane version crash on boot because
they can't query the schema cache version.

cc @rafaelfranca @Edouard-chin 