### PR TITLE
Update test to avoid Puma output format change

### DIFF
--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -36,7 +36,7 @@ module ApplicationTests
         rails("restart")
 
         assert_output("Restarting", primary)
-        assert_output("tcp://localhost:3000", primary)
+        assert_output("Listening", primary)
       ensure
         kill(pid) if pid
       end


### PR DESCRIPTION
We are seeing some test failures for this test in #37291. It looks like
what's going on is that Puma has changed the output for this command
between 4.1 and 4.2

Previously:

```
...
* Environment: development
* Listening on tcp://localhost:3000
...
```

Now:

```
...
* Environment: development
* Listening on tcp://127.0.0.1:3000
* Listening on tcp://[::1]:3000
...
```

So to get around this, instead of checking the binding address, just
check for the presence of 'Listening' generally like we do on server
start.

cc / @eileencodes 