### PR TITLE
Fix random CI fail due to non-deterministic order

### DIFF
--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -218,12 +218,12 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
-    special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
+    default_scope = SpecialPostWithDefaultScope.all
     posts = []
     SpecialPostWithDefaultScope.find_in_batches do |batch|
       posts.concat(batch)
     end
-    assert_equal special_posts_ids, posts.map(&:id)
+    assert_equal default_scope.pluck(:id).sort, posts.map(&:id).sort
   end
 
   def test_find_in_batches_should_not_modify_passed_options
@@ -436,12 +436,12 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_not_ignore_default_scope_without_order_statements
-    special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
+    default_scope = SpecialPostWithDefaultScope.all
     posts = []
     SpecialPostWithDefaultScope.in_batches do |relation|
       posts.concat(relation)
     end
-    assert_equal special_posts_ids, posts.map(&:id)
+    assert_equal default_scope.pluck(:id).sort, posts.map(&:id).sort
   end
 
   def test_in_batches_should_not_modify_passed_options


### PR DESCRIPTION
See https://buildkite.com/rails/rails/builds/64385#78d02d3f-51b4-45fc-af67-a5b9b543d2cc

Although `in_batches` does apply an order to prevent batch overlap, the relation it yields to its block does not.  Therefore, test results must be sorted for comparison.
