### PR TITLE
Allow migrations that have `null:true` and `default:` options.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   `t.timestamp 'column_name' null: true, default -> { "CURRENT_TIMESTAMP" }` migration now create nullable column
+
+    Before:
+    
+    ```ruby
+    t.timestamp 'column_name', null: true, default -> { "CURRENT_TIMESTAMP" } #=> generate NOT NULL column
+    ```
+
+    After:
+    
+    ```ruby
+    t.timestamp 'column_name', null: true, default -> { "CURRENT_TIMESTAMP" } #=> generate NULL column
+    ```
+ 
+    *Shinpei Maruyama*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -100,7 +100,12 @@ module ActiveRecord
         end
 
         def add_column_options!(sql, options)
-          sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
+          if options_include_default?(options)
+            if options[:null] == true
+              sql << " NULL"
+            end
+            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}"
+          end
           # must explicitly check for :null to allow change_column to work on migrations
           if options[:null] == false
             sql << " NOT NULL"

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -321,6 +321,16 @@ module ActiveRecord
       ensure
         connection.drop_table :my_table, if_exists: true
       end
+
+      def test_add_column_with_default_value_and_null_true
+        connection.create_table "my_table", force: true do |t|
+          t.timestamp :time, null: true, default: -> { "CURRENT_TIMESTAMP" }
+        end
+
+        assert connection.columns("my_table").find { |c| c.name == "time" }.null, "Column 'time' must allow nulls"
+      ensure
+        connection.drop_table :my_table, if_exists: true
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

In MySQL, DDL below create time column with NOT NULL constraint.

    CREATE TABLE my_table(
      id INT AUTO_INCREMENT,
      time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       PRIMARY KEY (id)
    );

On the other hand, Rails migration ignores `null: true` option
because RDBMS accept NULL value when the column was created with
DDL which doesn't have `NULL` nor `NOT NULL`.

Therefore, migrations that specify `t.timestamp null:true, default: ->{ "CURRENT TIMESTAMP" }`
create NOT NULL columns against `null: true` option.

This patch fixes this behavior and now such migrations create NULL columns.


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
