### PR TITLE
Improve autosave documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -91,8 +91,9 @@ module ActiveRecord
   #   post.save # => saves both post and comment
   #
   #   post = Post.create(title: 'ruby rocks')
-  #   post.comments.create(body: 'hello world')
-  #   post.save # => saves both post and comment
+  #   comment = post.comments.create(body: 'hello world')
+  #   comment.body = 'hi everyone'
+  #   post.save # => saves post, but not comment
   #
   # When <tt>:autosave</tt> is true all children are saved, no matter whether they
   # are new records or not:
@@ -102,11 +103,10 @@ module ActiveRecord
   #   end
   #
   #   post = Post.create(title: 'ruby rocks')
-  #   post.comments.create(body: 'hello world')
-  #   post.comments[0].body = 'hi everyone'
+  #   comment = post.comments.create(body: 'hello world')
+  #   comment.body = 'hi everyone'
   #   post.comments.build(body: "good morning.")
-  #   post.title += "!"
-  #   post.save # => saves both post and comments.
+  #   post.save # => saves post and both comments.
   #
   # Destroying one of the associated models as part of the parent's save action
   # is as simple as marking it for destruction:


### PR DESCRIPTION
### Summary
The current autosave documentation conflicts with other documentation and the implementation.
When `:autosave` is not declared on an association only new children are saved.
```ruby
  # When <tt>:autosave</tt> is not declared new children are saved when their parent is saved:
  # ....
  #   post = Post.create(title: 'ruby rocks')
  #   post.comments.create(body: 'hello world')
  #   post.save # => saves both post and comment
```
The last line is incorrect.
The following tests shows only new children are saved:

```ruby
begin
  require 'bundler/inline'
rescue LoadError => e
  $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails'
  gem 'sqlite3'
  gem 'byebug'
end



require 'active_record'
require 'action_controller/railtie'
require 'rack/test'
require 'minitest/autorun'
require 'logger'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts do |t|
    t.string :title
    t.timestamps
  end

  create_table :comments do |t|
    t.belongs_to :post
    t.string :body
    t.timestamps
  end
end

class Post < ActiveRecord::Base
  has_many :comments # :autosave option is not declared
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_autosave
    post = Post.new(title: 'ruby rocks')
    comment = post.comments.build(body: 'hello world')
    post.save
    assert_equal(post.reload.title, 'ruby rocks')
    assert_equal(comment.reload.body, 'hello world')

    post = Post.create(title: 'ruby rocks')
    comment = post.comments.build(body: 'hello world')
    post.save
    assert_equal(post.reload.title, 'ruby rocks')
    assert_equal(comment.reload.body, 'hello world')

    post = Post.create(title: 'ruby rocks')
    comment = post.comments.create(body: 'hello world')
    post.title = 'rails rocks'
    comment.body = 'hi world'
    post.save
    assert_equal(post.reload.title, 'rails rocks')
    assert_equal(comment.reload.body, 'hi world')
    # fails with: 
    # Failure:
    #   BugTest#test_autosave [inline_rails_nested_attrs.rb:68]:
    #     Expected: "hello world"
    #     Actual: "hi world"
  end
end
```
