### PR TITLE
Adopt mini-css-extract-plugin chunking on production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -10,9 +10,11 @@
     <%- else -%>
       <%- unless options[:skip_turbolinks] -%>
     <%%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
       <%- else -%>
     <%%= stylesheet_link_tag 'application', media: 'all' %>
+    <%%= stylesheet_pack_tag 'application', media: 'all' %>
     <%%= javascript_pack_tag 'application' %>
       <%- end -%>
     <%- end -%>


### PR DESCRIPTION
### Summary

As @rails/webpacker takes `MiniCssExtractPlugin` as default css-loaders on production, there is a need to add

 ```erb 
 <!-- app/views/layouts/application.html.erb -->
<html>
  <head>
  ...

  <%= stylesheet_pack_tag 'application', media: 'all' %> 
  # follows 
  <%= javascript_pack_tag 'application', media: 'all' %>
  </head>
```

So that CSS imported to the default entry could be extracted and loaded to work on production normally without modifying the main layout.

### Other Information

This is to help new developers who are not familiar with webpack. They can be confused by the zero-configuration of [@rails/webpacker](https://github.com/rails/webpacker). The CSS loader mechanism of [style-loader](https://github.com/webpack-contrib/style-loader) to support HMR in development and the [MiniCssExtractPlugin](https://github.com/webpack-contrib/mini-css-extract-plugin) then it will cost them some hours for investigating why their CSS cannot be served on production.

For developers using server rendering, they have in-depth knowledge and know where to modify/replace the boilerplate code.

