### PR TITLE
Fixed typo in comment in ActionCable::Connection::TestCase [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -85,7 +85,7 @@ module ActionCable
     #     end
     #   end
     #
-    # +connect+ accepts additional information the HTTP request with the
+    # +connect+ accepts additional information about the HTTP request with the
     # +params+, +headers+, +session+ and Rack +env+ options.
     #
     #   def test_connect_with_headers_and_query_string


### PR DESCRIPTION
Fixed a typo in documentation of ActionCable::Connection::TestCase