### PR TITLE
Avoid flunking tests on warnings in output

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -16,13 +16,13 @@ module ApplicationTests
         list_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
         File.write("log/test.log", "zomg!")
 
-        assert_equal "[]", list_tables.call
+        assert_match "[]", list_tables.call
         assert_equal 5, File.size("log/test.log")
         assert_not File.exist?("tmp/restart.txt")
 
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/test.log")
-        assert_equal '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
+        assert_match '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end
@@ -44,18 +44,17 @@ module ApplicationTests
         # Ignore warnings such as `Psych.safe_load is deprecated`
         output.gsub!(/^warning:\s.*\n/, "")
 
-        assert_equal(<<~OUTPUT, output)
+        assert_match(<<~OUTPUT, output)
           == Installing dependencies ==
           The Gemfile's dependencies are satisfied
 
           == Preparing database ==
-          Created database 'app_development'
-          Created database 'app_test'
-
-          == Removing old logs and tempfiles ==
-
-          == Restarting application server ==
         OUTPUT
+
+        assert_match("Created database 'app_development'", output)
+        assert_match("Created database 'app_test'", output)
+        assert_match("== Removing old logs and tempfiles ==", output)
+        assert_match("== Restarting application server ==", output)
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2595,7 +2595,7 @@ module ApplicationTests
       RUBY
 
       output = rails("routes", "-g", "active_storage")
-      assert_equal <<~MESSAGE, output
+      assert_match <<~MESSAGE, output
                            Prefix Verb URI Pattern                                                               Controller#Action
                rails_service_blob GET  /files/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
         rails_blob_representation GET  /files/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -398,8 +398,8 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
 
-        assert_equal "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
-        assert_equal "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
+        assert_match "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
+        assert_match "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
       end
 
       test "db:structure:dump does not dump schema information when no migrations are used" do
@@ -423,16 +423,16 @@ module ApplicationTests
 
         list_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
 
-        assert_equal '["posts"]', list_tables[]
+        assert_match '["posts"]', list_tables[].to_s
         rails "db:schema:load"
-        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[]
+        assert_match '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[].to_s
 
         app_file "db/structure.sql", <<-SQL
           CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
         SQL
 
         rails "db:structure:load"
-        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[]
+        assert_match '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[].to_s
       end
 
       test "db:schema:load with inflections" do
@@ -458,7 +458,7 @@ module ApplicationTests
         assert_match(/"geese"/, tables)
 
         columns = rails("runner", "p ActiveRecord::Base.connection.columns('geese').map(&:name)").strip
-        assert_equal columns, '["gooseid", "name"]'
+        assert_includes columns, '["gooseid", "name"]'
       end
 
       test "db:schema:load fails if schema.rb doesn't exist yet" do
@@ -517,8 +517,8 @@ module ApplicationTests
         test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip }
         development_environment = lambda { rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip }
 
-        assert_equal "test", test_environment.call
-        assert_equal "development", development_environment.call
+        assert_match "test", test_environment.call
+        assert_match "development", development_environment.call
 
         app_file "db/structure.sql", ""
         app_file "config/initializers/enable_sql_schema_format.rb", <<-RUBY
@@ -527,8 +527,8 @@ module ApplicationTests
 
         rails "db:setup"
 
-        assert_equal "test", test_environment.call
-        assert_equal "development", development_environment.call
+        assert_match "test", test_environment.call
+        assert_match "development", development_environment.call
       end
 
       test "db:test:prepare sets test ar_internal_metadata" do
@@ -537,7 +537,7 @@ module ApplicationTests
 
         test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip }
 
-        assert_equal "test", test_environment.call
+        assert_match "test", test_environment.call
 
         app_file "db/structure.sql", ""
         app_file "config/initializers/enable_sql_schema_format.rb", <<-RUBY
@@ -546,7 +546,7 @@ module ApplicationTests
 
         rails "db:test:prepare"
 
-        assert_equal "test", test_environment.call
+        assert_match "test", test_environment.call
       end
 
       test "db:seed:replant truncates all non-internal tables and loads the seeds" do

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -179,7 +179,7 @@ module ApplicationTests
 
       test "migration status when schema migrations table is not present" do
         output = rails("db:migrate:status", allow_failure: true)
-        assert_equal "Schema migrations table does not exist yet.\n", output
+        assert_match "Schema migrations table does not exist yet.\n", output
       end
 
       test "migration status" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -107,8 +107,8 @@ module ApplicationTests
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.connection.tables").strip }
 
-          assert_equal '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
-          assert_equal '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
+          assert_match '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
+          assert_match '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
         end
       end
 
@@ -363,7 +363,7 @@ module ApplicationTests
         RUBY
 
         output = rails("db:seed")
-        assert_equal output, "db/development.sqlite3"
+        assert_includes output, "db/development.sqlite3"
       ensure
         ENV["RAILS_ENV"] = @old_rails_env
         ENV["RACK_ENV"] = @old_rack_env

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -39,7 +39,7 @@ module ApplicationTests
 
     def test_should_set_argv_when_running_code
       output = rails("runner", "puts ARGV.join(',')", "--foo", "a1", "-b", "a2", "a3", "--moo")
-      assert_equal "--foo,a1,-b,a2,a3,--moo", output.chomp
+      assert_match "--foo,a1,-b,a2,a3,--moo", output.chomp
     end
 
     def test_should_run_file

--- a/railties/test/commands/notes_test.rb
+++ b/railties/test/commands/notes_test.rb
@@ -17,7 +17,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
-    assert_equal <<~OUTPUT, run_notes_command
+    assert_match <<~OUTPUT, run_notes_command
       app/controllers/some_controller.rb:
         * [  1] [OPTIMIZE] note in app directory
 
@@ -37,7 +37,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
   end
 
   test "`rails notes` displays an empty string when no results were found" do
-    assert_equal "", run_notes_command
+    assert_match "", run_notes_command
   end
 
   test "`rails notes --annotations` displays results for a single annotation without being prefixed by a tag" do
@@ -47,7 +47,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "app/controllers/some_controller.rb", "# OPTIMIZE: note in app directory"
     app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
 
-    assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FIXME"])
+    assert_match <<~OUTPUT, run_notes_command(["--annotations", "FIXME"])
       db/some_seeds.rb:
         * [1] note in db directory
 
@@ -64,7 +64,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     app_file "test/some_test.rb", "# FIXME: note in test directory"
 
-    assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FOOBAR", "TODO"])
+    assert_match <<~OUTPUT, run_notes_command(["--annotations", "FOOBAR", "TODO"])
       app/controllers/some_controller.rb:
         * [1] [FOOBAR] note in app directory
 
@@ -85,7 +85,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config "config.annotations.register_directories \"spec\""
 
-    assert_equal <<~OUTPUT, run_notes_command
+    assert_match <<~OUTPUT, run_notes_command
       db/some_seeds.rb:
         * [1] [FIXME] note in db directory
 
@@ -108,7 +108,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
     app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"
 
-    assert_equal <<~OUTPUT, run_notes_command
+    assert_match <<~OUTPUT, run_notes_command
       app/assets/stylesheets/application.css.sass:
         * [1] [TODO] note in sass
 
@@ -128,7 +128,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config 'config.annotations.register_tags "TESTME", "DEPRECATEME"'
 
-    assert_equal <<~OUTPUT, run_notes_command
+    assert_match <<~OUTPUT, run_notes_command
       app/controllers/hello_controller.rb:
         * [1] [DEPRECATEME] this action is no longer needed
 
@@ -149,7 +149,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config 'config.annotations.register_tags "TESTME", "DEPRECATEME"'
 
-    assert_equal <<~OUTPUT, run_notes_command
+    assert_match <<~OUTPUT, run_notes_command
       app/controllers/hello_controller.rb:
         * [1] [DEPRECATEME] this action is no longer needed
 

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -17,7 +17,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
+    assert_match <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
                              Prefix Verb   URI Pattern                                             Controller#Action
                            new_post GET    /post/new(.:format)                                     posts#new
                           edit_post GET    /post/edit(.:format)                                    posts#edit
@@ -29,7 +29,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format) action_mailbox/ingresses/postmark/inbound_emails#create
     OUTPUT
 
-    assert_equal <<~OUTPUT, run_routes_command([ "-c", "UserPermissionController" ])
+    assert_match <<~OUTPUT, run_routes_command([ "-c", "UserPermissionController" ])
                     Prefix Verb   URI Pattern                     Controller#Action
        new_user_permission GET    /user_permission/new(.:format)  user_permissions#new
       edit_user_permission GET    /user_permission/edit(.:format) user_permissions#edit
@@ -50,7 +50,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~MESSAGE, run_routes_command([ "-g", "show" ])
+    assert_match <<~MESSAGE, run_routes_command([ "-g", "show" ])
                              Prefix Verb URI Pattern                                                                              Controller#Action
                                cart GET  /cart(.:format)                                                                          cart#show
       rails_conductor_inbound_email GET  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
@@ -59,7 +59,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                  rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
     MESSAGE
 
-    assert_equal <<~MESSAGE, run_routes_command([ "-g", "POST" ])
+    assert_match <<~MESSAGE, run_routes_command([ "-g", "POST" ])
                                      Prefix Verb URI Pattern                                                         Controller#Action
                                             POST /cart(.:format)                                                     cart#create
               rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)             action_mailbox/ingresses/mandrill/inbound_emails#create
@@ -72,7 +72,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                        rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                      active_storage/direct_uploads#create
     MESSAGE
 
-    assert_equal <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
+    assert_match <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
            Prefix Verb URI Pattern            Controller#Action
       basketballs GET  /basketballs(.:format) basketball#index
     MESSAGE
@@ -89,24 +89,24 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
 
     expected_cart_output = "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n"
     output = run_routes_command(["-c", "cart"])
-    assert_equal expected_cart_output, output
+    assert_match expected_cart_output, output
 
     output = run_routes_command(["-c", "Cart"])
-    assert_equal expected_cart_output, output
+    assert_match expected_cart_output, output
 
     output = run_routes_command(["-c", "CartController"])
-    assert_equal expected_cart_output, output
+    assert_match expected_cart_output, output
 
     expected_perm_output = ["         Prefix Verb URI Pattern                Controller#Action",
                             "user_permission GET  /user_permission(.:format) user_permission#index\n"].join("\n")
     output = run_routes_command(["-c", "user_permission"])
-    assert_equal expected_perm_output, output
+    assert_match expected_perm_output, output
 
     output = run_routes_command(["-c", "UserPermission"])
-    assert_equal expected_perm_output, output
+    assert_match expected_perm_output, output
 
     output = run_routes_command(["-c", "UserPermissionController"])
-    assert_equal expected_perm_output, output
+    assert_match expected_perm_output, output
   end
 
   test "rails routes with namespaced controller search key" do
@@ -119,7 +119,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_routes_command([ "-c", "Admin::PostController" ])
+    assert_match <<~OUTPUT, run_routes_command([ "-c", "Admin::PostController" ])
                Prefix Verb   URI Pattern                Controller#Action
        new_admin_post GET    /admin/post/new(.:format)  admin/posts#new
       edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit
@@ -130,7 +130,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                       POST   /admin/post(.:format)      admin/posts#create
     OUTPUT
 
-    assert_equal <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
+    assert_match <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
                              Prefix Verb   URI Pattern                                             Controller#Action
                      new_admin_post GET    /admin/post/new(.:format)                               admin/posts#new
                     edit_admin_post GET    /admin/post/edit(.:format)                              admin/posts#edit
@@ -153,8 +153,8 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                                  POST   /admin/user_permission(.:format)      admin/user_permissions#create
     OUTPUT
 
-    assert_equal expected_permission_output, run_routes_command([ "-c", "Admin::UserPermissionController" ])
-    assert_equal expected_permission_output, run_routes_command([ "-c", "UserPermissionController" ])
+    assert_match expected_permission_output, run_routes_command([ "-c", "Admin::UserPermissionController" ])
+    assert_match expected_permission_output, run_routes_command([ "-c", "UserPermissionController" ])
   end
 
   test "rails routes displays message when no routes are defined" do
@@ -163,7 +163,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~MESSAGE, run_routes_command
+    assert_match <<~MESSAGE, run_routes_command
                                      Prefix Verb   URI Pattern                                                                              Controller#Action
               rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
               rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
@@ -199,7 +199,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     end
 
     # rubocop:disable Layout/TrailingWhitespace
-    assert_equal <<~MESSAGE, output
+    assert_match <<~MESSAGE, output
       --[ Route 1 ]--------------
       Prefix            | cart
       Verb              | GET


### PR DESCRIPTION
Some railties tests are very strict about about expected output, and fail when Ruby head throws some of its recent warnings.

```
u@x:~/code/rails/railties$ ruby -v
ruby 2.7.0dev (2019-09-15T14:22:41Z master 4a403e3f98) [x86_64-linux]
```

This commit avoids the following:

```
F

Failure:
Rails::Command::RoutesTest#test_rails_routes_displays_message_when_no_routes_are_defined [test/commands/routes_test.rb:166]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"                               Prefix Verb   URI Pattern                                                                              Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+                               Prefix Verb   URI Pattern                                                                              Controller#Action
         rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create


rails test test/commands/routes_test.rb:160

F

Failure:
Rails::Command::RoutesTest#test_rails_routes_with_expanded_option [test/commands/routes_test.rb:202]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"--[ Route 1 ]--------------
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+--[ Route 1 ]--------------
 Prefix            | cart
 Verb              | GET
 URI               | /cart(.:format)


rails test test/commands/routes_test.rb:190

F

Failure:
Rails::Command::RoutesTest#test_rails_routes_with_namespaced_controller_search_key [test/commands/routes_test.rb:122]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"         Prefix Verb   URI Pattern                Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+         Prefix Verb   URI Pattern                Controller#Action
  new_admin_post GET    /admin/post/new(.:format)  admin/posts#new
 edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit
      admin_post GET    /admin/post(.:format)      admin/posts#show


rails test test/commands/routes_test.rb:112

F

Failure:
Rails::Command::RoutesTest#test_rails_routes_with_controller_search_key [test/commands/routes_test.rb:92]:
--- expected
+++ actual
@@ -1,3 +1,5 @@
-"Prefix Verb URI Pattern     Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+Prefix Verb URI Pattern     Controller#Action
   cart GET  /cart(.:format) cart#show
 "


rails test test/commands/routes_test.rb:81

F

Failure:
Rails::Command::RoutesTest#test_singular_resource_output_in_rails_routes [test/commands/routes_test.rb:20]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"                       Prefix Verb   URI Pattern                                             Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+                       Prefix Verb   URI Pattern                                             Controller#Action
                      new_post GET    /post/new(.:format)                                     posts#new
                     edit_post GET    /post/edit(.:format)                                    posts#edit
                          post GET    /post(.:format)                                         posts#show


rails test test/commands/routes_test.rb:12

F

Failure:
Rails::Command::RoutesTest#test_rails_routes_with_global_search_key [test/commands/routes_test.rb:53]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"                       Prefix Verb URI Pattern                                                                              Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+                       Prefix Verb URI Pattern                                                                              Controller#Action
                          cart GET  /cart(.:format)                                                                          cart#show
 rails_conductor_inbound_email GET  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
            rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show


rails test test/commands/routes_test.rb:44
```
:scissors:
```
F

Failure:
Rails::Command::NotesTest#test_`rails_notes_--annotations`_displays_results_for_multiple_annotations_being_prefixed_by_a_tag [test/commands/notes_test.rb:67]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"app/controllers/some_controller.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+app/controllers/some_controller.rb:
   * [1] [FOOBAR] note in app directory
 
 config/initializers/some_initializer.rb:


rails test test/commands/notes_test.rb:60

F

Failure:
Rails::Command::NotesTest#test_displays_results_from_additional_file_extensions_added_to_the_default_extensions_from_a_config_file [test/commands/notes_test.rb:111]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"app/assets/stylesheets/application.css.sass:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+app/assets/stylesheets/application.css.sass:
   * [1] [TODO] note in sass
 
 app/assets/stylesheets/application.css.scss:


rails test test/commands/notes_test.rb:104

F

Failure:
Rails::Command::NotesTest#test_displays_results_from_additional_tags_added_to_the_default_tags_from_a_config_file [test/commands/notes_test.rb:131]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"app/controllers/hello_controller.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+app/controllers/hello_controller.rb:
   * [1] [DEPRECATEME] this action is no longer needed
 
 app/models/profile.rb:


rails test test/commands/notes_test.rb:124

F

Failure:
Rails::Command::NotesTest#test_`rails_notes_--annotations`_displays_results_for_a_single_annotation_without_being_prefixed_by_a_tag [test/commands/notes_test.rb:50]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"db/some_seeds.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+db/some_seeds.rb:
   * [1] note in db directory
 
 test/some_test.rb:


rails test test/commands/notes_test.rb:43

F

Failure:
Rails::Command::NotesTest#test_`rails_notes`_displays_an_empty_string_when_no_results_were_found [test/commands/notes_test.rb:40]:
--- expected
+++ actual
@@ -1 +1,3 @@
-""
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+"


rails test test/commands/notes_test.rb:39

F

Failure:
Rails::Command::NotesTest#test_does_not_display_results_from_tags_that_are_neither_default_nor_registered [test/commands/notes_test.rb:152]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"app/controllers/hello_controller.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+app/controllers/hello_controller.rb:
   * [1] [DEPRECATEME] this action is no longer needed
 
 app/models/profile.rb:


rails test test/commands/notes_test.rb:144

F

Failure:
Rails::Command::NotesTest#test_`rails_notes`_displays_results_for_default_directories_and_default_annotations_with_aligned_line_number_and_annotation_tag [test/commands/notes_test.rb:20]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"app/controllers/some_controller.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+app/controllers/some_controller.rb:
   * [  1] [OPTIMIZE] note in app directory
 
 config/initializers/some_initializer.rb:


rails test test/commands/notes_test.rb:11

F

Failure:
Rails::Command::NotesTest#test_displays_results_from_additional_directories_added_to_the_default_directories_from_a_config_file [test/commands/notes_test.rb:88]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"db/some_seeds.rb:
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+db/some_seeds.rb:
   * [1] [FIXME] note in db directory
 
 lib/some_file.rb:


rails test test/commands/notes_test.rb:80

```
:scissors:
```
.........F

Failure:
ApplicationTests::RakeTests::RakeMigrationsTest#test_migration_status_when_schema_migrations_table_is_not_present [test/application/rake/migrations_test.rb:182]:
--- expected
+++ actual
@@ -1,2 +1,4 @@
-"Schema migrations table does not exist yet.
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+Schema migrations table does not exist yet.
 "


rails test test/application/rake/migrations_test.rb:180
```
:scissors:
```
F

Failure:
ApplicationTests::RakeTests::RakeMultiDbsTest#test_db:seed_uses_primary_database_connection [test/application/rake/multi_dbs_test.rb:110]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"[\"schema_migrations\", \"ar_internal_metadata\", \"books\"]"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+[\"schema_migrations\", \"ar_internal_metadata\", \"books\"]"


rails test test/application/rake/multi_dbs_test.rb:353
```
:scissors:
```
F

Failure:
ApplicationTests::RakeTests::RakeDbsTest#test_db:schema:load_and_db:structure:load_do_not_purge_the_existing_database [test/application/rake/dbs_test.rb:426]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"[\"posts\"]"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+[\"posts\"]"


rails test test/application/rake/dbs_test.rb:415

..F

Failure:
ApplicationTests::RakeTests::RakeDbsTest#test_db:schema:load_with_inflections [test/application/rake/dbs_test.rb:461]:
--- expected
+++ actual
@@ -1,3 +1 @@
-"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
-/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
-[\"gooseid\", \"name\"]"
+"[\"gooseid\", \"name\"]"


rails test test/application/rake/dbs_test.rb:438

..F

Failure:
ApplicationTests::RakeTests::RakeDbsTest#test_db:structure:dump_and_db:structure:load_set_ar_internal_metadata [test/application/rake/dbs_test.rb:401]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"test"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+test"


rails test test/application/rake/dbs_test.rb:397

..F

Failure:
ApplicationTests::RakeTests::RakeDbsTest#test_db:test:prepare_sets_test_ar_internal_metadata [test/application/rake/dbs_test.rb:540]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"test"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+test"


rails test test/application/rake/dbs_test.rb:534

.F

Failure:
ApplicationTests::RakeTests::RakeDbsTest#test_db:setup_sets_ar_internal_metadata [test/application/rake/dbs_test.rb:520]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"test"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+test"
```
:scissors:
```
F

Failure:
ApplicationTests::BinSetupTest#test_bin_setup [test/application/bin_setup_test.rb:19]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"[]"
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+[]"


rails test test/application/bin_setup_test.rb:12


F

Failure:
ApplicationTests::BinSetupTest#test_bin_setup_output [test/application/bin_setup_test.rb:47]:
--- expected
+++ actual
@@ -2,10 +2,38 @@
 The Gemfile's dependencies are satisfied
 
 == Preparing database ==
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+/home/u/code/rails/activerecord/lib/active_record/type.rb:27: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/type/adapter_specific_registry.rb:9: warning: for `add_modifier' defined here
+/home/u/code/rails/activerecord/lib/active_record/type.rb:27: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/type/adapter_specific_registry.rb:9: warning: for `add_modifier' defined here
 Created database 'app_development'
 Created database 'app_test'
+/home/u/code/rails/activerecord/lib/active_record/internal_metadata.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:228: warning: for `string' defined here
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:16: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:528: warning: for `type_to_sql' defined here
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:16: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:528: warning: for `type_to_sql' defined here
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:16: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:528: warning: for `type_to_sql' defined here
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:16: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:528: warning: for `type_to_sql' defined here
 
 == Removing old logs and tempfiles ==
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:627: warning: for `rm_rf' defined here
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:605: warning: for `rm_r' defined here
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:559: warning: for `rm' defined here
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:559: warning: for `rm' defined here
 
 == Restarting application server ==
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:197: warning: for `mkdir_p' defined here
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35: warning: The last argument is used as the keyword parameter
+/home/u/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:1120: warning: for `touch' defined here
 "


rails test test/application/bin_setup_test.rb:30
```
:scissors:
```
.F

Failure:
ApplicationTests::ConfigurationTest#test_ActiveStorage.routes_prefix_can_be_configured_via_config.active_storage.routes_prefix [test/application/configuration_test.rb:2598]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"                   Prefix Verb URI Pattern                                                               Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+                   Prefix Verb URI Pattern                                                               Controller#Action
        rails_service_blob GET  /files/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
 rails_blob_representation GET  /files/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
        rails_disk_service GET  /files/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show


rails test test/application/configuration_test.rb:2590
```
:scissors:
```
.F

Failure:
ApplicationTests::ConfigurationTest#test_ActiveStorage.routes_prefix_can_be_configured_via_config.active_storage.routes_prefix [test/application/configuration_test.rb:2598]:
--- expected
+++ actual
@@ -1,4 +1,6 @@
-"                   Prefix Verb URI Pattern                                                               Controller#Action
+"/home/u/code/rails/actionpack/lib/action_dispatch/middleware/stack.rb:37: warning: The last argument is used as the keyword parameter
+/home/u/code/rails/actionpack/lib/action_dispatch/middleware/static.rb:111: warning: for `initialize' defined here
+                   Prefix Verb URI Pattern                                                               Controller#Action
        rails_service_blob GET  /files/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
 rails_blob_representation GET  /files/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
        rails_disk_service GET  /files/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show


rails test test/application/configuration_test.rb:2590
```