### PR TITLE
Add indent_size option for stylesheet_link_tag and javascript_include…

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -87,6 +87,7 @@ module ActionView
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         early_hints_links = []
+        indent = " " * (options["indent_size"] || 2)
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
@@ -98,7 +99,7 @@ module ActionView
             tag_options["nonce"] = content_security_policy_nonce
           end
           content_tag("script", "", tag_options)
-        }.join("\n").html_safe
+        }.join("\n#{indent}").html_safe
 
         request.send_early_hints("Link" => early_hints_links.join("\n")) if respond_to?(:request) && request
 
@@ -137,6 +138,7 @@ module ActionView
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
         early_hints_links = []
+        indent = " " * (options["indent_size"] || 2)
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
@@ -147,7 +149,7 @@ module ActionView
             "href" => href
           }.merge!(options)
           tag(:link, tag_options)
-        }.join("\n").html_safe
+        }.join("\n#{indent}").html_safe
 
         request.send_early_hints("Link" => early_hints_links.join("\n")) if respond_to?(:request) && request
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -477,7 +477,7 @@ class AssetTagHelperTest < ActionView::TestCase
   end
 
   def test_stylesheet_link_tag_should_not_output_the_same_asset_twice
-    assert_dom_equal %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("wellington", "wellington", "amsterdam")
+    assert_dom_equal %(<link href="/stylesheets/wellington.css" media="screen" rel="stylesheet" />\n  <link href="/stylesheets/amsterdam.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("wellington", "wellington", "amsterdam")
   end
 
   def test_stylesheet_link_tag_with_relative_protocol


### PR DESCRIPTION
Add indent when generating multiple tag,  instead of

```
  <link rel="stylesheet" media="all" href="/assets/foo.css" />
<link rel="stylesheet" media="all" href="/assets/aoo.css" />
<link rel="stylesheet" media="all" href="/assets/bar.css" />
```

but

```
  <link rel="stylesheet" media="all" href="/assets/foo.css" />
  <link rel="stylesheet" media="all" href="/assets/aoo.css" /> 
  <link rel="stylesheet" media="all" href="/assets/bar.css" />
```
