### PR TITLE
Add .byebug_history to generated plugin .gitignore

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -17,3 +17,4 @@ pkg/
 <% end -%>
 <%= dummy_path %>/tmp/
 <% end -%>
+.byebug_history


### PR DESCRIPTION
The generated plugin Gemfile includes the Byebug gem (commented out), so it makes sense to include the history file in the generated .gitignore.
