### PR TITLE
[ci skip] Remove reference to legacy Rails 2.x command

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -235,10 +235,10 @@ CODE
 
 ### yes?(question) or no?(question)
 
-These methods let you ask questions from templates and decide the flow based on the user's answer. Let's say you want to Freeze Rails only if the user wants to:
+These methods let you ask questions from templates and decide the flow based on the user's answer. Let's say you want to prompt the user to run migrations:
 
 ```ruby
-rails_command("rails:freeze:gems") if yes?("Freeze rails gems?")
+rails_command("db:migrate") if yes?("Run database migrations?")
 # no?(question) acts just the opposite.
 ```
 


### PR DESCRIPTION
### Summary

Update the Rails Application Templates guide to remove a reference to the `rails:freeze:gems` rake task that was removed in Rails 3.0.

### Other Information

https://guides.rubyonrails.org/3_0_release_notes.html#living-on-the-edge
