### PR TITLE
Add citext support for associations

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -88,6 +88,9 @@ module ActiveRecord
             else
               key
             end
+            if association_key_type == :citext || owner_key_type == :citext
+              key.to_s.upcase
+            end
           end
 
           def association_key_type


### PR DESCRIPTION
The database i'm working with has an association that has to be linked with a citext attribute (it is on a table that is used to integrate with another database). While requesting the parent object with includes, i was getting "undefined method `first' for nil:NilClass", that was traced to "activerecord (6.0.0) lib/active_record/associations/preloader/association.rb:105:in `block in records_for'".

I debugged that function using the web console and found out that even if citext could detect case insensitive, it would return nil on rails because it is case sensitive. (eg: sql can relate "123F" with "123f" using citext). So, this PR proposition is that, at the convert_keys function, both keys would be upcased if either types are citext.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
