### PR TITLE
Output routes definition in JSON format by `rails routes -o json`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -2,6 +2,7 @@
 
 require "delegate"
 require "io/console/size"
+require "json"
 
 module ActionDispatch
   module Routing
@@ -229,6 +230,31 @@ module ActionDispatch
           def route_header(index:)
             "--[ Route #{index} ]".ljust(@width, "-")
           end
+      end
+    end
+
+    class JSONFormatter
+      def initialize
+        @buffer = { routes: [] }
+      end
+
+      def section_title(title)
+      end
+
+      def section(routes)
+        routes.each do |r|
+          @buffer[:routes] << { path: r[:path], verb: r[:verb], prefix: r[:name], controller_and_action: r[:reqs] }
+        end
+      end
+
+      def header(routes)
+      end
+
+      def no_routes(*)
+      end
+
+      def result
+        JSON.dump @buffer
       end
     end
 

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -8,6 +8,7 @@ module Rails
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
+      class_option :format, aliases: "-o", desc: "Print routes with specified format (currentry, json only)."
 
       def perform(*)
         require_application_and_environment!
@@ -22,6 +23,8 @@ module Rails
         end
 
         def formatter
+          return ActionDispatch::Routing::JSONFormatter.new if options.dig("format") == "json"
+
           if options.key?("expanded")
             ActionDispatch::Routing::ConsoleFormatter::Expanded.new
           else

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -304,6 +304,28 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     # rubocop:enable Layout/TrailingWhitespace
   end
 
+  test "rails routes with json format" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resources :users
+      end
+    RUBY
+
+    output = JSON.dump(
+      { routes: [
+        { path: "/users(.:format)",          verb: "GET",    prefix: "users",     controller_and_action: "users#index" },
+        { path: "/users(.:format)",          verb: "POST",   prefix: "",          controller_and_action: "users#create" },
+        { path: "/users/new(.:format)",      verb: "GET",    prefix: "new_user",  controller_and_action: "users#new" },
+        { path: "/users/:id/edit(.:format)", verb: "GET",    prefix: "edit_user", controller_and_action: "users#edit" },
+        { path: "/users/:id(.:format)",      verb: "GET",    prefix: "user",      controller_and_action: "users#show" },
+        { path: "/users/:id(.:format)",      verb: "PATCH",  prefix: "",          controller_and_action: "users#update" },
+        { path: "/users/:id(.:format)",      verb: "PUT",    prefix: "",          controller_and_action: "users#update" },
+        { path: "/users/:id(.:format)",      verb: "DELETE", prefix: "",          controller_and_action: "users#destroy" },
+      ] }
+    )
+    assert_equal output, run_routes_command([ "--format", "json", "-c", "UsersController"]).chomp
+  end
+
   private
     def run_routes_command(args = [])
       rails "routes", args


### PR DESCRIPTION
### Summary
The code outputs routing definition by JSON format to stdout in
"rails routes --format=json" command.

Result of "rails routes" command is easy to read for human but it's hard
to parse and we have no way to use public API to get an easily parsable
routing format of the application.

### schema
```ruby
      { routes: [
        { path: "/users(.:format)",  verb: "GET", prefix: "users",  controller_and_action: "users#index" },
      #...
      ]
}
```
I think it's debatable...

### Other Information
It's one of the use cases of JSON format routing, my gem https://github.com/unasuke/openapi3_definition_generator-rails generates OpenAPI3 specification YAML by rails routing.
It was a more easy job if rails outputs JSON format routings in a built-in feature.