### PR TITLE
add eager_group query method

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -21,6 +21,7 @@ require "active_record/relation/delegation"
 require "active_record/attributes"
 require "active_record/type_caster"
 require "active_record/database_configurations"
+require "active_record/eager_group"
 
 module ActiveRecord #:nodoc:
   # = Active Record
@@ -320,6 +321,7 @@ module ActiveRecord #:nodoc:
     include Store
     include SecureToken
     include Suppressor
+    include EagerGroup
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/eager_group.rb
+++ b/activerecord/lib/active_record/eager_group.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ActiveRecord #:nodoc:
+  # = Active Record EagerGroup
+  module EagerGroup
+    extend ActiveSupport::Autoload
+    extend ActiveSupport::Concern
+
+    autoload :Definition
+    autoload :Preloader
+
+    class_methods do
+      mattr_accessor :eager_group_definitions, default: {}
+
+      # class Post
+      #   define_eager_group :comments_avergage_rating, :comments, :average, :rating
+      #   define_eager_group :approved_comments_count, :comments, :count, :*, -> { approved }
+      # end
+      def define_eager_group(attr, association, aggregate_function, column_name, scope = nil)
+        send :attr_accessor, attr
+        eager_group_definitions[attr] = Definition.new(association, aggregate_function, column_name, scope)
+
+        define_method attr,
+                      lambda { |*args|
+                        query_result_cache = instance_variable_get("@#{attr}")
+                        return query_result_cache if args.blank? && query_result_cache.present?
+
+                        preload_eager_group(attr, *args)
+                        instance_variable_get("@#{attr}")
+                      }
+
+        define_method "#{attr}=" do |val|
+          instance_variable_set("@#{attr}", val)
+        end
+      end
+    end
+
+    protected
+      def preload_eager_group(*eager_group_value)
+        EagerGroup::Preloader.new(self.class, [self], [eager_group_value]).run
+      end
+  end
+end

--- a/activerecord/lib/active_record/eager_group/definition.rb
+++ b/activerecord/lib/active_record/eager_group/definition.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module EagerGroup # :nodoc:
+    class Definition # :nodoc:
+      attr_reader :association, :aggregate_function, :column_name, :scope
+
+      def initialize(association, aggregate_function, column_name, scope)
+        @association = association
+        @aggregate_function = aggregate_function
+        @column_name = column_name
+        @scope = scope
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/eager_group/preloader.rb
+++ b/activerecord/lib/active_record/eager_group/preloader.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module EagerGroup # :nodoc:
+    class Preloader # :nodoc:
+      def initialize(klass, records, eager_group_values)
+        @klass = klass
+        @records = Array.wrap(records).compact.uniq
+        @eager_group_values = eager_group_values
+      end
+
+      # Preload aggregate functions
+      def run
+        primary_key = @klass.primary_key
+        @eager_group_values.each do |eager_group_value|
+          definition_key, arguments =
+            eager_group_value.is_a?(Array) ? [eager_group_value.shift, eager_group_value] : [eager_group_value, nil]
+
+          if definition_key.is_a?(Hash)
+            association_name, definition_key = *definition_key.first
+            @records = @records.flat_map { |record| record.send(association_name) }
+            next if @records.empty?
+
+            @klass = @records.first.class
+          end
+          record_ids = @records.map { |record| record.send(primary_key) }
+          next unless definition = @klass.eager_group_definitions[definition_key]
+
+          reflection = @klass.reflect_on_association(definition.association)
+          association_class = reflection.klass
+          association_class = association_class.instance_exec(*arguments, &definition.scope) if definition.scope
+
+          foreign_key, aggregate_hash =
+            if reflection.is_a?(ActiveRecord::Reflection::HasAndBelongsToManyReflection)
+              ["#{reflection.join_table}.#{reflection.foreign_key}", @klass.joins(reflection.name)]
+            elsif reflection.through_reflection
+              ["#{reflection.through_reflection.name}.#{reflection.through_reflection.foreign_key}", @klass.joins(reflection.name)]
+            else
+              [reflection.foreign_key, association_class]
+            end
+          aggregate_hash = aggregate_hash.where(foreign_key => record_ids)
+                                         .where(polymophic_as_condition(reflection))
+                                         .group(foreign_key)
+                                         .send(definition.aggregate_function, definition.column_name)
+          @records.each do |record|
+            id = record.send(primary_key)
+            record.send("#{definition_key}=", aggregate_hash[id] || 0)
+          end
+        end
+      end
+
+      private
+        def polymophic_as_condition(reflection)
+          reflection.type ? { reflection.name => { reflection.type => @klass.base_class.name } } : []
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
+      :where, :rewhere, :preload, :extract_associated, :eager_load, :eager_group, :includes, :from, :lock, :readonly, :extending, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,
       :pluck, :pick, :ids

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   # = Active Record \Relation
   class Relation
-    MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
+    MULTI_VALUE_METHODS  = [:includes, :eager_load, :eager_group, :preload, :select, :group,
                             :order, :joins, :left_outer_joins, :references,
                             :extending, :unscope, :optimizer_hints, :annotate]
 
@@ -827,6 +827,7 @@ module ActiveRecord
             end
 
           preload_associations(@records) unless skip_preloading_value
+          EagerGroup::Preloader.new(klass, @records, eager_group_values).run if eager_group_values.present?
 
           @records.each(&:readonly!) if readonly_value
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -161,6 +161,24 @@ module ActiveRecord
       self
     end
 
+    # Forces eager grouping by performing a LEFT OUTER JOIN on +args+:
+    #
+    #   Post.eager_group(:comments_average_rating)
+    #   # SELECT "posts".* FROM "posts";
+    #   # SELECT AVG("comments"."rating") AS average_comments_rating, post_id AS post_id
+    #   # FROM "comments"
+    #   # WHERE "comments"."post_id" IN (1, 2, 3)
+    #   # GROUP BY post_id;
+    def eager_group(*args)
+      check_if_method_has_arguments!("eager_group", args)
+      spawn.eager_group!(*args)
+    end
+
+    def eager_group!(*args) # :nodoc:
+      self.eager_group_values += args
+      self
+    end
+
     # Allows preloading of +args+, in the same way that #includes does:
     #
     #   User.preload(:posts)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -167,6 +167,8 @@ class Author < ActiveRecord::Base
   has_many :top_posts, -> { order(id: :asc) }, class_name: "Post"
   has_many :other_top_posts, -> { order(id: :asc) }, class_name: "Post"
 
+  define_eager_group :comments_count, :comments, :count, :*
+
   attr_accessor :post_log
   after_initialize :set_post_log
 

--- a/activerecord/test/models/college.rb
+++ b/activerecord/test/models/college.rb
@@ -9,4 +9,6 @@ class College < ARUnit2Model
   with_options dependent: :destroy do |assoc|
     assoc.has_many :students, -> { where(active: true) }
   end
+
+  define_eager_group :students_count, :students, :count, :*
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -174,6 +174,8 @@ class Post < ActiveRecord::Base
   has_many :lazy_readers_unscope_skimmers, -> { skimmers_or_not }, class_name: "LazyReader"
   has_many :lazy_people_unscope_skimmers, through: :lazy_readers_unscope_skimmers, source: :person
 
+  define_eager_group :special_comments_count, :comments, :count, :*, -> { where(type: "SpecialComment") }
+
   def self.top(limit)
     ranked_by_comments.limit_by(limit)
   end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -25,6 +25,9 @@ class Project < ActiveRecord::Base
     ActiveRecord::Base.belongs_to_required_by_default = previous_value
   end
 
+  define_eager_group :developers_average_salary, :developers, :average, :salary
+  define_eager_group :developers_total_salary, :developers, :sum, :salary
+
   attr_accessor :developers_log
   after_initialize :set_developers_log
 


### PR DESCRIPTION
### Summary

It comes from my gem [eager_group](https://github.com/flyerhzm/eager_group), which fixes n+1 aggregate sql functions for rails.

It will change n+1 aggregate sql functions for rails, like

```sql
SELECT "posts".* FROM "posts";
SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = 1 AND "comments"."status" = 'approved'
SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = 2 AND "comments"."status" = 'approved'
SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = 3 AND "comments"."status" = 'approved'
```
=>
```sql
SELECT "posts".* FROM "posts";
SELECT COUNT(*) AS count_all, post_id AS post_id FROM "comments" WHERE "comments"."post_id" IN (1, 2, 3) AND "comments"."status" = 'approved' GROUP BY post_id;
```

or

```sql
SELECT "posts".* FROM "posts";
SELECT AVG("comments"."rating") AS avg_id FROM "comments" WHERE "comments"."post_id" = 1;
SELECT AVG("comments"."rating") AS avg_id FROM "comments" WHERE "comments"."post_id" = 2;
SELECT AVG("comments"."rating") AS avg_id FROM "comments" WHERE "comments"."post_id" = 3;
```
=>
```sql
SELECT "posts".* FROM "posts";
SELECT AVG("comments"."rating") AS average_comments_rating, post_id AS post_id FROM "comments" WHERE "comments"
```

First, you need to define what aggregate function you want to eager load.

```ruby
class Post < ActiveRecord::Base
  has_many :comments

  define_eager_group :comments_average_rating, :comments, :average, :rating
  define_eager_group :approved_comments_count, :comments, :count, :*, -> { approved }
end

class Comment < ActiveRecord::Base
  belongs_to :post

  scope :approved, -> { where(status: 'approved') }
end
```

The parameters for `define_eager_group` are as follows

* `definition_name`, it's used to be a reference in `eager_group` query method, it also generates a method with the same name to fetch the result.
* `association`, association name you want to aggregate.
* `aggregate_function`, aggregate sql function, can be one of `average`, `count`, `maximum`, `minimum`, `sum`.
* `column_name`, aggregate column name, it can be `:*` for `count`
* `scope`, scope is optional, it's used to filter data for aggregation.

Then you can use `eager_group` to fix n+1 aggregate sql functions when querying

```ruby
posts = Post.all.eager_group(:comments_average_rating, :approved_comments_count)
posts.each do |post|
  post.comments_average_rating
  post.approved_comments_count
end
```

EagerGroup will execute `GROUP BY` sqls for you then set the value of attributes.

### Other Information

I wrote a benchmark script [here](https://github.com/flyerhzm/eager_group/blob/master/benchmark.rb), it queries approved comments count and comments average rating for 20 posts, with eager_group, it gets 10 times faster.
