### PR TITLE
Show different console message when credentials file is saved with same content

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -20,6 +20,12 @@ module ActiveSupport
       end
     end
 
+    class NoContentChangesError < RuntimeError
+      def initialize
+        super "No changes were made to the file."
+      end
+    end
+
     CIPHER = "aes-128-gcm"
 
     def self.generate_key
@@ -67,7 +73,9 @@ module ActiveSupport
 
         updated_contents = tmp_path.binread
 
-        write(updated_contents) if updated_contents != contents
+        raise NoContentChangesError if updated_contents == contents
+
+        write(updated_contents)
       ensure
         FileUtils.rm(tmp_path) if tmp_path&.exist?
       end

--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -22,7 +22,7 @@ module ActiveSupport
 
     class NoContentChangesError < RuntimeError
       def initialize
-        super "No changes were made to the file."
+        super "File not saved: No changes were made to the file."
       end
     end
 

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -53,6 +53,15 @@ class EncryptedFileTest < ActiveSupport::TestCase
     end
   end
 
+  test "raise NoContentChangesError when file content is not changed" do
+    @encrypted_file.write @content
+    assert_raise(ActiveSupport::EncryptedFile::NoContentChangesError) do
+      @encrypted_file.change do |file|
+        file.write(@content)
+      end
+    end
+  end
+
   test "respects existing content_path symlink" do
     @encrypted_file.write(@content)
 

--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -28,6 +28,8 @@ module Rails
             say "Aborted changing file: nothing saved."
           rescue ActiveSupport::EncryptedFile::MissingKeyError => error
             say error.message
+          rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+            say "File not saved: #{error.message}"
           end
       end
     end

--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -26,10 +26,8 @@ module Rails
             yield
           rescue Interrupt
             say "Aborted changing file: nothing saved."
-          rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+          rescue ActiveSupport::EncryptedFile::MissingKeyError, ActiveSupport::EncryptedFile::NoContentChangesError => error
             say error.message
-          rescue ActiveSupport::EncryptedFile::MissingKeyError => error
-            say "File not saved: #{error.message}"
           end
       end
     end

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -36,9 +36,8 @@ module Rails
 
         catch_editing_exceptions do
           change_credentials_in_system_editor
+          say "File encrypted and saved."
         end
-
-        say "File encrypted and saved."
       rescue ActiveSupport::MessageEncryptor::InvalidMessage
         say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
       end

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -30,9 +30,8 @@ module Rails
 
         catch_editing_exceptions do
           change_encrypted_file_in_system_editor(file_path, options[:key])
+          say "File encrypted and saved."
         end
-
-        say "File encrypted and saved."
       rescue ActiveSupport::MessageEncryptor::InvalidMessage
         say "Couldn't decrypt #{file_path}. Perhaps you passed the wrong key?"
       end


### PR DESCRIPTION
### Summary

This PR adds new console message for the `rails credentials:edit` command.

**File not saved: No changes were made to the file.**

This message will now be printed when credentials file is opened and then closed without any changes being made to the content of the file.

Currently "File encrypted and saved." is always printed, even when no changes were made to the file.