### PR TITLE
Fixed a bug in ActionView resolver.

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -15,7 +15,7 @@ module ActionView
 
       def self.build(name, prefix, partial)
         virtual = ""
-        virtual << "#{prefix}/" unless prefix.empty?
+        virtual << "#{prefix}/" if prefix.present?
         virtual << (partial ? "_#{name}" : name)
         new name, prefix, partial, virtual
       end


### PR DESCRIPTION
### Summary

When unnamed controller class was in chain of inheritance then ActionView Resolver would get prefix equal to nil. Nil does not have 'empty?' method. That change fixes this bug.

### Other Information

I'm building a ResourceController that injects itself in between ApplicationController and ie. ProductsController with unnamed class. I'm fixing this with monkey patch currently but I guess this could be incorporated directly into rails.