### PR TITLE
Fixes raw_post being empty for "Transfer-Encoding: chunked"

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -990,6 +990,12 @@ XML
     post :render_json, body: { foo: "heyo" }.to_json, as: :json
     assert_equal({ "foo" => "heyo" }, response.parsed_body)
   end
+
+  def test_chunked_request
+    @request.headers["Transfer-Encoding"] = "chunked"
+    post :test_params, params: { foo: "heyo" }, xhr: true
+    assert_equal("foo=heyo", @request.raw_post)
+  end
 end
 
 class ResponseDefaultHeadersTest < ActionController::TestCase


### PR DESCRIPTION
### Summary

We had an issue raised in puma (https://github.com/puma/puma/issues/1839) for chunked requests where the `raw_post` is empty, after digging through the issue I realised this is a bug in rails and not puma (tried with thin web server and `raw_post` is empty too).

Example request:

`curl -H "Transfer-Encoding: chunked" -H "Content-Type: application/json" -d '{"abc": "123"}' -X POST http://localhost:3000/posts/create`

I have repro the issue -- https://github.com/hahmed/chunk-puma-test

EDIT: I tested this PR with the app (chunk-puma-test) aforementioned, which no produces the correct output for `request.raw_post`