### PR TITLE
Instantiate ConnectionPool with a DatabaseConfig rather than a ConnectionSpecification

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -126,14 +126,19 @@ module ActiveRecord
       def schema_migration # :nodoc:
         @schema_migration ||= begin
                                 conn = self
-                                spec_name = conn.pool.spec.name
+                                spec_name = conn.pool.db_config.spec_name
                                 name = "#{spec_name}::SchemaMigration"
 
                                 Class.new(ActiveRecord::SchemaMigration) do
                                   define_singleton_method(:name) { name }
                                   define_singleton_method(:to_s) { name }
 
-                                  self.connection_specification_name = spec_name
+                                  connection_handler.connection_pool_names.each do |pool_name|
+                                    if conn.pool == connection_handler.retrieve_connection_pool(pool_name)
+                                      self.connection_specification_name = pool_name
+                                      break
+                                    end
+                                  end
                                 end
                               end
       end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -227,7 +227,7 @@ module ActiveRecord
     #
     # Please use only for reading.
     def connection_config
-      connection_pool.spec.db_config.configuration_hash
+      connection_pool.db_config.configuration_hash
     end
 
     def connection_pool

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -139,7 +139,7 @@ module ActiveRecord
         old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |db_config| create(db_config) }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.db_config)
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.db_config)
         end
       end
 

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -191,8 +191,7 @@ module ActiveRecord
 
         ActiveRecord::Base.connection_handlers.values.each do |handler|
           if handler != writing_handler
-            handler.connection_pool_list.each do |pool|
-              name = pool.spec.name
+            handler.connection_pool_names.each do |name|
               writing_connection = writing_handler.retrieve_connection_pool(name)
               handler.send(:owner_to_pool)[name] = writing_connection
             end

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
       def setup
         @connection = ActiveRecord::Base.connection
-        db          = Post.connection_pool.spec.db_config.database
+        db          = Post.connection_pool.db_config.database
         table       = Post.table_name
         @db_name    = db
 

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -40,7 +40,7 @@ module ActiveRecord
 
       def test_close
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", {})
-        pool = Pool.new(ConnectionSpecification.new("primary", db_config))
+        pool = Pool.new(db_config)
         pool.insert_connection_for_test! @adapter
         @adapter.pool = pool
 

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -82,10 +82,10 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { writing: :primary, reading: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("primary")
-          assert_equal "db/primary.sqlite3", pool.spec.db_config.database
+          assert_equal "db/primary.sqlite3", pool.db_config.database
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.db_config.database
+          assert_equal "db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -140,10 +140,10 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { default: :primary, readonly: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:default].retrieve_connection_pool("primary")
-          assert_equal "db/primary.sqlite3", pool.spec.db_config.database
+          assert_equal "db/primary.sqlite3", pool.db_config.database
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:readonly].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.db_config.database
+          assert_equal "db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -162,7 +162,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.spec.db_config.configuration_hash)
+            assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
           end
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
@@ -182,7 +182,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config, pool.spec.db_config.configuration_hash)
+            assert_equal(config, pool.db_config.configuration_hash)
           end
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
@@ -222,7 +222,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["animals"], pool.spec.db_config.configuration_hash)
+            assert_equal(config["default_env"]["animals"], pool.db_config.configuration_hash)
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -249,7 +249,7 @@ module ActiveRecord
             assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
             assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["primary"], pool.spec.db_config.configuration_hash)
+            assert_equal(config["default_env"]["primary"], pool.db_config.configuration_hash)
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -284,7 +284,7 @@ module ActiveRecord
           ActiveRecord::Base.connects_to database: { writing: :development, reading: :development_readonly }
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.spec.db_config.database
+          assert_equal "db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         super
 
         # Keep a duplicate pool so we do not bother others
-        @pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+        @pool = ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
 
         if in_memory_db?
           # Separate connections to an in-memory database create an entirely new database,
@@ -198,9 +198,9 @@ module ActiveRecord
 
       def test_idle_timeout_configuration
         @pool.disconnect!
-        spec = ActiveRecord::Base.connection_pool.spec
-        spec.db_config.configuration_hash.merge!(idle_timeout: "0.02")
-        @pool = ConnectionPool.new(spec)
+        db_config = ActiveRecord::Base.connection_pool.db_config
+        db_config.configuration_hash.merge!(idle_timeout: "0.02")
+        @pool = ConnectionPool.new(db_config)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
 
@@ -223,9 +223,9 @@ module ActiveRecord
 
       def test_disable_flush
         @pool.disconnect!
-        spec = ActiveRecord::Base.connection_pool.spec
-        spec.db_config.configuration_hash.merge!(idle_timeout: -5)
-        @pool = ConnectionPool.new(spec)
+        db_config = ActiveRecord::Base.connection_pool.db_config
+        db_config.configuration_hash.merge!(idle_timeout: -5)
+        @pool = ConnectionPool.new(db_config)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
 
@@ -315,7 +315,7 @@ module ActiveRecord
       end
 
       def test_checkout_behaviour
-        pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+        pool = ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
         main_connection = pool.connection
         assert_not_nil main_connection
         threads = []
@@ -448,7 +448,7 @@ module ActiveRecord
       end
 
       def test_automatic_reconnect_restores_after_disconnect
-        pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+        pool = ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
         assert pool.automatic_reconnect
         assert pool.connection
 
@@ -457,7 +457,7 @@ module ActiveRecord
       end
 
       def test_automatic_reconnect_can_be_disabled
-        pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+        pool = ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
         pool.disconnect!
         pool.automatic_reconnect = false
 
@@ -718,13 +718,12 @@ module ActiveRecord
 
       private
         def with_single_connection_pool
-          old_config = ActiveRecord::Base.connection_pool.spec.db_config.configuration_hash
+          old_config = ActiveRecord::Base.connection_pool.db_config.configuration_hash
           db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", old_config.dup)
-          one_conn_spec = ConnectionSpecification.new("primary", db_config)
 
-          one_conn_spec.db_config.configuration_hash[:pool] = 1 # this is safe to do, because .dupped ConnectionSpecification also auto-dups its config
+          db_config.configuration_hash[:pool] = 1 # this is safe to do, because .dupped ConnectionSpecification also auto-dups its config
 
-          yield(pool = ConnectionPool.new(one_conn_spec))
+          yield(pool = ConnectionPool.new(db_config))
         ensure
           pool.disconnect! if pool
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1412,7 +1412,7 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
   private
     def with_temporary_connection_pool
       old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
       ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
 
       yield

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -37,7 +37,7 @@ end
 
 def in_memory_db?
   current_adapter?(:SQLite3Adapter) &&
-  ActiveRecord::Base.connection_pool.spec.db_config.database == ":memory:"
+  ActiveRecord::Base.connection_pool.db_config.database == ":memory:"
 end
 
 def subsecond_precision_supported?

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -556,7 +556,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   private
     def with_temporary_connection_pool
       old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new ActiveRecord::Base.connection_pool.spec
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
       ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
 
       yield

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -359,7 +359,7 @@ module ApplicationTests
         db_migrate_and_schema_dump_and_load "schema"
 
         app_file "db/seeds.rb", <<-RUBY
-          print Book.connection.pool.spec.db_config.database
+          print Book.connection.pool.db_config.database
         RUBY
 
         output = rails("db:seed")


### PR DESCRIPTION
This goes towards the goal we discussed of getting rid of `ConnectionSpecification`, the main place it's used is for instantiating `ConnectionPool`.

Most of this is a very straightforward change, except in a couple places that I'll explain in diff comments.

@eileencodes @seejohnrun @rafaelfranca @matthewd 