### PR TITLE
Optimize Module#delegate to no longer be linear

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -190,7 +190,13 @@ class Module
     to = to.to_s
     to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
 
-    method_names = methods.map do |method|
+    method_def = []
+    method_names = []
+
+    methods.map do |method|
+      method_name = prefix ? "#{method_prefix}#{method}" : method
+      method_names << method_name.to_sym
+
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.
       definition = /[^\]]=$/.match?(method) ? "arg" : "*args, &block"
@@ -203,34 +209,33 @@ class Module
       # whereas conceptually, from the user point of view, the delegator should
       # be doing one call.
       if allow_nil
-        method_def = [
-          "def #{method_prefix}#{method}(#{definition})",
-          "  _ = #{to}",
-          "  if !_.nil? || nil.respond_to?(:#{method})",
-          "    _.#{method}(#{definition})",
-          "  end",
+        method = method.to_s
+
+        method_def <<
+          "def #{method_name}(#{definition})" <<
+          "  _ = #{to}" <<
+          "  if !_.nil? || nil.respond_to?(:#{method})" <<
+          "    _.#{method}(#{definition})" <<
+          "  end" <<
           "end"
-        ].join ";"
       else
-        exception = %(raise DelegationError, "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+        method = method.to_s
+        method_name = method_name.to_s
 
-        method_def = [
-          "def #{method_prefix}#{method}(#{definition})",
-          "  _ = #{to}",
-          "  _.#{method}(#{definition})",
-          "rescue NoMethodError => e",
-          "  if _.nil? && e.name == :#{method}",
-          "    #{exception}",
-          "  else",
-          "    raise",
-          "  end",
+        method_def <<
+          "def #{method_name}(#{definition})" <<
+          "  _ = #{to}" <<
+          "  _.#{method}(#{definition})" <<
+          "rescue NoMethodError => e" <<
+          "  if _.nil? && e.name == :#{method}" <<
+          %(   raise DelegationError, "#{self}##{method_name} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}") <<
+          "  else" <<
+          "    raise" <<
+          "  end" <<
           "end"
-        ].join ";"
       end
-
-      module_eval(method_def, file, line)
     end
-
+    module_eval(method_def.join(";"), file, line)
     private(*method_names) if private
     method_names
   end


### PR DESCRIPTION
The previous implementation is pretty much linear.
Delegating 10 methods is 10 times slower than delegating 1 method.

```
     old_delegate(1)     27.299k (± 2.7%) i/s -    138.216k in   5.066863s
     old_delegate(2)     14.372k (± 2.5%) i/s -     72.879k in   5.074092s
     old_delegate(3)      9.434k (± 7.3%) i/s -     47.750k in   5.092412s
     old_delegate(4)      6.771k (±10.4%) i/s -     33.810k in   5.060218s
     old_delegate(5)      5.733k (± 4.4%) i/s -     28.861k in   5.044486s
```

Beside a few micro-optimizations, this patch mostly try to call `module_eval`
only once, because it has a significant fixed cost every time it's called.

By concatenating the method definitions to together, we gain performance when
multiple methods are delegated at once:

```
     new_delegate(1)     28.531k (± 2.6%) i/s -    143.052k in   5.017356s
     new_delegate(2)     16.751k (± 2.4%) i/s -     85.072k in   5.081371s
     new_delegate(3)     12.021k (± 3.0%) i/s -     61.048k in   5.083224s
     new_delegate(4)      9.433k (± 3.1%) i/s -     47.944k in   5.087528s
     new_delegate(5)      7.745k (± 3.0%) i/s -     38.849k in   5.020850s
```

Which is respectively 5%, 16%, 27%, 39% and 35% improvements.

The full benchmark can be found here: https://gist.github.com/casperisfine/d52754308e2048fbe2b84e1b60ff56be

cc @rafaelfranca @Edouard-chin 