### PR TITLE
Require missing module

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -15,6 +15,7 @@ require "active_support/core_ext/name_error"
 require "active_support/core_ext/string/starts_ends_with"
 require "active_support/dependencies/interlock"
 require "active_support/inflector"
+require "active_support/time"
 
 module ActiveSupport #:nodoc:
   module Dependencies #:nodoc:


### PR DESCRIPTION
Resolves https://github.com/rails/rails/issues/37391

I found out `12959dee0f19a8e050dd1236b031c2c690729905` to be the offending commit by using `git bisect` and making sure to `spring stop` before running `bundle exec rails c` on each commit.

I think that the commit makes sense, but it just had a side effect because the `time` file wasn't correctly required in some other place. For that reason I went with the approach of requiring the `time` file in the `dependencies` file. I'm not familiar with this code so it's possible that there is a better place where to do it.