### PR TITLE
Update `rails server` terminal output in Guides [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -124,10 +124,10 @@ With no further work, `rails server` will run our new shiny Rails app:
 $ cd commandsapp
 $ rails server
 => Booting Puma
-=> Rails 5.1.0 application starting in development on http://0.0.0.0:3000
-=> Run `rails server -h` for more startup options
+=> Rails 6.0.0 application starting in development
+=> Run `rails server --help` for more startup options
 Puma starting in single mode...
-* Version 3.0.2 (ruby 2.3.0-p0), codename: Plethora of Penguin Pinatas
+* Version 3.12.1 (ruby 2.5.7-p206), codename: Llamas in Pajamas
 * Min threads: 5, max threads: 5
 * Environment: development
 * Listening on tcp://localhost:3000

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -350,10 +350,10 @@ For example:
 
 ```bash
 => Booting Puma
-=> Rails 5.1.0 application starting in development on http://0.0.0.0:3000
-=> Run `rails server -h` for more startup options
+=> Rails 6.0.0 application starting in development
+=> Run `rails server --help` for more startup options
 Puma starting in single mode...
-* Version 3.4.0 (ruby 2.3.1-p112), codename: Owl Bowl Brawl
+* Version 3.12.1 (ruby 2.5.7-p206), codename: Llamas in Pajamas
 * Min threads: 5, max threads: 5
 * Environment: development
 * Listening on tcp://localhost:3000


### PR DESCRIPTION
### Summary

In previous Rails versions of the Guides, the terminal output of `rails server` reflects the version of Rails that's being used. However, in Rails 5.2 and Rails 6.0 versions of the Guides, the terminal output in the following pages:

* The Rails Command Line
* Debugging Rails Applications

are stuck at Rails 5.1 (it shows an older version of Puma and Ruby as well). For example:

```bash
$ rails server
=> Booting Puma
=> Rails 5.1.0 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
Puma starting in single mode...
* Version 3.0.2 (ruby 2.3.0-p0), codename: Plethora of Penguin Pinatas
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://localhost:3000
Use Ctrl-C to stop
```

This change simply updates these 2 pages to use the same output from running `rails server` with Rails 6.

### Other Information

In one instance in the Guides where `rails server` output was displayed, the output is immediately truncated and the lines after "Booting Puma" line are not displayed:

```bash
$ rails server
=> Booting Puma...
```

This is an alternative approach we can do so that in future Rails 6.x versions and beyond, we would no longer need to update the terminal output for `rails server` in the Guides (unless Puma is replaced). Please let me know if we should use this alternative approach instead.
