### PR TITLE
Skip insert all tests when features are unavailable

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -651,6 +651,8 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
   end
 
   def test_insert_all
+    skip unless supports_insert_on_duplicate_skip?
+
     assert_called(ActiveRecord::Base.connection, :clear_query_cache, times: 2) do
       Task.cache { Task.insert({ starting: Time.now }) }
     end
@@ -658,7 +660,9 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
     assert_called(ActiveRecord::Base.connection, :clear_query_cache, times: 2) do
       Task.cache { Task.insert_all([{ starting: Time.now }]) }
     end
+  end
 
+  def test_insert_all_bang
     assert_called(ActiveRecord::Base.connection, :clear_query_cache, times: 2) do
       Task.cache { Task.insert!({ starting: Time.now }) }
     end
@@ -666,6 +670,10 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
     assert_called(ActiveRecord::Base.connection, :clear_query_cache, times: 2) do
       Task.cache { Task.insert_all!([{ starting: Time.now }]) }
     end
+  end
+
+  def test_upsert_all
+    skip unless supports_insert_on_duplicate_update?
 
     assert_called(ActiveRecord::Base.connection, :clear_query_cache, times: 2) do
       Task.cache { Task.upsert({ starting: Time.now }) }


### PR DESCRIPTION
These tests added in https://github.com/rails/rails/pull/37154 are causing the Ruby master build to fail in CI. The Docker image we use is based on Ubuntu Bionic which provides SQLite 3.22.0, and the features required to use `insert_all` and `upsert_all` are not available in that version.

https://packages.ubuntu.com/bionic/libsqlite3-0
https://sqlite.org/lang_UPSERT.html