### PR TITLE
Fix Rails.application.eager_load! regression in Zeitwerk autoloader mode

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -471,8 +471,7 @@ module Rails
     end
 
     def eager_load!
-      # Already done by Zeitwerk::Loader.eager_load_all in the finisher.
-      return if Rails.autoloaders.zeitwerk_enabled?
+      return Zeitwerk::Loader.eager_load_all if Rails.autoloaders.zeitwerk_enabled?
 
       config.eager_load_paths.each do |load_path|
         # Starts after load_path plus a slash, ends before ".rb".


### PR DESCRIPTION
### Summary

This fixes #37006. In Previous versions of rails prior to Zeitwerk mode `Rails.application.eager_load!` is often called outside of production environments and used in rake tasks or other contexts in order to iterate through models or other components of the entire application for various operations - search indexing, DB dumps, etc.

This change brings Zeitwerk `Rails.application.eager_load!` functionality back to parity with the classic autoloader mode functionality.

### Other Information

I'm unaware if this will have any unintended consequences elsewhere and a review by people far more familiar with the autoloader/Zeitwerk mechanisms would be very much appreciated.