### PR TITLE
Scaffold: renders a 'select' tag for fields representing foreign-key in _form.html.erb

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -26,7 +26,7 @@
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
 <% elsif attribute.reference? -%>
     <%%= form.label :<%= attribute.column_name %>, '<%= attribute.name.capitalize %>' %>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>,  <%= attribute.name.camelize %>.pluck(:id) %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, <%= attribute.name.camelize %>.pluck(:id) %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -24,6 +24,9 @@
 <% elsif attribute.attachments? -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
+<% elsif attribute.reference? -%>
+    <%%= form.label :<%= attribute.column_name %>, '<%= attribute.name.capitalize %>' %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>,  <%= attribute.name.camelize %>.pluck(:id) %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -83,6 +83,7 @@ module Rails
                         when :rich_text                then :rich_text_area
                         when :boolean                  then :check_box
                         when :attachment, :attachments then :file_field
+                        when :references, :belongs_to  then :select
                         else
                           :text_field
         end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -457,7 +457,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/views/accounts/_form.html.erb" do |content|
       assert_match(/^\W{4}<%= form\.text_field :name %>/, content)
-      assert_match(/^\W{4}<%= form\.text_field :currency_id %>/, content)
+      assert_match(/^\W{4}<%= form\.label :currency_id, 'Currency' %>/, content)
+      assert_match(/^\W{4}<%= form\.select :currency_id, Currency\.pluck\(:id\) %>/, content)
     end
 
     assert_file "app/views/accounts/index.html.erb" do |content|


### PR DESCRIPTION
renders a 'select' tag for fields representing foreign-key in _form during scaffold.


### Summary
When I generated a scaffold using following command,

```bash
rails g scaffold haga name university:references
```

It generated the `_form.html.erb` which had

```erb
  <div class="field">
    <%= form.label :university_id %>
    <%= form.text_field :university_id %>
  </div>
```

**now**

```erb
  <div class="field">
    <%= form.label :university_id, 'University' %>
    <%= form.select :university_id,  University.pluck(:id) %>
  </div>

```

which is **expected**.

>**Note:** `.pluck` method is supported by all the `ORM`s


<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->