### PR TITLE
Tidy up the build output for Active Job adapters

### DIFF
--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -68,10 +68,17 @@ def run_without_aborting(tasks)
   errors = []
 
   tasks.each do |task|
+    puts "\n\n---   rake #{task}\n"
+
     Rake::Task[task].invoke
   rescue Exception
+    puts "\n^^^ +++"
+
     errors << task
   end
 
-  abort "Errors running #{errors.join(', ')}" if errors.any?
+  if errors.any?
+    puts "\n\n+++   Summary\n"
+    abort "Errors running #{errors.join(', ')}"
+  end
 end

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-puts "\n\n*** rake test:integration:#{ENV['AJ_ADAPTER']} ***\n"
-
 ENV["RAILS_ENV"] = "test"
 ActiveJob::Base.queue_name_prefix = nil
 


### PR DESCRIPTION
This won't fix the current failure (discussed in #37517), but while there is one, I'm using the opportunity to [hopefully] make it a bit clearer.