### PR TITLE
Allow config env to set autoload path

### DIFF
--- a/guides/source/autoloading_and_reloading_constants_classic_mode.md
+++ b/guides/source/autoloading_and_reloading_constants_classic_mode.md
@@ -482,8 +482,6 @@ What is described above are the defaults with a newly generated Rails app. There
 
 See also [Autoloading in the Test Environment](#autoloading-in-the-test-environment).
 
-`config.autoload_paths` is not changeable from environment-specific configuration files.
-
 The value of `autoload_paths` can be inspected. In a just-generated application
 it is (edited):
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Allow environment configuration files to change autoload_paths, autoload_once_paths and eager_load_paths
+
+  *Allen Hsu*
+
 * Support using environment variable to set pidfile
 
   *Ben Thorner*

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -560,6 +560,12 @@ module Rails
       end
     end
 
+    initializer :load_environment_config, before: :load_environment_hook, group: :all do
+      paths["config/environments"].existent.each do |environment|
+        require environment
+      end
+    end
+
     initializer :set_load_path, before: :bootstrap_hook do |app|
       _all_load_paths(app.config.add_autoload_paths_to_load_path).reverse_each do |path|
         $LOAD_PATH.unshift(path) if File.directory?(path)
@@ -605,12 +611,6 @@ module Rails
       unless views.empty?
         ActiveSupport.on_load(:action_controller) { prepend_view_path(views) if respond_to?(:prepend_view_path) }
         ActiveSupport.on_load(:action_mailer) { prepend_view_path(views) }
-      end
-    end
-
-    initializer :load_environment_config, before: :load_environment_hook, group: :all do
-      paths["config/environments"].existent.each do |environment|
-        require environment
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1213,6 +1213,25 @@ module ApplicationTests
       assert_raises(ArgumentError) { config.autoloader = :unknown }
     end
 
+    test "loading paths can be set by environment config file" do
+      build_app(directories: ["autoload_path", "eager_load_path", "autoload_once_path"])
+      add_to_env_config "development", <<-RUBY
+        config.autoload_paths << Rails.root.join("autoload_path").to_s
+        config.autoload_once_paths << Rails.root.join("autoload_once_path").to_s
+        config.eager_load_paths << Rails.root.join("eager_load_path").to_s
+      RUBY
+
+      app "development"
+
+      assert_equal ["#{app_path}/autoload_path"], Rails.application.config.autoload_paths
+      assert_equal ["#{app_path}/autoload_once_path"], Rails.application.config.autoload_once_paths
+      assert Rails.application.config.eager_load_paths.include?("#{app_path}/eager_load_path")
+      assert $LOAD_PATH.include? "#{app_path}/autoload_path"
+      assert $LOAD_PATH.include? "#{app_path}/eager_load_path"
+      assert $LOAD_PATH.include? "#{app_path}/autoload_once_path"
+    end
+
+
     test "config.action_view.cache_template_loading with cache_classes default" do
       add_to_config "config.cache_classes = true"
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -104,6 +104,12 @@ module TestHelpers
       FileUtils.rm_rf(app_path)
       FileUtils.cp_r(app_template_path, app_path)
 
+      if options[:directories]
+        options[:directories].each do |directory|
+          FileUtils.mkdir_p("#{app_path}/#{directory}")
+        end
+      end
+
       # Delete the initializers unless requested
       unless options[:initializers]
         Dir["#{app_path}/config/initializers/**/*.rb"].each do |initializer|


### PR DESCRIPTION
### Summary
Resolves https://github.com/rails/rails/issues/37331

Moves environment file loading before autoload path initialization.
Attention @fxn.