### PR TITLE
Use correct escaping function for regex-based path resolver builder

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -350,7 +350,7 @@ module ActionView
       end
 
       def build_regex(path, details)
-        query = escape_entry(File.join(@path, path))
+        query = Regexp.escape(File.join(@path, path))
         exts = EXTENSIONS.map do |ext, prefix|
           match =
             if ext == :variants && details[ext] == :any


### PR DESCRIPTION
### Summary

Glob-based escape is used for escaping view path in a regexp-building function, resulting in:

- error when trying to `render 'view_with_unbalanced_parenthesis)'` 
- missing view for `render 'view_with_(parentheses)'` even though the file exists.

### Other Information

Not sure if test is needed. Also it shouldn't cause any behavior change as the path only serves as prefix for extension lookup (afaict).