### PR TITLE
Make UrlConfig a subclass of HashConfig

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -14,8 +14,7 @@ module ActiveRecord
       end
 
       def config
-        ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
-        configuration_hash.stringify_keys
+        raise NotImplementedError
       end
 
       def adapter_method
@@ -23,7 +22,7 @@ module ActiveRecord
       end
 
       def adapter
-        configuration_hash[:adapter]
+        raise NotImplementedError
       end
 
       def replica?

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -30,6 +30,11 @@ module ActiveRecord
         @config = config.symbolize_keys
       end
 
+      def config
+        ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
+        configuration_hash.stringify_keys
+      end
+
       def configuration_hash
         @config
       end
@@ -46,6 +51,10 @@ module ActiveRecord
       # will return its value.
       def migrations_paths
         configuration_hash[:migrations_paths]
+      end
+
+      def adapter
+        configuration_hash[:adapter]
       end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -28,49 +28,24 @@ module ActiveRecord
     # * <tt>:config</tt> - The config hash. This is the hash that contains the
     #   database adapter, name, and other important information for database
     #   connections.
-    class UrlConfig < DatabaseConfig
+    class UrlConfig < HashConfig
       attr_reader :url
 
       def initialize(env_name, spec_name, url, config = {})
-        super(env_name, spec_name)
-        @config = build_config(config, url).symbolize_keys
+        super(env_name, spec_name, config)
+
         @url = url
-      end
-
-      def configuration_hash
-        @config
-      end
-
-      # Determines whether a database configuration is for a replica / readonly
-      # connection. If the +replica+ key is present in the config, +replica?+ will
-      # return +true+.
-      def replica?
-        configuration_hash[:replica]
-      end
-
-      # The migrations paths for a database configuration. If the
-      # +migrations_paths+ key is present in the config, +migrations_paths+
-      # will return its value.
-      def migrations_paths
-        configuration_hash[:migrations_paths]
+        @config.merge!(build_url_hash)
       end
 
       private
-        def build_url_hash(url)
+        # Return a Hash that can be merged into the main config that represents
+        # the passed in url
+        def build_url_hash
           if url.nil? || /^jdbc:/.match?(url)
             { url: url }
           else
             ConnectionUrlResolver.new(url).to_hash
-          end
-        end
-
-        def build_config(original_config, url)
-          hash = build_url_hash(url)
-
-          if original_config[env_name]
-            original_config[env_name].merge(hash)
-          else
-            original_config.merge(hash)
           end
         end
     end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -165,6 +165,13 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_url_removed_from_hash
+        config   = { "default_env" => { "url" => "postgres://localhost/foo" } }
+        actual   = resolve_spec(:default_env, config)
+
+        assert_not_includes actual, :url
+      end
+
       def test_hash
         config = { "production" => { "adapter" => "postgres", "database" => "foo" } }
         actual = resolve_config(config, "production")


### PR DESCRIPTION
A `UrlConfig` is a `HashConfig` that mixes in connection information
based on a `url` passed from the constructor.

Previously, for each new property we wanted to introduce an accessor
for, we'd need to write an implementation for `HashConfig` _and_ for
`UrlConfig`.

Now we make `UrlConfig` descend from `HashConfig` so we can write a
single implementation for both cases.

Also while we're in here, take the `adapter` implementation into
`HashConfig` so that `DatabaseConfig` isn't making any assumptions about
the structure of its subclasses.

cc / @eileencodes 