### PR TITLE
Fix establishing connections for models with custom connection specification names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1164,7 +1164,7 @@ module ActiveRecord
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
             # the specification and establish a new connection with it.
-            establish_connection(ancestor_pool.spec.db_config.configuration_hash).tap do |pool|
+            establish_connection(ancestor_pool.spec.db_config.configuration_hash.merge(name: spec_name)).tap do |pool|
               pool.schema_cache = ancestor_pool.schema_cache if ancestor_pool.schema_cache
             end
           else


### PR DESCRIPTION
We have an internal engine whose models, for backwards compatibility with older Rails versions, override `#connection_specification_name` to connect to a shared DB rather than using Rails 6 multi-DB support.

b8fc0150 [changed](https://github.com/rails/rails/commit/b8fc0150d66866ce7e86c2608dc779fdd7688a61#diff-7735c67f539e7d1e2908a4d5d8909c24L1167-R1167) `ConnectionPool#retrieve_connection_pool` to pass `DatabaseConfig#config_hash` to `#establish_connection` where it previously passed `ConnectionSpecification#to_hash`. But `DatabaseConfig#config_hash` isn’t equivalent to `ConnectionSpecification#to_hash`—it doesn’t include the specification name, so `#establish_connection` falls back to `"primary"`. The host app's primary DB connections and our engine's shared DB connections get mixed in the same pool as a result. Engine models sometimes erroneously check out app DB connections and app models check out engine DB connections.

I’m not immediately sure whether this affects multi-DB apps. It seems like it would, but I need to look more closely.

To fix, we merge the connection specification name into the DB config hash before passing it into `ConnectionPool#establish_connection`.

---

To-do:

- [x] Tests