### PR TITLE
Store connection_handler per-fiber and per-thread.

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -133,11 +133,16 @@ module ActiveRecord
       self.filter_attributes = []
 
       def self.connection_handler
-        Thread.current.thread_variable_get(:ar_connection_handler) || default_connection_handler
+        thread = Thread.current
+
+        thread[:ar_connection_handler] || thread.thread_variable_get(:ar_connection_handler) || default_connection_handler
       end
 
       def self.connection_handler=(handler)
-        Thread.current.thread_variable_set(:ar_connection_handler, handler)
+        thread = Thread.current
+
+        thread[:ar_connection_handler] = handler
+        thread.thread_variable_set(:ar_connection_handler, handler)
       end
 
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new


### PR DESCRIPTION
Default to per-fiber if specified, otherwise revert to per-thread.

### Summary

In Rails 6, the "per-thread connection handler" was made to be actually per-thread, not per-fiber. However, I'm concerned this breaks `falcon` which is a fiber-per-request web server. So, I'd like to explore how we can fix this.

One thing I also need to do is check if this breaks on falcon or not, so independently of this PR, I'll evaluate how the issue manifests (or not) on `falcon`.

https://github.com/rails/rails/issues/30047