### PR TITLE
Fix a typo in DatabaseTasks#current_config

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -111,12 +111,13 @@ module ActiveRecord
       end
 
       def current_config(options = {})
-        options.reverse_merge! env: env
-        options[:spec] ||= "primary"
         if options.has_key?(:config)
           @current_config = options[:config]
         else
-          @current_config ||= ActiveRecord::Base.configurations.configs_for(env_name: options[:env], spec_name: options[:spec]).db_config.configuration_hash
+          env_name = options[:env] || env
+          spec_name = options[:spec] || "primary"
+
+          @current_config ||= ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)&.configuration_hash
         end
       end
 


### PR DESCRIPTION
This commit fixes a method typo that was introduced in #37199, also also
adds tests for the `DatabaseTasks#current_config` method given it's
current implementation.

While I was in here, I also made it so that if `current_config` is
called with an `env` it won't try to look up the `Rails.env`
potentially resulting in an error for non-Rails application.

IMO this method should be deprecated & removed as it's no longer used in
Rails, is confusing (for example: see `test_current_config_read_after_set`),
and is currently dependent on Rails if `env` isn't passed.

cc / @eileencodes 