### PR TITLE
Allow Redis id to be configured to nil for ActionCable

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -15,7 +15,7 @@ module ActionCable
       # Overwrite this factory method for Redis connections if you want to use a different Redis library than the redis gem.
       # This is needed, for example, when using Makara proxies for distributed Redis.
       cattr_accessor :redis_connector, default: ->(config) do
-        config[:id] ||= "ActionCable-PID-#{$$}"
+        config[:id] = "ActionCable-PID-#{$$}" unless config.has_key?(:id)
         ::Redis.new(config.except(:adapter, :channel_prefix))
       end
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -50,6 +50,14 @@ class RedisAdapterTest::Connector < ActionCable::TestCase
     end
   end
 
+  test "doesn't add default id if it is specified to nil" do
+    config = { url: 1, host: 2, port: 3, db: 4, password: 5, id: nil }
+
+    assert_called_with ::Redis, :new, [ config ] do
+      connect config
+    end
+  end
+
   def connect(config)
     ActionCable::SubscriptionAdapter::Redis.redis_connector.call(config)
   end


### PR DESCRIPTION
### Summary

With this change, Redis for ActionCable can be selectively configured with id = nil.

### Other Information

- This is logically more natural behavior.
- To my best knowledge, Action Cable won't work on Google's Cloud Memorystore because [it blocks `client` command](https://cloud.google.com/memorystore/docs/reference/redis-configs#blocked). This change allows us to have a workaround [to keep a `Redis::Client` from calling the command](https://github.com/redis/redis-rb/blob/0559b503f9303e9716957bdbea2f731006d549b2/lib/redis/client.rb#L109).