### PR TITLE
Add response_body option to redirect_to to set response_body easily

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -44,6 +44,10 @@ module ActionController
     #   redirect_to posts_url, status: :see_other
     #   redirect_to action: 'index', status: 303
     #
+    # If you want to set response_body as json or so, <tt>:response_body</tt> option is available.
+    #
+    #   redirect_to posts_url, response_body: { code: 302, location: posts_url }.to_json
+    #
     # It is also possible to assign a flash message as part of the redirection. There are two special accessors for the commonly used flash names
     # +alert+ and +notice+ as well as a general purpose +flash+ bucket.
     #
@@ -60,8 +64,9 @@ module ActionController
       raise AbstractController::DoubleRenderError if response_body
 
       self.status        = _extract_redirect_to_status(options, response_options)
+      response_body      = _extract_redirect_to_response_body(options, response_options)
       self.location      = _compute_redirect_to_location(request, options)
-      self.response_body = "<html><body>You are being <a href=\"#{ERB::Util.unwrapped_html_escape(response.location)}\">redirected</a>.</body></html>"
+      self.response_body = response_body || _default_redirect_to_response_body
     end
 
     # Redirects the browser to the page that issued the request (the referrer)
@@ -122,6 +127,20 @@ module ActionController
         else
           302
         end
+      end
+
+      def _extract_redirect_to_response_body(options, response_options)
+        if options.is_a?(Hash) && options.key?(:response_body)
+          options.delete(:response_body)
+        elsif response_options.key?(:response_body)
+          response_options[:response_body]
+        else
+          nil
+        end
+      end
+
+      def _default_redirect_to_response_body
+        "<html><body>You are being <a href=\"#{ERB::Util.unwrapped_html_escape(response.location)}\">redirected</a>.</body></html>"
       end
 
       def _url_host_allowed?(url)

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -44,6 +44,18 @@ class RedirectController < ActionController::Base
     redirect_to({ action: "hello_world" }, { status: 301 })
   end
 
+  def redirect_with_response_body
+    redirect_to action: "hello_world", response_body: "302 Found"
+  end
+
+  def redirect_without_response_body
+    redirect_to action: "hello_world"
+  end
+
+  def redirect_with_response_body_hash
+    redirect_to({ action: "hello_world" }, { response_body: "302 Found" })
+  end
+
   def redirect_with_protocol
     redirect_to action: "hello_world", protocol: "https"
   end
@@ -189,6 +201,27 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_with_status_hash
     get :redirect_with_status_hash
     assert_response 301
+    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_redirect_with_response_body
+    get :redirect_with_response_body
+    assert_response 302
+    assert_equal @response.body, "302 Found"
+    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_redirect_without_response_body
+    get :redirect_without_response_body
+    assert_response 302
+    assert_equal @response.body, '<html><body>You are being <a href="http://test.host/redirect/hello_world">redirected</a>.</body></html>'
+    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_redirect_with_response_body_hash
+    get :redirect_with_response_body_hash
+    assert_response 302
+    assert_equal @response.body, "302 Found"
     assert_equal "http://test.host/redirect/hello_world", redirect_to_url
   end
 


### PR DESCRIPTION
### Summary

When we set `redirect_to` with custom response_body,
we need to set response_body after send `redirect_to` like following

```ruby
redirect_to posts_url
self.response_body = "custom response body"
```

This patch adds `response_body` option to `redirect_to` to set response_body easily like following

```ruby
redirect_to posts_url, response_body: { code: 302, location: posts_url }.to_json
```

This is useful when we are validating that the response body is valid json format or not, at another layer of rails app.

### Other Information

