### PR TITLE
Enforce that activestorage compiled JS is in sync with source code

### DIFF
--- a/activestorage/test/javascript_package_test.rb
+++ b/activestorage/test/javascript_package_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class JavascriptPackageTest < ActiveSupport::TestCase
+  def test_compiled_code_is_in_sync_with_source_code
+    compiled_file = File.expand_path("../app/assets/javascripts/activestorage.js", __dir__)
+
+    assert_no_changes -> { File.read(compiled_file) } do
+      system "yarn build"
+    end
+  end
+end


### PR DESCRIPTION
### Summary

(Note: this is effectively the same change that we did for actioncable in fefc304199503dbd5290e077357ac431e5fd7441 (#37485) applied to activestorage, per https://github.com/rails/rails/pull/37485#issuecomment-544033448.)

We have run into issues in the past where the activestorage compiled javascript bundle got out of sync with the source code. For example, in 880f977925601c3afe125274b5cc95e150341a9f (#33413) the compiled bundle was modified in a way that was inconsistent with the results of running `yarn build` in the activestorage directory. This meant that running `yarn build` there would produce a dirty git status indicating changes to the compiled bundle, despite not having made any changes to the activestorage javascript source code. That particular inconsistency was fixed in 0e77706dc5d2928e945c34b9ac49ff0807888ba5 (#33656). However, the same problem could reoccur.

To address this, I've added a new test to enforce that activestorage's compiled javascript bundle is in sync with the source code. When the compiled bundle is in sync with the source code, the test will pass. However, if the two are not in sync, the test will fail. For example, if you were to apply the following patch (which only updates the source code):

```patch
diff --git a/activestorage/app/javascript/activestorage/index.js b/activestorage/app/javascript/activestorage/index.js
index a340008fb9..a05b7223a5 100644
--- a/activestorage/app/javascript/activestorage/index.js
+++ b/activestorage/app/javascript/activestorage/index.js
@@ -8,4 +8,4 @@ function autostart() {
   }
 }

-setTimeout(autostart, 1)
+setTimeout(autostart, 2)
```
the test would then fail. Thus, the activestorage test suite will now prevent "the compiled bundle is out of sync" issues going forward.