### PR TITLE
consider-nil-value-in-constraints

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -165,7 +165,7 @@ module ActionDispatch
             value.include?(request.send(method))
           when TrueClass
             request.send(method).present?
-          when FalseClass
+          when FalseClass, NilClass
             request.send(method).blank?
           else
             value === request.send(method)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4448,6 +4448,8 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
 
       get "/search" => ok, :constraints => { subdomain: false }
 
+      get "/config" => ok, :constraints => { subdomain: nil }
+
       get "/logs" => ok, :constraints => { subdomain: true }
     end
   end
@@ -4483,6 +4485,15 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
     assert_equal "http://example.com/search", search_url
 
     get "http://api.example.com/search"
+    assert_response :not_found
+  end
+
+  test "nil constraint expression check for absence of values" do
+    get "http://example.com/config"
+    assert_response :success
+    assert_equal "http://example.com/config", config_url
+
+    get "http://api.example.com/config"
     assert_response :not_found
   end
 


### PR DESCRIPTION
## Summary

compare with `blank?` when constraints value is `nil`.

## use case

For example, we want to use subdomain only on production,
so write like this.

```ruby
constraints subdomain: ENV['ADMIN_SUBDOMAIN'] do
  get '/admin'
end
```

But now, `GET /admin` does not matches to this route,
because `constraints[:subdomain]` is `nil`, but `request.subdomain` is `''`.