### PR TITLE
Fix bug with locating a view template when the path includes regex metacharacters

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -263,7 +263,7 @@ module ActionView
       end
 
       def escape_entry(entry)
-        entry.gsub(/[*?{}\[\]]/, '\\\\\\&')
+        entry.gsub(/[.*?{}()\[\]]/, '\\\\\\&')
       end
 
       # Extract handler, formats and variant from path. If a format cannot be found neither

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -79,6 +79,18 @@ module ResolverSharedTests
     assert_kind_of ActionView::Template::Handlers::ERB, templates[0].handler
   end
 
+  def test_can_find_when_directory_includes_regex_characters
+    with_file "test.directory (with regex characters)/hello_world", "Hello default!"
+
+    templates = resolver.find_all("hello_world", "test.directory (with regex characters)", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    assert_equal 1, templates.size
+    assert_equal "Hello default!", templates[0].source
+    assert_equal "test.directory (with regex characters)/hello_world", templates[0].virtual_path
+    assert_nil templates[0].format
+    assert_nil templates[0].variant
+    assert_kind_of ActionView::Template::Handlers::Raw, templates[0].handler
+  end
+
   def test_doesnt_find_template_with_wrong_details
     with_file "test/hello_world.html.erb", "Hello plain text!"
 


### PR DESCRIPTION
### Summary

Fixes #37107.
View templates can be found successfully even if the path to the template includes regex metacharacters in the directory.

### Other Information

This is my first Rails PR – I think I've found the right fix for this bug, but if there's anything I should do differently, just let me know!