### PR TITLE
Fix setting a more verbose thread-local log level

### DIFF
--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -144,6 +144,19 @@ class LoggerTest < ActiveSupport::TestCase
     assert_includes @output.string, "THIS IS HERE"
   end
 
+  def test_unsilencing
+    @logger.level = Logger::INFO
+
+    @logger.debug "NOT THERE"
+
+    @logger.silence Logger::DEBUG do
+      @logger.debug "THIS IS HERE"
+    end
+
+    assert_not @output.string.include?("NOT THERE")
+    assert_includes @output.string, "THIS IS HERE"
+  end
+
   def test_logger_silencing_works_for_broadcast
     another_output  = StringIO.new
     another_logger  = ActiveSupport::Logger.new(another_output)


### PR DESCRIPTION
We prepend a check against the thread-local level to `Logger#add`, but because it proceeds to check against the thread-global level, only setting a quieter thread-local level works. The quietest of the two wins. Fix by reimplementing `#add` entirely.

It's unfortunate to have to do this, but I've already [patched upstream Logger](https://github.com/ruby/logger/pull/41) to prefer the `level` instance method over the `@level` instance variable, so we'll be able to avoid touching `#add` at all in the future.