### PR TITLE
Permit service_name in direct uploads

### DIFF
--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -11,7 +11,9 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
 
   private
     def blob_args
-      params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, :metadata).to_h.symbolize_keys
+      params.require(:blob).permit(
+        :filename, :byte_size, :checksum, :content_type, :metadata, :service_name,
+      ).to_h.symbolize_keys
     end
 
     def direct_upload_json(blob)

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -113,6 +113,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
 
     @response.parsed_body.tap do |details|
       assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed(details["signed_id"])
+      assert_equal "local", details["service_name"]
       assert_equal "hello.txt", details["filename"]
       assert_equal 6, details["byte_size"]
       assert_equal checksum, details["checksum"]
@@ -133,6 +134,24 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
     @response.parsed_body.tap do |details|
       assert_nil details["blob"]
       assert_not_nil details["id"]
+    end
+  end
+
+  test "creating new direct upload with non-default service" do
+    checksum = Digest::MD5.base64digest("Hello")
+
+    post rails_direct_uploads_url, params: {
+      blob: {
+        filename: "hello.txt",
+        byte_size: 6,
+        checksum: checksum,
+        content_type: "text/plain",
+        service_name: "local_public",
+      }
+    }
+
+    @response.parsed_body.tap do |details|
+      assert_equal "local_public", details["service_name"]
     end
   end
 


### PR DESCRIPTION
### Summary

For apps with multiple services (eg. a public one and a private one), they should be able to choose which service they want to directly upload to.

How should we expose this in the JS API? Currently, you use `direct_upload: true` to denote a direct upload file field. I was thinking of allowing something along the lines of `direct_upload: { service: "x" }`. We could also try to infer it from the `ActiveStorage::Attached::One/Many` object, but I don't see an easy way of doing that. WDYT?

cc @javan @georgeclaghorn 
