### PR TITLE
Don't use Process#clock_gettime CLOCK_PROCESS_CPUTIME_ID on Solaris

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't use `Process#clock_gettime(CLOCK_PROCESS_CPUTIME_ID)` on Solaris
+
+    *Iain Beeston*
+
 *   Prevent `ActiveSupport::Duration.build(value)` from creating instances of
     `ActiveSupport::Duration` unless `value` is of type `Numeric`.
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -57,7 +57,8 @@ module ActiveSupport
 
       def self.clock_gettime_supported? # :nodoc:
         defined?(Process::CLOCK_PROCESS_CPUTIME_ID) &&
-          !Gem.win_platform?
+          !Gem.win_platform? &&
+          !RUBY_PLATFORM.match?(/solaris/i)
       end
       private_class_method :clock_gettime_supported?
 


### PR DESCRIPTION
### Summary

On solaris (I'm using SunOS 5.11), it seems to be impossible to start an application using rails 6 (I'm using rails 6.0.0), because on startup an `Invalid argument - clock_gettime (Errno::EINVAL)` error is thrown:

    activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:145:in `clock_gettime': Invalid argument - clock_gettime (Errno::EINVAL)
	from activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:145:in `now_cpu'
	from activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:80:in `start!'
	from activesupport-6.0.0/lib/active_support/subscriber.rb:132:in `start'
	from activesupport-6.0.0/lib/active_support/log_subscriber.rb:103:in `start'
	from activesupport-6.0.0/lib/active_support/notifications/fanout.rb:156:in `start'
	from activesupport-6.0.0/lib/active_support/notifications/fanout.rb:58:in `block in start'
	from activesupport-6.0.0/lib/active_support/notifications/fanout.rb:58:in `each'
	from activesupport-6.0.0/lib/active_support/notifications/fanout.rb:58:in `start'
	from activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:36:in `start'
	from activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:22:in `instrument'
	from activerecord-6.0.0/lib/active_record/connection_adapters/abstract_adapter.rb:697:in `log'

The error occurs because rails incorrectly tries to use `Process.clock_gettime(Process::CLOCK_PROCESS_CPUTIME_ID)` (on solaris `defined?(Process::CLOCK_PROCESS_CPUTIME_ID)` returns `true`), but this clock type is not supported.

There is already a workaround for the same issue on windows (added in #34410), so I have extended this to also check if rails is running on solaris, and then avoid using this system call.