### PR TITLE
Prefer one liners OS requirement install commands

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -98,10 +98,7 @@ To install all run:
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install sqlite3 libsqlite3-dev
-    mysql-server libmysqlclient-dev
-    postgresql postgresql-client postgresql-contrib libpq-dev
-    redis-server memcached imagemagick ffmpeg mupdf mupdf-tools
+$ sudo apt-get install sqlite3 libsqlite3-dev mysql-server libmysqlclient-dev postgresql postgresql-client postgresql-contrib libpq-dev redis-server memcached imagemagick ffmpeg mupdf mupdf-tools
 
 # Install Yarn
 $ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
@@ -114,10 +111,7 @@ $ sudo apt-get install yarn
 To install all run:
 
 ```bash
-$ sudo dnf install sqlite-devel sqlite-libs
-    mysql-server mysql-devel
-    postgresql-server postgresql-devel
-    redis memcached imagemagick ffmpeg mupdf
+$ sudo dnf install sqlite-devel sqlite-libs mysql-server mysql-devel postgresql-server postgresql-devel redis memcached imagemagick ffmpeg mupdf
 
 # Install Yarn
 # Use this command if you do not have Node.js installed
@@ -132,11 +126,7 @@ $ sudo dnf install yarn
 To install all run:
 
 ```bash
-$ sudo pacman -S sqlite
-    mariadb libmariadbclient mariadb-clients
-    postgresql postgresql-libs
-    redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler
-    yarn
+$ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn
 $ sudo systemctl start redis
 ```
 
@@ -148,11 +138,7 @@ use MariaDB instead (see [this announcement](https://www.archlinux.org/news/mari
 To install all run:
 
 ```bash
-# pkg install sqlite3
-    mysql80-client mysql80-server
-    postgresql11-client postgresql11-server
-    memcached imagemagick ffmpeg mupdf
-    yarn
+$ pkg install sqlite3 mysql80-client mysql80-server postgresql11-client postgresql11-server memcached imagemagick ffmpeg mupdf yarn
 # portmaster databases/redis
 ```
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This is probably a dumb PR but I'll propose it anyways.

I was getting some problems when running `bundle install` on a fresh clone. It was due to some extension building errors that usually point out missing OS dependencies.

So I run "rg apt-get" hoping to find some suggestion to install requirements for my OS. However, the result was misleading, because dependencies are split across several lines, so I missed many of them.

I think a one liner is better and it's also slightly easier to copy-paste.