### PR TITLE
Remove WSL fs notifications note [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -147,10 +147,6 @@ This will create a Rails application called Blog in a `blog` directory and
 install the gem dependencies that are already mentioned in `Gemfile` using
 `bundle install`.
 
-NOTE: If you're using Windows Subsystem for Linux then there are currently some
-limitations on file system notifications that mean you should disable the `spring`
-and `listen` gems which you can do by running `rails new blog --skip-spring --skip-listen`.
-
 TIP: You can see all of the command line options that the Rails application
 builder accepts by running `rails new -h`.
 


### PR DESCRIPTION
### Summary
It's no longer true that you need to skip spring/listen on project creation running under Windows Subsystem for Linux. `rails new appname` works fine as of Win10 build 18362.418, but maybe somebody knows what exact version this was fixed in?

I'm just getting started with rails for the first time and this note scared me away from trying WSL out. After two days of trying to install/run Rails 6 natively, I found some forum post saying the WSL fs notifications worked now, so I tried it and sure enough. WSL is a much smoother way to get Rails running if you're on Win10, and this note has probably scared others away from trying it.