### PR TITLE
fix action mailbox config example

### DIFF
--- a/actionmailbox/lib/rails/generators/installer.rb
+++ b/actionmailbox/lib/rails/generators/installer.rb
@@ -5,6 +5,6 @@ copy_file "#{__dir__}/mailbox/templates/application_mailbox.rb", "app/mailboxes/
 
 environment <<~end_of_config, env: "production"
   # Prepare the ingress controller used to receive mail
-  # config.action_mailbox.ingress = :postfix
+  # config.action_mailbox.ingress = :relay
 
 end_of_config


### PR DESCRIPTION
example config in `config/environments/production.rb` is a little misleading. there's no `postfix` ingress, `relay` is the correct equivalent.

