### PR TITLE
Maintain eager loading joining order as before

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -70,6 +70,10 @@ module ActiveRecord
         @join_type = join_type
       end
 
+      def base_klass
+        join_root.base_klass
+      end
+
       def reflections
         join_root.drop(1).map!(&:reflection)
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1108,6 +1108,10 @@ module ActiveRecord
           buckets[:stashed_join] << construct_join_dependency(left_joins, Arel::Nodes::OuterJoin)
         end
 
+        if joins.last.is_a?(ActiveRecord::Associations::JoinDependency)
+          buckets[:stashed_join] << joins.pop if joins.last.base_klass == klass
+        end
+
         joins.map! do |join|
           if join.is_a?(String)
             table.create_string_join(Arel.sql(join.strip)) unless join.blank?

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -79,6 +79,14 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_equal [authors(:david)], authors
   end
 
+  def test_eager_load_with_string_joins
+    string_join = <<~SQL
+      LEFT JOIN people agents_people ON agents_people.primary_contact_id = agents_people_2.id AND agents_people.id > agents_people_2.id
+    SQL
+
+    assert_equal 3, Person.eager_load(:agents).joins(string_join).count
+  end
+
   def test_construct_finder_sql_ignores_empty_joins_hash
     sql = Author.joins({}).to_sql
     assert_no_match(/JOIN/i, sql)


### PR DESCRIPTION
If a relation has eager_load and string joins only, string joins will be
regarded as leading joins unlike before, due to #36805.

To maintain that joining order as before, check eager loading join
first before string joins.

Fixes #37133.