### PR TITLE
Add create database actionable error

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -185,6 +185,11 @@ module ActiveRecord
 
   # Raised when a given database does not exist.
   class NoDatabaseError < StatementInvalid
+    include ActiveSupport::ActionableError
+
+    action "Create database" do
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
   end
 
   # Raised when creating a database if it exists.


### PR DESCRIPTION
### Summary
This pull request includes a create database action for `ActiveRecord::NoDatabaseError`.

![rails-pr](https://user-images.githubusercontent.com/3727827/64959262-2970cc00-d867-11e9-86b6-f5e081e5921e.gif)


I noticed that `rails db:prepare` is included in `bin/setup` but I found this useful when I run `rails new`. The command will install all the dependencies, but it doesn't create the database so I often forget to do it.
I guess we could also include the database creation inside `rails new`, but I wanted to open this to know what you think about it.

### Other Information
I just opened this with a simple implementation to get some feedback. If this turns out to be wanted, I'll include tests and discuss the multi-database case.