### PR TITLE
[ci skip] Small fix to ActiveSupport docs

### DIFF
--- a/activesupport/lib/active_support/rails.rb
+++ b/activesupport/lib/active_support/rails.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This is private interface.
+# This is a private interface.
 #
 # Rails components cherry pick from Active Support as needed, but there are a
 # few features that are used for sure in some way or another and it is not worth


### PR DESCRIPTION
### Summary

This is a small documentation fix for the ActiveSupport rails.rb private interface. 