### PR TITLE
Fix fraction float assertions in time_ext_test

### DIFF
--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -114,13 +114,13 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Rational(1, 1_000_000_000), time.sec_fraction
 
     time = Time.utc(2016, 4, 23, 0, 0, 0.000_000_001)
-    assert_equal Rational(1, 1_000_000_000), time.sec_fraction
+    assert_equal 0.000_000_001.to_r, time.sec_fraction
 
     time = Time.utc(2016, 4, 23, 0, 0, 0, Rational(1, 1_000))
     assert_equal Rational(1, 1_000_000_000), time.sec_fraction
 
     time = Time.utc(2016, 4, 23, 0, 0, 0, 0.001)
-    assert_equal Rational(1, 1_000_000_000), time.sec_fraction
+    assert_equal 0.001.to_r / 1000000, time.sec_fraction
   end
 
   def test_beginning_of_day


### PR DESCRIPTION
Fixes a failing test. See https://github.com/rails/rails/commit/d96a71585957da21cf5e95d2276b1aa4aeab22ae#r35302233

These failed previously because decimals floats don't make perfect decimal numbers and Rational represents them exactly (either as decimal or the inexact float value).

This changes the asserts to match that value.