### PR TITLE
Remove Capistrano from asset pipeline guide

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -677,17 +677,6 @@ The command is:
 $ RAILS_ENV=production rails assets:precompile
 ```
 
-Capistrano (v2.15.1 and above) includes a recipe to handle this in deployment.
-Add the following line to `Capfile`:
-
-```ruby
-# Capistrano version 2
-load 'deploy/assets'
-
-# Capistrano version 3
-require "capistrano/rails/assets"
-```
-
 This links the folder specified in `config.assets.prefix` to `shared/assets`.
 If you already use this shared folder you'll need to write your own deployment
 command.
@@ -793,9 +782,8 @@ duplication of work.
 Local compilation allows you to commit the compiled files into source control,
 and deploy as normal.
 
-There are three caveats:
+There are two caveats:
 
-* You must not run the Capistrano deployment task that precompiles assets.
 * You must ensure any necessary compressors or minifiers are
 available on your development system.
 * You must change the following application configuration setting:


### PR DESCRIPTION
Remove Capistrano from asset pipeline docs. Followup on https://github.com/rails/rails/pull/37111.