### PR TITLE
Show how to enforce params as a scalar type

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -258,6 +258,13 @@ scalar values, map the key to an empty array:
 params.permit(id: [])
 ```
 
+To declare that a value in `params` must be of a specific scalar type,
+specify the type by passing it in to the method call as a symbol:
+
+```ruby
+params.permit(start_date: :datetime)
+```
+
 Sometimes it is not possible or convenient to declare the valid keys of
 a hash parameter or its internal structure. Just map to an empty hash:
 


### PR DESCRIPTION
### Summary

This change shows how to enforce that a param should be of a specific scalar type. I couldn't find this documented anywhere else (though my google-fu could have been failing me) so I thought to add it here

### Other Information

N/A