### PR TITLE
Do not set response "Vary" header if it has already been set

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -78,7 +78,9 @@ module ActionController
       end
 
       def _set_vary_header
-        self.headers["Vary"] = "Accept" if request.should_apply_vary_header?
+        if self.headers["Vary"].blank? && request.should_apply_vary_header?
+          self.headers["Vary"] = "Accept"
+        end
       end
 
       # Normalize arguments by catching blocks and setting them on :update.

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -182,6 +182,15 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       end
     end
 
+    def get_with_vary_set_x_requested_with
+      respond_to do |format|
+        format.json do
+          response.headers["Vary"] = "X-Requested-With"
+          render json: "JSON OK", status: 200
+        end
+      end
+    end
+
     def get_with_params
       render plain: "foo: #{params[:foo]}", status: 200
     end
@@ -554,6 +563,13 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       get "/get", params: { format: "json" }
       assert_nil response.headers["Vary"]
+    end
+  end
+
+  def test_not_setting_vary_header_when_it_has_already_been_set
+    with_test_route_set do
+      get "/get_with_vary_set_x_requested_with", headers: { "Accept" => "application/json" }, xhr: true
+      assert_equal "X-Requested-With", response.headers["Vary"]
     end
   end
 


### PR DESCRIPTION
PR https://github.com/rails/rails/pull/36213 adds the `Vary: Accept` header when using `Accept` header for response. This poses a problem in cases where the application sets the `Vary` header to a value other than `Accept`. In that case, the `_set_vary_header` method will reset the header value to `"Accept"` regardless of the header set in the controller action.

This commit checks the header to be sure that it does not already have a value before setting the header to `"Accept"`. If the header value is blank, it sets the header accordingly. If the header already has a value, then `_set_vary_header` will do nothing undertake assumption that the application is already handling this header.

CC: @st0012, @rafaelfranca, @eileencodes 