### PR TITLE
Fix eager load for no :has_many with limit and joins for :has_many

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -384,7 +384,8 @@ module ActiveRecord
         )
         relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
 
-        if eager_loading && !using_limitable_reflections?(join_dependency.reflections)
+        reflections = join_dependency.reflections + joins_values.map { |joins_value| reflect_on_association(joins_value) }.reject(&:blank?)
+        if eager_loading && !using_limitable_reflections?(reflections)
           if has_limit_or_offset?
             limited_ids = limited_ids_for(relation)
             limited_ids.empty? ? relation.none! : relation.where!(primary_key => limited_ids)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1336,6 +1336,12 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [0, 1, 1], posts.map(&:author_id).sort
   end
 
+  def test_eager_load_for_no_has_many_with_limit_and_joins_for_has_many
+    relation = Post.eager_load(:author).joins(:comments)
+    assert_equal 5, relation.to_a.size
+    assert_equal relation.limit(5).to_a.size, relation.to_a.size
+  end
+
   def test_find_one_message_on_primary_key
     e = assert_raises(ActiveRecord::RecordNotFound) do
       Car.find(0)


### PR DESCRIPTION
### Summary
The results is deduplicated when eager loading. However, eager loading
for no :has_many with limit and joins for :has_many do not deal with
this while eager loading for :has_many deals with this.

Fixes #37356 
