### PR TITLE
Add title tag to mailer previews

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -26,6 +26,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       @email_action = File.basename(params[:path])
 
       if @preview.email_exists?(@email_action)
+        @page_title = "Mailer Preview for #{@preview.preview_name}##{@email_action}"
         @email = @preview.call(@email_action, params)
 
         if params[:part]

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html><head>
+<title><%= @page_title %></title>
 <meta name="viewport" content="width=device-width" />
 <style type="text/css">
   html, body, iframe {

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -823,6 +823,35 @@ module ApplicationTests
       assert_equal 200, last_response.status
     end
 
+    test "mailer preview title tag" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Hello, World!
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app("development")
+
+      get "/rails/mailers/notifier/foo"
+      assert_match "<title>Mailer Preview for notifier#foo</title>", last_response.body
+    end
+
     private
       def build_app
         super


### PR DESCRIPTION
### Summary

Individual mailer previews currently don't have a title tag, while the mailers index page does. I thought it appropriate to add a title tag to them as well.
