### PR TITLE
Allow inspected records to be marshaled

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -584,12 +584,16 @@ module ActiveRecord
         self.class.instance_method(:inspect).owner != ActiveRecord::Base.instance_method(:inspect).owner
       end
 
+      class InspectionMask < DelegateClass(::String)
+        def pretty_print(pp)
+          pp.text __getobj__
+        end
+      end
+      private_constant :InspectionMask
+
       def inspection_filter
         @inspection_filter ||= begin
-          mask = DelegateClass(::String).new(ActiveSupport::ParameterFilter::FILTERED)
-          def mask.pretty_print(pp)
-            pp.text __getobj__
-          end
+          mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
           ActiveSupport::ParameterFilter.new(self.class.filter_attributes, mask: mask)
         end
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1173,6 +1173,16 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal expected.attributes, actual.attributes
   end
 
+  def test_marshal_inspected_round_trip
+    expected = posts(:welcome)
+    expected.inspect
+
+    marshalled = Marshal.dump(expected)
+    actual = Marshal.load(marshalled)
+
+    assert_equal expected.attributes, actual.attributes
+  end
+
   def test_marshal_new_record_round_trip
     marshalled = Marshal.dump(Post.new)
     post       = Marshal.load(marshalled)


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/36401.

Since https://github.com/rails/rails/pull/34208, records which have had `inspect` called on them can't be marshaled, because of this anonymous `DelegateClass`. We can fix this by giving the class a concrete name.