### PR TITLE
Optimize Action Text's plain text conversion

### DIFF
--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -18,9 +18,11 @@ module ActionText
       end
 
       def plain_text_for_node_children(node)
-        node.children.each_with_index.map do |child, index|
-          plain_text_for_node(child, index)
-        end.compact.join("")
+        texts = []
+        node.children.each_with_index do |child, index|
+          texts << plain_text_for_node(child, index)
+        end
+        texts.join("")
       end
 
       def plain_text_method_for_node(node)

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -73,6 +73,21 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "deeply nested tags are converted" do
+    assert_converted_to(
+      "Hello world!\nHow are you?",
+      ActionText::Fragment.wrap("<div>Hello world!</div><div></div>").tap do |fragment|
+        node = fragment.source.children.last
+        1_000.times do
+          child = node.clone
+          child.parent = node
+          node = child
+        end
+        node.inner_html = "How are you?"
+      end
+    )
+  end
+
   test "preserves non-linebreak whitespace after text" do
     assert_converted_to(
       "Hello world!",


### PR DESCRIPTION
Fixes that converting deeply nested elements could exceed the stack level, as seen in the added test failing before the optimization:

```
.....................................E

Error:
ActionText::PlainTextConversionTest#test_deeply_nested_tags_are_converted:
SystemStackError: stack level too deep
```

See also: https://twitter.com/javan/status/1164545630079016965