### PR TITLE
Always load validator class to verify it exists

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -112,7 +112,6 @@ module ActiveModel
         defaults[:attributes] = attributes
 
         validations.each do |key, options|
-          next unless options
           key = "#{key.to_s.camelize}Validator"
 
           begin
@@ -120,6 +119,8 @@ module ActiveModel
           rescue NameError
             raise ArgumentError, "Unknown validator: '#{key}'"
           end
+
+          next unless options
 
           validates_with(validator, defaults.merge(_parse_validates_options(options)))
         end

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -131,6 +131,10 @@ class ValidatesTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Person.validates :karma, unknown: true }
   end
 
+  def test_validates_with_disabled_unknown_validator
+    assert_raise(ArgumentError) { Person.validates :karma, unknown: false }
+  end
+
   def test_validates_with_included_validator
     PersonWithValidator.validates :title, presence: true
     person = PersonWithValidator.new


### PR DESCRIPTION
When updating our app for https://github.com/rails/rails/pull/35350, I found several incorrectly configured validations like this:

```ruby
validates :name, uniqueness: true, case_sensitive: false
```

The intent is clearly for `case_sensitive: false` to be passed as an option to the uniqueness validator, but instead it's being passed as its own separate validation. Because the value `false` disables the validation, the validator class isn't loaded and the failure is silent.

The validator should always be loaded, even if it's disabled, to ensure it exists and avoid configuration errors like the one described above.