### PR TITLE
Backport #37228 and #37112 to 6-0-stable

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -3,7 +3,6 @@
 require "active_support/rails"
 require "abstract_controller"
 require "action_dispatch"
-require "action_controller/metal/live"
 require "action_controller/metal/strong_parameters"
 
 module ActionController
@@ -21,6 +20,10 @@ module ActionController
   end
 
   autoload_under "metal" do
+    eager_autoload do
+      autoload :Live
+    end
+
     autoload :ConditionalGet
     autoload :ContentSecurityPolicy
     autoload :Cookies

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -535,4 +535,6 @@ module ActionDispatch # :nodoc:
       end
     end
   end
+
+  ActiveSupport.run_load_hooks(:action_dispatch_response, Response)
 end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -42,9 +42,11 @@ module ActionDispatch
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
-      ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
-      ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
-      ActionDispatch::Response.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_media_type_on_content_type
+      ActiveSupport.on_load(:action_dispatch_response) do
+        self.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
+        self.default_headers = app.config.action_dispatch.default_headers
+        self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_media_type_on_content_type
+      end
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2472,12 +2472,12 @@ module ApplicationTests
       remove_from_config '.*config\.load_defaults.*\n'
 
       app_file "config/initializers/new_framework_defaults_6_0.rb", <<-RUBY
-        Rails.application.config.action_dispatch.return_only_media_type_on_content_type = true
+        Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
       RUBY
 
       app "development"
 
-      assert_equal true, ActionDispatch::Response.return_only_media_type_on_content_type
+      assert_equal false, ActionDispatch::Response.return_only_media_type_on_content_type
     end
 
     test "ActionMailbox.logger is Rails.logger by default" do


### PR DESCRIPTION
Both https://github.com/rails/rails/pull/37228 and https://github.com/rails/rails/pull/37112 need to be backported to 6-0-stable to fix the problem described in https://github.com/rails/rails/pull/37112: after upgrading to 6.0.0 and running `app:update`, uncommenting this line has no effect:

https://github.com/rails/rails/blob/66cabeda2c46c582d19738e1318be8d59584cc5b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt#L19-L20