### PR TITLE
Don't modify relative ./ paths in BacktraceCleaner

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -4,7 +4,7 @@ require "active_support/backtrace_cleaner"
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner
-    APP_DIRS_PATTERN = /\A\/?(?:app|config|lib|test|\(\w*\))/
+    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/
     RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
 
     def initialize
@@ -19,9 +19,6 @@ module Rails
         else
           line
         end
-      end
-      add_filter do |line|
-        line.start_with?("./") ? line.from(1) : line
       end
       add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -17,6 +17,15 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal 1, result.length
   end
 
+  test "should show relative paths" do
+    backtrace = [ "./test/backtrace_cleaner_test.rb:123",
+                  "/Path/to/rails/activesupport/some_testing_file.rb:42:in `test'",
+                  "bin/rails:4:in `<main>'" ]
+    result = @cleaner.clean(backtrace)
+    assert_equal "./test/backtrace_cleaner_test.rb:123", result[0]
+    assert_equal 1, result.length
+  end
+
   test "can filter for noise" do
     backtrace = [ "(irb):1",
                   "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",


### PR DESCRIPTION
From discussion with @kaspth in https://github.com/rails/rails/pull/37348#discussion_r331162150

Previously a path starting with `./` would be replaced to start with `/`. IMO this didn't particularly make sense since `/` reads as though it's from the root of the filesystem.

This commit removes that filter, preserves `./`, and updates the silencer not to remove lines starting with `./`. This is both faster and (I think) more correct 🎉.

Alternatively we could have removed `./` from the beginning of these paths, but not doing so is a little bit simpler and faster.

**Before:**

```
$ be ruby -Itest ./test/failing_test.rb
Run options: --seed 65479

# Running:

E

Error:
FailingTest#test_fail:
RuntimeError:
    /test/failing_test.rb:5:in `test_fail'

Finished in 0.504473s, 1.9823 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skip
```


**After:**

```
$ be ruby -Itest ./test/failing_test.rb
Run options: --seed 8945

# Running:

E

Error:
FailingTest#test_fail:
RuntimeError:
    ./test/failing_test.rb:5:in `test_fail'

Finished in 0.520887s, 1.9198 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```