### PR TITLE
Accept block in travel_back time helper

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add block support to `ActiveSupport::Testing::TimeHelpers#travel_back`.
+
+    *Tim Masliuchenko*
+
 *   Update `ActiveSupport::Messages::Metadata#fresh?` to work for cookies with expiry set when
     `ActiveSupport.parse_json_times = true`.
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -102,6 +102,29 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_back_with_block
+    Time.stub(:now, Time.now) do
+      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+
+      travel_to expected_time
+      assert_equal expected_time, Time.now
+      assert_equal Date.new(2004, 11, 24), Date.today
+      assert_equal expected_time.to_datetime, DateTime.now
+
+      travel_back do
+        assert_not_equal expected_time, Time.now
+        assert_not_equal Date.new(2004, 11, 24), Date.today
+        assert_not_equal expected_time.to_datetime, DateTime.now
+      end
+
+      assert_equal expected_time, Time.now
+      assert_equal Date.new(2004, 11, 24), Date.today
+      assert_equal expected_time.to_datetime, DateTime.now
+    ensure
+      travel_back
+    end
+  end
+
   def test_time_helper_travel_to_with_nested_calls_with_blocks
     Time.stub(:now, Time.now) do
       outer_expected_time = Time.new(2004, 11, 24, 01, 04, 44)


### PR DESCRIPTION
### Summary

This PR adds support for a block to the `travel_back` time helper.

```ruby
Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
travel_back do
  Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
end
Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
```

This feature is useful when we want to make sure that some particular piece of the code is run without time stubs while the rest of the code with