### PR TITLE
Rename load_paths.

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -135,7 +135,7 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
-Note that appending directly to `I18n.load_paths` instead of to the application's configured i18n will _not_ override translations from external gems.
+Note that appending directly to `I18n.load_path` instead of to the application's configured i18n will _not_ override translations from external gems.
 
 ### Managing the Locale across Requests
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Hi, I found typo for Railsguide's i18n description. Don't exist `I18n.load_paths` method. 

ref:
https://github.com/ruby-i18n/i18n/search?q=load_paths&unscoped_q=load_paths

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
