### PR TITLE
Rollback in `after_commit` should not rollback state that already been succeeded

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -332,6 +332,7 @@ module ActiveRecord
     # Ensure that it is not called if the object was never persisted (failed create),
     # but call it after the commit of a destroyed object.
     def committed!(should_run_callbacks: true) #:nodoc:
+      force_clear_transaction_record_state
       if should_run_callbacks
         @_committed_already_called = true
         _run_commit_without_transaction_enrollment_callbacks
@@ -339,7 +340,6 @@ module ActiveRecord
       end
     ensure
       @_committed_already_called = false
-      force_clear_transaction_record_state
     end
 
     # Call the #after_rollback callbacks. The +force_restore_state+ argument indicates if the record

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -390,6 +390,23 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     end
   end
 
+  def test_after_commit_callback_should_not_rollback_state_that_already_been_succeeded
+    klass = Class.new(TopicWithCallbacks) do
+      self.inheritance_column = nil
+      validates :title, presence: true
+    end
+
+    first = klass.new(title: "foo")
+    first.after_commit_block { |r| r.update(title: nil) if r.persisted? }
+    first.save!
+
+    assert_predicate first, :persisted?
+    assert_not_nil first.id
+  ensure
+    first.destroy!
+  end
+  uses_transaction :test_after_commit_callback_should_not_rollback_state_that_already_been_succeeded
+
   def test_after_rollback_callback_when_raise_should_restore_state
     error_class = Class.new(StandardError)
 


### PR DESCRIPTION
Rollback in `after_commit` accidentally rollback state that already been
succeeded in the previous commit.

To fix this problem, remaining transaction state should immediately be
cleared after a transaction is committed before `after_commit` callbacks
are invoked.

Fixes #37152.