### PR TITLE
activesupport: Memoize name object allocation in CurrentAttributes.instance

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -91,7 +91,7 @@ module ActiveSupport
     class << self
       # Returns singleton instance for this class in this thread. If none exists, one is created.
       def instance
-        current_instances[name] ||= new
+        current_instances[current_instances_key] ||= new
       end
 
       # Declares one or more attributes that will be given both class and instance accessor methods.
@@ -148,6 +148,10 @@ module ActiveSupport
 
         def current_instances
           Thread.current[:current_attributes_instances] ||= {}
+        end
+
+        def current_instances_key
+          @current_instances_key ||= name.to_sym
         end
 
         def method_missing(name, *args, &block)


### PR DESCRIPTION
### Summary

This is purely a performance optimization.

## Problem

I was looking at a stackprof object allocation profile and noticed allocations from CurrentAttributes.instance's call to `name`.  Class#name allocates a new name string each time it is called, which is an unnecessary object allocation I would like to avoid.

The following script counts the object allocation

```ruby
require 'stackprof'
require 'active_support/all'

class Current < ActiveSupport::CurrentAttributes
end

Current.instance # memoize
p StackProf.run(mode: :object) { Current.instance }[:samples]
```

which returned `1` before this change.

## Solution

I simply memoized the `current_instances` key to get rid of the object allocation and turned it into a symbol to make the hash lookup more efficient.