### PR TITLE
Fix docs to replace http with https in activerecord [ci skip]

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -141,7 +141,7 @@ module ActiveRecord
       # converted to an instance of value class if necessary.
       #
       # For example, the +NetworkResource+ model has +network_address+ and +cidr_range+ attributes that should be
-      # aggregated using the +NetAddr::CIDR+ value class (http://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR).
+      # aggregated using the +NetAddr::CIDR+ value class (https://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR).
       # The constructor for the value class is called +create+ and it expects a CIDR address string as a parameter.
       # New values can be assigned to the value object using either another +NetAddr::CIDR+ object, a string
       # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -41,7 +41,7 @@ module ActiveRecord
   # separated by a blank line for your viewing pleasure.
   #
   # Note: Fixtures are unordered. If you want ordered fixtures, use the omap YAML type.
-  # See http://yaml.org/type/omap.html
+  # See https://yaml.org/type/omap.html
   # for the specification. You will need ordered fixtures when you have foreign key constraints
   # on keys in the same table. This is commonly needed for tree structures. Example:
   #

--- a/activerecord/lib/arel/nodes/join_source.rb
+++ b/activerecord/lib/arel/nodes/join_source.rb
@@ -5,7 +5,7 @@ module Arel # :nodoc: all
     ###
     # Class that represents a join source
     #
-    #   http://www.sqlite.org/syntaxdiagrams.html#join-source
+    #   https://www.sqlite.org/syntaxdiagrams.html#join-source
 
     class JoinSource < Arel::Nodes::Binary
       def initialize(single_source, joinop = [])

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -15,7 +15,7 @@ module Arel # :nodoc: all
 
         ###
         # :'(
-        # http://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
+        # https://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.offset && !o.limit
             o.limit = Arel::Nodes::Limit.new(18446744073709551615)

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -15,7 +15,7 @@ module Arel
 
       ###
       # :'(
-      # http://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
+      # https://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
       it "defaults limit to 18446744073709551615" do
         stmt = Nodes::SelectStatement.new
         stmt.offset = Nodes::Offset.new(1)

--- a/activerecord/test/fixtures/tasks.yml
+++ b/activerecord/test/fixtures/tasks.yml
@@ -1,4 +1,4 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 first_task:
   id: 1
   starting: 2005-03-30t06:30:00.00+01:00


### PR DESCRIPTION
### Summary

Fix documents to replace http with https in activerecord, because these URLs are redirected with status 301.

Following is one of the examples.
```
$ curl -I http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
HTTP/1.1 301 Moved Permanently
Server: nginx/1.14.0 (Ubuntu)
Date: Mon, 26 Aug 2019 13:38:25 GMT
Content-Type: text/html
Content-Length: 194
Connection: keep-alive
Location: https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
```