### PR TITLE
Avoid shelling out for generator `generate` action

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "shellwords"
 require "active_support/core_ext/string/strip"
 
 module Rails
@@ -221,13 +222,17 @@ module Rails
       # the generator or an Array that is joined.
       #
       #   generate(:authenticated, "user session")
-      def generate(what, *args)
-        log :generate, what
-
+      def generate(*args)
         options = args.extract_options!
-        argument = args.flat_map(&:to_s).join(" ")
+        args = Shellwords.split(args.join(" "))
 
-        execute_command :rails, "generate #{what} #{argument}", options
+        log :generate, args.first
+
+        in_root do
+          silence_warnings do
+            ::Rails::Command.invoke("generate", args, options)
+          end
+        end
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -384,16 +384,28 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file "app/models/my_model.rb", /MyModel/
   end
 
-  test "generate with concatenated arguments" do
+  test "generate should raise on failure" do
     run_generator
-    action :generate, "model MyModel name:string"
+    message = capture(:stderr) do
+      assert_raises SystemExit do
+        action :generate, "model", "1234567890"
+      end
+    end
+    assert_match(/1234567890/, message)
+  end
+
+  test "generate with inline option" do
+    run_generator
+    assert_not_called(generator, :run) do
+      action :generate, "model", "MyModel", inline: true
+    end
     assert_file "app/models/my_model.rb", /MyModel/
   end
 
-  test "generate should raise on failure" do
+  test "generate with inline option should raise on failure" do
     run_generator
     error = assert_raises do
-      action :generate, "model", "1234567890"
+      action :generate, "model", "1234567890", inline: true
     end
     assert_match(/1234567890/, error.message)
   end
@@ -501,6 +513,22 @@ class ActionsTest < Rails::Generators::TestCase
         action :rails_command, "invalid", abort_on_failure: true
       end
     end
+  end
+
+  test "rails_command with inline option" do
+    run_generator
+    assert_not_called(generator, :run) do
+      action :rails_command, "generate model MyModel", inline: true
+    end
+    assert_file "app/models/my_model.rb", /MyModel/
+  end
+
+  test "rails_command with inline option should raise on failure" do
+    run_generator
+    error = assert_raises do
+      action :rails_command, "generate model 1234567890", inline: true
+    end
+    assert_match(/1234567890/, error.message)
   end
 
   test "route should add route" do


### PR DESCRIPTION
This change addresses a few issues:

First, shelling out to the `rails` command requires the destination directory to contain certain files that the command uses to initialize itself.  While this is not an issue when running generators normally, it is troublesome when testing generator-invoking generators which output to ephemeral destination directories.

Second, shelling out to the `rails` command is very slow.  This also is not a particular concern when running generators normally, but it makes test suites for generator-invoking generators painfully slow.

Third, shelling out to the `rails` command fails silently by default.  Such silent failures can be surprising, and can lead to confusing downstream failures.

---

Some previous history regarding the `generate` action:

* #34418 was created to prevent generator sub-invocations from failing silently.  It was rejected due to concerns about backward compatibility.
* #34420 was created to solve a generalized form of the issue addressed by #34418, but the solution is opt-in.
* #34980 was created to fix a regression introduced by #34420, specific to `generate`.

The changes in this PR are similar to #34418, but with backward-compatibility concerns mostly addressed.  However, unlike the alternative #34420, `generate` will now always raise on failure.  This could be made opt-in behavior, but I could not think of a scenario where you would want `generate` to fail silently.

This PR does not revert #34420, which affected more than `generate`, but this PR does obsolete the `abort_on_failure` option for `generate`.  Since `abort_on_failure` was previously only tested with `generate`, this PR adds tests for the `abort_on_failure` option with other actions.

~This PR does revert #34980, which is no longer necessary.~  (See #37979)

Also, a crude and informal performance measurement: for a test suite with fewer than a dozen generator-invoking-generator tests, this change reduced the run time from 57 seconds to 3.3 seconds. :rocket: