### PR TITLE
Cast ActiveRecord::Store values with ActiveRecord::Attributes

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -143,7 +143,7 @@ module ActiveRecord
               value = read_store_attribute(store_attribute, key)
               return value unless defined?(super)
               
-              self[accessor_key] = value
+              @attributes.write_from_database(accessor_key, value)
               super()
             end
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -134,7 +134,7 @@ module ActiveRecord
 
             define_method("#{accessor_key}=") do |value|
               return write_store_attribute(store_attribute, key, value) unless defined?(super)
-              
+
               super(value)
               write_store_attribute(store_attribute, key, @attributes[accessor_key].value_for_database)
             end
@@ -142,7 +142,7 @@ module ActiveRecord
             define_method(accessor_key) do
               value = read_store_attribute(store_attribute, key)
               return value unless defined?(super)
-              
+
               @attributes.write_from_database(accessor_key, value)
               super()
             end

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -133,18 +133,17 @@ module ActiveRecord
             accessor_key = "#{accessor_prefix}#{key}#{accessor_suffix}"
 
             define_method("#{accessor_key}=") do |value|
-              type = self.class.attribute_types[accessor_key]
-              if type
-                value = type.cast(value)
-                value = type.serialize(value)
-              end
+              value = super(value) if defined?(super)
               write_store_attribute(store_attribute, key, value)
             end
 
             define_method(accessor_key) do
-              type = self.class.attribute_types[accessor_key]
               value = read_store_attribute(store_attribute, key)
-              type ? type.deserialize(value) : value
+              if defined?(super)
+                self[accessor_key] = value
+                value = super()
+              end
+              value
             end
 
             define_method("#{accessor_key}_changed?") do

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -133,17 +133,18 @@ module ActiveRecord
             accessor_key = "#{accessor_prefix}#{key}#{accessor_suffix}"
 
             define_method("#{accessor_key}=") do |value|
-              value = super(value) if defined?(super)
-              write_store_attribute(store_attribute, key, value)
+              return write_store_attribute(store_attribute, key, value) unless defined?(super)
+              
+              super(value)
+              write_store_attribute(store_attribute, key, @attributes[accessor_key].value_for_database)
             end
 
             define_method(accessor_key) do
               value = read_store_attribute(store_attribute, key)
-              if defined?(super)
-                self[accessor_key] = value
-                value = super()
-              end
-              value
+              return value unless defined?(super)
+              
+              self[accessor_key] = value
+              super()
             end
 
             define_method("#{accessor_key}_changed?") do

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -133,11 +133,18 @@ module ActiveRecord
             accessor_key = "#{accessor_prefix}#{key}#{accessor_suffix}"
 
             define_method("#{accessor_key}=") do |value|
+              type = self.class.attribute_types[accessor_key]
+              if type
+                value = type.cast(value)
+                value = type.serialize(value)
+              end
               write_store_attribute(store_attribute, key, value)
             end
 
             define_method(accessor_key) do
-              read_store_attribute(store_attribute, key)
+              type = self.class.attribute_types[accessor_key]
+              value = read_store_attribute(store_attribute, key)
+              type ? type.deserialize(value) : value
             end
 
             define_method("#{accessor_key}_changed?") do


### PR DESCRIPTION
### Summary

The goal is to automatically use  cast, serialize and deserialize attributes that are stored with ActiveRecord::Store using definitions from ActiveRecord::Attributes.

For example:

```ruby
class User < ApplicationRecord
  store_accessor :data, %i[active age birthday]

  attribute :active, :boolean
  attribute :age, :integer
  attribute :birthday, :date
end

u = User.new

u.active = '1' # => "1"
u.active # => true

u.age = '21.1' # => '21.1'
u.age # => 21

u.birthday = '2019-10-10' # => '2019-10-10'
u.birthday # => Thu, 10 Oct 2019

u.save
u.reload # Casting is consistent after a reload

u.active # => true
u.age # => 21
u.birthday # => Thu, 10 Oct 2019
```

### Other Information

I wasn't sure how to incorporate the `default:` option for [`ActiveRecord::Attributes.attribute`](https://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html#method-i-attribute).