### PR TITLE
Return `nil` instead of raising exceptions when casting invalid input to PostgreSQL Point

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
@@ -28,6 +28,8 @@ module ActiveRecord
             else
               value
             end
+          rescue
+            nil
           end
 
           def serialize(value)

--- a/activerecord/test/cases/adapters/postgresql/point_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/point_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      class PointTest < ActiveRecord::PostgreSQLTestCase
+        def setup
+          @type = OID::Point.new
+        end
+
+        def test_valid_user_input_cast
+          assert_equal(ActiveRecord::Point.new(3.4, 5.6), @type.cast("3.4, 5.6"))
+          assert_equal(ActiveRecord::Point.new(3.4, 5.6), @type.cast("(3.4, 5.6)"))
+        end
+
+        def test_invalid_user_input_cast
+          assert_nil @type.cast("   ")
+        end
+
+        def test_float_array_cast
+          assert_equal(ActiveRecord::Point.new(3.4, 5.6), @type.cast([3.4, 5.6]))
+        end
+
+        def test_unsupported_type_cast
+          assert_equal(4, @type.cast(4))
+          assert_equal(true, @type.cast(true))
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/point_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/point_test.rb
@@ -17,10 +17,15 @@ module ActiveRecord
 
         def test_invalid_user_input_cast
           assert_nil @type.cast("   ")
+          assert_nil @type.cast("3,")
         end
 
         def test_float_array_cast
           assert_equal(ActiveRecord::Point.new(3.4, 5.6), @type.cast([3.4, 5.6]))
+        end
+
+        def test_invalid_subtype_array_cast
+          assert_nil @type.cast([true, "a"])
         end
 
         def test_unsupported_type_cast


### PR DESCRIPTION
Other `OID` types (like `Cidr`, `Uuid`, `Date`, `Decimal`, ...) do not raise exceptions when trying to cast invalid inputs with `#cast` or `#cast_value` methods. `OID::Point#cast` raises errors in such cases (for instance, `OID::Point.new.cast('3, ')`).

This PR adds some non-regression tests and makes `#cast` return `nil` value instead of raising exceptions with invalid inputs.