### PR TITLE
Use ObjectSpace.each_object enumerator in descendants

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -15,11 +15,9 @@ class Class
   #   class D < C; end
   #   C.descendants # => [B, A, D]
   def descendants
-    descendants = []
-    ObjectSpace.each_object(singleton_class) do |k|
-      descendants.unshift k unless k.singleton_class? || k == self
+    ObjectSpace.each_object(singleton_class).reject do |k|
+      k.singleton_class? || k == self
     end
-    descendants
   end
 
   # Returns an array with the direct children of +self+.

--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -17,8 +17,7 @@ class Class
   def descendants
     descendants = []
     ObjectSpace.each_object(singleton_class) do |k|
-      next if k.singleton_class?
-      descendants.unshift k unless k == self
+      descendants.unshift k unless k.singleton_class? || k == self
     end
     descendants
   end


### PR DESCRIPTION
By taking advantage of ObjectSpace.each_object returning an Enumerator, we can make this code much more readable.