### PR TITLE
[ActionText] Allow setting rich text body using abbreviated assignment

### DIFF
--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -26,11 +26,15 @@ module ActionText
       def has_rich_text(name)
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
-            rich_text_#{name} || build_rich_text_#{name}
+            rich_text_#{name}
+          end
+
+          def find_or_build_#{name}
+            self.#{name} || build_rich_text_#{name}
           end
 
           def #{name}=(body)
-            self.#{name}.body = body
+            find_or_build_#{name}.body = body
           end
         CODE
 

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -17,7 +17,6 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create!(subject: "Greetings")
     assert message.content.nil?
     assert message.content.blank?
-    assert message.content.empty?
     assert_not message.content.present?
   end
 
@@ -27,6 +26,13 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert message.content.blank?
     assert message.content.empty?
     assert_not message.content.present?
+  end
+
+  test "abbreviated assignment" do
+    message = Message.create!(subject: "Greetings")
+    assert message.content.blank?
+    message.content ||= "Hello world"
+    assert_equal "Hello world", message.content.to_plain_text
   end
 
   test "embed extraction" do
@@ -81,7 +87,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message = Message.create!(subject: "Greetings")
 
     assert_no_difference -> { ActionText::RichText.count } do
-      assert_kind_of ActionText::RichText, message.content
+      assert message.content.nil?
     end
   end
 end


### PR DESCRIPTION
### Summary

At the moment, it is not possible to set rich text body using abbreviated assignment. 
```rb
message = Message.create!(subject: "Greetings")
message.content ||= "Hello world"
``` 
This will silently fail, since content attribute is lazily built when accessed.

This PR changes the behavior, by delaying building `ActionText::RichText` until the attribute is assigned a value.

```rb
message = Message.create!(subject: "Greetings")
message.content  # => nil
message.content ||= "Hello world"
message.content  # => #<ActionText::RichText ...>
``` 
