### PR TITLE
Make DatabaseTasks use DatabaseConfig objects

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -591,7 +591,7 @@ module ActiveRecord
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
-          Tasks::DatabaseTasks.schema_up_to_date?(db_config.configuration_hash, ActiveRecord::Base.schema_format, nil, Rails.env, db_config.spec_name)
+          Tasks::DatabaseTasks.schema_up_to_date?(db_config, ActiveRecord::Base.schema_format)
         end
 
         if needs_update

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -29,7 +29,7 @@ db_namespace = namespace :db do
       desc "Create #{spec_name} database for current environment"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Tasks::DatabaseTasks.create(db_config.configuration_hash)
+        ActiveRecord::Tasks::DatabaseTasks.create(db_config)
       end
     end
   end
@@ -48,7 +48,7 @@ db_namespace = namespace :db do
       desc "Drop #{spec_name} database for current environment"
       task spec_name => [:load_config, :check_protected_environments] do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Tasks::DatabaseTasks.drop(db_config.configuration_hash)
+        ActiveRecord::Tasks::DatabaseTasks.drop(db_config)
       end
     end
   end
@@ -81,7 +81,7 @@ db_namespace = namespace :db do
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+      ActiveRecord::Base.establish_connection(db_config)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     end
     db_namespace["_dump"].invoke
@@ -107,7 +107,7 @@ db_namespace = namespace :db do
       desc "Migrate #{spec_name} database for current environment"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+        ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
       end
     end
@@ -150,7 +150,7 @@ db_namespace = namespace :db do
 
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
 
-          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+          ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
           ActiveRecord::Base.connection.migration_context.run(
             :up,
@@ -184,7 +184,7 @@ db_namespace = namespace :db do
 
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
 
-          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+          ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
           ActiveRecord::Base.connection.migration_context.run(
             :down,
@@ -199,7 +199,7 @@ db_namespace = namespace :db do
     desc "Display status of migrations"
     task status: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+        ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate_status
       end
     end
@@ -209,7 +209,7 @@ db_namespace = namespace :db do
         desc "Display status of migrations for #{spec_name} database"
         task spec_name => :load_config do
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+          ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.migrate_status
         end
       end
@@ -253,7 +253,7 @@ db_namespace = namespace :db do
   # desc "Raises an error if there are pending migrations"
   task abort_if_pending_migrations: :load_config do
     pending_migrations = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).flat_map do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+      ActiveRecord::Base.establish_connection(db_config)
 
       ActiveRecord::Base.connection.migration_context.open.pending_migrations
     end
@@ -274,7 +274,7 @@ db_namespace = namespace :db do
       # desc "Raises an error if there are pending migrations for #{spec_name} database"
       task spec_name => :load_config do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
-        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+        ActiveRecord::Base.establish_connection(db_config)
 
         pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations
 
@@ -297,22 +297,20 @@ db_namespace = namespace :db do
     seed = false
 
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-      ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+      ActiveRecord::Base.establish_connection(db_config)
 
       # Skipped when no database
       ActiveRecord::Tasks::DatabaseTasks.migrate
       if ActiveRecord::Base.dump_schema_after_migration
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, ActiveRecord::Base.schema_format, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, ActiveRecord::Base.schema_format)
       end
 
     rescue ActiveRecord::NoDatabaseError
       ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)
       ActiveRecord::Tasks::DatabaseTasks.load_schema(
-        db_config.configuration_hash,
+        db_config,
         ActiveRecord::Base.schema_format,
-        nil,
-        db_config.env_name,
-        db_config.spec_name
+        nil
       )
 
       seed = true
@@ -385,8 +383,8 @@ db_namespace = namespace :db do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, :ruby, db_config.spec_name)
+        ActiveRecord::Base.establish_connection(db_config)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :ruby)
       end
 
       db_namespace["schema:dump"].reenable
@@ -405,7 +403,7 @@ db_namespace = namespace :db do
       desc "Creates a db/schema_cache.yml file."
       task dump: :load_config do
         ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-          ActiveRecord::Base.establish_connection(db_config.configuration_hash)
+          ActiveRecord::Base.establish_connection(db_config)
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config.spec_name)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
             ActiveRecord::Base.connection,
@@ -428,8 +426,8 @@ db_namespace = namespace :db do
     desc "Dumps the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config.configuration_hash)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config.configuration_hash, :sql, db_config.spec_name)
+        ActiveRecord::Base.establish_connection(db_config)
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :sql)
       end
 
       db_namespace["structure:dump"].reenable
@@ -462,7 +460,7 @@ db_namespace = namespace :db do
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.configuration_hash, :ruby, filename, "test")
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, filename)
       end
     ensure
       if should_reconnect
@@ -474,14 +472,14 @@ db_namespace = namespace :db do
     task load_structure: %w(db:test:purge) do
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :sql)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config.configuration_hash, :sql, filename, "test")
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, filename)
       end
     end
 
     # desc "Empty the test database"
     task purge: %w(load_config check_protected_environments) do
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-        ActiveRecord::Tasks::DatabaseTasks.purge(db_config.configuration_hash)
+        ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
       end
     end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -121,23 +121,23 @@ module ActiveRecord
         end
       end
 
-      def create(*arguments)
-        configuration = arguments.first.symbolize_keys
-        class_for_adapter(configuration[:adapter]).new(*arguments).create
-        $stdout.puts "Created database '#{configuration[:database]}'" if verbose?
+      def create(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).create
+        $stdout.puts "Created database '#{db_config.configuration_hash[:database]}'" if verbose?
       rescue DatabaseAlreadyExists
-        $stderr.puts "Database '#{configuration[:database]}' already exists" if verbose?
+        $stderr.puts "Database '#{db_config.configuration_hash[:database]}' already exists" if verbose?
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't create '#{configuration[:database]}' database. Please check your configuration."
+        $stderr.puts "Couldn't create '#{db_config.configuration_hash[:database]}' database. Please check your configuration."
         raise
       end
 
       def create_all
         old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
-        each_local_configuration { |configuration| create configuration }
+        each_local_configuration { |db_config| create(db_config) }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.db_config.configuration_hash)
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.db_config)
         end
       end
 
@@ -181,36 +181,32 @@ module ActiveRecord
       end
 
       def create_current(environment = env, spec_name = nil)
-        each_current_configuration(environment, spec_name) { |configuration|
-          create configuration
-        }
+        each_current_configuration(environment, spec_name) { |db_config| create(db_config) }
         ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
-      def drop(*arguments)
-        configuration = arguments.first.symbolize_keys
-        class_for_adapter(configuration[:adapter]).new(*arguments).drop
-        $stdout.puts "Dropped database '#{configuration[:database]}'" if verbose?
+      def drop(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).drop
+        $stdout.puts "Dropped database '#{db_config.configuration_hash[:database]}'" if verbose?
       rescue ActiveRecord::NoDatabaseError
-        $stderr.puts "Database '#{configuration[:database]}' does not exist"
+        $stderr.puts "Database '#{db_config.configuration_hash[:database]}' does not exist"
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't drop database '#{configuration[:database]}'"
+        $stderr.puts "Couldn't drop database '#{db_config.configuration_hash[:database]}'"
         raise
       end
 
       def drop_all
-        each_local_configuration { |configuration| drop configuration }
+        each_local_configuration { |db_config| drop(db_config) }
       end
 
       def drop_current(environment = env)
-        each_current_configuration(environment) { |configuration|
-          drop configuration
-        }
+        each_current_configuration(environment) { |db_config| drop(db_config) }
       end
 
-      def truncate_tables(configuration)
-        ActiveRecord::Base.connected_to(database: { truncation: configuration }) do
+      def truncate_tables(db_config)
+        ActiveRecord::Base.connected_to(database: { truncation: db_config.configuration_hash }) do
           conn = ActiveRecord::Base.connection
           table_names = conn.tables
           table_names -= [
@@ -225,7 +221,7 @@ module ActiveRecord
 
       def truncate_all(environment = env)
         ActiveRecord::Base.configurations.configs_for(env_name: environment).each do |db_config|
-          truncate_tables db_config.configuration_hash
+          truncate_tables(db_config)
         end
       end
 
@@ -269,107 +265,113 @@ module ActiveRecord
         ENV["VERSION"].to_i if ENV["VERSION"] && !ENV["VERSION"].empty?
       end
 
-      def charset_current(environment = env, specification_name = spec)
-        charset ActiveRecord::Base.configurations.configs_for(env_name: environment, spec_name: specification_name).configuration_hash
+      def charset_current(env_name = env, spec_name = spec)
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+        charset(db_config)
       end
 
-      def charset(*arguments)
-        configuration = arguments.first.symbolize_keys
-        class_for_adapter(configuration[:adapter]).new(*arguments).charset
+      def charset(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).charset
       end
 
-      def collation_current(environment = env, specification_name = spec)
-        collation ActiveRecord::Base.configurations.configs_for(env_name: environment, spec_name: specification_name).configuration_hash
+      def collation_current(env_name = env, spec_name = spec)
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+        collation(db_config)
       end
 
-      def collation(*arguments)
-        configuration = arguments.first.symbolize_keys
-        class_for_adapter(configuration[:adapter]).new(*arguments).collation
+      def collation(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).collation
       end
 
       def purge(configuration)
-        configuration = configuration.symbolize_keys
-        class_for_adapter(configuration[:adapter]).new(configuration).purge
+        db_config = resolve_configuration(configuration)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash).purge
       end
 
       def purge_all
-        each_local_configuration { |configuration|
-          purge configuration
-        }
+        each_local_configuration { |db_config| purge(db_config) }
       end
 
       def purge_current(environment = env)
-        each_current_configuration(environment) { |configuration|
-          purge configuration
-        }
+        each_current_configuration(environment) { |db_config| purge(db_config) }
         ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
-      def structure_dump(*arguments)
-        configuration = arguments.first.symbolize_keys
-        filename = arguments.delete_at 1
-        class_for_adapter(configuration[:adapter]).new(*arguments).structure_dump(filename, structure_dump_flags)
+      def structure_dump(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        filename = arguments.delete_at(0)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).structure_dump(filename, structure_dump_flags)
       end
 
-      def structure_load(*arguments)
-        configuration = arguments.first.symbolize_keys
-        filename = arguments.delete_at 1
-        class_for_adapter(configuration[:adapter]).new(*arguments).structure_load(filename, structure_load_flags)
+      def structure_load(configuration, *arguments)
+        db_config = resolve_configuration(configuration)
+        filename = arguments.delete_at(0)
+        class_for_adapter(db_config.configuration_hash[:adapter]).new(db_config.configuration_hash, *arguments).structure_load(filename, structure_load_flags)
       end
 
-      def load_schema(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = env, spec_name = "primary") # :nodoc:
-        file ||= dump_filename(spec_name, format)
+      def load_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
+        file ||= dump_filename(db_config.spec_name, format)
 
         verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]
         check_schema_file(file)
-        ActiveRecord::Base.establish_connection(configuration)
+        ActiveRecord::Base.establish_connection(db_config)
 
         case format
         when :ruby
           load(file)
         when :sql
-          structure_load(configuration, file)
+          structure_load(db_config, file)
         else
           raise ArgumentError, "unknown format #{format.inspect}"
         end
         ActiveRecord::InternalMetadata.create_table
-        ActiveRecord::InternalMetadata[:environment] = environment
+        ActiveRecord::InternalMetadata[:environment] = db_config.env_name
         ActiveRecord::InternalMetadata[:schema_sha1] = schema_sha1(file)
       ensure
         Migration.verbose = verbose_was
       end
 
-      def schema_up_to_date?(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = env, spec_name = "primary")
+      def schema_up_to_date?(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = nil, spec_name = nil)
+        db_config = resolve_configuration(configuration)
+
+        if environment || spec_name
+          ActiveSupport::Deprecation.warn("`environment` and `spec_name` will be removed as parameters in 6.2.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead.")
+        end
+
+        spec_name ||= db_config.spec_name
+
         file ||= dump_filename(spec_name, format)
 
         return true unless File.exist?(file)
 
-        ActiveRecord::Base.establish_connection(configuration)
+        ActiveRecord::Base.establish_connection(db_config)
         return false unless ActiveRecord::InternalMetadata.table_exists?
         ActiveRecord::InternalMetadata[:schema_sha1] == schema_sha1(file)
       end
 
-      def reconstruct_from_schema(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = env, spec_name = "primary") # :nodoc:
-        file ||= dump_filename(spec_name, format)
+      def reconstruct_from_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
+        file ||= dump_filename(db_config.spec_name, format)
 
         check_schema_file(file)
 
-        ActiveRecord::Base.establish_connection(configuration)
+        ActiveRecord::Base.establish_connection(db_config)
 
-        if schema_up_to_date?(configuration, format, file, environment, spec_name)
-          truncate_tables(configuration)
+        if schema_up_to_date?(db_config, format, file)
+          truncate_tables(db_config)
         else
-          purge(configuration)
-          load_schema(configuration, format, file, environment, spec_name)
+          purge(db_config)
+          load_schema(db_config, format, file)
         end
       rescue ActiveRecord::NoDatabaseError
-        create(configuration)
-        load_schema(configuration, format, file, environment, spec_name)
+        create(db_config)
+        load_schema(db_config, format, file)
       end
 
-      def dump_schema(configuration, format = ActiveRecord::Base.schema_format, spec_name = "primary") # :nodoc:
+      def dump_schema(db_config, format = ActiveRecord::Base.schema_format) # :nodoc:
         require "active_record/schema_dumper"
-        filename = dump_filename(spec_name, format)
+        filename = dump_filename(db_config.spec_name, format)
         connection = ActiveRecord::Base.connection
 
         case format
@@ -378,7 +380,7 @@ module ActiveRecord
             ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
           end
         when :sql
-          structure_dump(configuration, filename)
+          structure_dump(db_config, filename)
           if connection.schema_migration.table_exists?
             File.open(filename, "a") do |f|
               f.puts connection.dump_schema_information
@@ -422,9 +424,9 @@ module ActiveRecord
       end
 
       def load_schema_current(format = ActiveRecord::Base.schema_format, file = nil, environment = env)
-        each_current_configuration(environment) { |configuration, spec_name, env|
-          load_schema(configuration, format, file, env, spec_name)
-        }
+        each_current_configuration(environment) do |db_config|
+          load_schema(db_config, format, file)
+        end
         ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
@@ -457,6 +459,11 @@ module ActiveRecord
       end
 
       private
+        def resolve_configuration(configuration)
+          resolver = ConnectionAdapters::Resolver.new(ActiveRecord::Base.configurations)
+          resolver.resolve(configuration)
+        end
+
         def verbose?
           ENV["VERBOSE"] ? ENV["VERBOSE"] != "false" : true
         end
@@ -477,26 +484,26 @@ module ActiveRecord
             ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|
               next if spec_name && spec_name != db_config.spec_name
 
-              yield db_config.configuration_hash, db_config.spec_name, env
+              yield db_config
             end
           end
         end
 
         def each_local_configuration
           ActiveRecord::Base.configurations.configs_for.each do |db_config|
-            configuration = db_config.configuration_hash
-            next unless configuration[:database]
+            next unless db_config.configuration_hash[:database]
 
-            if local_database?(configuration)
-              yield configuration
+            if local_database?(db_config)
+              yield db_config
             else
-              $stderr.puts "This task only modifies local databases. #{configuration[:database]} is on a remote host."
+              $stderr.puts "This task only modifies local databases. #{db_config.configuration_hash[:database]} is on a remote host."
             end
           end
         end
 
-        def local_database?(configuration)
-          configuration[:host].blank? || LOCAL_HOSTS.include?(configuration[:host])
+        def local_database?(db_config)
+          host = db_config.configuration_hash[:host]
+          host.blank? || LOCAL_HOSTS.include?(host)
         end
 
         def schema_sha1(file)

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration)
-        @configuration = configuration.symbolize_keys
+        @configuration = configuration
       end
 
       def create

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         to: ActiveRecord::Base
 
       def initialize(configuration)
-        @configuration = configuration.symbolize_keys
+        @configuration = configuration
       end
 
       def create(master_established = false)

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       delegate :connection, :establish_connection, to: ActiveRecord::Base
 
       def initialize(configuration, root = ActiveRecord::Tasks::DatabaseTasks.root)
-        @configuration, @root = configuration.symbolize_keys, root
+        @configuration, @root = configuration, root
       end
 
       def create

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
         db_config.configuration_hash[:database] += "-#{i}"
-        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config.configuration_hash, ActiveRecord::Base.schema_format, nil, env_name, db_config.spec_name)
+        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, ActiveRecord::Base.schema_format, nil)
       end
     ensure
       ActiveRecord::Base.establish_connection(Rails.env.to_sym)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -14,7 +14,9 @@ module ActiveRecord
           def drop; end
           def purge; end
           def charset; end
+          def charset_current; end
           def collation; end
+          def collation_current; end
           def structure_dump(*); end
           def structure_load(*); end
         end.new
@@ -313,7 +315,7 @@ module ActiveRecord
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
-          [database: "test-db"],
+          [config_for("test", "primary")]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
             ActiveSupport::StringInquirer.new("test")
@@ -327,7 +329,7 @@ module ActiveRecord
         assert_called_with(
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
-          [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
+          [config_for("production", "primary")]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
             ActiveSupport::StringInquirer.new("production")
@@ -342,8 +344,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [database: "dev-db"],
-            [database: "test-db"]
+            [config_for("development", "primary")],
+            [config_for("test", "primary")]
           ],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -362,8 +364,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [database: "dev-db"],
-            [database: "test-db"]
+            [config_for("development", "primary")],
+            [config_for("test", "primary")]
           ],
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -386,6 +388,10 @@ module ActiveRecord
     end
 
     private
+      def config_for(env_name, spec_name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      end
+
       def with_stubbed_configurations_establish_connection
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
@@ -413,8 +419,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -430,8 +436,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
-            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
+            [config_for("production", "primary")],
+            [config_for("production", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -447,10 +453,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"],
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")],
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -469,10 +475,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :create,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"],
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")],
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create_current(
@@ -499,6 +505,10 @@ module ActiveRecord
     end
 
     private
+      def config_for(env_name, spec_name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      end
+
       def with_stubbed_configurations_establish_connection
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
@@ -620,8 +630,11 @@ module ActiveRecord
 
     def test_drops_current_environment_database
       with_stubbed_configurations do
-        assert_called_with(ActiveRecord::Tasks::DatabaseTasks, :drop,
-          [database: "test-db"]) do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :drop,
+          [config_for("test", "primary")]
+        ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
             ActiveSupport::StringInquirer.new("test")
           )
@@ -631,8 +644,11 @@ module ActiveRecord
 
     def test_drops_current_environment_database_with_url
       with_stubbed_configurations do
-        assert_called_with(ActiveRecord::Tasks::DatabaseTasks, :drop,
-          [adapter: "abstract", database: "prod-db", host: "prod-db-host"]) do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :drop,
+          [config_for("production", "primary")]
+        ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
             ActiveSupport::StringInquirer.new("production")
           )
@@ -646,8 +662,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [database: "dev-db"],
-            [database: "test-db"]
+            [config_for("development", "primary")],
+            [config_for("test", "primary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -666,8 +682,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [database: "dev-db"],
-            [database: "test-db"]
+            [config_for("development", "primary")],
+            [config_for("test", "primary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -680,6 +696,10 @@ module ActiveRecord
     end
 
     private
+      def config_for(env_name, spec_name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      end
+
       def with_stubbed_configurations
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
@@ -705,8 +725,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -722,8 +742,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
-            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
+            [config_for("production", "primary")],
+            [config_for("production", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -739,10 +759,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"],
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")],
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -761,10 +781,10 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :drop,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"],
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")],
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.drop_current(
@@ -777,6 +797,10 @@ module ActiveRecord
     end
 
     private
+      def config_for(env_name, spec_name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      end
+
       def with_stubbed_configurations
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
@@ -973,7 +997,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        [database: "prod-db"]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
       ) do
         assert_called_with(ActiveRecord::Base, :establish_connection, [:production]) do
           ActiveRecord::Tasks::DatabaseTasks.purge_current("production")
@@ -993,7 +1017,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        [database: "my-db"]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "development", spec_name: "primary")]
       ) do
         ActiveRecord::Tasks::DatabaseTasks.purge_all
       end
@@ -1094,8 +1118,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            [database: "test-db"],
-            [database: "secondary-test-db"]
+            [config_for("test", "primary")],
+            [config_for("test", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1111,8 +1135,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            [adapter: "abstract", database: "prod-db", host: "prod-db-host"],
-            [adapter: "abstract", database: "secondary-prod-db", host: "secondary-prod-db-host"]
+            [config_for("production", "primary")],
+            [config_for("production", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1128,8 +1152,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1148,8 +1172,8 @@ module ActiveRecord
           ActiveRecord::Tasks::DatabaseTasks,
           :truncate_tables,
           [
-            [database: "dev-db"],
-            [database: "secondary-dev-db"]
+            [config_for("development", "primary")],
+            [config_for("development", "secondary")]
           ]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.truncate_all(
@@ -1162,6 +1186,10 @@ module ActiveRecord
     end
 
     private
+      def config_for(env_name, spec_name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      end
+
       def with_stubbed_configurations
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
@@ -1184,6 +1212,25 @@ module ActiveRecord
         end
       end
     end
+
+    def test_charset_current
+      old_configurations = ActiveRecord::Base.configurations
+      configurations = {
+        "production"  => { "database" => "prod-db" }
+      }
+
+      ActiveRecord::Base.configurations = configurations
+
+      assert_called_with(
+        ActiveRecord::Tasks::DatabaseTasks,
+        :charset,
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.charset_current("production", "primary")
+      end
+    ensure
+      ActiveRecord::Base.configurations = old_configurations
+    end
   end
 
   class DatabaseTasksCollationTest < ActiveRecord::TestCase
@@ -1197,6 +1244,25 @@ module ActiveRecord
           end
         end
       end
+    end
+
+    def test_collation_current
+      old_configurations = ActiveRecord::Base.configurations
+      configurations = {
+        "production"  => { "database" => "prod-db" }
+      }
+
+      ActiveRecord::Base.configurations = configurations
+
+      assert_called_with(
+        ActiveRecord::Tasks::DatabaseTasks,
+        :collation,
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.collation_current("production", "primary")
+      end
+    ensure
+      ActiveRecord::Base.configurations = old_configurations
     end
   end
 


### PR DESCRIPTION
We're moving in the direction of getting `DatabaseConfig` to be used in
more places instead of `Hash` connections configurations being passed
around directly.

Here we're making all of `DatabaseTasks` and `databases.rake` use
database configuration objects.

A few notes:

* This also contains some tests that were missing for public methods on
  `DatabaseTasks`: `charset_current` & `collation_current`

* There is a deprecation of some arguments in `schema_up_to_date?` that
  are now duplicative/confusing. One of them wasn't used previously
  (`environment`), and now `spec_name` can be pulled directly off of the
  `db_config (DatatabaseConfig)` object.

cc / @eileencodes 