### PR TITLE
Fix rdoc of ActiveRecord::Associations::CollectionProxy#replace [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -373,7 +373,7 @@ module ActiveRecord
       #   person.pets
       #   # => [#<Pet id: 1, name: "Gorby", group: "cats", person_id: 1>]
       #
-      #   other_pets = [Pet.new(name: 'Puff', group: 'celebrities']
+      #   other_pets = [Pet.new(name: 'Puff', group: 'celebrities')]
       #
       #   person.pets.replace(other_pets)
       #


### PR DESCRIPTION
I fixed a syntax error in rdoc of ActiveRecord::Associations::CollectionProxy#replace to execute the sample code.