### PR TITLE
Add a test for select argument error with block

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -952,6 +952,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ArgumentError) { Developer.select }
   end
 
+  def test_select_argument_error_with_block
+    assert_raises(ArgumentError) { Developer.select(:id) { |d| d.id % 2 == 0 } }
+  end
+
   def test_count
     posts = Post.all
 


### PR DESCRIPTION
### Summary
Add test for select with arguments and block, because there was no test referring to https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/query_methods.rb#L257 .