### PR TITLE
[ci skip] Fix lower case comments without punctuation

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb
@@ -21,7 +21,7 @@ class Hash
   end
 
   private
-    # support methods for deep transforming nested hashes and arrays
+    # Support methods for deep transforming nested hashes and arrays.
     def _deep_transform_values_in_object(object, &block)
       case object
       when Hash

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -112,7 +112,7 @@ class Hash
   end
 
   private
-    # support methods for deep transforming nested hashes and arrays
+    # Support methods for deep transforming nested hashes and arrays.
     def _deep_transform_keys_in_object(object, &block)
       case object
       when Hash


### PR DESCRIPTION
### Summary

Documentation fix in two places, comments started with lowercase and had no punctuation at the end.