### PR TITLE
Intern ActiveJob queue_name

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -49,7 +49,7 @@ module ActiveJob
       def queue_name_from_part(part_name) #:nodoc:
         queue_name = part_name || default_queue_name
         name_parts = [queue_name_prefix.presence, queue_name]
-        name_parts.compact.join(queue_name_delimiter)
+        -name_parts.compact.join(queue_name_delimiter)
       end
     end
 


### PR DESCRIPTION
Memory profiling shows that the queue name is always duplicated

```
Retained String Report
-----------------------------------
  ...
217  "default"
200  /tmp/bundle/ruby/2.6.0/bundler/gems/rails-59e746d4d07b/activejob/lib/active_job/queue_name.rb:52
```

Clearly this is not a lot of wasted memory, however:

  - The fix is dead simple
  - Since these strings are stored on the class, it's a good idea to freeze it, otherwise users might mistakenly mutate them.

cc @rafaelfranca @Edouard-chin 