### PR TITLE
Remove whitespace in config/environments/test.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -5,7 +5,8 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  <%# Spring executes the reloaders when files change. %>
+
+  <%-# Spring executes the reloaders when files change. %>
   <%- if spring_install? -%>
   config.cache_classes = false
   <%- else -%>


### PR DESCRIPTION
### Summary

before
```rb
Rails.application.configure do
  # Settings specified here will take precedence over those in config/application.rb.
  
  config.cache_classes = false
```

after
```rb
Rails.application.configure do
  # Settings specified here will take precedence over those in config/application.rb.

  config.cache_classes = false
```
### Other Information

