### PR TITLE
Enforce that actioncable compiled JS bundle is in sync with source code

### DIFF
--- a/actioncable/test/javascript_package_test.rb
+++ b/actioncable/test/javascript_package_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class JavascriptPackageTest < ActiveSupport::TestCase
+  def test_compiled_code_is_in_sync_with_source_code
+    compiled_file = File.expand_path("../app/assets/javascripts/action_cable.js", __dir__)
+    original_compiled_code = File.read(compiled_file)
+
+    system "yarn build"
+
+    rebuilt_compiled_code = File.read(compiled_file)
+    assert_equal original_compiled_code, rebuilt_compiled_code
+  end
+end


### PR DESCRIPTION
### Summary

Addresses https://github.com/rails/rails/issues/34473#issuecomment-439586208

We have run into issues in the past where the actioncable compiled javascript bundle got out of sync with the source code. For example, in 30a0c7e04093add0b14be6da17c7496e7dd40e10 (#34446) only the compiled bundle was modified. This meant that anyone who ran `yarn build` in the actioncable directory would then see a dirty git status indicating changes to the compiled bundle, despite not having made any changes to the actioncable javascript source code. We fixed that particular inconsistency in a4c27588d5a1e6f270df42b7a305f03a9aee54f2 (#34475). However, the same problem could reoccur.

To address this, I've added a new test to enforce that actioncable's compiled javascript bundle is in sync with the source code. When the compiled bundle is in sync with the source code, the test will pass:

    $ bundle exec ruby -Itest test/javascript_package_test.rb
    Run options: --seed 19308

    # Running:

    yarn run v1.12.3
    $ yarn lint && bundle exec rake assets:codegen
    $ eslint app/javascript
    $ rollup --config rollup.config.js

    app/javascript/action_cable/index.js → app/assets/javascripts/action_cable.js...
    created app/assets/javascripts/action_cable.js in 762ms
    ✨  Done in 6.35s.
    .

    Finished in 7.130345s, 0.1402 runs/s, 0.1402 assertions/s.
    1 runs, 1 assertions, 0 failures, 0 errors, 0 skips

However, if the two are not in sync, the test will fail. For example, if you were to apply the following patch (which only updates the source code):

```patch
diff --git a/actioncable/app/javascript/action_cable/adapters.js b/actioncable/app/javascript/action_cable/adapters.js
index 4de8131438..d38d9a6a0b 100644
--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,5 @@
 export default {
+  foo: self.foo,
   logger: self.console,
   WebSocket: self.WebSocket
 }
```

the test would then fail like this:

    $ bundle exec ruby -Itest test/javascript_package_test.rb
    Run options: --seed 26377

    # Running:

    yarn run v1.12.3
    $ yarn lint && bundle exec rake assets:codegen
    $ eslint app/javascript
    $ rollup --config rollup.config.js

    app/javascript/action_cable/index.js → app/assets/javascripts/action_cable.js...
    created app/assets/javascripts/action_cable.js in 776ms
    ✨  Done in 5.55s.
    F

    Failure:
    JavascriptPackageTest#test_compiled_code_is_in_sync_with_source_code [test/javascript_package_test.rb:16]:
    --- expected
    +++ actual
    @@ -3,6 +3,7 @@
     })(this, function(exports) {
       \"use strict\";
       var adapters = {
    +    foo: self.foo,
         logger: self.console,
         WebSocket: self.WebSocket
       };

    rails test test/javascript_package_test.rb:9

    Finished in 5.837403s, 0.1713 runs/s, 0.1713 assertions/s.
    1 runs, 1 assertions, 1 failures, 0 errors, 0 skips

Thus, the actioncable test suite will now prevent "the compiled bundle is out of sync" issues going forward.