### PR TITLE
`bin/yarn` exec `"yarn"` rather than `"yarnpkg"`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,7 +1,7 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   begin
-    exec "yarnpkg", *ARGV
+    exec "yarn", *ARGV
   rescue Errno::ENOENT
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
### Summary
Currently `bin/yarn` will run `exec "yarnpkg"`. By updating this to `exec "yarn"` we are keeping in line with the currently supported commands.

### Other Information
[`yarnpkg` has been deprecated](https://yarnpkg.com/en/package/yarnpkg) and not all installs alias to `yarnpkg` like homebrew does, (eg: `yvm`). This can be confusing, especially as web searches don't bring up information on this easily.

The only reason found for still using `yarnpkg` over `yarn` is that debian used to not have `yarn` as an executable, while most other operating systems would alias `yarnpkg`. However, [the supported installation for debian appears to give a `yarn` executable now](https://yarnpkg.com/lang/en/docs/install/#debian-stable).