### PR TITLE
Add `delete_multi` method to cache

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveSupport::Cache::Store#delete_multi` method to delete multiple keys from the cache store.
+
+    *Peter Zhu*
+
 *   Support multiple arguments in `HashWithIndifferentAccess` for `merge` and `update` methods, to
     follow Ruby 2.6 addition.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -477,6 +477,18 @@ module ActiveSupport
         end
       end
 
+      # Deletes multiple entries in the cache.
+      #
+      # Options are passed to the underlying cache implementation.
+      def delete_multi(names, options = nil)
+        options = merged_options(options)
+        names.map! { |key| normalize_key(key, options) }
+
+        instrument :delete_multi, names do
+          delete_multi_entries(names, options)
+        end
+      end
+
       # Returns +true+ if the cache contains an entry for the given key.
       #
       # Options are passed to the underlying cache implementation.
@@ -601,6 +613,18 @@ module ActiveSupport
         # implement this method.
         def delete_entry(key, options)
           raise NotImplementedError.new
+        end
+
+        # Deletes multiples entries in the cache implementation. Subclasses MAY
+        # implement this method.
+        def delete_multi_entries(entries, options)
+          entries.inject(0) do |sum, key|
+            if delete_entry(key, options)
+              sum + 1
+            else
+              sum
+            end
+          end
         end
 
         # Merges the default options with ones specific to a method call.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -420,6 +420,11 @@ module ActiveSupport
           end
         end
 
+        # Deletes multiple entries in the cache. Returns the number of entries deleted.
+        def delete_multi_entries(entries, options)
+          redis.with { |c| c.del(entries) }
+        end
+
         # Nonstandard store provider API to write multiple values at once.
         def write_multi_entries(entries, expires_in: nil, **options)
           if entries.any?

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -375,6 +375,16 @@ module CacheStoreBehavior
     assert_not @cache.exist?("foo")
   end
 
+  def test_delete_multi
+    @cache.write("foo", "bar")
+    assert @cache.exist?("foo")
+    @cache.write("hello", "world")
+    assert @cache.exist?("foo")
+    assert_equal 2, @cache.delete_multi(["foo", "does_not_exist", "hello"])
+    assert_not @cache.exist?("foo")
+    assert_not @cache.exist?("hello")
+  end
+
   def test_original_store_objects_should_not_be_immutable
     bar = +"bar"
     @cache.write("foo", bar)


### PR DESCRIPTION
### Summary

Adds `ActiveSupport::Cache::Store#delete_multi` to delete an array of keys from the cache.

For most implementations, this just calls `ActiveSupport::Cache::Store#delete` `n` times, but Redis supports [deleting an array of keys](https://redis.io/commands/del). This can improve performance because it turns what is previously `n` delete calls into a single call.

Memcached [does not support multi delete](https://github.com/memcached/memcached/issues/245).