### PR TITLE
Add a missing runtime dependency of activesupport

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   # NOTE: Please read our dependency guidelines before updating versions:
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
+  s.add_dependency "activesupport", version
   s.add_dependency "actionpack", version
 
   s.add_dependency "nio4r",            "~> 2.0"

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   # NOTE: Please read our dependency guidelines before updating versions:
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
+  s.add_dependency "activesupport", version
   s.add_dependency "actionpack", version
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -28,9 +28,10 @@ Gem::Specification.new do |s|
   # NOTE: Please read our dependency guidelines before updating versions:
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
-  s.add_dependency "actionpack",   version
-  s.add_dependency "activejob",    version
-  s.add_dependency "activerecord", version
+  s.add_dependency "activesupport", version
+  s.add_dependency "actionpack",    version
+  s.add_dependency "activejob",     version
+  s.add_dependency "activerecord",  version
 
   s.add_dependency "marcel", "~> 0.3.1"
 end


### PR DESCRIPTION
### Summary

This adds `activesupport` as runtime dependency to actioncable, actionmailer and activestorage.

This change is not necessarily required because of the other dependency depends on activesupport.
But this makes sence since each of those gems requires activesupport module directly.

Also, definitions already exist in gemspecs of the other gems.

### Other Information

