### PR TITLE
Support the OPTIONS Http Verb in Integration tests

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -50,7 +50,7 @@ module ActionDispatch
       # Performs an OPTIONS request with the given parameters. See ActionDispatch::Integration::Session#process
       # for more details.
       def options(path, **args)
-        process(:head, path, **args)
+        process(:options, path, **args)
       end
 
       # Follow a single redirect response. If the last response was not a

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -47,6 +47,12 @@ module ActionDispatch
         process(:head, path, **args)
       end
 
+      # Performs an OPTIONS request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def options(path, **args)
+        process(:head, path, **args)
+      end
+
       # Follow a single redirect response. If the last response was not a
       # redirect, an exception will be raised. Otherwise, the redirect is
       # performed on the location header. If the redirection is a 307 redirect,


### PR DESCRIPTION
### Summary

ActionDispatch::Integration::Session#process already lists OPTIONS as a valid verb symbol to pass
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/integration.rb#L184
Therefore it should be as simple as allowing the method through.

### Other Information

Rails doesn't appear to allow OPTIONS verb in it's router, so people depend on gems like Rack::Cors for it normally. However as part of [adding Swagger support for both OPTIONS and TRACE verbs](https://github.com/rswag/rswag/issues/231), I'm having to find work-around for this.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
There is another conversation about testing using `:options` in this conversation here where Rack::Cors uses :options on process directly, therefore this should work.

https://github.com/rails/rails/pull/14071#issuecomment-164094861