### PR TITLE
Fix config.cache_classes default value in guide.

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -66,7 +66,7 @@ These configuration methods are to be called on a `Rails::Railtie` object, such 
 
 * `config.add_autoload_paths_to_load_path` says whether autoload paths have to be added to `$LOAD_PATH`. This flag is `true` by default, but it is recommended to be set to `false` in `:zeitwerk` mode early, in `config/application.rb`. Zeitwerk uses absolute paths internally, and applications running in `:zeitwerk` mode do not need `require_dependency`, so models, controllers, jobs, etc. do not need to be in `$LOAD_PATH`. Setting this to `false` saves Ruby from checking these directories when resolving `require` calls with relative paths, and saves Bootsnap work and RAM, since it does not need to build an index for them.
 
-* `config.cache_classes` controls whether or not application classes and modules should be reloaded on each request. Defaults to `false` in development mode, and `true` in test and production modes.
+* `config.cache_classes` controls whether or not application classes and modules should be reloaded on each request. Defaults to `false` in development mode, and `true` in production mode. In test mode, the default is `false` if Spring is installed, `true` otherwise.
 
 * `config.beginning_of_week` sets the default beginning of week for the
 application. Accepts a valid day of week as a symbol (e.g. `:monday`).


### PR DESCRIPTION
### Summary
Starting with rails 6, the default value of `config.cache_classes` in the test environment be switched depending on whether spring is installed.

By default, rails installs spring, so it be false.

but In the description of rails guide, default value of the test environment is true.

I fixed discription to `config.cache_classes` default value.

How about this PR?

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
Related commits: generate config.cache_classes = false if Spring
65344f254cde87950c7f176cb7aa09c002a6f882

Rails guide: 2 Upgrading from Rails 5.2 to Rails 6.0/2.6.9 Spring and the test Environment
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#spring-and-the-test-environment

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
