### PR TITLE
Improve MySQL error detection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Improve detection of ActiveRecord::StatementTimeout with mysql2 adapter in the edge case when the query is terminated during filesort.
+
+    *Kir Shatrov*
+
 *   Stop trying to read yaml file fixtures when loading Active Record fixtures.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -574,6 +574,7 @@ module ActiveRecord
 
         # See https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
         ER_DB_CREATE_EXISTS     = 1007
+        ER_FILSORT_ABORT        = 1028
         ER_DUP_ENTRY            = 1062
         ER_NOT_NULL_VIOLATION   = 1048
         ER_NO_REFERENCED_ROW    = 1216
@@ -617,7 +618,7 @@ module ActiveRecord
             Deadlocked.new(message, sql: sql, binds: binds)
           when ER_LOCK_WAIT_TIMEOUT
             LockWaitTimeout.new(message, sql: sql, binds: binds)
-          when ER_QUERY_TIMEOUT
+          when ER_QUERY_TIMEOUT, ER_FILSORT_ABORT
             StatementTimeout.new(message, sql: sql, binds: binds)
           when ER_QUERY_INTERRUPTED
             QueryCanceled.new(message, sql: sql, binds: binds)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -240,6 +240,21 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Base.establish_connection :arunit
   end
 
+  def test_statement_timeout_error_codes
+    raw_conn = @conn.raw_connection
+    assert_raises(ActiveRecord::StatementTimeout) do
+      raw_conn.stub(:query, ->(_sql) { raise Mysql2::Error.new("fail", 50700, ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::ER_FILSORT_ABORT) }) {
+        @conn.execute("SELECT 1")
+      }
+    end
+
+    assert_raises(ActiveRecord::StatementTimeout) do
+      raw_conn.stub(:query, ->(_sql) { raise Mysql2::Error.new("fail", 50700, ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::ER_QUERY_TIMEOUT) }) {
+        @conn.execute("SELECT 1")
+      }
+    end
+  end
+
   private
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)
       super(@conn, "ex", definition, &block)


### PR DESCRIPTION
On a query that failed due a statement timeout, an exception from mysql2 will get raised which ActiveRecord matches to `ActiveRecord::StatementTimeout`, based on `3024` error code from the server (https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L591).

However, thanks to @clandry94 we found an occurrence of `ActiveRecord::StatementInvalid (Mysql2::Error: Sort aborted: Query execution was interrupted, maximum statement execution time exceeded)` where `StatementInvalid` is the basic AR error class, which tells us that the error code was != `3024` so AR didn't match it to `StatementTimeout`. Also, `Sort aborted:` in the exception message looks suspicious.

I looked in MySQL 5.7 [docs](https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html) and I found another error code:

```
Error number: 1028; Symbol: ER_FILSORT_ABORT; SQLSTATE: HY000
Message: Sort aborted
```

It sounds like if the statement was canceled at the stage of filesort, the eror code is going to be `1028`, not `3024`. I'd love a DBA opinion on whether I'm right or not.

If I'm right, I'd like to raise `StatementTimeout` on both `1028` and `3024` server errors.
This PR is missing tests which I'll attempt to add once I verify my hypothesis.

Another option to detect `StatementTimeout` would be to match the error message against `maximum statement execution time exceeded`, but that doesn't seem great.