### PR TITLE
Optimize UrlHelper.optimize_helper?

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -178,7 +178,7 @@ module ActionDispatch
           end
 
           def self.optimize_helper?(route)
-            !route.glob? && route.path.requirements.empty?
+            route.path.requirements.empty? && !route.glob?
           end
 
           attr_reader :url_strategy, :route_name


### PR DESCRIPTION
### Context

In our application, generating the url helpers is the slowest part of boot time:

```
WALL
--------
TOTAL    (pct)     SAMPLES    (pct)     FRAME
 7423  (17.3%)        7181  (16.7%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper

CPU
--------
TOTAL    (pct)     SAMPLES    (pct)     FRAME
 7439  (17.1%)        7222  (16.6%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

### The patch

Checking wether a route has requirements is about 10 times faster than checking wether it contains a glob:

```ruby
>> Benchmark.realtime { Rails.application.routes.named_routes.count { |_, r| r.glob? } }
=> 0.028945999998541083
>> Benchmark.realtime { Rails.application.routes.named_routes.count { |_, r| r.path.requirements.empty? } }
=> 0.0022919999973964877
```

Because of this, it's much better to check the fast condition first, in the off chance that we don't need to check the second one.

### Results

Still on our app the difference is quite significant:
```
WALL
--------
TOTAL    (pct)     SAMPLES    (pct)     FRAME
 7463  (16.2%)        7256  (15.8%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper

CPU
--------
TOTAL    (pct)     SAMPLES    (pct)     FRAME
 7670  (14.3%)        7424  (13.8%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

Of course the effect will vary depending how much you use glob routes and path requirements, but it for sure won't make things worse. Worst case there won't be any noticeable gain.

cc @Edouard-chin @rafaelfranca 