### PR TITLE
Correctly establish connection in truncate and simplify method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -188,6 +188,8 @@ module ActiveRecord
       end
 
       def truncate_tables(*table_names) # :nodoc:
+        table_names -= [schema_migration.table_name, InternalMetadata.table_name]
+
         return if table_names.empty?
 
         with_multi_statements do

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -208,16 +208,10 @@ module ActiveRecord
       end
 
       def truncate_tables(db_config)
-        ActiveRecord::Base.connected_to(database: { truncation: db_config.configuration_hash }) do
-          conn = ActiveRecord::Base.connection
-          table_names = conn.tables
-          table_names -= [
-            conn.schema_migration.table_name,
-            InternalMetadata.table_name
-          ]
+        ActiveRecord::Base.establish_connection(db_config)
 
-          ActiveRecord::Base.connection.truncate_tables(*table_names)
-        end
+        connection = ActiveRecord::Base.connection
+        connection.truncate_tables(*connection.tables)
       end
       private :truncate_tables
 


### PR DESCRIPTION
We want to call establish connection, not `connected_to` with a database
key for truncate. Then we simplified the method by pushing the removed
tables into truncate.

This also removes an instance of unnecessarily calling
`configuration_hash` when we already have a `db_config` to pass around.

cc / @eileencodes 