### PR TITLE
Include connection in cached query notifications

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -134,6 +134,7 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection_id: object_id,
+            connection: self,
             cached: true
           }
         end

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -72,5 +72,30 @@ module ActiveRecord
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
+
+    def test_payload_connection_with_query_cache_disabled
+      connection = Book.connection
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        assert_equal connection, event.payload[:connection]
+      end
+      Book.first
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_connection_with_query_cache_enabled
+      connection = Book.connection
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        assert_equal connection, event.payload[:connection]
+      end
+      Book.cache do
+        Book.first
+        Book.first
+      end
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
   end
 end


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/34602 the `sql.active_record` notification includes the connection that executed the query, but only when the result comes from the database, not the query cache.

This change was suggested by @kamipo in https://github.com/rails/rails/pull/36456#discussion_r292138321. I'd like to make it separately from removing `connection_id`, so that it can be backported to 6-0-stable to improve the migration path.