### PR TITLE
Update ActiveSupport::Messages::Metadata#fresh? to handle parse_json_times = true

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Update `ActiveSupport::Messages::Metadata#fresh?` to work for cookies with expiry set when
+    `ActiveSupport.parse_json_times = true`.
+
+    *Christian Gregg*
+
 *   Support symbolic links for `content_path` in `ActiveSupport::EncryptedFile`.
 
     *Takumi Shotoku*

--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -6,7 +6,8 @@ module ActiveSupport
   module Messages #:nodoc:
     class Metadata #:nodoc:
       def initialize(message, expires_at = nil, purpose = nil)
-        @message, @expires_at, @purpose = message, expires_at, purpose
+        @message, @purpose = message, purpose
+        @expires_at = expires_at.is_a?(String) ? Time.iso8601(expires_at) : expires_at
       end
 
       def as_json(options = {})
@@ -64,7 +65,7 @@ module ActiveSupport
         end
 
         def fresh?
-          @expires_at.nil? || Time.now.utc < Time.iso8601(@expires_at)
+          @expires_at.nil? || Time.now.utc < @expires_at
         end
     end
   end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -92,6 +92,23 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_equal @data, @verifier.verify(signed_message)
   end
 
+  def test_verify_with_parse_json_times
+    prev = ActiveSupport.parse_json_times
+    prev_zone = Time.zone
+
+    ActiveSupport.parse_json_times = true
+    Time.zone = ActiveSupport::TimeZone.new("UTC")
+
+    time = Time.now.iso8601
+    json = { _rails: { message: ::Base64.strict_encode64("hi"), exp: time, pur: nil } }.to_json
+
+    ActiveSupport::Messages::Metadata.verify(json, nil)
+  ensure
+    ActiveSupport.parse_json_times = prev
+    Time.zone = prev_zone
+  end
+
+
   def test_rotating_secret
     old_message = ActiveSupport::MessageVerifier.new("old", digest: "SHA1").generate("old")
 


### PR DESCRIPTION
### Summary
When trying to verify cookies that have an expiry set with `ActiveSupport.parse_json_times = true` currently there is a `TypeError` raised as it is assumed that the decoded `expires_at` value is a String, which is not always the case.

### Other Information

From new rails 6 app: https://github.com/CGA1123/rails-active-support-cookies/commit/d4c9d3d7df0d5575205768fe590c160858bca891
<details><summary>Reproducible Snippet</summary>

<p>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "rails", "6.0.0"
end

require "rack/test"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.session_store :cookie_store, key: "cookie_store_key"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/" => "test#index"
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    ActiveSupport.parse_json_times = params[:parse].present?
    cookies.signed['chocolate_chip_cookie'] = { value: 'yum', expires: Time.now }
    cookies.signed['chocolate_chip_cookie']
    render plain: "Home"
  end
end

require "minitest/autorun"

class BugTest < Minitest::Test
  include Rack::Test::Methods

  def test_returns_success
    get "/"
    assert last_response.ok?
  end

  def test_fail
    get "/?parse=1"
    assert last_response.ok?
  end

  private
    def app
      Rails.application
    end
end
```
</p>
</details>