### PR TITLE
[ci skip] Add modern way to enable asset precompile with Capistrano to asset pipeline guide

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -681,7 +681,11 @@ Capistrano (v2.15.1 and above) includes a recipe to handle this in deployment.
 Add the following line to `Capfile`:
 
 ```ruby
+# Capistrano version 2
 load 'deploy/assets'
+
+# Capistrano version 3
+require "capistrano/rails/assets"
 ```
 
 This links the folder specified in `config.assets.prefix` to `shared/assets`.


### PR DESCRIPTION
### Summary

Capistrano version 3 changed its way to enable asset precompile during deployment.
This commit doesn't remove old way but only add new way for v3.

See: https://github.com/capistrano/rails#usage