### PR TITLE
Fixed problem with Ruby 2.4+ which caused stack level too deep

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -119,6 +119,7 @@ class Numeric
   end
 
   [Float, Fixnum, Bignum, BigDecimal].each do |klass|
+    next if klass.method_defined?(:to_default_s)
     klass.send(:alias_method, :to_default_s, :to_s)
 
     klass.send(:define_method, :to_s) do |*args|


### PR DESCRIPTION
### Summary

Fixed a problem with compatibility with Ruby 2.4+ which caused "stack level too deep" error.