### PR TITLE
Change trix require to import statement

### DIFF
--- a/actiontext/lib/templates/actiontext.scss
+++ b/actiontext/lib/templates/actiontext.scss
@@ -3,7 +3,7 @@
 // the trix-editor content (whether displayed or under editing). Feel free to incorporate this
 // inclusion directly in any other asset bundle and remove this file.
 //
-//= require trix/dist/trix
+@import 'trix/dist/trix';
 
 // We need to override trix.css’s image gallery styles to accommodate the
 // <action-text-attachment> element we wrap around attachments. Otherwise,


### PR DESCRIPTION
### Summary

This PR changes the trix require statement in actiontext.scss template to instead use an import statement. Currently, the require statement does not pull in the dependency as expected; however, using an import statement corrects this.
