### PR TITLE
Use the model's adapter for the attribute type lookup

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -247,7 +247,8 @@ module ActiveRecord
         super
         attributes_to_define_after_schema_loads.each do |name, (type, options)|
           if type.is_a?(Symbol)
-            type = ActiveRecord::Type.lookup(type, **options.except(:default))
+            adapter_name = ActiveRecord::Type.adapter_name_from(self)
+            type = ActiveRecord::Type.lookup(type, **options.except(:default), adapter: adapter_name)
           end
 
           define_attribute(name, type, **options.slice(:default))

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -46,9 +46,14 @@ module ActiveRecord
         @default_value ||= Value.new
       end
 
+      def adapter_name_from(model) # :nodoc:
+        # TODO: this shouldn't depend on a connection to the database
+        model.connection.adapter_name.downcase.to_sym
+      end
+
       private
         def current_adapter_name
-          ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+          adapter_name_from(ActiveRecord::Base)
         end
     end
 


### PR DESCRIPTION
@hkdsun, @rafaelfranca 

### Problem

We have a multi-database application which we want to be resilient to the ActiveRecord::Base connection not being available.  However, when attributes are being defined for a model, types are looked up in an adapter specific way by using `ActiveRecord::Base.connection` to get the adapter name.  This is also the case for models that use a different connection, so `ActiveRecord::Base.connection` not being able to establish a connection will prevent queries for all models that haven't yet defined their attributes.

This also means that an application using different adapters for different models will lookup the wrong attribute types.

### Solution

The call to `ActiveRecord::Type.lookup` wasn't using the adapter argument, so I changed that to have the caller pass that in, using the model's connection to lookup the adapter name.

Ideally we wouldn't need a connection at all, but the `adapter_name` on the connection can differ from the database configuration's adapter name (e.g. `SQLite3Adapter#connection_name` returns `"SQLite"` but `DatabaseConfig#adapter` returns `:sqlite3`).