### PR TITLE
Markdown `word highlight` doesn't work inside lists. Add CSS to fix […

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -34,7 +34,7 @@ pre, code {
   color: #222;
 }
 
-p code {
+p code, ul code {
   background: #eee;
   border-radius: 2px;
   padding: 1px 3px;


### PR DESCRIPTION
…ci skip]

We use markdown backticks to highlight code related words in the guide. When converted to html, we see that our content is wrapped within `<code>` html tag.

The [main.css](https://github.com/rails/rails/blob/master/guides/assets/stylesheets/main.css#L28-L49) of the guides site adds css to visually enhance this `<code>` wrapped content.

The problem is, the visual distinction is seen only if the word/phrase is within a `<p>` tag. It doesn't work if they are within a `<ul>` tag. Some of our guide pages have such content. 

Screenshot example:

This is how the markdown highlights are seen now without the css fix. 
https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions

(screenshot beginning 👇 )
<img width="661" alt="image" src="https://user-images.githubusercontent.com/856853/64067686-65dae000-cc4a-11e9-8381-335cfe578e1d.png">
(screenshot end ☝️  )

Note that, the the very last paragraph has backtick highlighted content. It's visually distinguishable. But the list has many such backtick content, but none have the same distinction. It's because the css rule is not scoped for the list.

Here's how it looks with this fix:

(screenshot beginning 👇 )
<img width="650" alt="image" src="https://user-images.githubusercontent.com/856853/64067737-f0bbda80-cc4a-11e9-8e6e-6948af322bb0.png">
(screenshot end ☝️  )

This change will make many other guides a bit more readable because they too have this problem.
Just one of the many examples: https://edgeguides.rubyonrails.org/active_job_basics.html#supported-types-for-arguments
