### PR TITLE
Expand on helpers available in Action Mailer

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -733,8 +733,17 @@ end
 Using Action Mailer Helpers
 ---------------------------
 
-Action Mailer now just inherits from `AbstractController`, so you have access to
-the same generic helpers as you do in Action Controller.
+Action Mailer inherits from `AbstractController`, so you have access to most
+of the same helpers as you do in Action Controller.
+
+There are also some Action Mailer-specific helper methods available in
+`ActionMailer::MailHelper`. For example, these allow accessing the mailer
+instance from your view with `mailer`, and accessing the message as `message`:
+
+```erb
+<%= stylesheet_link_tag mailer.name.underscore %>
+<h1><%= message.subject %></h1>
+```
 
 Action Mailer Configuration
 ---------------------------


### PR DESCRIPTION
### Summary

Some updates to the Action Mailer guide helper section, offering a tiny bit more information, and documenting two important action mailer-specific helpers.

### Other Information

Remove 'now just' — document the current state in an accessible way. Make it clear the set of helpers isn't *exactly* the same

Add references to `mailer` and `message` helpers which can be very useful.

`attachments` is already covered in "Making Inline Attachments"

Finding the mail-specific formatting helpers are left as an exercise for the reader