### PR TITLE
constant Gem::RubyGemsVersion is deprecated

### DIFF
--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -68,7 +68,7 @@ module Rails
 
     # The RubyGems version, if it's installed.
     property "RubyGems version" do
-      Gem::RubyGemsVersion
+      Gem::VERSION
     end
 
     property "Rack version" do


### PR DESCRIPTION
As of ruby/ruby@c4f7c260f995778a40c6fc15107090fdb51d49a8.

```
~/code/rails$ ruby -v
ruby 2.7.0dev (2019-08-17T03:32:34Z master dc020b06ff) [x86_64-linux]

/home/u/.rbenv/versions/2.7.0-dev/bin/ruby -w -Itest -Ilib
-I../activesupport/lib -I../actionpack/lib -I../actionview/lib
-I../activemodel/lib test/rails_info_controller_test.rb
/home/u/code/rails/railties/lib/rails/info.rb:71: warning: constant
Gem::RubyGemsVersion is deprecated

/home/u/.rbenv/versions/2.7.0-dev/bin/ruby -w -Itest -Ilib
-I../activesupport/lib -I../actionpack/lib -I../actionview/lib
-I../activemodel/lib test/rails_info_test.rb
/home/u/code/rails/railties/lib/rails/info.rb:71: warning: constant
Gem::RubyGemsVersion is deprecated

/home/u/.rbenv/versions/2.7.0-dev/bin/ruby -w -Itest -Ilib
-I../activesupport/lib -I../actionpack/lib -I../actionview/lib
-I../activemodel/lib test/application/routing_test.rb
Run options: --seed 26063

....../home/u/code/rails/railties/lib/rails/info.rb:71: warning:
constant Gem::RubyGemsVersion is deprecated
.................../home/u/code/rails/railties/lib/rails/info.rb:71:
warning: constant Gem::RubyGemsVersion is deprecated
.

```