### PR TITLE
Use FileUpdateChecker for Migration::CheckPending 

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -3,6 +3,7 @@
 require "benchmark"
 require "set"
 require "zlib"
+require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/actionable_error"
 
@@ -553,21 +554,37 @@ module ActiveRecord
     # This class is used to verify that all migrations have been run before
     # loading a web page if <tt>config.active_record.migration_error</tt> is set to :page_load
     class CheckPending
-      def initialize(app)
+      def initialize(app, file_watcher: ActiveSupport::FileUpdateChecker)
         @app = app
-        @last_check = 0
+        @needs_check = true
+        @mutex = Mutex.new
+        @file_watcher = file_watcher
       end
 
       def call(env)
-        mtime = ActiveRecord::Base.connection.migration_context.last_migration.mtime.to_i
-        if @last_check < mtime
-          ActiveRecord::Migration.check_pending!(connection)
-          @last_check = mtime
+        @mutex.synchronize do
+          @watcher ||= build_watcher do
+            @needs_check = true
+            ActiveRecord::Migration.check_pending!(connection)
+            @needs_check = false
+          end
+
+          if @needs_check
+            @watcher.execute
+          else
+            @watcher.execute_if_updated
+          end
         end
+
         @app.call(env)
       end
 
       private
+        def build_watcher(&block)
+          paths = Array(connection.migration_context.migrations_paths)
+          @file_watcher.new([], paths.index_with(["rb"]), &block)
+        end
+
         def connection
           ActiveRecord::Base.connection
         end
@@ -993,10 +1010,6 @@ module ActiveRecord
       File.basename(filename)
     end
 
-    def mtime
-      File.mtime filename
-    end
-
     delegate :migrate, :announce, :write, :disable_ddl_transaction, to: :migration
 
     private
@@ -1008,16 +1021,6 @@ module ActiveRecord
         require(File.expand_path(filename))
         name.constantize.new(name, version)
       end
-  end
-
-  class NullMigration < MigrationProxy #:nodoc:
-    def initialize
-      super(nil, 0, nil, nil)
-    end
-
-    def mtime
-      0
-    end
   end
 
   class MigrationContext #:nodoc:
@@ -1096,10 +1099,6 @@ module ActiveRecord
 
     def any_migrations?
       migrations.any?
-    end
-
-    def last_migration #:nodoc:
-      migrations.last || NullMigration.new
     end
 
     def migrations

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -82,10 +82,11 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { LogSubscriber.backtrace_cleaner = ::Rails.backtrace_cleaner }
     end
 
-    initializer "active_record.migration_error" do
+    initializer "active_record.migration_error" do |app|
       if config.active_record.delete(:migration_error) == :page_load
         config.app_middleware.insert_after ::ActionDispatch::Callbacks,
-          ActiveRecord::Migration::CheckPending
+          ActiveRecord::Migration::CheckPending,
+          file_watcher: app.config.file_watcher
       end
     end
 

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -7,34 +7,98 @@ module ActiveRecord
     if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       class PendingMigrationsTest < ActiveRecord::TestCase
         setup do
+          @migration_dir = Dir.mktmpdir("activerecord-migrations-")
+
           file = ActiveRecord::Base.connection.raw_connection.filename
-          @conn = ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:", migrations_paths: MIGRATIONS_ROOT + "/valid"
+          @conn = ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:", migrations_paths: @migration_dir
           source_db = SQLite3::Database.new file
           dest_db = ActiveRecord::Base.connection.raw_connection
           backup = SQLite3::Backup.new(dest_db, "main", source_db, "main")
           backup.step(-1)
           backup.finish
+
+          ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
+
+          @app = Minitest::Mock.new
         end
 
         teardown do
           @conn.release_connection if @conn
           ActiveRecord::Base.establish_connection :arunit
+          FileUtils.rm_rf(@migration_dir)
+        end
+
+        def run_migrations
+          migrator = Base.connection.migration_context
+          capture(:stdout) { migrator.migrate }
+        end
+
+        def create_migration(number, name)
+          filename = "#{number}_#{name.underscore}.rb"
+          File.write(File.join(@migration_dir, filename), <<~RUBY)
+            class #{name.classify} < ActiveRecord::Migration::Current
+            end
+          RUBY
         end
 
         def test_errors_if_pending
-          ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
+          create_migration "01", "create_foo"
 
           assert_raises ActiveRecord::PendingMigrationError do
-            CheckPending.new(Proc.new { }).call({})
+            CheckPending.new(@app).call({})
+          end
+
+          # Continues failing
+          assert_raises ActiveRecord::PendingMigrationError do
+            CheckPending.new(@app).call({})
           end
         end
 
         def test_checks_if_supported
-          ActiveRecord::SchemaMigration.create_table
-          migrator = Base.connection.migration_context
-          capture(:stdout) { migrator.migrate }
+          run_migrations
 
-          assert_nil CheckPending.new(Proc.new { }).call({})
+          check_pending = CheckPending.new(@app)
+
+          @app.expect :call, nil, [{}]
+          check_pending.call({})
+          @app.verify
+
+          # With cached result
+          @app.expect :call, nil, [{}]
+          check_pending.call({})
+          @app.verify
+        end
+
+        def test_okay_with_no_migrations
+          check_pending = CheckPending.new(@app)
+
+          @app.expect :call, nil, [{}]
+          check_pending.call({})
+          @app.verify
+
+          # With cached result
+          @app.expect :call, nil, [{}]
+          check_pending.call({})
+          @app.verify
+        end
+
+        # Regression test for https://github.com/rails/rails/pull/29759
+        def test_understands_migrations_created_out_of_order
+          # With a prior file before even initialization
+          create_migration "05", "create_bar"
+          run_migrations
+
+          check_pending = CheckPending.new(@app)
+
+          @app.expect :call, nil, [{}]
+          check_pending.call({})
+          @app.verify
+
+          # It understands the new migration created at 01
+          create_migration "01", "create_foo"
+          assert_raises ActiveRecord::PendingMigrationError do
+            check_pending.call({})
+          end
         end
       end
     end


### PR DESCRIPTION
This is a second attempt at #29759, which I should have got around to sooner, it wasn't that hard to fix 😅.

`Migration::CheckPending` is a rack middleware normally used in development to raise an exception when there are pending migrations.

This commit replaces the existing caching, which avoided checking all migrations if the newest migration hasn't changed. Instead, we now use `FileUpdateChecker`, which has two advantages: it can detect new migrations which aren't the highest version number, and it is faster.


## Improved checking

The existing code watched for the value of `last_migration.mtime` to change, the modification time on the  file with the highest version number. This works most of the time, but when merging/rebasing/checking out other branches, it's likely to have "new" migrations arrive with a lower version number than the previous highest. In this event the `CheckPending` will not notice and not re-check that migrations are up to date.

What we really want is to check for the greatest `mtime` of all migrations, and re-check if any files are new. This happens to be exactly what `ActiveSupport::FileUpdateChecker` already does! :tada: 

## Improved performance

This middleware is probably only run in development, but this check was actually quite slow (not shown in logs because the middleware came first). As an example I tested Discourse (900+ migrations) which added 25ms extra per request in development mode.

This slowness is because `last_migration` is `migrations.last`, and `migrations` needs to glob and then for each migration file needs to `File.basename`, a regex to extract version/name/scope, and `camelize`. Using `FileUpdateChecker` is a bit faster in my testing.

In the base case, we'll use `EventedFileUpdateChecker` (default for new apps), 

## Performance testing

For testing, I made a new rails application, and generated 500 migrations

```
$ bundle exec rails new --dev sandbox
$ bundle exec rails c
> require "rails/generators"
> require "rails/generators/rails/migration/migration_generator"
> 500.times { |i| Rails::Generators::MigrationGenerator.start(["TestSomeMigrations#{i}", "--orm=active_record"]) }
$ bundle exec rake db:migrate
```

I have the following benchmark script
``` ruby
require "benchmark/ips"
require "./config/environment"

check_pending = ActiveRecord::Migration::CheckPending.new(->(env){})
# check_pending = ActiveRecord::Migration::CheckPending.new(->(env){}, file_watcher: ActiveSupport::EventedFileUpdateChecker)

env = {}

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report("CheckPending#call") { check_pending.call(env) }
end
```

**Original**

```
$ be ruby benchmark.rb
Warming up --------------------------------------
   CheckPending#call    11.000  i/100ms
Calculating -------------------------------------
   CheckPending#call    135.510  (±12.5%) i/s -    671.000  in   5.083931s
```

**This PR** (when `file_watcher == FileUpdateChecker`)

```
$ be ruby benchmark.rb
Warming up --------------------------------------
   CheckPending#call    34.000  i/100ms
Calculating -------------------------------------
   CheckPending#call    348.063  (±18.1%) i/s -      1.666k in   5.024624s
```

**This PR** (when `file_watcher == EventedFileUpdateChecker`)

(It basically becomes a no-op, because the file changes are reported async)

```
$ be ruby benchmark.rb
Warming up --------------------------------------
   CheckPending#call   128.936k i/100ms
Calculating -------------------------------------
   CheckPending#call      1.884M (± 2.5%) i/s -      9.412M in   5.000561s
```
