### PR TITLE
correct information about record identification in form helper

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -317,7 +317,7 @@ form_with(model: @article, url: article_path(@article), method: "patch")
 form_with(model: @article)
 ```
 
-Notice how the short-style `form_with` invocation is conveniently the same, regardless of the record being new or existing. Record identification is smart enough to figure out if the record is new by asking `record.new_record?`. It also selects the correct path to submit to, and the name based on the class of the object.
+Notice how the short-style `form_with` invocation is conveniently the same, regardless of the record being new or existing. Record identification is smart enough to figure out if the record is new by asking `record.persisted?`. It also selects the correct path to submit to, and the name based on the class of the object.
 
 WARNING: When you're using STI (single-table inheritance) with your models, you can't rely on record identification on a subclass if only their parent class is declared a resource. You will have to specify `:url`, and `:scope` (the model name) explicitly.
 


### PR DESCRIPTION
# Summary

I pretty certain that the information in `guides/source/form_helpers.md` is wrong or outdated, which states that 

> [...] _Record identification is smart enough to figure out if the record is new by asking `record.new_record?`_

I haven't found any usage of `.new_record?` in the form helper, and experiments have shown that `.persisted?` is used to derive the button text and form action.

Can anyone confirm this?