### PR TITLE
Fix typo, shoud -> should [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1858,7 +1858,7 @@ class ProductTest < ActionCable::TestCase
 end
 ```
 
-If you want to test the broadcasting made with `Channel.broadcast_to`, you shoud use
+If you want to test the broadcasting made with `Channel.broadcast_to`, you should use
 `Channel.broadcasting_for` to generate an underlying stream name:
 
 ```ruby


### PR DESCRIPTION
### Summary
Fix typo in the testing doc, shoud -> should