### PR TITLE
Heed config.force_ssl when building URL

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -18,11 +18,6 @@ module ActionMailer
       paths   = app.config.paths
       options = app.config.action_mailer
 
-      if app.config.force_ssl
-        options.default_url_options ||= {}
-        options.default_url_options[:protocol] ||= "https"
-      end
-
       options.assets_dir      ||= paths["public"].first
       options.javascripts_dir ||= paths["public/javascripts"].first
       options.stylesheets_dir ||= paths["public/stylesheets"].first

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `url_for` will now use "https://" as the default protocol when
+    `Rails.application.config.force_ssl` is set to true.
+
+    *Jonathan Hefner*
+
 *   Accept and default to base64_urlsafe CSRF tokens.
 
     Base64 strict-encoded CSRF tokens are not inherently websafe, which makes

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -9,6 +9,7 @@ module ActionDispatch
       HOST_REGEXP     = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/
       PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
 
+      mattr_accessor :secure_protocol, default: false
       mattr_accessor :tld_length, default: 1
 
       class << self
@@ -139,7 +140,7 @@ module ActionDispatch
           def normalize_protocol(protocol)
             case protocol
             when nil
-              "http://"
+              secure_protocol ? "https://" : "http://"
             when false, "//"
               "//"
             when PROTOCOL_REGEXP

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -39,6 +39,7 @@ module ActionDispatch
     config.eager_load_namespaces << ActionDispatch
 
     initializer "action_dispatch.configure" do |app|
+      ActionDispatch::Http::URL.secure_protocol = app.config.force_ssl
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
       ActionDispatch::Request.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -55,6 +55,17 @@ module TestUrlGeneration
       assert_equal "http://www.example.com/foo", foo_url(protocol: "http")
     end
 
+    test "respects secure_protocol configuration when protocol not present" do
+      old_secure_protocol = ActionDispatch::Http::URL.secure_protocol
+
+      begin
+        ActionDispatch::Http::URL.secure_protocol = true
+        assert_equal "https://www.example.com/foo", foo_url(protocol: nil)
+      ensure
+        ActionDispatch::Http::URL.secure_protocol = old_secure_protocol
+      end
+    end
+
     test "extracting protocol from host when protocol not present" do
       assert_equal "httpz://www.example.com/foo", foo_url(host: "httpz://www.example.com", protocol: nil)
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -110,7 +110,7 @@ application. Accepts a valid day of week as a symbol (e.g. `:monday`).
 you don't want shown in the logs, such as passwords or credit card
 numbers. It also filters out sensitive values of database columns when call `#inspect` on an Active Record object. By default, Rails filters out passwords by adding `Rails.application.config.filter_parameters += [:password]` in `config/initializers/filter_parameter_logging.rb`. Parameters filter works by partial matching regular expression.
 
-* `config.force_ssl` forces all requests to be served over HTTPS by using the `ActionDispatch::SSL` middleware, and sets `config.action_mailer.default_url_options` to be `{ protocol: 'https' }`. This can be configured by setting `config.ssl_options` - see the [ActionDispatch::SSL documentation](https://api.rubyonrails.org/classes/ActionDispatch/SSL.html) for details.
+* `config.force_ssl` forces all requests to be served over HTTPS, and sets "https://" as the default protocol when generating URLs. Enforcement of HTTPS is handled by the `ActionDispatch::SSL` middleware, which can be configured via `config.ssl_options` - see its [documentation](https://api.rubyonrails.org/classes/ActionDispatch/SSL.html) for details.
 
 * `config.log_formatter` defines the formatter of the Rails logger. This option defaults to an instance of `ActiveSupport::Logger::SimpleFormatter` for all modes. If you are setting a value for `config.logger` you must manually pass the value of your formatter to your logger before it is wrapped in an `ActiveSupport::TaggedLogging` instance, Rails will not do it for you.
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -50,17 +50,6 @@ module ApplicationTests
       assert_equal "test.rails", ActionMailer::Base.default_url_options[:host]
     end
 
-    test "Default to HTTPS for ActionMailer URLs when force_ssl is on" do
-      app_file "config/environments/development.rb", <<-RUBY
-        Rails.application.configure do
-          config.force_ssl = true
-        end
-      RUBY
-
-      require "#{app_path}/config/environment"
-      assert_equal "https", ActionMailer::Base.default_url_options[:protocol]
-    end
-
     test "includes URL helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
@@ -181,6 +170,17 @@ module ApplicationTests
       add_to_config "config.encoding = '#{charset}'"
       require "#{app_path}/config/environment"
       assert_equal charset, ActionDispatch::Response.default_charset
+    end
+
+    test "URL builder is configured to use HTTPS when force_ssl is on" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.force_ssl = true
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal true, ActionDispatch::Http::URL.secure_protocol
     end
 
     # AS


### PR DESCRIPTION
`url_for` will now use "https://" as the default protocol when `Rails.application.config.force_ssl` is set to true.

Action Mailer already behaves this way, effectively.  This commit extends that behavior application-wide.

Closes #23543.
