### PR TITLE
Support extra stuff in the Content-Type header via Mime registration

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -82,7 +82,7 @@ module ActionDispatch # :nodoc:
     SET_COOKIE   = "Set-Cookie"
     LOCATION     = "Location"
     NO_CONTENT_CODES = [100, 101, 102, 204, 205, 304]
-    CONTENT_TYPE_PARSER = /\A(?<type>[^;\s]+)?(?:.*;\s*charset=(?<quote>"?)(?<charset>[^;\s]+)\k<quote>)?/ # :nodoc:
+    CONTENT_TYPE_PARSER = /\A(?<type>[^;\s]+)?\s*(?:;\s*(?<extra>.+))?(?:;\s*charset=(?<quote>"?)(?<charset>[^;\s]+)\k<quote>)/ # :nodoc:
 
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers
@@ -419,14 +419,14 @@ module ActionDispatch # :nodoc:
     end
 
   private
-    ContentTypeHeader = Struct.new :mime_type, :charset
-    NullContentTypeHeader = ContentTypeHeader.new nil, nil
+    ContentTypeHeader = Struct.new :mime_type, :extra, :charset
+    NullContentTypeHeader = ContentTypeHeader.new nil, nil, nil
 
     def parse_content_type(content_type)
       if content_type && match = CONTENT_TYPE_PARSER.match(content_type)
-        ContentTypeHeader.new(match[:type], match[:charset])
+        ContentTypeHeader.new(match[:type], match[:extra], match[:charset])
       else
-        NullContentTypeHeader
+        ContentTypeHeader.new(content_type, nil)
       end
     end
 

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -13,6 +13,12 @@ class RespondToController < ActionController::Base
     end
   }
 
+  def my_html_fragment
+    respond_to do |type|
+      type.html_fragment { render body: "neat" }
+    end
+  end
+
   def html_xml_or_rss
     respond_to do |type|
       type.html { render body: "HTML"    }
@@ -321,6 +327,7 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.register_alias("text/html", :iphone)
     Mime::Type.register("text/x-mobile", :mobile)
     Mime::Type.register("application/fancy-xml", :fancy_xml)
+    Mime::Type.register("text/html; fragment", :html_fragment)
   end
 
   def teardown
@@ -328,6 +335,14 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.unregister(:iphone)
     Mime::Type.unregister(:mobile)
     Mime::Type.unregister(:fancy_xml)
+    Mime::Type.unregister(:html_fragment)
+  end
+
+  def test_html_fragment
+    @request.accept = "text/html; fragment"
+    get :my_html_fragment
+    assert_equal "text/html; fragment; charset=utf-8", @response.headers["Content-Type"]
+    assert_equal "neat", @response.body
   end
 
   def test_html


### PR DESCRIPTION
I'm not sure a better way to describe this, but we need to set extra
stuff in the Content-Type header and we're doing it via Mime
registration so that we can have the "html_fragment" method on the
respond_to type.  This worked in Rails 5.2, but it's broken in 6.0

In the future, I think we should probably give `register` a block that
takes the response object so we can do more interesting and complex
stuff without doing weird string manipulation.  But this patch fixes the
issue we have today.

Fixes #36993