### PR TITLE
Refactor `define_url_helper` to share the same instance between _path and _url

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -110,8 +110,10 @@ module ActionDispatch
             @url_helpers_module.undef_method url_name
           end
           routes[key] = route
-          define_url_helper @path_helpers_module, route, path_name, route.defaults, name, PATH
-          define_url_helper @url_helpers_module,  route, url_name,  route.defaults, name, UNKNOWN
+
+          helper = UrlHelper.create(route, route.defaults, name)
+          define_url_helper @path_helpers_module, path_name, helper, PATH
+          define_url_helper @url_helpers_module, url_name, helper, UNKNOWN
 
           @path_helpers << path_name
           @url_helpers << url_name
@@ -169,11 +171,11 @@ module ActionDispatch
         end
 
         class UrlHelper
-          def self.create(route, options, route_name, url_strategy)
+          def self.create(route, options, route_name)
             if optimize_helper?(route)
-              OptimizedUrlHelper.new(route, options, route_name, url_strategy)
+              OptimizedUrlHelper.new(route, options, route_name)
             else
-              new route, options, route_name, url_strategy
+              new(route, options, route_name)
             end
           end
 
@@ -181,18 +183,18 @@ module ActionDispatch
             route.path.requirements.empty? && !route.glob?
           end
 
-          attr_reader :url_strategy, :route_name
+          attr_reader :route_name
 
           class OptimizedUrlHelper < UrlHelper
             attr_reader :arg_size
 
-            def initialize(route, options, route_name, url_strategy)
+            def initialize(route, options, route_name)
               super
               @required_parts = @route.required_parts
               @arg_size       = @required_parts.size
             end
 
-            def call(t, args, inner_options)
+            def call(t, args, inner_options, url_strategy)
               if args.size == arg_size && !inner_options && optimize_routes_generation?(t)
                 options = t.url_options.merge @options
                 options[:path] = optimized_helper(args)
@@ -249,15 +251,14 @@ module ActionDispatch
               end
           end
 
-          def initialize(route, options, route_name, url_strategy)
+          def initialize(route, options, route_name)
             @options      = options
             @segment_keys = route.segment_keys.uniq
             @route        = route
-            @url_strategy = url_strategy
             @route_name   = route_name
           end
 
-          def call(t, args, inner_options)
+          def call(t, args, inner_options, url_strategy)
             controller_options = t.url_options
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
@@ -312,8 +313,7 @@ module ActionDispatch
           #
           #   foo_url(bar, baz, bang, sort_by: 'baz')
           #
-          def define_url_helper(mod, route, name, opts, route_key, url_strategy)
-            helper = UrlHelper.create(route, opts, route_key, url_strategy)
+          def define_url_helper(mod, name, helper, url_strategy)
             mod.define_method(name) do |*args|
               last = args.last
               options = \
@@ -323,7 +323,7 @@ module ActionDispatch
                 when ActionController::Parameters
                   args.pop.to_h
                 end
-              helper.call self, args, options
+              helper.call(self, args, options, url_strategy)
             end
           end
       end


### PR DESCRIPTION
Profiling shows that an important part of routes loading was spent instantiating `UrlHelper` objects:

<img width="1016" alt="Capture d’écran, le 2019-09-06 à 15 02 20" src="https://user-images.githubusercontent.com/19192189/64429945-73afbb80-d0b7-11e9-847f-1f4dc3470b2d.png">

After some digging, it appears that we're instantiating two almost identical objects for each routes. One to back up the `_path` helper, and one for `_url`. The only difference between the two is one `Proc` object that's only used in the `call` method.

By passing that proc as argument to `call` rather than store it as instance variable, we're able to share the `UrlHelper` for both `_path` and `_url`, hence cut in half these allocations.

The performance impact isn't as visible as I hoped (it's more or less in the margin or error), but still there, and I really don't see how this patch could make things slower.

Before:

```
WALL
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7815  (16.9%)        7523  (16.3%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper

CPU
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      8113  (16.2%)        7739  (15.4%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

After:

```
WALL
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7240  (15.6%)        7240  (15.6%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper

CPU
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      7378  (15.1%)        7378  (15.1%)     ActionDispatch::Routing::RouteSet::NamedRouteCollection#define_url_helper
```

Another added benefit is a small memory retention reduction:

Before:
```
retained memory by file
-----------------------------------
   4.07 MB  /tmp/bundle/ruby/2.6.0/bundler/gems/rails-d05f1f036ff4/actionpack/lib/action_dispatch/routing/route_set.rb

retained objects by file
-----------------------------------
    30233  /tmp/bundle/ruby/2.6.0/bundler/gems/rails-d05f1f036ff4/actionpack/lib/action_dispatch/routing/route_set.rb
```

```
retained memory by file
-----------------------------------
   3.57 MB  /tmp/bundle/ruby/2.6.0/bundler/gems/rails-7b53016b985d/actionpack/lib/action_dispatch/routing/route_set.rb

retained objects by file
-----------------------------------
    23052  /tmp/bundle/ruby/2.6.0/bundler/gems/rails-7b53016b985d/actionpack/lib/action_dispatch/routing/route_set.rb
```

But that's for ~3500 routes (~140B and 2 objects per route), so not that impressive either to be honest.

cc @rafaelfranca @Edouard-chin 