### PR TITLE
Fix a button_to documentation example

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -290,7 +290,7 @@ module ActionView
       #
       #
       #   <%= button_to('Destroy', 'http://www.example.com',
-      #             method: "delete", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' }) %>
+      #             method: :delete, remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' }) %>
       #   # => "<form class='button_to' method='post' action='http://www.example.com' data-remote='true'>
       #   #       <input name='_method' value='delete' type='hidden' />
       #   #       <input value='Destroy' type='submit' data-disable-with='loading...' data-confirm='Are you sure?' />


### PR DESCRIPTION
### Summary

Fixes an example in `button_to`'s documentation; the description states `button_to` only takes a symbol for the `method` argument:

> `:method` - Symbol of HTTP verb. Supported verbs are `:post`, `:get`, `:delete`, `:patch`, and `:put`. By default it will be `:post`.

 but an example just below uses a string:

```
button_to('Destroy', 'http://www.example.com',
          method: "delete", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' }) %>
```

Passing an all-lowercase string incidentally works, so the example is technically functional despite being undefined behavior. But passing an all-uppercase string fails, and this is a pretty common practice when specifying HTTP methods (e.g. `DELETE`), so I think it's best this example is put in line with the documentation and converted to use a symbol.

Reproduction steps:

```sh
rails new buttonto
cd buttonto
rails c
# Prevent an error from calling button_to in the console
> def protect_against_forgery?
>   false
> end
=> :protect_against_forgery?

# Example verbatim (works)
>  button_to('Destroy', 'http://www.example.com', method: "delete", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' })
=> "<form class=\"button_to\" method=\"post\" action=\"http://www.example.com\" data-remote=\"true\"><input type=\"hidden\" name=\"_method\" value=\"delete\" /><input data-confirm=\"Are you sure?\" data-disable-with=\"loading...\" type=\"submit\" value=\"Destroy\" /></form>"

# Example with uppercase method (fails; renders a form without _method=delete)
>  button_to('Destroy', 'http://www.example.com', method: "DELETE", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' })
=> "<form class=\"button_to\" method=\"post\" action=\"http://www.example.com\" data-remote=\"true\"><input data-confirm=\"Are you sure?\" data-disable-with=\"loading...\" type=\"submit\" value=\"Destroy\" /></form>"
```

### Other Information

I fell for this example myself and tried to pass an all-uppercase string after seeing the example without reading the options descriptions.