### PR TITLE
Add request_id to action_controller instrumentation

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -24,7 +24,8 @@ module ActionController
         headers: request.headers,
         format: request.format.ref,
         method: request.request_method,
-        path: request.fullpath
+        path: request.fullpath,
+        request_id: request.request_id
       }
 
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload)

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -116,6 +116,7 @@ Action Controller
 | `:format`     | html/js/json/xml etc                                      |
 | `:method`     | HTTP request verb                                         |
 | `:path`       | Request path                                              |
+| `:request_id` | Request id                                                |
 
 ```ruby
 {


### PR DESCRIPTION
# Summary

For `action_controller` notifications it would be useful to have a uniq identifier to be able to group them together. Adding the `request_id` to the payload.

For instance, the influx-db rails gem subscribes to several action_controller instrumentations and needs to group them together then based on a uniq identifier. I think that is a common usecase. (see https://github.com/influxdata/influxdb-rails#custom-tags).
