### PR TITLE
Add extra metadata URI to the gemspecs

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actioncable",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actioncable",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionmailbox",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailbox/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actionmailbox/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actionmailbox",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -22,8 +22,11 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionmailer",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actionmailer",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -22,8 +22,11 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionpack",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actionpack",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actiontext",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actiontext/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actiontext/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actiontext",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -22,8 +22,11 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionview",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/actionview",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activejob",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/activejob",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activemodel",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/activemodel",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,8 +24,11 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ["--main",  "README.rdoc"]
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activerecord",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/activerecord",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -21,8 +21,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activestorage",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activestorage/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/activestorage/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/activestorage",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -23,8 +23,11 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ["--encoding",  "UTF-8"]
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activesupport",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/activesupport",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -20,6 +20,13 @@ Gem::Specification.new do |s|
 
   s.files = ["README.md"]
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}",
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
   s.add_dependency "actionview",    version

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -26,8 +26,11 @@ Gem::Specification.new do |s|
   s.rdoc_options << "--exclude" << "."
 
   s.metadata = {
-    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/railties",
-    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md"
+    "bug_tracker_uri"   => "https://github.com/rails/rails/issues",
+    "changelog_uri"     => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md",
+    "documentation_uri" => "https://api.rubyonrails.org/v#{version}/",
+    "mailing_list_uri"  => "https://groups.google.com/forum/#!forum/rubyonrails-talk",
+    "source_code_uri"   => "https://github.com/rails/rails/tree/v#{version}/railties",
   }
 
   # NOTE: Please read our dependency guidelines before updating versions:


### PR DESCRIPTION
### Summary

Add `bug_tracker_uri`, `documentation_uri`, and `mailing_list_uri` to the gemspec metadata. Also `source_code_uri` to the Rails gemspec.

### Other Information

These extra [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The extra URI will be available on the various rubygems project pages, via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.