### PR TITLE
Add Hash#deep_transform_pairs and deep_transform_pairs!

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/hash/conversions"
 require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/hash/deep_transform_values"
+require "active_support/core_ext/hash/deep_transform_pairs"
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/keys"

--- a/activesupport/lib/active_support/core_ext/hash/deep_transform_pairs.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_transform_pairs.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Hash
+  # Returns a new hash with all keys and values converted by a pair of block operations.
+  # This includes the keys and values from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #  hash = { person: { name: 'Bobby', age: '21' } }
+  #
+  #  hash.deep_transform_pairs(
+  #    key_block: -> (k) { k.to_s.upcase },
+  #    value_block: -> (v) { v.to_s.upcase }
+  #  )
+  # => {"PERSON": {"NAME": "BOBBY", "AGE": "21"}}
+  def deep_transform_pairs(key_block:, value_block:)
+    _deep_transform_pairs_in_object(self, key_block, value_block)
+  end
+
+  # Destructively converts all keys and values by using a pair of block operations.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  def deep_transform_pairs!(key_block:, value_block:)
+    _deep_transform_pairs_in_object!(self, key_block, value_block)
+  end
+
+  private
+    # Support methods for deep transforming nested hashes and arrays.
+    def _deep_transform_pairs_in_object(object, key_block, value_block)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          result[key_block.call(key)] = _deep_transform_pairs_in_object(value, key_block, value_block)
+        end
+      when Array
+        object.map { |e| _deep_transform_pairs_in_object(e, key_block, value_block) }
+      else
+        value_block.call(object)
+      end
+    end
+
+    def _deep_transform_pairs_in_object!(object, key_block, value_block)
+      case object
+      when Hash
+        object.keys.each do |key|
+          value = object.delete(key)
+          object[key_block.call(key)] = _deep_transform_pairs_in_object!(value, key_block, value_block)
+        end
+        object
+      when Array
+        object.map! { |e| _deep_transform_pairs_in_object!(e, key_block, value_block) }
+      else
+        value_block.call(object)
+      end
+    end
+end

--- a/activesupport/lib/active_support/core_ext/hash/deep_transform_pairs.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_transform_pairs.rb
@@ -8,8 +8,8 @@ class Hash
   #  hash = { person: { name: 'Bobby', age: '21' } }
   #
   #  hash.deep_transform_pairs(
-  #    key_block: -> (k) { k.to_s.upcase },
-  #    value_block: -> (v) { v.to_s.upcase }
+  #    key_block: -> (key) { key.to_s.upcase },
+  #    value_block: -> (value) { value.to_s.upcase }
   #  )
   # => {"PERSON": {"NAME": "BOBBY", "AGE": "21"}}
   def deep_transform_pairs(key_block:, value_block:)
@@ -22,6 +22,63 @@ class Hash
   def deep_transform_pairs!(key_block:, value_block:)
     _deep_transform_pairs_in_object!(self, key_block, value_block)
   end
+
+  # Returns a new hash with all keys and values converted by a pair of nested block
+  # operations. This includes the keys and values from the root hash and from all
+  # nested hashes and arrays. If either `on_key` or `on_value` are not called the
+  # respective value is returned, unchanged.
+  #
+  #  hash = { person: { name: 'Bobby', age: '21' } }
+  #
+  #  hash.deep_transform_pairs_v2 do
+  #    on_key do |key|
+  #      key.to_s.upcase
+  #    end
+  #
+  #    on_value do |value|
+  #      value.to_s.upcase
+  #    end
+  #  end
+  # => {"PERSON": {"NAME": "BOBBY", "AGE": "21"}}
+  def deep_transform_pairs_v2(&block)
+    helper = DeepTransformPairsHelper.new
+    helper.instance_exec(&block)
+    _deep_transform_pairs_in_object(self, helper.key_block, helper.value_block)
+  end
+
+  # Destructively converts all keys and values by using a block
+  # containing nested `on_key` and `on_value` operations.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays. If either `on_key` or `on_value`
+  # are not called the respective value is returned, unchanged.
+  def deep_transform_pairs_v2!(&block)
+    helper = DeepTransformPairsHelper.new
+    helper.instance_exec(&block)
+    _deep_transform_pairs_in_object!(self, helper.key_block, helper.value_block)
+  end
+
+  class DeepTransformPairsHelper
+    attr_reader :key_block, :value_block
+
+    def initialize
+      @key_block = pass_through_block
+      @value_block = pass_through_block
+    end
+
+    def on_key(&key_block)
+      @key_block = key_block
+    end
+
+    def on_value(&value_block)
+      @value_block = value_block
+    end
+
+    private
+      def pass_through_block
+        @pass_through_block ||= -> (key_or_value) { key_or_value }
+      end
+  end
+  private_constant :DeepTransformPairsHelper
 
   private
     # Support methods for deep transforming nested hashes and arrays.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -36,6 +36,8 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_transform_keys!
     assert_respond_to h, :deep_transform_values
     assert_respond_to h, :deep_transform_values!
+    assert_respond_to h, :deep_transform_pairs
+    assert_respond_to h, :deep_transform_pairs!
     assert_respond_to h, :symbolize_keys
     assert_respond_to h, :symbolize_keys!
     assert_respond_to h, :deep_symbolize_keys
@@ -104,6 +106,13 @@ class HashExtTest < ActiveSupport::TestCase
     transformed_hash.deep_transform_values! { |value| value.to_s }
     assert_equal({ "a" => { b: { "c" => "3" } } }, transformed_hash)
     assert_equal({ "a" => { b: { "c" => 3 } } }, @nested_mixed)
+  end
+
+  def test_deep_transform_pairs
+    expected = { "A" => [1], "B" => [2] }
+    actual = @strings.deep_transform_pairs(key_block: -> (k) { k.upcase }, value_block: -> (v) { Array[v] })
+
+    assert_equal(expected, actual)
   end
 
   def test_symbolize_keys

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -110,9 +110,62 @@ class HashExtTest < ActiveSupport::TestCase
 
   def test_deep_transform_pairs
     expected = { "A" => [1], "B" => [2] }
-    actual = @strings.deep_transform_pairs(key_block: -> (k) { k.upcase }, value_block: -> (v) { Array[v] })
+    actual = @strings.deep_transform_pairs(key_block: -> (key) { key.upcase }, value_block: -> (value) { Array[value] })
 
     assert_equal(expected, actual)
+  end
+
+  def test_deep_transform_pairs_v2
+    expected = { "A" => [1], "B" => [2] }
+
+    actual = @strings.deep_transform_pairs_v2 do
+      on_key do |key|
+        key.upcase
+      end
+
+      on_value do |value|
+        Array[value]
+      end
+    end
+    assert_equal(expected, actual)
+
+    expected = { "A" => 1, "B" => 2 }
+
+    actual = @strings.deep_transform_pairs_v2 do
+      on_key do |key|
+        key.upcase
+      end
+    end
+    assert_equal(expected, actual)
+
+    expected = { "a" => 1, "b" => 2 }
+
+    actual = @strings.deep_transform_pairs_v2 do
+      # Not passing a block to `on_key` or `on_value` has no effect on the Hash.
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_deep_transform_pairs!
+    expected = { "A" => [1], "B" => [2] }
+    @strings.deep_transform_pairs!(key_block: -> (key) { key.upcase }, value_block: -> (value) { Array[value] })
+
+    assert_equal(expected, @strings)
+  end
+
+  def test_deep_transform_pairs_v2!
+    expected = { "A" => [1], "B" => [2] }
+
+    @strings.deep_transform_pairs_v2! do
+      on_key do |key|
+        key.upcase
+      end
+
+      on_value do |value|
+        Array[value]
+      end
+    end
+    assert_equal(expected, @strings)
   end
 
   def test_symbolize_keys


### PR DESCRIPTION
### Summary
https://api.rubyonrails.org/classes/Hash.html

`deep_transform_keys` and `deep_transform_values` both exist and provide a way to transform either keys or values recursively on a Hash.

I propose `deep_transform_pairs` and `deep_transform_pairs!`, methods which take two blocks and let users transform both keys and values in one recursion.

I'm looking for early feedback on interface/naming options. I don't think it's possible in Ruby to pass two blocks to a method via its arguments, apart from positional or keyword args. So I went with:

```ruby
hash.deep_transform_pairs(key_block: <callable>, value_block: <callable>)
```

#### Alternate syntax

I've also included in this PR a second possible syntax that came to mind. It uses `instance_exec` to call to a private class responsible for gathering the `on_key` and `on_value` blocks to use when transforming Hash keys and values.

```ruby
hash = { person: { name: 'Bobby', age: '21' } }

hash.deep_transform_pairs_v2 do
  on_key do |key|
    key.to_s.upcase
  end

  on_value do |value|
    value.to_s.upcase
  end
end
=> {"PERSON": {"NAME": "BOBBY", "AGE": "21"}}
```

Maybe this is a nicer interface?

#### Related, possible follow-up work

`Hash.to_h` has a lesser-known ability to transform top-level keys and values in a single iteration. Would it make sense to introduce `Hash#transform_pairs` and its `!` equivalent, which requires a block and performs the same behaviour as `to_h(&block)`, to improve discoverability?

```ruby
{ a: 1, b: 2 }.to_h { |k, v| [k.to_s.upcase.to_sym, v+1] }
=> {:A=>2, :B=>3}
```

