### PR TITLE
Updated `ActionDispatch::Request.remote_ip=`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Updated `ActionDispatch::Request.remote_ip` setter to clear set the instance
+    `remote_ip` to `nil` before setting the header that the value is derived
+    from.
+
+    Fixes https://github.com/rails/rails/issues/37383
+
+    *Norm Provost*
+
 *   `ActionController::Base.log_at` allows setting a different log level per request.
 
     ```ruby

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -281,6 +281,7 @@ module ActionDispatch
     end
 
     def remote_ip=(remote_ip)
+      @remote_ip = nil
       set_header "action_dispatch.remote_ip", remote_ip
     end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -103,6 +103,11 @@ class RequestIP < BaseRequestTest
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "not_ip_address"
     assert_nil request.remote_ip
+
+    request = stub_request "REMOTE_ADDR" => "1.2.3.4"
+    assert_equal "1.2.3.4", request.remote_ip
+    request.remote_ip = "2.3.4.5"
+    assert_equal "2.3.4.5", request.remote_ip
   end
 
   test "remote ip spoof detection" do


### PR DESCRIPTION
### Summary

Updated the setter to clear the value in the `@remote_ip` instance
variable before setting the header that the value is derived from in the
getter.

Related open issue: https://github.com/rails/rails/issues/37383

