### PR TITLE
Allow multi db `connected_to` to use a config hash supplied via method argument

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -115,7 +115,7 @@ module ActiveRecord
     #
     # When using the database key a new connection will be established every time. It is not
     # recommended to use this outside of one-off scripts.
-    def connected_to(database: nil, role: nil, prevent_writes: false, &blk)
+    def connected_to(database: nil, role: nil, prevent_writes: false, config_hash: nil, &blk)
       if database && role
         raise ArgumentError, "connected_to can only accept a `database` or a `role` argument, but not both arguments."
       elsif database
@@ -138,6 +138,11 @@ module ActiveRecord
         else
           with_handler(role.to_sym, &blk)
         end
+      elsif config_hash
+        handler = lookup_connection_handler(nil)
+        handler.establish_connection(config_hash)
+
+        with_handler(nil, &blk)
       else
         raise ArgumentError, "must provide a `database` or a `role`."
       end


### PR DESCRIPTION
### Summary

Allowing the programmer to supply the config hash would go a long way to helping applications like mine, where it is impractical to edit `database.yml` for each database we have. 

I know there are plans for sharding, and I am not sure how this affects that, but happy to adjust it in a manner that fits your plans. Perhaps this could be a good first step, in allowing the application developer to specify the config information in the program, rather than needing to deploy changes to `database.yml` each time they need a new config option. 

If that's already possible, please let me know. I did try to do it on my own, and to read the source, but I am not confident I didn't miss something. 

Overall, this pull request is a WIP to see if Rails would accept something like it, and give direction on how it might be implemented. I plan to edit CHANGELOG and documentation, error messages, etc. if this approach is acceptable.

Thanks!
