### PR TITLE
Changed controller name (Typo fix) in rails engines documentation [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -805,7 +805,7 @@ added above the `title` field with this code:
 </div>
 ```
 
-Next, we need to update our `Blorgh::ArticleController#article_params` method to
+Next, we need to update our `Blorgh::ArticlesController#article_params` method to
 permit the new form parameter:
 
 ```ruby


### PR DESCRIPTION
### Summary

- The controller created in the guides explaining rails engines is `Blorgh::ArticlesController`
- Changed to `Blorgh::ArticlesController` instead of `Blorgh::ArticleController`
- This was the single occurrence where controller name was incorrectly specified


