### PR TITLE
Update comment in controller generators

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -49,7 +49,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     end
 
-    # Only allow a trusted parameter "white list" through.
+    # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -56,7 +56,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
     end
 
-    # Only allow a trusted parameter "white list" through.
+    # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
       params.fetch(:<%= singular_table_name %>, {})


### PR DESCRIPTION
In #33681 we stopped using "whitelist" in Rails in favor of
allowed/trusted. I found this because jbuilder is using old text from
2013 but noticed this still uses "white list". I think the new comment
is a bit clearer as well.
