### PR TITLE
Clarify severe security issues maintenance policy [ci skip]

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -65,7 +65,7 @@ Severe Security Issues
 ----------------------
 
 For severe security issues all releases in the current major series, and also the
-last major release series will receive patches and new versions. The
+last release in the previous major series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
 
 **Currently included series:** `6.0.Z`, `5.2.Z`.


### PR DESCRIPTION
There's been some confusion about which releases are covered: https://github.com/rails/rails/issues/36957, https://github.com/rails/rails/issues/36960, https://github.com/rails/rails/issues/37058.

It wasn't clear whether "the last major release series" meant the most recent release in the last major series, or all releases in that series.

The updated wording here is closer to what's on https://rubyonrails.org/security/.