### PR TITLE
Fix: ActiveModel::Errors#added? doesn't work for the errors with 'options' hash containing 'value' key

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -145,7 +145,7 @@ module ActiveModel
     def strict_match?(attribute, type, **options)
       return false unless match?(attribute, type)
 
-      options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
+      options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS + [:value])
     end
 
     def ==(other)

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -75,6 +75,14 @@ class ErrorTest < ActiveModel::TestCase
     assert subject.match?(:mineral, :not_enough, count: 2)
   end
 
+  # strict_match?
+
+  test "strict_match? with type as a symbol" do
+    subject = ActiveModel::Error.new(Person.new, :name, :too_long, value: 'unimaginably_long_value')
+    assert_not subject.strict_match?(:name, :blank)
+    assert subject.strict_match?(:name, :too_long)
+  end
+
   # message
 
   test "message with type as a symbol" do

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -78,7 +78,7 @@ class ErrorTest < ActiveModel::TestCase
   # strict_match?
 
   test "strict_match? with type as a symbol" do
-    subject = ActiveModel::Error.new(Person.new, :name, :too_long, value: 'unimaginably_long_value')
+    subject = ActiveModel::Error.new(Person.new, :name, :too_long, value: "unimaginably_long_value")
     assert_not subject.strict_match?(:name, :blank)
     assert subject.strict_match?(:name, :too_long)
   end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -10,7 +10,7 @@ class ErrorsTest < ActiveModel::TestCase
       @errors = ActiveModel::Errors.new(self)
     end
 
-    attr_accessor :name, :age, :gender, :city
+    attr_accessor :id, :name, :age, :gender, :city
     attr_reader   :errors
 
     def validate!
@@ -379,6 +379,13 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, :wrong)
     assert_not person.errors.added?(:name, :used)
     assert person.errors.added?(:name, :wrong)
+  end
+
+  test "added? returns true with symbol error type and value option" do
+    person = Person.new
+    person.errors.add(:id, :too_long, value: 'unimaginably long id')
+
+    assert person.errors.added?(:id, :too_long)
   end
 
   test "of_kind? returns false when checking for an error, but not providing message argument" do

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -383,7 +383,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   test "added? returns true with symbol error type and value option" do
     person = Person.new
-    person.errors.add(:id, :too_long, value: 'unimaginably long id')
+    person.errors.add(:id, :too_long, value: "unimaginably long id")
 
     assert person.errors.added?(:id, :too_long)
   end


### PR DESCRIPTION

### Summary

Currently, the `ActiveModel::Errors#added?` method relies on `ActiveModel::Error#strict_match?` which strictly matches against the `value` option.

This PR ignores the `value` option in `ActiveModel::Error#strict_match?` while comparing the provided options hash with the own options hash which contains the `value` option.

Fixes: https://github.com/rails/rails/issues/36573