### PR TITLE
Prevent decrypt_and_verify return NoMethodError when message is nil

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -181,6 +181,7 @@ module ActiveSupport
       end
 
       def _decrypt(encrypted_message, purpose)
+        raise InvalidMessage if encrypted_message.nil?
         cipher = new_cipher
         encrypted_data, iv, auth_tag = encrypted_message.split("--").map { |v| ::Base64.strict_decode64(v) }
 

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -95,6 +95,12 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_aead_not_decrypted(encryptor, "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca")
   end
 
+  def test_aead_mode_with_nil
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
+
+    assert_aead_not_decrypted(encryptor, nil)
+  end
+
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")


### PR DESCRIPTION
### Summary

Just a fix follow #36890 for ActiveSupport::MessageEncryptor.

When the message is nil, it should raise `ActiveSupport::MessageVerifier::InvalidMessage` instead `NoMethodError` during decrypting.
