### PR TITLE
Fixed performance regression introduced MySQL 8.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed the performance regression for `primary_keys` introduced MySQL 8.0.
+
+    *Hiroyuki Ishii*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -433,11 +433,11 @@ module ActiveRecord
 
         query_values(<<~SQL, "SCHEMA")
           SELECT column_name
-          FROM information_schema.key_column_usage
-          WHERE constraint_name = 'PRIMARY'
+          FROM information_schema.statistics
+          WHERE index_name = 'PRIMARY'
             AND table_schema = #{scope[:schema]}
             AND table_name = #{scope[:name]}
-          ORDER BY ordinal_position
+          ORDER BY seq_in_index
         SQL
       end
 


### PR DESCRIPTION
### Summary

MySQL8.0 changed metadata storage from metadata files to data dictionary.
`INFORMATION_SCHEMA.KEY_COLUMN_USAGE` is slower and it caused the performance regression for [`#primary_keys`](https://github.com/rails/rails/blob/d87a0c6a206cecefac25c96e707e8cd1ad97cd5d/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L429) and [`#foreign_keys`](https://github.com/rails/rails/blob/d87a0c6a206cecefac25c96e707e8cd1ad97cd5d/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L365).

[MySQL8.0 - 14.2 Removal of File-based Metadata Storage](https://dev.mysql.com/doc/refman/8.0/en/data-dictionary-file-removal.html)

### Other Information

MySQL versions performance comparison.
[benchmark](https://github.com/alpaca-tc/performance_regression_mysql/blob/master/test.rb) / [CI](https://github.com/alpaca-tc/performance_regression_mysql/blob/master/.circleci/config.yml)

```sql
# Setup tables
CREATE TABLE `users` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY);
```

```
# Old SQL
EXPLAIN SELECT COLUMN_NAME
FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
WHERE CONSTRAINT_NAME = 'PRIMARY'
  AND TABLE_SCHEMA = database()
  AND TABLE_NAME = 'users'
ORDER BY ORDINAL_POSITION;

# MySQL 5.7
+----+-------------+------------------+------------+------+---------------+-------------------------+---------+------+------+----------+-------------------------------------------------------------------+
| id | select_type | table            | partitions | type | possible_keys | key                     | key_len | ref  | rows | filtered | Extra                                                             |
+----+-------------+------------------+------------+------+---------------+-------------------------+---------+------+------+----------+-------------------------------------------------------------------+
|  1 | SIMPLE      | KEY_COLUMN_USAGE | NULL       | ALL  | NULL          | TABLE_SCHEMA,TABLE_NAME | NULL    | NULL | NULL | NULL     | Using where; Open_full_table; Scanned 0 databases; Using filesort |
+----+-------------+------------------+------------+------+---------------+-------------------------+---------+------+------+----------+-------------------------------------------------------------------+

# MySQL 8.0
+------+--------------+------------+------------+--------+----------------------------------+-------------+---------+----------------------+------+----------+----------------------------------------------------+
| id   | select_type  | table      | partitions | type   | possible_keys                    | key         | key_len | ref                  | rows | filtered | Extra                                              |
+------+--------------+------------+------------+--------+----------------------------------+-------------+---------+----------------------+------+----------+----------------------------------------------------+
|    1 | PRIMARY      | <derived2> | NULL       | ref    | <auto_key0>                      | <auto_key0> | 583     | const,const,const    |   10 |    100.0 | Using filesort                                     |
|    2 | DERIVED      | cat        | NULL       | index  | PRIMARY                          | name        | 194     | NULL                 |    1 |    100.0 | Using index                                        |
|    2 | DERIVED      | sch        | NULL       | ref    | PRIMARY,catalog_id               | catalog_id  | 8       | mysql.cat.id         |    6 |    100.0 | Using index                                        |
|    2 | DERIVED      | idx        | NULL       | ALL    | PRIMARY,table_id                 | NULL        | NULL    | NULL                 |  246 |     40.0 | Using where; Using join buffer (Block Nested Loop) |
|    2 | DERIVED      | tbl        | NULL       | eq_ref | PRIMARY,schema_id                | PRIMARY     | 8       | mysql.idx.table_id   |    1 |    24.88 | Using where                                        |
|    2 | DERIVED      | icu        | NULL       | ref    | index_id,index_id_2,column_id    | index_id_2  | 8       | mysql.idx.id         |    4 |    100.0 | Using index                                        |
|    2 | DERIVED      | col        | NULL       | eq_ref | PRIMARY                          | PRIMARY     | 8       | mysql.icu.column_id  |    1 |    100.0 | Using where                                        |
|    3 | UNION        | cat        | NULL       | index  | PRIMARY                          | name        | 194     | NULL                 |    1 |    100.0 | Using index                                        |
|    3 | UNION        | fk         | NULL       | ALL    | PRIMARY,schema_id,table_id       | NULL        | NULL    | NULL                 |   51 |    100.0 | Using join buffer (Block Nested Loop)              |
|    3 | UNION        | sch        | NULL       | eq_ref | PRIMARY,catalog_id               | PRIMARY     | 8       | mysql.fk.schema_id   |    1 |    100.0 | Using where                                        |
|    3 | UNION        | fkcu       | NULL       | ref    | PRIMARY,foreign_key_id,column_id | PRIMARY     | 8       | mysql.fk.id          |    1 |    100.0 | NULL                                               |
|    3 | UNION        | tbl        | NULL       | eq_ref | PRIMARY                          | PRIMARY     | 8       | mysql.fk.table_id    |    1 |    100.0 | NULL                                               |
|    3 | UNION        | col        | NULL       | eq_ref | PRIMARY                          | PRIMARY     | 8       | mysql.fkcu.column_id |    1 |    100.0 | Using where                                        |
| NULL | UNION RESULT | <union2,3> | NULL       | ALL    | NULL                             | NULL        | NULL    | NULL                 | NULL | NULL     | Using temporary                                    |
+------+--------------+------------+------------+--------+----------------------------------+-------------+---------+----------------------+------+----------+----------------------------------------------------+
```

```
# New SQL
EXPLAIN SELECT COLUMN_NAME
FROM INFORMATION_SCHEMA.STATISTICS
WHERE TABLE_SCHEMA = database()
  AND INDEX_NAME = 'PRIMARY'
  AND TABLE_NAME = 'users'
ORDER BY SEQ_IN_INDEX;

# MySQL 5.7
+----+-------------+------------+------------+------+---------------+-------------------------+---------+------+------+----------+-----------------------------------------------------------------+
| id | select_type | table      | partitions | type | possible_keys | key                     | key_len | ref  | rows | filtered | Extra                                                           |
+----+-------------+------------+------------+------+---------------+-------------------------+---------+------+------+----------+-----------------------------------------------------------------+
|  1 | SIMPLE      | STATISTICS | NULL       | ALL  | NULL          | TABLE_SCHEMA,TABLE_NAME | NULL    | NULL | NULL | NULL     | Using where; Open_frm_only; Scanned 0 databases; Using filesort |
+----+-------------+------------+------------+------+---------------+-------------------------+---------+------+------+----------+-----------------------------------------------------------------+

# MySQL 8.0
+----+-------------+-------+------------+--------+--------------------------------+-------------+---------+-------------------------------------------+------+----------+----------------------------------------------+
| id | select_type | table | partitions | type   | possible_keys                  | key         | key_len | ref                                       | rows | filtered | Extra                                        |
+----+-------------+-------+------------+--------+--------------------------------+-------------+---------+-------------------------------------------+------+----------+----------------------------------------------+
|  1 | SIMPLE      | cat   | NULL       | index  | PRIMARY                        | name        | 194     | NULL                                      |    1 |    100.0 | Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | sch   | NULL       | eq_ref | PRIMARY,catalog_id             | catalog_id  | 202     | mysql.cat.id,const                        |    1 |    100.0 | Using index                                  |
|  1 | SIMPLE      | tbl   | NULL       | eq_ref | PRIMARY,schema_id,collation_id | schema_id   | 202     | mysql.sch.id,const                        |    1 |    100.0 | Using where                                  |
|  1 | SIMPLE      | idx   | NULL       | eq_ref | PRIMARY,table_id               | table_id    | 202     | mysql.tbl.id,const                        |    1 |    100.0 | Using where                                  |
|  1 | SIMPLE      | coll  | NULL       | eq_ref | PRIMARY                        | PRIMARY     | 8       | mysql.tbl.collation_id                    |    1 |    100.0 | Using index                                  |
|  1 | SIMPLE      | icu   | NULL       | ref    | index_id,index_id_2,column_id  | index_id_2  | 8       | mysql.idx.id                              |    4 |    100.0 | Using where; Using index                     |
|  1 | SIMPLE      | col   | NULL       | eq_ref | PRIMARY                        | PRIMARY     | 8       | mysql.icu.column_id                       |    1 |    100.0 | NULL                                         |
|  1 | SIMPLE      | stat  | NULL       | eq_ref | schema_name                    | schema_name | 776     | const,const,mysql.idx.name,mysql.col.name |    1 |    100.0 | Using where; Using index                     |
+----+-------------+-------+------------+--------+--------------------------------+-------------+---------+-------------------------------------------+------+----------+----------------------------------------------+
```
