### PR TITLE
 Fix `ConnectionPool::Reaper` reaping parent connection pool after fork.

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -204,6 +204,62 @@ module ActiveRecord
         assert_equal([@pool], @handler.connection_pools)
       end
 
+      def test_a_class_using_custom_pool_and_switching_back_to_primary
+        klass2 = Class.new(Base) { def self.name; "klass2"; end }
+
+        assert_same klass2.connection, ActiveRecord::Base.connection
+
+        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.spec.config)
+        assert_same klass2.connection, pool.connection
+        assert_not_same klass2.connection, ActiveRecord::Base.connection
+
+        klass2.remove_connection
+
+        assert_same klass2.connection, ActiveRecord::Base.connection
+      end
+
+      class ApplicationRecord < ActiveRecord::Base
+        self.abstract_class = true
+      end
+
+      class MyClass < ApplicationRecord
+      end
+
+      def test_connection_specification_name_should_fallback_to_parent
+        Object.send :const_set, :ApplicationRecord, ApplicationRecord
+
+        klassA = Class.new(Base)
+        klassB = Class.new(klassA)
+        klassC = Class.new(MyClass)
+
+        assert_equal klassB.connection_specification_name, klassA.connection_specification_name
+        assert_equal klassC.connection_specification_name, klassA.connection_specification_name
+
+        assert_equal "primary", klassA.connection_specification_name
+        assert_equal "primary", klassC.connection_specification_name
+
+        klassA.connection_specification_name = "readonly"
+        assert_equal "readonly", klassB.connection_specification_name
+
+        ActiveRecord::Base.connection_specification_name = "readonly"
+        assert_equal "readonly", klassC.connection_specification_name
+      ensure
+        Object.send :remove_const, :ApplicationRecord
+        ActiveRecord::Base.connection_specification_name = "primary"
+      end
+
+      def test_remove_connection_should_not_remove_parent
+        klass2 = Class.new(Base) { def self.name; "klass2"; end }
+        klass2.remove_connection
+        assert_not_nil ActiveRecord::Base.connection
+        assert_same klass2.connection, ActiveRecord::Base.connection
+      end
+
+      def test_default_handlers_are_writing_and_reading
+        assert_equal :writing, ActiveRecord::Base.writing_role
+        assert_equal :reading, ActiveRecord::Base.reading_role
+      end
+
       if Process.respond_to?(:fork)
         def test_connection_pool_per_pid
           object_id = ActiveRecord::Base.connection.object_id
@@ -351,62 +407,6 @@ module ActiveRecord
             file.close
             file.unlink
           end
-        end
-
-        def test_a_class_using_custom_pool_and_switching_back_to_primary
-          klass2 = Class.new(Base) { def self.name; "klass2"; end }
-
-          assert_same klass2.connection, ActiveRecord::Base.connection
-
-          pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.spec.config)
-          assert_same klass2.connection, pool.connection
-          assert_not_same klass2.connection, ActiveRecord::Base.connection
-
-          klass2.remove_connection
-
-          assert_same klass2.connection, ActiveRecord::Base.connection
-        end
-
-        class ApplicationRecord < ActiveRecord::Base
-          self.abstract_class = true
-        end
-
-        class MyClass < ApplicationRecord
-        end
-
-        def test_connection_specification_name_should_fallback_to_parent
-          Object.send :const_set, :ApplicationRecord, ApplicationRecord
-
-          klassA = Class.new(Base)
-          klassB = Class.new(klassA)
-          klassC = Class.new(MyClass)
-
-          assert_equal klassB.connection_specification_name, klassA.connection_specification_name
-          assert_equal klassC.connection_specification_name, klassA.connection_specification_name
-
-          assert_equal "primary", klassA.connection_specification_name
-          assert_equal "primary", klassC.connection_specification_name
-
-          klassA.connection_specification_name = "readonly"
-          assert_equal "readonly", klassB.connection_specification_name
-
-          ActiveRecord::Base.connection_specification_name = "readonly"
-          assert_equal "readonly", klassC.connection_specification_name
-        ensure
-          Object.send :remove_const, :ApplicationRecord
-          ActiveRecord::Base.connection_specification_name = "primary"
-        end
-
-        def test_remove_connection_should_not_remove_parent
-          klass2 = Class.new(Base) { def self.name; "klass2"; end }
-          klass2.remove_connection
-          assert_not_nil ActiveRecord::Base.connection
-          assert_same klass2.connection, ActiveRecord::Base.connection
-        end
-
-        def test_default_handlers_are_writing_and_reading
-          assert_equal :writing, ActiveRecord::Base.writing_role
-          assert_equal :reading, ActiveRecord::Base.reading_role
         end
       end
     end


### PR DESCRIPTION
After forking, the connection handler will discard any connection pools that belongs to the parent process. However, it will continue to hold a reference to the connection pools of the parent process which is used for retrieval of the connection pool in the child process. Therefore, the `weakref_alive?` check in the connection pool reaper is insufficient since the connection pools of the parent process is never GCed.

cc @jhawthorn @eileencodes @tenderlove 