### PR TITLE
Fix docs to update http and www.ruby-doc.org [ci skip]

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -132,7 +132,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
   SQLite3[link:classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html].
 
 
-* Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc].
+* Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[https://ruby-doc.org/stdlib/libdoc/logger/rdoc/].
 
     ActiveRecord::Base.logger = ActiveSupport::Logger.new(STDOUT)
     ActiveRecord::Base.logger = Log4r::Logger.new('Application Log')

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -424,7 +424,7 @@ within our system.
 
 NOTE: There are `public`, `private` and `protected` methods in Ruby,
 but only `public` methods can be actions for controllers.
-For more details check out [Programming Ruby](http://www.ruby-doc.org/docs/ProgrammingRuby/).
+For more details check out [Programming Ruby](https://ruby-doc.org/docs/ProgrammingRuby/).
 
 If you refresh <http://localhost:3000/articles/new> now, you'll get a new error:
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1207,7 +1207,7 @@ If your application currently depends on MultiJSON directly, you have a few opti
 
 WARNING: Do not simply replace `MultiJson.dump` and `MultiJson.load` with
 `JSON.dump` and `JSON.load`. These JSON gem APIs are meant for serializing and
-deserializing arbitrary Ruby objects and are generally [unsafe](http://www.ruby-doc.org/stdlib-2.2.2/libdoc/json/rdoc/JSON.html#method-i-load).
+deserializing arbitrary Ruby objects and are generally [unsafe](https://ruby-doc.org/stdlib-2.2.2/libdoc/json/rdoc/JSON.html#method-i-load).
 
 #### JSON gem compatibility
 


### PR DESCRIPTION
### Summary
- Replace http with https
- Replace `www.ruby-doc.org` with ruby-doc.org

Following is an example that `www.ruby-doc.org` is redirected.
```
$ curl -I https://www.ruby-doc.orgHTTP/1.1 301 Moved Permanently
Date: Mon, 09 Sep 2019 00:38:53 GMT
Server: Apache/2.2.22 (Ubuntu)
Location: https://ruby-doc.org/
Vary: Accept-Encoding
Content-Type: text/html; charset=iso-8859-1
```