### PR TITLE
Autoload the `AS::SecureCompareRotator` class:

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -45,6 +45,7 @@ module ActiveSupport
   autoload :LogSubscriber
   autoload :Notifications
   autoload :Reloader
+  autoload :SecureCompareRotator
 
   eager_autoload do
     autoload :BacktraceCleaner


### PR DESCRIPTION
Autoload the `AS::SecureCompareRotator` class:

- In 123bcf5faa6 I forgot to autoload that class which means
  requiring "activesupport/all" doesn't autoload it.

cc/ @paracycle 