### PR TITLE
Support ActiveModel::Error translation lookup on indexed attributes.

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -69,9 +69,14 @@ module ActiveModel
 
       if base.class.respond_to?(:i18n_scope)
         i18n_scope = base.class.i18n_scope.to_s
+        unindexed_attribute = attribute.to_s.remove(/\[\d\]/)
+
         defaults = base.class.lookup_ancestors.flat_map do |klass|
-          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+          [
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{unindexed_attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}"
+          ]
         end
         defaults << :"#{i18n_scope}.errors.messages.#{type}"
 

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -69,14 +69,11 @@ module ActiveModel
 
       if base.class.respond_to?(:i18n_scope)
         i18n_scope = base.class.i18n_scope.to_s
-        unindexed_attribute = attribute.to_s.remove(/\[\d\]/)
+        attribute = attribute.to_s.remove(/\[\d\]/)
 
         defaults = base.class.lookup_ancestors.flat_map do |klass|
-          [
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{unindexed_attribute}.#{type}",
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}"
-          ]
+          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
         end
         defaults << :"#{i18n_scope}.errors.messages.#{type}"
 

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -26,6 +26,16 @@ class ErrorTest < ActiveModel::TestCase
     end
   end
 
+  class Manager < Person
+    def read_attribute_for_validation(attr)
+      try(attr)
+    end
+
+    def self.i18n_scope
+      :activemodel
+    end
+  end
+
   def test_initialize
     base = Person.new
     error = ActiveModel::Error.new(base, :name, :too_long, foo: :bar)
@@ -142,6 +152,15 @@ class ErrorTest < ActiveModel::TestCase
     I18n.with_locale(:pl) {
       assert_equal "jest nieprawidłowe", error.message
     }
+  end
+
+  test "message with type as a symbol and indexed attribute can lookup without index in attribute key" do
+    I18n.backend.store_translations(:en, activemodel: { errors: { models: { 'error_test/manager': {
+      attributes: { reports: { name: { presence: "must be present" } } } } } } })
+
+    error = ActiveModel::Error.new(Manager.new, :'reports[0].name', :presence)
+
+    assert_equal "must be present", error.message
   end
 
   test "message uses current locale" do


### PR DESCRIPTION
### Summary
The intent of this PR is to allow instances of `ActiveModel::Error` where the `attribute` in question is an indexed attribute to lookup their message without the indexed suffix. This usually happens for `ActiveRecord` models that use `index_errors: true`.

Here's a generic example leading up to the error:
```ruby
class Manager < ActiveRecord::Base
  has_many :reports, index_errors: true
end

class Report < ActiveRecord::Base
  belongs_to :manager
  validates_presence_of :name
end

manager = Manager.new
invalid_report = Report.new
manager.reports = [invalid_report]
manager.save

error = manager.errors.first
error.attribute
# => :"reports[0].name"
error.type
# => :presence
```

As you can see, the attribute is indexed - great for matching the appropriate `Report` record, but not great if you have a custom translation message, as the lookup for `message` will try look for it here:

https://github.com/rails/rails/blob/94584c2510743a45d9030d1b94dd33a074518b17/activemodel/lib/active_model/error.rb#L72-L75

Which, in our specific case, will resolve the first example to:

```ruby
# :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}"
:"activerecord.errors.models.manager.attributes.reports[0].name.presence"
```

The index makes it impossible to form a generic message for our specific error message. While the index is useful for mapping a specific error to the relevant record, it's not particularly necessary when defining translation keys, as the index is probably irrelevant to what you want to surface.

By adding an additional lookup entry that strips the index from the lookup key (very similar to what was done in https://github.com/rails/rails/pull/33615), we're able to lookup translations without the index. 

### Other Information
The rationale for an additional lookup entry (as opposed to replacing the current one) is that I don't know if any users are working around the index lookup problem with embedded `yml` files that handle keys with indexes, e.g. with regex. 

Not sure if this is something that I should add a changelog entry for. I'd be happy to add one if necessary.

@Larochelle @rafaelfranca @Edouard-chin 