### PR TITLE
Allow ActionDispatch::Response to be autoloaded

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -2,7 +2,6 @@
 
 require "abstract_controller"
 require "action_dispatch"
-require "action_controller/metal/live"
 require "action_controller/metal/strong_parameters"
 
 module ActionController
@@ -20,6 +19,10 @@ module ActionController
   end
 
   autoload_under "metal" do
+    eager_autoload do
+      autoload :Live
+    end
+
     autoload :ConditionalGet
     autoload :ContentSecurityPolicy
     autoload :Cookies


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/37187, this defers loading `ActionDispatch::Response` until after initialization, which allows applications to boot a bit faster in development but also paves the way for `return_only_media_type_on_content_type` to work correctly when set from `new_framework_defaults_6_0.rb` in https://github.com/rails/rails/pull/37112.

Co-authored by @serenaf! 🍐 

## Benchmark:

    $ cat test.rb
    require "bundler/setup"
    before = ObjectSpace.each_object(Module).count
    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    require "action_controller"
    finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    after = ObjectSpace.each_object(Module).count
    puts "took #{finish - start} and created #{after - before} modules"

## Before:

    $ ruby test.rb
    took 0.35654300000169314 and created 608 modules

## After:

    $ ruby test.rb
    took 0.2770050000108313 and created 466 modules