### PR TITLE
[ci skip] Note removal of `render :text` & `:nothing` options from 5.1 upgrade guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -530,6 +530,16 @@ To:
 Rails.application.secrets[:smtp_settings][:address]
 ```
 
+### Removed deprecated support to `:text` and `:nothing` in `render`
+
+If your views are using `render :text`, they will no longer work. The new method
+of rendering text with MIME type of `text/plain` is to use `render :plain`.
+
+Similarly, `render :nothing` is also removed and you should use the `head` method
+to send responses that contain only headers. For example, `head :ok` sends a
+200 response with no body to render.
+
+
 Upgrading from Rails 4.2 to Rails 5.0
 -------------------------------------
 


### PR DESCRIPTION
### Summary

This makes it explicit that the `render :text` and `:nothing` options have been removed in the Rails 5.0 to Rails 5.1 upgrade guide.  It addresses #37145 

