### PR TITLE
Fix an error message to replace http with https in a reference URL

### DIFF
--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -54,7 +54,7 @@ module ActiveRecord
             data = YAML.load(render(IO.read(@file)))
             data ? validate(data).to_a : []
           rescue ArgumentError, Psych::SyntaxError => error
-            raise Fixture::FormatError, "a YAML error occurred parsing #{@file}. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Please have a look at http://www.yaml.org/faq.html\nThe exact error was:\n  #{error.class}: #{error}", error.backtrace
+            raise Fixture::FormatError, "a YAML error occurred parsing #{@file}. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Please have a look at https://www.yaml.org/faq.html\nThe exact error was:\n  #{error.class}: #{error}", error.backtrace
           end
         end
 


### PR DESCRIPTION
### Summary
Following is an example using curl for this URL.
```
$ curl -I http://www.yaml.org/faq.html
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Mon, 02 Sep 2019 01:02:51 GMT
Content-Type: text/html
Connection: close
Location: https://yaml.org/faq.html
Cache-Control: max-age=10800
Vary: Accept-Language
```