### PR TITLE
Deprecate `to_h` and `to_legacy_hash`

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -79,12 +79,11 @@ module ActiveRecord
 
     # Returns the DatabaseConfigurations object as a Hash.
     def to_h
-      configs = configurations.reverse.inject({}) do |memo, db_config|
-        memo.merge(db_config.to_legacy_hash)
+      configurations.inject({}) do |memo, db_config|
+        memo.merge(db_config.env_name => db_config.configuration_hash.stringify_keys)
       end
-
-      Hash[configs.to_a.reverse]
     end
+    deprecate to_h: "You can use `ActiveRecord::Base.configurations.configs_for(env_name: 'env', spec_name: 'primary').configuration_hash` to get the configuration hashes."
 
     # Checks if the application's configurations are empty.
     #

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -38,10 +38,6 @@ module ActiveRecord
         false
       end
 
-      def to_legacy_hash
-        { env_name => configuration_hash.stringify_keys }
-      end
-
       def for_current_env?
         env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
       end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -48,11 +48,13 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal "primary", config.spec_name
   end
 
-  def test_to_h_turns_db_config_object_back_into_a_hash
+  def test_to_h_turns_db_config_object_back_into_a_hash_and_is_deprecated
     configs = ActiveRecord::Base.configurations
     assert_equal "ActiveRecord::DatabaseConfigurations", configs.class.name
-    assert_equal "Hash", configs.to_h.class.name
-    assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements"], ActiveRecord::Base.configurations.to_h.keys.sort
+    assert_deprecated do
+      assert_equal "Hash", configs.to_h.class.name
+      assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements"], ActiveRecord::Base.configurations.to_h.keys.sort
+    end
   end
 end
 
@@ -73,9 +75,11 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_can_turn_configurations_into_a_hash
-    assert ActiveRecord::Base.configurations.to_h.is_a?(Hash), "expected to be a hash but was not."
-    assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements"].sort, ActiveRecord::Base.configurations.to_h.keys.sort
+  def test_can_turn_configurations_into_a_hash_and_is_deprecated
+    assert_deprecated do
+      assert ActiveRecord::Base.configurations.to_h.is_a?(Hash), "expected to be a hash but was not."
+      assert_equal ["arunit", "arunit2", "arunit_without_prepared_statements"].sort, ActiveRecord::Base.configurations.to_h.keys.sort
+    end
   end
 
   def test_each_is_deprecated


### PR DESCRIPTION
These should have been deprecated when I added them but for some reason
I didn't.

As we move away from passing hashes around we no longer need these
methods, and since we no longer use configuration hashes as database
configuration we can deprecate this in favor of using the database
configuration objects and access the connection hashes from there.

cc/ @seejohnrun @casperisfine @matthewd @rafaelfranca