### PR TITLE
Don't instantiate new role

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1055,7 +1055,7 @@ module ActiveRecord
           payload[:config] = db_config.configuration_hash
         end
 
-        role = owner_to_role[role.connection_specification_name] = Role.new(role.connection_specification_name, db_config)
+        owner_to_role[role.connection_specification_name] = role
 
         message_bus.instrument("!connection.active_record", payload) do
           role.pool


### PR DESCRIPTION
This was a typo from #37503 where we instantiate a `Role` twice. We
already have a role so we don't need to create it again.

cc/ @casperisfine @Edouard-chin 