### PR TITLE
Fix new default value for return_only_media_type_on_content_type

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -17,7 +17,7 @@
 # Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = true
+# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
 # Return false instead of self when enqueuing is aborted from a callback.
 # Rails.application.config.active_job.return_false_on_aborted_enqueue = true


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/36490.

Uncommenting this line should opt applications in to the new behaviour; in this case, `false` is the value needed to do that. This is the value set when `config.load_defaults 6.0` is called:

https://github.com/rails/rails/blob/5a4305f0ec24c638aef582654ece476e0be62658/railties/lib/rails/application/configuration.rb#L133