### PR TITLE
Small docs fix inside `ActiveStorage` [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -37,7 +37,7 @@ module ActiveStorage
 
     # Returns true if any attachments has been made.
     #
-    #   class Gallery < ActiveRecord::Base
+    #   class Gallery < ApplicationRecord
     #     has_many_attached :photos
     #   end
     #

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -10,7 +10,7 @@ module ActiveStorage
     class_methods do
       # Specifies the relation between a single attachment and the model.
       #
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     has_one_attached :avatar
       #   end
       #
@@ -66,7 +66,7 @@ module ActiveStorage
 
       # Specifies the relation between multiple attachments and the model.
       #
-      #   class Gallery < ActiveRecord::Base
+      #   class Gallery < ApplicationRecord
       #     has_many_attached :photos
       #   end
       #

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -37,7 +37,7 @@ module ActiveStorage
 
     # Returns +true+ if an attachment has been made.
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationRecord
     #     has_one_attached :avatar
     #   end
     #


### PR DESCRIPTION
### Summary
`ActiveRecord::Base` -> `ApplicationRecord` for consistency with default
Rails generators and ActiveStorage guides.

