### PR TITLE
Fix failed tests in Active Record when using ruby 2.7.0dev

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -12,11 +12,12 @@ module ActiveRecord
       module ClassMethods # :nodoc:
         private
           def define_method_attribute=(name)
+            kw = RUBY_VERSION >= "2.7" ? ", **options" : nil
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
               generated_attribute_methods, name, writer: true,
             ) do |temp_method_name, attr_name_expr|
               generated_attribute_methods.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def #{temp_method_name}(value)
+                def #{temp_method_name}(value#{kw})
                   name = #{attr_name_expr}
                   _write_attribute(name, value)
                 end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -573,7 +573,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "declared suffixed attribute method affects respond_to? and method_missing" do
     %w(_default _title_default _it! _candidate= able?).each do |suffix|
-      @target.class_eval "def attribute#{suffix}(*args) args end"
+      kw = RUBY_VERSION >= "2.7" ? ", **options" : nil
+      @target.class_eval "def attribute#{suffix}(*args#{kw}) args end"
       @target.attribute_method_suffix suffix
       topic = @target.new(title: "Budget")
 
@@ -587,7 +588,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "declared affixed attribute method affects respond_to? and method_missing" do
     [["mark_", "_for_update"], ["reset_", "!"], ["default_", "_value?"]].each do |prefix, suffix|
-      @target.class_eval "def #{prefix}attribute#{suffix}(*args) args end"
+      kw = RUBY_VERSION >= "2.7" ? ", **options" : nil
+      @target.class_eval "def #{prefix}attribute#{suffix}(*args#{kw}) args end"
       @target.attribute_method_affix(prefix: prefix, suffix: suffix)
       topic = @target.new(title: "Budget")
 


### PR DESCRIPTION
### Summary
Some tests in Active Record failed in my local environment when using ruby 2.7.0dev.
```
$ ruby --version
ruby 2.7.0dev (2019-08-26T22:59:50Z trunk 2283411265) [x86_64-darwin17]
```

Following are examples of failed tests when executing `$ bundle exec rake test:sqlite3`.

```
Error:
UniquenessValidationTest#test_validate_uniqueness_with_alias_attribute:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_methods/write.rb:19:in `title='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_methods.rb:380:in `new_title='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `public_send'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `_assign_attribute'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:43:in `block in _assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `each'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_assignment.rb:21:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:35:in `assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/core.rb:325:in `initialize'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /Users/tnakata/workspace/rails/activerecord/test/cases/validations/uniqueness_validation_test.rb:98:in `test_validate_uniqueness_with_alias_attribute'

rails test Users/tnakata/workspace/rails/activerecord/test/cases/validations/uniqueness_validation_test.rb:94
```
```
Failure:
AttributeMethodsTest#test_declared_affixed_attribute_method_affects_respond_to?_and_method_missing [/Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:596]:
Expected: ["title"]
  Actual: ["title", {}]

rails test Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:588
```

<details>
<summary>more</summary>

```
Error:
AttributeMethodsTest#test_write_attribute_allows_writing_to_aliased_attributes:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_methods/write.rb:19:in `title='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_methods.rb:380:in `heading='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `public_send'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `_assign_attribute'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:43:in `block in _assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `each'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_assignment.rb:21:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:35:in `assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/persistence.rb:620:in `block in update'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/transactions.rb:374:in `block in with_transaction_returning_status'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:281:in `block in transaction'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:295:in `block in within_new_transaction'
    /Users/tnakata/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/monitor.rb:235:in `mon_synchronize'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:293:in `within_new_transaction'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:281:in `transaction'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/transactions.rb:212:in `transaction'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/transactions.rb:365:in `with_transaction_returning_status'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/persistence.rb:619:in `update'
    /Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:329:in `block (2 levels) in <class:AttributeMethodsTest>'
    /Users/tnakata/workspace/rails/activesupport/lib/active_support/testing/assertions.rb:32:in `assert_nothing_raised'
    /Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:329:in `block in <class:AttributeMethodsTest>'

rails test Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:326
```
```
Failure:
AttributeMethodsTest#test_declared_suffixed_attribute_method_affects_respond_to?_and_method_missing [/Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:582]:
Expected: ["title"]
  Actual: ["title", {}]

rails test Users/tnakata/workspace/rails/activerecord/test/cases/attribute_methods_test.rb:574
```
```
Error:
ActiveRecord::RelationTest#test_selecting_aliased_attribute_quotes_column_name_when_from_is_used:
ArgumentError: wrong number of arguments (given 2, expected 1)
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_methods/write.rb:19:in `desc='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_methods.rb:380:in `description='
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `public_send'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:50:in `_assign_attribute'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:43:in `block in _assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `each'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:42:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_assignment.rb:21:in `_assign_attributes'
    /Users/tnakata/workspace/rails/activemodel/lib/active_model/attribute_assignment.rb:35:in `assign_attributes'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/core.rb:325:in `initialize'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/inheritance.rb:70:in `new'
    /Users/tnakata/workspace/rails/activerecord/lib/active_record/persistence.rb:54:in `create!'
    /Users/tnakata/workspace/rails/activerecord/test/cases/relation_test.rb:292:in `test_selecting_aliased_attribute_quotes_column_name_when_from_is_used'


rails test Users/tnakata/workspace/rails/activerecord/test/cases/relation_test.rb:286
```

</details>

### Other Information
This fix just made tests pass. If there is any other good way to fix this, close this PR.