### PR TITLE
Allow bulk alter to drop and recreate named index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow bulk `ALTER` statements to drop and recreate indexes with the same name.
+
+    *Eugene Kenny*
+
 *   `insert`, `insert_all`, `upsert`, and `upsert_all` now clear the query cache.
 
     *Eugene Kenny*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1195,9 +1195,6 @@ module ActiveRecord
 
         validate_index_length!(table_name, index_name, options.fetch(:internal, false))
 
-        if data_source_exists?(table_name) && index_name_exists?(table_name, index_name)
-          raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
-        end
         index_columns = quoted_columns_for_index(column_names, **options).join(", ")
 
         [index_name, index_type, index_columns, index_options, algorithm, using, comment]

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -28,9 +28,6 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_add_index
-    # add_index calls index_name_exists? which can't work since execute is stubbed
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.define_method(:index_name_exists?) { |*| false }
-
     expected = %(CREATE UNIQUE INDEX  "index_people_on_last_name" ON "people"  ("last_name") WHERE state = 'active')
     assert_equal expected, add_index(:people, :last_name, unique: true, where: "state = 'active'")
 
@@ -73,8 +70,6 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :copy)
     end
-
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.remove_method :index_name_exists?
   end
 
   def test_remove_index

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -49,13 +49,6 @@ module ActiveRecord
         assert connection.index_name_exists?(table_name, "old_idx")
       end
 
-      def test_double_add_index
-        connection.add_index(table_name, [:foo], name: "some_idx")
-        assert_raises(ArgumentError) {
-          connection.add_index(table_name, [:foo], name: "some_idx")
-        }
-      end
-
       def test_remove_nonexistent_index
         assert_raise(ArgumentError) { connection.remove_index(table_name, "no_such_index") }
       end


### PR DESCRIPTION
In 3809c80cd55ac2838f050346800889b6f8e041ef, adding an index with a name that's already in use was changed from an error to a warning, to allow other statements in the same migration to complete successfully.

In 55d0d57bfc72c0bdbc81ae5d95c99729f16899af this decision was reversed, but instead of allowing the statement to execute and raise an adapter-specific error as it did before, an `ArgumentError` was raised instead.

This interferes with a legitimate use case: on MySQL, it's possible to drop an index and add another one with the same name in a single `ALTER` statement. Right now an `ArgumentError` is raised when trying to do so, even though the resulting statement would execute successfully.

There's no corresponding `ArgumentError` raised when attempting to add a duplicate column, so I think we can safely remove the check and allow the adapter to raise its own error about duplicate indexes again.