### PR TITLE
[ci skip] Fix lower case comments without punctuation

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -16,7 +16,7 @@ module ActiveSupport
         @number = RoundingHelper.new(options).round(number)
         @number = Float(number)
 
-        # for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
+        # For backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files.
         unless options.key?(:strip_insignificant_zeros)
           options[:strip_insignificant_zeros] = true
         end

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -13,7 +13,7 @@ module ActiveSupport
       def convert
         @number = Float(number)
 
-        # for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
+        # For backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files.
         unless options.key?(:strip_insignificant_zeros)
           options[:strip_insignificant_zeros] = true
         end


### PR DESCRIPTION
### Summary

Documentation fix for number_helper. Comments started with a lowercase letter and had no punctuation at the end.