### PR TITLE
Required mysql2 gem 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
 
   group :db do
     gem "pg", ">= 0.18.0"
-    gem "mysql2", ">= 0.4.10"
+    gem "mysql2", "~> 0.5"
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,8 +337,6 @@ GEM
     mustache (1.1.0)
     mustermann (1.0.3)
     mysql2 (0.5.2)
-    mysql2 (0.5.2-x64-mingw32)
-    mysql2 (0.5.2-x86-mingw32)
     nio4r (2.4.0)
     nio4r (2.4.0-java)
     nokogiri (1.10.4)
@@ -565,7 +563,7 @@ DEPENDENCIES
   minitest-bisect
   minitest-reporters
   minitest-retry
-  mysql2 (>= 0.4.10)
+  mysql2 (~> 0.5)
   nokogiri (>= 1.8.1)
   pg (>= 0.18.0)
   psych (~> 3.0)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -3,7 +3,7 @@
 require "active_record/connection_adapters/abstract_mysql_adapter"
 require "active_record/connection_adapters/mysql/database_statements"
 
-gem "mysql2", ">= 0.4.4"
+gem "mysql2", "~> 0.5"
 require "mysql2"
 
 module ActiveRecord

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -13,7 +13,7 @@ module Rails
 
       def gem_for_database(database = options[:database])
         case database
-        when "mysql"          then ["mysql2", [">= 0.4.4"]]
+        when "mysql"          then ["mysql2", ["~> 0.5"]]
         when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
         when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -543,7 +543,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcmysql-adapter"
     else
-      assert_gem "mysql2", "'>= 0.4.4'"
+      assert_gem "mysql2", "'~> 0.5'"
     end
   end
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -54,7 +54,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use mysql2 as the database for Active Record", content
-              assert_match "gem 'mysql2', '>= 0.4.4'", content
+              assert_match "gem 'mysql2', '~> 0.5'", content
             end
           end
 
@@ -83,7 +83,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use mysql2 as the database for Active Record", content
-              assert_match "gem 'mysql2', '>= 0.4.4'", content
+              assert_match "gem 'mysql2', '~> 0.5'", content
             end
           end
         end


### PR DESCRIPTION
This follows up #36692, `Mysql2::Error::TimeoutError` is introduced from
mysql2 gem 0.5.0. https://github.com/brianmario/mysql2/pull/911