### PR TITLE
Fork tracker fixes

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -36,6 +36,7 @@ module ActiveSupport
 
       def hook!
         ::Object.prepend(CoreExtPrivate)
+        ::Kernel.prepend(CoreExtPrivate)
         ::Kernel.singleton_class.prepend(CoreExt)
         ::Process.singleton_class.prepend(CoreExt)
       end

--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -18,6 +18,11 @@ module ActiveSupport
       end
     end
 
+    module CoreExtPrivate
+      include CoreExt
+      private :fork
+    end
+
     @pid = Process.pid
     @callbacks = []
 
@@ -30,7 +35,7 @@ module ActiveSupport
       end
 
       def hook!
-        ::Object.prepend(CoreExt)
+        ::Object.prepend(CoreExtPrivate)
         ::Kernel.singleton_class.prepend(CoreExt)
         ::Process.singleton_class.prepend(CoreExt)
       end

--- a/activesupport/test/fork_tracker_test.rb
+++ b/activesupport/test/fork_tracker_test.rb
@@ -12,6 +12,7 @@ class ForkTrackerTest < ActiveSupport::TestCase
       write.write "forked"
     end
 
+    assert_not respond_to?(:fork)
     pid = fork do
       read.close
       write.close


### PR DESCRIPTION
### Summary

This fixes a couple of issues I found while reviewing #37312:
* fork became public on all Object instances
* Kernel#fork was not overriden 

If we don't care about the second point, the first commit can be shipped separately.

### Other Information

Since the module is prepended, we can't make the method private in the module and turn it public in the class. We can't leave the method public in the module and make it private only where it matters either since it's prepended. The way I fixed it was to create a new module that includes the first and make the method private, send prepend that in the place we want the method to be private.

@matthewd @byroot 
