### PR TITLE
Allow DESCRIBE queries on read-only connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -19,7 +19,9 @@ module ActiveRecord
           execute(sql, name).to_a
         end
 
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback) # :nodoc:
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
+          :begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback, :describe, :desc
+        ) # :nodoc:
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -217,6 +217,13 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_doesnt_error_when_a_describe_query_is_called_while_preventing_writes
+    @connection_handler.while_preventing_writes do
+      @conn.execute("DESCRIBE engines")
+      @conn.execute("DESC engines") # DESC is an alias for DESCRIBE
+    end
+  end
+
   def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
 


### PR DESCRIPTION
@rafaelfranca 

## Problem

We want to allow employees to query for production table metadata by allowing them to make raw queries on a restricted connection.  One of the statements they have been using is `DESCRIBE` or `DESC` which are aliases for `EXPLAIN`.   However, when the mysql connection configuration uses `replica: true` then this results in a `ActiveRecord::ReadOnlyError`

## Solution

I've added `:describe` and `:desc` to the read-only query whitelist for mysql.