### PR TITLE
Fix error on reap/flush for closed connection pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -648,6 +648,7 @@ module ActiveRecord
       # or a thread dies unexpectedly.
       def reap
         stale_connections = synchronize do
+          return unless @connections
           @connections.select do |conn|
             conn.in_use? && !conn.owner.alive?
           end.each do |conn|
@@ -672,6 +673,7 @@ module ActiveRecord
         return if minimum_idle.nil?
 
         idle_connections = synchronize do
+          return unless @connections
           @connections.select do |conn|
             !conn.in_use? && conn.seconds_idle >= minimum_idle
           end.each do |conn|


### PR DESCRIPTION
Fixes issue described in https://github.com/rails/rails/pull/36998#issuecomment-523141926 where calling reap/flush on a closed connection pool errors.

~I'm still working on a test~ Now with a test!

cc @tgxworld