### PR TITLE
Fix typo a InboxMailbox -> an InboxMailbox [ci skip]

### DIFF
--- a/actionmailbox/lib/rails/generators/mailbox/USAGE
+++ b/actionmailbox/lib/rails/generators/mailbox/USAGE
@@ -7,6 +7,6 @@ Example:
 ========
     rails generate mailbox inbox
 
-    creates a InboxMailbox class and test:
+    creates an InboxMailbox class and test:
         Mailbox:  app/mailboxes/inbox_mailbox.rb
         Test:     test/mailboxes/inbox_mailbox_test.rb


### PR DESCRIPTION
### Summary
```
$ git grep -ni '\ba inbox'
actionmailbox/lib/rails/generators/mailbox/USAGE:10:    creates a InboxMailbox class and test:
```
