### PR TITLE
Encode ActionDispatch::TestRequest::DEFAULT_ENV headers as ASCII-8BIT

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -6,9 +6,9 @@ require "rack/utils"
 module ActionDispatch
   class TestRequest < Request
     DEFAULT_ENV = Rack::MockRequest.env_for("/",
-      "HTTP_HOST"                => "test.host",
-      "REMOTE_ADDR"              => "0.0.0.0",
-      "HTTP_USER_AGENT"          => "Rails Testing",
+      "HTTP_HOST"                => "test.host".b,
+      "REMOTE_ADDR"              => "0.0.0.0".b,
+      "HTTP_USER_AGENT"          => "Rails Testing".b,
     )
 
     # Create a new test request with default +env+ values.


### PR DESCRIPTION
Request headers provided by servers are ASCII-8BIT encoded. This commit sets up the `ActionDispatch::TestRequest::DEFAULT_ENV` headers so that they are likewise encoded as ASCII-8BIT.

cc @tenderlove 