### PR TITLE
Fix activestorage Error When Using with ExectJS / NodeJS

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -435,7 +435,6 @@
       return Constructor;
     };
   }();
-  var fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice;
   var FileChecksum = function() {
     createClass(FileChecksum, null, [ {
       key: "create",
@@ -484,6 +483,7 @@
     }, {
       key: "readNextChunk",
       value: function readNextChunk() {
+        var fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice;
         if (this.chunkIndex < this.chunkCount || this.chunkIndex == 0 && this.chunkCount == 0) {
           var start = this.chunkIndex * this.chunkSize;
           var end = Math.min(start + this.chunkSize, this.file.size);
@@ -929,7 +929,7 @@
     input.disabled = false;
   }
   function autostart() {
-    if (window.ActiveStorage) {
+    if (typeof window !== "undefined" && window.ActiveStorage) {
       start();
     }
   }

--- a/activestorage/app/javascript/activestorage/file_checksum.js
+++ b/activestorage/app/javascript/activestorage/file_checksum.js
@@ -1,7 +1,5 @@
 import SparkMD5 from "spark-md5"
 
-const fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice
-
 export class FileChecksum {
   static create(file, callback) {
     const instance = new FileChecksum(file)
@@ -39,6 +37,7 @@ export class FileChecksum {
   }
 
   readNextChunk() {
+    const fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice
     if (this.chunkIndex < this.chunkCount || (this.chunkIndex == 0 && this.chunkCount == 0)) {
       const start = this.chunkIndex * this.chunkSize
       const end = Math.min(start + this.chunkSize, this.file.size)

--- a/activestorage/app/javascript/activestorage/index.js
+++ b/activestorage/app/javascript/activestorage/index.js
@@ -3,7 +3,7 @@ import { DirectUpload } from "./direct_upload"
 export { start, DirectUpload }
 
 function autostart() {
-  if (window.ActiveStorage) {
+  if (typeof(window) !== "undefined" && window.ActiveStorage) {
     start()
   }
 }


### PR DESCRIPTION
### Summary

File and window are not defined when using ExecJS / NodeJS. This makes it difficult to integrate this library with server side rendering through packages like react-rails (need to skip or stub File / window).

Running when using:

```sh
node --eval "require('./assets/javascripts/activestorage.js')"
```

**Before:**

    Thrown:
    ReferenceError: File is not defined
        at /assets/javascripts/activestorage.js:438
        at /assets/javascripts/activestorage.js:2

**After:**

    { start: [Function: start], DirectUpload: [Function: DirectUpload] }