### PR TITLE
Fix grammar for attached? method doc

### DIFF
--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -35,7 +35,7 @@ module ActiveStorage
       end
     end
 
-    # Returns true if any attachments has been made.
+    # Returns true if any attachments have been made.
     #
     #   class Gallery < ApplicationRecord
     #     has_many_attached :photos


### PR DESCRIPTION
Attachments is plural, so it should be 'have'.