### PR TITLE
Don't run callbacks on has_many inverse add

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -290,7 +290,7 @@ module ActiveRecord
         when Array
           super
         else
-          add_to_target(record)
+          add_to_target(record, true)
         end
       end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -620,6 +620,11 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     assert_equal i.topic, iz.topic, "Interest topics should be the same after changes to parent-owned instance"
   end
 
+  def test_does_not_trigger_association_callbacks_on_set_when_the_inverse_is_a_has_many
+    man = interests(:trainspotting).man_with_callbacks
+    assert_not_predicate man, :add_callback_called?
+  end
+
   def test_child_instance_should_be_shared_with_replaced_via_accessor_parent
     f = Face.first
     m = Man.new(name: "Charles")
@@ -715,6 +720,11 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_equal i.topic, iz.topic, "Interest topics should be the same after changes to child"
     iz.topic = "Cow tipping"
     assert_equal i.topic, iz.topic, "Interest topics should be the same after changes to parent-owned instance"
+  end
+
+  def test_does_not_trigger_association_callbacks_on_set_when_the_inverse_is_a_has_many
+    man = interests(:llama_wrangling).polymorphic_man_with_callbacks
+    assert_not_predicate man, :add_callback_called?
   end
 
   def test_trying_to_access_inverses_that_dont_exist_shouldnt_raise_an_error

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -2,6 +2,15 @@
 
 class Interest < ActiveRecord::Base
   belongs_to :man, inverse_of: :interests
+  belongs_to :man_with_callbacks,
+    class_name: "Man",
+    foreign_key: :man_id,
+    inverse_of: :interests_with_callbacks
   belongs_to :polymorphic_man, polymorphic: true, inverse_of: :polymorphic_interests
+  belongs_to :polymorphic_man_with_callbacks,
+    foreign_key: :polymorphic_man_id,
+    foreign_type: :polymorphic_man_type,
+    polymorphic: true,
+    inverse_of: :polymorphic_interests_with_callbacks
   belongs_to :zine, inverse_of: :interests
 end

--- a/activerecord/test/models/man.rb
+++ b/activerecord/test/models/man.rb
@@ -5,11 +5,31 @@ class Man < ActiveRecord::Base
   has_one :polymorphic_face, class_name: "Face", as: :polymorphic_man, inverse_of: :polymorphic_man
   has_one :polymorphic_face_without_inverse, class_name: "Face", as: :poly_man_without_inverse
   has_many :interests, inverse_of: :man
-  has_many :polymorphic_interests, class_name: "Interest", as: :polymorphic_man, inverse_of: :polymorphic_man
+  has_many :interests_with_callbacks,
+    class_name: "Interest",
+    before_add: :add_called,
+    after_add: :add_called,
+    inverse_of: :man_with_callbacks
+  has_many :polymorphic_interests,
+    class_name: "Interest",
+    as: :polymorphic_man,
+    inverse_of: :polymorphic_man
+  has_many :polymorphic_interests_with_callbacks,
+    class_name: "Interest",
+    as: :polymorphic_man,
+    before_add: :add_called,
+    after_add: :add_called,
+    inverse_of: :polymorphic_man
   # These are "broken" inverse_of associations for the purposes of testing
   has_one :dirty_face, class_name: "Face", inverse_of: :dirty_man
   has_many :secret_interests, class_name: "Interest", inverse_of: :secret_man
   has_one :mixed_case_monkey
+
+  attribute :add_callback_called, :boolean, default: false
+
+  def add_called(_interest)
+    self.add_callback_called = true
+  end
 end
 
 class Human < Man


### PR DESCRIPTION
### Summary

Stop running association callbacks on `has_many` inverse adds.

Related to https://github.com/rails/rails/pull/34533, we want to silently set the inverse in `has_many` relations, as to not trigger logic meant for newly added records.

Setting an inverse on `has_many` will very likely break existing applications, but it is correct behaviour. I'll followup with another PR to make this behaviour opt-in so we can give people more time to adjust their apps.