### PR TITLE
 Fix route from "(:a)(foo/:b)" when only given :b

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -398,12 +398,21 @@ module ActionDispatch
           end
       end
 
-      # Invokes Journey::Router::Utils.normalize_path and ensure that
-      # (:locale) becomes (/:locale) instead of /(:locale). Except
-      # for root cases, where the latter is the correct one.
+      # Invokes Journey::Router::Utils.normalize_path, then ensures that
+      # /(:locale) becomes (/:locale). Except for root cases, where the
+      # former is the correct one.
       def self.normalize_path(path)
         path = Journey::Router::Utils.normalize_path(path)
-        path.gsub!(%r{/(\(+)/?}, '\1/') unless %r{^/(\(+[^)]+\)){1,}$}.match?(path)
+
+        # the path for a root URL at this point can be something like
+        # "/(/:locale)(/:platform)/(:browser)", and we would want
+        # "/(:locale)(/:platform)(/:browser)"
+
+        # reverse "/(", "/((" etc to "(/", "((/" etc
+        path.gsub!(%r{/(\(+)/?}, '\1/')
+        # if a path is all optional segments, change the leading "(/" back to
+        # "/(" so it evaluates to "/" when interpreted with no options.
+        path.sub!(%r{^(\(+)/}, '/\1') if %r{^(\(+[^)]+\)){1,}$}.match?(path)
         path
       end
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -412,7 +412,9 @@ module ActionDispatch
         path.gsub!(%r{/(\(+)/?}, '\1/')
         # if a path is all optional segments, change the leading "(/" back to
         # "/(" so it evaluates to "/" when interpreted with no options.
-        path.sub!(%r{^(\(+)/}, '/\1') if %r{^(\(+[^)]+\)){1,}$}.match?(path)
+        # Unless, however, at least one secondary segment consists of a static
+        # part, ex. "(/:locale)(/pages/:page)"
+        path.sub!(%r{^(\(+)/}, '/\1') if %r{^(\(+[^)]+\))(\(+/:[^)]+\))*$}.match?(path)
         path
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1382,7 +1382,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "projects#index", @response.body
   end
 
-  def test_optionally_scoped_root_unscoped_access
+  def test_optional_scoped_root_hierarchy
     draw do
       scope "(:locale)" do
         scope "(:platform)" do
@@ -1394,7 +1394,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     assert_equal "/", root_path
+    assert_equal "/en", root_path(locale: "en")
+    assert_equal "/en/osx", root_path(locale: "en", platform: "osx")
+    assert_equal "/en/osx/chrome",
+      root_path(locale: "en", platform: "osx", browser: "chrome")
+
     get "/"
+    assert_equal "projects#index", @response.body
+
+    get "/en"
+    assert_equal "projects#index", @response.body
+
+    get "/en/osx"
+    assert_equal "projects#index", @response.body
+
+    get "/en/osx/chrome"
     assert_equal "projects#index", @response.body
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1412,6 +1412,53 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "projects#index", @response.body
   end
 
+  def test_optional_scoped_root_multiple_choice
+    draw do
+      scope "(:locale)" do
+        scope "(p/:platform)" do
+          scope "(b/:browser)" do
+            root to: "projects#index"
+          end
+        end
+      end
+    end
+
+    # Note, in this particular case where we rely on pattern matching instead
+    # of hierarchy to match parameters in a root path, root_path returns ""
+    # when given no path parameters.
+
+    assert_equal "/en", root_path(locale: "en")
+    assert_equal "/p/osx", root_path(platform: "osx")
+    assert_equal "/en/p/osx", root_path(locale: "en", platform: "osx")
+    assert_equal "/b/chrome", root_path(browser: "chrome")
+    assert_equal "/en/b/chrome", root_path(locale: "en", browser: "chrome")
+    assert_equal "/p/osx/b/chrome",
+      root_path(platform: "osx", browser: "chrome")
+    assert_equal "/en/p/osx/b/chrome",
+      root_path(locale: "en", platform: "osx", browser: "chrome")
+
+    get "/en"
+    assert_equal "projects#index", @response.body
+
+    get "/p/osx"
+    assert_equal "projects#index", @response.body
+
+    get "/en/p/osx"
+    assert_equal "projects#index", @response.body
+
+    get "/b/chrome"
+    assert_equal "projects#index", @response.body
+
+    get "/en/b/chrome"
+    assert_equal "projects#index", @response.body
+
+    get "/p/osx/b/chrome"
+    assert_equal "projects#index", @response.body
+
+    get "/en/p/osx/b/chrome"
+    assert_equal "projects#index", @response.body
+  end
+
   def test_scope_with_format_option
     draw do
       get "direct/index", as: :no_format_direct, format: false


### PR DESCRIPTION
Previously, when generating a root path from a route having nested
optional scopes where second-level or greater scopes had a static part,
and when providing only a second-level option, it would result in an
invalid path leading with "//". Ex. a path generated from the route
"(:a)(foo/:b)", given `b: 'bar'`, would return "//foo/bar".

Commit 7670d60 introduced this bug while fixing the edge case of
empty strings returned when no options are passed to such routes.

A separate (dependent) commit fixes this for simpler hierarchical cases like
"(:a)(:b)(:c)", and this fixes it for "(:a)(foo/:b)(bar/:c)".

### Summary

#37073 fixes a clear regression caused by 7670d60977a, with no tradeoff. However, I'm affected by another, more edge-case change caused by the commit, and this proposed fix involves what I consider a small concession.

As noted in #37073, prior to Rails 5.2.3 the following was true:

    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "(/:locale)(/region/:region)"

The option-less root path evaluates to an empty string, but works given any combination of options.

#37073 fixes one regression in 5.2.3, but if accepted, the following will still be true:

    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "/(:locale)(/region/:region)"

Similar to the behavior of Rails >= 5.2.3, this would evaluate correctly with no options, but incorrectly evaluate to have a preceding `//` if locale is omitted.

This fix proposes reverting the special case of, for lack of a better term, "multiple choice" optional routes. I.e. when second-level (or greater) paths have fixed sections that the router can match on, therefore not relying solely on hierarchy. This would mean pre-5.2.3 behavior where providing no options evaluates to a path of `""`:

    ActionDispatch::Routing::Mapper.normalize_path('(/:locale)(/region/:region)')
    #=> "(/:locale)(/region/:region)"

Two rationales to allow this concession:

1. For a decade or so, many more cases than this particular one evaluated to empty root paths, so it's obviously workable for most.
2. It is unlikely that after the 5.2.3 release, many people rely on providing no options to optional nested routes, that are also broken when options are provided.

In my experience reviewers sometimes want to know about the use case behind a request, so I'll provide mine. We have a site-wide homepage and site search, but mostly navigate the site scoped to targeted regions that also have a homepage and site search. Plus, our site uses a base `"(:locale)"` scope. So, our routes look something like this (simplified for brevity):

    scope "(:locale)" do
      root "home#index"
      scope '(r/:region)' do
        root 'regions/landing_pages#show', as: :region
        get '/search' => 'search#index'
        get '/pages/:id' => 'pages#show'
      end
    end

The landing page code is specific to regions, but search and interior pages share a lot of code for regionalized and site-wide content. I'm sure there are other ways to do it, but this is pretty clean. It generates SEO-friendly pages that demonstrate a clear site hierarchy in the URL with a minimum of effort. And, note, I wouldn't rely on the root path implied by the optional locale and region scopes anyways, since I route to a `HomeController` for the site-wide homepage.