### PR TITLE
Reduce primary access

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -132,7 +132,7 @@ module ActiveRecord
             connection.with_yaml_fallback(types[key].serialize(value))
           end
 
-          Arel::InsertManager.new.create_values_list(values_list).to_sql
+          Arel::InsertManager.new.create_values_list(values_list).to_sql(model)
         end
 
         def returning


### PR DESCRIPTION
### Summary

`Nodes::ValuesList#to_sql` can use `model` attribute at `Builder` class.