### PR TITLE
activerecord: Allow comment prefix in queries when preventing writes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -76,6 +76,7 @@ module ActiveRecord
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
+      COMMENT_REGEX = %r{/\*(?:[^\*]|\*[^/])*\*/}m
 
       attr_accessor :pool
       attr_reader :visitor, :owner, :logger, :lock
@@ -102,8 +103,8 @@ module ActiveRecord
       end
 
       def self.build_read_query_regexp(*parts) # :nodoc:
-        parts = parts.map { |part| /\A[\(\s]*#{part}/i }
-        Regexp.union(*parts)
+        parts = parts.map { |part| /#{part}/i }
+        /\A(?:[\(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
       end
 
       def self.quoted_column_names # :nodoc:

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -221,7 +221,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
 
     @connection_handler.while_preventing_writes do
-      assert_equal 1, @conn.execute("(\n( SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594' ) )").entries.count
+      assert_equal 1, @conn.execute("/*action:index*/(\n( SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594' ) )").entries.count
     end
   end
 


### PR DESCRIPTION
@rafaelfranca 

## Problem

We use [marginalia](https://github.com/basecamp/marginalia) attach comments to queries to help provide context for queries in the slow query log.  We also use `Marginalia::Comment.prepend_comment = true` to prepend the comment so it isn't lost from truncation.  However, this resulted in the `ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements::READ_QUERY` to no longer match any queries, which would prevent any queries from being performed on a database connection configured with `replica: true` due to it trying to prevent write queries.

## Solution

Update the regex to ignore `/*` ... `*/` comments at the start of the query string.