### PR TITLE
Ensure public-read ACL for S3 service with public mode.

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -17,8 +17,10 @@ module ActiveStorage
       @bucket = @client.bucket(bucket)
 
       @multipart_upload_threshold = upload.fetch(:multipart_threshold, 100.megabytes)
-      @upload_options = upload
       @public = public
+
+      @upload_options = upload
+      @upload_options[:acl] = "public-read" if public?
     end
 
     def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, **)

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -10,6 +10,10 @@ if SERVICE_CONFIGURATIONS[:s3_public]
 
     include ActiveStorage::Service::SharedServiceTests
 
+    test "public acl options" do
+      assert_equal "public-read", @service.upload_options[:acl]
+    end
+
     test "public URL generation" do
       url = @service.url(@key, filename: ActiveStorage::Filename.new("avatar.png"))
 


### PR DESCRIPTION
Quote from AWS SDK:

https://github.com/aws/aws-sdk-ruby/blob/d4a50ffae6054b3837ec929ad685375358713231/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb#L827

```
# @example Request syntax with placeholder values
#
#   object.put({
#     acl: "private", # accepts private, public-read, public-read-write, authenticated-read, aws-exec-read, bucket-owner-read, bucket-owner-full-control
#     body: source_file,
```

In AWS SDK, the `acl` option default value is `private`, when we setup `public: true`, we also need ensure that the acl option is `public-read`.