### PR TITLE
Use String#+@ before mutating the result of Symbol#to_s

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -39,7 +39,7 @@ module ActiveSupport
     end
 
     def method_missing(name, *args)
-      name_string = name.to_s
+      name_string = +name.to_s
       if name_string.chomp!("=")
         self[name_string] = args.first
       else


### PR DESCRIPTION
* String#+@ is available since Ruby 2.3.
* See the upstream Ruby change making Symbol#to_s return a frozen String
  for efficiency: https://github.com/ruby/ruby/pull/2437

### Summary

Ruby 2.7 will return a frozen String  for Symbol#to_s to avoid extra allocations:
https://github.com/ruby/ruby/pull/2437
https://bugs.ruby-lang.org/issues/16150#note-18

That is currently an experimental change, but I think it would make a lot of sense and I would expect only few places need to be adapted to handle a frozen Symbol#to_s.