### PR TITLE
WIP: Delete association later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
     activemodel (6.0.0.beta3)
       activesupport (= 6.0.0.beta3)
     activerecord (6.0.0.beta3)
+      activejob (= 6.0.0.beta3)
       activemodel (= 6.0.0.beta3)
       activesupport (= 6.0.0.beta3)
     activestorage (6.0.0.beta3)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `ActiveRecord::Base.destroy_later` for automatically destroying records
+    after a specified amount of time.
+
+    ```ruby
+    class Export < ApplicationRecord
+      # Destroy all exports 30 days after creation
+      destroy_later after: 30.days
+
+      # Destroy exports 30 days after completing them
+      destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }
+
+      # Destroy exports 30 days after completing them, ensuring they're still completed at destroy time
+      destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }, ensuring: :completed?
+    end
+    ```
+
+    *DHH*, *George Claghorn*
+
 *   Don't call commit/rollback callbacks despite a record isn't saved.
 
     Fixes #29747.

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
+  s.add_dependency "activejob",     version
 end

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -75,6 +75,7 @@ module ActiveRecord
   autoload :Validations
   autoload :SecureToken
   autoload :DatabaseSelector, "active_record/middleware/database_selector"
+  autoload :DeleteAssociationLaterJob
   autoload :DestroyLater
   autoload :DestroyJob
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -26,6 +26,7 @@
 require "active_support"
 require "active_support/rails"
 require "active_model"
+require "active_job"
 require "arel"
 require "yaml"
 
@@ -74,6 +75,8 @@ module ActiveRecord
   autoload :Validations
   autoload :SecureToken
   autoload :DatabaseSelector, "active_record/middleware/database_selector"
+  autoload :DestroyLater
+  autoload :DestroyJob
 
   eager_autoload do
     autoload :ActiveRecordError, "active_record/errors"

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -11,6 +11,8 @@ module ActiveRecord
         when :destroy
           target.destroy
           raise ActiveRecord::Rollback unless target.destroyed?
+        when :background_delete
+          ActiveRecord::DeleteAssociationLaterJob.perform_later([target])
         else
           target.send(options[:dependent])
         end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete]
+      [:destroy, :delete, :background_delete]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception]
+      [:destroy, :delete_all, :background_delete, :nullify, :restrict_with_error, :restrict_with_exception]
     end
   end
 end

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -13,7 +13,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete, :nullify, :restrict_with_error, :restrict_with_exception]
+      [:destroy, :delete, :background_delete, :nullify, :restrict_with_error, :restrict_with_exception]
     end
 
     def self.add_destroy_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -26,6 +26,12 @@ module ActiveRecord
           # No point in executing the counter update since we're going to destroy the parent anyway
           load_target.each { |t| t.destroyed_by_association = reflection }
           destroy_all
+
+        when :background_delete
+          # No point in executing the counter update since we're going to destroy the parent anyway
+          load_target.each { |t| t.destroyed_by_association = reflection }
+
+          ActiveRecord::DeleteAssociationLaterJob.perform_later(load_target)
         else
           delete_all
         end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -28,6 +28,8 @@ module ActiveRecord
           case method
           when :delete
             target.delete
+          when :background_delete
+            ActiveRecord::DeleteAssociationLaterJob.perform_later([target])
           when :destroy
             target.destroyed_by_association = reflection
             target.destroy

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -322,6 +322,7 @@ module ActiveRecord #:nodoc:
     include Store
     include SecureToken
     include Suppressor
+    include DestroyLater
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -26,6 +26,12 @@ module ActiveRecord
       mattr_accessor :verbose_query_logs, instance_writer: false, default: false
 
       ##
+      # :singleton-method:
+      #
+      # Specifies the names of the queues used by background jobs.
+      mattr_accessor :queues, instance_accessor: false, default: {}
+
+      ##
       # Contains the database configuration - as is typically stored in config/database.yml -
       # as an ActiveRecord::DatabaseConfigurations object.
       #

--- a/activerecord/lib/active_record/delete_association_later_job.rb
+++ b/activerecord/lib/active_record/delete_association_later_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+ module ActiveRecord
+  class DeleteAssociationLaterJob < ActiveJob::Base
+    queue_as { ActiveRecord::Base.queues[:destroy] }
+
+     discard_on ActiveJob::DeserializationError
+
+     def perform(records)
+      records.each do |r|
+        r.delete
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/delete_association_later_job.rb
+++ b/activerecord/lib/active_record/delete_association_later_job.rb
@@ -1,15 +1,15 @@
-# frozen_string_literal: true
+ # frozen_string_literal: true
 
  module ActiveRecord
-  class DeleteAssociationLaterJob < ActiveJob::Base
-    queue_as { ActiveRecord::Base.queues[:destroy] }
+   class DeleteAssociationLaterJob < ActiveJob::Base
+     queue_as { ActiveRecord::Base.queues[:destroy] }
 
      discard_on ActiveJob::DeserializationError
 
      def perform(records)
-      records.each do |r|
-        r.delete
-      end
+       records.each do |r|
+         r.delete
+       end
     end
-  end
-end
+   end
+ end

--- a/activerecord/lib/active_record/destroy_job.rb
+++ b/activerecord/lib/active_record/destroy_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class DestroyJob < ActiveJob::Base
+    queue_as { ActiveRecord::Base.queues[:destroy] }
+
+    discard_on ActiveJob::DeserializationError
+
+    def perform(record, ensuring: nil)
+      record.destroy! if eligible?(record, ensuring)
+    end
+
+    private
+      def eligible?(record, ensuring)
+        ensuring.nil? || record.public_send(ensuring)
+      end
+  end
+end

--- a/activerecord/lib/active_record/destroy_later.rb
+++ b/activerecord/lib/active_record/destroy_later.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # Automatically destroy records after a specified amount of time.
+  #
+  #   class Export < ApplicationRecord
+  #     # Destroy all exports 30 days after creation
+  #     destroy_later after: 30.days
+  #
+  #     # Destroy exports 30 days after completing them
+  #     destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }
+  #   end
+  #
+  # +destroy_later+ adds an +after_commit+ callback that schedules an ActiveRecord::DestroyJob. In the example above,
+  # we use +completed_previously_changed?+ to check whether the record's +completed+ flag was changed in the preceding
+  # save. (+completed_changed?+ wouldn't work because any prior changes to the record have been saved at the time the
+  # condition is evaluated.)
+  #
+  # Optionally pass the name of an instance method in +ensuring:+. If the given method returns false at the
+  # scheduled destroy time, the record will not be destroyed.
+  #
+  #   # Destroy exports 30 days after completing them, ensuring they're still marked as completed at destroy time
+  #   class Export < ApplicationRecord
+  #     destroy_later after: 30.days, if: -> { status_previously_changed? && completed? }, ensuring: :completed?
+  #   end
+  module DestroyLater
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def destroy_later(after:, if: nil, ensuring: nil)
+        after_commit -> { destroy_later after: after, ensuring: ensuring },
+          on: binding.local_variable_get(:if) ? %i[ create update ] : :create, if: binding.local_variable_get(:if)
+      end
+    end
+
+    def destroy_later(after:, ensuring: nil)
+      ActiveRecord::DestroyJob.set(wait: after).perform_later(self, ensuring: ensuring)
+    end
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -3,6 +3,7 @@
 require "active_record"
 require "rails"
 require "active_model/railtie"
+require "active_job/railtie"
 
 # For now, action_controller must always be present with
 # Rails, so let's make sure that it gets required before
@@ -30,6 +31,8 @@ module ActiveRecord
 
     config.active_record.sqlite3 = ActiveSupport::OrderedOptions.new
     config.active_record.sqlite3.represent_boolean_as_integer = nil
+
+    config.active_record.queues = ActiveSupport::InheritableOptions.new(destroy: :active_record_destroy)
 
     config.eager_load_namespaces << ActiveRecord
 

--- a/activerecord/test/cases/delete_association_later_test.rb
+++ b/activerecord/test/cases/delete_association_later_test.rb
@@ -9,24 +9,24 @@ require "models/da_join"
 require "models/da_has_many"
 require "models/da_has_many_through"
 
- class DeleteAssociationLaterTest < ActiveRecord::TestCase
+class DeleteAssociationLaterTest < ActiveRecord::TestCase
   include ActiveJob::TestHelper
 
-   test "enqueues the has_many through to be deleted" do
-    da_has_many = DaHasManyThrough.create!
-    da_has_many2 = DaHasManyThrough.create!
-    parent = DeleteAssociationParent.create!
-    parent.da_has_many_through << [da_has_many2, da_has_many]
-    parent.save!
-    parent.destroy
-    assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
+  test "enqueues the has_many through to be deleted" do
+   da_has_many = DaHasManyThrough.create!
+   da_has_many2 = DaHasManyThrough.create!
+   parent = DeleteAssociationParent.create!
+   parent.da_has_many_through << [da_has_many2, da_has_many]
+   parent.save!
+   parent.destroy
+   assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
 
-     assert_difference -> { DaJoin.count }, -2 do
-       assert_difference -> { DaHasManyThrough.count }, -2 do
-        perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
-      end
+   assert_difference -> { DaJoin.count }, -2 do
+    assert_difference -> { DaHasManyThrough.count }, -2 do
+      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
     end
   end
+ end
 
   test "belongs to" do
     parent = DeleteAssociationParent.create!
@@ -37,9 +37,9 @@ require "models/da_has_many_through"
 
     assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
 
-     assert_difference -> { DeleteAssociationParent.count }, -1 do
-      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
-    end
+    assert_difference -> { DeleteAssociationParent.count }, -1 do
+     perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+   end
   end
 
   test "has_one" do
@@ -50,9 +50,9 @@ require "models/da_has_many_through"
     parent.destroy
     assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
 
-     assert_difference -> { DaHasOne.count }, -1 do
-      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
-    end
+    assert_difference -> { DaHasOne.count }, -1 do
+     perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+   end
   end
 
   test "has_many" do
@@ -64,8 +64,8 @@ require "models/da_has_many_through"
     parent.destroy
     assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
 
-     assert_difference -> { DaHasMany.count }, -2 do
-      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
-    end
+    assert_difference -> { DaHasMany.count }, -2 do
+     perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+   end
   end
 end

--- a/activerecord/test/cases/delete_association_later_test.rb
+++ b/activerecord/test/cases/delete_association_later_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+require "models/delete_association_parent"
+require "models/da_belongs_to"
+require "models/da_has_one"
+require "models/da_join"
+require "models/da_has_many"
+require "models/da_has_many_through"
+
+ class DeleteAssociationLaterTest < ActiveRecord::TestCase
+  include ActiveJob::TestHelper
+
+   test "enqueues the has_many through to be deleted" do
+    da_has_many = DaHasManyThrough.create!
+    da_has_many2 = DaHasManyThrough.create!
+    parent = DeleteAssociationParent.create!
+    parent.da_has_many_through << [da_has_many2, da_has_many]
+    parent.save!
+    parent.destroy
+    assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
+
+     assert_difference -> { DaJoin.count }, -2 do
+       assert_difference -> { DaHasManyThrough.count }, -2 do
+        perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+      end
+    end
+  end
+
+  test "belongs to" do
+    parent = DeleteAssociationParent.create!
+    da_belongs_to = DaBelongsTo.create!
+    da_belongs_to.delete_association_parent = parent
+    da_belongs_to.save!
+    da_belongs_to.destroy
+
+    assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
+
+     assert_difference -> { DeleteAssociationParent.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+    end
+  end
+
+  test "has_one" do
+    parent = DeleteAssociationParent.create!
+    da_has_one = DaHasOne.create!
+    parent.da_has_one = da_has_one
+    parent.save!
+    parent.destroy
+    assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
+
+     assert_difference -> { DaHasOne.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+    end
+  end
+
+  test "has_many" do
+    da_has_many = DaHasMany.create!
+    da_has_many2 = DaHasMany.create!
+    parent = DeleteAssociationParent.create!
+    parent.da_has_many << [da_has_many2, da_has_many]
+    parent.save!
+    parent.destroy
+    assert_enqueued_with job: ActiveRecord::DeleteAssociationLaterJob
+
+     assert_difference -> { DaHasMany.count }, -2 do
+      perform_enqueued_jobs only: ActiveRecord::DeleteAssociationLaterJob
+    end
+  end
+end

--- a/activerecord/test/cases/destroy_later_test.rb
+++ b/activerecord/test/cases/destroy_later_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+require "models/book"
+require "models/pirate"
+require "models/parrot"
+
+class DestroyLaterTest < ActiveRecord::TestCase
+  include ActiveJob::TestHelper
+
+  fixtures :books, :pirates
+
+  test "creating a pirate enqueues it for unconditional destruction 10 days later" do
+    freeze_time
+
+    pirate = Pirate.create!(catchphrase: "Arr, matey!")
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ pirate, ensuring: nil ], at: 10.days.from_now
+
+    travel 10.days
+
+    assert_difference -> { Pirate.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "updating a pirate does not enqueue it for destruction" do
+    assert_no_enqueued_jobs only: ActiveRecord::DestroyJob do
+      pirates(:redbeard).update! catchphrase: "Shiver me timbers!"
+    end
+  end
+
+  test "updating a pirate does not prevent its scheduled destruction" do
+    freeze_time
+
+    pirate = Pirate.create!(catchphrase: "Arr, matey!")
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ pirate, ensuring: nil ], at: 10.days.from_now
+
+    travel 2.days
+
+    pirate.update! catchphrase: "Shiver me timbers!"
+
+    travel 8.days
+
+    assert_difference -> { Pirate.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "publishing a book enqueues it for destruction 30 days later" do
+    freeze_time
+
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ books(:rfr), ensuring: :published? ], at: 30.days.from_now do
+      books(:rfr).published!
+    end
+
+    travel 30.days
+
+    assert_difference -> { Book.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "creating a published book enqueues it for destruction 30 days later" do
+    freeze_time
+
+    book = Book.create!(name: "Getting Real", status: :published)
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ book, ensuring: :published? ], at: 30.days.from_now
+
+    travel 30.days
+
+    assert_difference -> { Book.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "unpublishing a book prevents its scheduled destruction" do
+    freeze_time
+
+    assert_enqueued_with job: ActiveRecord::DestroyJob, args: [ books(:rfr), ensuring: :published? ], at: 30.days.from_now do
+      books(:rfr).published!
+    end
+
+    travel 10.days
+
+    assert_no_enqueued_jobs do
+      books(:rfr).proposed!
+    end
+
+    travel 20.days
+
+    assert_no_difference -> { Book.count } do
+      perform_enqueued_jobs only: ActiveRecord::DestroyJob
+    end
+  end
+
+  test "writing a book does not enqueue it for destruction" do
+    assert_no_enqueued_jobs do
+      books(:rfr).written!
+    end
+  end
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -203,4 +203,12 @@ module InTimeZone
     end
 end
 
+require "global_id"
+GlobalID.app = "ActiveRecordExampleApp"
+ActiveRecord::Base.include GlobalID::Identification
+
+require "active_job"
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = ActiveSupport::Logger.new(nil)
+
 require_relative "../../../tools/test_common"

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -19,6 +19,8 @@ class Book < ActiveRecord::Base
   enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
 
+  destroy_later after: 30.days, if: -> { status_previously_changed? && published? }, ensuring: :published?
+
   def published!
     super
     "do publish work..."

--- a/activerecord/test/models/da_belongs_to.rb
+++ b/activerecord/test/models/da_belongs_to.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DaBelongsTo < ActiveRecord::Base
+  belongs_to :delete_association_parent, dependent: :background_delete
+end

--- a/activerecord/test/models/da_has_many.rb
+++ b/activerecord/test/models/da_has_many.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DaHasMany < ActiveRecord::Base
+end

--- a/activerecord/test/models/da_has_many_through.rb
+++ b/activerecord/test/models/da_has_many_through.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DaHasManyThrough < ActiveRecord::Base
+end

--- a/activerecord/test/models/da_has_one.rb
+++ b/activerecord/test/models/da_has_one.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DaHasOne < ActiveRecord::Base
+end

--- a/activerecord/test/models/da_join.rb
+++ b/activerecord/test/models/da_join.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class DaJoin < ActiveRecord::Base
+  belongs_to :delete_association_parent
+  belongs_to :da_has_many_through
+end

--- a/activerecord/test/models/delete_association_parent.rb
+++ b/activerecord/test/models/delete_association_parent.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DeleteAssociationParent < ActiveRecord::Base
+  has_one :da_has_one, dependent: :background_delete
+  has_many :da_has_many, dependent: :background_delete
+  has_many :da_join, dependent: :background_delete
+  has_many :da_has_many_through, through: :da_join, dependent: :background_delete
+end

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -53,6 +53,8 @@ class Pirate < ActiveRecord::Base
 
   validates_presence_of :catchphrase
 
+  destroy_later after: 10.days
+
   def ship_log
     @ship_log ||= []
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -282,6 +282,29 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
+  create_table :da_belongs_tos, force: true do |t|
+    t.references :delete_association_parent
+  end
+
+  create_table :da_has_ones, force: true do |t|
+    t.references :delete_association_parent
+  end
+
+  create_table :da_has_manies, force: true do |t|
+    t.references :delete_association_parent
+  end
+
+  create_table :da_has_many_throughs, force: true do |t|
+  end
+
+  create_table :da_joins, force: true do |t|
+    t.references :delete_association_parent
+    t.references :da_has_many_through
+  end
+
+  create_table :delete_association_parents, force: true do |t|
+  end
+
   create_table :developers, force: true do |t|
     t.string   :name
     t.string   :first_name

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -381,6 +381,8 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
+* `config.active_record.queues.destroy` allows specifying the Active Job queue to use for destroy jobs. It defaults to `:active_record_destroy`.
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
Motivation:

In #36912 I added background destroys, this pr brings in deletes as
well. Currently in the GitHub codebase we have methods that make both of
these functions available, I just learned this thanks @seejohnrun.
However it is hidden and likely underutlized due to the fact that it is
not core Rails functionality.

It would be nice to upstream both these tools if the Rails core team is
interested.

This pr builds off the work of @georgeclaghorn in PR #34901 and is
currently a simple proposal of how this could work. I branched off his
pr for now to quickly product this proof of concept.

Related Issues:

- #34901
- rails/actionmailbox#16
- #36912

Changes:

- Added a new job to handle deleting associations.
- Added a new dependent option on associations,
background_delete (Open to other names).

# ToDos:

- In our code base we throw an error if the user tries to setup delete in the background on a model that has destroy callbacks. This seems like a nice safe gaurd for the developer but is not inline with what Rails does. I am not sure what the proper opinion is here. 

- Still need to setup a proper method param, should be consistent with the destroy function open to suggestions.

cc @tenderlove 