### PR TITLE
Implicitly assert no exception is raised in block assertions

### DIFF
--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -42,10 +42,10 @@ module ActionCable
     #     end
     #   end
     #
-    def assert_broadcasts(stream, number)
+    def assert_broadcasts(stream, number, &block)
       if block_given?
         original_count = broadcasts_size(stream)
-        yield
+        assert_nothing_raised(&block)
         new_count = broadcasts_size(stream)
         actual_count = new_count - original_count
       else
@@ -94,7 +94,7 @@ module ActionCable
     #     end
     #   end
     #
-    def assert_broadcast_on(stream, data)
+    def assert_broadcast_on(stream, data, &block)
       # Encode to JSON and back–we want to use this value to compare
       # with decoded JSON.
       # Comparing JSON strings doesn't work due to the order if the keys.
@@ -106,7 +106,7 @@ module ActionCable
         old_messages = new_messages
         clear_messages(stream)
 
-        yield
+        assert_nothing_raised(&block)
         new_messages = broadcasts(stream)
         clear_messages(stream)
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -613,8 +613,8 @@ module RequestForgeryProtectionTests
     assert_response :success
   end
 
-  def assert_not_blocked
-    assert_nothing_raised { yield }
+  def assert_not_blocked(&block)
+    assert_nothing_raised(&block)
     assert_response :success
   end
 
@@ -1019,8 +1019,8 @@ class SkipProtectionControllerTest < ActionController::TestCase
     end
   end
 
-  def assert_not_blocked
-    assert_nothing_raised { yield }
+  def assert_not_blocked(&block)
+    assert_nothing_raised(&block)
     assert_response :success
   end
 end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -117,11 +117,11 @@ module ActiveJob
     #       HelloJob.perform_later('elfassy')
     #     end
     #   end
-    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil)
+    def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil, &block)
       if block_given?
         original_count = enqueued_jobs_with(only: only, except: except, queue: queue)
 
-        yield
+        assert_nothing_raised(&block)
 
         new_count = enqueued_jobs_with(only: only, except: except, queue: queue)
 
@@ -379,7 +379,7 @@ module ActiveJob
     #       MyJob.set(wait_until: Date.tomorrow.noon).perform_later
     #     end
     #   end
-    def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
+    def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil, &block)
       expected = { job: job, args: args, at: at, queue: queue }.compact
       expected_args = prepare_args_for_assertion(expected)
       potential_matches = []
@@ -387,7 +387,7 @@ module ActiveJob
       if block_given?
         original_enqueued_jobs_count = enqueued_jobs.count
 
-        yield
+        assert_nothing_raised(&block)
 
         jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
       else
@@ -550,7 +550,7 @@ module ActiveJob
     #
     # If the +:at+ option is specified, then only run jobs enqueued to run
     # immediately or before the given time
-    def perform_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil)
+    def perform_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil, &block)
       return flush_enqueued_jobs(only: only, except: except, queue: queue, at: at) unless block_given?
 
       validate_option(only: only, except: except)
@@ -570,7 +570,7 @@ module ActiveJob
         queue_adapter.queue = queue
         queue_adapter.at = at
 
-        yield
+        assert_nothing_raised(&block)
       ensure
         queue_adapter.perform_enqueued_jobs = old_perform_enqueued_jobs
         queue_adapter.perform_enqueued_at_jobs = old_perform_enqueued_at_jobs

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -162,10 +162,12 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_job_error_logging
-    perform_enqueued_jobs { RescueJob.perform_later "other" }
-  rescue RescueJob::OtherError
-    assert_match(/Performing RescueJob \(Job ID: .*?\) from .*? with arguments:.*other/, @logger.messages)
-    assert_match(/Error performing RescueJob \(Job ID: .*?\) from .*? in .*ms: RescueJob::OtherError \(Bad hair\):\n.*\brescue_job\.rb:\d+:in `perform'/, @logger.messages)
+    perform_enqueued_jobs do
+      RescueJob.perform_later "other"
+    rescue RescueJob::OtherError
+      assert_match(/Performing RescueJob \(Job ID: .*?\) from .*? with arguments:.*other/, @logger.messages)
+      assert_match(/Error performing RescueJob \(Job ID: .*?\) from .*? in .*ms: RescueJob::OtherError \(Bad hair\):\n.*\brescue_job\.rb:\d+:in `perform'/, @logger.messages)
+    end
   end
 
   def test_enqueue_retry_logging

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -30,6 +30,8 @@ module ActiveSupport
       #   end
       def assert_nothing_raised
         yield
+      rescue => error
+        raise Minitest::UnexpectedError.new(error)
       end
 
       # Test numeric difference between the return value of an expression as a
@@ -95,7 +97,7 @@ module ActiveSupport
         }
         before = exps.map(&:call)
 
-        retval = yield
+        retval = assert_nothing_raised(&block)
 
         expressions.zip(exps, before) do |(code, diff), exp, before_value|
           error  = "#{code.inspect} didn't change by #{diff}"
@@ -172,7 +174,7 @@ module ActiveSupport
         exp = expression.respond_to?(:call) ? expression : -> { eval(expression.to_s, block.binding) }
 
         before = exp.call
-        retval = yield
+        retval = assert_nothing_raised(&block)
 
         unless from == UNTRACKED
           error = "#{expression.inspect} isn't #{from.inspect}"
@@ -214,7 +216,7 @@ module ActiveSupport
         exp = expression.respond_to?(:call) ? expression : -> { eval(expression.to_s, block.binding) }
 
         before = exp.call
-        retval = yield
+        retval = assert_nothing_raised(&block)
         after = exp.call
 
         error = "#{expression.inspect} did change to #{after}"

--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -27,7 +27,7 @@ module Rails
           assert File.exist?(absolute), "Expected file #{relative.inspect} to exist, but does not"
 
           read = File.read(absolute) if block_given? || !contents.empty?
-          yield read if block_given?
+          assert_nothing_raised { yield read } if block_given?
 
           contents.each do |content|
             case content
@@ -99,7 +99,7 @@ module Rails
         #   end
         def assert_instance_method(method, content)
           assert content =~ /(\s+)def #{method}(\(.+\))?(.*?)\n\1end/m, "Expected to have method #{method}"
-          yield $3.strip if block_given?
+          assert_nothing_raised { yield $3.strip } if block_given?
         end
         alias :assert_method :assert_instance_method
 


### PR DESCRIPTION
Ref: https://github.com/Shopify/statsd-instrument/pull/184#issuecomment-535425202

This simply a quick proof of concept to showcase a fairly nasty foot gun with some block based assertions. See [this comment chain for the initial discussion](https://github.com/Shopify/statsd-instrument/pull/184#issuecomment-535425202), but I'll explain it all here.

### The problem

See the following test case:

```ruby
class CounterTest < ActiveSupport::TestCase
  class Counter
    attr_reader :count

    def initialize
      @count = 0
    end

    def increment!
      @count += 1
      raise "OMG"
    end
  end

  test "it works" do
    counter = Counter.new

    assert_raises RuntimeError do
      assert_no_difference -> { counter.count } do
        counter.increment!
      end
    end
  end
end
```

It passes even though `counter.count` changed from `0` to `1`, this is because `assert_difference` like most other block based assertions (e.g. `assert_enqueued_*`) are totally bypassed when an error happen.

Of course the test is arguably broken, the user here should put the `assert_raises` inside the `assert_no_difference`.

But realistically it's not hard to overlook this, so I think it would make sense to consider any raised exception, as an assertion failure.

@rafaelfranca @wvanbergen thoughts?