### PR TITLE
Add note to Attachment about Blob methods

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/module/delegation"
 # Attachments associate records with blobs. Usually that's a one record-many blobs relationship,
 # but it is possible to associate many different records with the same blob. A foreign-key constraint
 # on the attachments table prevents blobs from being purged if they’re still attached to any records.
+#
+# Attachments also have access to all methods from {ActiveStorage::Blob}[rdoc-ref:ActiveStorage::Blob].
 class ActiveStorage::Attachment < ActiveRecord::Base
   self.table_name = "active_storage_attachments"
 


### PR DESCRIPTION
### Summary

`ActiveStorage::Attachment` delegates missing methods to `ActiveStorage::Blob`:

https://github.com/rails/rails/blob/d05f1f036ff4987918c907eb7e78ef8e8eedd6ea/activestorage/app/models/active_storage/attachment.rb#L14

This isn't mentioned in the documentation, so I wasn't aware of the ability to do things like `User.avatar.filename`. Hopefully this makes things more clear :)

I looked at a few other places where method delegation was mentioned in the docs, but the closest one I could find was `This class delegates unknown methods to the <tt>association</tt>'s relation class via a delegate cache.` in [CollectionProxy](https://github.com/rails/rails/blob/f7049ec583a727c72ee7b218fbff267a06cd7882/activerecord/lib/active_record/associations/collection_proxy.rb#L20-L21). I can change this to be worded more like that, if we prefer.