### PR TITLE
Remove patch for old JRuby versions

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -1,40 +1,26 @@
 # frozen_string_literal: true
 
 class Class
-  begin
-    # Test if this Ruby supports each_object against singleton_class
-    ObjectSpace.each_object(Numeric.singleton_class) { }
-
-    # Returns an array with all classes that are < than its receiver.
-    #
-    #   class C; end
-    #   C.descendants # => []
-    #
-    #   class B < C; end
-    #   C.descendants # => [B]
-    #
-    #   class A < B; end
-    #   C.descendants # => [B, A]
-    #
-    #   class D < C; end
-    #   C.descendants # => [B, A, D]
-    def descendants
-      descendants = []
-      ObjectSpace.each_object(singleton_class) do |k|
-        next if k.singleton_class?
-        descendants.unshift k unless k == self
-      end
-      descendants
+  # Returns an array with all classes that are < than its receiver.
+  #
+  #   class C; end
+  #   C.descendants # => []
+  #
+  #   class B < C; end
+  #   C.descendants # => [B]
+  #
+  #   class A < B; end
+  #   C.descendants # => [B, A]
+  #
+  #   class D < C; end
+  #   C.descendants # => [B, A, D]
+  def descendants
+    descendants = []
+    ObjectSpace.each_object(singleton_class) do |k|
+      next if k.singleton_class?
+      descendants.unshift k unless k == self
     end
-  rescue StandardError # JRuby 9.0.4.0 and earlier
-    def descendants
-      descendants = []
-      ObjectSpace.each_object(Class) do |k|
-        descendants.unshift k if k < self
-      end
-      descendants.uniq!
-      descendants
-    end
+    descendants
   end
 
   # Returns an array with the direct children of +self+.


### PR DESCRIPTION
JRuby 9.0.5.0 (released January 26 2016 and Ruby 2.2 compatible) supports each_object(singleton_class) (#22385). Given that Rails 6 requires Ruby 2.5.0 or newer, we should be able to drop support for versions of JRuby older than 9.0.5.0.