### PR TITLE
Making tagged logger work inside a Fiber

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -51,7 +51,8 @@ module ActiveSupport
       def current_tags
         # We use our object ID here to avoid conflicting with other instances
         thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}"
-        Thread.current[thread_key] ||= []
+        Thread.current.thread_variable_set(thread_key, []) unless Thread.current.thread_variable_get(thread_key)
+        Thread.current.thread_variable_get(thread_key)
       end
 
       def tags_text

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -83,6 +83,17 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "Dull story\n[OMG] Cool story\n[BCX] Funky time\n", @output.string
   end
 
+  test "can create fibers with the same tags" do
+    @logger.tagged("BCX") do
+      Fiber.new do
+        @logger.info "Dull story"
+        @logger.tagged("OMG") { @logger.info "Cool story" }
+      end.resume
+      @logger.info "Funky time"
+    end
+    assert_equal "[BCX] Dull story\n[BCX] [OMG] Cool story\n[BCX] Funky time\n", @output.string
+  end
+
   test "keeps each tag in their own instance" do
     other_output = StringIO.new
     other_logger = ActiveSupport::TaggedLogging.new(MyLogger.new(other_output))


### PR DESCRIPTION
Closes #37535

Using thread local variables and not fiber-local variables allows to keep the current behaviour of not supporting Threads but adds the possibility of working with Fibers.

This should be enough because:

```ruby
Thread.current[:fiber_local_var] = 'Result'
Fiber.new do
  puts Thread.current[:fiber_local_var]
end.resume
# => <Empty output>

Thread.current.thread_variable_set(:thread_local_var, 'Result')
Fiber.new do
  puts Thread.current.thread_variable_get(:thread_local_var)
end.resume
# => "Result"
```