### PR TITLE
Make content_tag a bit faster

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -24,8 +24,14 @@ module ActionView
                               visible).to_set
 
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map(&:to_sym))
+      BOOLEAN_ATTRIBUTES.freeze
 
-      TAG_PREFIXES = ["aria", "data", :aria, :data].to_set
+      TAG_PREFIXES = ["aria", "data", :aria, :data].to_set.freeze
+
+      TAG_TYPES = {}
+      TAG_TYPES.merge! BOOLEAN_ATTRIBUTES.index_with(:boolean)
+      TAG_TYPES.merge! TAG_PREFIXES.index_with(:prefix)
+      TAG_TYPES.freeze
 
       PRE_CONTENT_STRINGS             = Hash.new { "" }
       PRE_CONTENT_STRINGS[:textarea]  = "\n"
@@ -61,13 +67,14 @@ module ActionView
           output = +""
           sep    = " "
           options.each_pair do |key, value|
-            if TAG_PREFIXES.include?(key) && value.is_a?(Hash)
+            type = TAG_TYPES[key]
+            if type == :prefix && value.is_a?(Hash)
               value.each_pair do |k, v|
                 next if v.nil?
                 output << sep
                 output << prefix_tag_option(key, k, v, escape)
               end
-            elsif BOOLEAN_ATTRIBUTES.include?(key)
+            elsif type == :boolean
               if value
                 output << sep
                 output << boolean_tag_option(key)

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -88,9 +88,9 @@ module ActionView
           if value.is_a?(Array)
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
-            value = escape ? ERB::Util.unwrapped_html_escape(value).dup : value.to_s.dup
+            value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
           end
-          value.gsub!('"', "&quot;")
+          value = value.gsub('"', "&quot;") if value.include?('"')
           %(#{key}="#{value}")
         end
 


### PR DESCRIPTION
This speeds up `content_tag` by about 17%

1. Replacing two `Set` lookups with a single `Hash` lookup
2. Avoiding a `String#dup` for values which don't include `"`

One possible downside is that this requires freezing `TagHelper::BOOLEAN_ATTRIBUTES` and `TagHelper::TAG_PREFIXES`. I'm not sure if we expected users to be able to modify these.

## Benchmark

https://gist.github.com/jhawthorn/0d3b20e0156885799960da62a5aac23a

**Before**

```
$ be ruby benchmarks/content_tag.rb
Warming up --------------------------------------
              simple    24.325k i/100ms
          with quote    23.599k i/100ms
     octicons_helper     7.433k i/100ms
Calculating -------------------------------------
              simple    294.251k (± 5.2%) i/s -      1.484M in   5.056557s
          with quote    283.826k (± 3.3%) i/s -      1.440M in   5.077635s
     octicons_helper     84.693k (± 4.7%) i/s -    423.681k in   5.014594s

```

**After**

```
$ be ruby benchmarks/content_tag.rb
Warming up --------------------------------------
              simple    33.045k i/100ms
          with quote    31.069k i/100ms
     octicons_helper    10.563k i/100ms
Calculating -------------------------------------
              simple    366.623k (± 3.1%) i/s -      1.851M in   5.052713s
          with quote    327.993k (± 8.0%) i/s -      1.647M in   5.060007s
     octicons_helper    113.388k (± 5.2%) i/s -    570.402k in   5.045369s
```