### PR TITLE
Remove I18n reloader when `cache_classes` config is true

### DIFF
--- a/railties/lib/rails/application/reloader.rb
+++ b/railties/lib/rails/application/reloader.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_support/reloader"
+
+module Rails
+  class Application
+    class Reloader < ::ActiveSupport::Reloader
+      class_attribute :registered_reloaders, default: {}
+
+      def self.register(name, &block)
+        registered_reloaders[name] = block
+      end
+
+      def self.fetch(name)
+        reloaders[name]
+      end
+
+      def self.should_reload?
+        reloaders.any? { |_, reloader| reloader.updated? }
+      end
+
+      def self.reloaders
+        @reloaders ||= begin
+          reloaders = {}
+
+          registered_reloaders.each do |name, block|
+            reloaders[name] = block.call
+          end
+
+          reloaders
+        end
+      end
+      private_class_method :reloaders
+    end
+  end
+end

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -58,7 +58,7 @@ module ApplicationTests
         config:           Rails.application.config,
         railties:         Rails.application.railties,
         routes_reloader:  Rails.application.routes_reloader,
-        reloaders:        Rails.application.reloaders,
+        reloader:         Rails.application.reloader,
         routes:           Rails.application.routes,
         helpers:          Rails.application.helpers,
         app_env_config:   Rails.application.env_config
@@ -67,7 +67,7 @@ module ApplicationTests
       assert_equal Rails.application.config, application1.config
       assert_equal Rails.application.railties, application1.railties
       assert_equal Rails.application.routes_reloader, application1.routes_reloader
-      assert_equal Rails.application.reloaders, application1.reloaders
+      assert_equal Rails.application.reloader, application1.reloader
       assert_equal Rails.application.routes, application1.routes
       assert_equal Rails.application.helpers, application1.helpers
       assert_equal Rails.application.env_config, application1.env_config


### PR DESCRIPTION
# Summary

This reduces memory usage and speeds up boot time in production where
`cache_classes` is usually true. `FileUpdateChecker` grabs the mtime
of each file in the directories listed and is a significant source of
objects allocations once the number of files increases.
