### PR TITLE
Add methods to the public API of ActiveRecord::Inheritance

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def klass
         type = owner[reflection.foreign_type]
-        type.presence && type.constantize
+        type.presence && owner.class.polymorphic_class_for(type)
       end
 
       def target_changed?

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -162,12 +162,38 @@ module ActiveRecord
         defined?(@abstract_class) && @abstract_class == true
       end
 
+      # Returns the value to be stored in the inheritance column for STI.
       def sti_name
         store_full_sti_class ? name : name.demodulize
       end
 
+      # Returns the class for the provided +type_name+.
+      #
+      # It is used to find the class correspondent to the value stored in the inheritance column.
+      def sti_class_for(type_name)
+        if store_full_sti_class
+          ActiveSupport::Dependencies.constantize(type_name)
+        else
+          compute_type(type_name)
+        end
+      rescue NameError
+        raise SubclassNotFound,
+          "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " \
+          "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " \
+          "Please rename this column if you didn't intend it to be used for storing the inheritance class " \
+          "or overwrite #{name}.inheritance_column to use another column for that information."
+      end
+
+      # Returns the value to be stored in the polymorphic type column for Polymorphic Associations.
       def polymorphic_name
         base_class.name
+      end
+
+      # Returns the class for the provided +name+.
+      #
+      # It is used to find the class correspondent to the value stored in the polymorphic type column.
+      def polymorphic_class_for(name)
+        name.constantize
       end
 
       def inherited(subclass)
@@ -224,22 +250,12 @@ module ActiveRecord
 
         def find_sti_class(type_name)
           type_name = base_class.type_for_attribute(inheritance_column).cast(type_name)
-          subclass = begin
-            if store_full_sti_class
-              ActiveSupport::Dependencies.constantize(type_name)
-            else
-              compute_type(type_name)
-            end
-          rescue NameError
-            raise SubclassNotFound,
-              "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " \
-              "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " \
-              "Please rename this column if you didn't intend it to be used for storing the inheritance class " \
-              "or overwrite #{name}.inheritance_column to use another column for that information."
-          end
+          subclass = sti_class_for(type_name)
+
           unless subclass == self || descendants.include?(subclass)
             raise SubclassNotFound, "Invalid single-table inheritance type: #{subclass.name} is not a subclass of #{name}"
           end
+
           subclass
         end
 


### PR DESCRIPTION
Those methods make possible to extend STI and Polymorphic associations.

They are useful for cases where you renamed a class and the name of the class doesn't match the data in the database.

You can now implement those methods in your model to load records with name of classes that don't exist anymore.

A simple implementation would look like:

    class Animal < ActiveRecord::Base
      @@old_names = {
        "Lion" => "BigCat"
      }
      def self.sti_name
        name = super
        @@old_names[name] || name
      end

      def self.sti_class_for(type_name)
        @@old_names.inverse[type_name]&.constantize || super
      end
    end