### PR TITLE
Update package.json files to use https url

### DIFF
--- a/actioncable/package.json
+++ b/actioncable/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/rails/rails/issues"
   },
-  "homepage": "http://rubyonrails.org/",
+  "homepage": "https://rubyonrails.org/",
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -6,7 +6,7 @@
   "files": [
     "app/javascript/actiontext/*.js"
   ],
-  "homepage": "http://rubyonrails.org/",
+  "homepage": "https://rubyonrails.org/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rails/rails.git"

--- a/actionview/package.json
+++ b/actionview/package.json
@@ -28,7 +28,7 @@
   "bugs": {
     "url": "https://github.com/rails/rails/issues"
   },
-  "homepage": "http://rubyonrails.org/",
+  "homepage": "https://rubyonrails.org/",
   "devDependencies": {
     "coffeelint": "^2.1.0",
     "eslint": "^2.13.1"

--- a/activestorage/package.json
+++ b/activestorage/package.json
@@ -7,7 +7,7 @@
     "app/assets/javascripts/*.js",
     "src/*.js"
   ],
-  "homepage": "http://rubyonrails.org/",
+  "homepage": "https://rubyonrails.org/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rails/rails.git"


### PR DESCRIPTION
This PR updates the `homepage` value of the package.json files to use the current `https://rubyonrails.org/` instead of the `http` url.
