### PR TITLE
Make sure commands logged by railties tests always pass

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -90,6 +90,7 @@ namespace :test do
       fake_command = Shellwords.join([
         FileUtils::RUBY,
         "-w",
+        "-rbundler/setup",
         *dash_i.map { |dir| "-I#{Pathname.new(dir).relative_path_from(Pathname.pwd)}" },
         file,
       ])


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I didn't know too much about running Rails tests locally, so I run, inside the railties folder, `bundle exec rake test`. I noticed that command would log a command for each of the test files it runs. That was perfect for me, since I was only interested on running a single test file.

So I tried the suggested command, but it failed (see the failures log below).

This PR attempts to change the command that it's printed, so it can be copy pasted and it works ok.

The log of the failures is the following:

```
$ ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/generators/app_generator_test.rb
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32454: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32615: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32651: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32740: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32756: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32822: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32863: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32888: warning: statement not reached
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:31984: warning: assigned but unused variable - testEof
Run options: --seed 17851

# Running:

.......................E

Error:
AppGeneratorTest#test_generation_use_original_bundle_environment:
NameError: uninitialized constant AppGeneratorTest::Bundler
    test/generators/app_generator_test.rb:812:in `test_generation_use_original_bundle_environment'

rails test test/generators/app_generator_test.rb:801

............................Traceback (most recent call last):
	17: from bin/rails:3:in `<main>'
	16: from bin/rails:3:in `require_relative'
	15: from /home/deivid/Code/rails/railties/test/fixtures/tmp/myfirstapp/config/boot.rb:3:in `<top (required)>'
	14: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	13: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	12: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/setup.rb:20:in `<top (required)>'
	11: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler.rb:107:in `setup'
	10: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:20:in `setup'
	 9: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:108:in `block in definition_method'
	 8: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:226:in `requested_specs'
	 7: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:237:in `specs_for'
	 6: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:170:in `specs'
	 5: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:258:in `resolve'
	 4: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:22:in `resolve'
	 3: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:49:in `start'
	 2: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `verify_gemfile_dependencies_are_found!'
	 1: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `each'
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:287:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'rails (~> 6.1.0.alpha)' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
F

Failure:
AppGeneratorTest#test_application_new_exits_with_message_and_non_zero_code_when_generating_inside_existing_rails_directory [test/generators/app_generator_test.rb:154]:
--- expected
+++ actual
@@ -1,3 +1 @@
-"Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.
-Type 'rails' for help.
-"
+""

rails test test/generators/app_generator_test.rb:147

...........................Traceback (most recent call last):
	17: from bin/rails:3:in `<main>'
	16: from bin/rails:3:in `require_relative'
	15: from /home/deivid/Code/rails/railties/test/fixtures/tmp/myfirstapp/config/boot.rb:3:in `<top (required)>'
	14: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	13: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	12: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/setup.rb:20:in `<top (required)>'
	11: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler.rb:107:in `setup'
	10: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:20:in `setup'
	 9: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:108:in `block in definition_method'
	 8: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:226:in `requested_specs'
	 7: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:237:in `specs_for'
	 6: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:170:in `specs'
	 5: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:258:in `resolve'
	 4: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:22:in `resolve'
	 3: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:49:in `start'
	 2: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `verify_gemfile_dependencies_are_found!'
	 1: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `each'
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:287:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'rails (~> 6.1.0.alpha)' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
F

Failure:
AppGeneratorTest#test_application_new_show_help_message_inside_existing_rails_directory [test/generators/app_generator_test.rb:164]:
Expected /rails new APP_PATH \[options\]/ to match "".

rails test test/generators/app_generator_test.rb:158

.......................Traceback (most recent call last):
	17: from ./bin/rails:3:in `<main>'
	16: from ./bin/rails:3:in `require_relative'
	15: from /home/deivid/Code/rails/railties/test/fixtures/tmp/myfirstapp/config/boot.rb:3:in `<top (required)>'
	14: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	13: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	12: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/setup.rb:20:in `<top (required)>'
	11: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler.rb:107:in `setup'
	10: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:20:in `setup'
	 9: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/runtime.rb:108:in `block in definition_method'
	 8: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:226:in `requested_specs'
	 7: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:237:in `specs_for'
	 6: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:170:in `specs'
	 5: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/definition.rb:258:in `resolve'
	 4: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:22:in `resolve'
	 3: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:49:in `start'
	 2: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `verify_gemfile_dependencies_are_found!'
	 1: from /home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:255:in `each'
/home/deivid/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-2.0.2/lib/bundler/resolver.rb:287:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'rails (~> 6.1.0.alpha)' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
F

Failure:
AppGeneratorTest#test_new_application_load_defaults [test/generators/app_generator_test.rb:230]:
--- expected
+++ actual
@@ -1,2 +1 @@
-"false
-"
+""

rails test test/generators/app_generator_test.rb:218

...................

Finished in 16.544232s, 7.4951 runs/s, 54.9436 assertions/s.
124 runs, 909 assertions, 3 failures, 1 errors, 0 skips
```