### PR TITLE
Give `concerning` the ability to prepend the concern

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -106,8 +106,9 @@ class Module
   # * stop leaning on protected/private for crude "this is internal stuff" modularity.
   module Concerning
     # Define a new concern and mix it in.
-    def concerning(topic, &block)
-      include concern(topic, &block)
+    def concerning(topic, prepend: false, &block)
+      method = prepend ? :prepend : :include
+      __send__(method, concern(topic, &block))
     end
 
     # A low-cruft shortcut to define a concern.

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -13,11 +13,11 @@ class ConcernTest < ActiveSupport::TestCase
       end
 
       def included_ran=(value)
-        @@included_ran = value
+        @included_ran = value
       end
 
       def included_ran
-        @@included_ran
+        @included_ran
       end
     end
 

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -19,10 +19,22 @@ class ConcernTest < ActiveSupport::TestCase
       def included_ran
         @included_ran
       end
+
+      def prepended_ran=(value)
+        @prepended_ran = value
+      end
+
+      def prepended_ran
+        @prepended_ran
+      end
     end
 
     included do
       self.included_ran = true
+    end
+
+    prepended do
+      self.prepended_ran = true
     end
 
     def baz
@@ -71,8 +83,20 @@ class ConcernTest < ActiveSupport::TestCase
     assert_includes @klass.included_modules, ConcernTest::Baz
   end
 
+  def test_module_is_prepended_normally
+    @klass.prepend(Baz)
+    assert_equal "baz", @klass.new.baz
+    assert_includes @klass.included_modules, ConcernTest::Baz
+  end
+
   def test_class_methods_are_extended
     @klass.include(Baz)
+    assert_equal "baz", @klass.baz
+    assert_equal ConcernTest::Baz::ClassMethods, (class << @klass; included_modules; end)[0]
+  end
+
+  def test_class_methods_are_extended_when_prepended
+    @klass.prepend(Baz)
     assert_equal "baz", @klass.baz
     assert_equal ConcernTest::Baz::ClassMethods, (class << @klass; included_modules; end)[0]
   end
@@ -102,6 +126,21 @@ class ConcernTest < ActiveSupport::TestCase
     assert_equal true, @klass.included_ran
   end
 
+  def test_included_block_is_not_ran_when_prepended
+    @klass.prepend(Baz)
+    assert_nil @klass.included_ran
+  end
+
+  def test_prepended_block_is_ran
+    @klass.prepend(Baz)
+    assert_equal true, @klass.prepended_ran
+  end
+
+  def test_prepended_block_is_not_ran_when_included
+    @klass.include(Baz)
+    assert_nil @klass.prepended_ran
+  end
+
   def test_modules_dependencies_are_met
     @klass.include(Bar)
     assert_equal "bar", @klass.new.bar
@@ -112,6 +151,11 @@ class ConcernTest < ActiveSupport::TestCase
 
   def test_dependencies_with_multiple_modules
     @klass.include(Foo)
+    assert_equal [ConcernTest::Foo, ConcernTest::Bar, ConcernTest::Baz], @klass.included_modules[0..2]
+  end
+
+  def test_dependencies_with_multiple_modules_when_prepended
+    @klass.prepend(Foo)
     assert_equal [ConcernTest::Foo, ConcernTest::Bar, ConcernTest::Baz], @klass.included_modules[0..2]
   end
 
@@ -129,7 +173,21 @@ class ConcernTest < ActiveSupport::TestCase
     end
   end
 
-  def test_no_raise_on_same_included_call
+  def test_raise_on_multiple_prepended_calls
+    assert_raises(ActiveSupport::Concern::MultiplePrependBlocks) do
+      Module.new do
+        extend ActiveSupport::Concern
+
+        prepended do
+        end
+
+        prepended do
+        end
+      end
+    end
+  end
+
+  def test_no_raise_on_same_included_or_prepended_call
     assert_nothing_raised do
       2.times do
         load File.expand_path("../fixtures/concern/some_concern.rb", __FILE__)

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -7,6 +7,9 @@ class ModuleConcerningTest < ActiveSupport::TestCase
   def test_concerning_declares_a_concern_and_includes_it_immediately
     klass = Class.new { concerning(:Foo) { } }
     assert_includes klass.ancestors, klass::Foo, klass.ancestors.inspect
+
+    klass = Class.new { concerning(:Foo, prepend: true) { } }
+    assert_includes klass.ancestors, klass::Foo, klass.ancestors.inspect
   end
 
   def test_concerning_can_prepend_concern
@@ -27,6 +30,7 @@ class ModuleConcernTest < ActiveSupport::TestCase
     klass = Class.new do
       concern :Baz do
         included { @foo = 1 }
+        prepended { @foo = 2 }
         def should_be_public; end
       end
     end
@@ -42,6 +46,9 @@ class ModuleConcernTest < ActiveSupport::TestCase
 
     # Calls included hook
     assert_equal 1, Class.new { include klass::Baz }.instance_variable_get("@foo")
+
+    # Calls prepended hook
+    assert_equal 2, Class.new { prepend klass::Baz }.instance_variable_get("@foo")
   end
 
   class Foo
@@ -64,6 +71,26 @@ class ModuleConcernTest < ActiveSupport::TestCase
         def doesnt_clobber; end
       end
     end
+
+    concerning :Baz, prepend:true do
+      module ClassMethods
+        def will_be_orphaned_also; end
+      end
+
+      const_set :ClassMethods, Module.new {
+        def hacked_on_also; end
+      }
+
+      # Doesn't overwrite existing ClassMethods module.
+      class_methods do
+        def nicer_dsl_also; end
+      end
+
+      # Doesn't overwrite previous class_methods definitions.
+      class_methods do
+        def doesnt_clobber_also; end
+      end
+    end
   end
 
   def test_using_class_methods_blocks_instead_of_ClassMethods_module
@@ -75,5 +102,16 @@ class ModuleConcernTest < ActiveSupport::TestCase
     # Orphan in Foo::ClassMethods, not Bar::ClassMethods.
     assert Foo.const_defined?(:ClassMethods)
     assert Foo::ClassMethods.method_defined?(:will_be_orphaned)
+  end
+
+  def test_using_class_methods_blocks_instead_of_ClassMethods_module_prepend
+    assert_not_respond_to Foo, :will_be_orphaned_also
+    assert_respond_to Foo, :hacked_on_also
+    assert_respond_to Foo, :nicer_dsl_also
+    assert_respond_to Foo, :doesnt_clobber_also
+
+    # Orphan in Foo::ClassMethods, not Bar::ClassMethods.
+    assert Foo.const_defined?(:ClassMethods)
+    assert Foo::ClassMethods.method_defined?(:will_be_orphaned_also)
   end
 end

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -8,6 +8,18 @@ class ModuleConcerningTest < ActiveSupport::TestCase
     klass = Class.new { concerning(:Foo) { } }
     assert_includes klass.ancestors, klass::Foo, klass.ancestors.inspect
   end
+
+  def test_concerning_can_prepend_concern
+    klass = Class.new do
+      def hi; "self"; end
+
+      concerning(:Foo, prepend: true) do
+        def hi; "hello, #{super}"; end
+      end
+    end
+
+    assert_equal "hello, self", klass.new.hi
+  end
 end
 
 class ModuleConcernTest < ActiveSupport::TestCase

--- a/activesupport/test/fixtures/concern/some_concern.rb
+++ b/activesupport/test/fixtures/concern/some_concern.rb
@@ -8,4 +8,8 @@ module SomeConcern
   included do
     # shouldn't raise when module is loaded more than once
   end
+
+  prepended do
+    # shouldn't raise when module is loaded more than once
+  end
 end


### PR DESCRIPTION
### Summary

**New Feature**

It is occasionally necessary to insert a module at the front of the ancestor hierarchy. For instance, when the module's methods should override the host class's methods, but the module's methods still need access to the host's methods via super.

Ruby 2.0 provides this ability with with `prepend`.

However, it is _also_ occasionally desirable for this prepended module to be defined inline, ala `concerning`. (For all the same reasons that `concerning` makes for wonderful syntactic sugar.)

This PR adds a `prepend:` option to `concerning` such that the immediately-mixed-in-concern is _prepende_ to the ancestor hierarchy as if `prepend FooConcern` had been used.

### Other Information

For completeness sake, it is probably desirable for Concern to also gain `prepended` as a corrolary to `included`; but that is not yet supported in this PR.