### PR TITLE
Deprecate leaking scope in callback block for association relation

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -16,15 +16,18 @@ module ActiveRecord
     end
 
     def build(*args, &block)
+      block = _deprecated_scope_block("new", &block)
       scoping { @association.build(*args, &block) }
     end
     alias new build
 
     def create(*args, &block)
+      block = _deprecated_scope_block("create", &block)
       scoping { @association.create(*args, &block) }
     end
 
     def create!(*args, &block)
+      block = _deprecated_scope_block("create!", &block)
       scoping { @association.create!(*args, &block) }
     end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2499,14 +2499,34 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   test "first_or_initialize adds the record to the association" do
     firm = Firm.create! name: "omg"
-    client = firm.clients_of_firm.first_or_initialize
+    client = firm.clients_of_firm.where(name: "lol").first_or_initialize do |cli|
+      assert_deprecated do
+        assert_equal 0, Client.count
+      end
+    end
     assert_equal [client], firm.clients_of_firm
   end
 
   test "first_or_create adds the record to the association" do
     firm = Firm.create! name: "omg"
     firm.clients_of_firm.load_target
-    client = firm.clients_of_firm.first_or_create name: "lol"
+    client = firm.clients_of_firm.where(name: "lol").first_or_create do |cli|
+      assert_deprecated do
+        assert_equal 0, Client.count
+      end
+    end
+    assert_equal [client], firm.clients_of_firm
+    assert_equal [client], firm.reload.clients_of_firm
+  end
+
+  test "first_or_create! adds the record to the association" do
+    firm = Firm.create! name: "omg"
+    firm.clients_of_firm.load_target
+    client = firm.clients_of_firm.where(name: "lol").first_or_create! do |cli|
+      assert_deprecated do
+        assert_equal 0, Client.count
+      end
+    end
     assert_equal [client], firm.clients_of_firm
     assert_equal [client], firm.reload.clients_of_firm
   end

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -9,7 +9,7 @@ class Bulb < ActiveRecord::Base
 
   after_initialize :record_scope_after_initialize
   def record_scope_after_initialize
-    @scope_after_initialize = self.class.all
+    @scope_after_initialize = self.class.unscoped.all
   end
 
   after_initialize :record_attributes_after_initialize


### PR DESCRIPTION
Follow up of #35280, I missed that `AssociationRelation` is using
`scoping` and not use `super`.