### PR TITLE
Make prepared statement status thread and instance-specific

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -39,8 +39,8 @@ module ActiveRecord
       include MySQL::DatabaseStatements
 
       def initialize(connection, logger, connection_options, config)
-        super
-        @prepared_statements = false unless config.key?(:prepared_statements)
+        superclass_config = config.reverse_merge(prepared_statements: false)
+        super(connection, logger, connection_options, superclass_config)
         configure_connection
       end
 

--- a/activerecord/test/cases/prepared_statement_status_test.rb
+++ b/activerecord/test/cases/prepared_statement_status_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/course"
+require "models/entrant"
+
+module ActiveRecord
+  class PreparedStatementStatusTest < ActiveRecord::TestCase
+    def test_prepared_statement_status_is_thread_and_instance_specific
+      course_conn = Course.connection
+      entrant_conn = Entrant.connection
+
+      inside = Concurrent::Event.new
+      preventing = Concurrent::Event.new
+      finished = Concurrent::Event.new
+
+      assert_not_same course_conn, entrant_conn
+
+      if current_adapter?(:Mysql2Adapter)
+        # The mysql adapter does not use prepared
+        # statements by default.
+        assert_not course_conn.prepared_statements
+        assert_not entrant_conn.prepared_statements
+      else
+        t1 = Thread.new do
+          course_conn.unprepared_statement do
+            inside.set
+            preventing.wait
+            assert_not course_conn.prepared_statements
+            assert entrant_conn.prepared_statements
+            finished.set
+          end
+        end
+
+        t2 = Thread.new do
+          entrant_conn.unprepared_statement do
+            inside.wait
+            assert course_conn.prepared_statements
+            assert_not entrant_conn.prepared_statements
+            preventing.set
+            finished.wait
+          end
+        end
+
+        t1.join
+        t2.join
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes a race condition in system tests where prepared
statements can be incorrectly parameterized when multiple
threads observe the mutation of the @prepared_statements
instance variable on the connection.

Fixes #36763 
