### PR TITLE
Simplify subclasses method using reject

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -28,10 +28,9 @@ class Class
   #
   #   Foo.subclasses # => [Bar]
   def subclasses
-    subclasses, chain = [], descendants
-    chain.each do |k|
-      subclasses << k unless chain.any? { |c| c > k }
+    chain = descendants
+    chain.reject do |k|
+      chain.any? { |c| c > k }
     end
-    subclasses
   end
 end

--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -28,9 +28,8 @@ class Class
   #
   #   Foo.subclasses # => [Bar]
   def subclasses
-    chain = descendants
-    chain.reject do |k|
-      chain.any? { |c| c > k }
+    descendants.find_all do |k|
+      k.superclass == self
     end
   end
 end


### PR DESCRIPTION
This keeps the functionality the same while reducing the complexity of the code.