### PR TITLE
Fix typo and simplify autoload paths intro

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -84,7 +84,7 @@ Please, check the [Zeitwerk documentation](https://github.com/fxn/zeitwerk#file-
 Autoload paths
 --------------
 
-We call _autoload paths_ to the list of application directories whose contents are to be autoloaded. For example, `app/models`. Such directories represent the root namespace: `Object`.
+We refer to the list of application directories whose contents are to be autoloaded as _autoload paths_. For example, `app/models`. Such directories represent the root namespace: `Object`.
 
 INFO. Autoload paths are called _root directories_ in Zeitwerk documentation, but we'll stay with "autoload path" in this guide.
 


### PR DESCRIPTION
Initially I just wanted to remove _to_ from _We call autoload paths to the list..._. But this sentence also seemed a little bit overcomplicated 😅
