### PR TITLE
Run inline jobs in separate threads

### DIFF
--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :inline
     class InlineAdapter
       def enqueue(job) #:nodoc:
-        Base.execute(job.serialize)
+        Thread.new { Base.execute(job.serialize) }.join
       end
 
       def enqueue_at(*) #:nodoc:

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -4,6 +4,7 @@ require "helper"
 require "jobs/logging_job"
 require "jobs/hello_job"
 require "jobs/provider_jid_job"
+require "jobs/thread_job"
 require "active_support/core_ext/numeric/time"
 
 class QueuingTest < ActiveSupport::TestCase
@@ -144,5 +145,22 @@ class QueuingTest < ActiveSupport::TestCase
     assert job_executed "#{@id}.1"
     assert job_executed "#{@id}.2"
     assert job_executed_at("#{@id}.2") < job_executed_at("#{@id}.1")
+  end
+
+  test "inline jobs run on separate threads" do
+    skip unless adapter_is?(:inline)
+
+    after_job_thread = Thread.new do
+      ThreadJob.latch.wait
+      assert_nil Thread.current[:job_ran]
+      assert ThreadJob.thread[:job_ran]
+      ThreadJob.test_latch.count_down
+    end
+
+    ThreadJob.perform_later
+
+    after_job_thread.join
+
+    assert_nil Thread.current[:job_ran]
   end
 end

--- a/activejob/test/jobs/thread_job.rb
+++ b/activejob/test/jobs/thread_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ThreadJob < ActiveJob::Base
+  class << self
+    attr_accessor :thread
+
+    def latch
+      @latch ||= Concurrent::CountDownLatch.new
+    end
+
+    def test_latch
+      @test_latch ||= Concurrent::CountDownLatch.new
+    end
+  end
+
+  def perform
+    Thread.current[:job_ran] = true
+    self.class.thread = Thread.current
+    self.class.latch.count_down
+    self.class.test_latch.wait
+  end
+end


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/37526.

Runs inline jobs in separate threads so that thread locals (eg. current attributes) are properly scoped and reset when running jobs inline.