### PR TITLE
Fix has_one through reflection casting check

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -766,7 +766,8 @@ module ActiveRecord
       def klass
         @klass ||= delegate_reflection.compute_class(class_name).tap do |klass|
           if !parent_reflection.is_a?(HasAndBelongsToManyReflection) &&
-             !klass.reflections.include?(options[:through].to_s) &&
+             !(klass.reflections.key?(options[:through].to_s) ||
+               klass.reflections.key?(options[:through].to_s.pluralize)) &&
              active_record.type_for_attribute(active_record.primary_key).type != :integer
             raise NotImplementedError, <<~MSG.squish
               In order to correctly type cast #{active_record}.#{active_record.primary_key},

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -256,14 +256,6 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_kind_of ThroughReflection, Subscriber.reflect_on_association(:books)
   end
 
-  def test_uncastable_has_many_through_reflection
-    error = assert_raises(NotImplementedError) { Subscriber.new.published_books }
-    assert_equal <<~MSG.squish, error.message
-      In order to correctly type cast Subscriber.nick,
-      PublishedBook needs to define a :subscriptions association.
-    MSG
-  end
-
   def test_chain
     expected = [
       Organization.reflect_on_association(:author_essay_categories),
@@ -523,4 +515,65 @@ class ReflectionTest < ActiveRecord::TestCase
         assert_equal(value, reflection.send(method))
       end
     end
+end
+
+class UncastableReflectionTest < ActiveRecord::TestCase
+  class Book < ActiveRecord::Base
+  end
+
+  class Subscription < ActiveRecord::Base
+    belongs_to :subscriber
+    belongs_to :book
+  end
+
+  class Subscriber < ActiveRecord::Base
+    self.primary_key = "nick"
+    has_many :subscriptions
+    has_one :subscription
+    has_many :books, through: :subscriptions
+    has_one :book, through: :subscription
+  end
+
+  setup do
+    @subscriber = Subscriber.create!(nick: "unique")
+  end
+
+  teardown do
+    Book._reflections.clear
+    Book.clear_reflections_cache
+    Subscriber.has_many :books, through: :subscriptions
+    Subscriber.has_one :book, through: :subscription
+  end
+
+  test "uncastable has_many through: reflection" do
+    error = assert_raises(NotImplementedError) { @subscriber.books }
+    assert_equal <<~MSG.squish, error.message
+      In order to correctly type cast UncastableReflectionTest::Subscriber.nick,
+      UncastableReflectionTest::Book needs to define a :subscriptions association.
+    MSG
+  end
+
+  test "fixing uncastable has_many through: reflection with has_many" do
+    Book.has_many :subscriptions
+    @subscriber.books
+  end
+
+  test "uncastable has_one through: reflection" do
+    error = assert_raises(NotImplementedError) { @subscriber.book }
+
+    assert_equal <<~MSG.squish, error.message
+      In order to correctly type cast UncastableReflectionTest::Subscriber.nick,
+      UncastableReflectionTest::Book needs to define a :subscription association.
+    MSG
+  end
+
+  test "fixing uncastable has_one through: reflection with has_many" do
+    Book.has_many :subscriptions
+    @subscriber.book
+  end
+
+  test "fixing uncastable has_one through: reflection with has_one" do
+    Book.has_one :subscription
+    @subscriber.book
+  end
 end


### PR DESCRIPTION
### Summary

Fixes a bug where has_one through relations with non-integer primary keys were incorrectly raising an implementation error even though a reflectable association was present.

Related to https://github.com/rails/rails/pull/36847, specifically [this line](https://github.com/rails/rails/blob/a8aca0235092c33527aedea6ce8bf82766f8cec1/activerecord/lib/active_record/table_metadata.rb#L48).

Fixes https://github.com/rails/rails/issues/36984.
