### PR TITLE
Added methods to return beginning, end and all of the half-year in ActiveSupport.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `Date#beginning_of_half_year` and `Date#end_of_half_year` to return the dates for the beginning and end of the half-year.
+    Add `Date#all_half_year` to returns a range representing the whole half-year of the current date/time.
+
+    *Dmitry Voronov*
+
 *   Improve `Range#===`, `Range#include?`, and `Range#cover?` to work with beginless (startless)
     and endless range targets.
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -145,6 +145,24 @@ module DateAndTime
     end
     alias :at_end_of_quarter :end_of_quarter
 
+    # Returns a new date/time at the beginning of the half-year.
+    #
+    #   today = Date.today # => Fri, 8 May 2015
+    #   today.beginning_of_half_year # => Thu, 01 Jan 2015
+    #
+    #   today = Date.today # => Sun, 4 Oct 2015
+    #   today.beginning_of_half_year # => Wed, 01 Jul 2015
+    #
+    # +DateTime+ objects will have a time set to 0:00.
+    #
+    #   now = DateTime.current # => Sat, 12 Dec 2015 18:41:29 +0000
+    #   now.beginning_of_half_year # => Wed, 01 Jul 2015 00:00:00 +0000
+    def beginning_of_half_year
+      first_half_year_month = month < 7 ? 1 : 7
+      change(month: first_half_year_month).beginning_of_month
+    end
+    alias :at_beginning_of_half_year :beginning_of_half_year
+
     # Returns a new date/time at the beginning of the year.
     #
     #   today = Date.today # => Fri, 10 Jul 2015
@@ -277,6 +295,14 @@ module DateAndTime
     end
     alias :at_end_of_month :end_of_month
 
+    # Returns a new date/time representing the end of the half-year.
+    # DateTime objects will have a time set to 23:59:59.
+    def end_of_half_year
+      last_half_year_month = month < 7 ? 6 : 12
+      change(month: last_half_year_month).end_of_month
+    end
+    alias :at_end_of_half_year :end_of_half_year
+
     # Returns a new date/time representing the end of the year.
     # DateTime objects will have a time set to 23:59:59.
     def end_of_year
@@ -303,6 +329,11 @@ module DateAndTime
     # Returns a Range representing the whole quarter of the current date/time.
     def all_quarter
       beginning_of_quarter..end_of_quarter
+    end
+    
+    # Returns a Range representing the whole half-year of the current date/time.
+    def all_half_year
+      beginning_of_half_year..end_of_half_year
     end
 
     # Returns a Range representing the whole year of the current date/time.

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -92,6 +92,11 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2008, 6, 30, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2008, 5, 31, 0, 0, 0).end_of_quarter
   end
 
+  def test_beginning_of_half_year
+    assert_equal date_time_init(2005, 1, 1, 0, 0, 0), date_time_init(2005, 5, 8, 10, 10, 10).beginning_of_half_year
+    assert_equal date_time_init(2005, 7, 1, 0, 0, 0), date_time_init(2005, 10, 4, 10, 10, 10).beginning_of_half_year
+  end
+
   def test_beginning_of_year
     assert_equal date_time_init(2005, 1, 1, 0, 0, 0), date_time_init(2005, 2, 22, 10, 10, 10).beginning_of_year
   end
@@ -261,6 +266,11 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2005, 3, 31, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2005, 3, 20, 10, 10, 10).end_of_month
     assert_equal date_time_init(2005, 2, 28, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2005, 2, 20, 10, 10, 10).end_of_month
     assert_equal date_time_init(2005, 4, 30, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2005, 4, 20, 10, 10, 10).end_of_month
+  end
+
+  def test_end_of_half_year
+    assert_equal date_time_init(2007, 6, 30, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2007, 5, 8, 10, 10, 10).end_of_half_year
+    assert_equal date_time_init(2007, 12, 31, 23, 59, 59, Rational(999999999, 1000)), date_time_init(2007, 10, 4, 10, 10, 10).end_of_half_year
   end
 
   def test_end_of_year

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -101,7 +101,12 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   def test_end_of_week_in_calendar_reform
     assert_equal Date.new(1582, 10, 17), Date.new(1582, 10, 4).end_of_week # thursday
   end
-
+  
+  def test_end_of_half_year
+    assert_equal Date.new(2008, 6, 30).to_s, Date.new(2008, 5, 8).end_of_half_year.to_s
+    assert_equal Date.new(2008, 12, 31).to_s, Date.new(2008, 10, 4).end_of_half_year.to_s
+  end
+  
   def test_end_of_year
     assert_equal Date.new(2008, 12, 31).to_s, Date.new(2008, 2, 22).end_of_year.to_s
   end
@@ -301,6 +306,11 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
 
   def test_all_quarter
     assert_equal Date.new(2011, 4, 1)..Date.new(2011, 6, 30), Date.new(2011, 6, 7).all_quarter
+  end
+
+  def test_all_half_year
+    assert_equal Date.new(2011, 1, 1)..Date.new(2011, 6, 30), Date.new(2011, 5, 8).all_half_year
+    assert_equal Date.new(2011, 7, 1)..Date.new(2011, 12, 31), Date.new(2011, 10, 4).all_half_year
   end
 
   def test_all_year

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -917,6 +917,11 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2011, 4, 1, 0, 0, 0)..Time.local(2011, 6, 30, 23, 59, 59, Rational(999999999, 1000)), Time.local(2011, 6, 7, 10, 10, 10).all_quarter
   end
 
+  def test_all_half_year
+    assert_equal Time.local(2011, 1, 1, 0, 0, 0)..Time.local(2011, 6, 30, 23, 59, 59, Rational(999999999, 1000)), Time.local(2011, 5, 8, 10, 10, 10).all_half_year
+    assert_equal Time.local(2011, 7, 1, 0, 0, 0)..Time.local(2011, 12, 31, 23, 59, 59, Rational(999999999, 1000)), Time.local(2011, 10, 4, 10, 10, 10).all_half_year
+  end
+
   def test_all_year
     assert_equal Time.local(2011, 1, 1, 0, 0, 0)..Time.local(2011, 12, 31, 23, 59, 59, Rational(999999999, 1000)), Time.local(2011, 6, 7, 10, 10, 10).all_year
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2948,6 +2948,24 @@ d.end_of_quarter         # => Wed, 30 Jun 2010
 
 NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
 
+##### `beginning_of_half_year`, `end_of_half_year`
+
+The methods `beginning_of_half_year` and `end_of_half_year` return the dates for the beginning and end of the half-year:
+
+```ruby
+d = Date.new(2010, 5, 8) # => Sat, 08 May 2010
+d.beginning_of_half_year # => Fri, 01 Jen 2010
+d.end_of_half_year       # => Wed, 30 Jun 2010
+
+d = Date.new(2010, 10, 4) # => Mon, 04 Oct 2010
+d.beginning_of_half_year  # => Thu, 01 Jul 2010
+d.end_of_half_year        # => Fri, 31 Dec 2010
+```
+
+`beginning_of_half_year` is aliased to `at_beginning_of_half_year`, and `end_of_half_year` is aliased to `at_end_of_half_year`.
+
+NOTE: Defined in `active_support/core_ext/date_and_time/calculations.rb`.
+
 ##### `beginning_of_year`, `end_of_year`
 
 The methods `beginning_of_year` and `end_of_year` return the dates for the beginning and end of the year:


### PR DESCRIPTION
In financial applications it is often required to determine the beginning and the end of the half-year of the given date.

`ActiveSupport` provides methods for getting the beginning and the end of calendar periods, such as `beginning_of_week`, `beginning_of_month`, `beginning_of_quarter` and `beginning_of_year`. But there are no such methods for the half-year.

So we think that it will be helpful to have these methods in `ActiveSupport`.

```ruby
today = Date.today # => Fri, 8 May 2015
today.beginning_of_half_year # => Thu, 01 Jan 2015
today.end_of_half_year # => Tue, 30 Jun 2015

today = Date.today # => Sun, 4 Oct 2015
today.beginning_of_half_year # => Wed, 01 Jul 2015
today.end_of_half_year # => Thu, 31 Dec 2015

today = Date.today # => Sat, 12 Dec 2015
today.all_half_year # => Wed, 01 Jul 2015..Thu, 31 Dec 2015
```
