### PR TITLE
Remove mysql2 specific rescue in abstract adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -623,11 +623,7 @@ module ActiveRecord
           when ER_QUERY_INTERRUPTED
             QueryCanceled.new(message, sql: sql, binds: binds)
           else
-            if exception.is_a?(Mysql2::Error::TimeoutError)
-              ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
-            else
-              super
-            end
+            super
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -140,6 +140,14 @@ module ActiveRecord
         def get_full_version
           @connection.server_info[:version]
         end
+
+        def translate_exception(exception, message:, sql:, binds:)
+          if !exception.error_number && exception.is_a?(Mysql2::Error::TimeoutError)
+            ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
+          else
+            super
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
The AbstractMysqlAdapter is supposed to contain mysql-specific, but mysql2-independant code 😅.

#36692 introduced this reference to `Mysql2::Error`, which should go in the `Mysql2Adapter` instead.