### PR TITLE
Add SES delivery method and mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,11 @@ end
 gem "aws-sdk-sns", require: false
 gem "webmock"
 
+# Action Mailer
+group :mailer do
+  gem "aws-sdk-ses", require: false
+end
+
 group :ujs do
   gem "qunit-selenium"
   gem "webdrivers"

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "action_mailer/ses_mailer"
 
 module ActionMailer
   # This module handles everything related to mail delivery, from registering
@@ -34,6 +35,8 @@ module ActionMailer
         arguments: "-i"
 
       add_delivery_method :test, Mail::TestMailer
+
+      add_delivery_method :ses, SESMailer
     end
 
     # Helpers for creating and wrapping delivery behavior, used by DeliveryMethods.

--- a/actionmailer/lib/action_mailer/ses_mailer.rb
+++ b/actionmailer/lib/action_mailer/ses_mailer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+gem "aws-sdk-ses", "~> 1"
+
+require "aws-sdk-ses"
+
+module ActionMailer
+  module DeliveryMethods
+    # Provides a delivery method for ActionMailer that uses Amazon Simple
+    # Email Service. This uses the AWS SDK for Ruby's credential provider
+    # chain when creating an SES client instance. SES can also be used with
+    # Mail::SMTP but only with static credentials.
+    class SESMailer
+      # @param [Hash] options Passes along initialization options to
+      #   [Aws::SES::Client.new](http://docs.aws.amazon.com/sdkforruby/api/Aws/SES/Client.html#initialize-instance_method).
+      def initialize(options = {})
+        @client = Aws::SES::Client.new(options)
+      end
+
+      # Rails expects this method to exist, and to handle a Mail::Message
+      # object correctly. Called during mail delivery.
+      def deliver!(message)
+        send_opts = {}
+        send_opts[:raw_message] = {}
+        send_opts[:raw_message][:data] = message.to_s
+
+        if message.respond_to?(:destinations)
+          send_opts[:destinations] = message.destinations
+        end
+
+        @client.send_raw_email(send_opts).tap do |response|
+          message.header[:ses_message_id] = response.message_id
+        end
+      end
+
+      # ActionMailer expects this method to be present and to return a hash.
+      def settings
+        {}
+      end
+    end
+  end
+end

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -45,6 +45,11 @@ class DefaultsDeliveryMethodsTest < ActiveSupport::TestCase
     }
     assert_equal settings, ActionMailer::Base.sendmail_settings
   end
+
+  test "default ses settings" do
+    settings = {}
+    assert_equal settings, ActionMailer::Base.ses_settings
+  end
 end
 
 class CustomDeliveryMethodsTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

This PR will add a Simple Email Service (SES) delivery method for Action Mailer. SES can be used today using SMTP but only supports *static* credentials. When using the SES client from the SDK, credentials are pulled from the credential provider chain, which may include rotatable credentials and those from config files located in ~/.aws/.

### Other Information

I am having trouble creating unit tests for this - I'm not sure how to best organize the code in the package. Please give me any feedback for this and I am happy to add tests.

I was able to test this in an adhoc manner by creating a new rails application (and pointing the path in the Gemfile to the updated rails source). I set the delivery method to :ses and used a simple mailer class to email myself using a controller action.
