### PR TITLE
Upgrade sass-rails to 6 version

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -306,7 +306,7 @@ module Rails
       def assets_gemfile_entry
         return [] if options[:skip_sprockets]
 
-        GemfileEntry.version("sass-rails", ">= 5", "Use SCSS for stylesheets")
+        GemfileEntry.version("sass-rails", "~> 6", "Use SCSS for stylesheets")
       end
 
       def webpacker_gemfile_entry


### PR DESCRIPTION
### Summary

Upgrade sass-rails to 6 version for Rails 6
