### PR TITLE
Add `Array#middle` method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Array#middle` to return the middle element of an array.
+
+    *Sinan Mujan*
+
 *   Fix `Range#include?` to work with beginless and endless ranges.
 
     *Allen Hsu*

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -101,4 +101,16 @@ class Array
   def second_to_last
     self[-2]
   end
+
+  # Returns the middle element of an array.
+  #
+  #   %w( a b c d e ).middle # => "c"
+  #
+  # If the array has an even number of elements,
+  # the greater of the two middle elements is returned.
+  #
+  #   %w( a b c d ).middle # => "c"
+  def middle
+    self[self.size / 2]
+  end
 end

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -47,4 +47,9 @@ class AccessTest < ActiveSupport::TestCase
   def test_without
     assert_equal [1, 2, 4], [1, 2, 3, 4, 5].without(3, 5)
   end
+
+  def test_middle
+    assert_equal "b", %w( a b c ).middle
+    assert_equal "c", %w( a b c d ).middle
+  end
 end


### PR DESCRIPTION
### Summary

Returns the middle element of an array.

```
    %w( a b c d e ).middle # => c
```

If the array has an even number of elements, the greater of the two
middle elements is returned. This was motivated by Ruby's `Array#median` method which, for a evenly numbered sorted array, returns the greater of the two middle elements.

```
    %w( a b c d ).middle # => c
```