### PR TITLE
Allow OPTIONS verb in mapper

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -749,6 +749,14 @@ module ActionDispatch
           map_method(:delete, args, &block)
         end
 
+        # Define a route that only recognizes HTTP OPTIONS.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   options 'carrots', to: 'food#carrots'
+        def options(*args, &block)
+          map_method(:get, args, &block)
+        end
+
         private
           def map_method(method, args, &block)
             options = args.extract_options!

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -754,7 +754,7 @@ module ActionDispatch
         #
         #   options 'carrots', to: 'food#carrots'
         def options(*args, &block)
-          map_method(:get, args, &block)
+          map_method(:options, args, &block)
         end
 
         private


### PR DESCRIPTION
### Summary

Add a helper for the OPTIONS verb. The router's Mapper already allows the syntax below making this just sugar.
Current:
```
match 'bar', to: 'foo#bar', via: :options
```
With this PR:
```
options 'bar', to: 'foo#bar'
```

### Other Information

Related to https://github.com/rails/rails/pull/37369
