### PR TITLE
Reduce stat(2) calls

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -92,9 +92,11 @@ module ActionDispatch
       end
 
       def file_readable?(path)
-        file_path = File.join(@root, path.b)
-        File.file?(file_path) && File.readable?(file_path)
+        file_stat = File.stat(File.join(@root, path.b))
       rescue SystemCallError
+        false
+      else
+        file_stat.file? && file_stat.readable?
       end
   end
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -131,7 +131,12 @@ module Rails
         found = commands.detect do |cmd|
           dirs_on_path.detect do |path|
             full_path_command = File.join(path, cmd)
-            File.file?(full_path_command) && File.executable?(full_path_command)
+            begin
+              stat = File.stat(full_path_command)
+            rescue SystemCallError
+            else
+              stat.file? && stat.executable?
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

`File.file?` and other predicates for permissions can use same stat(2) call result.
