### PR TITLE
Remove lonely alignment whitespace from Puma config

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -10,7 +10,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
### Summary

Removes parameter alignment whitespace from `puma.rb` that is only present on a single line. It's arguably more visually distracting than unaligned because nothing else in the file uses additional whitespace for aligning parameters.