### PR TITLE
Update multi_json to the latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
     msgpack (1.3.1-java)
     msgpack (1.3.1-x64-mingw32)
     msgpack (1.3.1-x86-mingw32)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     multipart-post (2.1.1)
     mustache (1.1.0)
     mustermann (1.0.3)


### PR DESCRIPTION
Avoid `warning: tried to create a Proc object without giving a block` in Ruby head.

Fixed in intridea/multi_json@26a94ab8c78a394cc237e2ea292c1de4f6ed30d7 .