### PR TITLE
Use symbols everywhere for database configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `DatabaseConfig#configuration_hash` to return database configuration hashes with symbol keys, and use all symbol-key configuration hashes internally. Deprecate `DatabaseConfig#config` which returns a String-keyed `Hash` with the same values.
+
+    *John Crepezzi*, *Eileen Uchitelle*
+
 *   Allow column names to be passed to `remove_index` positionally along with other options.
 
     Passing other options can be necessary to make `remove_index` correctly reversible.

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -5,14 +5,18 @@ require "uri"
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecification #:nodoc:
-      attr_reader :name, :config, :adapter_method
+      attr_reader :name, :adapter_method
 
       def initialize(name, config, adapter_method)
         @name, @config, @adapter_method = name, config, adapter_method
       end
 
+      def underlying_configuration_hash
+        @config
+      end
+
       def initialize_dup(original)
-        @config = original.config.dup
+        @config = original.underlying_configuration_hash.dup
       end
 
       def to_hash
@@ -26,14 +30,14 @@ module ActiveRecord
         #   url = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
         #   ConnectionUrlResolver.new(url).to_hash
         #   # => {
-        #     "adapter"  => "postgresql",
-        #     "host"     => "localhost",
-        #     "port"     => 9000,
-        #     "database" => "foo_test",
-        #     "username" => "foo",
-        #     "password" => "bar",
-        #     "pool"     => "5",
-        #     "timeout"  => "3000"
+        #     adapter:  "postgresql",
+        #     host:     "localhost",
+        #     port:     9000,
+        #     database: "foo_test",
+        #     username: "foo",
+        #     password: "bar",
+        #     pool:     "5",
+        #     timeout:  "3000"
         #   }
         def initialize(url)
           raise "Database URL cannot be empty" if url.blank?
@@ -65,29 +69,31 @@ module ActiveRecord
           # Converts the query parameters of the URI into a hash.
           #
           #   "localhost?pool=5&reaping_frequency=2"
-          #   # => { "pool" => "5", "reaping_frequency" => "2" }
+          #   # => { pool: "5", reaping_frequency: "2" }
           #
           # returns empty hash if no query present.
           #
           #   "localhost"
           #   # => {}
           def query_hash
-            Hash[(@query || "").split("&").map { |pair| pair.split("=") }]
+            Hash[(@query || "").split("&").map { |pair| pair.split("=") }].symbolize_keys
           end
 
           def raw_config
             if uri.opaque
               query_hash.merge(
-                "adapter"  => @adapter,
-                "database" => uri.opaque)
+                adapter: @adapter,
+                database: uri.opaque
+              )
             else
               query_hash.merge(
-                "adapter"  => @adapter,
-                "username" => uri.user,
-                "password" => uri.password,
-                "port"     => uri.port,
-                "database" => database_from_path,
-                "host"     => uri.hostname)
+                adapter: @adapter,
+                username: uri.user,
+                password: uri.password,
+                port: uri.port,
+                database: database_from_path,
+                host: uri.hostname
+              )
             end
           end
 
@@ -126,13 +132,13 @@ module ActiveRecord
         #
         #   configurations = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
         #   Resolver.new(configurations).resolve(:production)
-        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3"}
+        #   # => { host: "localhost", database: "foo", adapter: "sqlite3"}
         #
         # Initialized with URL configuration strings.
         #
         #   configurations = { "production" => "postgresql://localhost/foo" }
         #   Resolver.new(configurations).resolve(:production)
-        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+        #   # => { host: "localhost", database: "foo", adapter: "postgresql" }
         #
         def resolve(config_or_env, pool_name = nil)
           if config_or_env
@@ -151,8 +157,8 @@ module ActiveRecord
         #   spec = Resolver.new(config).spec(:production)
         #   spec.adapter_method
         #   # => "sqlite3_connection"
-        #   spec.config
-        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
+        #   spec.underlying_configuration_hash
+        #   # => { host: "localhost", database: "foo", adapter: "sqlite3" }
         #
         def spec(config)
           pool_name = config if config.is_a?(Symbol)
@@ -205,12 +211,12 @@ module ActiveRecord
           # One layer deep hash of connection values.
           #
           #   Resolver.new({}).resolve_connection("adapter" => "sqlite3")
-          #   # => { "adapter" => "sqlite3" }
+          #   # => { adapter: "sqlite3" }
           #
           # Connection URL.
           #
           #   Resolver.new({}).resolve_connection("postgresql://localhost/foo")
-          #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+          #   # => { host: "localhost", database: "foo", adapter: "postgresql" }
           #
           def resolve_connection(config_or_env, pool_name = nil)
             case config_or_env
@@ -236,16 +242,16 @@ module ActiveRecord
           #   configurations = #<ActiveRecord::DatabaseConfigurations:0x00007fd9fdace3e0
           #     @configurations=[
           #       #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd9fdace250
-          #         @env_name="production", @spec_name="primary", @config={"database"=>"my_db"}>
+          #         @env_name="production", @spec_name="primary", @config={database: "my_db"}>
           #       ]>
           #
           #   Resolver.new(configurations).resolve_symbol_connection(:production, "primary")
-          #   # => { "database" => "my_db" }
+          #   # => { database: "my_db" }
           def resolve_symbol_connection(env_name, pool_name)
             db_config = configurations.find_db_config(env_name)
 
             if db_config
-              resolve_connection(db_config.config).merge("name" => pool_name.to_s)
+              resolve_connection(db_config.configuration_hash).merge(name: pool_name.to_s)
             else
               raise AdapterNotSpecified, <<~MSG
                 The `#{env_name}` database is not configured for the `#{ActiveRecord::ConnectionHandling::DEFAULT_ENV.call}` environment.
@@ -275,8 +281,8 @@ module ActiveRecord
           # hash and merges with the rest of the hash.
           # Connection details inside of the "url" key win any merge conflicts
           def resolve_hash_connection(spec)
-            if spec["url"] && !spec["url"].match?(/^jdbc:/)
-              connection_hash = resolve_url_connection(spec.delete("url"))
+            if spec[:url] && !spec[:url].match?(/^jdbc:/)
+              connection_hash = resolve_url_connection(spec.delete(:url))
               spec.merge!(connection_hash)
             end
             spec
@@ -285,7 +291,7 @@ module ActiveRecord
           # Takes a connection URL.
           #
           #   Resolver.new({}).resolve_url_connection("postgresql://localhost/foo")
-          #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+          #   # => { host: "localhost", database: "foo", adapter: "postgresql" }
           #
           def resolve_url_connection(url)
             ConnectionUrlResolver.new(url).to_hash

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -227,7 +227,7 @@ module ActiveRecord
     #
     # Please use only for reading.
     def connection_config
-      connection_pool.spec.config
+      connection_pool.spec.underlying_configuration_hash
     end
 
     def connection_pool

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -43,9 +43,9 @@ module ActiveRecord
       #
       #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-      #       @spec_name="primary", @config={"adapter"=>"sqlite3", "database"=>"db/development.sqlite3"}>,
+      #       @spec_name="primary", @config={adapter: "sqlite3", database: "db/development.sqlite3"}>,
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
-      #       @spec_name="primary", @config={"adapter"=>"sqlite3", "database"=>"db/production.sqlite3"}>
+      #       @spec_name="primary", @config={adapter: "sqlite3", database: "db/production.sqlite3"}>
       #   ]>
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -61,7 +61,7 @@ module ActiveRecord
     #   { database: "my_db", adapter: "mysql2" }
     def default_hash(env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s)
       default = find_db_config(env)
-      default.config if default
+      default.configuration_hash if default
     end
     alias :[] :default_hash
 
@@ -96,14 +96,14 @@ module ActiveRecord
     def each
       throw_getter_deprecation(:each)
       configurations.each { |config|
-        yield [config.env_name, config.config]
+        yield [config.env_name, config.configuration_hash]
       }
     end
 
     def first
       throw_getter_deprecation(:first)
       config = configurations.first
-      [config.env_name, config.config]
+      [config.env_name, config.configuration_hash]
     end
 
     private
@@ -147,7 +147,7 @@ module ActiveRecord
         when String
           build_db_config_from_string(env_name, spec_name, config)
         when Hash
-          build_db_config_from_hash(env_name, spec_name, config.stringify_keys)
+          build_db_config_from_hash(env_name, spec_name, config.symbolize_keys)
         else
           raise InvalidConfigurationError, "'{ #{env_name} => #{config} }' is not a valid configuration. Expected '#{config}' to be a URL string or a Hash."
         end
@@ -164,10 +164,10 @@ module ActiveRecord
       end
 
       def build_db_config_from_hash(env_name, spec_name, config)
-        if config.has_key?("url")
-          url = config["url"]
+        if config.has_key?(:url)
+          url = config[:url]
           config_without_url = config.dup
-          config_without_url.delete "url"
+          config_without_url.delete :url
 
           ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url, config_without_url)
         else
@@ -179,7 +179,7 @@ module ActiveRecord
         configs.map do |config|
           next config if config.url_config? || config.env_name != current_env
 
-          url_config = environment_url_config(current_env, config.spec_name, config.config)
+          url_config = environment_url_config(current_env, config.spec_name, config.configuration_hash)
           url_config || config
         end
       end
@@ -205,7 +205,7 @@ module ActiveRecord
           configs_for(env_name: args.first)
         when :values
           throw_getter_deprecation(method)
-          configurations.map(&:config)
+          configurations.map(&:configuration_hash)
         when :[]=
           throw_setter_deprecation(method)
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -13,6 +13,11 @@ module ActiveRecord
         @spec_name = spec_name
       end
 
+      def config
+        ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
+        configuration_hash.stringify_keys
+      end
+
       def replica?
         raise NotImplementedError
       end
@@ -26,7 +31,7 @@ module ActiveRecord
       end
 
       def to_legacy_hash
-        { env_name => config }
+        { env_name => configuration_hash.stringify_keys }
       end
 
       def for_current_env?

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -12,7 +12,7 @@ module ActiveRecord
     # Becomes:
     #
     #   #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10
-    #     @env_name="development", @spec_name="primary", @config={"database"=>"db_name"}>
+    #     @env_name="development", @spec_name="primary", @config={database: "db_name"}>
     #
     # ==== Options
     #
@@ -25,25 +25,27 @@ module ActiveRecord
     #   database adapter, name, and other important information for database
     #   connections.
     class HashConfig < DatabaseConfig
-      attr_reader :config
-
       def initialize(env_name, spec_name, config)
         super(env_name, spec_name)
-        @config = config
+        @config = config.symbolize_keys
+      end
+
+      def configuration_hash
+        @config
       end
 
       # Determines whether a database configuration is for a replica / readonly
       # connection. If the +replica+ key is present in the config, +replica?+ will
       # return +true+.
       def replica?
-        config["replica"]
+        configuration_hash[:replica]
       end
 
       # The migrations paths for a database configuration. If the
       # +migrations_paths+ key is present in the config, +migrations_paths+
       # will return its value.
       def migrations_paths
-        config["migrations_paths"]
+        configuration_hash[:migrations_paths]
       end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -14,7 +14,7 @@ module ActiveRecord
     #
     #   #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x00007fdc3238f340
     #     @env_name="default_env", @spec_name="primary",
-    #     @config={"adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost"},
+    #     @config={adapter: "postgresql", database: "foo", host: "localhost"},
     #     @url="postgres://localhost/foo">
     #
     # ==== Options
@@ -29,12 +29,16 @@ module ActiveRecord
     #   database adapter, name, and other important information for database
     #   connections.
     class UrlConfig < DatabaseConfig
-      attr_reader :url, :config
+      attr_reader :url
 
       def initialize(env_name, spec_name, url, config = {})
         super(env_name, spec_name)
-        @config = build_config(config, url)
+        @config = build_config(config, url).symbolize_keys
         @url = url
+      end
+
+      def configuration_hash
+        @config
       end
 
       def url_config? # :nodoc:
@@ -45,20 +49,20 @@ module ActiveRecord
       # connection. If the +replica+ key is present in the config, +replica?+ will
       # return +true+.
       def replica?
-        config["replica"]
+        configuration_hash[:replica]
       end
 
       # The migrations paths for a database configuration. If the
       # +migrations_paths+ key is present in the config, +migrations_paths+
       # will return its value.
       def migrations_paths
-        config["migrations_paths"]
+        configuration_hash[:migrations_paths]
       end
 
       private
         def build_url_hash(url)
           if url.nil? || /^jdbc:/.match?(url)
-            { "url" => url }
+            { url: url }
           else
             ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
           end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -591,7 +591,7 @@ module ActiveRecord
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
-          Tasks::DatabaseTasks.schema_up_to_date?(db_config.config, ActiveRecord::Base.schema_format, nil, Rails.env, db_config.spec_name)
+          Tasks::DatabaseTasks.schema_up_to_date?(db_config.configuration_hash, ActiveRecord::Base.schema_format, nil, Rails.env, db_config.spec_name)
         end
 
         if needs_update

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -29,7 +29,7 @@ db_namespace = namespace :db do
       desc "Create #{spec_name} database for current environment"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Tasks::DatabaseTasks.create(db_config.config)
+        ActiveRecord::Tasks::DatabaseTasks.create(db_config.configuration_hash)
       end
     end
   end
@@ -48,7 +48,7 @@ db_namespace = namespace :db do
       desc "Drop #{spec_name} database for current environment"
       task spec_name => [:load_config, :check_protected_environments] do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Tasks::DatabaseTasks.drop(db_config.config)
+        ActiveRecord::Tasks::DatabaseTasks.drop(db_config.configuration_hash)
       end
     end
   end
@@ -81,7 +81,7 @@ db_namespace = namespace :db do
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.config)
+      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     end
     db_namespace["_dump"].invoke
@@ -107,7 +107,7 @@ db_namespace = namespace :db do
       desc "Migrate #{spec_name} database for current environment"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Base.establish_connection(db_config.config)
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
         ActiveRecord::Tasks::DatabaseTasks.migrate
       end
     end
@@ -150,7 +150,7 @@ db_namespace = namespace :db do
 
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
 
-          ActiveRecord::Base.establish_connection(db_config.config)
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
           ActiveRecord::Base.connection.migration_context.run(
             :up,
@@ -184,7 +184,7 @@ db_namespace = namespace :db do
 
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
 
-          ActiveRecord::Base.establish_connection(db_config.config)
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
           ActiveRecord::Base.connection.migration_context.run(
             :down,
@@ -199,7 +199,7 @@ db_namespace = namespace :db do
     desc "Display status of migrations"
     task status: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.config)
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
         ActiveRecord::Tasks::DatabaseTasks.migrate_status
       end
     end
@@ -209,7 +209,7 @@ db_namespace = namespace :db do
         desc "Display status of migrations for #{spec_name} database"
         task spec_name => :load_config do
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-          ActiveRecord::Base.establish_connection(db_config.config)
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
           ActiveRecord::Tasks::DatabaseTasks.migrate_status
         end
       end
@@ -253,7 +253,7 @@ db_namespace = namespace :db do
   # desc "Raises an error if there are pending migrations"
   task abort_if_pending_migrations: :load_config do
     pending_migrations = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).flat_map do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.config)
+      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
 
       ActiveRecord::Base.connection.migration_context.open.pending_migrations
     end
@@ -274,7 +274,7 @@ db_namespace = namespace :db do
       # desc "Raises an error if there are pending migrations for #{spec_name} database"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Base.establish_connection(db_config.config)
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
 
         pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations
 
@@ -297,18 +297,18 @@ db_namespace = namespace :db do
     seed = false
 
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.config)
+      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
 
       # Skipped when no database
       ActiveRecord::Tasks::DatabaseTasks.migrate
       if ActiveRecord::Base.dump_schema_after_migration
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, ActiveRecord::Base.schema_format, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, ActiveRecord::Base.schema_format, db_config.spec_name)
       end
 
     rescue ActiveRecord::NoDatabaseError
       ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)
       ActiveRecord::Tasks::DatabaseTasks.load_schema(
-        db_config.config,
+        db_config.configuration_hash,
         ActiveRecord::Base.schema_format,
         nil,
         db_config.env_name,
@@ -385,8 +385,8 @@ db_namespace = namespace :db do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.config)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, :ruby, db_config.spec_name)
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, :ruby, db_config.spec_name)
       end
 
       db_namespace["schema:dump"].reenable
@@ -405,7 +405,7 @@ db_namespace = namespace :db do
       desc "Creates a db/schema_cache.yml file."
       task dump: :load_config do
         ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-          ActiveRecord::Base.establish_connection(db_config.config)
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
             ActiveRecord::Base.connection,
@@ -428,8 +428,8 @@ db_namespace = namespace :db do
     desc "Dumps the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.config)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.config, :sql, db_config.spec_name)
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, :sql, db_config.spec_name)
       end
 
       db_namespace["structure:dump"].reenable
@@ -462,7 +462,7 @@ db_namespace = namespace :db do
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, :ruby, filename, "test")
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.configuration_hash, :ruby, filename, "test")
       end
     ensure
       if should_reconnect
@@ -474,14 +474,14 @@ db_namespace = namespace :db do
     task load_structure: %w(db:test:purge) do
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :sql)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.config, :sql, filename, "test")
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.configuration_hash, :sql, filename, "test")
       end
     end
 
     # desc "Empty the test database"
     task purge: %w(load_config check_protected_environments) do
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-        ActiveRecord::Tasks::DatabaseTasks.purge(db_config.config)
+        ActiveRecord::Tasks::DatabaseTasks.purge(db_config.configuration_hash)
       end
     end
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -6,11 +6,11 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration, root = ActiveRecord::Tasks::DatabaseTasks.root)
-        @configuration, @root = configuration, root
+        @configuration, @root = configuration.symbolize_keys, root
       end
 
       def create
-        raise DatabaseAlreadyExists if File.exist?(configuration["database"])
+        raise DatabaseAlreadyExists if File.exist?(configuration[:database])
 
         establish_connection configuration
         connection
@@ -18,7 +18,7 @@ module ActiveRecord
 
       def drop
         require "pathname"
-        path = Pathname.new configuration["database"]
+        path = Pathname.new configuration[:database]
         file = path.absolute? ? path.to_s : File.join(root, path)
 
         FileUtils.rm(file)
@@ -40,7 +40,7 @@ module ActiveRecord
       def structure_dump(filename, extra_flags)
         args = []
         args.concat(Array(extra_flags)) if extra_flags
-        args << configuration["database"]
+        args << configuration[:database]
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
@@ -53,7 +53,7 @@ module ActiveRecord
       end
 
       def structure_load(filename, extra_flags)
-        dbfile = configuration["database"]
+        dbfile = configuration[:database]
         flags = extra_flags.join(" ") if extra_flags
         `sqlite3 #{flags} #{dbfile} < "#{filename}"`
       end

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -12,8 +12,8 @@ module ActiveRecord
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
-        db_config.config["database"] += "-#{i}"
-        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config.config, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
+        db_config.configuration_hash[:database] += "-#{i}"
+        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config.configuration_hash, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
       end
     ensure
       ActiveRecord::Base.establish_connection(Rails.env.to_sym)

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
       def setup
         @connection = ActiveRecord::Base.connection
-        db          = Post.connection_pool.spec.config[:database]
+        db          = Post.connection_pool.spec.underlying_configuration_hash[:database]
         table       = Post.table_name
         @db_name    = db
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -537,8 +537,7 @@ module ActiveRecord
       end
 
       def test_statement_closed
-        db = ::SQLite3::Database.new(ActiveRecord::Base.
-                                   configurations["arunit"]["database"])
+        db = ::SQLite3::Database.new(ActiveRecord::Base.configurations["arunit"][:database])
         statement = ::SQLite3::Statement.new(db,
                                            "CREATE TABLE statement_test (number integer not null)")
         statement.stub(:step, -> { raise ::SQLite3::BusyException.new("busy") }) do

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -62,13 +62,13 @@ module ActiveRecord
         @handler.establish_connection(:readonly)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("readonly")
-        assert_equal "db/readonly.sqlite3", pool.spec.config[:database]
+        assert_equal "db/readonly.sqlite3", pool.spec.underlying_configuration_hash[:database]
 
         assert_not_nil pool = @handler.retrieve_connection_pool("primary")
-        assert_equal "db/primary.sqlite3", pool.spec.config[:database]
+        assert_equal "db/primary.sqlite3", pool.spec.underlying_configuration_hash[:database]
 
         assert_not_nil pool = @handler.retrieve_connection_pool("common")
-        assert_equal "db/common.sqlite3", pool.spec.config[:database]
+        assert_equal "db/common.sqlite3", pool.spec.underlying_configuration_hash[:database]
       ensure
         ActiveRecord::Base.configurations = @prev_configs
         ENV["RAILS_ENV"] = previous_env
@@ -92,7 +92,7 @@ module ActiveRecord
 
           ActiveRecord::Base.establish_connection
 
-          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
+          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.underlying_configuration_hash[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
@@ -115,7 +115,7 @@ module ActiveRecord
 
           ActiveRecord::Base.establish_connection
 
-          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.config[:database]
+          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.spec.underlying_configuration_hash[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
@@ -131,7 +131,7 @@ module ActiveRecord
         @handler.establish_connection(:development)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("development")
-        assert_equal "db/primary.sqlite3", pool.spec.config[:database]
+        assert_equal "db/primary.sqlite3", pool.spec.underlying_configuration_hash[:database]
       ensure
         ActiveRecord::Base.configurations = @prev_configs
       end
@@ -146,7 +146,7 @@ module ActiveRecord
         @handler.establish_connection(:development_readonly)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("development_readonly")
-        assert_equal "db/readonly.sqlite3", pool.spec.config[:database]
+        assert_equal "db/readonly.sqlite3", pool.spec.underlying_configuration_hash[:database]
       ensure
         ActiveRecord::Base.configurations = @prev_configs
       end
@@ -172,8 +172,9 @@ module ActiveRecord
           assert_instance_of ActiveRecord::DatabaseConfigurations::HashConfig, db_config
           assert_instance_of String, db_config.env_name
           assert_instance_of String, db_config.spec_name
-          db_config.config.keys.each do |key|
-            assert_instance_of String, key
+
+          db_config.configuration_hash.keys.each do |key|
+            assert_instance_of Symbol, key
           end
         end
       ensure
@@ -209,7 +210,7 @@ module ActiveRecord
 
         assert_same klass2.connection, ActiveRecord::Base.connection
 
-        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.spec.config)
+        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.spec.underlying_configuration_hash)
         assert_same klass2.connection, pool.connection
         assert_not_same klass2.connection, ActiveRecord::Base.connection
 

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -82,10 +82,10 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { writing: :primary, reading: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("primary")
-          assert_equal "db/primary.sqlite3", pool.spec.config[:database]
+          assert_equal "db/primary.sqlite3", pool.spec.underlying_configuration_hash[:database]
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.config[:database]
+          assert_equal "db/readonly.sqlite3", pool.spec.underlying_configuration_hash[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -140,10 +140,10 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { default: :primary, readonly: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:default].retrieve_connection_pool("primary")
-          assert_equal "db/primary.sqlite3", pool.spec.config[:database]
+          assert_equal "db/primary.sqlite3", pool.spec.underlying_configuration_hash[:database]
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:readonly].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.config[:database]
+          assert_equal "db/readonly.sqlite3", pool.spec.underlying_configuration_hash[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -162,7 +162,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.spec.config)
+            assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.spec.underlying_configuration_hash)
           end
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
@@ -182,7 +182,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config, pool.spec.config)
+            assert_equal(config, pool.spec.underlying_configuration_hash)
           end
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
@@ -222,7 +222,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["animals"], pool.spec.config)
+            assert_equal(config["default_env"]["animals"], pool.spec.underlying_configuration_hash)
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -249,7 +249,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["primary"], pool.spec.config)
+            assert_equal(config["default_env"]["primary"], pool.spec.underlying_configuration_hash)
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -284,7 +284,7 @@ module ActiveRecord
           ActiveRecord::Base.connects_to database: { writing: :development, reading: :development_readonly }
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.config[:database]
+          assert_equal "db/readonly.sqlite3", pool.spec.underlying_configuration_hash[:database]
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class ConnectionSpecificationTest < ActiveRecord::TestCase
       def test_dup_deep_copy_config
         spec = ConnectionSpecification.new("primary", { a: :b }, "bar")
-        assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
+        assert_not_equal(spec.underlying_configuration_hash.object_id, spec.dup.underlying_configuration_hash.object_id)
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "default_env" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "default_env" }
         assert_equal expected, actual
       end
 
@@ -58,7 +58,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "foo" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
         assert_equal expected, actual
       end
 
@@ -66,7 +66,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "foo"
         config = { "foo" => { "adapter" => "postgres", "url" => ENV["DATABASE_URL"] } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgres", "url" => nil, "name" => "foo" }
+        expected = { adapter: "postgres", url: nil, name: "foo" }
         assert_equal expected, actual
       end
 
@@ -76,7 +76,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost", "name" => "foo" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
         assert_equal expected, actual
       end
 
@@ -84,7 +84,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:production, config)
-        expected = { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost", "name" => "production" }
+        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost", name: "production" }
         assert_equal expected, actual
       end
 
@@ -94,7 +94,7 @@ module ActiveRecord
 
         config   = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
         actual   = resolve_spec(:test, config)
-        expected = { "adapter" => "postgresql", "database" => "foo_test", "host" => "localhost", "name" => "test" }
+        expected = { adapter: "postgresql", database: "foo_test", host: "localhost", name: "test" }
         assert_equal expected, actual
       end
 
@@ -110,7 +110,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "not-postgres://not-localhost/not_foo"
         config   = { "production" => {  "adapter" => "also_not_postgres", "database" => "also_not_foo" } }
         actual   = resolve_spec("postgres://localhost/foo", config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -132,7 +132,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "ibm-db://localhost/foo"
         config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter" => "ibm_db", "database" => "foo", "host" => "localhost", "name" => "default_env" }
+        expected = { adapter: "ibm_db", database: "foo", host: "localhost", name: "default_env" }
         assert_equal expected, actual
       end
 
@@ -351,19 +351,19 @@ module ActiveRecord
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").config
+        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").configuration_hash
         expected = {
-          "adapter"  => "postgresql",
-          "database" => "foo",
-          "host"     => "localhost",
-          "pool"     => 5
+          adapter:  "postgresql",
+          database: "foo",
+          host:     "localhost",
+          pool:     5
         }
 
         assert_equal expected, actual
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").config
-        expected = { "pool" => 5 }
+        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").configuration_hash
+        expected = { pool: 5 }
 
         assert_equal expected, actual
       end
@@ -381,12 +381,12 @@ module ActiveRecord
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").config
-        assert_equal "primary", actual["database"]
+        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").configuration_hash
+        assert_equal "primary", actual[:database]
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").config
-        assert_equal "animals", actual["database"]
+        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").configuration_hash
+        assert_equal "animals", actual[:database]
       ensure
         ENV.delete("PRIMARY_DATABASE_URL")
         ENV.delete("ANIMALS_DATABASE_URL")
@@ -397,14 +397,14 @@ module ActiveRecord
         config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
 
         actual = resolve_spec(:production, config)
-        assert_equal config["production"].merge("name" => "production"), actual
+        assert_equal config["production"].symbolize_keys.merge(name: "production"), actual
 
         actual = resolve_spec(:default_env, config)
         assert_equal({
-          "host" => "localhost",
-          "database" => "foo",
-          "adapter" => "postgresql",
-          "name" => "default_env"
+          host: "localhost",
+          database: "foo",
+          adapter: "postgresql",
+          name: "default_env"
         }, actual)
       end
     end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -199,7 +199,7 @@ module ActiveRecord
       def test_idle_timeout_configuration
         @pool.disconnect!
         spec = ActiveRecord::Base.connection_pool.spec
-        spec.config.merge!(idle_timeout: "0.02")
+        spec.underlying_configuration_hash.merge!(idle_timeout: "0.02")
         @pool = ConnectionPool.new(spec)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
@@ -224,7 +224,7 @@ module ActiveRecord
       def test_disable_flush
         @pool.disconnect!
         spec = ActiveRecord::Base.connection_pool.spec
-        spec.config.merge!(idle_timeout: -5)
+        spec.underlying_configuration_hash.merge!(idle_timeout: -5)
         @pool = ConnectionPool.new(spec)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
@@ -719,7 +719,7 @@ module ActiveRecord
       private
         def with_single_connection_pool
           one_conn_spec = ActiveRecord::Base.connection_pool.spec.dup
-          one_conn_spec.config[:pool] = 1 # this is safe to do, because .dupped ConnectionSpecification also auto-dups its config
+          one_conn_spec.underlying_configuration_hash[:pool] = 1 # this is safe to do, because .dupped ConnectionSpecification also auto-dups its config
           yield(pool = ConnectionPool.new(one_conn_spec))
         ensure
           pool.disconnect! if pool

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -40,98 +40,104 @@ module ActiveRecord
         def test_url_from_environment
           spec = resolve :production, "production" => "abstract://foo?encoding=utf8"
           assert_equal({
-            "adapter"  =>  "abstract",
-            "host"     =>  "foo",
-            "encoding" => "utf8",
-            "name"     => "production" }, spec)
+            adapter:  "abstract",
+            host:     "foo",
+            encoding: "utf8",
+            name:     "production"
+          }, spec)
         end
 
         def test_url_sub_key
           spec = resolve :production, "production" => { "url" => "abstract://foo?encoding=utf8" }
           assert_equal({
-            "adapter"  => "abstract",
-            "host"     => "foo",
-            "encoding" => "utf8",
-            "name"     => "production" }, spec)
+            adapter:  "abstract",
+            host:     "foo",
+            encoding: "utf8",
+            name:     "production"
+          }, spec)
         end
 
         def test_url_sub_key_merges_correctly
           hash = { "url" => "abstract://foo?encoding=utf8&", "adapter" => "sqlite3", "host" => "bar", "pool" => "3" }
           spec = resolve :production, "production" => hash
           assert_equal({
-            "adapter"  => "abstract",
-            "host"     => "foo",
-            "encoding" => "utf8",
-            "pool"     => "3",
-            "name"     => "production" }, spec)
+            adapter:  "abstract",
+            host:     "foo",
+            encoding: "utf8",
+            pool:     "3",
+            name:     "production"
+          }, spec)
         end
 
         def test_url_host_no_db
           spec = resolve "abstract://foo?encoding=utf8"
           assert_equal({
-            "adapter"  => "abstract",
-            "host"     => "foo",
-            "encoding" => "utf8" }, spec)
+            adapter:  "abstract",
+            host:     "foo",
+            encoding: "utf8"
+          }, spec)
         end
 
         def test_url_missing_scheme
           spec = resolve "foo"
-          assert_equal({
-            "database" => "foo" }, spec)
+          assert_equal({ database: "foo" }, spec)
         end
 
         def test_url_host_db
           spec = resolve "abstract://foo/bar?encoding=utf8"
           assert_equal({
-            "adapter"  => "abstract",
-            "database" => "bar",
-            "host"     => "foo",
-            "encoding" => "utf8" }, spec)
+            adapter:  "abstract",
+            database: "bar",
+            host:     "foo",
+            encoding: "utf8"
+          }, spec)
         end
 
         def test_url_port
           spec = resolve "abstract://foo:123?encoding=utf8"
           assert_equal({
-            "adapter"  => "abstract",
-            "port"     => 123,
-            "host"     => "foo",
-            "encoding" => "utf8" }, spec)
+            adapter:  "abstract",
+            port:     123,
+            host:     "foo",
+            encoding: "utf8"
+          }, spec)
         end
 
         def test_encoded_password
           password = "am@z1ng_p@ssw0rd#!"
           encoded_password = URI.encode_www_form_component(password)
           spec = resolve "abstract://foo:#{encoded_password}@localhost/bar"
-          assert_equal password, spec["password"]
+          assert_equal password, spec[:password]
         end
 
         def test_url_with_authority_for_sqlite3
           spec = resolve "sqlite3:///foo_test"
-          assert_equal("/foo_test", spec["database"])
+          assert_equal("/foo_test", spec[:database])
         end
 
         def test_url_absolute_path_for_sqlite3
           spec = resolve "sqlite3:/foo_test"
-          assert_equal("/foo_test", spec["database"])
+          assert_equal("/foo_test", spec[:database])
         end
 
         def test_url_relative_path_for_sqlite3
           spec = resolve "sqlite3:foo_test"
-          assert_equal("foo_test", spec["database"])
+          assert_equal("foo_test", spec[:database])
         end
 
         def test_url_memory_db_for_sqlite3
           spec = resolve "sqlite3::memory:"
-          assert_equal(":memory:", spec["database"])
+          assert_equal(":memory:", spec[:database])
         end
 
         def test_url_sub_key_for_sqlite3
           spec = resolve :production, "production" => { "url" => "sqlite3:foo?encoding=utf8" }
           assert_equal({
-            "adapter"  => "sqlite3",
-            "database" => "foo",
-            "encoding" => "utf8",
-            "name"     => "production" }, spec)
+            adapter:  "sqlite3",
+            database: "foo",
+            encoding: "utf8",
+            name:     "production"
+          }, spec)
         end
 
         def test_spec_name_on_key_lookup

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -36,7 +36,7 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     original_rails_env = ENV["RAILS_ENV"]
     ENV["RAILS_ENV"] = "arunit"
 
-    assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").config, ActiveRecord::Base.configurations.default_hash
+    assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").configuration_hash, ActiveRecord::Base.configurations.default_hash
   ensure
     ENV["RAILS_ENV"] = original_rails_env
   end
@@ -89,7 +89,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   end
 
   def test_first_is_deprecated
-    first_config = ActiveRecord::Base.configurations.configurations.map(&:config).first
+    first_config = ActiveRecord::Base.configurations.configurations.map(&:configuration_hash).first
     assert_deprecated do
       env_name, config = ActiveRecord::Base.configurations.first
       assert_equal "arunit", env_name
@@ -106,10 +106,16 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   end
 
   def test_values_are_deprecated
-    config_hashes = ActiveRecord::Base.configurations.configurations.map(&:config)
+    config_hashes = ActiveRecord::Base.configurations.configurations.map(&:configuration_hash)
     assert_deprecated do
       assert_equal config_hashes, ActiveRecord::Base.configurations.values
     end
+  end
+
+  def test_deprecated_config_method
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+
+    assert_equal db_config.configuration_hash.stringify_keys, assert_deprecated { db_config.config }
   end
 
   def test_unsupported_method_raises

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -37,7 +37,7 @@ end
 
 def in_memory_db?
   current_adapter?(:SQLite3Adapter) &&
-  ActiveRecord::Base.connection_pool.spec.config[:database] == ":memory:"
+  ActiveRecord::Base.connection_pool.spec.underlying_configuration_hash[:database] == ":memory:"
 end
 
 def subsecond_precision_supported?

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -68,7 +68,7 @@ module ActiveRecord
 
       def test_reaping_frequency_configuration
         spec = ActiveRecord::Base.connection_pool.spec.dup
-        spec.config[:reaping_frequency] = "10.01"
+        spec.underlying_configuration_hash[:reaping_frequency] = "10.01"
         pool = ConnectionPool.new spec
         assert_equal 10.01, pool.reaper.frequency
       ensure
@@ -77,7 +77,7 @@ module ActiveRecord
 
       def test_connection_pool_starts_reaper
         spec = ActiveRecord::Base.connection_pool.spec.dup
-        spec.config[:reaping_frequency] = "0.0001"
+        spec.underlying_configuration_hash[:reaping_frequency] = "0.0001"
 
         pool = ConnectionPool.new spec
 
@@ -95,7 +95,7 @@ module ActiveRecord
 
       def test_reaper_works_after_pool_discard
         spec = ActiveRecord::Base.connection_pool.spec.dup
-        spec.config[:reaping_frequency] = "0.0001"
+        spec.underlying_configuration_hash[:reaping_frequency] = "0.0001"
 
         2.times do
           pool = ConnectionPool.new spec
@@ -126,7 +126,7 @@ module ActiveRecord
 
       def test_connection_pool_starts_reaper_in_fork
         spec = ActiveRecord::Base.connection_pool.spec.dup
-        spec.config[:reaping_frequency] = "0.0001"
+        spec.underlying_configuration_hash[:reaping_frequency] = "0.0001"
 
         pool = ConnectionPool.new spec
         pool.checkout

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -262,7 +262,7 @@ module ActiveRecord
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
-          ["database" => "test-db"],
+          [database: "test-db"],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
             ActiveSupport::StringInquirer.new("test")
@@ -276,7 +276,7 @@ module ActiveRecord
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
-          ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"],
+          [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
             ActiveSupport::StringInquirer.new("production")
@@ -291,8 +291,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["database" => "dev-db"],
-            ["database" => "test-db"]
+            [database: "dev-db"],
+            [database: "test-db"]
           ],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -311,8 +311,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["database" => "dev-db"],
-            ["database" => "test-db"]
+            [database: "dev-db"],
+            [database: "test-db"]
           ],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -362,8 +362,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -379,8 +379,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"],
-            ["adapter" => "abstract", "database" => "secondary-prod-db", "host" => "secondary-prod-db-host"]
+            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
+            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -396,10 +396,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"],
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"],
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -418,10 +418,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"],
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"],
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -570,7 +570,7 @@ module ActiveRecord
     def test_drops_current_environment_database
       with_stubbed_configurations do
         assert_called_with(ActiveRecord::Tasks::DatabaseTasks, :drop,
-          ["database" => "test-db"]) do
+          [database: "test-db"]) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
             ActiveSupport::StringInquirer.new("test")
           )
@@ -581,7 +581,7 @@ module ActiveRecord
     def test_drops_current_environment_database_with_url
       with_stubbed_configurations do
         assert_called_with(ActiveRecord::Tasks::DatabaseTasks, :drop,
-          ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"]) do
+          [adapter: "abstract", database: "prod-db", host: "prod-db-host"]) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
             ActiveSupport::StringInquirer.new("production")
           )
@@ -595,8 +595,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["database" => "dev-db"],
-            ["database" => "test-db"]
+            [database: "dev-db"],
+            [database: "test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -615,8 +615,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["database" => "dev-db"],
-            ["database" => "test-db"]
+            [database: "dev-db"],
+            [database: "test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -654,8 +654,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -671,8 +671,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"],
-            ["adapter" => "abstract", "database" => "secondary-prod-db", "host" => "secondary-prod-db-host"]
+            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
+            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -688,10 +688,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"],
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"],
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -710,10 +710,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"],
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"],
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -922,7 +922,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        ["database" => "prod-db"]
+        [database: "prod-db"]
       ) do
         assert_called_with(ActiveRecord::Base, :establish_connection, [:production]) do
           ActiveRecord::Tasks::DatabaseTasks.purge_current("production")
@@ -942,7 +942,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        ["database" => "my-db"]
+        [database: "my-db"]
       ) do
         ActiveRecord::Tasks::DatabaseTasks.purge_all
       end
@@ -1043,8 +1043,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            ["database" => "test-db"],
-            ["database" => "secondary-test-db"]
+            [database: "test-db"],
+            [database: "secondary-test-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1060,8 +1060,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            ["adapter" => "abstract", "database" => "prod-db", "host" => "prod-db-host"],
-            ["adapter" => "abstract", "database" => "secondary-prod-db", "host" => "secondary-prod-db-host"]
+            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
+            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1077,8 +1077,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1097,8 +1097,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            ["database" => "dev-db"],
-            ["database" => "secondary-dev-db"]
+            [database: "dev-db"],
+            [database: "secondary-dev-db"]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -29,8 +29,8 @@ if current_adapter?(:Mysql2Adapter)
             ActiveRecord::Base,
             :establish_connection,
             [
-              [ "adapter" => "mysql2", "database" => nil ],
-              [ "adapter" => "mysql2", "database" => "my-app-db" ],
+              [ adapter: "mysql2", database: nil ],
+              [ adapter: "mysql2", database: "my-app-db" ],
             ]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration
@@ -72,8 +72,8 @@ if current_adapter?(:Mysql2Adapter)
             ActiveRecord::Base,
             :establish_connection,
             [
-              ["adapter" => "mysql2", "database" => nil],
-              [@configuration]
+              [adapter: "mysql2", database: nil],
+              [@configuration.symbolize_keys]
             ]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration
@@ -158,7 +158,7 @@ if current_adapter?(:Mysql2Adapter)
           assert_called_with(
             ActiveRecord::Base,
             :establish_connection,
-            [@configuration]
+            [@configuration.symbolize_keys]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.drop @configuration
           end
@@ -205,7 +205,7 @@ if current_adapter?(:Mysql2Adapter)
           assert_called_with(
             ActiveRecord::Base,
             :establish_connection,
-            [@configuration]
+            [@configuration.symbolize_keys]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.purge @configuration
           end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -27,13 +27,13 @@ if current_adapter?(:PostgreSQLAdapter)
             :establish_connection,
             [
               [
-                "adapter"            => "postgresql",
-                "database"           => "postgres",
-                "schema_search_path" => "public"
+                adapter: "postgresql",
+                database: "postgres",
+                schema_search_path: "public"
               ],
               [
-                "adapter"            => "postgresql",
-                "database"           => "my-app-db"
+                adapter: "postgresql",
+                database: "my-app-db"
               ]
             ]
           ) do
@@ -47,7 +47,7 @@ if current_adapter?(:PostgreSQLAdapter)
           assert_called_with(
             @connection,
             :create_database,
-            ["my-app-db", @configuration.merge("encoding" => "utf8")]
+            ["my-app-db", @configuration.symbolize_keys.merge(encoding: "utf8")]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration
           end
@@ -59,7 +59,7 @@ if current_adapter?(:PostgreSQLAdapter)
           assert_called_with(
             @connection,
             :create_database,
-            ["my-app-db", @configuration.merge("encoding" => "latin")]
+            ["my-app-db", @configuration.symbolize_keys.merge(encoding: "latin")]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.create @configuration.
               merge("encoding" => "latin")
@@ -74,10 +74,10 @@ if current_adapter?(:PostgreSQLAdapter)
             :create_database,
             [
               "my-app-db",
-              @configuration.merge(
-                "encoding" => "utf8",
-                "collation" => "ja_JP.UTF8",
-                "ctype" => "ja_JP.UTF8"
+              @configuration.symbolize_keys.merge(
+                encoding: "utf8",
+                collation: "ja_JP.UTF8",
+                ctype: "ja_JP.UTF8"
               )
             ]
           ) do
@@ -94,12 +94,12 @@ if current_adapter?(:PostgreSQLAdapter)
             :establish_connection,
             [
               [
-                "adapter"            => "postgresql",
-                "database"           => "postgres",
-                "schema_search_path" => "public"
+                adapter: "postgresql",
+                database: "postgres",
+                schema_search_path: "public"
               ],
               [
-                @configuration
+                @configuration.symbolize_keys
               ]
             ]
           ) do
@@ -169,9 +169,9 @@ if current_adapter?(:PostgreSQLAdapter)
             ActiveRecord::Base,
             :establish_connection,
             [
-              "adapter"            => "postgresql",
-              "database"           => "postgres",
-              "schema_search_path" => "public"
+              adapter: "postgresql",
+              database: "postgres",
+              schema_search_path: "public"
             ]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.drop @configuration
@@ -238,13 +238,13 @@ if current_adapter?(:PostgreSQLAdapter)
             :establish_connection,
             [
               [
-                "adapter"            => "postgresql",
-                "database"           => "postgres",
-                "schema_search_path" => "public"
+                adapter: "postgresql",
+                database: "postgres",
+                schema_search_path: "public"
               ],
               [
-                "adapter"            => "postgresql",
-                "database"           => "my-app-db"
+                adapter: "postgresql",
+                database: "my-app-db"
               ]
             ]
           ) do
@@ -269,7 +269,7 @@ if current_adapter?(:PostgreSQLAdapter)
             assert_called_with(
               @connection,
               :create_database,
-              ["my-app-db", @configuration.merge("encoding" => "utf8")]
+              ["my-app-db", @configuration.symbolize_keys.merge(encoding: "utf8")]
             ) do
               ActiveRecord::Tasks::DatabaseTasks.purge @configuration
             end
@@ -284,12 +284,12 @@ if current_adapter?(:PostgreSQLAdapter)
             :establish_connection,
             [
               [
-                "adapter"            => "postgresql",
-                "database"           => "postgres",
-                "schema_search_path" => "public"
+                adapter: "postgresql",
+                database: "postgres",
+                schema_search_path: "public"
               ],
               [
-                @configuration
+                @configuration.symbolize_keys
               ]
             ]
           ) do

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -54,7 +54,7 @@ if current_adapter?(:SQLite3Adapter)
       end
 
       def test_db_create_establishes_a_connection
-        assert_called_with(ActiveRecord::Base, :establish_connection, [@configuration]) do
+        assert_called_with(ActiveRecord::Base, :establish_connection, [@configuration.symbolize_keys]) do
           ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
         end
       end

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -17,54 +17,54 @@ module Rails
     def start
       ENV["RAILS_ENV"] ||= @options[:environment] || environment
 
-      case config["adapter"]
+      case config[:adapter]
       when /^(jdbc)?mysql/
         args = {
-          "host"      => "--host",
-          "port"      => "--port",
-          "socket"    => "--socket",
-          "username"  => "--user",
-          "encoding"  => "--default-character-set",
-          "sslca"     => "--ssl-ca",
-          "sslcert"   => "--ssl-cert",
-          "sslcapath" => "--ssl-capath",
-          "sslcipher" => "--ssl-cipher",
-          "sslkey"    => "--ssl-key"
+          host: "--host",
+          port: "--port",
+          socket: "--socket",
+          username: "--user",
+          encoding: "--default-character-set",
+          sslca: "--ssl-ca",
+          sslcert: "--ssl-cert",
+          sslcapath: "--ssl-capath",
+          sslcipher: "--ssl-cipher",
+          sslkey: "--ssl-key"
         }.map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }.compact
 
-        if config["password"] && @options["include_password"]
-          args << "--password=#{config['password']}"
-        elsif config["password"] && !config["password"].to_s.empty?
+        if config[:password] && @options[:include_password]
+          args << "--password=#{config[:password]}"
+        elsif config[:password] && !config[:password].to_s.empty?
           args << "-p"
         end
 
-        args << config["database"]
+        args << config[:database]
 
         find_cmd_and_exec(["mysql", "mysql5"], *args)
 
       when /^postgres|^postgis/
-        ENV["PGUSER"]     = config["username"] if config["username"]
-        ENV["PGHOST"]     = config["host"] if config["host"]
-        ENV["PGPORT"]     = config["port"].to_s if config["port"]
-        ENV["PGPASSWORD"] = config["password"].to_s if config["password"] && @options["include_password"]
-        find_cmd_and_exec("psql", config["database"])
+        ENV["PGUSER"]     = config[:username] if config[:username]
+        ENV["PGHOST"]     = config[:host] if config[:host]
+        ENV["PGPORT"]     = config[:port].to_s if config[:port]
+        ENV["PGPASSWORD"] = config[:password].to_s if config[:password] && @options[:include_password]
+        find_cmd_and_exec("psql", config[:database])
 
       when "sqlite3"
         args = []
 
-        args << "-#{@options['mode']}" if @options["mode"]
-        args << "-header" if @options["header"]
-        args << File.expand_path(config["database"], Rails.respond_to?(:root) ? Rails.root : nil)
+        args << "-#{@options[:mode]}" if @options[:mode]
+        args << "-header" if @options[:header]
+        args << File.expand_path(config[:database], Rails.respond_to?(:root) ? Rails.root : nil)
 
         find_cmd_and_exec("sqlite3", *args)
 
       when "oracle", "oracle_enhanced"
         logon = ""
 
-        if config["username"]
-          logon = config["username"].dup
-          logon << "/#{config['password']}" if config["password"] && @options["include_password"]
-          logon << "@#{config['database']}" if config["database"]
+        if config[:username]
+          logon = config[:username].dup
+          logon << "/#{config[:password]}" if config[:password] && @options[:include_password]
+          logon << "@#{config[:database]}" if config[:database]
         end
 
         find_cmd_and_exec("sqlplus", logon)
@@ -72,20 +72,20 @@ module Rails
       when "sqlserver"
         args = []
 
-        args += ["-D", "#{config['database']}"] if config["database"]
-        args += ["-U", "#{config['username']}"] if config["username"]
-        args += ["-P", "#{config['password']}"] if config["password"]
+        args += ["-D", "#{config[:database]}"] if config[:database]
+        args += ["-U", "#{config[:username]}"] if config[:username]
+        args += ["-P", "#{config[:password]}"] if config[:password]
 
-        if config["host"]
-          host_arg = +"#{config['host']}"
-          host_arg << ":#{config['port']}" if config["port"]
+        if config[:host]
+          host_arg = +"#{config[:host]}"
+          host_arg << ":#{config[:port]}" if config[:port]
           args += ["-S", host_arg]
         end
 
         find_cmd_and_exec("sqsh", *args)
 
       else
-        abort "Unknown command-line client for #{config['database']}."
+        abort "Unknown command-line client for #{config[:database]}."
       end
     end
 
@@ -94,12 +94,12 @@ module Rails
         # We need to check whether the user passed the database the
         # first time around to show a consistent error message to people
         # relying on 2-level database configuration.
-        if @options["database"] && configurations[database].blank?
+        if @options[:database] && configurations[database].blank?
           raise ActiveRecord::AdapterNotSpecified, "'#{database}' database is not configured. Available configuration: #{configurations.inspect}"
         elsif configurations[environment].blank? && configurations[database].blank?
           raise ActiveRecord::AdapterNotSpecified, "'#{environment}' database is not configured. Available configuration: #{configurations.inspect}"
         else
-          configurations[database] || configurations[environment].presence
+          (configurations[database] || configurations[environment].presence).symbolize_keys
         end
       end
     end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -51,7 +51,7 @@ module ApplicationTests
 
       test "db:create and db:drop without database URL" do
         require "#{app_path}/config/environment"
-        db_create_and_drop ActiveRecord::Base.configurations[Rails.env]["database"]
+        db_create_and_drop ActiveRecord::Base.configurations[Rails.env][:database]
       end
 
       test "db:create and db:drop with database URL" do
@@ -310,7 +310,7 @@ module ApplicationTests
 
       test "db:migrate and db:migrate:status without database_url" do
         require "#{app_path}/config/environment"
-        db_migrate_and_status ActiveRecord::Base.configurations[Rails.env]["database"]
+        db_migrate_and_status ActiveRecord::Base.configurations[Rails.env][:database]
       end
 
       test "db:migrate and db:migrate:status with database_url" do
@@ -350,7 +350,7 @@ module ApplicationTests
 
       test "db:fixtures:load without database_url" do
         require "#{app_path}/config/environment"
-        db_fixtures_load ActiveRecord::Base.configurations[Rails.env]["database"]
+        db_fixtures_load ActiveRecord::Base.configurations[Rails.env][:database]
       end
 
       test "db:fixtures:load with database_url" do
@@ -385,7 +385,7 @@ module ApplicationTests
 
       test "db:structure:dump and db:structure:load without database_url" do
         require "#{app_path}/config/environment"
-        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env]["database"]
+        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
       end
 
       test "db:structure:dump and db:structure:load with database_url" do
@@ -396,7 +396,7 @@ module ApplicationTests
 
       test "db:structure:dump and db:structure:load set ar_internal_metadata" do
         require "#{app_path}/config/environment"
-        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env]["database"]
+        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
 
         assert_equal "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
         assert_equal "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
@@ -475,7 +475,7 @@ module ApplicationTests
           require "#{app_path}/app/models/book"
           # if structure is not loaded correctly, exception would be raised
           assert_equal 0, Book.count
-          assert_match ActiveRecord::Base.configurations["test"]["database"],
+          assert_match ActiveRecord::Base.configurations["test"][:database],
             ActiveRecord::Base.connection_config[:database]
         end
       end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -220,14 +220,14 @@ module ApplicationTests
       test "db:create and db:drop works on all databases for env" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_create_and_drop db_config.spec_name, db_config.config["database"]
+          db_create_and_drop db_config.spec_name, db_config.configuration_hash[:database]
         end
       end
 
       test "db:create:namespace and db:drop:namespace works on specified databases" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_create_and_drop_namespace db_config.spec_name, db_config.config["database"]
+          db_create_and_drop_namespace db_config.spec_name, db_config.configuration_hash[:database]
         end
       end
 
@@ -359,7 +359,7 @@ module ApplicationTests
         db_migrate_and_schema_dump_and_load "schema"
 
         app_file "db/seeds.rb", <<-RUBY
-          print Book.connection.pool.spec.config[:database]
+          print Book.connection.pool.spec.underlying_configuration_hash[:database]
         RUBY
 
         output = rails("db:seed")

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -966,7 +966,7 @@ module ApplicationTests
 
           class EnvironmentTest < ActiveSupport::TestCase
             def test_environment
-              test_db = ActiveRecord::Base.configurations[#{env.dump}]["database"]
+              test_db = ActiveRecord::Base.configurations[#{env.dump}][:database]
               db_file = ActiveRecord::Base.connection_config[:database]
               assert_match(test_db, db_file)
               assert_equal #{env.dump}, ENV["RAILS_ENV"]

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -29,7 +29,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       }
     }
     app_db_config(config_sample) do
-      assert_equal config_sample["test"], Rails::DBConsole.new.config
+      assert_equal config_sample["test"].symbolize_keys, Rails::DBConsole.new.config
     end
   end
 
@@ -44,14 +44,14 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_config_with_database_url_only
     ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
     expected = {
-      "adapter"  => "postgresql",
-      "host"     => "localhost",
-      "port"     => 9000,
-      "database" => "foo_test",
-      "username" => "foo",
-      "password" => "bar",
-      "pool"     => "5",
-      "timeout"  => "3000"
+      adapter:  "postgresql",
+      host:     "localhost",
+      port:     9000,
+      database: "foo_test",
+      username: "foo",
+      password: "bar",
+      pool:     "5",
+      timeout:  "3000"
     }.sort
 
     app_db_config(nil) do
@@ -75,7 +75,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       }
     }
     app_db_config(sample_config) do
-      assert_equal host, Rails::DBConsole.new.config["host"]
+      assert_equal host, Rails::DBConsole.new.config[:host]
     end
   end
 
@@ -212,7 +212,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     }
 
     app_db_config(sample_config) do
-      assert_equal "postgresql", Rails::DBConsole.new.config["adapter"]
+      assert_equal "postgresql", Rails::DBConsole.new.config[:adapter]
     end
   end
 
@@ -295,7 +295,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
     def start(config = {}, argv = [])
       @dbconsole = make_dbconsole.new(parse_arguments(argv))
-      @dbconsole.stub(:config, config.stringify_keys) do
+      @dbconsole.stub(:config, config) do
         capture_abort { @dbconsole.start }
       end
     end


### PR DESCRIPTION
Previously in some places we used symbol keys, and in some places we used
string keys. That made it pretty confusing to figure out in a particular
place what type of configuration object you were working with.

Now internally, all configuration hashes are keyed by symbols and
converted to such on the way in.

A few exceptions:

- `DatabaseConfigurations#to_h` still returns strings for backward compatibility
- Same for `legacy_hash`
- `default_hash` previously could return strings, but the associated
  comment mentions it returns symbol-key `Hash` and now it always does

Because this is a change in behavior, a few method renames have happened:

- `DatabaseConfig#config` is now `DatabaseConfig#configuration_hash` and returns a symbol-key `Hash`
- `ConnectionSpecification#config` is now `ConnectionSpecification#underlying_configuration_hash` and returns the `Hash` of the underlying `DatabaseConfig`
- `DatabaseConfig#config` was added back, returns `String`-keys for backward compatibility, and is deprecated in favor of the new `configuration_hash`

cc / @eileencodes 