### PR TITLE
Preserve blank line after magic comment in migrations copied from engines

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+    Add blank line after magic comment in migrations copied from engines.
+
+    *Zach Meyer*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -910,7 +910,7 @@ module ActiveRecord
             # insert our comment after the first newline(end of the magic comment line)
             # so the magic keep working.
             # Note that magic comments must be at the first line(except sh-bang).
-            source.sub!(/\A(?:#.*\b(?:en)?coding:\s*\S+|#\s*frozen_string_literal:\s*(?:true|false)).*\n/) do |magic_comment|
+            source.sub!(/\A(?:#.*\b(?:en)?coding:\s*\S+|#\s*frozen_string_literal:\s*(?:true|false)).*\n(\n?)/) do |magic_comment|
               magic_comments << magic_comment; ""
             end || break
           end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1016,8 +1016,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert File.exist?(@migrations_path + "/5_people_have_descriptions.bukkits.rb")
     assert_equal [@migrations_path + "/4_people_have_hobbies.bukkits.rb", @migrations_path + "/5_people_have_descriptions.bukkits.rb"], copied.map(&:filename)
 
-    expected = "# This migration comes from bukkits (originally 1)"
-    assert_equal expected, IO.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")[1].chomp
+    expected = "# frozen_string_literal: true\n\n# This migration comes from bukkits (originally 1)"
+    assert_equal expected, IO.readlines(@migrations_path + "/4_people_have_hobbies.bukkits.rb")[0..2].join.chomp
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     copied = ActiveRecord::Migration.copy(@migrations_path, bukkits: MIGRATIONS_ROOT + "/to_copy")
@@ -1118,10 +1118,15 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
     copied = ActiveRecord::Migration.copy(@migrations_path, bukkits: MIGRATIONS_ROOT + "/magic")
     assert File.exist?(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")
-    assert_equal [@migrations_path + "/4_currencies_have_symbols.bukkits.rb"], copied.map(&:filename)
+    assert_equal [@migrations_path + "/4_currencies_have_symbols.bukkits.rb",
+                  @migrations_path + "/5_currencies_have_amounts.bukkits.rb"],
+                 copied.map(&:filename)
 
-    expected = "# frozen_string_literal: true\n# coding: ISO-8859-15\n# This migration comes from bukkits (originally 1)"
-    assert_equal expected, IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..2].join.chomp
+    expected = "# frozen_string_literal: true\n# coding: ISO-8859-15\n\n# This migration comes from bukkits (originally 1)"
+    assert_equal expected, IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..3].join.chomp
+
+    expected = "# frozen_string_literal: true\n\n# This migration comes from bukkits (originally 2)"
+    assert_equal expected, IO.readlines(@migrations_path + "/5_currencies_have_amounts.bukkits.rb")[0..2].join.chomp
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     copied = ActiveRecord::Migration.copy(@migrations_path, bukkits: MIGRATIONS_ROOT + "/magic")

--- a/activerecord/test/migrations/magic/2_currencies_have_amounts.rb
+++ b/activerecord/test/migrations/magic/2_currencies_have_amounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CurrenciesHaveAmounts < ActiveRecord::Migration::Current
+  def change
+    add_column :currencies, :amount, :decimal
+  end
+end


### PR DESCRIPTION
### Summary
Proposed fix to #37371

This PR will preserve the blank line after a magic comment in migrations copied from an engine to the main app.

### Other Information
* CHANGELOG entry added