### PR TITLE
Maintain extra joins for string or complex arel conditions

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -37,7 +37,7 @@ module ActiveRecord
             nodes = arel.constraints.first
 
             others = nodes.children.extract! do |node|
-              Arel.fetch_attribute(node) { |attr| attr.relation.name != table.name }
+              !Arel.fetch_attribute(node) { |attr| attr.relation.name == table.name }
             end
 
             joins << table.create_join(table, table.create_on(nodes), join_type)

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -3,6 +3,6 @@
 class Rating < ActiveRecord::Base
   belongs_to :comment
   has_many :taggings, as: :taggable
-  has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": nil) }, as: :taggable, class_name: "Tagging"
+  has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"
 end


### PR DESCRIPTION
49bcb00 has changed to maintain extra joins only if other table's
condition is found (e.g. `other_table[:id].eq(table[:foreign_id])`).

It means that cannot maintain extra joins for complex conditions
(especially "(... OR ...)"), so it has caused a regression #37167.

This changes to maintain extra joins for complex conditions too like as
before.

Fixes #37167.