### PR TITLE
Rename 'attributes' to 'model' in ForcedMutationTracker

### DIFF
--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -82,7 +82,7 @@ module ActiveModel
   end
 
   class ForcedMutationTracker < AttributeMutationTracker # :nodoc:
-    def initialize(attributes, forced_changes = {})
+    def initialize(model, forced_changes = {})
       super
       @finalized_changes = nil
     end
@@ -131,7 +131,7 @@ module ActiveModel
       end
 
       def fetch_value(attr_name)
-        attributes.send(:_read_attribute, attr_name)
+        model.send(:_read_attribute, attr_name)
       end
 
       def clone_value(attr_name)


### PR DESCRIPTION
I'm reading through this code and noticed that the `attributes` in the `ForcedMutationTracker` are not actually attributes at all, but an instance of a model. I think the naming is confusing, so I've renamed the variable to `model`.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->