### PR TITLE
Remove outdated line about flipping the defaults [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt
@@ -2,8 +2,6 @@
 #
 # This file contains migration options to ease your Rails 6.0 upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
-#
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Don't force requests from old versions of IE to be UTF-8 encoded.


### PR DESCRIPTION
We don't need to flip the defaults but just uncomment them to enable.

cc @kaspth 