### PR TITLE
Fix defaults for database configs

### DIFF
--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -58,17 +58,17 @@ module ActiveRecord
       end
 
       def pool
-        configuration_hash.fetch(:pool, 5).to_i
+        (configuration_hash[:pool] || 5).to_i
       end
 
       def checkout_timeout
-        configuration_hash.fetch(:checkout_timeout, 5).to_f
+        (configuration_hash[:checkout_timeout] || 5).to_f
       end
 
       # +reaping_frequency+ is configurable mostly for historical reasons, but it could
       # also be useful if someone wants a very low +idle_timeout+.
       def reaping_frequency
-        configuration_hash.fetch(:reaping_frequency, 60).to_f
+        configuration_hash.fetch(:reaping_frequency, 60)&.to_f
       end
 
       def idle_timeout

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class HashConfigTest < ActiveRecord::TestCase
+      def test_pool_default_when_nil
+        config = HashConfig.new("default_env", "primary", pool: nil)
+        assert_equal 5, config.pool
+      end
+
+      def test_pool_overrides_with_value
+        config = HashConfig.new("default_env", "primary", pool: "0")
+        assert_equal 0, config.pool
+      end
+
+      def test_when_no_pool_uses_default
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal 5, config.pool
+      end
+
+      def test_checkout_timeout_default_when_nil
+        config = HashConfig.new("default_env", "primary", checkout_timeout: nil)
+        assert_equal 5.0, config.checkout_timeout
+      end
+
+      def test_checkout_timeout_overrides_with_value
+        config = HashConfig.new("default_env", "primary", checkout_timeout: "0")
+        assert_equal 0.0, config.checkout_timeout
+      end
+
+      def test_when_no_checkout_timeout_uses_default
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal 5.0, config.checkout_timeout
+      end
+
+      def test_reaping_frequency_default_when_nil
+        config = HashConfig.new("default_env", "primary", reaping_frequency: nil)
+        assert_nil config.reaping_frequency
+      end
+
+      def test_reaping_frequency_overrides_with_value
+        config = HashConfig.new("default_env", "primary", reaping_frequency: "0")
+        assert_equal 0.0, config.reaping_frequency
+      end
+
+      def test_when_no_reaping_frequency_uses_default
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal 60.0, config.reaping_frequency
+      end
+
+      def test_idle_timeout_default_when_nil
+        config = HashConfig.new("default_env", "primary", idle_timeout: nil)
+        assert_nil config.idle_timeout
+      end
+
+      def test_idle_timeout_overrides_with_value
+        config = HashConfig.new("default_env", "primary", idle_timeout: "1")
+        assert_equal 1.0, config.idle_timeout
+      end
+
+      def test_when_no_idle_timeout_uses_default
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal 300.0, config.idle_timeout
+      end
+
+      def test_idle_timeout_nil_when_less_than_or_equal_to_zero
+        config = HashConfig.new("default_env", "primary", idle_timeout: "0")
+        assert_nil config.idle_timeout
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we moved the defaults from hash accessors to methods a few of the
settings got mis-configured. This change fixes the defaults and adds a
hash config test to prevent future regressions.

cc/ @seejohnrun 