### PR TITLE
Fix route from "(:a)(:b)" when given only :a or :b

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -398,12 +398,21 @@ module ActionDispatch
           end
       end
 
-      # Invokes Journey::Router::Utils.normalize_path and ensure that
-      # (:locale) becomes (/:locale) instead of /(:locale). Except
-      # for root cases, where the latter is the correct one.
+      # Invokes Journey::Router::Utils.normalize_path, then ensures that
+      # /(:locale) becomes (/:locale). Except for root cases, where the
+      # former is the correct one.
       def self.normalize_path(path)
         path = Journey::Router::Utils.normalize_path(path)
-        path.gsub!(%r{/(\(+)/?}, '\1/') unless %r{^/(\(+[^)]+\)){1,}$}.match?(path)
+
+        # the path for a root URL at this point can be something like
+        # "/(/:locale)(/:platform)/(:browser)", and we would want
+        # "/(:locale)(/:platform)(/:browser)"
+
+        # reverse "/(", "/((" etc to "(/", "((/" etc
+        path.gsub!(%r{/(\(+)/?}, '\1/')
+        # if a path is all optional segments, change the leading "(/" back to
+        # "/(" so it evaluates to "/" when interpreted with no options.
+        path.sub!(%r{^(\(+)/}, '/\1') if %r{^(\(+[^)]+\)){1,}$}.match?(path)
         path
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1382,7 +1382,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "projects#index", @response.body
   end
 
-  def test_optionally_scoped_root_unscoped_access
+  def test_optional_scoped_root_hierarchy
     draw do
       scope "(:locale)" do
         scope "(:platform)" do
@@ -1394,7 +1394,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     assert_equal "/", root_path
+    assert_equal "/en", root_path(locale: "en")
+    assert_equal "/en/osx", root_path(locale: "en", platform: "osx")
+    assert_equal "/en/osx/chrome",
+      root_path(locale: "en", platform: "osx", browser: "chrome")
+
     get "/"
+    assert_equal "projects#index", @response.body
+
+    get "/en"
+    assert_equal "projects#index", @response.body
+
+    get "/en/osx"
+    assert_equal "projects#index", @response.body
+
+    get "/en/osx/chrome"
     assert_equal "projects#index", @response.body
   end
 


### PR DESCRIPTION
Previously, when generating a root path from a route having nested
optional scopes, and when providing an option, it would result in an
invalid path leading with "//". For example, the route
"(:locale)(:region)", given `locale: 'es'`, would output "//es".

Commit 7670d60977a introduced this bug while fixing the edge case of
empty strings returned when no options are passed to such routes.

This commit fixes both cases.

### Summary

See test cases in this commit, or try the following in a Rails console running Rails >= 5.2.3:

    ActionDispatch::Routing::Mapper.normalize_path('/(:locale)')
    #=> "/(:locale)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/:region)')
    #=> "/(/:locale)(/:region)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "/(/:locale)(/region/:region)"

You can see how including the locale, region, or both would result in a path starting with "//" for the nested cases.

Here's how it looked prior to Rails 5.2.3:

    ActionDispatch::Routing::Mapper.normalize_path('/(:locale)')
    #=> "/(:locale)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/:region)')
    #=> "(/:locale)(/:region)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "(/:locale)(/region/:region)"

There you can see how including either locale, region, or both would result in the correct path, but including neither would produce `""`.

This commit offers the following:

    ActionDispatch::Routing::Mapper.normalize_path('/(:locale)')
    #=> "/(:locale)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/:region)')
    #=> "/(:locale)(/:region)"
    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "/(:locale)(/region/:region)"

Here we're fixing the second example, i.e. the case that relies on a hierarchy of options where each successive option depends on the presence of the prior option. With a route having scopes generally of the form `(:locale)/(:region)`, for example, you can't provide only the region because the router would interpret it as the locale.

Therefore, resolving the general form `(:locale)/(:region)` to specifically `/(:locale)(/:region)` is correct. With no options it evaluates to `"/"`, with just locale ex. `"/en"`, and with locale and region ex. `"/en/us"`.

The final case, `(/:locale)(/region/:region)`, will evaluate to an incorrect path (leading with `"//"`) if given a region but not a locale. Fixing this involves a small concession, so has been done in a follow-up commit of its own.

