### PR TITLE
Avoid unnecessary query on empty *_ids assignment

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -57,11 +57,16 @@ module ActiveRecord
         primary_key = reflection.association_primary_key
         pk_type = klass.type_for_attribute(primary_key)
         ids = Array(ids).compact_blank
-        ids.map! { |i| pk_type.cast(i) }
 
-        records = klass.where(primary_key => ids).index_by do |r|
-          r.public_send(primary_key)
-        end.values_at(*ids).compact
+        records = if ids.empty?
+          ids
+        else
+          ids.map! { |i| pk_type.cast(i) }
+
+          klass.where(primary_key => ids).index_by do |r|
+            r.public_send(primary_key)
+          end.values_at(*ids).compact
+        end
 
         if records.size != ids.size
           found_ids = records.map { |record| record.public_send(primary_key) }

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -101,6 +101,14 @@ class HasManyAssociationsTestPrimaryKeys < ActiveRecord::TestCase
     assert_equal ["Remote Work"], david.essays.map(&:name)
   end
 
+  def test_empty_ids_assignment_should_not_try_to_fetch_records
+    susan = people(:susan)
+
+    assert_queries 1 do
+      susan.essay_ids = []
+    end
+  end
+
   def test_blank_custom_primary_key_on_new_record_should_not_run_queries
     author = Author.new
     assert_not_predicate author.essays, :loaded?


### PR DESCRIPTION
### Summary

Assigning an empty or blank array using associations helper `<association>_ids=` results in an unnecessary query to retrieve the "non-existing" records. This patch removes the query.

### Example

Running the following code

```ruby
class Person < ActiveRecord::Base
  has_many :essays, primary_key: "first_name", foreign_key: "writer_id"
end

susan = Person.first
susan.essay_ids = []
```

gives the following results:

```
Before:
  SELECT `essays`.* FROM `essays` WHERE 1=0
  SELECT `essays`.* FROM `essays` WHERE `essays`.`writer_id` = 'Susan'

After:
  SELECT `essays`.* FROM `essays` WHERE `essays`.`writer_id` = 'Susan'
```