### PR TITLE
Fix error message for AdapterNotFound in spec

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -185,7 +185,7 @@ module ActiveRecord
           adapter_method = "#{spec[:adapter]}_connection"
 
           unless ActiveRecord::Base.respond_to?(adapter_method)
-            raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
+            raise AdapterNotFound, "database configuration specifies nonexistent #{spec[:adapter]} adapter"
           end
 
           ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method)

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -26,6 +26,14 @@ module ActiveRecord
           assert_match "Could not load the 'ridiculous' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", error.message
         end
 
+        def test_error_if_no_adapter_method
+          error = assert_raises(AdapterNotFound) do
+            spec "abstract://foo?encoding=utf8"
+          end
+
+          assert_match "database configuration specifies nonexistent abstract adapter", error.message
+        end
+
         # The abstract adapter is used simply to bypass the bit of code that
         # checks that the adapter file can be required in.
 


### PR DESCRIPTION
When this case was his previously, an error would be thrown like:
`<NoMethodError: "undefined method config for...">` because we were
erroneously calling `config` on a `Hash`.

This PR adds a test for this case, and fixes the hash access.

cc / @eileencodes 