### PR TITLE
Allow using comparison operators on `Arel` `NodeExpression` objects and `Attribute` objects.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow using `:<`, `:>`, `:<=`, and `:>=` operators on `Arel` `NodeExpression` objects and `Attribute` objects.
+
+    *Kevin Deisz*
+
 *   Allow bulk `ALTER` statements to drop and recreate indexes with the same name.
 
     *Eugene Kenny*

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -167,6 +167,7 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
     def gteq(right)
       Nodes::GreaterThanOrEqual.new self, quoted_node(right)
     end
+    alias >= gteq
 
     def gteq_any(others)
       grouping_any :gteq, others
@@ -179,6 +180,7 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
     def gt(right)
       Nodes::GreaterThan.new self, quoted_node(right)
     end
+    alias > gt
 
     def gt_any(others)
       grouping_any :gt, others
@@ -191,6 +193,7 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
     def lt(right)
       Nodes::LessThan.new self, quoted_node(right)
     end
+    alias < lt
 
     def lt_any(others)
       grouping_any :lt, others
@@ -203,6 +206,7 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
     def lteq(right)
       Nodes::LessThanOrEqual.new self, quoted_node(right)
     end
+    alias <= lteq
 
     def lteq_any(others)
       grouping_any :lteq, others

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -69,6 +69,11 @@ module Arel
           relation[:id].gt(10).must_be_kind_of Nodes::GreaterThan
         end
 
+        it "should alias the > operator" do
+          relation = Table.new(:users)
+          (relation[:id] > 10).must_be_kind_of Nodes::GreaterThan
+        end
+
         it "should generate > in sql" do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]
@@ -139,6 +144,11 @@ module Arel
           relation[:id].gteq(10).must_be_kind_of Nodes::GreaterThanOrEqual
         end
 
+        it "should alias the >= operator" do
+          relation = Table.new(:users)
+          (relation[:id] >= 10).must_be_kind_of Nodes::GreaterThanOrEqual
+        end
+
         it "should generate >= in sql" do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]
@@ -198,6 +208,11 @@ module Arel
           relation[:id].lt(10).must_be_kind_of Nodes::LessThan
         end
 
+        it "should alias the < operator" do
+          relation = Table.new(:users)
+          (relation[:id] < 10).must_be_kind_of Nodes::LessThan
+        end
+
         it "should generate < in sql" do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]
@@ -255,6 +270,11 @@ module Arel
         it "should create a LessThanOrEqual node" do
           relation = Table.new(:users)
           relation[:id].lteq(10).must_be_kind_of Nodes::LessThanOrEqual
+        end
+
+        it "should alias the <= operator" do
+          relation = Table.new(:users)
+          (relation[:id] <= 10).must_be_kind_of Nodes::LessThanOrEqual
         end
 
         it "should generate <= in sql" do


### PR DESCRIPTION
We already have methods for all the basic arithmetic operators as well as bitwise operators, so I was surprised to find it didn't have comparison operators.