### PR TITLE
WIP: Extract distance_of_time_in_words logic for reuse

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -139,6 +139,24 @@ module ActionView
         end
       end
 
+      def distance_of_dates_in_words_simple_example(from:, to:)
+        distance = DateDistance.new(from, to)
+
+        duration = if distance.in_days < 1.0
+          { key: :x_hours, count: [distance.in_hours.round, 1].min }
+        elsif distance.in_days < 30.0
+          { key: :x_days, count: distance.in_days.round }
+        elsif distance.in_years < 1.0
+          { key: :x_months, count: distance.in_months.round }
+        else
+          { key: :x_years, count: distance.in_years.round }
+        end
+
+        I18n.with_options scope: :'datetime.distance_in_words' do |locale|
+          locale.t(duration[:key], count: duration[:count])
+        end
+      end
+
       class DateDistance
         attr_reader :from_time, :to_time, :in_minutes, :in_seconds
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -97,20 +97,15 @@ module ActionView
           scope: :'datetime.distance_in_words'
         }.merge!(options)
 
-        from_time = normalize_distance_of_time_argument_to_time(from_time)
-        to_time = normalize_distance_of_time_argument_to_time(to_time)
-        from_time, to_time = to_time, from_time if from_time > to_time
-        distance_in_minutes = ((to_time - from_time) / 60.0).round
-        distance_in_seconds = (to_time - from_time).round
+        distance = DateDistance.new(from_time, to_time)
 
         I18n.with_options locale: options[:locale], scope: options[:scope] do |locale|
-          case distance_in_minutes
-          when 0..1
-            return distance_in_minutes == 0 ?
+          if distance.in_minutes <= 1
+            return distance.in_minutes == 0 ?
                    locale.t(:less_than_x_minutes, count: 1) :
-                   locale.t(:x_minutes, count: distance_in_minutes) unless options[:include_seconds]
+                   locale.t(:x_minutes, count: distance.in_minutes) unless options[:include_seconds]
 
-            case distance_in_seconds
+            case distance.in_seconds
             when 0..4   then locale.t :less_than_x_seconds, count: 5
             when 5..9   then locale.t :less_than_x_seconds, count: 10
             when 10..19 then locale.t :less_than_x_seconds, count: 20
@@ -118,34 +113,21 @@ module ActionView
             when 40..59 then locale.t :less_than_x_minutes, count: 1
             else             locale.t :x_minutes,           count: 1
             end
-
-          when 2...45           then locale.t :x_minutes,      count: distance_in_minutes
-          when 45...90          then locale.t :about_x_hours,  count: 1
-            # 90 mins up to 24 hours
-          when 90...1440        then locale.t :about_x_hours,  count: (distance_in_minutes.to_f / 60.0).round
-            # 24 hours up to 42 hours
-          when 1440...2520      then locale.t :x_days,         count: 1
-            # 42 hours up to 30 days
-          when 2520...43200     then locale.t :x_days,         count: (distance_in_minutes.to_f / 1440.0).round
-            # 30 days up to 60 days
-          when 43200...86400    then locale.t :about_x_months, count: (distance_in_minutes.to_f / 43200.0).round
-            # 60 days up to 365 days
-          when 86400...525600   then locale.t :x_months,       count: (distance_in_minutes.to_f / 43200.0).round
+          elsif distance.in_minutes < 45
+            locale.t :x_minutes,      count: distance.in_minutes
+          elsif distance.in_days < 1
+            locale.t :about_x_hours,  count: distance.in_hours.round
+          elsif distance.in_days < 1.75
+            locale.t :x_days,         count: 1
+          elsif distance.in_days < 30
+            locale.t :x_days,         count: distance.in_days.round
+          elsif distance.in_days < 60
+            locale.t :about_x_months, count: distance.in_months.round
+          elsif distance.in_days < 365
+            locale.t :x_months,       count: distance.in_months.round
           else
-            from_year = from_time.year
-            from_year += 1 if from_time.month >= 3
-            to_year = to_time.year
-            to_year -= 1 if to_time.month < 3
-            leap_years = (from_year > to_year) ? 0 : (from_year..to_year).count { |x| Date.leap?(x) }
-            minute_offset_for_leap_year = leap_years * 1440
-            # Discount the leap year days when calculating year distance.
-            # e.g. if there are 20 leap year days between 2 dates having the same day
-            # and month then the based on 365 days calculation
-            # the distance in years will come out to over 80 years when in written
-            # English it would read better as about 80 years.
-            minutes_with_offset = distance_in_minutes - minute_offset_for_leap_year
-            remainder                   = (minutes_with_offset % MINUTES_IN_YEAR)
-            distance_in_years           = (minutes_with_offset.div MINUTES_IN_YEAR)
+            remainder                   = (distance.in_minutes_excluding_leap_days % MINUTES_IN_YEAR)
+            distance_in_years           = (distance.in_minutes_excluding_leap_days.div MINUTES_IN_YEAR)
             if remainder < MINUTES_IN_QUARTER_YEAR
               locale.t(:about_x_years,  count: distance_in_years)
             elsif remainder < MINUTES_IN_THREE_QUARTERS_YEAR
@@ -153,6 +135,63 @@ module ActionView
             else
               locale.t(:almost_x_years, count: distance_in_years + 1)
             end
+          end
+        end
+      end
+
+      class DateDistance
+        attr_reader :from_time, :to_time, :in_minutes, :in_seconds
+
+        def initialize(from_time, to_time)
+          @from_time = normalize_distance_of_time_argument_to_time(from_time)
+          @to_time = normalize_distance_of_time_argument_to_time(to_time)
+          @from_time, @to_time = @to_time, @from_time if @from_time > @to_time
+          @in_minutes = ((@to_time - @from_time) / 60.0).round
+          @in_seconds = (@to_time - @from_time).round
+        end
+
+        def in_hours
+          in_minutes.to_f / 60.0
+        end
+
+        def in_days
+          in_minutes.to_f / 1440.0
+        end
+
+        def in_months
+          in_minutes.to_f / 43200.0
+        end
+
+        def in_years
+          minutes_excluding_leap_days / MINUTES_IN_YEAR.to_f
+        end
+
+        def in_minutes_excluding_leap_days
+          # Discount the leap year days for calculating year distance.
+          # e.g. if there are 20 leap year days between 2 dates having the same day
+          # and month then the based on 365 days calculation
+          # the distance in years will come out to over 80 years when in written
+          # English it would read better as about 80 years.
+          @minutes_excluding_leap_days ||= begin
+            from_year = @from_time.year
+            from_year += 1 if @from_time.month >= 3
+            to_year = @to_time.year
+            to_year -= 1 if @to_time.month < 3
+
+            leap_years = (from_year > to_year) ? 0 : (from_year..to_year).count { |x| Date.leap?(x) }
+            minute_offset_for_leap_year = leap_years * 1440
+            @in_minutes - minute_offset_for_leap_year
+          end
+        end
+
+      private
+        def normalize_distance_of_time_argument_to_time(value)
+          if value.is_a?(Numeric)
+            Time.at(value)
+          elsif value.respond_to?(:to_time)
+            value.to_time
+          else
+            raise ArgumentError, "#{value.inspect} can't be converted to a Time value"
           end
         end
       end
@@ -686,17 +725,6 @@ module ActionView
 
         content_tag("time", content, options.reverse_merge(datetime: date_or_time.iso8601), &block)
       end
-
-      private
-        def normalize_distance_of_time_argument_to_time(value)
-          if value.is_a?(Numeric)
-            Time.at(value)
-          elsif value.respond_to?(:to_time)
-            value.to_time
-          else
-            raise ArgumentError, "#{value.inspect} can't be converted to a Time value"
-          end
-        end
     end
 
     class DateTimeSelector #:nodoc:

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -231,7 +231,11 @@ module ActionView
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
       def time_ago_in_words(from_time, options = {})
-        distance_of_time_in_words(from_time, Time.now, options)
+        if options[:real_days] && (from_time - Time.now).abs >= 1.day
+          distance_of_time_in_words(from_time.midday, Time.now.midday, options)
+        else
+          distance_of_time_in_words(from_time, Time.now, options)
+        end
       end
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words


### PR DESCRIPTION
Does this pull request look worthwhile? I've set this as draft as I'd like to get feedback before adding tests/documentation. 

### What

Extracts a new class from `distance_of_time_in_words` for doing distance comparisons. Uses this to replace `when 1440...2520` style comparisons with `elsif distance.in_days < 1.75` style for clarity.

### Why

I wanted to create my own helper with custom boundaries but would have been unable to reuse any of the existing logic. In particular I didn't want `:about_x` style translations.

### Why not

Custom conversions might not need the existing logic for normalization, leap years etc so it may be acceptable for each app to just reimplement a similar method when needed.

I also haven't considered performance much, so the float comparisons might have an impact.

### Related issues asking for different boundaries

- https://github.com/rails/rails/issues/34625 asked for different handling around the 1day/2day boundary. When using the start or end of a day as the input to the method the 1.75 day boundary becomes particularly unusual. Another approach might be an option to change that boundary.
- https://github.com/rails/rails/issues/23982 asked for different handling around the 1month boundary which is set at 30 days so can have unexpected behaviour in February.
- https://github.com/rails/rails/issues/21916 outlines some quirks including 41 hours being treated as a day and some rounding errors we could also fix.
