### PR TITLE
Fix ignore fixture tests causing random AR failures

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1282,6 +1282,10 @@ end
 class IgnoreFixturesTest < ActiveRecord::TestCase
   fixtures :other_books, :parrots
 
+  # Set to false to blow away fixtures cache and ensure our fixtures are loaded
+  # without interfering with other tests that use the same `model_class`.
+  self.use_transactional_tests = false
+
   test "ignores books fixtures" do
     assert_raise(StandardError) { other_books(:published) }
     assert_raise(StandardError) { other_books(:published_paperback) }


### PR DESCRIPTION
### Summary

Since #36303 we allow to ignore specific fixtures from being loaded, but
because that introduced a new fixture `other_books` that uses the same
underlying model `Book`, sometimes depending on the run order the tests
might end up not loading the actual `books` fixtures thinking they are
already cached/loaded. Disabling the transactional fixtures for that
test that was introduced above for the ignore fixtures feature fixes
that.

Closes #37244.
Closes #37245.
Thanks @yahonda for finding a way to reproduce these failures.