### PR TITLE
Delay ActionDispatch::Response configuration to load-time

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -540,4 +540,6 @@ module ActionDispatch # :nodoc:
       end
     end
   end
+
+  ActiveSupport.run_load_hooks(:action_dispatch_response, Response)
 end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -42,9 +42,11 @@ module ActionDispatch
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
-      ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
-      ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
-      ActionDispatch::Response.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_media_type_on_content_type
+      ActiveSupport.on_load(:action_dispatch_response) do
+        self.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
+        self.default_headers = app.config.action_dispatch.default_headers
+        self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_media_type_on_content_type
+      end
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2472,12 +2472,12 @@ module ApplicationTests
       remove_from_config '.*config\.load_defaults.*\n'
 
       app_file "config/initializers/new_framework_defaults_6_0.rb", <<-RUBY
-        Rails.application.config.action_dispatch.return_only_media_type_on_content_type = true
+        Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
       RUBY
 
       app "development"
 
-      assert_equal true, ActionDispatch::Response.return_only_media_type_on_content_type
+      assert_equal false, ActionDispatch::Response.return_only_media_type_on_content_type
     end
 
     test "ActionMailbox.logger is Rails.logger by default" do


### PR DESCRIPTION
### Summary

I encountered an issue similar to #33283.

In a rails app which has just upgraded to Rails 6.0.0 from 5.2.3, I turned on `Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false` config but it wasn't propagated to `ActionDispatch::Response.return_only_media_type_on_content_type`. I checked if [the initializer]((https://github.com/rails/rails/blob/v6.0.0/actionpack/lib/action_dispatch/railtie.rb#L41-L56)) is loaded too early from any third-party library (by inserting `raise "foo"` there and then running `bin/rails c`) but every row of the backtrace was in rails.

In ActionMailer [the configuration is delayed to load-time](https://github.com/rails/rails/blob/v6.0.0/actionmailer/lib/action_mailer/railtie.rb#L40-L54), so I guess ActionDispatch should also do that in [its initializer](https://github.com/rails/rails/blob/v6.0.0/actionpack/lib/action_dispatch/railtie.rb#L41-L56).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
