### PR TITLE
Pass db_config object around instead of hashes

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -184,7 +184,7 @@ module ActiveRecord
       self.connection_specification_name = pool_name
 
       resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(Base.configurations)
-      config_hash = resolver.resolve(config_or_env, pool_name).symbolize_keys
+      config_hash = resolver.resolve(config_or_env, pool_name).configuration_hash
       config_hash[:name] = pool_name
 
       config_hash

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -18,6 +18,10 @@ module ActiveRecord
         configuration_hash.stringify_keys
       end
 
+      def initialize_dup(original)
+        @config = original.configuration_hash.dup
+      end
+
       def replica?
         raise NotImplementedError
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -28,6 +28,8 @@ module ActiveRecord
       def initialize(env_name, spec_name, config)
         super(env_name, spec_name)
         @config = config.symbolize_keys
+
+        resolve_url_key
       end
 
       def configuration_hash
@@ -47,6 +49,14 @@ module ActiveRecord
       def migrations_paths
         configuration_hash[:migrations_paths]
       end
+
+      private
+        def resolve_url_key
+          if configuration_hash[:url] && !configuration_hash[:url].match?(/^jdbc:/)
+            connection_hash = ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(configuration_hash[:url]).to_hash
+            configuration_hash.merge!(connection_hash)
+          end
+        end
     end
   end
 end

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -39,7 +39,8 @@ module ActiveRecord
       end
 
       def test_close
-        pool = Pool.new(ConnectionSpecification.new("primary", {}, nil))
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", {})
+        pool = Pool.new(ConnectionSpecification.new("primary", db_config, nil))
         pool.insert_connection_for_test! @adapter
         @adapter.pool = pool
 

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -6,7 +6,8 @@ module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecificationTest < ActiveRecord::TestCase
       def test_dup_deep_copy_config
-        spec = ConnectionSpecification.new("primary", { a: :b }, "bar")
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("development", "primary", { a: :b })
+        spec = ConnectionSpecification.new("primary", db_config, "bar")
         assert_not_equal(spec.underlying_configuration_hash.object_id, spec.dup.underlying_configuration_hash.object_id)
       end
     end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       def resolve_spec(spec, config)
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(configs)
-        resolver.resolve(spec, spec)
+        resolver.resolve(spec, spec).configuration_hash
       end
 
       def test_invalid_string_config

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         def resolve(spec, config = {})
           configs = ActiveRecord::DatabaseConfigurations.new(config)
           resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(configs)
-          resolver.resolve(spec, spec)
+          resolver.resolve(spec, spec).configuration_hash
         end
 
         def spec(spec, config = {})


### PR DESCRIPTION
This is part 1 of removing the need to pass hashes around inside
connection management. This PR creates database config objects every
time when passing a hash, string, or symbol and sends that object to
connection specification. ConnectionSpecification reaches into the
config hash on db_config when needed, but eventually we'll get rid of
that and ConnectionSpecification since it's doing duplicate work with
the DatabaseConfigurations.

We also chose to change the keys to strings because that's what the
database.yml would create and what apps currently expect. While symbols
are nicer, we'd end up having to deprecate the string behavior first.

cc / @eileencodes @casperisfine