### PR TITLE
Duration#+, -, since and ago should return Time consistently

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActiveSupport::Duration#+`, `-`, `since` and `ago` returns Time consistently for Date object
+
+    *Junichi Ito*
+    
 *   Improve `Range#===`, `Range#include?`, and `Range#cover?` to work with beginless (startless)
     and endless range targets.
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -403,7 +403,7 @@ module ActiveSupport
 
     private
       def sum(sign, time = ::Time.current)
-        parts.inject(time) do |t, (type, number)|
+        (parts.presence || { seconds: 0 }).inject(time) do |t, (type, number)|
           if t.acts_like?(:time) || t.acts_like?(:date)
             if type == :seconds
               t.since(sign * number)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -174,6 +174,14 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal 1 + 1.second, 1.second + 1, "Duration + Numeric should == Numeric + Duration"
   end
 
+  def test_date_plus_ago_minus_returns_consistent_type
+    date = Date.today
+    assert_kind_of Time, (date + 1.hour)
+    assert_kind_of Time, (date + 0.hours)
+    assert_kind_of Time, (date - 1.hour)
+    assert_kind_of Time, (date - 0.hours)
+  end
+
   def test_time_plus_duration_returns_same_time_datatype
     twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Moscow"], Time.utc(2016, 4, 28, 00, 45))
     now = Time.now.utc
@@ -263,6 +271,14 @@ class DurationTest < ActiveSupport::TestCase
     end
   ensure
     Time.zone = nil
+  end
+
+  def test_date_since_and_ago_returns_consistent_type
+    date = Date.today
+    assert_kind_of Time, 1.hour.since(date)
+    assert_kind_of Time, 0.hours.since(date)
+    assert_kind_of Time, 1.hour.ago(date)
+    assert_kind_of Time, 0.hours.ago(date)
   end
 
   def test_before_and_afer


### PR DESCRIPTION
### Summary

`Duration#+`, `-`, `since` and `ago` always return Time even if they are used with Date and zero duration.

This fixes https://github.com/rails/rails/issues/37450