### PR TITLE
Update .yardopts to document *.rb files in [GEM]/app

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --exclude /templates/
 --quiet
 act*/lib/**/*.rb
+act*/app/**/*.rb
 railties/lib/**/*.rb


### PR DESCRIPTION
Fixes #36321

Enables missing documentation for:
- `actionmailbox/app/controllers/{.,**}/*.rb`
- `actionmailbox/app/jobs/{.,**}/*.rb`
- `actionmailbox/app/models/{.,**}/*.rb`
- `actiontext/app/models/{.,**}/*.rb`
- `activestorage/app/controllers/{.,**}/*.rb`
- `activestorage/app/jobs/{.,**}/*.rb`
- `activestorage/app/models/{.,**}/*.rb`

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
