### PR TITLE
Fix FrozenError on ActiveModel::Error clear and delete

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -569,6 +569,12 @@ module ActiveModel
       __setobj__ prepare_content
     end
 
+    def delete(attribute)
+      ActiveSupport::Deprecation.warn("Calling `delete` to an ActiveModel::Errors messages hash is deprecated. Please call `ActiveModel::Errors#delete` instead.")
+
+      @errors.delete(attribute)
+    end
+
     private
       def prepare_content
         content = @errors.to_hash
@@ -598,6 +604,12 @@ module ActiveModel
       @errors.add(@attribute, message)
       __setobj__ @errors.messages_for(@attribute)
       self
+    end
+
+    def clear
+      ActiveSupport::Deprecation.warn("Calling `clear` to an ActiveModel::Errors message array in order to delete all errors is deprecated. Please call `ActiveModel::Errors#delete` instead.")
+
+      @errors.delete(@attribute)
     end
   end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -103,6 +103,15 @@ class ErrorsTest < ActiveModel::TestCase
     assert_empty person.errors
   end
 
+  test "clear errors by key" do
+    person = Person.new
+    person.validate!
+
+    assert_equal 1, person.errors.count
+    assert_deprecated { person.errors[:name].clear }
+    assert_empty person.errors
+  end
+
   test "error access is indifferent" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, "omg")
@@ -617,6 +626,15 @@ class ErrorsTest < ActiveModel::TestCase
       },
       errors.details
     )
+  end
+
+  test "messages delete (deprecated)" do
+    person = Person.new
+    person.validate!
+
+    assert_equal 1, person.errors.count
+    assert_deprecated { person.errors.messages.delete(:name) }
+    assert_empty person.errors
   end
 
   test "group_by_attribute" do


### PR DESCRIPTION
### Summary

This PR fixes a `FrozenError` when attempting to clear or delete `ActiveModel::Errors` through the deprecated array methods. In particular the error happens in the following situations:

```rb
# calling `clear` on the deprecated array
errors[:some_attribute].clear

# calling `delete` on the deprecated messages hash
errors.messages.delete(:some_attribute)
```

Following the recent introduction of `ActiveModel::Error`, this PR adds deprecation warnings for those two messages.

Fixes https://github.com/rails/rails/issues/37081

### Other Information

It's not clear to me if there are other methods that try to mutate the errors require the same treatment. 

I would also love some feedback on whether the deprecation warnings make sense. 🙇 ❤️ 
