### PR TITLE
Avoid string allocations in BacktraceCleaner

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -4,18 +4,25 @@ require "active_support/backtrace_cleaner"
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner
-    APP_DIRS_PATTERN = /^\/?(app|config|lib|test|\(\w*\))/
+    APP_DIRS_PATTERN = /\A\/?(?:app|config|lib|test|\(\w*\))/
     RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
-    EMPTY_STRING = ""
-    SLASH        = "/"
-    DOT_SLASH    = "./"
 
     def initialize
       super
       @root = "#{Rails.root}/"
-      add_filter { |line| line.sub(@root, EMPTY_STRING) }
-      add_filter { |line| line.sub(RENDER_TEMPLATE_PATTERN, EMPTY_STRING) }
-      add_filter { |line| line.sub(DOT_SLASH, SLASH) } # for tests
+      add_filter do |line|
+        line.start_with?(@root) ? line.from(@root.size) : line
+      end
+      add_filter do |line|
+        if RENDER_TEMPLATE_PATTERN.match?(line)
+          line.sub(RENDER_TEMPLATE_PATTERN, "")
+        else
+          line
+        end
+      end
+      add_filter do |line|
+        line.start_with?("./") ? line.from(1) : line
+      end
       add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end
   end


### PR DESCRIPTION
Our backtraces tend to be fairly large so this operates over quite a few strings.

Previously, each filter would call `String#sub`, which always returns a new string object, and uses a new string buffer any time it modifies the string.

Using `String#slice` instead allows Ruby to share the same internal string buffer, which should be faster and use less memory. In cases where changes aren't necessary we can also reuse the same string object.

This should not change behaviour except for the last filter which changes from `sub(/\.\//, "")` to `sub(/\A\.\//, "")`, which I think was the original intention.

---

Benchmarked using [the same script](https://gist.github.com/jhawthorn/bc8417d99846a543d098a3c606d3f2c3) as #35985

**Before:**

IPS (more better):
```
       clean(caller)      1.593k (± 2.8%) i/s -      8.058k in   5.064170s
clean(caller.lazy).first
                          4.180k (± 4.1%) i/s -     21.164k in   5.072036s

```

Memory (lower better):
```
       clean(caller)    44.108k memsize (     0.000  retained)
                       817.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
clean(caller.lazy).first
                        15.500k memsize (     0.000  retained)
                       308.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

**After**

IPS (more better):
```
       clean(caller)      3.526k (± 2.6%) i/s -     17.697k in   5.022163s
clean(caller.lazy).first
                          7.848k (± 4.6%) i/s -     39.300k in   5.019788s
```

Memory (lower better):
```
       clean(caller)    19.504k memsize (     0.000  retained)
                       210.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
clean(caller.lazy).first
                         8.056k memsize (     0.000  retained)
                       130.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```