### PR TITLE
CHANGED: Fix Oracle application dependency

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby <%= "'#{RUBY_VERSION}'" -%>
 
+<%- if options[:database] == 'oracle' %>
+gem 'ruby-oci8', platforms: :ruby  # only for CRuby users<%- end -%>
 <% unless gemfile_entries.first.comment -%>
 
 <% end -%>


### PR DESCRIPTION
### Summary

**Rails Version:** 6.0
**Ruby Version:** 2.6.3p62

Because of the way [gemfile_entries](https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/app_base.rb#L128) works in [Gemfile.tt](https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/rails/app/templates/Gemfile.tt) and references the [database_gemfile_entry](https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/app_base.rb#L185) method in `app_base.rb`, it appears only 1 gem at a time can be passed for a database dependency from the [gem_for_database](https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/database.rb#L14) method. But when using Oracle, not only does a Rails application require the [activerecord-oracle_enhanced-adapter](https://github.com/rsim/oracle-enhanced) gem, it also required the [ruby-oci8](https://github.com/kubo/ruby-oci8) gem in order to interface with the database

Without including the `ruby-oci8` gem when generating a new rails application it'll only partially generate a rails application before failing, due to unmet dependencies.

`rails new myapp -d oracle`

```shell
.
.
.
Using rails 6.0.0
Using sass-rails 5.1.0
Bundle complete! 17 Gemfile dependencies, 76 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle binstubs bundler
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
         run  bundle exec spring binstub --all
* bin/rake: Spring inserted
* bin/rails: Spring inserted
       rails  webpacker:install
rails aborted!
LoadError: ERROR: 'cannot load such file -- oci8'. ActiveRecord oracle_enhanced adapter could not load ruby-oci8 library. You may need install ruby-oci8 gem.
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-oracle_enhanced-adapter-6.0.0/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:9:in `rescue in <main>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-oracle_enhanced-adapter-6.0.0/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:5:in `<main>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/zeitwerk-2.1.9/lib/zeitwerk/kernel.rb:23:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-oracle_enhanced-adapter-6.0.0/lib/active_record/connection_adapters/oracle_enhanced/connection.rb:122:in `<main>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/zeitwerk-2.1.9/lib/zeitwerk/kernel.rb:23:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-oracle_enhanced-adapter-6.0.0/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:35:in `<main>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/zeitwerk-2.1.9/lib/zeitwerk/kernel.rb:23:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-oracle_enhanced-adapter-6.0.0/lib/activerecord-oracle_enhanced-adapter.rb:12:in `block in <class:OracleEnhancedRailtie>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:72:in `class_eval'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:72:in `block in execute_hook'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:51:in `each'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-6.0.0/lib/active_record/base.rb:327:in `<module:ActiveRecord>'
/Users/tarellel/.rvm/gems/ruby-2.6.3/gems/activerecord-6.0.0/lib/active_record/base.rb:27:in `<main>'
```
