### PR TITLE
Add ActiveStorage::Blob.concat

### DIFF
--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -11,7 +11,7 @@ module ActiveStorage
     def open(key, checksum:, name: "ActiveStorage-", tmpdir: nil)
       open_tempfile(name, tmpdir) do |file|
         download key, file
-        verify_integrity_of file, checksum: checksum
+        verify_integrity_of file, checksum: checksum if checksum
         yield file
       end
     end

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -121,6 +121,16 @@ module ActiveStorage
       { "Content-Type" => content_type, "Content-MD5" => checksum, "x-ms-blob-type" => "BlockBlob" }
     end
 
+    def concat(*source_keys, destination_key)
+      client.create_append_blob(container, destination_key).tap do |blob|
+        source_keys.each do |source_key|
+          download(source_key) do |chunk|
+            client.append_blob_block(container, destination_key, chunk)
+          end
+        end
+      end
+    end
+
     private
       def uri_for(key)
         client.generate_uri("#{container}/#{key}")

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -129,6 +129,16 @@ module ActiveStorage
       File.join root, folder_for(key), key
     end
 
+    def concat(*source_keys, destination_key)
+      File.open(make_path_for(destination_key), "w") do |file|
+        source_keys.each do |source_key|
+          download(source_key) do |chunk|
+            file << chunk
+          end
+        end
+      end
+    end
+
     private
       def stream(key)
         File.open(path_for(key), "rb") do |file|

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -108,6 +108,10 @@ module ActiveStorage
       { "Content-MD5" => checksum }
     end
 
+    def concat(*source_keys, destination_key)
+      bucket.compose(source_keys, key)
+    end
+
     private
       attr_reader :config
 

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -46,6 +46,10 @@ module ActiveStorage
       perform_across_services :delete_prefixed, prefix
     end
 
+    def concat(*source_keys, destination_key)
+      perform_across_services :concat, *source_keys, destination_key
+    end
+
 
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.
     def mirror(key, checksum:)

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -101,6 +101,14 @@ module ActiveStorage
       { "Content-Type" => content_type, "Content-MD5" => checksum }
     end
 
+    def concat(*source_keys, destination_key)
+      object = object_for(destination_key).multipart_upload
+      source_keys.each do |source_key|
+        object.copy_part(source_key)
+      end
+      object.complete
+    end
+
     private
       MAXIMUM_UPLOAD_PARTS_COUNT = 10000
       MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -57,6 +57,21 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "concat" do
+    blobs = 3.times.map { create_blob(data: "123", filename: "numbers.txt", content_type: "text/plain", identify: false) }
+    blob = ActiveStorage::Blob.concat(filename: "all_numbers.txt", blobs: blobs)
+    assert_equal "123123123", blob.download
+  end
+
+  test "concat with unpersisted blobs" do
+    blobs = 3.times.map { create_blob(data: "123", filename: "numbers.txt", content_type: "text/plain", identify: false).dup }
+
+    error = assert_raises(ActiveRecord::RecordNotSaved) do
+      ActiveStorage::Blob.concat(filename: "all_numbers.txt", blobs: blobs)
+    end
+    assert_equal "All blobs must be persisted.", error.message
+  end
+
   test "image?" do
     blob = create_file_blob filename: "racecar.jpg"
     assert_predicate blob, :image?

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -136,5 +136,18 @@ module ActiveStorage::Service::SharedServiceTests
       @service.delete("a/a/b")
       @service.delete("a/b/a")
     end
+
+    test "concat" do
+      keys = 3.times.map { SecureRandom.base58(24) }
+      data = %w(To get her)
+      keys.zip(data).each do |key, data|
+        @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html")
+      end
+
+      destination_key = SecureRandom.base58(24)
+      @service.concat(*keys, destination_key)
+
+      assert_equal "Together", @service.download(destination_key)
+    end
   end
 end


### PR DESCRIPTION
### Summary

Add `ActiveStorage::Blob.concat` for appending large files together.

TODO

- [ ] Find a way to compute the checksum after files have been concatenated via the service.
