### PR TITLE
Use dynamic Rails version in plugin dummy apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -25,8 +25,12 @@ Bundler.require(*Rails.groups)
 
 module <%= app_const_base %>
   class Application < Rails::Application
+<%- if !options.dummy_app? -%>
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults <%= build(:config_target_version) %>
+<%- else -%>
+    config.load_defaults Rails::VERSION::STRING.to_f
+<%- end -%>
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -442,6 +442,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_dummy_application_uses_dynamic_rails_version_number
+    run_generator
+
+    assert_file "test/dummy/config/application.rb" do |contents|
+      assert_match(/^\s*config\.load_defaults Rails::VERSION::STRING\.to_f/, contents)
+    end
+  end
+
   def test_dummy_application_skip_listen_by_default
     run_generator
 


### PR DESCRIPTION
It is common to test Rails plugins with multiple versions of Rails.  When doing so, it's preferable that the dummy app be configured like an actual Rails app would be, which includes loading version-appropriate defaults.  Additionally, using a dynamic version number eliminates transient warnings that occur when testing newer versions of Rails with older configuration defaults.

---

The approach I took here was inspired by d1eb0ef88bfded6d797203e09c71d74bd651e09b.  Originally, I considered modifying "config/application.rb" via the plugin generator, like so:

```diff
diff --git a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
index 4c18bdb430..0b69c17f9c 100644
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -381,7 +381,8 @@ def application_definition
           dummy_application_path = File.expand_path("#{dummy_path}/config/application.rb", destination_root)
           unless options[:pretend] || !File.exist?(dummy_application_path)
             contents = File.read(dummy_application_path)
-            contents[(contents.index(/module ([\w]+)\n(.*)class Application/m))..-1]
+            contents[(contents.index(/module ([\w]+)\n(.*)class Application/m))..-1].
+              sub(/(?:^[ ]*#.*\n)*(^[ ]*config.load_defaults ).+/, '\1Rails::VERSION::STRING.to_f')
           end
         end
       end
```

But the current approach seemed cleaner.
