### PR TITLE
Use db_config to retrieve adapter in Resolver

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/resolver.rb
+++ b/activerecord/lib/active_record/connection_adapters/resolver.rb
@@ -25,14 +25,13 @@ module ActiveRecord
         pool_name = config if config.is_a?(Symbol)
 
         db_config = resolve(config, pool_name)
-        spec = db_config.configuration_hash
 
-        raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
+        raise(AdapterNotSpecified, "database configuration does not specify adapter") unless db_config.adapter
 
         # Require the adapter itself and give useful feedback about
         #   1. Missing adapter gems and
         #   2. Adapter gems' missing dependencies.
-        path_to_adapter = "active_record/connection_adapters/#{spec[:adapter]}_adapter"
+        path_to_adapter = "active_record/connection_adapters/#{db_config.adapter}_adapter"
         begin
           require path_to_adapter
         rescue LoadError => e
@@ -41,20 +40,20 @@ module ActiveRecord
           if e.path == path_to_adapter
             # We can assume that a non-builtin adapter was specified, so it's
             # either misspelled or missing from Gemfile.
-            raise LoadError, "Could not load the '#{spec[:adapter]}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
+            raise LoadError, "Could not load the '#{db_config.adapter}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
 
             # Bubbled up from the adapter require. Prefix the exception message
             # with some guidance about how to address it and reraise.
           else
-            raise LoadError, "Error loading the '#{spec[:adapter]}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+            raise LoadError, "Error loading the '#{db_config.adapter}' Active Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
           end
         end
 
         unless ActiveRecord::Base.respond_to?(db_config.adapter_method)
-          raise AdapterNotFound, "database configuration specifies nonexistent #{spec[:adapter]} adapter"
+          raise AdapterNotFound, "database configuration specifies nonexistent #{db_config.adapter} adapter"
         end
 
-        ConnectionSpecification.new(spec.delete(:name) || "primary", db_config)
+        ConnectionSpecification.new(db_config.configuration_hash.delete(:name) || "primary", db_config)
       end
 
       # Returns fully resolved connection, accepts hash, string or symbol.


### PR DESCRIPTION
We had changed all other uses of `configuration_hash[:adapter]` to pull
the adapter directly off of the `DatabaseConfig` objects, but missed
these because the `Hash` was put into a local named `spec`.

We ran into it in some code today, so let's get it switched over!

cc / @eileencodes 