### PR TITLE
Ignore Errno::ENOTEMPTY when calling AS::Cache::FileStore#clear with race conditions

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -36,7 +36,7 @@ module ActiveSupport
       def clear(options = nil)
         root_dirs = (Dir.children(cache_path) - GITKEEP_FILES)
         FileUtils.rm_r(root_dirs.collect { |f| File.join(cache_path, f) })
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT, Errno::ENOTEMPTY
       end
 
       # Preemptively iterates through all stored keys and removes the ones which have expired.


### PR DESCRIPTION
### Summary

Currently `Rails.cache.clear` raises Errno::ENOTEMPTY on highly accessed server.
The error just can be ignored.

### Other Information

#### How to reproduce

```sh
$ rails r 'Rails.cache.clear'
```

#### Stack trace

```
Traceback (most recent call last):
        23: from bin/rails:4:in `<main>'
        22: from bin/rails:4:in `require'
        21: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/commands.rb:18:in `<top (required)>'
        20: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/command.rb:46:in `invoke'
        19: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/command/base.rb:65:in `perform'
        18: from /project root/.bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        17: from /project root/.bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
        16: from /project root/.bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
        15: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/commands/runner/runner_command.rb:41:in `perform'
        14: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/commands/runner/runner_command.rb:41:in `eval'
        13: from /project root/.bundle/ruby/2.5.0/gems/railties-5.2.2.1/lib/rails/commands/runner/runner_command.rb:41:in `<main>'
        12: from /project root/.bundle/ruby/2.5.0/gems/activesupport-5.2.2.1/lib/active_support/cache/strategy/local_cache.rb:96:in `clear'
        11: from /project root/.bundle/ruby/2.5.0/gems/activesupport-5.2.2.1/lib/active_support/cache/file_store.rb:34:in `clear'
        10: from /usr/local/lib/ruby/2.5.0/fileutils.rb:553:in `rm_r'
         9: from /usr/local/lib/ruby/2.5.0/fileutils.rb:553:in `each'
         8: from /usr/local/lib/ruby/2.5.0/fileutils.rb:557:in `block in rm_r'
         7: from /usr/local/lib/ruby/2.5.0/fileutils.rb:689:in `remove_entry'
         6: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1386:in `postorder_traverse'
         5: from /usr/local/lib/ruby/2.5.0/fileutils.rb:691:in `block in remove_entry'
         4: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1329:in `remove'
         3: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1336:in `remove_dir1'
         2: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1348:in `platform_support'
         1: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1337:in `block in remove_dir1'
/usr/local/lib/ruby/2.5.0/fileutils.rb:1337:in `rmdir': Directory not empty @ dir_s_rmdir - /project root/tmp/cache/xxx (Errno::ENOTEMPTY)
```