### PR TITLE
Fix minor typo in rails/engine docs

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -229,7 +229,7 @@ module Rails
   #     resources :articles
   #   end
   #
-  # If +MyEngine+ is isolated, The routes above will point to
+  # If +MyEngine+ is isolated, the routes above will point to
   # <tt>MyEngine::ArticlesController</tt>. You also don't need to use longer
   # URL helpers like +my_engine_articles_path+. Instead, you should simply use
   # +articles_path+, like you would do with your main application.


### PR DESCRIPTION
### Summary

Change a `T` to a `t`.

### Other Information

I was reading through https://api.rubyonrails.org/v5.1/classes/Rails/Engine.html and saw this typo. I hope this is all that's needed to fix it :)