### PR TITLE
Correctly classify the files and directories that pass to watcher

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -351,7 +351,7 @@ module Rails
       files, dirs = config.watchable_files.dup, config.watchable_dirs.dup
 
       ActiveSupport::Dependencies.autoload_paths.each do |path|
-        dirs[path.to_s] = [:rb]
+        File.file?(path) ? files << path.to_s : dirs[path.to_s] = [:rb]
       end
 
       [files, dirs]

--- a/railties/test/application/watcher_test.rb
+++ b/railties/test/application/watcher_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class WatcherTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    setup :build_app
+    teardown :teardown_app
+
+    def app
+      @app ||= Rails.application
+    end
+
+    test "watchable_args classifies files included in autoload path" do
+      add_to_config <<-RUBY
+        config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+      RUBY
+      app_file "app/README.md", ""
+
+      require "#{rails_root}/config/environment"
+
+      files, _ = Rails.application.watchable_args
+      assert_includes files, "#{rails_root}/app/README.md"
+    end
+  end
+end


### PR DESCRIPTION
Currently, autoload paths pass to the watcher as directories. If using evented watcher, this possibly pass as it is to `Listen`.
But autoload paths include files and `Listen` raise an error when was passed file. So, it is necessary to classify files and directories correctly.

Fixes #37011.
