### PR TITLE
Adds more inflection words to pluralize and singularize correctly

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -63,10 +63,12 @@ module ActiveSupport
     inflect.irregular("person", "people")
     inflect.irregular("man", "men")
     inflect.irregular("child", "children")
+    inflect.irregular("tooth", "teeth")
+    inflect.irregular("goose", "geese")
     inflect.irregular("sex", "sexes")
     inflect.irregular("move", "moves")
     inflect.irregular("zombie", "zombies")
 
-    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
+    inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police moose))
   end
 end


### PR DESCRIPTION
### Summary

```ruby
[1] pry(main)> 'goose'.pluralize
=> "gooses" # should be geese
[2] pry(main)> 'moose'.pluralize
=> "mooses" # should be moose
[3] pry(main)> 'tooth'.pluralize
=> "tooths" # should be teeth
```

### Other Information

This will pluralize and singularize these words correctly.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->