### PR TITLE
Refactor ConnectionHandler#establish_connection to accept a ConnectionSpecification rather than a Hash

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1062,10 +1062,7 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(config)
-        resolver = ConnectionSpecification::Resolver.new(Base.configurations)
-        spec = resolver.spec(config)
-
+      def establish_connection(spec)
         remove_connection(spec.name)
 
         message_bus = ActiveSupport::Notifications.instrumenter
@@ -1164,7 +1161,7 @@ module ActiveRecord
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
             # the specification and establish a new connection with it.
-            establish_connection(ancestor_pool.spec.to_hash).tap do |pool|
+            establish_connection(ancestor_pool.spec).tap do |pool|
               pool.schema_cache = ancestor_pool.schema_cache if ancestor_pool.schema_cache
             end
           else

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -136,7 +136,7 @@ module ActiveRecord
         old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |configuration| create configuration }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.to_hash)
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec)
         end
       end
 

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       end
 
       def test_close
-        pool = Pool.new(ConnectionSpecification.new("primary", {}, nil))
+        pool = Pool.new(ConnectionSpecification.new("primary", {}))
         pool.insert_connection_for_test! @adapter
         @adapter.pool = pool
 

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecificationTest < ActiveRecord::TestCase
       def test_dup_deep_copy_config
-        spec = ConnectionSpecification.new("primary", { a: :b }, "bar")
+        spec = ConnectionSpecification.new("primary", { a: :b })
         assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
       end
     end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -48,8 +48,9 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "default_env" }
-        assert_equal expected, actual
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "default_env" }
+        assert_equal "default_env", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rails_env
@@ -58,16 +59,18 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "foo" }
-        assert_equal expected, actual
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
+        assert_equal "foo", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_nil_database_url_and_current_env
         ENV["RAILS_ENV"] = "foo"
         config = { "foo" => { "adapter" => "postgres", "url" => ENV["DATABASE_URL"] } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgres", "url" => nil, "name" => "foo" }
-        assert_equal expected, actual
+        expected = { adapter: "postgres", url: nil, name: "foo" }
+        assert_equal "foo", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rack_env
@@ -76,16 +79,18 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "foo" }
-        assert_equal expected, actual
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
+        assert_equal "foo", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_database_uri_and_known_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:production, config)
-        expected = { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost", "name" => "production" }
-        assert_equal expected, actual
+        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost", name: "production" }
+        assert_equal "production", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_database_uri_and_multiple_envs
@@ -94,8 +99,9 @@ module ActiveRecord
 
         config   = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
         actual   = resolve_spec(:test, config)
-        expected = { "adapter" => "postgresql", "database" => "foo_test", "host" => "localhost", "name" => "test" }
-        assert_equal expected, actual
+        expected = { adapter: "postgresql", database: "foo_test", host: "localhost", name: "test" }
+        assert_equal "test", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_resolver_with_database_uri_and_unknown_symbol_key
@@ -110,8 +116,8 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "not-postgres://not-localhost/not_foo"
         config   = { "production" => {  "adapter" => "also_not_postgres", "database" => "also_not_foo" } }
         actual   = resolve_spec("postgres://localhost/foo", config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
-        assert_equal expected, actual
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+        assert_equal expected, actual.config
       end
 
       def test_jdbc_url
@@ -132,8 +138,9 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "ibm-db://localhost/foo"
         config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter" => "ibm_db", "database" => "foo", "host" => "localhost", "name" => "default_env" }
-        assert_equal expected, actual
+        expected = { adapter: "ibm_db", database: "foo", host: "localhost", name: "default_env" }
+        assert_equal "default_env", actual.name
+        assert_equal expected, actual.config
       end
 
       def test_string_connection
@@ -397,15 +404,15 @@ module ActiveRecord
         config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
 
         actual = resolve_spec(:production, config)
-        assert_equal config["production"].merge("name" => "production"), actual
+        assert_equal config["production"].merge("name" => "production").symbolize_keys, actual.config
 
         actual = resolve_spec(:default_env, config)
         assert_equal({
-          "host" => "localhost",
-          "database" => "foo",
-          "adapter" => "postgresql",
-          "name" => "default_env"
-        }, actual)
+          host: "localhost",
+          database: "foo",
+          adapter: "postgresql",
+          name: "default_env"
+        }, actual.config)
       end
     end
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -362,8 +362,9 @@ class QueryCacheTest < ActiveRecord::TestCase
     skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
     with_temporary_connection_pool do
       spec_name = Task.connection_specification_name
-      conf = ActiveRecord::Base.configurations["arunit"].merge("name" => "test2")
-      ActiveRecord::Base.connection_handler.establish_connection(conf)
+      conf = ActiveRecord::Base.configurations["arunit"].symbolize_keys
+      spec = ActiveRecord::ConnectionAdapters::ConnectionSpecification.new("test2", conf)
+      ActiveRecord::Base.connection_handler.establish_connection(spec)
       Task.connection_specification_name = "test2"
       assert_not_predicate Task, :connected?
 


### PR DESCRIPTION
Ultimately I'd like to reach a point where connection hashes / urls are immediately casted into `DatabaseConfig` instances.

This is just one step toward that goal. It's consolidating the connection handler code to deal with `ConnectionSpecification` instances rather than constantly cast from and to hashes.

