### PR TITLE
added info about config.hosts error on migration to 6.0

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -170,6 +170,38 @@ resp.content_type #=> "text/csv; header=present; charset=utf-16"
 resp.media_type   #=> "text/csv"
 ```
 
+### [ActionDispatch::HostAuthorization](https://api.rubyonrails.org/v6.0/classes/ActionDispatch/HostAuthorization.html) needs config.hosts if not using `0.0.0.0`, `::`, or `localhost`
+
+If you’re upgrading to Rails 6 you may find the following error in your browser: `Blocked host`
+
+To allow requests to hostname, add the following to your environment configuration:
+
+`config.hosts << "hostname"`
+
+You ran into Host Authorization, new middleware included in Rails to prevent against DNS rebinding attacks.
+
+By default this feature allows requests from `0.0.0.0`, `::`, and `localhost`. 
+
+##There are basically two ways to work around this.
+
+The first option is to whitelist the development hostname in `config/environments/development.rb`.
+
+`Rails.application.configure do
+  #Whitelist one hostname
+  config.hosts << "hostname"
+  #Whitelist a test domain
+  config.hosts << /application\.local\Z/
+ end`
+
+The second option is to clear the entire whitelist, which lets through requests for all hostnames.
+
+`Rails.application.configure do
+  config.hosts.clear
+end`
+
+Never whitelist everything in production as it essentially turns off the feature.
+
+
 ### Autoloading
 
 The default configuration for Rails 6

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -182,7 +182,7 @@ You ran into Host Authorization, new middleware included in Rails to prevent aga
 
 By default this feature allows requests from `0.0.0.0`, `::`, and `localhost`. 
 
-##There are basically two ways to work around this.
+#### There are basically two ways to work around this.
 
 The first option is to whitelist the development hostname in `config/environments/development.rb`.
 


### PR DESCRIPTION
### Summary

in reply to this missing information on a migration to 6.0 here: https://github.com/rails/rails/issues/36959 about needing to specify a config.hosts file if its outside of the local development environment and giving a "blocked host" error if you do not.

to resolve this, I added a blurb on how to accomplish this, on second commit I changed some verbiage and formatting to make it work for documentation along with adding a backlink to the rails api about `ActionDispatch::HostAuthorization`

