### PR TITLE
Update mini_magick to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
-    mini_magick (4.9.2)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)


### PR DESCRIPTION
Squashes 7 warnings tickled by ActiveStorage test task.

Before:

```
~/code/rails/activestorage$ bundle exec rake test 2>&1 | grep
mini_magick

/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:122:
warning: method redefined; discarding old processor
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:128:
warning: method redefined; discarding old processor=
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:138:
warning: method redefined; discarding old cli
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:139:
warning: instance variable @cli not initialized
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:143:
warning: method redefined; discarding old cli=
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:153:
warning: method redefined; discarding old cli_path
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:154:
warning: instance variable @cli_path not initialized
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:154:
warning: instance variable @processor_path not initialized
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.2/lib/mini_magick/configuration.rb:157:
warning: method redefined; discarding old debug=
```

After:

```
~/code/rails/activestorage$ bundle exec rake test 2>&1 | grep
mini_magick

/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.5/lib/mini_magick/configuration.rb:142:
warning: method redefined; discarding old cli
/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/mini_magick-4.9.5/lib/mini_magick/configuration.rb:157:
warning: method redefined; discarding old cli=
```

