### PR TITLE
Cleanup unneeded blank string params in ActionText

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -29,7 +29,7 @@ module ActionText
           attachment_gallery.attachments.map do |attachment|
             attachment.node.inner_html = render(attachment, in_gallery: true).chomp
             attachment.to_html
-          end.join("").html_safe
+          end.join.html_safe
         end.chomp
       end
     end

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -22,7 +22,7 @@ module ActionText
         node.children.each_with_index do |child, index|
           texts << plain_text_for_node(child, index)
         end
-        texts.join("")
+        texts.join
       end
 
       def plain_text_method_for_node(node)


### PR DESCRIPTION
I am pretty sure these blank string parameters can be left out.
Otherwise I'm curious why not.