### PR TITLE
Fix escaping in OptimizedFileSystemResolver

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -350,7 +350,7 @@ module ActionView
       end
 
       def build_regex(path, details)
-        query = escape_entry(File.join(@path, path))
+        query = Regexp.escape(File.join(@path, path))
         exts = EXTENSIONS.map do |ext, prefix|
           match =
             if ext == :variants && details[ext] == :any

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -79,6 +79,16 @@ module ResolverSharedTests
     assert_kind_of ActionView::Template::Handlers::ERB, templates[0].handler
   end
 
+  def test_can_find_when_special_chars_in_path
+    dir = "test +()[]{}"
+    with_file "#{dir}/hello_world", "Hello funky path!"
+
+    templates = resolver.find_all("hello_world", dir, false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    assert_equal 1, templates.size
+    assert_equal "Hello funky path!", templates[0].source
+    assert_equal "#{dir}/hello_world", templates[0].virtual_path
+  end
+
   def test_doesnt_find_template_with_wrong_details
     with_file "test/hello_world.html.erb", "Hello plain text!"
 


### PR DESCRIPTION
`OptimizedFileSystemResolver` builds a regular expression to match view template paths.  Prior to this patch, only file globbing special characters were escaped when building this regular expression, leaving other regular expression special characters unescaped.

This patch properly escapes all regular expression special characters, and adds test coverage for paths that include these characters.

Fixes #37107.
