### PR TITLE
Refactor connection specification and connection handler

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/role.rb
+++ b/activerecord/lib/active_record/connection_adapters/role.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class Role # :nodoc:
       include Mutex_m
 
-      attr_reader :db_config, :connection_specification_name
+      attr_reader :db_config, :name
       attr_accessor :schema_cache
 
       INSTANCES = ObjectSpace::WeakMap.new
@@ -17,9 +17,9 @@ module ActiveRecord
         end
       end
 
-      def initialize(connection_specification_name, db_config)
+      def initialize(name, db_config)
         super()
-        @connection_specification_name = connection_specification_name
+        @name = name
         @db_config = db_config
         @pool = nil
         INSTANCES[self] = self

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -134,14 +134,6 @@ module ActiveRecord
 
       self.filter_attributes = []
 
-      def self.connection_handler
-        Thread.current.thread_variable_get(:ar_connection_handler) || default_connection_handler
-      end
-
-      def self.connection_handler=(handler)
-        Thread.current.thread_variable_set(:ar_connection_handler, handler)
-      end
-
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -199,7 +199,7 @@ end_error
     # and then establishes the connection.
     initializer "active_record.initialize_database" do
       ActiveSupport.on_load(:active_record) do
-        self.connection_handlers = { writing_role => ActiveRecord::Base.default_connection_handler }
+        self.connection_handlers = { "ActiveRecord::Base" => ActiveRecord::Base.default_connection_handler }
         self.configurations = Rails.application.config.database_configuration
         establish_connection
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -136,7 +136,7 @@ module ActiveRecord
       end
 
       def create_all
-        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
+        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.writing_role)
         each_local_configuration { |db_config| create(db_config) }
         if old_pool
           ActiveRecord::Base.connection_handler.establish_connection(old_pool.db_config)

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -11,16 +11,15 @@ module ActiveRecord
       fixtures :people
 
       def setup
-        @handlers = { writing: ConnectionHandler.new, reading: ConnectionHandler.new }
-        @rw_handler = @handlers[:writing]
-        @ro_handler = @handlers[:reading]
-        @spec_name = "primary"
-        @rw_pool = @handlers[:writing].establish_connection(ActiveRecord::Base.configurations["arunit"])
-        @ro_pool = @handlers[:reading].establish_connection(ActiveRecord::Base.configurations["arunit"])
+        @handlers = { "Base" => ConnectionHandler.new, "Animal" => ConnectionHandler.new }
+        @primary_handler = @handlers["Base"]
+        @animals_handler = @handlers["Animal"]
+        @rw_pool = @handlers["Base"].establish_connection(ActiveRecord::Base.configurations["arunit"], role: :writing)
+        @ro_pool = @handlers["Animal"].establish_connection(ActiveRecord::Base.configurations["arunit"], role: :reading)
       end
 
       def teardown
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        ActiveRecord::Base.connection_handlers = { "ActiveRecord::Base" => ActiveRecord::Base.default_connection_handler }
       end
 
       class MultiConnectionTestModel < ActiveRecord::Base
@@ -81,11 +80,11 @@ module ActiveRecord
 
           ActiveRecord::Base.connects_to(database: { writing: :default, reading: :readonly })
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("primary")
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:writing)
           assert_equal "db/primary.sqlite3", pool.db_config.database
           assert_equal "default", pool.db_config.spec_name
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:reading)
           assert_equal "db/readonly.sqlite3", pool.db_config.database
           assert_equal "readonly", pool.db_config.spec_name
         ensure
@@ -108,16 +107,14 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { writing: :primary, reading: :readonly })
 
           ActiveRecord::Base.connected_to(role: :reading) do
-            @ro_handler = ActiveRecord::Base.connection_handler
-            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:reading]
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
             assert_equal :reading, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :reading)
             assert_not ActiveRecord::Base.connected_to?(role: :writing)
           end
 
           ActiveRecord::Base.connected_to(role: :writing) do
-            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:writing]
-            assert_not_equal @ro_handler, ActiveRecord::Base.connection_handler
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
             assert_equal :writing, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :writing)
             assert_not ActiveRecord::Base.connected_to?(role: :reading)
@@ -141,10 +138,10 @@ module ActiveRecord
 
           ActiveRecord::Base.connects_to(database: { default: :primary, readonly: :readonly })
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:default].retrieve_connection_pool("primary")
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:default)
           assert_equal "db/primary.sqlite3", pool.db_config.database
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:readonly].retrieve_connection_pool("primary")
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:readonly)
           assert_equal "db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -161,9 +158,9 @@ module ActiveRecord
             assert ActiveRecord::Base.connected_to?(role: :writing)
 
             handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_equal handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
+            assert_not_nil pool = handler.retrieve_connection_pool(:writing)
             assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
           end
         ensure
@@ -181,9 +178,9 @@ module ActiveRecord
             assert ActiveRecord::Base.connected_to?(role: :writing)
 
             handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_equal handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
+            assert_not_nil pool = handler.retrieve_connection_pool(:writing)
             assert_equal(config, pool.db_config.configuration_hash)
           end
         ensure
@@ -221,9 +218,9 @@ module ActiveRecord
             assert ActiveRecord::Base.connected_to?(role: :writing)
 
             handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_equal handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
+            assert_not_nil pool = handler.retrieve_connection_pool(:writing)
             assert_equal(config["default_env"]["animals"], pool.db_config.configuration_hash)
           end
         ensure
@@ -248,9 +245,9 @@ module ActiveRecord
             assert ActiveRecord::Base.connected_to?(role: :writing)
 
             handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_equal handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
+            assert_not_nil pool = handler.retrieve_connection_pool(:writing)
             assert_equal(config["default_env"]["primary"], pool.db_config.configuration_hash)
           end
         ensure
@@ -264,16 +261,19 @@ module ActiveRecord
             "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+          @previous_connection_handlers = ActiveRecord::Base.connection_handlers
+          ActiveRecord::Base.connection_handlers = {}
 
           ActiveRecord::Base.connects_to database: { writing: :development }
 
           assert_equal 1, ActiveRecord::Base.connection_handlers.size
-          assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:writing]
+          assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers["ActiveRecord::Base"]
           assert_equal :writing, ActiveRecord::Base.current_role
           assert ActiveRecord::Base.connected_to?(role: :writing)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
+          ActiveRecord::Base.connection_handlers = @previous_connection_handlers
         end
 
         def test_connects_to_using_top_level_key_in_two_level_config
@@ -285,8 +285,8 @@ module ActiveRecord
 
           ActiveRecord::Base.connects_to database: { writing: :development, reading: :development_readonly }
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
-          assert_equal "db/readonly.sqlite3", pool.db_config.database
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:writing)
+          assert_equal "db/primary.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -303,8 +303,8 @@ module ActiveRecord
 
           assert_equal(
             [
-              ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("primary"),
-              ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("primary")
+              ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:writing),
+              ActiveRecord::Base.connection_handlers["ActiveRecord::Base"].retrieve_connection_pool(:reading)
             ],
             result
           )
@@ -315,87 +315,86 @@ module ActiveRecord
       end
 
       def test_connection_pools
-        assert_equal([@rw_pool], @handlers[:writing].connection_pools)
-        assert_equal([@ro_pool], @handlers[:reading].connection_pools)
+        assert_equal([@rw_pool], @handlers["Base"].connection_pools)
+        assert_equal([@ro_pool], @handlers["Animal"].connection_pools)
       end
 
       def test_retrieve_connection
-        assert @rw_handler.retrieve_connection(@spec_name)
-        assert @ro_handler.retrieve_connection(@spec_name)
+        assert @primary_handler.retrieve_connection(:writing)
+        assert @animals_handler.retrieve_connection(:reading)
       end
 
-      def test_active_connections?
-        assert_not_predicate @rw_handler, :active_connections?
-        assert_not_predicate @ro_handler, :active_connections?
+      def test_active_connections
+        assert_not_predicate @primary_handler, :active_connections?
+        assert_not_predicate @animals_handler, :active_connections?
 
-        assert @rw_handler.retrieve_connection(@spec_name)
-        assert @ro_handler.retrieve_connection(@spec_name)
+        assert @primary_handler.retrieve_connection(:writing)
+        assert @animals_handler.retrieve_connection(:reading)
 
-        assert_predicate @rw_handler, :active_connections?
-        assert_predicate @ro_handler, :active_connections?
+        assert_predicate @primary_handler, :active_connections?
+        assert_predicate @animals_handler, :active_connections?
 
-        @rw_handler.clear_active_connections!
-        assert_not_predicate @rw_handler, :active_connections?
+        @primary_handler.clear_active_connections!
+        assert_not_predicate @primary_handler, :active_connections?
 
-        @ro_handler.clear_active_connections!
-        assert_not_predicate @ro_handler, :active_connections?
+        @animals_handler.clear_active_connections!
+        assert_not_predicate @animals_handler, :active_connections?
       end
 
       def test_retrieve_connection_pool
-        assert_not_nil @rw_handler.retrieve_connection_pool(@spec_name)
-        assert_not_nil @ro_handler.retrieve_connection_pool(@spec_name)
+        assert_not_nil @primary_handler.retrieve_connection_pool(:writing)
+        assert_not_nil @animals_handler.retrieve_connection_pool(:reading)
       end
 
       def test_retrieve_connection_pool_with_invalid_id
-        assert_nil @rw_handler.retrieve_connection_pool("foo")
-        assert_nil @ro_handler.retrieve_connection_pool("foo")
+        assert_nil @primary_handler.retrieve_connection_pool("foo")
+        assert_nil @animals_handler.retrieve_connection_pool("foo")
       end
 
-      def test_connection_handlers_are_per_thread_and_not_per_fiber
-        original_handlers = ActiveRecord::Base.connection_handlers
-
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler, reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new }
-
-        reading_handler = ActiveRecord::Base.connection_handlers[:reading]
-
-        reading = ActiveRecord::Base.with_handler(:reading) do
-          Person.connection_handler
+      def test_connection_role_are_per_thread_and_not_per_fiber
+        reading = Person.connected_to(role: :reading) do
+          Person.connection_handler.current_role
         end
 
-        assert_not_equal reading, ActiveRecord::Base.connection_handler
-        assert_equal reading, reading_handler
-      ensure
-        ActiveRecord::Base.connection_handlers = original_handlers
+        assert_not_equal reading, ActiveRecord::Base.connection_handler.current_role
+        assert_equal Person.current_role, ActiveRecord::Base.current_role
       end
 
       def test_connection_handlers_swapping_connections_in_fiber
-        original_handlers = ActiveRecord::Base.connection_handlers
-
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler, reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new }
-
-        reading_handler = ActiveRecord::Base.connection_handlers[:reading]
-
         enum = Enumerator.new do |r|
-          r << ActiveRecord::Base.connection_handler
+          r << ActiveRecord::Base.current_role
         end
 
-        reading = ActiveRecord::Base.with_handler(:reading) do
+        reading_role = ActiveRecord::Base.connected_to(role: :reading) do
           enum.next
         end
 
-        assert_equal reading, reading_handler
-      ensure
-        ActiveRecord::Base.connection_handlers = original_handlers
+        assert_equal :reading, reading_role
       end
 
       def test_calling_connected_to_on_a_non_existent_handler_raises
-        error = assert_raises ActiveRecord::ConnectionNotEstablished do
-          ActiveRecord::Base.connected_to(role: :reading) do
-            Person.first
+        klassA = Class.new(ActiveRecord::Base) do
+          def self.name
+            "KlassA"
           end
         end
 
-        assert_equal "No connection pool with 'primary' found for the 'reading' role.", error.message
+        klassB = Class.new(klassA) do
+          def self.name
+            "KlassB"
+          end
+        end
+
+        klassA.establish_connection(ActiveRecord::Base.configurations["arunit2"])
+        error = assert_raises ActiveRecord::ConnectionNotEstablished do
+          klassA.connected_to(role: :some_role) do
+            klassB.first
+          end
+        end
+
+        database_name = klassA.connection_config[:database]
+
+        assert_equal "No connection pool for 'some_role' role found for the '#{database_name}' database.", error.message
       end
 
       def test_default_handlers_are_writing_and_reading

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       def resolve_spec(spec, config)
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         resolver = ConnectionAdapters::Resolver.new(configs)
-        resolver.resolve(spec, spec).configuration_hash
+        resolver.resolve(spec).configuration_hash
       end
 
       def test_invalid_string_config
@@ -48,7 +48,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "default_env" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -58,7 +58,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -66,7 +66,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "foo"
         config = { "foo" => { "adapter" => "postgres", "url" => ENV["DATABASE_URL"] } }
         actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgres", url: nil, name: "foo" }
+        expected = { adapter: "postgres", url: nil }
         assert_equal expected, actual
       end
 
@@ -76,7 +76,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -84,7 +84,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:production, config)
-        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost", name: "production" }
+        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -94,7 +94,7 @@ module ActiveRecord
 
         config   = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
         actual   = resolve_spec(:test, config)
-        expected = { adapter: "postgresql", database: "foo_test", host: "localhost", name: "test" }
+        expected = { adapter: "postgresql", database: "foo_test", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -137,7 +137,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "ibm-db://localhost/foo"
         config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { adapter: "ibm_db", database: "foo", host: "localhost", name: "default_env" }
+        expected = { adapter: "ibm_db", database: "foo", host: "localhost" }
         assert_equal expected, actual
       end
 
@@ -395,14 +395,13 @@ module ActiveRecord
         config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
 
         actual = resolve_spec(:production, config)
-        assert_equal config["production"].symbolize_keys.merge(name: "production"), actual
+        assert_equal config["production"].symbolize_keys, actual
 
         actual = resolve_spec(:default_env, config)
         assert_equal({
           host: "localhost",
           database: "foo",
           adapter: "postgresql",
-          name: "default_env"
         }, actual)
       end
     end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -495,9 +495,10 @@ module ActiveRecord
           payloads << payload
         end
         ConnectionTestModel.establish_connection :arunit
+        database_name = ActiveRecord::Base.connection_config[:database]
 
-        assert_equal [:config, :connection_id, :spec_name], payloads[0].keys.sort
-        assert_equal "ActiveRecord::ConnectionAdapters::ConnectionPoolTest::ConnectionTestModel", payloads[0][:spec_name]
+        assert_equal [:config, :connection_id], payloads[0].keys.sort
+        assert_equal database_name, payloads[0][:config][:database]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         def resolve(role, config = {})
           configs = ActiveRecord::DatabaseConfigurations.new(config)
           resolver = ConnectionAdapters::Resolver.new(configs)
-          resolver.resolve(role, role).configuration_hash
+          resolver.resolve(role).configuration_hash
         end
 
         def resolve_role(role, config = {})
@@ -43,7 +43,6 @@ module ActiveRecord
             adapter:  "abstract",
             host:     "foo",
             encoding: "utf8",
-            name:     "production"
           }, role)
         end
 
@@ -53,7 +52,6 @@ module ActiveRecord
             adapter:  "abstract",
             host:     "foo",
             encoding: "utf8",
-            name:     "production"
           }, role)
         end
 
@@ -65,7 +63,6 @@ module ActiveRecord
             host:     "foo",
             encoding: "utf8",
             pool:     "3",
-            name:     "production"
           }, role)
         end
 
@@ -136,18 +133,7 @@ module ActiveRecord
             adapter:  "sqlite3",
             database: "foo",
             encoding: "utf8",
-            name:     "production"
           }, role)
-        end
-
-        def test_role_connection_specification_name_on_key_lookup
-          role = resolve_role(:readonly, "readonly" => { "adapter" => "sqlite3" })
-          assert_equal "readonly", role.connection_specification_name
-        end
-
-        def test_role_connection_specification_name_with_inline_config
-          role = resolve_role("adapter" => "sqlite3")
-          assert_equal "primary", role.connection_specification_name, "should default to primary id"
         end
 
         def test_role_with_invalid_type

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
     end
 
     teardown do
-      ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+      ActiveRecord::Base.connection_handlers = { activerecord_unittest: ActiveRecord::Base.default_connection_handler }
     end
 
     def test_empty_session

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -539,7 +539,7 @@ class FixturesTest < ActiveRecord::TestCase
   def test_fixtures_are_set_up_with_database_env_variable
     db_url_tmp = ENV["DATABASE_URL"]
     ENV["DATABASE_URL"] = "sqlite3::memory:"
-    ActiveRecord::Base.stub(:configurations, {}) do
+    ActiveRecord::Base.stub(:configurations, ActiveRecord::DatabaseConfigurations.new) do
       test_case = Class.new(ActiveRecord::TestCase) do
         fixtures :accounts
 
@@ -1390,35 +1390,24 @@ end
 
 class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
   test "enlist_fixture_connections ensures multiple databases share a connection pool" do
-    old_handlers = ActiveRecord::Base.connection_handlers
-    ActiveRecord::Base.connection_handlers = {}
-
-    with_temporary_connection_pool do
-      ActiveRecord::Base.connects_to database: { writing: :arunit, reading: :arunit2 }
-
-      rw_conn = ActiveRecord::Base.connection
-      ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
-
-      assert_not_equal rw_conn, ro_conn
-
-      enlist_fixture_connections
-
-      rw_conn = ActiveRecord::Base.connection
-      ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
-
-      assert_equal rw_conn, ro_conn
-    end
-  ensure
-    ActiveRecord::Base.connection_handlers = old_handlers
-  end
-
-  private
-    def with_temporary_connection_pool
-      role = ActiveRecord::Base.connection_handler.send(:owner_to_role).fetch("primary")
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(role)
-
-      role.stub(:pool, new_pool) do
-        yield
+    klassA = Class.new(ActiveRecord::Base) do
+      def self.name
+        "KlassA"
       end
     end
+
+    klassA.connects_to database: { writing: :arunit, reading: :arunit }
+
+    rw_conn = klassA.connection
+    ro_conn = ActiveRecord::Base.connection_handlers["KlassA"].retrieve_connection(:reading)
+
+    assert_not_equal rw_conn, ro_conn
+
+    enlist_fixture_connections
+
+    rw_conn = klassA.connection
+    ro_conn = ActiveRecord::Base.connection_handlers["KlassA"].retrieve_connection(:reading)
+
+    assert_equal rw_conn, ro_conn
+  end
 end

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -27,10 +27,10 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_swapping_the_connection
-    old_spec_name, Course.connection_specification_name = Course.connection_specification_name, "primary"
+    old_handler, Course.connection_handler = Course.connection_handler, Entrant.connection_handler
     assert_equal(Entrant.connection, Course.connection)
   ensure
-    Course.connection_specification_name = old_spec_name
+    Course.connection_handler = old_handler
   end
 
   def test_find

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -295,10 +295,10 @@ module ActiveRecord
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
 
-        # To refrain from connecting to a newly created empty DB in
-        # sqlite3_mem tests
-        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
-          yield
+        stub_any_instance(ActiveRecord::ConnectionAdapters::ConnectionHandler, instance: ActiveRecord::Base.connection_handler) do |instance|
+          instance.stub(:establish_connection, nil) do
+            yield
+          end
         end
       ensure
         ActiveRecord::Base.configurations = old_configurations
@@ -400,8 +400,10 @@ module ActiveRecord
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
 
-        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
-          yield
+        stub_any_instance(ActiveRecord::ConnectionAdapters::ConnectionHandler, instance: ActiveRecord::Base.connection_handler) do |instance|
+          instance.stub(:establish_connection, nil) do
+            yield
+          end
         end
       ensure
         ActiveRecord::Base.configurations = old_configurations
@@ -517,8 +519,10 @@ module ActiveRecord
         old_configurations = ActiveRecord::Base.configurations
         ActiveRecord::Base.configurations = @configurations
 
-        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
-          yield
+        stub_any_instance(ActiveRecord::ConnectionAdapters::ConnectionHandler, instance: ActiveRecord::Base.connection_handler) do |instance|
+          instance.stub(:establish_connection, nil) do
+            yield
+          end
         end
       ensure
         ActiveRecord::Base.configurations = old_configurations
@@ -1046,7 +1050,7 @@ module ActiveRecord
       def teardown
         SchemaMigration.delete_all
         InternalMetadata.delete_all
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        ActiveRecord::Base.connection_handlers = { "ActiveRecord::Base" => ActiveRecord::Base.default_connection_handler }
       end
 
       def test_truncate_tables

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -3,7 +3,7 @@
 module ContactFakeColumns
   def self.extended(base)
     base.class_eval do
-      establish_connection(adapter: "fake")
+      establish_connection(adapter: "fake", database: "fake")
 
       connection.data_sources = [table_name]
       connection.primary_keys = {

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -21,7 +21,7 @@ module ARTest
   def self.connect
     puts "Using #{connection_name}"
     ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
-    ActiveRecord::Base.connection_handlers = { ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler }
+    ActiveRecord::Base.connection_handlers = { "ActiveRecord::Base" => ActiveRecord::Base.default_connection_handler }
     ActiveRecord::Base.configurations = connection_config
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -133,12 +133,12 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord, "primary::SchemaMigration"].collect(&:to_s).sort
+    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord].collect(&:to_s).sort
     assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort
     get "/load"
     assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial
     get "/unload"
-    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration", "primary::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
+    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
   end
 
   test "initialize cant be called twice" do


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/37296

There is a lot of tests to fix on this PR, but I tested it against a small application, it's mostly functional. I'd just like to validate the direction it's taking before investing a lot more time into it.

### Current state

Right now, here's what a two DB setup, each with one writer and one reader looks like:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
  connects_to database: { writing: :primary, reading: :primary_replica }
end

class AnimalBase < ApplicationRecord
  self.abstract_class = true
  connects_to database: { writing: :animals, reading: :animals_replica }
end
```

With the following state:

```ruby
>> ApplicationRecord.connection_specification_name
=> "primary"
>> AnimalBase.connection_specification_name
=> "AnimalBase"
>> ActiveRecord::Base.connection_handlers.keys
=> [:writing, :reading]
>> ActiveRecord::Base.connection_handlers.fetch(:reading).connection_pool_names
=> ["primary", "AnimalBase"]
```

So in other words, there's one `ConnectionHandler` instance per `role`. And each `ConnectionHandler` connects to different "database schemas"

### Where this PR is trying to go

IMO it should be the inverse, there should be one `ConnectionHandler` per "database schema" (`primary` vs `animals`), and it should handle all the roles of that schema (`writing`, `reading`, etc).

With this PR:

```ruby
>> ApplicationRecord.connection_handler.connection_pool_names
=> [:writing, :reading]
>> AnimalBase.connection_handler.connection_pool_names
=> [:writing, :reading]
```

Whenever you call `connects_to` on a model, it assign a new `ConnectionHandler` on it, and from there the inheritance chain take care of accessing the right set of connections.

Also rather then switching handlers, we only switch the currently selected role:

```ruby
>> AnimalBase.current_role
=> :writing
>> AnimalBase.connected_to(role: :reading) { AnimalBase.current_role }
=> :reading
>> AnimalBase.connected_to(role: :reading) { ApplicationRecord.current_role }
=> :writing
```

@matthewd @eileencodes @seejohnrun at this stage I'd like your opinions here, because It's heavily changing how multidb connection works, and I think at least part of the backward compatibility will have to be broken (not 100% sure yet).

cc @rafaelfranca @Edouard-chin @etiennebarrie  

