### PR TITLE
Fix typo in connection specification error handling

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -185,7 +185,7 @@ module ActiveRecord
           adapter_method = "#{spec[:adapter]}_connection"
 
           unless ActiveRecord::Base.respond_to?(adapter_method)
-            raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
+            raise AdapterNotFound, "database configuration specifies nonexistent #{spec[:adapter]} adapter"
           end
 
           ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method)


### PR DESCRIPTION
### Summary

Fix typo in connection specification error handling. When creating an adapter that the ActiveRecord::Base class does not respond to, the error handling logic erronously attempts to call the config method on the `spec` hash, rather than returning the adapter name in the error description.