### PR TITLE
Add covering index support for PostgreSQL 11+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add covering index support for PostgreSQL 11+.
+
+    *Sebastián Palma*
+
 *   Support `where` with comparison operators (`>`, `>=`, `<`, and `<=`).
 
     ```ruby

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -749,6 +749,10 @@
 
     *Hiroyuki Ishii*
 
+*   Fixed the performance regression for `primary_keys` introduced MySQL 8.0.
+
+    *Hiroyuki Ishii*
+
 *   Add support for `belongs_to` to `has_many` inversing.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -97,10 +97,15 @@ module ActiveRecord
           sql << "IF NOT EXISTS" if o.if_not_exists
           sql << o.algorithm if o.algorithm
           sql << index.type if index.type
-          sql << "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
+          sql << if index.includes
+            "#{quote_column_name(index.name)} ON #{index.table}(#{quoted_columns(index)})"
+          else
+            "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
+          end
           sql << "USING #{index.using}" if supports_index_using? && index.using
-          sql << "(#{quoted_columns(index)})"
+          sql << "(#{quoted_columns(index)})" unless index.includes
           sql << "WHERE #{index.where}" if supports_partial_index? && index.where
+          sql << "INCLUDE (#{index.includes})" if index.includes
 
           sql.join(" ")
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment, :includes
 
       def initialize(
         table, name,
@@ -18,7 +18,8 @@ module ActiveRecord
         where: nil,
         type: nil,
         using: nil,
-        comment: nil
+        comment: nil,
+        includes: nil
       )
         @table = table
         @name = name
@@ -31,6 +32,7 @@ module ActiveRecord
         @type = type
         @using = using
         @comment = comment
+        @includes = includes
       end
 
       def column_options

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -290,6 +290,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support covering indices?
+      def supports_covering_indexes?
+        false
+      end
+
       # Does this adapter support partial indices?
       def supports_partial_index?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -109,6 +109,7 @@ module ActiveRecord
             comment = row[5]
 
             using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
+            includes = inddef.scan(/(?:\G(?!\A) *, *"?| INCLUDE +\()\K\w+(?=[^()]*\))/)
 
             orders = {}
             opclasses = {}
@@ -144,7 +145,8 @@ module ActiveRecord
               opclasses: opclasses,
               where: where,
               using: using.to_sym,
-              comment: comment.presence
+              comment: comment.presence,
+              includes: includes
             )
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -150,6 +150,10 @@ module ActiveRecord
         database_version >= 110_000
       end
 
+      def supports_covering_indexes?
+        true
+      end
+
       def supports_partial_index?
         true
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -216,6 +216,7 @@ HEADER
         index_parts << "using: #{index.using.inspect}" if !@connection.default_index_type?(index)
         index_parts << "type: #{index.type.inspect}" if index.type
         index_parts << "comment: #{index.comment.inspect}" if index.comment
+        index_parts << "includes: #{index.includes.inspect}" if index.includes.present?
         index_parts
       end
 

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -74,12 +74,12 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
       add_index(:people, :last_name, algorithm: :copy)
     end
 
-    expected = %(CREATE  INDEX  "index_people_on_first_name_last_name" ON people("first_name") INCLUDE ("last_name"))
+    expected = %(CREATE INDEX "index_people_on_first_name_last_name" ON people("first_name") INCLUDE ("last_name"))
     assert_equal expected, add_index(:people, :first_name, includes: :last_name)
     assert_equal expected, add_index(:people, "first_name", includes: :last_name)
     assert_equal expected, add_index(:people, :first_name, includes: [:last_name])
     assert_equal expected, add_index(:people, :first_name, includes: ["last_name"])
-    expected = %(CREATE  INDEX  "index_people_on_first_name_last_name_state" ON people("first_name") INCLUDE ("last_name", "state"))
+    expected = %(CREATE INDEX "index_people_on_first_name_last_name_state" ON people("first_name") INCLUDE ("last_name", "state"))
     assert_equal expected, add_index(:people, :first_name, includes: [:last_name, :state])
     assert_equal expected, add_index(:people, :first_name, includes: ["last_name", :state])
     [[], nil, ""].each do |unsupported_object|

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -273,6 +273,22 @@ module ActiveRecord
         end
       end
 
+      def test_index_with_includes
+        with_example_table do
+          @connection.add_index "ex", "data", includes: "number"
+          index = @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_number" }
+          assert_equal ["data", "number"], index.columns.sort
+          @connection.remove_index "ex", ["data", "number"]
+          assert_not @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_number" }
+
+          @connection.add_index "ex", "data", includes: ["id", "number"]
+          index = @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_id_number" }
+          assert_equal ["data", "id", "number"], index.columns.sort
+          @connection.remove_index "ex", ["data", "id", "number"]
+          assert_not @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data_id_number" }
+        end
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
This PR introduces the support for [covering indexes](https://www.postgresql.org/docs/11/indexes-index-only-scans.html) when using PostgreSQL 11 or newer.

The method `add_index` has been extended to allow an `includes` option, which
receives a single column or an array of columns:

    add_index :posts, :title, includes: :subtitle

Which produces a database index as:

    CREATE INDEX index_posts_on_title_subtitle ON posts(title) INCLUDE (subtitle);

The method `remove_index` has no changes, since it isn't needed to specify the includes columns to delete the index from the database, as we can use just the name (like with other index types).

There's a guard clause that checks if the `options` when invoking `add_index` contains `includes`, if so it checks if the PostgreSQL version is less than `110000` which is the value and format returned for versions greater or equal to 11. If the condition is true it raises a `NotImplementedError` error to warn the user the feature isn't available for the current PostgreSQL version used.

The clause is `INCLUDE` but the code was developed making use of `includes` as `include` is an already defined statement.