### PR TITLE
Use MigrationContext#schema_migration connection in Migration

### DIFF
--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -10,6 +10,7 @@ module ActiveRecord
 
       Migration = Struct.new(:name, :version) do
         def disable_ddl_transaction; false end
+        def with_connection_pool(pool); yield; end
         def migrate(direction)
           # do nothing
         end


### PR DESCRIPTION
cc @eileencodes, @casperisfine 

## Problem

Migrations are currently expected to run with the ActiveRecord::Base connection being established to the database to migrate.  This means that inside a migration for a non-primary database, model's inheriting the primary database connection will actually be switched to be connected to the non-primary database.  This could cause problems when using the models to query/modify the database as shown in migration documentation examples https://guides.rubyonrails.org/v6.0/active_record_migrations.html#when-helpers-aren-t-enough and https://guides.rubyonrails.org/v6.0/active_record_migrations.html#migrations-and-seed-data .

## Solution

I changed the Migrator to use the connection from the `schema_migration` that is passed into its initializer from the MigrationContext.

I also injected the connection pool from that schema_migration model into the migration by adding an undocumented `with_connection_pool` method to set the connection pool to use by the migrate method.  At first I was going to do this by passing it as a parameter to the `migrate` method on the Migration, but the migration compatibility tests were overriding the `migrate` method, so it seemed like we might need to support old migrations like that.  I couldn't find examples of migrations like that in the old guides, so let me know if we don't need to support migrations that override the `migrate` method.

## Future Work

This PR doesn't change the migrate tasks to not switch the ActiveRecord::Base connection, but I would like to do that as a follow-up.  I'm thinking that ActiveRecord::Tasks::DatabaseTasks#migrate could take an optional `configuration` parameter, similar to `create`, and use that to get the `migration_context` on the right connection.

Ideally, we would also actually switch the connection on base model for the database (e.g. on `AnimalsBase` for the `animals` database in the [Multiple Databases guide](https://guides.rubyonrails.org/v6.0/active_record_multiple_databases.html#setting-up-your-application) example), but we would first have to have a convention and/or database configuration to find that constant.