### PR TITLE
TypeError Regexp#match?(nil) in Ruby Head

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -280,7 +280,7 @@ module ActionController #:nodoc:
 
       # Check for cross-origin JavaScript responses.
       def non_xhr_javascript_response? # :doc:
-        %r(\A(?:text|application)/javascript).match?(media_type) && !request.xhr?
+        media_type && %r(\A(?:text|application)/javascript).match?(media_type) && !request.xhr?
       end
 
       AUTHENTICITY_TOKEN_LENGTH = 32

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -231,7 +231,7 @@ module Mime
     class InvalidMimeType < StandardError; end
 
     def initialize(string, symbol = nil, synonyms = [])
-      unless MIME_REGEXP.match?(string)
+      if string.nil? || ! MIME_REGEXP.match?(string)
         raise InvalidMimeType, "#{string.inspect} is not a valid MIME type"
       end
       @symbol, @synonyms = symbol, synonyms

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -265,7 +265,8 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      /XMLHttpRequest/i.match?(get_header("HTTP_X_REQUESTED_WITH"))
+      header = get_header("HTTP_X_REQUESTED_WITH")
+      header && /XMLHttpRequest/i.match?(header)
     end
     alias :xhr? :xml_http_request?
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -151,7 +151,7 @@ module ActionDispatch
                 missing_keys << key
               end
             else
-              unless /\A#{tests[key]}\Z/.match?(parts[key])
+              if parts[key].nil? || !/\A#{tests[key]}\Z/.match?(parts[key])
                 missing_keys ||= []
                 missing_keys << key
               end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -346,7 +346,7 @@ module ActionDispatch
           end
 
           def split_to(to)
-            if /#/.match?(to)
+            if to && /#/.match?(to)
               to.split("#")
             else
               []
@@ -355,7 +355,7 @@ module ActionDispatch
 
           def add_controller_module(controller, modyoule)
             if modyoule && !controller.is_a?(Regexp)
-              if %r{\A/}.match?(controller)
+              if controller && controller.start_with?("/")
                 controller[1..-1]
               else
                 [modyoule, controller].compact.join("/")

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -280,7 +280,12 @@ module ActionView
       def _write_layout_method # :nodoc:
         silence_redefinition_of_method(:_layout)
 
-        prefixes = /\blayouts/.match?(_implied_layout_name) ? [] : ["layouts"]
+        prefixes = if _implied_layout_name &&
+            /\blayouts/.match?(_implied_layout_name)
+          []
+        else
+          ["layouts"]
+        end
         default_behavior = "lookup_context.find_all('#{_implied_layout_name}', #{prefixes.inspect}, false, [], { formats: formats }).first || super"
         name_clause = if name
           default_behavior

--- a/activemodel/test/validators/email_validator.rb
+++ b/activemodel/test/validators/email_validator.rb
@@ -2,7 +2,7 @@
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
+    if value.nil? || ! /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i.match?(value)
       record.errors.add(attribute, message: options[:message] || "is not an email")
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -47,7 +47,9 @@ module ActiveRecord
       set_callback :checkin, :after, :enable_lazy_transactions!
 
       def self.type_cast_config_to_integer(config)
-        if config.is_a?(Integer)
+        if config.nil?
+          config
+        elsif config.is_a?(Integer)
           config
         elsif SIMPLE_INT.match?(config)
           config.to_i

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -162,7 +162,7 @@ module ActiveRecord
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
             default, default_function = field[:Default], nil
 
-            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(default)
+            if type_metadata.type == :datetime && default && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(default)
               default, default_function = nil, default
             elsif type_metadata.extra == "DEFAULT_GENERATED"
               default = +"(#{default})" unless default.start_with?("(")

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -620,7 +620,7 @@ module ActiveRecord
         end
 
         def has_default_function?(default_value, default)
-          !default_value && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
+          !default_value && default && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
         end
 
         def load_additional_types(oids = nil)


### PR DESCRIPTION
Aa of ruby/ruby@2a22a6b2d8465934e75520a7fdcf522d50890caf calling
`Regexp#match?(nil)` raises an exception.

This fixes instances instances raised by the test suite.