### PR TITLE
Manage connection pools in a new Role class rather than in DatabaseConfig

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -6,60 +6,13 @@ module ActiveRecord
     # UrlConfig respectively. It will never return a DatabaseConfig object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
-      include Mutex_m
-
       attr_reader :env_name, :spec_name
 
       attr_accessor :schema_cache
 
-      INSTANCES = ObjectSpace::WeakMap.new
-      private_constant :INSTANCES
-
-      class << self
-        def discard_pools!
-          INSTANCES.each_key(&:discard_pool!)
-        end
-      end
-
       def initialize(env_name, spec_name)
-        super()
         @env_name = env_name
         @spec_name = spec_name
-        @pool = nil
-
-        INSTANCES[self] = self
-      end
-
-      def disconnect!
-        ActiveSupport::ForkTracker.check!
-
-        return unless @pool
-
-        synchronize do
-          return unless @pool
-
-          @pool.automatic_reconnect = false
-          @pool.disconnect!
-        end
-
-        nil
-      end
-
-      def connection_pool
-        ActiveSupport::ForkTracker.check!
-
-        @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
-      end
-
-      def discard_pool!
-        return unless @pool
-
-        synchronize do
-          return unless @pool
-
-          @pool.discard!
-          @pool = nil
-        end
       end
 
       def config
@@ -109,4 +62,4 @@ module ActiveRecord
   end
 end
 
-ActiveSupport::ForkTracker.after_fork { ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools! }
+ActiveSupport::ForkTracker.after_fork { ActiveRecord::ConnectionAdapters::Role.discard_pools! }

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -192,7 +192,7 @@ module ActiveRecord
         ActiveRecord::Base.connection_handlers.values.each do |handler|
           if handler != writing_handler
             handler.connection_pool_names.each do |name|
-              handler.send(:owner_to_config)[name] = writing_handler.send(:owner_to_config)[name]
+              handler.send(:owner_to_role)[name] = writing_handler.send(:owner_to_role)[name]
             end
           end
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1414,10 +1414,10 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
 
   private
     def with_temporary_connection_pool
-      db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
+      role = ActiveRecord::Base.connection_handler.send(:owner_to_role).fetch("primary")
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(role.db_config)
 
-      db_config.stub(:connection_pool, new_pool) do
+      role.stub(:pool, new_pool) do
         yield
       end
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -555,10 +555,10 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   private
     def with_temporary_connection_pool
-      db_config = ActiveRecord::Base.connection_handler.send(:owner_to_config).fetch("primary")
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(db_config)
+      role = ActiveRecord::Base.connection_handler.send(:owner_to_role).fetch("primary")
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(role.db_config)
 
-      db_config.stub(:connection_pool, new_pool) do
+      role.stub(:pool, new_pool) do
         yield
       end
     end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -13,7 +13,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
     @specification = ActiveRecord::Base.remove_connection
 
     # Clear out connection info from other pids (like a fork parent) too
-    ActiveRecord::DatabaseConfigurations::DatabaseConfig.discard_pools!
+    ActiveRecord::ConnectionAdapters::Role.discard_pools!
   end
 
   teardown do


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/pull/37408

This allows to keep `DatabaseConfig` as a simple configuration holder, and free of the connection pool management logic.

@eileencodes @seejohnrun @rafaelfranca does that solves your issue ?