### PR TITLE
Use "ON" join for foreign_keys method in AbstractMysqlAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -376,7 +376,8 @@ module ActiveRecord
                  rc.delete_rule AS 'on_delete'
           FROM information_schema.referential_constraints rc
           JOIN information_schema.key_column_usage fk
-          USING (constraint_schema, constraint_name)
+          ON fk.constraint_schema = rc.constraint_schema
+            AND fk.constraint_name = rc.constraint_name
           WHERE fk.referenced_column_name IS NOT NULL
             AND fk.table_schema = #{scope[:schema]}
             AND fk.table_name = #{scope[:name]}


### PR DESCRIPTION
### Summary

This fixes the `AbstractMysqlAdapter` `#foreign_keys` method to work with recent (buggy) versions of MariaDB.

I came across this issue while trying to run some old migrations on MariaDB 10.4, and discovered that [there is a bug](https://jira.mariadb.org/browse/MDEV-19990) in recent MariaDB versions (JIRA says 10.3 and 10.4) which apparently affects `information_schema` only, and makes joins with `USING` clauses return no results (empty set).  Switching to an `ON` clause (as per the patch) has fixed things for me.

### Other Information

An alternative would be to wait for this issue to be fixed in MariaDB.
