### PR TITLE
Add SECURITY.md file, linking to security policy

### DIFF
--- a/.github/security.md
+++ b/.github/security.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open up a GitHub issue if the bug is a security vulnerability in Rails**.
+Instead refer to our [security policy](https://rubyonrails.org/security/).
+
+## Supported Versions
+
+Security backports are provided for some previous release series. For details
+of which release series are currently receiving security backports see our
+[security policy](https://rubyonrails.org/security/).


### PR DESCRIPTION
### Summary

Adds a `SECURITY.md` file that GitHub will pick up and link to from a tooltip when users are creating their first issue. [See an example on nodejs/nodejs](https://github.com/nodejs/node/issues/new).

### Other Information

 I've duplicated the "Supported versions" information from https://rubyonrails.org/security/ here because it's relatively stable (minor/major releases are infrequent), but could scrap that without reducing the value of having a `SECURITY.md` file much.