### PR TITLE
Update rails js packages to 6.0.0 for generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/package.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/package.json.tt
@@ -2,10 +2,10 @@
   "name": "<%= app_name %>",
   "private": true,
   "dependencies": {
-    "@rails/ujs": "^6.0.0-alpha"<% unless options[:skip_turbolinks] %>,
+    "@rails/ujs": "^6.0.0"<% unless options[:skip_turbolinks] %>,
     "turbolinks": "^5.2.0"<% end -%><% unless skip_active_storage? %>,
-    "@rails/activestorage": "^6.0.0-alpha"<% end -%><% unless options[:skip_action_cable] %>,
-    "@rails/actioncable": "^6.0.0-alpha"<% end %>
+    "@rails/activestorage": "^6.0.0"<% end -%><% unless options[:skip_action_cable] %>,
+    "@rails/actioncable": "^6.0.0"<% end %>
   },
   "version": "0.1.0"
 }


### PR DESCRIPTION
Update rails js packages to 6.0.0 for generator

### Summary

Use `6.0.0` rails js packages instead of alpha version when creating new project.

### Other Information

N/A

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
