### PR TITLE
Resolve Hash with `url` key as a `UrlConfig`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/resolver.rb
+++ b/activerecord/lib/active_record/connection_adapters/resolver.rb
@@ -86,7 +86,7 @@ module ActiveRecord
         when String
           DatabaseConfigurations::UrlConfig.new(env, "primary", config_or_env)
         when Hash
-          DatabaseConfigurations::HashConfig.new(env, "primary", config_or_env)
+          resolve_hash_configuration(env, config_or_env.symbolize_keys)
         when DatabaseConfigurations::DatabaseConfig
           config_or_env
         else
@@ -95,6 +95,20 @@ module ActiveRecord
       end
 
       private
+        # Resolve a hash to a valid configuration object. This method will
+        # either return a HashConfig, or a UrlConfig if the passed Hash
+        # contains a `:url` key.
+        def resolve_hash_configuration(env, config)
+          if config.has_key?(:url)
+            url = config[:url]
+            config_without_url = config.dup
+            config_without_url.delete :url
+            DatabaseConfigurations::UrlConfig.new(env, "primary", url, config)
+          else
+            DatabaseConfigurations::HashConfig.new(env, "primary", config)
+          end
+        end
+
         # Takes the environment such as +:production+ or +:development+ and a
         # pool name the corresponds to the name given by the connection pool
         # to the connection. That pool name is merged into the hash with the

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -28,8 +28,6 @@ module ActiveRecord
       def initialize(env_name, spec_name, config)
         super(env_name, spec_name)
         @config = config.symbolize_keys
-
-        resolve_url_key
       end
 
       def configuration_hash
@@ -49,14 +47,6 @@ module ActiveRecord
       def migrations_paths
         configuration_hash[:migrations_paths]
       end
-
-      private
-        def resolve_url_key
-          if configuration_hash[:url] && !configuration_hash[:url].match?(/^jdbc:/)
-            connection_hash = ConnectionUrlResolver.new(configuration_hash[:url]).to_hash
-            configuration_hash.merge!(connection_hash)
-          end
-        end
     end
   end
 end


### PR DESCRIPTION
In `DatabaseConfigurations#configs_for`, `Hash` configs that contain a
`:url` key resolve to a `UrlConfig`.  Since we weren't mirroring that behavior
in `Resolver`, we had to add explicit handling for `url` keys to the
`HashConfig` implementation.

Now we're going to always resolve these hashes as `UrlConfig` and can
remove the extra implementation of URL handling from `HashConfig`.

Of course, this does introduce some duplication between
`DatabaseConfigurations` and `Resolver` which we plan to address in a
future PR.

cc / @eileencodes 