### PR TITLE
Add doc about I18n support for :placeholder option [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -166,6 +166,8 @@ module ActionView
       # * <tt>:size</tt> - The number of visible characters that will fit in the input.
       # * <tt>:maxlength</tt> - The maximum number of characters that the browser will allow the user to enter.
       # * <tt>:placeholder</tt> - The text contained in the field by default which is removed when the field receives focus.
+      #   If set to true, use a translation is found in the current I18n locale
+      #   (through helpers.placeholders.<modelname>.<attribute>).
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples


### PR DESCRIPTION
The :placeholder option accepts true, so it should be mentioned in the documentation.

Ref: https://github.com/rails/rails/pull/16438