### PR TITLE
Prevent TagBuilder modify options

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -88,7 +88,7 @@ module ActionView
           if value.is_a?(Array)
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
-            value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s.dup
+            value = escape ? ERB::Util.unwrapped_html_escape(value).dup : value.to_s.dup
           end
           value.gsub!('"', "&quot;")
           %(#{key}="#{value}")

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -79,6 +79,13 @@ class TagHelperTest < ActionView::TestCase
       tag.p(disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true)
   end
 
+  def test_tag_builder_do_not_modify_html_safe_options
+    html_safe_str = '"'.html_safe
+    assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
+    assert_equal '"', html_safe_str
+    assert html_safe_str.html_safe?
+  end
+
   def test_content_tag
     assert_equal "<a href=\"create\">Create</a>", content_tag("a", "Create", "href" => "create")
     assert_predicate content_tag("a", "Create", "href" => "create"), :html_safe?


### PR DESCRIPTION
### Summary

TagBuilder modify option string and make it html unsafe when it is html safe.
This patch fix this.

