### PR TITLE
Deprecate `current_config` and `current_config=`

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -49,6 +49,7 @@ module ActiveRecord
       extend self
 
       attr_writer :current_config, :db_dir, :migrations_paths, :fixtures_path, :root, :env, :seed_loader
+      deprecate :current_config=
       attr_accessor :database_configuration
 
       LOCAL_HOSTS = ["127.0.0.1", "localhost"]
@@ -120,6 +121,7 @@ module ActiveRecord
           @current_config ||= ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)&.configuration_hash
         end
       end
+      deprecate :current_config
 
       def create(*arguments)
         configuration = arguments.first.symbolize_keys

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -156,10 +156,14 @@ module ActiveRecord
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = { "production" => { "exists" => { "database" => "my-db" } } }
 
-        yield
+        assert_deprecated do
+          yield
+        end
       ensure
         ActiveRecord::Base.configurations = old_configurations
-        ActiveRecord::Tasks::DatabaseTasks.current_config = nil
+        assert_deprecated do
+          ActiveRecord::Tasks::DatabaseTasks.current_config = nil
+        end
       end
   end
 


### PR DESCRIPTION
Uses of `current_config` and `current_config=` were removed when
implementing multiple datatbase Rails tasks. This means they are no
longer used internally. However, since it is a documented method it may
be used in gems or applications. This change deprecates these methods so
that we can remove them in 6.2.

cc/ @seejohnrun @casperisfine @matthewd @rafaelfranca 