### PR TITLE
Fixes #36956 by dup'ing the value and entry object returned from MemoryStore.

### DIFF
--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -124,6 +124,8 @@ module ActiveSupport
           entry = @data[key]
           synchronize do
             if entry
+              entry = entry.dup
+              entry.dup_value!
               @key_access[key] = Time.now.to_f
             else
               @key_access.delete(key)

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -107,6 +107,36 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     assert_not @cache.exist?(1)
   end
 
+  def test_cache_not_mutated
+    item = { "foo" => "bar" }
+    key = "test_key"
+    @cache.write(key, item)
+
+    read_item = @cache.read(key)
+    read_item["foo"] = "xyz"
+    assert_equal item, @cache.read(key)
+  end
+
+  def test_cache_different_object_ids_hash
+    item = { "foo" => "bar" }
+    key = "test_key"
+    @cache.write(key, item)
+
+    read_item = @cache.read(key)
+    assert_not_equal item.object_id, read_item.object_id
+    assert_not_equal read_item.object_id, @cache.read(key).object_id
+  end
+
+  def test_cache_different_object_ids_string
+    item = "my_string"
+    key = "test_key"
+    @cache.write(key, item)
+
+    read_item = @cache.read(key)
+    assert_not_equal item.object_id, read_item.object_id
+    assert_not_equal read_item.object_id, @cache.read(key).object_id
+  end
+
   def test_write_with_unless_exist
     assert_equal true, @cache.write(1, "aaaaaaaaaa")
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
