### PR TITLE
[Proposal] WIP Make `t.timestamps` create columns with specified column names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -402,15 +402,18 @@ module ActiveRecord
       # <tt>:updated_at</tt> to the table. See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
       #
       #   t.timestamps null: false
-      def timestamps(**options)
+      def timestamps(*column_names, **options)
         options[:null] = false if options[:null].nil?
 
         if !options.key?(:precision) && @conn.supports_datetime_with_precision?
           options[:precision] = 6
         end
 
-        column(:created_at, :datetime, **options)
-        column(:updated_at, :datetime, **options)
+        column_names = %i[ created_at updated_at ] if column_names.empty?
+
+        column_names.map do |column_name|
+          column(column_name, :datetime, **options)
+        end
       end
 
       # Adds a reference.
@@ -589,10 +592,11 @@ module ActiveRecord
       # Adds timestamps (+created_at+ and +updated_at+) columns to the table.
       #
       #  t.timestamps(null: false)
+      #  t.timestamps(:last_accessed_at, null: false)
       #
       # See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
-      def timestamps(options = {})
-        @base.add_timestamps(name, options)
+      def timestamps(*column_names, **options)
+        @base.add_timestamps(name, *column_names, **options)
       end
 
       # Changes the column's definition according to the new options.
@@ -643,8 +647,8 @@ module ActiveRecord
       #  t.remove_timestamps
       #
       # See {connection.remove_timestamps}[rdoc-ref:SchemaStatements#remove_timestamps]
-      def remove_timestamps(options = {})
-        @base.remove_timestamps(name, options)
+      def remove_timestamps(*column_names, **options)
+        @base.remove_timestamps(name, *column_names, **options)
       end
 
       # Renames a column.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1148,27 +1148,49 @@ module ActiveRecord
 
       # Adds timestamps (+created_at+ and +updated_at+) columns to +table_name+.
       # Additional options (like +:null+) are forwarded to #add_column.
+      # You may provide column names to specify what column should be created.
+      #
+      # Add +created_at+ and +updated_at+ columns to +suppliers+ table.
       #
       #   add_timestamps(:suppliers, null: true)
       #
-      def add_timestamps(table_name, options = {})
+      # Add specific (optional) column names to +suppliers+ table.
+      #
+      #   add_timestamps(:suppliers, :created_at, null: true)
+      #
+      def add_timestamps(table_name, *column_names, **options)
         options[:null] = false if options[:null].nil?
 
         if !options.key?(:precision) && supports_datetime_with_precision?
           options[:precision] = 6
         end
 
-        add_column table_name, :created_at, :datetime, **options
-        add_column table_name, :updated_at, :datetime, **options
+        column_names = %i[ created_at updated_at ] if column_names.empty?
+
+        column_names.map do |column_name|
+          add_column table_name, column_name, :datetime, **options
+        end
       end
 
       # Removes the timestamp columns (+created_at+ and +updated_at+) from the table definition.
+      # You may provide column names to specify what column should be removed.
       #
-      #  remove_timestamps(:suppliers)
+      # Remove +created_at+ and +updated_at+ columns from +suppliers+ table.
       #
-      def remove_timestamps(table_name, options = {})
-        remove_column table_name, :updated_at
-        remove_column table_name, :created_at
+      #   remove_timestamps(:suppliers)
+      #
+      # Remove +updated_at+ column from +suppliers+ table.
+      #
+      #   remove_timestamps(:suppliers, :updated_at)
+      #
+      # The specific optional may equal to +created_at+ or +updated_at+
+      #
+      def remove_timestamps(table_name, *column_names, **options)
+        column_names = %i[ created_at updated_at ] if column_names.empty?
+
+        column_names.map do |column_name|
+          remove_column table_name, column_name
+        end
       end
 
       def update_table_definition(table_name, base) #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -673,18 +673,26 @@ module ActiveRecord
           "DROP INDEX #{quote_column_name(index_name)}"
         end
 
-        def add_timestamps_for_alter(table_name, options = {})
+        def add_timestamps_for_alter(table_name, *column_names, **options)
           options[:null] = false if options[:null].nil?
 
           if !options.key?(:precision) && supports_datetime_with_precision?
             options[:precision] = 6
           end
 
-          [add_column_for_alter(table_name, :created_at, :datetime, options), add_column_for_alter(table_name, :updated_at, :datetime, options)]
+          column_names = %i[ created_at updated_at ] if column_names.empty?
+
+          column_names.map do |column_name|
+            add_column_for_alter(table_name, column_name, :datetime, options)
+          end
         end
 
-        def remove_timestamps_for_alter(table_name, options = {})
-          [remove_column_for_alter(table_name, :updated_at), remove_column_for_alter(table_name, :created_at)]
+        def remove_timestamps_for_alter(table_name, *column_names, **options)
+          column_names = %i[ created_at updated_at ] if column_names.empty?
+
+          column_names.map do |column_name|
+            remove_column_for_alter(table_name, column_name)
+          end
         end
 
         def supports_rename_index?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -719,18 +719,26 @@ module ActiveRecord
             "ALTER COLUMN #{quote_column_name(column_name)} #{null ? 'DROP' : 'SET'} NOT NULL"
           end
 
-          def add_timestamps_for_alter(table_name, options = {})
+          def add_timestamps_for_alter(table_name, *column_names, **options)
             options[:null] = false if options[:null].nil?
 
             if !options.key?(:precision) && supports_datetime_with_precision?
               options[:precision] = 6
             end
 
-            [add_column_for_alter(table_name, :created_at, :datetime, options), add_column_for_alter(table_name, :updated_at, :datetime, options)]
+            column_names = %i[ created_at updated_at ] if column_names.empty?
+
+            column_names.map do |column_name|
+              add_column_for_alter(table_name, column_name, :datetime, options)
+            end
           end
 
-          def remove_timestamps_for_alter(table_name, options = {})
-            [remove_column_for_alter(table_name, :updated_at), remove_column_for_alter(table_name, :created_at)]
+          def remove_timestamps_for_alter(table_name, *column_names, **options)
+            column_names = %i[ created_at updated_at ] if column_names.empty?
+
+            column_names.map do |column_name|
+              remove_column_for_alter(table_name, column_name)
+            end
           end
 
           def add_index_opclass(quoted_columns, **options)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
       class V5_2 < V6_0
         module TableDefinition
-          def timestamps(**options)
+          def timestamps(*column_names, **options)
             options[:precision] ||= nil
             super
           end
@@ -66,7 +66,7 @@ module ActiveRecord
           end
         end
 
-        def add_timestamps(table_name, **options)
+        def add_timestamps(table_name, *column_names, **options)
           options[:precision] ||= nil
           super
         end
@@ -180,7 +180,7 @@ module ActiveRecord
           end
           alias :belongs_to :references
 
-          def timestamps(**options)
+          def timestamps(*column_names, **options)
             options[:null] = true if options[:null].nil?
             super
           end
@@ -192,7 +192,7 @@ module ActiveRecord
         end
         alias :add_belongs_to :add_reference
 
-        def add_timestamps(table_name, **options)
+        def add_timestamps(table_name, *column_names, **options)
           options[:null] = true if options[:null].nil?
           super
         end

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -147,6 +147,17 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_add_timestamps_only_created_at
+    with_real_execute do
+      ActiveRecord::Base.connection.create_table :delete_me
+      ActiveRecord::Base.connection.add_timestamps :delete_me, :created_at, null: true
+      assert_not column_exists?("delete_me", "updated_at", "datetime")
+      assert column_exists?("delete_me", "created_at", "datetime")
+    ensure
+      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
+    end
+  end
+
   def test_remove_timestamps
     with_real_execute do
       ActiveRecord::Base.connection.create_table :delete_me do |t|
@@ -154,6 +165,19 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
       end
       ActiveRecord::Base.connection.remove_timestamps :delete_me, null: true
       assert_not column_exists?("delete_me", "updated_at", "datetime")
+      assert_not column_exists?("delete_me", "created_at", "datetime")
+    ensure
+      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
+    end
+  end
+
+  def test_remove_timestamps_only_created_at
+    with_real_execute do
+      ActiveRecord::Base.connection.create_table :delete_me do |t|
+        t.timestamps null: true
+      end
+      ActiveRecord::Base.connection.remove_timestamps :delete_me, :created_at
+      assert column_exists?("delete_me", "updated_at", "datetime")
       assert_not column_exists?("delete_me", "created_at", "datetime")
     ensure
       ActiveRecord::Base.connection.drop_table :delete_me rescue nil

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -209,5 +209,49 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
       assert @connection.column_exists?(:has_timestamps, :created_at, precision: 6, null: false)
       assert @connection.column_exists?(:has_timestamps, :updated_at, precision: 6, null: false)
     end
+
+    def test_timestamps_with_only_created_at_creates_one_column_on_add_timestamps
+      ActiveRecord::Schema.define do
+        create_table :has_timestamps
+        add_timestamps :has_timestamps, :created_at, default: Time.now
+      end
+
+      assert @connection.column_exists?(:has_timestamps, :created_at, precision: 6, null: false)
+      assert_not @connection.column_exists?(:has_timestamps, :updated_at, precision: 6, null: false)
+    end
+
+    def test_timestamps_with_only_updated_at_creates_one_column_on_add_timestamps
+      ActiveRecord::Schema.define do
+        create_table :has_timestamps
+        add_timestamps :has_timestamps, :updated_at, default: Time.now
+      end
+
+      assert_not @connection.column_exists?(:has_timestamps, :created_at, precision: 6, null: false)
+      assert @connection.column_exists?(:has_timestamps, :updated_at, precision: 6, null: false)
+    end
+
+    def test_timestamps_with_only_updated_at_creates_one_column_on_create_table
+      ActiveRecord::Schema.define do
+        create_table :has_timestamps do |t|
+          t.timestamps :updated_at
+        end
+      end
+
+      assert_not @connection.column_exists?(:has_timestamps, :created_at, null: false)
+      assert @connection.column_exists?(:has_timestamps, :updated_at, null: false)
+    end
+
+    def test_timestamps_with_only_updated_at_creates_one_column_on_change_table
+      ActiveRecord::Schema.define do
+        create_table :has_timestamps
+
+        change_table :has_timestamps do |t|
+          t.timestamps :updated_at, default: Time.now
+        end
+      end
+
+      assert_not @connection.column_exists?(:has_timestamps, :created_at, null: false)
+      assert @connection.column_exists?(:has_timestamps, :updated_at, null: false)
+    end
   end
 end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -94,10 +94,24 @@ module ActiveRecord
         end
       end
 
-      def test_remove_timestamps_creates_updated_at_and_created_at
+      def test_timestamps_creates_only_created_at
+        with_change_table do |t|
+          @connection.expect :add_timestamps, nil, [:delete_me, :created_at, null: true]
+          t.timestamps :created_at, null: true
+        end
+      end
+
+      def test_remove_timestamps_removes_updated_at_and_created_at
         with_change_table do |t|
           @connection.expect :remove_timestamps, nil, [:delete_me, { null: true }]
-          t.remove_timestamps(null: true)
+          t.remove_timestamps null: true
+        end
+      end
+
+      def test_remove_timestamps_removes_only_created_at
+        with_change_table do |t|
+          @connection.expect :remove_timestamps, nil, [:delete_me, :created_at, { null: true }]
+          t.remove_timestamps :created_at, null: true
         end
       end
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -300,9 +300,19 @@ module ActiveRecord
         assert_equal [:remove_timestamps, [:table], nil], remove
       end
 
+      def test_invert_add_timestamps_with_only_option
+        remove = @recorder.inverse_of :add_timestamps, [:table, :created_at]
+        assert_equal [:remove_timestamps, [:table, :created_at], nil], remove
+      end
+
       def test_invert_remove_timestamps
         add = @recorder.inverse_of :remove_timestamps, [:table, { null: true }]
         assert_equal [:add_timestamps, [:table, { null: true }], nil], add
+      end
+
+      def test_invert_remove_timestamps_with_only_option
+        add = @recorder.inverse_of :remove_timestamps, [:table, :created_at, { null: true }]
+        assert_equal [:add_timestamps, [:table, :created_at, { null: true }], nil], add
       end
 
       def test_invert_add_reference

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -200,6 +200,34 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
       end
 
+      def test_timestamps_create_only_one_field_on_add_timestamps
+        migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def migrate(x)
+            add_timestamps :testings, :updated_at, default: Time.now
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+        assert_not connection.column_exists?(:testings, :created_at, null: false, **precision_implicit_default)
+        assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
+      end
+
+      def test_timestamps_create_only_one_field_on_change_table
+        migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def migrate(x)
+            change_table :testings do |t|
+              t.timestamps :updated_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+        assert_not connection.column_exists?(:testings, :created_at, null: false, **precision_implicit_default)
+        assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
+      end
+
       def test_legacy_migrations_raises_exception_when_inherited
         e = assert_raises(StandardError) do
           class_eval("class LegacyMigration < ActiveRecord::Migration; end")


### PR DESCRIPTION
## Summary

When creating a new migration in Rails we can specify timestamps:

```
class AddTimestampsToCars < ActiveRecord::Migration[6.0]
  def change
    add_timestamps :cars
  end
end
```

In general case it will create `created_at` and `updated_at` with `null: false` and `precision: 6`

```
t.datetime "created_at", precision: 6, null: false
t.datetime "updated_at", precision: 6, null: false
```

This patch adds the ability to selectively specify `datetime` columns, because in some cases we do not need two columns

```
add_timestamps :cars, :created_at
and
remove_timestamps :cars, :created_at
```
or you can create a bulk of columns:
```
create_table :posts do |t|
  t.timestamps :processed_at, :linked_at, :posted_at
end
```

Of course, we can create one column via `add_column`, but in this case, we have to not forget to add `:null` and `:precision` options
