### PR TITLE
Fix autosave validation context regression

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -270,7 +270,7 @@ module ActiveRecord
       # or saved. If +autosave+ is +false+ only new records will be returned,
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
-        if new_record
+        if new_record || custom_validation_context?
           association && association.target
         elsif autosave
           association.target.find_all(&:changed_for_autosave?)
@@ -302,7 +302,7 @@ module ActiveRecord
       def validate_single_association(reflection)
         association = association_instance_get(reflection.name)
         record      = association && association.reader
-        association_valid?(reflection, record) if record && record.changed_for_autosave?
+        association_valid?(reflection, record) if record && (record.changed_for_autosave? || custom_validation_context?)
       end
 
       # Validate the associated records if <tt>:validate</tt> or
@@ -322,7 +322,7 @@ module ActiveRecord
       def association_valid?(reflection, record, index = nil)
         return true if record.destroyed? || (reflection.options[:autosave] && record.marked_for_destruction?)
 
-        context = validation_context unless [:create, :update].include?(validation_context)
+        context = validation_context if custom_validation_context?
 
         unless valid = record.valid?(context)
           if reflection.options[:autosave]
@@ -490,6 +490,10 @@ module ActiveRecord
             saved if autosave
           end
         end
+      end
+
+      def custom_validation_context?
+        validation_context && [:create, :update].exclude?(validation_context)
       end
 
       def _ensure_no_duplicate_errors

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -35,7 +35,7 @@ require "models/tuning_peg"
 require "models/reply"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
-  def test_autosave_validation
+  def test_autosave_does_not_pass_through_non_custom_validation_contexts
     person = Class.new(ActiveRecord::Base) {
       self.table_name = "people"
       validate :should_be_cool, on: :create
@@ -55,8 +55,11 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     }
 
     u = person.create!(first_name: "cool")
-    u.update!(first_name: "nah") # still valid because validation only applies on 'create'
-    assert_predicate reference.create!(person: u), :persisted?
+    u.first_name = "nah"
+
+    assert_predicate u, :valid?
+    r = reference.new(person: u)
+    assert_predicate r, :valid?
   end
 
   def test_should_not_add_the_same_callbacks_multiple_times_for_has_one
@@ -1736,6 +1739,14 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     assert_equal(author_count_before_save, Author.count)
     assert_equal(book_count_before_save, Book.count)
   end
+
+  def test_validations_still_fire_on_unchanged_association_with_custom_validation_context
+    pirate = FamousPirate.create!(catchphrase: "Avast Ye!")
+    pirate.famous_ships.create!
+
+    assert pirate.valid?
+    assert_not pirate.valid?(:conference)
+  end
 end
 
 class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::TestCase
@@ -1779,6 +1790,13 @@ class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::
     assert_predicate @pirate, :valid?
     @pirate.non_validated_parrot = Parrot.new(name: "")
     assert_predicate @pirate, :valid?
+  end
+
+  def test_validations_still_fire_on_unchanged_association_with_custom_validation_context
+    firm_with_low_credit = Firm.create!(name: "Something", account: Account.new(credit_limit: 50))
+
+    assert firm_with_low_credit.valid?
+    assert_not firm_with_low_credit.valid?(:bank_loan)
   end
 end
 

--- a/activerecord/test/models/account.rb
+++ b/activerecord/test/models/account.rb
@@ -21,10 +21,15 @@ class Account < ActiveRecord::Base
   end
 
   validate :check_empty_credit_limit
+  validate :ensure_good_credit, on: :bank_loan
 
   private
     def check_empty_credit_limit
       errors.add("credit_limit", :blank) if credit_limit.blank?
+    end
+
+    def ensure_good_credit
+      errors.add(:credit_limit, "too low") unless credit_limit > 10_000
     end
 
     def private_method

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -95,7 +95,7 @@ end
 
 class FamousPirate < ActiveRecord::Base
   self.table_name = "pirates"
-  has_many :famous_ships
+  has_many :famous_ships, inverse_of: :famous_pirate, foreign_key: :pirate_id
   validates_presence_of :catchphrase, on: :conference
 end
 

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -37,6 +37,6 @@ end
 
 class FamousShip < ActiveRecord::Base
   self.table_name = "ships"
-  belongs_to :famous_pirate
+  belongs_to :famous_pirate, foreign_key: :pirate_id
   validates_presence_of :name, on: :conference
 end


### PR DESCRIPTION
This fixes a regression introduced by #36671 by ensuring autosaved associations always perform validations when a custom validation context is being used.

Prior to #36671, validations on a dependent singular association would always fire, regardless of whether the associated record was `changed_for_autosave?` or not. That change brought the autosave behaviour for both singular and collection associations inline such that dependent associations would only be validated/saved if they needed to be, according to `changed_for_autosave?`. The problem this highlighted/introduced is that the use of custom validation contexts became a bit broken in that the validations on the associated records now only fire if the associated records had actual changes on them, ignoring the fact that a custom context is a strong indicator that the context might be different to when the record was last save, and therefor their validity should be reconsidered.

This PR reinstates the previous behaviour for singular associations, but also updates the behaviour for collection associations so that they both behave consistently: if a custom validation context is used, the validations will always fire on the association records.

The first commit updates an existing regression test that became a false-positive when #36671 was merged.

Resolves #37192 and #36822.