### PR TITLE
Simplify dangerous_class_method?

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -115,13 +115,11 @@ module ActiveRecord
       # A class method is 'dangerous' if it is already (re)defined by Active Record, but
       # not by any ancestors. (So 'puts' is not dangerous but 'new' is.)
       def dangerous_class_method?(method_name)
-        RESTRICTED_CLASS_METHODS.include?(method_name.to_s) || class_method_defined_within?(method_name, Base)
-      end
+        return true if RESTRICTED_CLASS_METHODS.include?(method_name.to_s)
 
-      def class_method_defined_within?(name, klass, superklass = klass.superclass) # :nodoc:
-        if klass.respond_to?(name, true)
-          if superklass.respond_to?(name, true)
-            klass.method(name).owner != superklass.method(name).owner
+        if Base.respond_to?(method_name, true)
+          if Object.respond_to?(method_name, true)
+            Base.method(method_name).owner != Object.method(method_name).owner
           else
             true
           end


### PR DESCRIPTION
### Summary

`class_method_defined_within?` is only ever used in one context, where `klass` is `Base` and `superklass` is `Object`. Since it's private, the method shouldn't be used anywhere else, so we can collapse the whole thing and simplify it.

I suppose the reason this exists is as a class-level variant of `method_defined_within?`, but personally I think it's actually more confusing the way it is now. Note that `method_defined_within?` *is* needed (with all arguments) since it is called in two different ways from different points in the code.