### PR TITLE
Fix IRB deprecation warning on tab-completion

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -145,6 +145,10 @@ module ActiveSupport
         target.inspect
       end
 
+      # Don't give a deprecation warning on methods that IRB may invoke
+      # during tab-completion.
+      delegate :hash, :instance_methods, to: :target
+
       # Returns the class of the new constant.
       #
       #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)


### PR DESCRIPTION
IRB invokes `#hash` (via a call to `Hash#include?`) and `#instance_methods` on each object in `ObjectSpace.each_object(Module)` when performing tab-completion on chain of method calls.  This patch prevents a deprecation warning from being printed when any of those objects are a `ActiveSupport::Deprecation::DeprecatedConstantProxy`.

Fixes #37097.
