### PR TITLE
Document the new npm package names in the upgrade guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -112,6 +112,17 @@ If you require your cookies to be read by Rails 5.2 and older, or you are still 
 to be able to rollback set
 `Rails.application.config.action_dispatch.use_cookies_with_metadata` to `false`.
 
+### All npm packages have been moved to the `@rails` scope
+
+If you were previously loading any of the `actioncable`, `activestorage`,
+or `rails-ujs` packages through npm/yarn, you must update the names of these
+dependencies before you can upgrade them to `6.0.0`:
+```
+actioncable   → @rails/actioncable
+activestorage → @rails/activestorage
+rails-ujs     → @rails/ujs
+```
+
 ### Action Cable JavaScript API Changes
 
 The Action Cable JavaScript package has been converted from CoffeeScript


### PR DESCRIPTION
### Summary

As I was upgrading a rails 5.2 app to 6.0, I had to manually rename all references to the old npm packages (in the `package.json` `dependencies` and in my app's `import` statements) to the new package names under the `@rails` scope, as outlined in https://github.com/rails/rails/pull/34905:

> ```
> actioncable   → @rails/actioncable
> activestorage → @rails/activestorage
> rails-ujs     → @rails/ujs
> ```

I thought it would be helpful to specifically mention this in the upgrade guide, so that's what this PR does. (I didn't include the `actiontext → @rails/actiontext` rename in the upgrade guide since `actiontext` didn't exist in rails 5.2.)