### PR TITLE
Sets content_type on ActiveStorage variant uploads

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -98,7 +98,7 @@ class ActiveStorage::Variant
     def process
       blob.open do |input|
         variation.transform(input, format: format) do |output|
-          service.upload(key, output)
+          service.upload(key, output, content_type: content_type)
         end
       end
     end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -196,4 +196,16 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   ensure
     ActiveStorage.variant_processor = :mini_magick
   end
+
+  test "passes content_type on upload" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+    mock_upload = lambda do |_, _, options = {}|
+      assert_equal options[:content_type], "image/jpeg"
+    end
+
+    blob.service.stub(:upload, mock_upload) do
+      blob.variant(resize: "100x100").processed
+    end
+  end
 end


### PR DESCRIPTION
### Summary
For variants uploaded via an ActiveStorage service, pass along the `content_type` so it can be persisted (if the backing service cares about doing that).

I'm not sure if the test is the best way to ensure this functionality. It's essentially asserting that `.upload` is called in a certain way. The individual storage services themselves test that the `content_type` key is handled correctly in their implementation of `upload`, so it seems that the variant tests should only concern themselves with making sure it's properly passed along.

### Other Information
Our company uses ActiveStorage in a nonstandard way similar to what's described in #35043. Our application serves up public CloudFront URLs that are backed by an ActiveStorage-managed S3 bucket, which means it's important for Content-Type metadata to be set on objects in that bucket. Currently, original attachments send `content_type` when attached, but variants do not.