### PR TITLE
Do not enforce no braces for hash argument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,12 +34,6 @@ Rails/RefuteMethods:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -899,7 +899,7 @@ class CookiesTest < ActionController::TestCase
 
     key_generator = @request.env["action_dispatch.key_generator"]
     old_secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
-    old_value = ActiveSupport::MessageVerifier.new(old_secret).generate({bar: "baz"})
+    old_value = ActiveSupport::MessageVerifier.new(old_secret).generate({ bar: "baz" })
 
     @request.headers["Cookie"] = "foo=#{old_value}"
     get :get_signed_cookie

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -123,7 +123,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       encryptor = ActiveSupport::MessageEncryptor.new("A" * 32, cipher: "aes-256-gcm", serializer: Marshal)
 
-      cookies[SessionKey] = encryptor.encrypt_and_sign({"foo" => "bar", "session_id" => "abc"})
+      cookies[SessionKey] = encryptor.encrypt_and_sign({ "foo" => "bar", "session_id" => "abc" })
 
       get "/get_session_value"
 

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -162,11 +162,11 @@ module ActiveSupport
         end
 
         def translate_number_value_with_default(key, **i18n_options)
-          I18n.translate(key, **{default: default_value(key), scope: :number}.merge!(i18n_options))
+          I18n.translate(key, **{ default: default_value(key), scope: :number }.merge!(i18n_options))
         end
 
         def translate_in_locale(key, **i18n_options)
-          translate_number_value_with_default(key, **{locale: options[:locale]}.merge(i18n_options))
+          translate_number_value_with_default(key, **{ locale: options[:locale] }.merge(i18n_options))
         end
 
         def default_value(key)

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -65,7 +65,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
     encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.random_bytes(32), SecureRandom.random_bytes(128), serializer: JSONSerializer.new)
-    message = encryptor.encrypt_and_sign({:foo => 123, "bar" => Time.utc(2010)})
+    message = encryptor.encrypt_and_sign({ :foo => 123, "bar" => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, encryptor.decrypt_and_verify(message)
   ensure
@@ -126,7 +126,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
 
   def test_rotating_serializer
     old_message = ActiveSupport::MessageEncryptor.new(secrets[:old], cipher: "aes-256-gcm", serializer: JSON).
-      encrypt_and_sign({ahoy: :hoy})
+      encrypt_and_sign({ ahoy: :hoy })
 
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm", serializer: JSON)
     encryptor.rotate secrets[:old]
@@ -158,7 +158,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def test_on_rotation_is_called_and_returns_modified_messages
-    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({encoded: "message"})
+    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({ encoded: "message" })
 
     encryptor = ActiveSupport::MessageEncryptor.new(@secret)
     encryptor.rotate secrets[:old]
@@ -172,7 +172,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def test_on_rotation_can_be_passed_at_the_constructor_level
-    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({encoded: "message"})
+    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({ encoded: "message" })
 
     rotated = rotated = false  # double assigning to suppress "assigned but unused variable" warning
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, on_rotation: proc { rotated = true })
@@ -186,7 +186,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def test_on_rotation_option_takes_precedence_over_the_one_given_in_constructor
-    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({encoded: "message"})
+    older_message = ActiveSupport::MessageEncryptor.new(secrets[:older], "older sign").encrypt_and_sign({ encoded: "message" })
 
     rotated = rotated = false  # double assigning to suppress "assigned but unused variable" warning
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, on_rotation: proc { rotated = true })

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -53,7 +53,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
     verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", serializer: JSONSerializer.new)
-    message = verifier.generate({:foo => 123, "bar" => Time.utc(2010)})
+    message = verifier.generate({ :foo => 123, "bar" => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, verifier.verified(message)
     assert_equal exp, verifier.verify(message)
@@ -115,7 +115,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
   end
 
   def test_on_rotation_is_called_and_verified_returns_message
-    older_message = ActiveSupport::MessageVerifier.new("older", digest: "SHA1").generate({encoded: "message"})
+    older_message = ActiveSupport::MessageVerifier.new("older", digest: "SHA1").generate({ encoded: "message" })
 
     verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA512")
     verifier.rotate "old",   digest: "SHA256"


### PR DESCRIPTION
Non-kwargs parameters should be to be braced for https://github.com/ruby/ruby/pull/2395.
See https://bugs.ruby-lang.org/issues/14183 for details.

`Style/BracesAroundHashParameters` cop conflicts with that.

This removes `Style/BracesAroundHashParameters` cop and auto-correct to
following changes.

https://github.com/rails/rails/compare/d94263f...5665fb5