### PR TITLE
fix(fork-tracker): Only patch fork if it's supported

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -35,10 +35,12 @@ module ActiveSupport
       end
 
       def hook!
-        ::Object.prepend(CoreExtPrivate)
-        ::Kernel.prepend(CoreExtPrivate)
-        ::Kernel.singleton_class.prepend(CoreExt)
-        ::Process.singleton_class.prepend(CoreExt)
+        if Process.respond_to?(:fork)
+          ::Object.prepend(CoreExtPrivate)
+          ::Kernel.prepend(CoreExtPrivate)
+          ::Kernel.singleton_class.prepend(CoreExt)
+          ::Process.singleton_class.prepend(CoreExt)
+        end
       end
 
       def after_fork(&block)

--- a/activesupport/test/fork_tracker_test.rb
+++ b/activesupport/test/fork_tracker_test.rb
@@ -207,4 +207,4 @@ class ForkTrackerTest < ActiveSupport::TestCase
   ensure
     ActiveSupport::ForkTracker.unregister(handler)
   end
-end
+end if Process.respond_to?(:fork)


### PR DESCRIPTION
### Summary

Some tests are currently wrapped with  `if Process.respond_to?(:fork)`
but they're still executed on JRuby. The problem is that ForkTracker
unconditionally patches `#fork` so `Process` does indeed
`respond_to? :fork`.

Fix it by installing the patch conditionally with the same check.