### PR TITLE
Ensure connection reaper threads respawn in forks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -316,14 +316,15 @@ module ActiveRecord
 
         @mutex = Mutex.new
         @pools = {}
+        @threads = {}
 
         class << self
           def register_pool(pool, frequency) # :nodoc:
             @mutex.synchronize do
-              unless @pools.key?(frequency)
-                @pools[frequency] = []
-                spawn_thread(frequency)
+              unless @threads[frequency]&.alive?
+                @threads[frequency] = spawn_thread(frequency)
               end
+              @pools[frequency] ||= []
               @pools[frequency] << WeakRef.new(pool)
             end
           end
@@ -332,7 +333,7 @@ module ActiveRecord
             def spawn_thread(frequency)
               Thread.new(frequency) do |t|
                 running = true
-                while running do
+                while running
                   sleep t
                   @mutex.synchronize do
                     @pools[frequency].select!(&:weakref_alive?)
@@ -344,6 +345,7 @@ module ActiveRecord
 
                     if @pools[frequency].empty?
                       @pools.delete(frequency)
+                      @threads.delete(frequency)
                       running = false
                     end
                   end


### PR DESCRIPTION
Adapted from #36979

This ensures that the connection pool reaper is respawned in forked processes. This is done by tracking the threads and verifying that they are alive.

This includes a previously failing test case that checks that connections are reaped within a fork.

cc @tgxworld @tenderlove @eileencodes 