### PR TITLE
1.48x Faster Partial Caching - Alternative to #36310

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -65,7 +65,7 @@ module AbstractController
       # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
       # followed by any controller-wide key prefix values, ending
       # with the specified +key+ value.
-      def combined_fragment_cache_key(key)
+      def combined_fragment_cache_key(key = nil)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
 

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -65,7 +65,7 @@ module AbstractController
       # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
       # followed by any controller-wide key prefix values, ending
       # with the specified +key+ value.
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         head = self.class.fragment_cache_keys.map { |k| instance_exec(&k) }
         tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
 

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -208,11 +208,12 @@ module ActionView
       #
       # The digest will be generated using +virtual_path:+ if it is provided.
       #
-      def cache_fragment_name(name = {}, skip_digest: nil, virtual_path: nil, digest_path: nil)
+      def cache_fragment_name(name = {}, skip_digest: nil, virtual_path: nil, digest_path: nil, container: nil)
         if skip_digest
+          container << name if container
           name
         else
-          fragment_name_with_digest(name, virtual_path, digest_path)
+          fragment_name_with_digest(name, virtual_path, digest_path, container: container)
         end
       end
 
@@ -227,7 +228,7 @@ module ActionView
       end
 
     private
-      def fragment_name_with_digest(name, virtual_path, digest_path)
+      def fragment_name_with_digest(name, virtual_path, digest_path, container: nil)
         virtual_path ||= @virtual_path
 
         if virtual_path || digest_path
@@ -235,8 +236,14 @@ module ActionView
 
           digest_path ||= digest_path_from_template(@current_template)
 
-          [ digest_path, name ]
+          if container
+            container << digest_path
+            container << name
+          else
+            [ digest_path, name ]
+          end
         else
+          container << name if container
           name
         end
       end

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -59,7 +59,7 @@ module ActionView
         seed = callable_cache_key? ? @options[:cached] : ->(i) { i }
 
         digest_path = view.digest_path_from_template(template)
-        view_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key)
+        view_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key(nil))
 
         @collection.each_with_object([{}, []]) do |item, (hash, ordered_keys)|
           key = expanded_cache_key(seed.call(item), view_key, view, template, digest_path)

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -59,19 +59,15 @@ module ActionView
         seed = callable_cache_key? ? @options[:cached] : ->(i) { i }
 
         digest_path = view.digest_path_from_template(template)
-        view_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key(nil))
+        base_key = ActiveSupport::Cache::Key.new(view.combined_fragment_cache_key(nil))
 
         @collection.each_with_object([{}, []]) do |item, (hash, ordered_keys)|
-          key = expanded_cache_key(seed.call(item), view_key, view, template, digest_path)
+          key = ActiveSupport::Cache::Key.new(base_key)
+          key << cache_fragment_name(seed.call(item), view, template, digest_path)
+
           ordered_keys << key
           hash[key] = item
         end
-      end
-
-      def expanded_cache_key(item, view_key, view, template, digest_path)
-        key = ActiveSupport::Cache::Key.new(view_key)
-        key << cache_fragment_name(item, view, template, digest_path)
-        key
       end
 
       def cache_fragment_name(key, view, template, digest_path)

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -18,8 +18,8 @@ class MultifetchCacheTest < ActiveRecordTestCase
         []
       end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.with_view_paths(view_paths, {})
   end

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -18,7 +18,7 @@ class MultifetchCacheTest < ActiveRecordTestCase
         []
       end
 
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         [ :views, key ].compact
       end
     end.with_view_paths(view_paths, {})

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -48,7 +48,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def set_view_cache_dependencies
     def @view.view_cache_dependencies; []; end
-    def @view.combined_fragment_cache_key(*); "ahoy `controller` dependency"; end
+    def @view.combined_fragment_cache_key(*); ["ahoy `controller` dependency"]; end
   end
 
   def test_render_template_template

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -15,8 +15,8 @@ module RenderTestCases
     @view = Class.new(ActionView::Base.with_empty_template_cache) do
       def view_cache_dependencies; []; end
 
-      def combined_fragment_cache_key(key)
-        [ :views, key ]
+      def combined_fragment_cache_key(key = nil)
+        [ :views, key ].compact
       end
     end.with_view_paths(paths, @assigns)
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -15,7 +15,7 @@ module RenderTestCases
     @view = Class.new(ActionView::Base.with_empty_template_cache) do
       def view_cache_dependencies; []; end
 
-      def combined_fragment_cache_key(key = nil)
+      def combined_fragment_cache_key(key)
         [ :views, key ].compact
       end
     end.with_view_paths(paths, @assigns)

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
+require "active_support/cache/key"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -851,4 +852,3 @@ module ActiveSupport
     end
   end
 end
-require "active_support/cache/key"

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
+require "active_support/cache/key"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -86,21 +87,11 @@ module ActiveSupport
           expanded_cache_key << "#{prefix}/"
         end
 
-        expanded_cache_key << retrieve_cache_key(key)
+        expanded_cache_key << ActiveSupport::Cache::Key.cache_key_with_version(key)
         expanded_cache_key
       end
 
       private
-        def retrieve_cache_key(key)
-          case
-          when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
-          when key.respond_to?(:cache_key)              then key.cache_key
-          when key.is_a?(Array)                         then key.map { |element| retrieve_cache_key(element) }.to_param
-          when key.respond_to?(:to_a)                   then retrieve_cache_key(key.to_a)
-          else                                               key.to_param
-          end.to_s
-        end
-
         # Obtains the specified cache store class, given the name of the +store+.
         # Raises an error when the store class cannot be found.
         def retrieve_store_class(store)
@@ -315,6 +306,7 @@ module ActiveSupport
       #   cache.fetch('foo') # => "bar"
       def fetch(name, options = nil)
         if block_given?
+          name = ActiveSupport::Cache::Key(name)
           options = merged_options(options)
           key = normalize_key(name, options)
 
@@ -350,6 +342,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def read(name, options = nil)
         options = merged_options(options)
+        name    = ActiveSupport::Cache::Key(name)
         key     = normalize_key(name, options)
         version = normalize_version(name, options)
 
@@ -460,7 +453,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def write(name, value, options = nil)
         options = merged_options(options)
-
+        name = ActiveSupport::Cache::Key(name)
         instrument(:write, name, options) do
           entry = Entry.new(value, **options.merge(version: normalize_version(name, options)))
           write_entry(normalize_key(name, options), entry, **options)
@@ -671,24 +664,8 @@ module ActiveSupport
           end
         end
 
-        # Expands key to be a consistent string value. Invokes +cache_key+ if
-        # object responds to +cache_key+. Otherwise, +to_param+ method will be
-        # called. If the key is a Hash, then keys will be sorted alphabetically.
         def expanded_key(key)
-          return key.cache_key.to_s if key.respond_to?(:cache_key)
-
-          case key
-          when Array
-            if key.size > 1
-              key = key.collect { |element| expanded_key(element) }
-            else
-              key = expanded_key(key.first)
-            end
-          when Hash
-            key = key.sort_by { |k, _| k.to_s }.collect { |k, v| "#{k}=#{v}" }
-          end
-
-          key.to_param
+          ActiveSupport::Cache::Key(key).cache_key
         end
 
         def normalize_version(key, options = nil)
@@ -696,11 +673,7 @@ module ActiveSupport
         end
 
         def expanded_version(key)
-          case
-          when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
-          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
-          end
+          ActiveSupport::Cache::Key(key).cache_version
         end
 
         def instrument(operation, key, options = nil)

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,27 +1,9 @@
 # frozen_string_literal: true
 
+require 'active_support/cache'
+
 module ActiveSupport
   module Cache
-    # Convenience method to prevent re-generating a Key
-    # instance, if the element being passed in is already
-    # instance of the `Key` class.
-    #
-    # Example:
-    #
-    #   ActiveSupport::Cache::Key("foo").cache_key
-    #    # => "foo"
-    #
-    #   k1 = Key.new("foo")
-    #   key = ActiveSupport::Cache::Key(k1)
-    #   k1.object_id == key.object_id # => true
-    def self.Key(key_or_components) # :nodoc:
-      if key_or_components.is_a?(ActiveSupport::Cache::Key)
-        key_or_components
-      else
-        Key.new(key_or_components)
-      end
-    end
-
     # This class is responsible for coercing input into a valid
     # key format and cache version for cache stores.
     #
@@ -111,92 +93,44 @@ module ActiveSupport
     #   Key.new({foo: klass.new}).cache_version
     #   # => "foo"
     class Key # :nodoc:
-      attr_reader :cache_key, :cache_version
+      DEFAULT_KEY = Object.new
+      CACHE_METHOD_OBJ = ActiveSupport::Cache::Store.new
 
-      def initialize(key = nil)
-        @cache_key = +""
-        @cache_version = +""
-        @empty_key = true
+
+      def initialize(key = DEFAULT_KEY)
+        @cache_key = nil
+        @cache_version = nil
         @key_parts = []
-        self << key
+        self << key unless key == DEFAULT_KEY
+      end
+
+      def cache_key
+        @cache_key ||= begin
+          CACHE_METHOD_OBJ.send(:expanded_key, @key_parts)
+        end
+      end
+
+      def cache_version
+        @cache_version ||= begin
+          CACHE_METHOD_OBJ.send(:expanded_version, @key_parts)
+        end
       end
 
       def length
-        @cache_key.length
+        cache_key.length
       end
 
-      def self.cache_key_with_version(key)
-        case
-        when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
-        when key.respond_to?(:cache_key)              then key.cache_key
-        when key.is_a?(Array)                         then key.map { |element| cache_key_with_version(element) }.to_param
-        when key.respond_to?(:to_a)                   then cache_key_with_version(key.to_a)
-        else                                               key.to_param
-        end.to_s
-      end
-
-      def cache_key_with_version(key = @key_parts)
-        self.class.cache_key_with_version(key)
+      def cache_key_with_version
+        CACHE_METHOD_OBJ.send(:retrieve_cache_key, @key_parts)
       end
 
       def update(key)
         @key_parts << key
-        internal_update(key)
+        @cache_key = nil
+        @cache_version = nil
         self
       end
       alias :<< :update
-
-      private
-        def internal_update(key)
-          if key.respond_to?(:cache_key)
-            update_version(key)
-            update_key(key.cache_key.to_s)
-          else
-            split_key(key)
-          end
-        end
-
-        def update_key(key)
-          @cache_key << "/" unless @empty_key
-          @cache_key << key.to_param.to_s
-          @empty_key = false
-        end
-
-        def update_version(key)
-          if key.respond_to?(:cache_version)
-            @cache_version << "/" unless @cache_version.empty?
-            @cache_version << key.cache_version.to_param.to_s
-          else
-            split_version(key)
-          end
-        end
-
-        def split_key(key)
-          case key
-          when Array
-            key.each { |k| internal_update(k) }
-          when Hash
-            key = key.to_a
-            update_version(key)
-            key.sort_by! { |k, _| k.to_s }
-            key.each { |k, v| update_key("#{k}=#{v}") }
-          else
-            if key.respond_to?(:to_a) && !key.nil?
-              internal_update(key.to_a)
-            else
-              update_version(key)
-              update_key(key)
-            end
-          end
-        end
-
-        def split_version(key)
-          if key.is_a?(Array)
-            key.each { |k| update_version(k) }
-          elsif key.respond_to?(:to_a)
-            split_version(key.to_a)
-          end
-        end
     end
   end
 end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -113,6 +113,7 @@ module ActiveSupport
         @cache_version ||= begin
           cache_method_obj.send(:expanded_version, @key_parts)
         end
+        return nil if @cache_version == "/"
       end
 
       def cache_key_with_version

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -19,99 +19,30 @@ module ActiveSupport
     #   k1.cache_key == k2.cache_key
     #   # => true
     #
-    # In addition to passing a key into the initialize method,
-    # key fragments can be added onto an existing key through the
-    # `<<` method.
-    #
-    # Example:
-    #
-    #   key = Key.new
-    #   key << "foo"
-    #   key << "bar"
-    #   key.cache_key
-    #   # => "foo/bar"
-    #
-    # Multiple key entries generate the same key regardless of how
-    # they are added. I.e. if they're added via multiple arrays
-    # or directly via the `<<` operator.
-    #
-    # Example:
-    #
-    #   k1 = Key.new("foo")
-    #   k1 << "bar"
-    #   k2 = Key.new(["foo", "bar"])
-    #   k1.cache_key == k2.cache_key
-    #   # => true
-    #   k3 = Key.new(["foo", ["bar"]])
-    #   k2.cache_key == k3.cache_key
-    #   # => true
-    #
-    # It is faster to directly add objects to the
-    # Key object via `<<` than to generate
-    # an intermediate array of objects.
-    #
-    # The class supports strings, arrays, hashes,
-    # objects with a `cache_key` method and anything
-    # that can be implicitly cast to a string:
-    #
-    # Examples:
-    #
-    #   Key.new("foo").cache_key
-    #   # => "foo"
-    #
-    #   Key.new(["foo", "bar"]).cache_key
-    #   # => "foo/bar"
-    #
-    #   Key.new({ bar: 1, foo: 2 }).cache_key
-    #   # => "bar=1/foo=2"
-    #
-    #   klass = Class.new { def cache_key; "foo"; end }
-    #   Key.new(klass.new).cache_key
-    #   # => "foo"
-    #
-    # In addition to generating a `cache_key`,
-    # a `cache_version` is also generated if the object
-    # passed in responds to `cache_version` or if it contains
-    # an element that responds to `cache_version`.
-    #
-    # The purpose of keeping this value seperate from
-    # `cache_key` is to support the use of "cache versioning"
-    # where the same key is recycled but the version of the object
-    # being stored is kept directly in the cache.
-    #
-    # Example:
-    #
-    #   klass = Class.new { def cache_version; "foo"; end }
-    #   Key.new(klass.new).cache_version
-    #   # => "foo"
-    #
-    #   klass = Class.new { def cache_version; "foo"; end }
-    #   Key.new([klass.new]).cache_version
-    #   # => "foo"
-    #
-    #   klass = Class.new { def cache_version; "foo"; end }
-    #   Key.new({foo: klass.new}).cache_version
-    #   # => "foo"
     class Key # :nodoc:
-      DEFAULT_KEY = Object.new
-      CACHE_METHOD_OBJ = ActiveSupport::Cache::Store.new
-      @@has_rails_cache = :unknown
+      @cache_object = nil
 
-      def initialize(key = DEFAULT_KEY)
+      def self.cache_object
+        return @cache_object if @cache_object
+        if defined?(Rails) && Rails.respond_to?(:cache)
+          @cache_object = Rails.cache
+        else
+          @cache_object = ActiveSupport::Cache::Store.new
+        end
+      end
+
+      def initialize(key)
+        @key_parts = [key]
         @cache_key = nil
         @cache_version = nil
-        @key_parts = []
-        @cache_method_obj = cache_method_obj
-
-        self << key unless key == DEFAULT_KEY
       end
 
       def cache_key
-        @cache_key ||= @cache_method_obj.send(:expanded_key, @key_parts)
+        @cache_key ||= self.class.cache_object.send(:expanded_key, @key_parts)
       end
 
       def cache_version
-        @cache_version ||= @cache_method_obj.send(:expanded_version, @key_parts)
+        @cache_version ||= self.class.cache_object.send(:expanded_version, @key_parts)
 
         if @cache_version == "/"
           nil

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/cache"
-
 module ActiveSupport
   module Cache
     # This class is responsible for coercing input into a valid
@@ -52,7 +50,7 @@ module ActiveSupport
       end
 
       def cache_key_with_version
-        @cache_method_obj.send(:retrieve_cache_key, @key_parts)
+        self.class.cache_object.send(:retrieve_cache_key, @key_parts)
       end
 
       def update(key)
@@ -66,19 +64,6 @@ module ActiveSupport
       def length
         cache_key.length
       end
-
-      private
-        def cache_method_obj
-          if @@has_rails_cache == :unknown
-            @@has_rails_cache = defined?(Rails) && Rails.respond_to?(:cache)
-          end
-
-          if @@has_rails_cache
-            Rails.cache
-          else
-            CACHE_METHOD_OBJ
-          end
-        end
     end
   end
 end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -41,12 +41,6 @@ module ActiveSupport
 
       def cache_version
         @cache_version ||= self.class.cache_object.send(:expanded_version, @key_parts)
-
-        if @cache_version == "/"
-          nil
-        else
-          @cache_version
-        end
       end
 
       def cache_key_with_version

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -20,31 +20,23 @@ module ActiveSupport
     class Key # :nodoc:
       @cache_object = nil
 
-      def self.cache_object
-        return @cache_object if @cache_object
-        if defined?(Rails) && Rails.respond_to?(:cache)
-          @cache_object = Rails.cache
-        else
-          @cache_object = ActiveSupport::Cache::Store.new
-        end
-      end
-
-      def initialize(key)
+      def initialize(key, cache_object = self.class.default_cache_object)
         @key_parts = [key]
         @cache_key = nil
         @cache_version = nil
+        @cache_object = cache_object
       end
 
       def cache_key
-        @cache_key ||= self.class.cache_object.send(:expanded_key, @key_parts)
+        @cache_key ||= @cache_object.send(:expanded_key, @key_parts)
       end
 
       def cache_version
-        @cache_version ||= self.class.cache_object.send(:expanded_version, @key_parts)
+        @cache_version ||= @cache_object.send(:expanded_version, @key_parts)
       end
 
       def cache_key_with_version
-        self.class.cache_object.send(:retrieve_cache_key, @key_parts)
+        @cache_object.send(:retrieve_cache_key, @key_parts)
       end
 
       def update(key)
@@ -54,6 +46,15 @@ module ActiveSupport
         self
       end
       alias :<< :update
+
+      def self.default_cache_object
+        return @cache_object if @cache_object
+        if defined?(Rails) && Rails.respond_to?(:cache)
+          @cache_object = Rails.cache
+        else
+          @cache_object = ActiveSupport::Cache::Store.new
+        end
+      end
     end
   end
 end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -96,7 +96,6 @@ module ActiveSupport
       DEFAULT_KEY = Object.new
       CACHE_METHOD_OBJ = ActiveSupport::Cache::Store.new
 
-
       def initialize(key = DEFAULT_KEY)
         @cache_key = nil
         @cache_version = nil
@@ -106,22 +105,18 @@ module ActiveSupport
 
       def cache_key
         @cache_key ||= begin
-          CACHE_METHOD_OBJ.send(:expanded_key, @key_parts)
+          cache_method_obj.send(:expanded_key, @key_parts)
         end
       end
 
       def cache_version
         @cache_version ||= begin
-          CACHE_METHOD_OBJ.send(:expanded_version, @key_parts)
+          cache_method_obj.send(:expanded_version, @key_parts)
         end
       end
 
-      def length
-        cache_key.length
-      end
-
       def cache_key_with_version
-        CACHE_METHOD_OBJ.send(:retrieve_cache_key, @key_parts)
+        cache_method_obj.send(:retrieve_cache_key, @key_parts)
       end
 
       def update(key)
@@ -131,6 +126,15 @@ module ActiveSupport
         self
       end
       alias :<< :update
+
+      def length
+        cache_key.length
+      end
+
+      private
+        def cache_method_obj
+          defined?(Rails) && Rails.respond_to?(:cache) ? Rails.cache : CACHE_METHOD_OBJ
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/cache'
+require "active_support/cache"
 
 module ActiveSupport
   module Cache

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Cache
+    # Convenience method to prevent re-generating a Key
+    # instance, if the element being passed in is already
+    # instance of the `Key` class.
+    #
+    # Example:
+    #
+    #   ActiveSupport::Cache::Key("foo").cache_key
+    #    # => "foo"
+    #
+    #   k1 = Key.new("foo")
+    #   key = ActiveSupport::Cache::Key(k1)
+    #   k1.object_id == key.object_id # => true
+    def self.Key(key_or_components) # :nodoc:
+      if key_or_components.is_a?(ActiveSupport::Cache::Key)
+        key_or_components
+      else
+        Key.new(key_or_components)
+      end
+    end
+
+    # This class is responsible for coercing input into a valid
+    # key format and cache version for cache stores.
+    #
+    # The goal of this class is to provide a composable way
+    # to build keys. You can put an instance of Key
+    # into another instance of Key and it should produce
+    # the same `cache_key` and `cache_version`.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k2 = Key.new(k1)
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #
+    # In addition to passing a key into the initialize method,
+    # key fragments can be added onto an existing key through the
+    # `<<` method.
+    #
+    # Example:
+    #
+    #   key = Key.new
+    #   key << "foo"
+    #   key << "bar"
+    #   key.cache_key
+    #   # => "foo/bar"
+    #
+    # Multiple key entries generate the same key regardless of how
+    # they are added. I.e. if they're added via multiple arrays
+    # or directly via the `<<` operator.
+    #
+    # Example:
+    #
+    #   k1 = Key.new("foo")
+    #   k1 << "bar"
+    #   k2 = Key.new(["foo", "bar"])
+    #   k1.cache_key == k2.cache_key
+    #   # => true
+    #   k3 = Key.new(["foo", ["bar"]])
+    #   k2.cache_key == k3.cache_key
+    #   # => true
+    #
+    # It is faster to directly add objects to the
+    # Key object via `<<` than to generate
+    # an intermediate array of objects.
+    #
+    # The class supports strings, arrays, hashes,
+    # objects with a `cache_key` method and anything
+    # that can be implicitly cast to a string:
+    #
+    # Examples:
+    #
+    #   Key.new("foo").cache_key
+    #   # => "foo"
+    #
+    #   Key.new(["foo", "bar"]).cache_key
+    #   # => "foo/bar"
+    #
+    #   Key.new({ bar: 1, foo: 2 }).cache_key
+    #   # => "bar=1/foo=2"
+    #
+    #   klass = Class.new { def cache_key; "foo"; end }
+    #   Key.new(klass.new).cache_key
+    #   # => "foo"
+    #
+    # In addition to generating a `cache_key`,
+    # a `cache_version` is also generated if the object
+    # passed in responds to `cache_version` or if it contains
+    # an element that responds to `cache_version`.
+    #
+    # The purpose of keeping this value seperate from
+    # `cache_key` is to support the use of "cache versioning"
+    # where the same key is recycled but the version of the object
+    # being stored is kept directly in the cache.
+    #
+    # Example:
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new(klass.new).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new([klass.new]).cache_version
+    #   # => "foo"
+    #
+    #   klass = Class.new { def cache_version; "foo"; end }
+    #   Key.new({foo: klass.new}).cache_version
+    #   # => "foo"
+    class Key # :nodoc:
+      attr_reader :cache_key, :cache_version
+
+      def initialize(key = nil)
+        @cache_key = +""
+        @cache_version = +""
+        @empty_key = true
+        @key_parts = []
+        self << key
+      end
+
+      def length
+        @cache_key.length
+      end
+
+      def self.cache_key_with_version(key)
+        case
+        when key.respond_to?(:cache_key_with_version) then key.cache_key_with_version
+        when key.respond_to?(:cache_key)              then key.cache_key
+        when key.is_a?(Array)                         then key.map { |element| cache_key_with_version(element) }.to_param
+        when key.respond_to?(:to_a)                   then cache_key_with_version(key.to_a)
+        else                                               key.to_param
+        end.to_s
+      end
+
+      def cache_key_with_version(key = @key_parts)
+        self.class.cache_key_with_version(key)
+      end
+
+      def update(key)
+        @key_parts << key
+        internal_update(key)
+        self
+      end
+      alias :<< :update
+
+      private
+        def internal_update(key)
+          if key.respond_to?(:cache_key)
+            update_version(key)
+            update_key(key.cache_key.to_s)
+          else
+            split_key(key)
+          end
+        end
+
+        def update_key(key)
+          @cache_key << "/" unless @empty_key
+          @cache_key << key.to_param.to_s
+          @empty_key = false
+        end
+
+        def update_version(key)
+          if key.respond_to?(:cache_version)
+            @cache_version << "/" unless @cache_version.empty?
+            @cache_version << key.cache_version.to_param.to_s
+          else
+            split_version(key)
+          end
+        end
+
+        def split_key(key)
+          case key
+          when Array
+            key.each { |k| internal_update(k) }
+          when Hash
+            key = key.to_a
+            update_version(key)
+            key.sort_by! { |k, _| k.to_s }
+            key.each { |k, v| update_key("#{k}=#{v}") }
+          else
+            if key.respond_to?(:to_a) && !key.nil?
+              internal_update(key.to_a)
+            else
+              update_version(key)
+              update_key(key)
+            end
+          end
+        end
+
+        def split_version(key)
+          if key.is_a?(Array)
+            key.each { |k| update_version(k) }
+          elsif key.respond_to?(:to_a)
+            split_version(key.to_a)
+          end
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/cache/key.rb
+++ b/activesupport/lib/active_support/cache/key.rb
@@ -60,10 +60,6 @@ module ActiveSupport
         self
       end
       alias :<< :update
-
-      def length
-        cache_key.length
-      end
     end
   end
 end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -21,8 +21,9 @@ module CacheStoreBehavior
   end
 
   def test_fetch_with_cache_miss
-    assert_called_with(@cache, :write, ["foo", "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch("foo") { "baz" }
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
+      assert_equal "baz", @cache.fetch(key) { "baz" }
     end
   end
 
@@ -39,8 +40,9 @@ module CacheStoreBehavior
   def test_fetch_with_forced_cache_miss
     @cache.write("foo", "bar")
     assert_not_called(@cache, :read) do
-      assert_called_with(@cache, :write, ["foo", "bar", @cache.options.merge(force: true)]) do
-        @cache.fetch("foo", force: true) { "bar" }
+      key = ActiveSupport::Cache::Key.new("foo")
+      assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(force: true)]) do
+        @cache.fetch(key, force: true) { "bar" }
       end
     end
   end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -79,7 +79,7 @@ class KeyTest < ActiveSupport::TestCase
     assert_equal "//", key.cache_key
 
     key = ActiveSupport::Cache::Key.new([ :foo, [], [], :bar ])
-    assert_equal "foo/bar", key.cache_key
+    assert_equal "foo///bar", key.cache_key
   end
 
   def test_nested_to_a_cache_versions
@@ -90,16 +90,11 @@ class KeyTest < ActiveSupport::TestCase
 
   def test_call_returns_original_if_key
     k1 = ActiveSupport::Cache::Key.new("foo")
-    k2 = ActiveSupport::Cache::Key(k1)
-    assert_equal k1, k2
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_key, k2.cache_key
 
-    key = ActiveSupport::Cache::Key("foo")
+    key = ActiveSupport::Cache::Key.new("foo")
     assert_equal ActiveSupport::Cache::Key, key.class
     assert_equal "foo", key.cache_key
-  end
-
-  def test_enum
-    k1 = ActiveSupport::Cache::Key.new([1, 2, 3].to_enum)
-    assert_equal "1/2/3", k1.cache_key
   end
 end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/cache"
+
+class KeyTest < ActiveSupport::TestCase
+  def test_composability
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_key, k2.cache_key
+  end
+
+  def test_composable_elements
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k1 << "bar"
+    assert_equal "foo/bar", k1.cache_key
+
+    k2 = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal k1.cache_key, k2.cache_key
+
+    k3 = ActiveSupport::Cache::Key.new(["foo", ["bar"]])
+    assert_equal k2.cache_key, k3.cache_key
+  end
+
+  def test_cache_types
+    key = ActiveSupport::Cache::Key.new("foo")
+    assert_equal "foo", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["foo", "bar"])
+    assert_equal "foo/bar", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(bar: 1, foo: 2)
+    assert_equal "bar=1/foo=2", key.cache_key
+
+    klass = Class.new { def cache_key; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_key
+  end
+
+  def test_cache_version
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new([klass.new])
+    assert_equal "foo", key.cache_version
+
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(foo: klass.new)
+    assert_equal "foo", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "foo/foo", key.cache_version
+
+    klass = Class.new { def cache_version; nil; end }
+    key = ActiveSupport::Cache::Key.new(klass.new)
+    assert_equal "", key.cache_version
+
+    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
+    assert_equal "", key.cache_version
+  end
+
+  def test_cache_version_composability
+    klass = Class.new { def cache_version; "foo"; end }
+    k1 = ActiveSupport::Cache::Key.new(klass.new)
+    k2 = ActiveSupport::Cache::Key.new(k1)
+    assert_equal k1.cache_version, k2.cache_version
+  end
+
+  def test_nil_and_empty_keys
+    key = ActiveSupport::Cache::Key.new([ :a, nil, :b, "", :c ])
+    assert_equal "a//b//c", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(hello: nil, world: "today", nil: "rules")
+    assert_equal "hello=/nil=rules/world=today", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new(["", "", ""])
+    assert_equal "//", key.cache_key
+
+    key = ActiveSupport::Cache::Key.new([ :foo, [], [], :bar ])
+    assert_equal "foo/bar", key.cache_key
+  end
+
+  def test_nested_to_a_cache_versions
+    klass = Class.new { def cache_version; "foo"; end }
+    key = ActiveSupport::Cache::Key.new(hello: { world: klass.new })
+    assert_equal "foo", key.cache_version
+  end
+
+  def test_call_returns_original_if_key
+    k1 = ActiveSupport::Cache::Key.new("foo")
+    k2 = ActiveSupport::Cache::Key(k1)
+    assert_equal k1, k2
+
+    key = ActiveSupport::Cache::Key("foo")
+    assert_equal ActiveSupport::Cache::Key, key.class
+    assert_equal "foo", key.cache_key
+  end
+
+  def test_enum
+    k1 = ActiveSupport::Cache::Key.new([1, 2, 3].to_enum)
+    assert_equal "1/2/3", k1.cache_key
+  end
+end

--- a/activesupport/test/cache/key_test.rb
+++ b/activesupport/test/cache/key_test.rb
@@ -3,98 +3,103 @@
 require "abstract_unit"
 require "active_support/cache"
 
-class KeyTest < ActiveSupport::TestCase
-  def test_composability
-    k1 = ActiveSupport::Cache::Key.new("foo")
-    k2 = ActiveSupport::Cache::Key.new(k1)
-    assert_equal k1.cache_key, k2.cache_key
-  end
 
-  def test_composable_elements
-    k1 = ActiveSupport::Cache::Key.new("foo")
-    k1 << "bar"
-    assert_equal "foo/bar", k1.cache_key
+module ActiveSupport
+  module Cache
+    class KeyTest < ActiveSupport::TestCase
+      def test_composability
+        k1 = Key.new("foo")
+        k2 = Key.new(k1)
+        assert_equal k1.cache_key, k2.cache_key
+      end
 
-    k2 = ActiveSupport::Cache::Key.new(["foo", "bar"])
-    assert_equal k1.cache_key, k2.cache_key
+      def test_composable_elements
+        k1 = Key.new("foo")
+        k1 << "bar"
+        assert_equal "foo/bar", k1.cache_key
 
-    k3 = ActiveSupport::Cache::Key.new(["foo", ["bar"]])
-    assert_equal k2.cache_key, k3.cache_key
-  end
+        k2 = Key.new(["foo", "bar"])
+        assert_equal k1.cache_key, k2.cache_key
 
-  def test_cache_types
-    key = ActiveSupport::Cache::Key.new("foo")
-    assert_equal "foo", key.cache_key
+        k3 = Key.new(["foo", ["bar"]])
+        assert_equal k2.cache_key, k3.cache_key
+      end
 
-    key = ActiveSupport::Cache::Key.new(["foo", "bar"])
-    assert_equal "foo/bar", key.cache_key
+      def test_cache_types
+        key = Key.new("foo")
+        assert_equal "foo", key.cache_key
 
-    key = ActiveSupport::Cache::Key.new(bar: 1, foo: 2)
-    assert_equal "bar=1/foo=2", key.cache_key
+        key = Key.new(["foo", "bar"])
+        assert_equal "foo/bar", key.cache_key
 
-    klass = Class.new { def cache_key; "foo"; end }
-    key = ActiveSupport::Cache::Key.new(klass.new)
-    assert_equal "foo", key.cache_key
-  end
+        key = Key.new(bar: 1, foo: 2)
+        assert_equal "bar=1/foo=2", key.cache_key
 
-  def test_cache_version
-    klass = Class.new { def cache_version; "foo"; end }
-    key = ActiveSupport::Cache::Key.new(klass.new)
-    assert_equal "foo", key.cache_version
+        klass = Class.new { def cache_key; "foo"; end }
+        key = Key.new(klass.new)
+        assert_equal "foo", key.cache_key
+      end
 
-    klass = Class.new { def cache_version; "foo"; end }
-    key = ActiveSupport::Cache::Key.new([klass.new])
-    assert_equal "foo", key.cache_version
+      def test_cache_version
+        klass = Class.new { def cache_version; "foo"; end }
+        key = Key.new(klass.new)
+        assert_equal "foo", key.cache_version
 
-    klass = Class.new { def cache_version; "foo"; end }
-    key = ActiveSupport::Cache::Key.new(foo: klass.new)
-    assert_equal "foo", key.cache_version
+        klass = Class.new { def cache_version; "foo"; end }
+        key = Key.new([klass.new])
+        assert_equal "foo", key.cache_version
 
-    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
-    assert_equal "foo/foo", key.cache_version
+        klass = Class.new { def cache_version; "foo"; end }
+        key = Key.new(foo: klass.new)
+        assert_equal "foo", key.cache_version
 
-    klass = Class.new { def cache_version; nil; end }
-    key = ActiveSupport::Cache::Key.new(klass.new)
-    assert_equal "", key.cache_version
+        key = Key.new([klass.new, klass.new])
+        assert_equal "foo/foo", key.cache_version
 
-    key = ActiveSupport::Cache::Key.new([klass.new, klass.new])
-    assert_equal "", key.cache_version
-  end
+        klass = Class.new { def cache_version; nil; end }
+        key = Key.new(klass.new)
+        assert_equal "", key.cache_version
 
-  def test_cache_version_composability
-    klass = Class.new { def cache_version; "foo"; end }
-    k1 = ActiveSupport::Cache::Key.new(klass.new)
-    k2 = ActiveSupport::Cache::Key.new(k1)
-    assert_equal k1.cache_version, k2.cache_version
-  end
+        key = Key.new([klass.new, klass.new])
+        assert_equal "", key.cache_version
+      end
 
-  def test_nil_and_empty_keys
-    key = ActiveSupport::Cache::Key.new([ :a, nil, :b, "", :c ])
-    assert_equal "a//b//c", key.cache_key
+      def test_cache_version_composability
+        klass = Class.new { def cache_version; "foo"; end }
+        k1 = Key.new(klass.new)
+        k2 = Key.new(k1)
+        assert_equal k1.cache_version, k2.cache_version
+      end
 
-    key = ActiveSupport::Cache::Key.new(hello: nil, world: "today", nil: "rules")
-    assert_equal "hello=/nil=rules/world=today", key.cache_key
+      def test_nil_and_empty_keys
+        key = Key.new([ :a, nil, :b, "", :c ])
+        assert_equal "a//b//c", key.cache_key
 
-    key = ActiveSupport::Cache::Key.new(["", "", ""])
-    assert_equal "//", key.cache_key
+        key = Key.new(hello: nil, world: "today", nil: "rules")
+        assert_equal "hello=/nil=rules/world=today", key.cache_key
 
-    key = ActiveSupport::Cache::Key.new([ :foo, [], [], :bar ])
-    assert_equal "foo///bar", key.cache_key
-  end
+        key = Key.new(["", "", ""])
+        assert_equal "//", key.cache_key
 
-  def test_nested_to_a_cache_versions
-    klass = Class.new { def cache_version; "foo"; end }
-    key = ActiveSupport::Cache::Key.new(hello: { world: klass.new })
-    assert_equal "foo", key.cache_version
-  end
+        key = Key.new([ :foo, [], [], :bar ])
+        assert_equal "foo///bar", key.cache_key
+      end
 
-  def test_call_returns_original_if_key
-    k1 = ActiveSupport::Cache::Key.new("foo")
-    k2 = ActiveSupport::Cache::Key.new(k1)
-    assert_equal k1.cache_key, k2.cache_key
+      def test_nested_to_a_cache_versions
+        klass = Class.new { def cache_version; "foo"; end }
+        key = Key.new(hello: { world: klass.new })
+        assert_equal "foo", key.cache_version
+      end
 
-    key = ActiveSupport::Cache::Key.new("foo")
-    assert_equal ActiveSupport::Cache::Key, key.class
-    assert_equal "foo", key.cache_key
+      def test_call_returns_original_if_key
+        k1 = Key.new("foo")
+        k2 = Key.new(k1)
+        assert_equal k1.cache_key, k2.cache_key
+
+        key = Key.new("foo")
+        assert_equal Key, key.class
+        assert_equal "foo", key.cache_key
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a "safer" but slower alternative to #36310.

```
Then: 5.97/3.29 => 1.81x faster
Now: 5.97/4.02 => 1.48x faster
```

So the change in performance from #36310 to this PR is  about

```
1 - 3.29/4.02 => 18% # slower than #36310 but still 1.48x faster than master.
```

In #36310 performance was the main goal. In this PR the primary goal was to change as little as possible, performance was the secondary goal. The main difference between the two PRs comes from how `cache_version` and `cache_key` are computed. In #36310 that logic was ported over to the `Cache::Key` class where it could be optimized, in this PR the logic was not moved and instead the `Cache::Key` class leverages the `expanded_version` method in their original location.

How does this PR improve performance for rendering a partial and passing in a collection? 

- On master when a key is used in the cache it has to be generated 3 different times. By using the `Cache::Key` class, it is only generated once and then re-used
- On master, the key that represents the view partial that is being rendered is calculated for every object being pulled from cache inside of the loop, in this PR that view key is generated once outside the loop and re-used.

For safety: In addition to not changing the location of the `expanded_version` and `expanded_key` logic, this class will respect any modified logic of the `Rails.cache` store. So if a cache store customizes their version of `expanded_version` then that version will be used when generating the cache.

Here's some raw numbers from the benchmark provided in #36310 when applied to this PR.

```
$ bundle exec ruby perf_scripts/partial_cache.rb
-- create_table(:customers, {:force=>true})
   -> 0.0115s
/Users/rschneeman/Documents/projects/codetriage/perf_scripts/partial_cache
<#ActiveSupport::Cache::MemoryStore entries=1000, size=352893, options={}>
Warming up --------------------------------------
collection render: no cache
                        20.000  i/100ms
collection render: with cache
                         4.000  i/100ms
Calculating -------------------------------------
collection render: no cache
                        199.729  (± 9.0%) i/s -      1.000k in   5.051812s
collection render: with cache
                         49.642  (± 4.0%) i/s -    248.000  in   5.008595s

Comparison:
collection render: no cache:      199.7 i/s
collection render: with cache:       49.6 i/s - 4.02x  slower
```

> Note that while it's still slower, the prior version was 5.97x slower.
