### PR TITLE
Fix Pry deprecation warning on tab-completion

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -147,7 +147,7 @@ module ActiveSupport
 
       # Don't give a deprecation warning on methods that IRB may invoke
       # during tab-completion.
-      delegate :hash, :instance_methods, to: :target
+      delegate :hash, :instance_methods, :respond_to?, to: :target
 
       # Returns the class of the new constant.
       #


### PR DESCRIPTION
Same thing as #37100, but [pry also calls `#respond_to?` on the target object](https://github.com/pry/pry/blob/fa97d5c2997ff1cf03cf925df482a7a1d9ca3ea3/lib/pry/input_completer.rb#L194). 

Fixes #37097 for Pry users.