### PR TITLE
Fire callbacks if object state is changed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -126,7 +126,7 @@ module ActiveRecord
         while record = ite.shift
           if @run_commit_callbacks
             trigger_callbacks = record.trigger_transactional_callbacks?
-            should_run_callbacks = !already_run_callbacks[record] && trigger_callbacks
+            should_run_callbacks = (record.changed? || !already_run_callbacks[record]) && trigger_callbacks
             already_run_callbacks[record] ||= trigger_callbacks
             record.committed!(should_run_callbacks: should_run_callbacks)
           else


### PR DESCRIPTION
### Summary

`after_commit` callbacks are not always fired in case of soft delete records. In soft_deletion, we don't delete the record from database instead just updates some attributes of the record (like `is_deleted` etc). 
The hash of base record and soft delete records is the same therefore following code returns false and the callbacks are not fired.
```
should_run_callbacks = already_run_callbacks[record] ||= trigger_callbacks
```

To fix this, we should check is the state of the record is changed from the first callback to the last.

### Other Information

Run this [script](https://github.com/siddhantbajaj/Rails-after-commit/blob/master/ruby_script.rb), to see the example of above.

Thanks for contributing to Rails! -->
