### PR TITLE
Fix db:schema:load not working when has table comment and using partitioning

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -21,7 +21,8 @@ module ActiveRecord
           end
 
           def add_table_options!(create_sql, options)
-            add_sql_comment!(super, options[:comment])
+            add_sql_comment!(create_sql, options[:comment])
+            super
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -62,6 +62,14 @@ ActiveRecord::Schema.define do
     t.binary :binary_column,    limit: 1
   end
 
+  create_table :with_partitioning_tests, primary_key: %w(id date), options: "ENGINE=InnoDB DEFAULT CHARSET=utf8\n/*!50500 PARTITION BY RANGE  COLUMNS(`date`)\n(PARTITION p201901 VALUES LESS THAN ('2019-01-01') ENGINE = InnoDB,\n PARTITION p201902 VALUES LESS THAN ('2019-02-01') ENGINE = InnoDB,\n PARTITION p999999 VALUES LESS THAN (MAXVALUE) ENGINE = InnoDB) */", comment: "with_partitioning_tests", force: :cascade do |t|
+    t.bigint "id", null: false, auto_increment: true
+    t.string "name", comment: "name"
+    t.date "date", null: false, comment: "use partitioning column"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   execute "DROP PROCEDURE IF EXISTS ten"
 
   execute <<~SQL


### PR DESCRIPTION
# Summary


db:schema:load not working when has table comment and using partitioning.

e.g. there is `schema.rb` like this
```ruby
create_table :with_partitioning_tests, primary_key: %w(id date), options: "ENGINE=InnoDB DEFAULT CHARSET=utf8\n/*!50500 PARTITION BY RANGE  COLUMNS(`date`)\n(PARTITION p201901 VALUES LESS THAN ('2019-01-01') ENGINE = InnoDB,\n PARTITION p201902 VALUES LESS THAN ('2019-02-01') ENGINE = InnoDB,\n PARTITION p999999 VALUES LESS THAN (MAXVALUE) ENGINE = InnoDB) */", comment: "with_partitioning_tests", force: :cascade do |t|
  t.bigint "id", null: false, auto_increment: true
  t.string "name", comment: "name"
  t.date "date", null: false, comment: "use partitioning column"
  t.datetime "created_at", null: false
  t.datetime "updated_at", null: false
end
```

executed sql
```
CREATE TABLE `with_partitioning_tests` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `name` varchar(255) DEFAULT NULL COMMENT 'name',
  `date` date NOT NULL COMMENT 'use partitioning column',
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  PRIMARY KEY (`id`,`date`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8
/*!50500 PARTITION BY RANGE  COLUMNS(`date`)
(PARTITION p201901 VALUES LESS THAN ('2019-01-01') ENGINE = InnoDB,
 PARTITION p201902 VALUES LESS THAN ('2019-02-01') ENGINE = InnoDB,
 PARTITION p999999 VALUES LESS THAN (MAXVALUE) ENGINE = InnoDB) */ COMMENT='with_partitioning_tests'
                                                                  ^^^^ occurs syntax error
```

### solution
move comment option before create table option(include partitioning option)
