### PR TITLE
Modernize generated plugin gemspec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -1,14 +1,10 @@
-$:.push File.expand_path("lib", __dir__)
+require_relative "lib/<%= namespaced_name %>/version"
 
-# Maintain your gem's version:
-require "<%= namespaced_name %>/version"
-
-# Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name        = "<%= name %>"
+  spec.name        = <%= name.inspect %>
   spec.version     = <%= camelized_modules %>::VERSION
-  spec.authors     = ["<%= author %>"]
-  spec.email       = ["<%= email %>"]
+  spec.authors     = [<%= author.inspect %>]
+  spec.email       = [<%= email.inspect %>]
   spec.homepage    = "TODO"
   spec.summary     = "TODO: Summary of <%= camelized_modules %>."
   spec.description = "TODO: Description of <%= camelized_modules %>."
@@ -16,12 +12,11 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
This also makes the generated gemspec more closely resemble a gemspec generated via the `bundle gem` command.  ([Reference](https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/newgem.gemspec.tt))
