### PR TITLE
Allow system tests using Rack::Test to run without Chrome

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -118,6 +118,7 @@ module ActionDispatch
 
     def initialize(*) # :nodoc:
       super
+      self.class.driven_by(:selenium) unless self.class.driver?
       self.class.driver.use
     end
 
@@ -156,8 +157,6 @@ module ActionDispatch
 
       self.driver = SystemTesting::Driver.new(driver, **driver_options, &capabilities)
     end
-
-    driven_by :selenium
 
     private
       def url_helpers

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -10,7 +10,7 @@ module ActionDispatch
         @options = options[:options]
         @capabilities = capabilities
 
-        @browser.preload
+        @browser.preload unless name == :rack_test
       end
 
       def use

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -133,4 +133,10 @@ class DriverTest < ActiveSupport::TestCase
   ensure
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
   end
+
+  test "does not preload if :rack_test is set" do
+    assert_not_called_on_instance_of(ActionDispatch::SystemTesting::Browser, :preload) do
+      ActionDispatch::SystemTesting::Driver.new(:rack_test, using: :chrome)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

If you require "action_dispatch/system_test_case", the driven_by method will be executed immediately.

* https://github.com/rails/rails/blob/v6.0.0/actionpack/lib/action_dispatch/system_test_case.rb#L162

Then the preload method is called in SystemTesting::Driver#initialize.

* https://github.com/rails/rails/blob/v6.0.0/actionpack/lib/action_dispatch/system_testing/driver.rb#L13
* https://github.com/rails/rails/blob/v6.0.0/actionpack/lib/action_dispatch/system_testing/browser.rb#L46-L63

Therefore, a "Webdrivers::BrowserNotFound" error occurs in the browser preloading when you run system tests witout Chrome.

This commit avoid the error by lazy configuring the driver.

ref: #37410