### PR TITLE
Fix typo in actionpack changelog, `a HTTP` -> `an HTTP` [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 *   Add DSL for configuring HTTP Feature Policy
 
-    This new DSL provides a way to configure a HTTP Feature Policy at a
+    This new DSL provides a way to configure an HTTP Feature Policy at a
     global or per-controller level. Full details of HTTP Feature Policy
     specification and guidelines can be found at MDN:
 


### PR DESCRIPTION
### Summary
Fix typo in actionpack changelog, `a HTTP` -> `an HTTP`