### PR TITLE
Safer example in Rails::Railtie documentation

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -42,7 +42,7 @@ module Rails
   #   end
   #
   #   # lib/my_gem.rb
-  #   require 'my_gem/railtie' if defined?(Rails)
+  #   require 'my_gem/railtie' if defined?(Rails::Railtie)
   #
   # == Initializers
   #


### PR DESCRIPTION
As discussed with @rafaelfranca it's better to check for `Rails::Railtie`, because some gems define things inside the `Rails` namespace which might lead to false positives.

So `Rails::Railtie` is a better indicator of wether you are inside a Rails app.