### PR TITLE
Allow RedisCacheStore to fail safely when maximum client connections reached

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -476,7 +476,7 @@ module ActiveSupport
 
         def failsafe(method, returning: nil)
           yield
-        rescue ::Redis::BaseConnectionError => e
+        rescue ::Redis::BaseError => e
           handle_exception exception: e, method: method, returning: returning
           returning
         end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -233,13 +233,34 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
   end
 
-  class FailureSafetyTest < StoreTest
+  class MaxClientsReachedRedisClient < Redis::Client
+    def ensure_connected
+      raise Redis::CommandError
+    end
+  end
+
+  class FailureSafetyFromUnavailableClientTest < StoreTest
     include FailureSafetyBehavior
 
     private
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, UnavailableRedisClient)
+
+        yield ActiveSupport::Cache::RedisCacheStore.new
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureSafetyFromMaxClientsReachedErrorTest < StoreTest
+    include FailureSafetyBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, MaxClientsReachedRedisClient)
 
         yield ActiveSupport::Cache::RedisCacheStore.new
       ensure


### PR DESCRIPTION
This fixes #37337 

### Summary

Recently I encountered a service interruption relating to Heroku Redis, which I use for caching. The Redis server returned `ERR max number of clients reached`. Redis Cache Store has failsafes to make sure data is still returned when Redis suffers connection errors, but the max number of clients reached error is not a `Redis::ConnectionError`, it is instead a `Redis::CommandError`. Instead of being returned fresh data from the database, my users were sent 500 errors.

This fix simply changes the rescue to save requests from all Redis errors. Of course, errors are still reported to the error handler that can be registered so errors will still be sent via the method a user chooses. This is consistent with the other caching stores, which save from virtually all errors:

* MemCacheStore rescues from all Dalli errors (`Dalli::DalliError`).
* [ReadThis](https://github.com/sorentwo/readthis) (another Redis cache) rescues from `Redis::BaseError`.
* FileStore rescues doesn't declare a specific type and rescues from all.