### PR TITLE
Add `frozen_string_literal` to the migrations

### DIFF
--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_mailbox_inbound_emails do |t|

--- a/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActionTextTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_text_rich_texts do |t|

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
     create_table :active_storage_blobs do |t|


### PR DESCRIPTION
Whole codebase is following this convention, I think it should work for
migration files also.