### PR TITLE
Fixes TypeError raised for parameter filter if the json data has key as integer

### DIFF
--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "support/schema_dumping_helper"
+require "pp"
 
 module JSONSharedTestCases
   include SchemaDumpingHelper
@@ -249,6 +250,14 @@ module JSONSharedTestCases
     assert_equal({ "three" => "four" }, record.reload.settings.to_hash)
   end
 
+  def test_pretty_print
+    x = JsonDataTypeWithFilter.create!(payload: {})
+    x.payload[11] = "foo"
+    io = StringIO.new
+    PP.pp(x, io)
+    assert io.string
+  end
+
   private
     def klass
       JsonDataType
@@ -266,4 +275,13 @@ module JSONSharedTestCases
         "insert into json_data_type (payload) VALUES ('#{values}')"
       end
     end
+end
+
+class JsonDataTypeWithFilter < ActiveRecord::Base
+  self.table_name = "json_data_type"
+
+  def self.filter_attributes
+    # Rails.application.config.filter_parameters += [:password]
+    super + [:password]
+  end
 end

--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -107,7 +107,7 @@ module ActiveSupport
 
       def value_for_key(key, value, parents = [], original_params = nil)
         parents.push(key) if deep_regexps
-        if regexps.any? { |r| r.match?(key) }
+        if regexps.any? { |r| r.match?(key.to_s) }
           value = @mask
         elsif deep_regexps && (joined = parents.join(".")) && deep_regexps.any? { |r| r.match?(joined) }
           value = @mask

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -109,4 +109,16 @@ class ParameterFilterTest < ActiveSupport::TestCase
     assert_equal mask, parameter_filter.filter_param("barbar", "secret vlaue")
     assert_equal "non secret value", parameter_filter.filter_param("baz", "non secret value")
   end
+
+  test "process parameter filter with hash having integer keys" do
+    test_hashes = [
+      [{ 13 => "bar" }, { 13 => "[FILTERED]" }, %w'13'],
+      [{ 20 => "bar" }, { 20 => "bar" }, %w'13'],
+    ]
+
+    test_hashes.each do |before_filter, after_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterFilter.new(filter_words)
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #37428

For a JSON or JSONB data type for the model, when the keys are of type integer(before save) then filter attributes breaks with `TypeError: no implicit conversion of Integer into String`. This PR tries to fix the issue by convert integer to string while matching with the `filter_attributes`. JSON keys would always be string on save so pretty print would not throw error later but at the time of initialize they are could be integer. 

Honestly, I am not sure if this case should be handled. Just thought adding `to_s` won't affect anything but solve an issue with `pp` so raised a PR. Thanks.

