### PR TITLE
Treat nil as 0 for optimistic locking.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Treat `NULL` database values as equivalent to `0` for optimistic locking to avoid a bogus `ActiveRecord::StaleObjectError`.
+
+    Fixes #36264
+
+    *Mario de la Ossa*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -85,10 +85,14 @@ module ActiveRecord
 
             self[locking_column] += 1
 
-            affected_rows = self.class._update_record(
-              attributes_with_values(attribute_names),
-              @primary_key => id_in_database,
-              locking_column => previous_lock_value
+            # When `lock_version` is read as `0`, it may actually be `NULL` in the DB.
+            possible_previous_lock_value = previous_lock_value.to_i == 0 ? [nil, 0] : previous_lock_value
+
+            affected_rows = self.class.unscoped.where(
+              locking_column => possible_previous_lock_value,
+              self.class.primary_key => id_in_database
+            ).update_all(
+              attributes_with_values(attribute_names)
             )
 
             if affected_rows != 1

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -340,6 +340,15 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal "new title2", t2.title
   end
 
+  def test_lock_without_default_should_treat_null_as_0
+    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    t1 = LockWithoutDefault.last
+
+    t1.update!(title: "Bob", lock_version: 0)
+
+    assert_equal 1, t1.lock_version
+  end
+
   def test_lock_without_default_queries_count
     t1 = LockWithoutDefault.create(title: "title1")
 


### PR DESCRIPTION
### Summary

If the locking_column does not have a default value it is possible to
have records with a value of NULL for that column, whether because the
database exists from a time before rails defaulted the value saved to 0,
or because someone inserted values into the database directly.

This causes bogus `ActiveRecord::StaleObjectError`s as rails attempts
to update a record with a value of 0 in the locking_column, but the real
value is NULL.

### Other Information

I could no longer use `#_update_record` inside `#_update_row` as `#_update_record` uses an equality operator which does not do the right thing with the array passed to it.

Fixes #36264