### PR TITLE
Move pool and friends out of DatabaseConfig

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -6,60 +6,13 @@ module ActiveRecord
     # UrlConfig respectively. It will never return a DatabaseConfig object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
-      include Mutex_m
-
       attr_reader :env_name, :spec_name
 
       attr_accessor :schema_cache
 
-      INSTANCES = ObjectSpace::WeakMap.new
-      private_constant :INSTANCES
-
-      class << self
-        def discard_pools!
-          INSTANCES.each_key(&:discard_pool!)
-        end
-      end
-
       def initialize(env_name, spec_name)
-        super()
         @env_name = env_name
         @spec_name = spec_name
-        @pool = nil
-
-        INSTANCES[self] = self
-      end
-
-      def disconnect!
-        ActiveSupport::ForkTracker.check!
-
-        return unless @pool
-
-        synchronize do
-          return unless @pool
-
-          @pool.automatic_reconnect = false
-          @pool.disconnect!
-        end
-
-        nil
-      end
-
-      def connection_pool
-        ActiveSupport::ForkTracker.check!
-
-        @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
-      end
-
-      def discard_pool!
-        return unless @pool
-
-        synchronize do
-          return unless @pool
-
-          @pool.discard!
-          @pool = nil
-        end
       end
 
       def config
@@ -108,5 +61,3 @@ module ActiveRecord
     end
   end
 end
-
-ActiveSupport::ForkTracker.after_fork { ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools! }

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1417,8 +1417,11 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
 
-      db_config.stub(:connection_pool, new_pool) do
-        yield
-      end
+      old_pool = ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config]
+      ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config] = new_pool
+
+      yield
+    ensure
+      ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config] = old_pool
     end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -558,9 +558,12 @@ class QueryCacheTest < ActiveRecord::TestCase
       db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
 
-      db_config.stub(:connection_pool, new_pool) do
-        yield
-      end
+      old_pool = ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config]
+      ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config] = new_pool
+
+      yield
+    ensure
+      ActiveRecord::ConnectionAdapters::PoolManager.instance.config_to_pool[db_config] = old_pool
     end
 
     def middleware(&app)

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -13,7 +13,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
     @specification = ActiveRecord::Base.remove_connection
 
     # Clear out connection info from other pids (like a fork parent) too
-    ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools!
+    ActiveRecord::ConnectionAdapters::PoolManager.instance.discard_pools!
   end
 
   teardown do


### PR DESCRIPTION
Note: this PR removes WeakRef and no tests failed. If we need it we can add tests to make sure it sticks around in future refactorings.
 
cc/ @casperisfine @rafaelfranca @matthewd @seejohnrun @tenderlove @jhawthorn 

This PR moves `pool`, `disconnect_pools!`, `discard_pool!`,
`disconnect_pool!`, etc out of the `DatabaseConfig` and into a new
`PoolManager` class.

The `DatabaseConfig` is for storing how databases connect and shouldn't
have any knowledge of their pool.

We also removed the WeakMap since discard (which it calls) already
removes entries from the config_to_pool Hash - and no tests failed.
We should get the same behavior as WeakMap by deleting from the map.
