### PR TITLE
Add `ActiveStorage::Attached::Model#has_attachment_on?`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `#has_attachment_on?` method to check whether there is an attachment for a given attribute or not.
+
+    ```ruby
+    class User < ApplicationRecord
+      has_one_attached :avatar
+    end
+
+    user = User.new
+    user.has_attachment_on?(:avatar) # true
+    user.has_attachment_on?(:photo) # false
+    ```
+
+    *Leonardo Tegon*
+
 *   Make services aware of configuration names.
 
     *Gannon McGibbon*

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -173,6 +173,20 @@ module ActiveStorage
         end
     end
 
+    # Returns whether there is an attachment for a given +attribute+ or not.
+    #
+    #   class User < ApplicationRecord
+    #     has_one_attached :avatar
+    #   end
+    #
+    #   user = User.new
+    #   user.has_attachment_on?(:avatar) # true
+    #   user.has_attachment_on?(:photo) # false
+    #
+    def has_attachment_on?(attribute)
+      self.class.reflect_on_attachment(attribute).present?
+    end
+
     def attachment_changes #:nodoc:
       @attachment_changes ||= {}
     end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -608,6 +608,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_match(/Cannot configure service :unknown for User#featured_photos/, error.message)
   end
 
+  test "#has_attachment_on? returns whether there is an attachment for a given attribute or not" do
+    assert @user.has_attachment_on?(:highlights)
+    assert @user.has_attachment_on?(:vlogs)
+    assert_not @user.has_attachment_on?(:pictures)
+  end
+
   private
     def append_on_assign
       ActiveStorage.replace_on_assign_to_many, previous = false, ActiveStorage.replace_on_assign_to_many

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -574,4 +574,10 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
     assert_match(/Cannot configure service :unknown for User#featured_photo/, error.message)
   end
+
+  test "#has_attachment_on? returns whether there is an attachment for a given attribute or not" do
+    assert @user.has_attachment_on?(:avatar)
+    assert @user.has_attachment_on?(:cover_photo)
+    assert_not @user.has_attachment_on?(:picture)
+  end
 end


### PR DESCRIPTION
## Summary
This method is useful to check whether there is an attachment for a given attribute or not. Applications that would benefit from this are the ones that need to treat attributes differently based on their type.

## Why?
We found the need for this inside [Simple Form](https://github.com/plataformatec/simple_form/blob/v5.0.1/lib/simple_form/form_builder.rb#L591) where the library tries to guess the input type based on some conditions.

The idea is: if we're able to introduce an API for this in Active Storage we might be able to include it in other libraries too so that there will be a unified API for this across Rails' upload Gems.

## Examples
```ruby
class User < ApplicationRecord
  has_one_attached :avatar
end

user = User.new
user.has_attachment_on?(:avatar) # true
user.has_attachment_on?(:photo) # false
```