### PR TITLE
Ignore test env in DatabaseTasks when DATABASE_URL is present

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Skip test database when running `db:create` or `db:drop` in development
+    with `DATABASE_URL` set.
+
+    *Brian Buchalter*
+
 *   Don't allow mutations on the datbase configurations hash.
 
     Freeze the configurations hash to disallow directly changing the configurations hash. If applications need to change the hash, for example to create adatabases for parallelization, they should use the `DatabaseConfig` object directly.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -34,7 +34,7 @@ db_namespace = namespace :db do
     end
   end
 
-  desc "Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to creating the development and test databases."
+  desc "Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to creating the development and test databases, except when DATABASE_URL is present."
   task create: [:load_config] do
     ActiveRecord::Tasks::DatabaseTasks.create_current
   end
@@ -53,7 +53,7 @@ db_namespace = namespace :db do
     end
   end
 
-  desc "Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases."
+  desc "Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases, except when DATABASE_URL is present."
   task drop: [:load_config, :check_protected_environments] do
     db_namespace["drop:_unsafe"].invoke
   end
@@ -73,7 +73,7 @@ db_namespace = namespace :db do
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # desc "Empty the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:purge:all to purge all databases in the config). Without RAILS_ENV it defaults to purging the development and test databases."
+  # desc "Empty the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:purge:all to purge all databases in the config). Without RAILS_ENV it defaults to purging the development and test databases, except when DATABASE_URL is present."
   task purge: [:load_config, :check_protected_environments] do
     ActiveRecord::Tasks::DatabaseTasks.purge_current
   end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -484,7 +484,7 @@ module ActiveRecord
 
         def each_current_configuration(environment, spec_name = nil)
           environments = [environment]
-          environments << "test" if environment == "development"
+          environments << "test" if environment == "development" && !ENV["DATABASE_URL"]
 
           environments.each do |env|
             ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -60,6 +60,28 @@ module ApplicationTests
         db_create_and_drop database_url_db_name
       end
 
+      test "db:create and db:drop with database URL don't use YAML DBs" do
+        require "#{app_path}/config/environment"
+        set_database_url
+
+        File.write("#{app_path}/config/database.yml", <<~YAML)
+          test:
+            adapter: sqlite3
+            database: db/test.sqlite3
+
+          development:
+            adapter: sqlite3
+            database: db/development.sqlite3
+        YAML
+
+        with_rails_env "development" do
+          db_create_and_drop database_url_db_name do
+            assert_not File.exist?("#{app_path}/db/test.sqlite3")
+            assert_not File.exist?("#{app_path}/db/development.sqlite3")
+          end
+        end
+      end
+
       test "db:create and db:drop respect environment setting" do
         app_file "config/database.yml", <<-YAML
           <% 1 %>


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/28827.

The steps to reproduce are as follows:
```
git clone git@github.com:bbuchalter/rails-issue-28827.git
cd rails-issue-28827
bundle install
bin/rails db:create
```

Observe that we create both `development` and `test` databases when invoking `db:create` . Now observe what happens when we invoke our drop command while using `DATABASE_URL`.

```
DATABASE_URL=sqlite3://$(pwd)/db/database_url.sqlite3 bin/rails db:create
```

As expected, the `development` environment now uses the DATABASE_URL. What is unexpected is that the `test` environment does not.

It's unclear what the expected behavior should be in this case, but the cause of it is this: https://github.com/rails/rails/blob/9f2c74eda07ea5a9e4e624d5575a717714088dbf/activerecord/lib/active_record/tasks/database_tasks.rb#L494

Because of `each_local_configuration`, there seems to be no way invoke these database rake on only the `development` environment to ensure `DATABASE_URL` is respected.

The smallest scope of change I can think to make would be to conditionalize this behavior so it does not get applied when `DATABASE_URL` is present.

cc: @jhawthorn @eileencodes 

P.S. Forgive my omission of tests and a CHANGELOG entry. Wanted to put this up here to see if it got any interest before investing more time.
