### PR TITLE
Fix comments to update mysql version in reference URL [ci skip]

### DIFF
--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -15,7 +15,7 @@ module Arel # :nodoc: all
 
         ###
         # :'(
-        # https://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
+        # https://dev.mysql.com/doc/refman/8.0/en/select.html#id3482214
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.offset && !o.limit
             o.limit = Arel::Nodes::Limit.new(18446744073709551615)

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -15,7 +15,7 @@ module Arel
 
       ###
       # :'(
-      # https://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
+      # https://dev.mysql.com/doc/refman/8.0/en/select.html#id3482214
       it "defaults limit to 18446744073709551615" do
         stmt = Nodes::SelectStatement.new
         stmt.offset = Nodes::Offset.new(1)


### PR DESCRIPTION
### Summary
Mysql versions 5.5.8 and up are supported in rails6.
