### PR TITLE
Refactor ConnectionPool management

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -6,11 +6,60 @@ module ActiveRecord
     # UrlConfig respectively. It will never return a DatabaseConfig object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
+      include Mutex_m
+
       attr_reader :env_name, :spec_name
 
+      attr_accessor :schema_cache
+
+      INSTANCES = ObjectSpace::WeakMap.new
+      private_constant :INSTANCES
+
+      class << self
+        def discard_pools!
+          INSTANCES.each_key(&:discard_pool!)
+        end
+      end
+
       def initialize(env_name, spec_name)
+        super()
         @env_name = env_name
         @spec_name = spec_name
+        @pool = nil
+
+        INSTANCES[self] = self
+      end
+
+      def disconnect!
+        ActiveSupport::ForkTracker.check!
+
+        return unless @pool
+
+        synchronize do
+          return unless @pool
+
+          @pool.automatic_reconnect = false
+          @pool.disconnect!
+        end
+
+        nil
+      end
+
+      def connection_pool
+        ActiveSupport::ForkTracker.check!
+
+        @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
+      end
+
+      def discard_pool!
+        return unless @pool
+
+        synchronize do
+          return unless @pool
+
+          @pool.discard!
+          @pool = nil
+        end
       end
 
       def config
@@ -59,3 +108,5 @@ module ActiveRecord
     end
   end
 end
+
+ActiveSupport::ForkTracker.after_fork { ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools! }

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -192,8 +192,7 @@ module ActiveRecord
         ActiveRecord::Base.connection_handlers.values.each do |handler|
           if handler != writing_handler
             handler.connection_pool_names.each do |name|
-              writing_connection = writing_handler.retrieve_connection_pool(name)
-              handler.send(:owner_to_pool)[name] = writing_connection
+              handler.send(:owner_to_config)[name] = writing_handler.send(:owner_to_config)[name]
             end
           end
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1390,6 +1390,9 @@ end
 
 class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
   test "enlist_fixture_connections ensures multiple databases share a connection pool" do
+    old_handlers = ActiveRecord::Base.connection_handlers
+    ActiveRecord::Base.connection_handlers = {}
+
     with_temporary_connection_pool do
       ActiveRecord::Base.connects_to database: { writing: :arunit, reading: :arunit2 }
 
@@ -1406,17 +1409,16 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       assert_equal rw_conn, ro_conn
     end
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.connection_handler }
+    ActiveRecord::Base.connection_handlers = old_handlers
   end
 
   private
     def with_temporary_connection_pool
-      old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
-      ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
+      db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
 
-      yield
-    ensure
-      ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
+      db_config.stub(:connection_pool, new_pool) do
+        yield
+      end
     end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -555,13 +555,12 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   private
     def with_temporary_connection_pool
-      old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.db_config)
-      ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = new_pool
+      db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
 
-      yield
-    ensure
-      ActiveRecord::Base.connection_handler.send(:owner_to_pool)["primary"] = old_pool
+      db_config.stub(:connection_pool, new_pool) do
+        yield
+      end
     end
 
     def middleware(&app)

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -13,10 +13,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
     @specification = ActiveRecord::Base.remove_connection
 
     # Clear out connection info from other pids (like a fork parent) too
-    pool_map = ActiveRecord::Base.connection_handler.instance_variable_get(:@owner_to_pool)
-    (pool_map.keys - [Process.pid]).each do |other_pid|
-      pool_map.delete(other_pid)
-    end
+    ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools!
   end
 
   teardown do


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/37253

This is one more step toward [the topology idea we discussed](https://github.com/rails/rails/compare/master...Shopify:ar-topology). The main change here is that `DatabaseConfig` is now responsible for managing it's connection pool (and `schema_cache`).

@matthewd I'd love your input on `discard_unowned_pools`, looking at [the original commit](https://github.com/rails/rails/commit/f32cff5563f2188e657aa2fd9f8513f0da4a49ca) I understand why we discard old connection after forking, but I'm not quite sure to understand the need to be so eager about it:

  - A connection used before the fork but never after seem like quite the edge case
  - Even if it happens, how much memory are we talking about, does it matter that much?

Let me know what you think, and I can try to bring the behavior back if needed.

cc @eileencodes @seejohnrun @etiennebarrie @rafaelfranca @Edouard-chin 