### PR TITLE
Fix code block in the HTML version of the upgrade guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -117,6 +117,7 @@ to be able to rollback set
 If you were previously loading any of the `actioncable`, `activestorage`,
 or `rails-ujs` packages through npm/yarn, you must update the names of these
 dependencies before you can upgrade them to `6.0.0`:
+
 ```
 actioncable   → @rails/actioncable
 activestorage → @rails/activestorage


### PR DESCRIPTION
### Summary

In #37131 I added the section about npm package name changes to the upgrade guide. After it was merged, I noticed an issue in the rendering of the code block in the HTML version that doesn't appear in the corresponding markdown version. I was able to fix it by adding an extra newline before the code block (which doesn't affect the markdown version).

I verified the fix by running the `guides:generate:html` rake task locally. (I should have done this last time - sorry about that.)

Before:

![image](https://user-images.githubusercontent.com/1863540/64316451-2a774300-cfb5-11e9-985c-0697cfc23b9a.png)

After:

![image](https://user-images.githubusercontent.com/1863540/64316583-893cbc80-cfb5-11e9-9182-a2143d99f9d9.png)