### PR TITLE
Keep the symbolic link after editing credentials.yml.enc

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -30,7 +30,7 @@ module ActiveSupport
     attr_reader :content_path, :key_path, :env_key, :raise_if_missing_key
 
     def initialize(content_path:, key_path:, env_key:, raise_if_missing_key:)
-      path = File.symlink?(content_path) ? File.realpath(content_path) : content_path
+      path = File.symlink?(content_path) ? File.readlink(content_path) : content_path
       @content_path, @key_path = Pathname.new(path), Pathname.new(key_path)
       @env_key, @raise_if_missing_key = env_key, raise_if_missing_key
     end

--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -30,7 +30,8 @@ module ActiveSupport
     attr_reader :content_path, :key_path, :env_key, :raise_if_missing_key
 
     def initialize(content_path:, key_path:, env_key:, raise_if_missing_key:)
-      @content_path, @key_path = Pathname.new(content_path), Pathname.new(key_path)
+      path = File.symlink?(content_path) ? File.realpath(content_path) : content_path
+      @content_path, @key_path = Pathname.new(path), Pathname.new(key_path)
       @env_key, @raise_if_missing_key = env_key, raise_if_missing_key
     end
 

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -75,4 +75,21 @@ class EncryptedFileTest < ActiveSupport::TestCase
       FileUtils.rm_rf link_path
     end
   end
+
+  test "create a new file at the link destination when content_path is dead-symlink" do
+    link_path = File.join(Dir.tmpdir, "dead_symlink.txt.enc")
+    File.symlink(@content_path, link_path)
+
+    begin
+      link_encrypted_file = ActiveSupport::EncryptedFile.new(
+        content_path: link_path, key_path: @key_path, env_key: "CONTENT_KEY", raise_if_missing_key: true
+      )
+      link_encrypted_file.write(@content)
+
+      assert File.exist?(@content_path)
+      assert_equal @content, @encrypted_file.read
+    ensure
+      FileUtils.rm_rf link_path
+    end
+  end
 end

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -56,4 +56,23 @@ class EncryptedFileTest < ActiveSupport::TestCase
       ).read
     end
   end
+
+  test "keep the symlink" do
+    @encrypted_file.write("")
+
+    link_path = File.join(Dir.tmpdir, "link_content.txt.enc")
+    File.symlink(@encrypted_file.content_path, link_path)
+
+    begin
+      link_encrypted_file = ActiveSupport::EncryptedFile.new(
+        content_path: link_path, key_path: @key_path, env_key: "CONTENT_KEY", raise_if_missing_key: true
+      )
+      link_encrypted_file.write(@content)
+
+      assert File.symlink?(link_path)
+      assert_equal @content, @encrypted_file.read
+    ensure
+      FileUtils.rm_rf link_path
+    end
+  end
 end


### PR DESCRIPTION
### Summary

If you edit credentials.yml.enc after creating a symbolic link,
the symbolic link is removed and overwritten with a normal file.
This commit changes the behavior to keep the symbolic link.

Fixes #36411 