### PR TITLE
Ignore SQLite3 database files generated by parallel testing

### DIFF
--- a/actionmailbox/.gitignore
+++ b/actionmailbox/.gitignore
@@ -1,5 +1,6 @@
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-journal
+/test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/tmp/
 /tmp/

--- a/actiontext/.gitignore
+++ b/actiontext/.gitignore
@@ -1,5 +1,6 @@
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-journal
+/test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/public/packs-test
 /test/dummy/tmp/

--- a/activestorage/.gitignore
+++ b/activestorage/.gitignore
@@ -1,6 +1,7 @@
 /src/
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-journal
+/test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/tmp/
 /test/service/configurations.yml

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -11,6 +11,7 @@
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
+/db/*.sqlite3-*
 
 <% end -%>
 # Ignore all logfiles and tempfiles.

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -5,6 +5,7 @@ pkg/
 <% if sqlite3? -%>
 <%= dummy_path %>/db/*.sqlite3
 <%= dummy_path %>/db/*.sqlite3-journal
+<%= dummy_path %>/db/*.sqlite3-*
 <% end -%>
 <%= dummy_path %>/log/*.log
 <% unless options[:skip_javascript] -%>


### PR DESCRIPTION
### Summary

Rails 6.0 introduces parallel testing and the default degree of parallelism is configured based on the number of CPU. refer https://github.com/rails/rails/pull/34735 https://github.com/rails/rails/pull/31900

When any minitest executed under the OS where 2 or more CPU available,
SQLite 3 database files are not git-ignored.

Also updated other files which ignores SQLite database files.

* Steps to reproduce

```
$ grep processor /proc/cpuinfo | wc -l
6
$ git clone https://github.com/yahonda/rep_ignore_sqlite3_databases.git
$ cd rep_ignore_sqlite3_databases/
$ bin/rails test
$ git status
```

### Expected behavior:

- No `Untracked files:`

### Actual behavior:

- SQLite 3 database files appeared

```
$ git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	db/test.sqlite3-0
	db/test.sqlite3-1
	db/test.sqlite3-2
	db/test.sqlite3-3
	db/test.sqlite3-4
	db/test.sqlite3-5

nothing added to commit but untracked files present (use "git add" to track)
$
```
