### PR TITLE
Fix conditions in ActiveStorage

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -97,13 +97,13 @@ module ActiveStorage
           def #{name}=(attachables)
             if ActiveStorage.replace_on_assign_to_many
               attachment_changes["#{name}"] =
-                if attachables.nil? || Array(attachables).none?
+                if Array(attachables).none?
                   ActiveStorage::Attached::Changes::DeleteMany.new("#{name}", self)
                 else
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, attachables)
                 end
             else
-              if !attachables.nil? || Array(attachables).any?
+              if Array(attachables).any?
                 attachment_changes["#{name}"] =
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables)
               end


### PR DESCRIPTION
### Summary

I first wanted to fix this condition `!attachables.nil? || Array(attachables).any?` since if something is not `nil` it will always return `true` instead of checking if the array has any element. My guess is that this other condition that already existed `attachables.nil? || Array(attachables).none?` was tried to be negated unsuccessfully.

Then I realised that `Array(nil)` returns `[]` so we could simplify the conditions.

### Notes
Not sure why tests are failing