### PR TITLE
Avoid making query when using `where(attr: [])`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -810,7 +810,9 @@ module ActiveRecord
       def exec_queries(&block)
         skip_query_cache_if_necessary do
           @records =
-            if eager_loading?
+            if where_clause.contradiction?
+              []
+            elsif eager_loading?
               apply_join_dependency do |relation, join_dependency|
                 if relation.null_relation?
                   []

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -86,6 +86,10 @@ module ActiveRecord
         @empty ||= new([])
       end
 
+      def contradiction?
+        predicates.any? { |x| Arel::Nodes::In === x && Array === x.right && x.right.empty? }
+      end
+
       protected
         attr_reader :predicates
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -411,6 +411,21 @@ module ActiveRecord
       end
     end
 
+    test "no queries on empty IN" do
+      Post.send(:load_schema)
+      assert_no_queries do
+        Post.where(id: []).load
+      end
+    end
+
+    test "can unscope empty IN" do
+      Post.send(:load_schema)
+      queries = capture_sql do
+        Post.where(id: []).unscope(where: :id).load
+      end
+      assert_equal 1, queries.count
+    end
+
     private
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?


### PR DESCRIPTION
I was lucky to catch @mstruve's talk at RubyConf Colombia ([slides](https://twitter.com/molly_struve/status/1175438767672504320)), which had many performance tips, including avoiding ActiveRecord queries which look like `where(attr: [])` and instead using `Relation#none`.

Running `where(attr: [])` currently runs a query.

```
> User.where(id: [])
  User Load (0.3ms)  SELECT "users".* FROM "users" WHERE 1=0
[]
```

That query includes `WHERE 1=0`, so obviously Rails at some level knows that this query is impossible. Currently this is done in [arel's to SQL visitor](https://github.com/rails/rails/blob/03acb3fb4f1f4d67a4e1776deb0036aae960ab46/activerecord/lib/arel/visitors/to_sql.rb#L524).

Ideally, Rails would could detect that this where clause is impossible and skip making a query without needing to write extra code for this.

This PR adds ~`WhereClause#impossible?`~ `WhereClause#contradiction?` which does essentially the same check. This currently only checks the top level predicates, but I think that's maybe good enough 🤷‍♂.

This is checked in `exec_queries`. I first tried checking it earlier in where! and returning a `NullRelation`, but that seemed like the wrong approach, having a `NullRelation` unexpectedly wasn't great. Checking in `exec_queries` checks as late as we can and _hopefully_ shouldn't affect anything other than skipping the query.

After this change `where(attr: [])` does not run a query.

```
> User.where(id: [])
[]
```