### PR TITLE
generate field_number for decimal and float types

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -24,6 +24,9 @@
 <% elsif attribute.attachments? -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
+<% elsif attribute.decimal? -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, step: :any %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -74,15 +74,14 @@ module Rails
 
       def field_type
         @field_type ||= case type
-                        when :integer                  then :number_field
-                        when :float, :decimal          then :text_field
-                        when :time                     then :time_select
-                        when :datetime, :timestamp     then :datetime_select
-                        when :date                     then :date_select
-                        when :text                     then :text_area
-                        when :rich_text                then :rich_text_area
-                        when :boolean                  then :check_box
-                        when :attachment, :attachments then :file_field
+                        when :integer, :float, :decimal then :number_field
+                        when :time                      then :time_select
+                        when :datetime, :timestamp      then :datetime_select
+                        when :date                      then :date_select
+                        when :text                      then :text_area
+                        when :rich_text                 then :rich_text_area
+                        when :boolean                   then :check_box
+                        when :attachment, :attachments  then :file_field
                         else
                           :text_field
         end
@@ -176,6 +175,10 @@ module Rails
 
       def virtual?
         rich_text? || attachment? || attachments?
+      end
+
+      def decimal?
+        %i(float decimal).include?(type)
       end
 
       def inject_options

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -16,13 +16,13 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   end
 
   def test_field_type_returns_number_field
-    assert_field_type :integer, :number_field
+    %w(integer float decimal).each do |attribute_type|
+      assert_field_type attribute_type, :number_field
+    end
   end
 
   def test_field_type_returns_text_field
-    %w(float decimal string).each do |attribute_type|
-      assert_field_type attribute_type, :text_field
-    end
+    assert_field_type :string, :text_field
   end
 
   def test_field_type_returns_datetime_select


### PR DESCRIPTION
Today I realized that field_number is working wonderfully well with decimal columns on modern browsers (firefox, chrome and safari).

Many people like me (from brazil) need support localized input numbers, what I did was use gems like [delocalize](https://github.com/clemens/delocalize) or [i18n_alchemy
](https://github.com/carlosantoniodasilva/i18n_alchemy) to parse localized numbers from field_text to database format.

Today firefox, chrome and safari support decimal places with i18n and validation using browser language configuration, safari needs step="any" aditional property. 

I don't know how, but today we can use inputs like:`<%= form.number_field :weight, step: :any %>`
so, if a user with portuguese language on browser enter with "1500,5" it is submitted as "1500.5", and when initialized "1500.5" from html value property is rendered as "1500,5" on screen magically.
Input number doesn't support thousand separator that is a good thing and validate it as a bad number.

https://caniuse.com/#feat=input-number