### PR TITLE
[Needs feedback] Fix n+1 issue of ActionText attachments

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -9,16 +9,16 @@ module ActionText
     mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
     mattr_accessor(:scrubber)
 
-    def render_action_text_content(content)
-      sanitize_action_text_content(render_action_text_attachments(content))
+    def render_action_text_content(content, attachment_blobs)
+      sanitize_action_text_content(render_action_text_attachments(content, attachment_blobs))
     end
 
     def sanitize_action_text_content(content)
       sanitizer.sanitize(content.to_html, tags: allowed_tags, attributes: allowed_attributes, scrubber: scrubber).html_safe
     end
 
-    def render_action_text_attachments(content)
-      content.render_attachments do |attachment|
+    def render_action_text_attachments(content, attachment_blobs)
+      content.render_attachments(attachment_blobs) do |attachment|
         unless attachment.in?(content.gallery_attachments)
           attachment.node.tap do |node|
             node.inner_html = render(attachment, in_gallery: false).chomp

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -9,7 +9,7 @@ module ActionText
     self.table_name = "action_text_rich_texts"
 
     serialize :body, ActionText::Content
-    delegate :to_s, :nil?, to: :body
+    delegate :nil?, to: :body
 
     belongs_to :record, polymorphic: true, touch: true
     has_many_attached :embeds
@@ -20,6 +20,16 @@ module ActionText
 
     def to_plain_text
       body&.to_plain_text.to_s
+    end
+
+    def to_s
+      body.to_rendered_html_with_layout(attachment_blobs: embeds_blobs_table)
+    end
+
+    def embeds_blobs_table
+      embeds_blobs.to_a.inject({}) do |table, blob|
+        table[blob.id] = blob
+      end
     end
 
     delegate :blank?, :empty?, :present?, to: :to_plain_text

--- a/actiontext/app/views/action_text/content/_layout.html.erb
+++ b/actiontext/app/views/action_text/content/_layout.html.erb
@@ -1,3 +1,3 @@
 <div class="trix-content">
-  <%= render_action_text_content(content) %>
+  <%= render_action_text_content(content, attachment_blobs) %>
 </div>

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -15,8 +15,8 @@ module ActionText
         fragment_by_minifying_attachments(fragment_by_converting_trix_attachments(content))
       end
 
-      def from_node(node, attachable = nil)
-        new(node, attachable || ActionText::Attachable.from_node(node))
+      def from_node(node, attachment_blobs = {}, attachable = nil)
+        new(node, attachable || ActionText::Attachable.from_node(node, attachment_blobs))
       end
 
       def from_attachables(attachables)
@@ -31,7 +31,7 @@ module ActionText
 
       def from_attributes(attributes, attachable = nil)
         if node = node_from_attributes(attributes)
-          from_node(node, attachable)
+          from_node(node, {}, attachable)
         end
       end
 

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -38,7 +38,7 @@ module ActionText
           class_name: "ActionText::RichText", as: :record, inverse_of: :record, autosave: true, dependent: :destroy
 
         scope :"with_rich_text_#{name}", -> { includes("rich_text_#{name}") }
-        scope :"with_rich_text_#{name}_and_embeds", -> { includes("rich_text_#{name}": { embeds_attachments: :blob }) }
+        scope :"with_rich_text_#{name}_and_embeds", -> { includes("rich_text_#{name}": :embeds_blobs) }
       end
     end
   end

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -84,4 +84,36 @@ class ActionText::ModelTest < ActiveSupport::TestCase
       assert_kind_of ActionText::RichText, message.content
     end
   end
+
+  test "loading content with attachments" do
+    5.times do |i|
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+      Message.create!(subject: "Greetings #{i}", content: ActionText::Content.new("Hello world").append_attachables(blob))
+    end
+
+    messages = Message.with_rich_text_content_and_embeds
+
+    assert_queries(4) do
+      messages.each do |message|
+        message.content.to_s
+      end
+    end
+  end
+
+  def assert_queries(num)
+    ActiveRecord::Base.connection.materialize_transactions
+    count = 0
+    sqls = []
+
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      unless ["SCHEMA", "TRANSACTION"].include? payload[:name]
+        sqls << payload[:sql]
+        count += 1
+      end
+    end
+
+    result = yield
+    assert_equal num, count, "#{count} instead of #{num} queries were executed.\n#{sqls.join("\n")}"
+    result
+  end
 end


### PR DESCRIPTION
## Summary

**(The current state of this PR is to demonstrate my idea of the solution. So I hope I can get some feedback about the design.)**

This PR is for https://github.com/rails/rails/issues/36177. The issue is that eager loading helpers for ActionText contents doesn't work as expected. Users still get n+1 queries after using helper scope like

```ruby
Message.with_rich_text_content_and_embeds
```

The root cause of this issue is that we use globalid to query attachment blobs, which means it can't gain any benefit from preloaded data.

(See more detailed explanation [here](https://github.com/rails/rails/issues/36177#issuecomment-517941714))

So my solution is to preload those blobs and store them into a table. And before using globalid locator to do the search, we perform a` lookup in the table first. If it's found (which should be most of the cases) then we just return the records. Otherwise, we perform the search via globalid locator.