### PR TITLE
Remove UrlConfig#url_config?

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -157,7 +157,7 @@ module ActiveRecord
         url = config
         uri = URI.parse(url)
         if uri.scheme
-          ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url)
+          UrlConfig.new(env_name, spec_name, url)
         else
           raise InvalidConfigurationError, "'{ #{env_name} => #{config} }' is not a valid configuration. Expected '#{config}' to be a URL string or a Hash."
         end
@@ -169,15 +169,15 @@ module ActiveRecord
           config_without_url = config.dup
           config_without_url.delete :url
 
-          ActiveRecord::DatabaseConfigurations::UrlConfig.new(env_name, spec_name, url, config_without_url)
+          UrlConfig.new(env_name, spec_name, url, config_without_url)
         else
-          ActiveRecord::DatabaseConfigurations::HashConfig.new(env_name, spec_name, config)
+          HashConfig.new(env_name, spec_name, config)
         end
       end
 
       def merge_db_environment_variables(current_env, configs)
         configs.map do |config|
-          next config if config.url_config? || config.env_name != current_env
+          next config if config.is_a?(UrlConfig) || config.env_name != current_env
 
           url_config = environment_url_config(current_env, config.spec_name, config.configuration_hash)
           url_config || config
@@ -188,7 +188,7 @@ module ActiveRecord
         url = environment_value_for(spec_name)
         return unless url
 
-        ActiveRecord::DatabaseConfigurations::UrlConfig.new(env, spec_name, url, config)
+        UrlConfig.new(env, spec_name, url, config)
       end
 
       def environment_value_for(spec_name)

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -34,10 +34,6 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def url_config?
-        false
-      end
-
       def for_current_env?
         env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
       end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -41,10 +41,6 @@ module ActiveRecord
         @config
       end
 
-      def url_config? # :nodoc:
-        true
-      end
-
       # Determines whether a database configuration is for a replica / readonly
       # connection. If the +replica+ key is present in the config, +replica?+ will
       # return +true+.


### PR DESCRIPTION
This private method is only used in one place, to check whether an
object we have is an instance of `UrlConfig`.

Instead we can just check that we have the right type of object

cc / @eileencodes 