### PR TITLE
test: fix tests after minitest upgrade

### DIFF
--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -377,7 +377,7 @@ module Arel
         mgr.from table
         mgr.orders << Arel::Nodes::Ascending.new(Arel.sql("foo"))
         mgr.ast.grep(Arel::Nodes::OuterJoin)
-        mgr.to_sql.must_be_like %{ SELECT * FROM "users" ORDER BY foo ASC }
+        _(mgr.to_sql).must_be_like %{ SELECT * FROM "users" ORDER BY foo ASC }
       end
     end
 


### PR DESCRIPTION
Fixes fallout from e01bf7f88f. One `must_be_like` was missed.

### Summary

Fixes the failing test. Noticed while running JRuby's AR-JDBC test where we currently track the `6-0-stable` branch instead of an exact version.