### PR TITLE
Add coffee-rails update information to rails guides

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -474,6 +474,17 @@ user.highlights.second.filename # => "town.jpg"
 Opt in to the new default behavior by setting `config.active_storage.replace_on_assign_to_many` to `true`.
 The old behavior will be deprecated in Rails 6.1 and removed in a subsequent release.
 
+### Coffee-Rails
+
+Coffee-Rails should be at least version 5.0.0.
+
+To update coffee-rails, go to your Gemfile and change the existing gem to:
+```
+gem 'coffee-rails', '~> 5.0.0'
+```
+
+Then run `bundle`
+
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------
 


### PR DESCRIPTION
### Summary

When upgrading from Rails 5.2 to 6.0, I found the following error:

```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Coffee::Rails::TemplateHandler.call(template)
To:
  >> Coffee::Rails::TemplateHandler.call(template, source)
 (called from <main> at /Users/MediocreManta/Desktop/freedom_podcasting/Rakefile:6)
```

The fix to this is to update your version of `coffee-rails`.

This PR adds instructions for upgrading `coffee-rails` in the instructions for migrating from Rails 5.2 to 6.0.
