### PR TITLE
Fix collision check when using a generator and using the force option

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Generators that inherit from NamedBase respect `--force` option
+
+  *Josh Brody*
+
 * Support using environment variable to set pidfile
 
   *Ben Thorner*

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -252,6 +252,7 @@ module Rails
         def class_collisions(*class_names)
           return unless behavior == :invoke
           return if options.skip_collision_check?
+          return if options.force?
 
           class_names.flatten.each do |class_name|
             class_name = class_name.to_s
@@ -265,7 +266,7 @@ module Rails
             if last && last.const_defined?(last_name.camelize, false)
               raise Error, "The name '#{class_name}' is either already used in your application " \
                            "or reserved by Ruby on Rails. Please choose an alternative or use --skip-collision-check "  \
-                           "to skip this check and run this generator again."
+                           "or --force to skip this check and run this generator again."
             end
           end
         end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -208,5 +208,15 @@ module ApplicationTests
       output = rails("generate", "model", "post", "title:string", "body:string", "--skip-collision-check")
       assert_no_match(/The name 'Post' is either already used in your application or reserved/, output)
     end
+
+    test "force" do
+      rails("generate", "model", "post", "title:string")
+
+      output = rails("generate", "model", "post", "title:string", "body:string")
+      assert_match(/The name 'Post' is either already used in your application or reserved/, output)
+
+      output = rails("generate", "model", "post", "title:string", "body:string", "--force")
+      assert_no_match(/The name 'Post' is either already used in your application or reserved/, output)
+    end
   end
 end


### PR DESCRIPTION
### Summary

Fixes #37403 and #37538 

Generators that inherit from NamedBase have options `--force` or `-f` available to overwrite files that already exist. Prior to this PR, using this option would raise an error saying that the constant already existed or the name was reserved. See https://github.com/rails/rails/pull/36603 for more info.

### Other information

The migration generator respected this already.