### PR TITLE
remove blank? from Relation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -708,11 +708,6 @@ module ActiveRecord
       q.pp(records)
     end
 
-    # Returns true if relation is blank.
-    def blank?
-      records.blank?
-    end
-
     def values
       @values.dup
     end


### PR DESCRIPTION
In #5461, Relation#blank? was added.
That is because, at that time, Relation#empty? triggered COUNT query and
circumvention avoiding heavy query was required.
Today, Relation#empty? triggers EXISTS query which is not so heavy.

We are taught to prefer exists? over present? for performance.
However, distinction between them are easily forgotten.
It would be great if we could use them interchangeably.

This changes side effect of `present?` and `blank?`: it does not load
relation anymore.
I see ~65x performance gain of `scope.present?` for the relation that loads 500k rows.
