### PR TITLE
Renamed `assert_broadcasts_on` to `assert_broadcast_on` in documentation string

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -159,7 +159,7 @@ module ActionCable
     #  def test_speak
     #    subscribe room_id: rooms(:chat).id
     #
-    #    assert_broadcasts_on(rooms(:chat), text: "Hello, Rails!") do
+    #    assert_broadcast_on(rooms(:chat), text: "Hello, Rails!") do
     #      perform :speak, message: "Hello, Rails!"
     #    end
     #  end


### PR DESCRIPTION
### Summary

Renamed method in documentation string `assert_broadcasts_on` to the correct `assert_broadcast_on` (plural to singular)

### Other Information

None
