### PR TITLE
Suppress ruby2.7 kwargs warnings

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -49,7 +49,7 @@ module ActiveRecord
       # +to+ When passed, this method will return false unless the value was
       # changed to the given value
       def saved_change_to_attribute?(attr_name, **options)
-        mutations_before_last_save.changed?(attr_name.to_s, options)
+        mutations_before_last_save.changed?(attr_name.to_s, **options)
       end
 
       # Returns the change to an attribute during the last save. If the
@@ -99,7 +99,7 @@ module ActiveRecord
       # +to+ When passed, this method will return false unless the value will be
       # changed to the given value
       def will_save_change_to_attribute?(attr_name, **options)
-        mutations_from_database.changed?(attr_name.to_s, options)
+        mutations_from_database.changed?(attr_name.to_s, **options)
       end
 
       # Returns the change to an attribute that will be persisted during the


### PR DESCRIPTION
### Summary
This PR suppresses the following warnings.

```
$ ruby --version
ruby 2.7.0dev (2019-09-12T15:35:29Z trunk 69acf40b45) [x86_64-darwin17]

$ bundle exec rake test:sqlite3 TEST=test/cases/dirty_test.rb
(snip)
/Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:52: warning: The last argument is used as the keyword parameter
(snip)
/Users/tnakata/workspace/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:102: warning: The last argument is used as the keyword parameter
```
