### PR TITLE
Allow CTEs in read-only query with postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         end
 
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback, :describe, :desc
+          :begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback, :describe, :desc, :with
         ) # :nodoc:
         private_constant :READ_QUERY
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -67,7 +67,7 @@ module ActiveRecord
           end
         end
 
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback) # :nodoc:
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :set, :show, :release, :savepoint, :rollback, :with) # :nodoc:
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module DatabaseStatements
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback) # :nodoc:
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback, :with) # :nodoc:
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -232,6 +232,15 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
+    @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
+
+    @connection_handler.while_preventing_writes do
+      sql = "WITH matching_cars AS (SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594') SELECT * FROM matching_cars"
+      assert_equal 1, @conn.execute(sql).entries.count
+    end
+  end
+
   def test_read_timeout_exception
     ActiveRecord::Base.establish_connection(
       ActiveRecord::Base.configurations[:arunit].merge("read_timeout" => 1)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -457,6 +457,17 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
+        with_example_table do
+          @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          @connection_handler.while_preventing_writes do
+            sql = "WITH matching_ex_values AS (SELECT * FROM ex WHERE data = '138853948594') SELECT * FROM matching_ex_values"
+            assert_equal 1, @connection.execute(sql).entries.count
+          end
+        end
+      end
+
       private
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)
           super(@connection, "ex", definition, &block)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -652,6 +652,17 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
+        with_example_table "id int, data string" do
+          @conn.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          @connection_handler.while_preventing_writes do
+            sql = "WITH matching_ex_values AS (SELECT * FROM ex WHERE data = '138853948594') SELECT * FROM matching_ex_values"
+            assert_equal 1, @conn.execute(sql).entries.count
+          end
+        end
+      end
+
       private
         def assert_logged(logs)
           subscriber = SQLSubscriber.new


### PR DESCRIPTION
### Summary

Common Table Expressions in PostgreSQL allow a different way to define
derived tables. Here's an example from the pg docs:

	WITH regional_sales AS (
	        SELECT region, SUM(amount) AS total_sales
	        FROM orders
	        GROUP BY region
	     ), top_regions AS (
	        SELECT region
	        FROM regional_sales
	        WHERE total_sales > (SELECT SUM(total_sales)/10 FROM regional_sales)
	     )
	SELECT region,
	       product,
	       SUM(quantity) AS product_units,
	       SUM(amount) AS product_sales
	FROM orders
	WHERE region IN (SELECT region FROM top_regions)
	GROUP BY region, product;

https://www.postgresql.org/docs/current/queries-with.html

This commit adds the :with keyword to the set of keywords allowed to
begin a query against a `prevent_writes` PostgreSQL connection.

This commit adds the :with keyword to the set of keywords allowed to
begin a query against a `prevent_writes` PostgreSQL connection.


Thx to @kamipo, this also adds the same support for sqlite3 and mysql2

https://www.sqlite.org/lang_with.html
https://dev.mysql.com/doc/refman/8.0/en/with.html

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
