### PR TITLE
Update MySQL links to point to the current version of the manual

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -210,7 +210,7 @@ module ActiveRecord
       #
       # In order to get around this problem, #transaction will emulate the effect
       # of nested transactions, by using savepoints:
-      # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
+      # https://dev.mysql.com/doc/refman/en/savepoint.html
       #
       # It is safe to call this method if a database transaction is already open,
       # i.e. if #transaction is called within another #transaction block. In case
@@ -261,7 +261,7 @@ module ActiveRecord
       # semantics of these different levels:
       #
       # * https://www.postgresql.org/docs/current/static/transaction-iso.html
-      # * https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html
+      # * https://dev.mysql.com/doc/refman/en/set-transaction.html
       #
       # An ActiveRecord::TransactionIsolationError will be raised if:
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -104,7 +104,7 @@ module ActiveRecord
         mariadb? || database_version >= "5.7.5"
       end
 
-      # See https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html for more details.
+      # See https://dev.mysql.com/doc/refman/en/optimizer-hints.html for more details.
       def supports_optimizer_hints?
         !mariadb? && database_version >= "5.7.7"
       end
@@ -474,7 +474,7 @@ module ActiveRecord
       # In MySQL 5.7.5 and up, ONLY_FULL_GROUP_BY affects handling of queries that use
       # DISTINCT and ORDER BY. It requires the ORDER BY columns in the select list for
       # distinct queries, and requires that the ORDER BY include the distinct column.
-      # See https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
+      # See https://dev.mysql.com/doc/refman/en/group-by-handling.html
       def columns_for_distinct(columns, orders) # :nodoc:
         order_columns = orders.compact_blank.map { |s|
           # Convert Arel node to string
@@ -572,7 +572,7 @@ module ActiveRecord
           end
         end
 
-        # See https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
+        # See https://dev.mysql.com/doc/refman/en/server-error-reference.html
         ER_DB_CREATE_EXISTS     = 1007
         ER_FILSORT_ABORT        = 1028
         ER_DUP_ENTRY            = 1062
@@ -705,7 +705,7 @@ module ActiveRecord
           defaults = [":default", :default].to_set
 
           # Make MySQL reject illegal values rather than truncating or blanking them, see
-          # https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_strict_all_tables
+          # https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_all_tables
           # If the user has provided another value for sql_mode, don't replace it.
           if sql_mode = variables.delete("sql_mode")
             sql_mode = quote(sql_mode)
@@ -722,7 +722,7 @@ module ActiveRecord
           sql_mode_assignment = "@@SESSION.sql_mode = #{sql_mode}, " if sql_mode
 
           # NAMES does not have an equals sign, see
-          # https://dev.mysql.com/doc/refman/5.7/en/set-names.html
+          # https://dev.mysql.com/doc/refman/en/set-names.html
           # (trailing comma because variable_assignments will always have content)
           if @config[:encoding]
             encoding = +"NAMES #{@config[:encoding]}"

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -28,7 +28,7 @@ module ActiveRecord
             # By default, TIMESTAMP columns are NOT NULL, cannot contain NULL values,
             # and assigning NULL assigns the current timestamp. To permit a TIMESTAMP
             # column to contain NULL, explicitly declare it with the NULL attribute.
-            # See https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html
+            # See https://dev.mysql.com/doc/refman/en/timestamp-initialization.html
             if /\Atimestamp\b/.match?(options[:column].sql_type) && !options[:primary_key]
               sql << " NULL" unless options[:null] == false || options_include_default?(options)
             end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -122,7 +122,7 @@ module ActiveRecord
         end
 
         def table_alias_length
-          256 # https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+          256 # https://dev.mysql.com/doc/refman/en/identifiers.html
         end
 
         private

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -338,7 +338,7 @@ module ActiveRecord
   # See the following:
   #
   # * https://www.postgresql.org/docs/current/static/transaction-iso.html
-  # * https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_lock_deadlock
+  # * https://dev.mysql.com/doc/refman/en/server-error-reference.html#error_er_lock_deadlock
   class TransactionRollbackError < StatementInvalid
   end
 

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -53,7 +53,7 @@ module ActiveRecord
     #   end
     #
     # Database-specific information on row locking:
-    #   MySQL: https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+    #   MySQL: https://dev.mysql.com/doc/refman/en/innodb-locking-reads.html
     #   PostgreSQL: https://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
     module Pessimistic
       # Obtain a row lock on this record. Reloads the record to obtain the requested

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -170,7 +170,7 @@ module ActiveRecord
     # writing, the only database that we're aware of that supports true nested
     # transactions, is MS-SQL. Because of this, Active Record emulates nested
     # transactions by using savepoints. See
-    # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
+    # https://dev.mysql.com/doc/refman/en/savepoint.html
     # for more information about savepoints.
     #
     # === \Callbacks

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -13,9 +13,10 @@ module Arel # :nodoc: all
           visit o.expr, collector
         end
 
-        ###
         # :'(
-        # https://dev.mysql.com/doc/refman/8.0/en/select.html#id3482214
+        # To retrieve all rows from a certain offset up to the end of the result set,
+        # you can use some large number for the second parameter
+        # https://dev.mysql.com/doc/refman/en/select.html
         def visit_Arel_Nodes_SelectStatement(o, collector)
           if o.offset && !o.limit
             o.limit = Arel::Nodes::Limit.new(18446744073709551615)

--- a/activerecord/test/cases/adapters/mysql2/sp_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sp_test.rb
@@ -17,7 +17,7 @@ class Mysql2StoredProcedureTest < ActiveRecord::Mysql2TestCase
   # Test that MySQL allows multiple results for stored procedures
   #
   # In MySQL 5.6, CLIENT_MULTI_RESULTS is enabled by default.
-  # https://dev.mysql.com/doc/refman/5.6/en/call.html
+  # https://dev.mysql.com/doc/refman/en/call.html
   def test_multi_results
     rows = @connection.select_rows("CALL ten();")
     assert_equal 10, rows[0][0].to_i, "ten() did not return 10 as expected: #{rows.inspect}"

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -13,9 +13,10 @@ module Arel
         @visitor.accept(node, Collectors::SQLString.new).value
       end
 
-      ###
       # :'(
-      # https://dev.mysql.com/doc/refman/8.0/en/select.html#id3482214
+      # To retrieve all rows from a certain offset up to the end of the result set,
+      # you can use some large number for the second parameter
+      # https://dev.mysql.com/doc/refman/en/select.html
       it "defaults limit to 18446744073709551615" do
         stmt = Nodes::SelectStatement.new
         stmt.offset = Nodes::Offset.new(1)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -173,7 +173,7 @@ if current_adapter?(:Mysql2Adapter)
     # invalid or missing values and produces warnings. In strict mode,
     # you can produce this behavior by using INSERT IGNORE or UPDATE IGNORE.
     #
-    # https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
+    # https://dev.mysql.com/doc/refman/en/sql-mode.html#sql-mode-strict
     def test_mysql_not_null_defaults_non_strict
       using_strict(false) do
         with_mysql_not_null_table do |klass|

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2088,7 +2088,7 @@ following pointers may be helpful:
 
 * SQLite3: [EXPLAIN QUERY PLAN](https://www.sqlite.org/eqp.html)
 
-* MySQL: [EXPLAIN Output Format](https://dev.mysql.com/doc/refman/5.7/en/explain-output.html)
+* MySQL: [EXPLAIN Output Format](https://dev.mysql.com/doc/refman/en/explain-output.html)
 
 * MariaDB: [EXPLAIN](https://mariadb.com/kb/en/mariadb/explain/)
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -639,7 +639,7 @@ class Holiday < ApplicationRecord
     message: "should happen once per year" }
 end
 ```
-Should you wish to create a database constraint to prevent possible violations of a uniqueness validation using the `:scope` option, you must create a unique index on both columns in your database. See [the MySQL manual](https://dev.mysql.com/doc/refman/5.7/en/multiple-column-indexes.html) for more details about multiple column indexes or [the PostgreSQL manual](https://www.postgresql.org/docs/current/static/ddl-constraints.html) for examples of unique constraints that refer to a group of columns.
+Should you wish to create a database constraint to prevent possible violations of a uniqueness validation using the `:scope` option, you must create a unique index on both columns in your database. See [the MySQL manual](https://dev.mysql.com/doc/refman/en/multiple-column-indexes.html) for more details about multiple column indexes or [the PostgreSQL manual](https://www.postgresql.org/docs/current/static/ddl-constraints.html) for examples of unique constraints that refer to a group of columns.
 
 There is also a `:case_sensitive` option that you can use to define whether the
 uniqueness constraint will be case sensitive or not. This option defaults to

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -146,7 +146,7 @@ Or install everything through ports (these packages are located under the
 `databases` folder).
 
 NOTE: If you run into troubles during the installation of MySQL, please see
-[the MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/freebsd-installation.html).
+[the MySQL documentation](https://dev.mysql.com/doc/refman/en/freebsd-installation.html).
 
 ### Database Configuration
 


### PR DESCRIPTION
### Summary

Similar to https://www.postgresql.org/docs/current/, accessing the MySQL manual without a specific version number will redirect to the latest version of the manual. I checked all the links to make sure they were still working and pointing to the relevant section.

There was two case where the link didn't exist in the latest version of the manual because the information contained is only relevant before MySQL 5.7.5:
https://github.com/rails/rails/blob/804a4c144e5d800e5937c022d456994fe8803f0f/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt#L10
and 
https://github.com/rails/rails/blob/804a4c144e5d800e5937c022d456994fe8803f0f/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt#L10
Since we still support MySQL 5.5.8, I left the links as they were.