### PR TITLE
Removed repeated word 'done' from Active Storage guide [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -338,7 +338,7 @@ Call `images.attached?` to determine whether a particular message has any images
 @message.images.attached?
 ```
 
-Overriding the default service is done done the same way as `has_one_attached`, by using the `service` option:
+Overriding the default service is done the same way as `has_one_attached`, by using the `service` option:
 
 ```ruby
 class Message < ApplicationRecord


### PR DESCRIPTION
Removed repeated word `done` from the guide. Found it after my typo fix PR was merged so had to raise another PR. 