### PR TITLE
Extend `test_can_write_while_reading_from_replicas_if_explicit`

### DIFF
--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -62,7 +62,11 @@ module ActiveRecord
 
         ActiveRecord::Base.connected_to(role: :writing, prevent_writes: false) do
           assert ActiveRecord::Base.connected_to?(role: :writing)
+          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
         end
+
+        assert ActiveRecord::Base.connected_to?(role: :writing)
+        assert_predicate ActiveRecord::Base.connection, :preventing_writes?
       end
       assert called
     end


### PR DESCRIPTION
- Ensure that explicit method call `connected_to` with `prevent_writes: false`
  turns off 'preventing writes' in the passed block.
- Ensure that after explicit call method call `connected_to` with `prevent_writes: false`
  'preventing writes' is retained

Related to https://github.com/rails/rails/pull/37065
@eileencodes Please let me know whether you think those asserts makes sense to add.