### PR TITLE
Fix an issue with duplicate preloaded records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -111,7 +111,7 @@ module ActiveRecord
           association.flat_map { |parent, child|
             grouped_records(parent, records, polymorphic_parent).flat_map do |reflection, reflection_records|
               loaders = preloaders_for_reflection(reflection, reflection_records, scope)
-              recs = loaders.flat_map(&:preloaded_records)
+              recs = loaders.flat_map(&:preloaded_records).uniq
               child_polymorphic_parent = reflection && reflection.options[:polymorphic]
               loaders.concat Array.wrap(child).flat_map { |assoc|
                 preloaders_on assoc, recs, scope, child_polymorphic_parent

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -190,4 +190,15 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     assert_equal 3, authors[1].posts.size
     assert_equal 3, authors[0].posts.collect { |post| post.categorizations.size }.inject(0) { |sum, i| sum + i }
   end
+
+  # Regression test for https://github.com/rails/rails/issues/37446
+  def test_preloaded_records_are_not_duplicated
+    author = Author.first
+    expected = Post.where(author: author)
+      .includes(author: :first_posts).map { |post| post.author.first_posts.size }
+    actual = author.posts
+      .includes(author: :first_posts).map { |post| post.author.first_posts.size }
+
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
I executed `git bisect` and found d634c0d82b8ebd7b019baed535d89541bc8e4f6a that caused #37446.
I noticed that the commit removed uniq method was called for preloaded_records.

so I add a test case and uniq method.

Fixes #37446 