### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,7 +91,7 @@ Layout/IndentFirstArgument:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:


### PR DESCRIPTION
### Summary

When I try to run rubocop with command `rubocop --require rubocop-rails`
I got this:
```
Error: obsolete `EnforcedStyle: rails` (for Layout/IndentationConsistency) found in .rubocop.yml
`EnforcedStyle: rails` has been renamed to `EnforcedStyle: indented_internal_methods`
```

And after I changed from `EnforcedStyle: rails` to `EnforcedStyle: indented_internal_methods` like the suggestion, it works.