### PR TITLE
Fix a document to update postgresql version for rails6 [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -690,7 +690,7 @@ We had to create the **gitapp** directory and initialize an empty git repository
 
 ```bash
 $ cat config/database.yml
-# PostgreSQL. Versions 9.1 and up are supported.
+# PostgreSQL. Versions 9.3 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg


### PR DESCRIPTION
In rails6, PostgreSQL versions 9.3 and up are supported. I referred to https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L1.