### PR TITLE
Fix rendering ActionText attachments

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -21,13 +21,13 @@ module ActionText
       content.render_attachments do |attachment|
         unless attachment.in?(content.gallery_attachments)
           attachment.node.tap do |node|
-            node.inner_html = render(attachment, in_gallery: false).chomp
+            node.inner_html = render(attachment, in_gallery: false).body.chomp
           end
         end
       end.render_attachment_galleries do |attachment_gallery|
         render(layout: attachment_gallery, object: attachment_gallery) do
           attachment_gallery.attachments.map do |attachment|
-            attachment.node.inner_html = render(attachment, in_gallery: true).chomp
+            attachment.node.inner_html = render(attachment, in_gallery: true).body.chomp
             attachment.to_html
           end.join("").html_safe
         end.chomp


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
`render` returns a `ActionView::AbstractRenderer::RenderedTemplate`, whose rendered content is in the `body` attribute as a string.

Without this fix, rendering this view will cause an undefined method `chomp` for
`ActionView::AbstractRenderer::RenderedTemplate` exception.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
This should be backported to Rails 6.0.0