### PR TITLE
Don't load environment in rake command

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -30,7 +30,7 @@ module Rails
 
             return @rake_tasks if defined?(@rake_tasks)
 
-            require_application_and_environment!
+            require_application!
 
             Rake::TaskManager.record_task_metadata = true
             Rake.application.instance_variable_set(:@name, "rails")

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -934,6 +934,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_gem "webpacker"
+    assert_no_file "config/webpacker.yml"
+
+    output = Dir.chdir(destination_root) do
+      `rails --help`
+    end
+    assert_match(/The most common rails commands are:/, output)
+    assert_equal true, $?.success?
   end
 
   def test_generator_if_skip_turbolinks_is_given


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

While generating an application with the `--skip-webpack-install` flag, and then running `rails -h` on the generated application, I got the crash listed below.

I was suprised that Rails would load the full application environment just for the help command, so I located where the environment was being loaded and stopped loading it.

It fixed the error and didn't break any tests, so it's probably not necessary?

This is the backtrace for the error:

```
$ rails -h
The most common rails commands are:
 generate     Generate new code (short-cut alias: "g")
 console      Start the Rails console (short-cut alias: "c")
 server       Start the Rails server (short-cut alias: "s")
 test         Run tests except system tests (short-cut alias: "t")
 test:system  Run system tests
 dbconsole    Start a console for the database specified in config/database.yml
              (short-cut alias: "db")

 new          Create a new Rails application. "rails new my_app" creates a
              new application called MyApp in "./my_app"

All commands can be run with -h (or --help) for more information.
In addition to those commands, there are:

RAILS_ENV=development environment is not defined in config/webpacker.yml, falling back to production environment
Traceback (most recent call last):
	74: from bin/rails:3:in `<main>'
	73: from bin/rails:3:in `load'
	72: from /home/deivid/Code/playground/testapp/bin/spring:15:in `<top (required)>'
	71: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	70: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	69: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `<top (required)>'
	68: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `load'
	67: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/bin/spring:49:in `<top (required)>'
	66: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client.rb:30:in `run'
	65: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/command.rb:7:in `call'
	64: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `call'
	63: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `load'
	62: from /home/deivid/Code/playground/testapp/bin/rails:9:in `<top (required)>'
	61: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
	60: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
	59: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
	58: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	57: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	56: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	55: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
	54: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	53: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands.rb:18:in `<main>'
	52: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:46:in `invoke'
	51: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/base.rb:65:in `perform'
	50: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	49: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	48: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	47: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/help/help_command.rb:11:in `help'
	46: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:86:in `print_commands'
	45: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `commands'
	44: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `flat_map'
	43: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `each'
	42: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:12:in `printing_commands'
	41: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:42:in `formatted_rake_tasks'
	40: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:33:in `rake_tasks'
	39: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	38: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/actions.rb:28:in `require_environment!'
	37: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/application.rb:339:in `require_environment!'
	36: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
	35: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
	34: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
	33: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/zeitwerk-2.1.10/lib/zeitwerk/kernel.rb:23:in `require'
	32: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	31: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	30: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	29: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
	28: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	27: from /home/deivid/Code/playground/testapp/config/environment.rb:5:in `<main>'
	26: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/application.rb:363:in `initialize!'
	25: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:60:in `run_initializers'
	24: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:205:in `tsort_each'
	23: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:226:in `tsort_each'
	22: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `each_strongly_connected_component'
	21: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `call'
	20: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `each'
	19: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:349:in `block in each_strongly_connected_component'
	18: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:431:in `each_strongly_connected_component_from'
	17: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	16: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:228:in `block in tsort_each'
	15: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:61:in `block in run_initializers'
	14: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `run'
	13: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `instance_exec'
	12: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/railtie.rb:84:in `block in <class:Engine>'
	11: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker.rb:27:in `bootstrap'
	10: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/commands.rb:14:in `bootstrap'
	 9: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/manifest.rb:18:in `refresh'
	 8: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/manifest.rb:83:in `load'
	 7: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:47:in `public_manifest_path'
	 6: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:43:in `public_output_path'
	 5: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:39:in `public_path'
	 4: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:80:in `fetch'
	 3: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:84:in `data'
	 2: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:88:in `load'
	 1: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:88:in `read'
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:88:in `read': No such file or directory @ rb_sysopen - /home/deivid/Code/playground/testapp/config/webpacker.yml (Errno::ENOENT)
	73: from bin/rails:3:in `<main>'
	72: from bin/rails:3:in `load'
	71: from /home/deivid/Code/playground/testapp/bin/spring:15:in `<top (required)>'
	70: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	69: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	68: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `<top (required)>'
	67: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `load'
	66: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/bin/spring:49:in `<top (required)>'
	65: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client.rb:30:in `run'
	64: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/command.rb:7:in `call'
	63: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `call'
	62: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `load'
	61: from /home/deivid/Code/playground/testapp/bin/rails:9:in `<top (required)>'
	60: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
	59: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
	58: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
	57: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	56: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	55: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	54: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
	53: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	52: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands.rb:18:in `<main>'
	51: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:46:in `invoke'
	50: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/base.rb:65:in `perform'
	49: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	48: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	47: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	46: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/help/help_command.rb:11:in `help'
	45: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:86:in `print_commands'
	44: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `commands'
	43: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `flat_map'
	42: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command.rb:96:in `each'
	41: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:12:in `printing_commands'
	40: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:42:in `formatted_rake_tasks'
	39: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/commands/rake/rake_command.rb:33:in `rake_tasks'
	38: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	37: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/command/actions.rb:28:in `require_environment!'
	36: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/application.rb:339:in `require_environment!'
	35: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `require'
	34: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:291:in `load_dependency'
	33: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/dependencies.rb:325:in `block in require'
	32: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/zeitwerk-2.1.10/lib/zeitwerk/kernel.rb:23:in `require'
	31: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	30: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	29: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	28: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
	27: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	26: from /home/deivid/Code/playground/testapp/config/environment.rb:5:in `<main>'
	25: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/application.rb:363:in `initialize!'
	24: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:60:in `run_initializers'
	23: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:205:in `tsort_each'
	22: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:226:in `tsort_each'
	21: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `each_strongly_connected_component'
	20: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `call'
	19: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:347:in `each'
	18: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:349:in `block in each_strongly_connected_component'
	17: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:431:in `each_strongly_connected_component_from'
	16: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	15: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/2.6.0/tsort.rb:228:in `block in tsort_each'
	14: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:61:in `block in run_initializers'
	13: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `run'
	12: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `instance_exec'
	11: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/railtie.rb:84:in `block in <class:Engine>'
	10: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker.rb:27:in `bootstrap'
	 9: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/commands.rb:14:in `bootstrap'
	 8: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/manifest.rb:18:in `refresh'
	 7: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/manifest.rb:83:in `load'
	 6: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:47:in `public_manifest_path'
	 5: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:43:in `public_output_path'
	 4: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:39:in `public_path'
	 3: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:80:in `fetch'
	 2: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:84:in `data'
	 1: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:87:in `load'
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/webpacker-4.0.7/lib/webpacker/configuration.rb:91:in `rescue in load': Webpacker configuration file not found /home/deivid/Code/playground/testapp/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_sysopen - /home/deivid/Code/playground/testapp/config/webpacker.yml (RuntimeError)
```