### PR TITLE
Allow Sidekiq access to the underlying Job class

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -21,7 +21,7 @@ module ActiveJob
         # Sidekiq::Client does not support symbols as keys
         job.provider_job_id = Sidekiq::Client.push \
           "class"   => JobWrapper,
-          "wrapped" => job.class.to_s,
+          "wrapped" => job.class,
           "queue"   => job.queue_name,
           "args"    => [ job.serialize ]
       end
@@ -29,7 +29,7 @@ module ActiveJob
       def enqueue_at(job, timestamp) #:nodoc:
         job.provider_job_id = Sidekiq::Client.push \
           "class"   => JobWrapper,
-          "wrapped" => job.class.to_s,
+          "wrapped" => job.class,
           "queue"   => job.queue_name,
           "args"    => [ job.serialize ],
           "at"      => timestamp


### PR DESCRIPTION
Currently `wrapped` is a String.  Instead pass Class so that Sidekiq can get access to the ActiveJob and its configuration without having to constantize.  I verified that `JobClass.to_s` == `"JobClass"` so serialization to JSON should not be affected.

```ruby
> JSON.dump({"wrapped" => SomeJob})
=> "{\"wrapped\":\"SomeJob\"}"
```

By having access to the ActiveJob class, Sidekiq can get access to any `sidekiq_options` which have been set on that ActiveJob type to control underlying Sidekiq features and serialize those options into Redis.

```ruby
class MyJob < ActiveJob::Base
  queue_as :myqueue
  sidekiq_options retry: 10, backtrace: 20
  def perform(...)
  end
end
```