### PR TITLE
Fix cloning of custom attributes in an AR model

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -129,12 +129,14 @@ module ActiveModel
     end
 
     def initialize_dup(other) # :nodoc:
+      @skip_dup_attributes = false
       super
-      if self.class.respond_to?(:_default_attributes)
+      if !@skip_dup_attributes && self.class.respond_to?(:_default_attributes)
         @attributes = self.class._default_attributes.map do |attr|
           attr.with_value_from_user(@attributes.fetch_value(attr.name))
         end
       end
+      remove_instance_variable :@skip_dup_attributes
       @mutations_from_database = nil
     end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -406,9 +406,8 @@ module ActiveRecord
 
     ##
     def initialize_dup(other) # :nodoc:
-      @attributes = @attributes.deep_dup
+      clone_attributes
       @attributes.reset(@primary_key)
-      @skip_dup_attributes = true
 
       _run_initialize_callbacks
 
@@ -575,6 +574,11 @@ module ActiveRecord
     end
 
     private
+      def clone_attributes
+        # this is here only if someone composes a class uses AR::Core without AM::Dirty As AM::Dirty will override this method
+        @attributes = @attributes.deep_dup
+      end
+
       # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of
       # the array, and then rescues from the possible +NoMethodError+. If those elements are
       # +ActiveRecord::Base+'s, then this triggers the various +method_missing+'s that we have,

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -408,6 +408,7 @@ module ActiveRecord
     def initialize_dup(other) # :nodoc:
       @attributes = @attributes.deep_dup
       @attributes.reset(@primary_key)
+      @skip_dup_attributes = true
 
       _run_initialize_callbacks
 

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -64,6 +64,13 @@ module ActiveRecord
       assert_equal "Aaron", duped.author_name
     end
 
+    def test_dup_with_custom_attributes
+      topic = Topic.select("topics.*, 1 as extra").first
+      duped = topic.dup
+      assert_respond_to topic, :extra, "Original responds to extra"
+      assert_respond_to duped, :extra, "Duplicate responds to extra"
+    end
+
     def test_dup_with_changes
       dbtopic = Topic.first
       topic = Topic.new


### PR DESCRIPTION
### Summary

Fix for issue #34823

This allows the custom columns to be cloned again as they were in Rails 4.2.x.

Further it removed a redundant attribute deep_dup (as current code clones the attributes twice)

### Other Information