### PR TITLE
ActiveJob: Fix `queue_name_prefix` changes affecting unrelated jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Changes in `queue_name_prefix` of a job no longer affects all other jobs. Fixes #37084.
+
+    *Lucas Mansur*
+
 *   Allow `Class` and `Module` instances to be serialized.
 
     *Kevin Deisz*

--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -6,7 +6,6 @@ module ActiveJob
 
     # Includes the ability to override the default queue name and prefix.
     module ClassMethods
-      mattr_accessor :queue_name_prefix
       mattr_accessor :default_queue_name, default: "default"
 
       # Specifies the name of the queue to process the job on.
@@ -56,6 +55,7 @@ module ActiveJob
     included do
       class_attribute :queue_name, instance_accessor: false, default: -> { self.class.default_queue_name }
       class_attribute :queue_name_delimiter, instance_accessor: false, default: "_"
+      class_attribute :queue_name_prefix
     end
 
     # Returns the name of the queue the job will be run on.

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -2,6 +2,7 @@
 
 require "helper"
 require "jobs/hello_job"
+require "jobs/prefixed_job"
 require "jobs/logging_job"
 require "jobs/nested_job"
 
@@ -121,6 +122,24 @@ class QueueNamingTest < ActiveSupport::TestCase
     ensure
       ActiveJob::Base.queue_name_prefix = original_queue_name_prefix
       ActiveJob::Base.default_queue_name = original_default_queue_name
+    end
+  end
+
+  test "can change queue_name_prefix in a job class definition without affecting other jobs" do
+    assert_equal "production", PrefixedJob.queue_name_prefix
+    assert_nil HelloJob.queue_name_prefix
+  end
+
+  test "can change queue_name_prefix in a job class without affecting other jobs" do
+    original_prefix = PrefixedJob.queue_name_prefix
+
+    begin
+      PrefixedJob.queue_name_prefix = "staging"
+
+      assert_equal "staging", PrefixedJob.queue_name_prefix
+      assert_nil HelloJob.queue_name_prefix
+    ensure
+      PrefixedJob.queue_name_prefix = original_prefix
     end
   end
 

--- a/activejob/test/jobs/prefixed_job.rb
+++ b/activejob/test/jobs/prefixed_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PrefixedJob < ActiveJob::Base
+  self.queue_name_prefix = "production"
+
+  def perform; end
+end

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -202,6 +202,19 @@ end
 # on your staging environment
 ```
 
+You can also configure the prefix on a per job basis.
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  queue_as :low_priority
+  self.queue_name_prefix = nil
+  #....
+end
+
+# Now your job's queue won't be prefixed, overriding what
+# was configured in `config.active_job.queue_name_prefix`.
+```
+
 The default queue name prefix delimiter is '\_'.  This can be changed by setting
 `config.active_job.queue_name_delimiter` in `application.rb`:
 


### PR DESCRIPTION
Fixes #37084 

See #37084 for more information.