### PR TITLE
Allow tests to run without a TTY

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -200,6 +200,11 @@ module ActionDispatch
       end
 
       class Expanded < Base
+        def initialize(width: IO.console_size.second)
+          @width = width
+          super()
+        end
+
         def section_title(title)
           @buffer << "\n#{"[ #{title} ]"}"
         end
@@ -222,11 +227,7 @@ module ActionDispatch
           end
 
           def route_header(index:)
-            console_width = IO.console_size.second
-            header_prefix = "--[ Route #{index} ]"
-            dash_remainder = [console_width - header_prefix.size, 0].max
-
-            "#{header_prefix}#{'-' * dash_remainder}"
+            "--[ Route #{index} ]".ljust(@width, "-")
           end
       end
     end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -317,9 +317,6 @@ module ActionDispatch
       end
 
       def test_routes_when_expanded
-        previous_console_winsize = IO.console.winsize
-        IO.console.winsize = [0, 23]
-
         engine = Class.new(Rails::Engine) do
           def self.inspect
             "Blog::Engine"
@@ -329,7 +326,7 @@ module ActionDispatch
           get "/cart", to: "cart#show"
         end
 
-        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
+        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new(width: 23)) do
           get "/custom/assets", to: "custom_assets#show"
           get "/custom/furnitures", to: "custom_furnitures#show"
           mount engine => "/blog", :as => "blog"
@@ -357,8 +354,6 @@ module ActionDispatch
                       "Verb              | GET",
                       "URI               | /cart(.:format)",
                       "Controller#Action | cart#show"], output
-      ensure
-        IO.console.winsize = previous_console_winsize
       end
 
       def test_no_routes_matched_filter_when_expanded

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -188,17 +188,18 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
   end
 
   test "rails routes with expanded option" do
-    previous_console_winsize = IO.console.winsize
-    IO.console.winsize = [0, 27]
-
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
         get '/cart', to: 'cart#show'
       end
     RUBY
 
+    output = IO.stub(:console_size, [0, 27]) do
+      run_routes_command([ "--expanded" ])
+    end
+
     # rubocop:disable Layout/TrailingWhitespace
-    assert_equal <<~MESSAGE, run_routes_command([ "--expanded" ])
+    assert_equal <<~MESSAGE, output
       --[ Route 1 ]--------------
       Prefix            | cart
       Verb              | GET
@@ -301,8 +302,6 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       Controller#Action | active_storage/direct_uploads#create
     MESSAGE
     # rubocop:enable Layout/TrailingWhitespace
-  ensure
-    IO.console.winsize = previous_console_winsize
   end
 
   private


### PR DESCRIPTION
Extracted from #36893

We had two tests which assigned `IO.console.winsize` (to ensure output was consistent), however it's possible for `IO.console` to be nil.

This commit makes these tests stub `IO.console_size` directly (the method we actually call, we shouldn't have been relying on that calling `IO.console.winsize` anyways) or passes the width when initializing the class.

This allows tests to run without a TTY. This can be tested with

    ssh localhost "cd src/rails/actionpack && bundle exec rake"

or

    (setsid bundle exec rake) </dev/null |& cat
