### PR TITLE
Avoid setting up file watcher on cache_classes

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -216,7 +216,9 @@ module Rails
           app.reloader.check = lambda { true }
         end
 
-        if config.reload_classes_only_on_change
+        if config.cache_classes
+          # No reloader
+        elsif config.reload_classes_only_on_change
           reloader = config.file_watcher.new(*watchable_args, &callback)
           reloaders << reloader
 


### PR DESCRIPTION
Previously, if `cache_classes` was true we would build a `file_watcher` and add it to `reloaders` though it would never be used. This wasted some memory for `FileUpdateChecker` to maintain an array of all watched files, and added slightly to boot time.

Instead we should avoid building a file watcher it when `cache_classes` is `true`.