### PR TITLE
Don’t duplicate non-supported execution hints in subquery

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -408,6 +408,10 @@ module ActiveRecord
         false
       end
 
+      def optimizer_hint_allowed_in_subquery?(hint)
+        false
+      end
+
       def supports_lazy_transactions?
         false
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -109,6 +109,10 @@ module ActiveRecord
         !mariadb? && database_version >= "5.7.7"
       end
 
+      def optimizer_hint_allowed_in_subquery?(hint)
+        !hint.include?("MAX_EXECUTION_TIME")
+      end
+
       def supports_advisory_locks?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -362,6 +362,10 @@ module ActiveRecord
         @has_pg_hint_plan
       end
 
+      def optimizer_hint_allowed_in_subquery?(hint)
+        true
+      end
+
       def supports_lazy_transactions?
         true
       end

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -12,6 +12,10 @@ module ActiveRecord
           value = value.select(value.arel_attribute(value.klass.primary_key))
         end
 
+        value.optimizer_hints_values = value.optimizer_hints_values.select do |hint|
+          value.connection.optimizer_hint_allowed_in_subquery?(hint)
+        end
+
         attribute.in(value.arel)
       end
     end


### PR DESCRIPTION
Current behaviour of AR and optimizer hints allows hints in the subquery:

```ruby
posts = Post.optimizer_hints("MAX_EXECUTION_TIME(1000)")
subposts = posts.where("id > 999")
posts.where(id: subposts).load
```

The snippet above will produce the following query:

```
SELECT /*+ MAX_EXECUTION_TIME(20) */ `shops`.* FROM `shops` WHERE `shops`.`id` IN (SELECT /*+ MAX_EXECUTION_TIME(20) */ `posts`.`shop_id` FROM `posts` WHERE (id > 1))
```

You can notice two `/*+ MAX_EXECUTION_TIME(20) */`: in the top query and in the sub query.

In [strict mode](https://github.com/Shopify/activerecord-pedantmysql2-adapter), MySQL would consider this query bad and respond with a warning:

```
MAX_EXECUTION_TIME hint is supported by top-level
```

This warning makes sense to me, since there's little point in specifying more than one MAX_EXECUTION_TIME hint per query.

So far the workaround is to `.unscope(:optimizer_hints)` on the subquery. However, on a Shopify-size codebase that ends up quote a lot of unscopes.

Since it's something specific to MySQL, I've implemented it as an adapter check that removed this specific hint from subqueries.

@rafaelfranca this is an edge case that we talked about couple weeks ago.