### PR TITLE
Fix flaky activestorage tests

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_storage/downloader"
-
 # A blob is a record that contains the metadata about a file and a key for where that file resides on the service.
 # Blobs can be created in two ways:
 #

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_storage/log_subscriber"
+require "active_storage/downloader"
 require "action_dispatch"
 require "action_dispatch/http/content_disposition"
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -10,7 +10,9 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     @user = User.create!(name: "Josh")
   end
 
-  teardown { ActiveStorage::Blob.all.each(&:delete) }
+  teardown do
+    ActiveStorage::Blob.all.each(&:delete)
+  end
 
   test "attaching existing blobs to an existing record" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -12,7 +12,9 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     @user = User.create!(name: "Josh")
   end
 
-  teardown { ActiveStorage::Blob.all.each(&:delete) }
+  teardown do
+    ActiveStorage::Blob.all.each(&:delete)
+  end
 
   test "attaching an existing blob to an existing record" do
     @user.avatar.attach create_blob(filename: "funky.jpg")

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -52,6 +52,8 @@ ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 class ActiveSupport::TestCase
   self.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 
+  include ActiveRecord::TestFixtures
+
   setup do
     ActiveStorage::Current.host = "https://example.com"
   end


### PR DESCRIPTION
### Summary

Makes tests in Active Storage less flaky.

- Removes directly uploaded service blobs so they aren't re-deleted in later tests. This causes rate limit errors from GCS: https://buildkite.com/rails/rails/builds/64290#99942358-92a3-4145-bcaf-0a812773af47/989-1606

- Move `ActiveStorage::Downloader` require from blob to service (as I think blob doesn't use the downloader directly, only service does): https://buildkite.com/rails/rails/builds/64288#d14d1948-18f6-4fd7-8c4a-9c90a2768bd4/987-1030