### PR TITLE
Enumerator should be supported by ActiveSupport::SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -297,6 +297,8 @@ module ActiveSupport #:nodoc:
 
       def set_block_back_references(block, match_data)
         block.binding.eval("proc { |m| $~ = m }").call(match_data)
+      rescue ArgumentError
+        # Can't create binding from C level Proc
       end
   end
 end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -274,4 +274,9 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_equal "123foo 456bar", b
     assert_not_predicate b, :html_safe?
   end
+
+  test "Should support Enumerator" do
+    a = "aaa".html_safe.gsub!(/a/).with_index { |m, i| i }
+    assert_equal "012", a
+  end
 end


### PR DESCRIPTION
### Summary

Back references cannot be set because C level Proc doesn't support Binding.
This commit fixes #37422.
