### PR TITLE
Prevent `ActiveSupport::Duration.build(string)` comparison bug

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   Prevent `ActiveSupport::Duration.build(value)` from creating instances of
+    `ActiveSupport::Duration` unless `value` is of type `Numeric`.
+
+    Addresses the errant set of behaviours described in #37012 where
+    `ActiveSupport::Duration` comparisons would fail confusingly
+    or return unexpected results when comparing durations built from instances of `String`.
+
+    Before:
+
+        small_duration_from_string = ActiveSupport::Duration.build('9')
+        large_duration_from_string = ActiveSupport::Duration.build('100000000000000')
+        small_duration_from_int = ActiveSupport::Duration.build(9)
+
+        large_duration_from_string > small_duration_from_string
+            => false
+
+        small_duration_from_string == small_duration_from_int
+            => false
+
+        small_duration_from_int < large_duration_from_string
+            => ArgumentError (comparison of ActiveSupport::Duration::Scalar
+                    with ActiveSupport::Duration failed)
+
+        large_duration_from_string > small_duration_from_int
+            => ArgumentError (comparison of String with ActiveSupport::Duration failed)
+
+    After:
+
+        small_duration_from_string = ActiveSupport::Duration.build('9')
+            => TypeError (can't build an ActiveSupport::Duration from a String)
+
+    *Alexei Emam*
+
 *   Add `ActiveSupport::Cache::Store#delete_multi` method to delete multiple keys from the cache store.
 
     *Peter Zhu*

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -181,6 +181,10 @@ module ActiveSupport
       #   ActiveSupport::Duration.build(2716146).parts  # => {:months=>1, :days=>1}
       #
       def build(value)
+        unless value.is_a?(::Numeric)
+          raise TypeError, "can't build an #{self.name} from a #{value.class.name}"
+        end
+
         parts = {}
         remainder = value.to_f
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -661,6 +661,22 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal 660, (d1 + 60).to_i
   end
 
+  def test_string_build_raises_error
+    error = assert_raises(TypeError) do
+      ActiveSupport::Duration.build("9")
+    end
+
+    assert_equal "can't build an ActiveSupport::Duration from a String", error.message
+  end
+
+  def test_non_numeric_build_raises_error
+    error = assert_raises(TypeError) do
+      ActiveSupport::Duration.build(nil)
+    end
+
+    assert_equal "can't build an ActiveSupport::Duration from a NilClass", error.message
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
### Summary
This change prevents `ActiveSupport::Duration` instances being created by `ActiveSupport::Duration.build(value)` unless `value` is of type `::Numeric` (raises `TypeError`)

This addresses the errant set of behaviours described in #37012 where `ActiveSupport::Duration` comparisons would fail confusingly or return unexpected results when comparing durations built from strings.

e.g.

```ruby
## Setup
2.6.3 :001 > small_duration_from_string = ActiveSupport::Duration.build('9')
 => 9.0 seconds 
2.6.3 :002 > large_duration_from_string = ActiveSupport::Duration.build('100000000000000')
 => 3168873 years, 10 months, 6 days, 8 hours, 4 minutes, and 4.0 seconds 
2.6.3 :003 > small_duration_from_int = ActiveSupport::Duration.build(9)
 => 9.0 seconds 
## Comparison
2.6.3 :004 > large_duration_from_string > small_duration_from_string
 => false 
2.6.3 :005 > small_duration_from_string == small_duration_from_int
 => false 
2.6.3 :006 > small_duration_from_int < large_duration_from_string
Traceback (most recent call last):
        1: from (irb):6
ArgumentError (comparison of ActiveSupport::Duration::Scalar with ActiveSupport::Duration failed)
2.6.3 :007 > large_duration_from_string > small_duration_from_int
Traceback (most recent call last):
        2: from (irb):7
        1: from (irb):7:in `rescue in irb_binding'
ArgumentError (comparison of String with ActiveSupport::Duration failed)
```
### Other Information


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
