### PR TITLE
Adds 'enable_identification_in_direct_upload' config in 'active_storage' to disable or enable identification in direct upload.

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -114,5 +114,8 @@
 
     *George Claghorn*
 
+*   Add `config.active_storage.enable_identification_in_direct_upload` to disable identification in direct upload. The default is `true`.
+
+    *Sushant Mittal*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -104,7 +104,10 @@ class ActiveStorage::Blob < ActiveRecord::Base
     # Once the form using the direct upload is submitted, the blob can be associated with the right record using
     # the signed ID.
     def create_before_direct_upload!(key: nil, filename:, byte_size:, checksum:, content_type: nil, metadata: nil, service_name: nil, record: nil)
-      create! key: key, filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, metadata: metadata, service_name: service_name
+      blob_attributes = { key: key, filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, metadata: metadata, service_name: service_name }
+      blob_attributes[:identified] = true unless ActiveStorage.enable_identification_in_direct_upload
+
+      create! blob_attributes
     end
 
     # To prevent problems with case-insensitive filesystems, especially in combination

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -65,6 +65,8 @@ module ActiveStorage
 
   mattr_accessor :replace_on_assign_to_many, default: false
 
+  mattr_accessor :enable_identification_in_direct_upload, default: true
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -82,6 +82,8 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
+
+        ActiveStorage.enable_identification_in_direct_upload = app.config.active_storage.enable_identification_in_direct_upload != false
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -889,6 +889,8 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 * `config.active_storage.draw_routes` can be used to toggle Active Storage route generation. The default is `true`.
 
+* `config.active_storage.enable_identification_in_direct_upload` can be used to disable identification in direct upload. The default is `true`.
+
 ### Results of `load_defaults`
 
 #### With '5.0':

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2641,6 +2641,12 @@ module ApplicationTests
       assert Rails.configuration.disable_sandbox
     end
 
+    test "ActiveStorage.enable_identification_in_direct_upload is true by default" do
+      app "development"
+
+      assert ActiveStorage.enable_identification_in_direct_upload
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.


### PR DESCRIPTION
It adds `enable_identification_in_direct_upload` config in `active_storage` to disable identification in direct upload. The default is `true`.

It will resolve: https://github.com/rails/rails/issues/37147