### PR TITLE
Set Cache-Control headers when file server enabled in production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -22,7 +22,14 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  if ENV['RAILS_SERVE_STATIC_FILES'].blank?
+    config.public_file_server.enabled = false
+  else
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+    }
+  end
 
   <%- unless options.skip_sprockets? -%>
   # Compress CSS using a preprocessor.


### PR DESCRIPTION
### Summary

Currently development/test environments set `Cache-Control` header defaults on the public file server if the static server is enabled. I just discovered after running Lighthouse against one of our internal apps this is not the case in production. This change introduces a sensible default to the production.rb environment template.

### Other Information

I took the header value from the development option. It may be in production we are happy to send a more aggressive Cache-Control header by default? For my use case, I'd be happy to set max-age to 1mo+ since we are only serving hashed assets, but I could imagine there are cases where this might not work well?