### PR TITLE
Fix issues with ActiveSupport Range extensions on boundless Ranges

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `Range#===`, `Range#include?`, and `Range#cover?` to work with beginless (startless)
+    and endless range targets. Builds on work by Allen Hsu.
+
+    *Andrew Hodgkinson*
+
 *   Fix `Range#include?` to work with beginless and endless ranges.
 
     *Allen Hsu*

--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -11,13 +11,15 @@ module ActiveSupport
     # The native Range#=== behavior is untouched.
     #  ('a'..'f') === ('c') # => true
     #  (5..9) === (11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
     def ===(value)
       if value.is_a?(::Range)
         # 1...10 includes 1..9 but it does not include 1..10.
         # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
         value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && value_max.send(operator, last)
+        super(value.first) && (self.end.nil? || value_max.send(operator, last))
       else
         super
       end
@@ -32,13 +34,15 @@ module ActiveSupport
     # The native Range#include? behavior is untouched.
     #  ('a'..'f').include?('c') # => true
     #  (5..9).include?(11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
     def include?(value)
       if value.is_a?(::Range)
         # 1...10 includes 1..9 but it does not include 1..10.
         # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
         value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && value_max.send(operator, last)
+        super(value.first) && (self.end.nil? || value_max.send(operator, last))
       else
         super
       end
@@ -53,13 +57,15 @@ module ActiveSupport
     # The native Range#cover? behavior is untouched.
     #  ('a'..'f').cover?('c') # => true
     #  (5..9).cover?(11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
     def cover?(value)
       if value.is_a?(::Range)
         # 1...10 covers 1..9 but it does not cover 1..10.
         # 1..10 covers 1...11 but it does not cover 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
         value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && value_max.send(operator, last)
+        super(value.first) && (self.end.nil? || value_max.send(operator, last))
       else
         super
       end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -64,11 +64,27 @@ class RangeTest < ActiveSupport::TestCase
     def test_include_with_endless_range
       assert(eval("1..").include?(2))
     end
+
+    def test_should_include_range_with_endless_range
+      assert(eval("1..").include?(2..4))
+    end
+
+    def test_should_not_include_range_with_endless_range
+      assert_not(eval("1..").include?(0..4))
+    end
   end
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
     def test_include_with_beginless_range
       assert(eval("..2").include?(1))
+    end
+
+    def test_should_include_range_with_beginless_range
+      assert(eval("..2").include?(-1..1))
+    end
+
+    def test_should_not_include_range_with_beginless_range
+      assert_not(eval("..2").include?(-1..3))
     end
   end
 
@@ -82,6 +98,26 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_compare_other_with_exclusive_end
     assert((1..10) === (1...11))
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+    def test_should_compare_range_with_endless_range
+      assert(eval("1..") === (2..4))
+    end
+
+    def test_should_not_compare_range_with_endless_range
+      assert_not(eval("1..") === (0..4))
+    end
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+    def test_should_compare_range_with_beginless_range
+      assert(eval("..2") === (-1..1))
+    end
+
+    def test_should_not_compare_range_with_beginless_range
+      assert_not(eval("..2") === (-1..3))
+    end
   end
 
   def test_exclusive_end_should_not_include_identical_with_inclusive_end
@@ -107,6 +143,26 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_cover_other_with_exclusive_end
     assert((1..10).cover?(1...11))
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+    def test_should_cover_range_with_endless_range
+      assert(eval("1..").cover?(2..4))
+    end
+
+    def test_should_not_cover_range_with_endless_range
+      assert_not(eval("1..").cover?(0..4))
+    end
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+    def test_should_cover_range_with_beginless_range
+      assert(eval("..2").cover?(-1..1))
+    end
+
+    def test_should_not_cover_range_with_beginless_range
+      assert_not(eval("..2").cover?(-1..3))
+    end
   end
 
   def test_overlaps_on_time


### PR DESCRIPTION
### Summary

Please see https://github.com/rails/rails/issues/37177. Fixes ActiveSupport extensions to Range when the target object is "beginless" (startless, Ruby >= 2.7.0) or endless (Ruby >= 2.6.0) and the parameter is itself a Range, in `#include?`, `#cover?` and `===`.

Builds on good work by @aldhsu in https://github.com/rails/rails/pull/36460, taking basically the same approach to fixing and testing.