### PR TITLE
Add document for including and excluding methods[ci skip]

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2073,14 +2073,27 @@ to_visit << node if visited.exclude?(node)
 
 NOTE: Defined in `active_support/core_ext/enumerable.rb`.
 
-### `without`
+### `including`
 
-The method `without` returns a copy of an enumerable with the specified elements
+The method `including` returns a new enumerable that includes the passed elements:
+
+```ruby
+[ 1, 2, 3 ].including(4, 5)                    # => [ 1, 2, 3, 4, 5 ]
+["David", "Rafael"].including %w[ Aaron Todd ] # => ["David", "Rafael", "Aaron", "Todd"]
+```
+
+NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+
+### `excluding`
+
+The method `excluding` returns a copy of an enumerable with the specified elements
 removed:
 
 ```ruby
-["David", "Rafael", "Aaron", "Todd"].without("Aaron", "Todd") # => ["David", "Rafael"]
+["David", "Rafael", "Aaron", "Todd"].excluding("Aaron", "Todd") # => ["David", "Rafael"]
 ```
+
+`excluding` is aliased to `without`.
 
 NOTE: Defined in `active_support/core_ext/enumerable.rb`.
 
@@ -2112,6 +2125,22 @@ Similarly, `from` returns the tail from the element at the passed index to the e
 %w(a b c d).from(2)  # => ["c", "d"]
 %w(a b c d).from(10) # => []
 [].from(0)           # => []
+```
+
+The method `including` returns a new array that includes the passed elements:
+
+```ruby
+[ 1, 2, 3 ].including(4, 5)          # => [ 1, 2, 3, 4, 5 ]
+[ [ 0, 1 ] ].including([ [ 1, 0 ] ]) # => [ [ 0, 1 ], [ 1, 0 ] ]
+```
+
+The method `excluding` returns a copy of the Array excluding the specified elements.
+This is an optimization of `Enumerable#excluding` that uses `Array#-`
+instead of `Array#reject` for performance reasons.
+
+```ruby
+["David", "Rafael", "Aaron", "Todd"].excluding("Aaron", "Todd") # => ["David", "Rafael"]
+[ [ 0, 1 ], [ 1, 0 ] ].excluding([ [ 1, 0 ] ])                  # => [ [ 0, 1 ] ]
 ```
 
 The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element, as do `second_to_last` and `third_to_last` (`first` and `last` are built-in). Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.


### PR DESCRIPTION
### Summary
- Add document for `Enumerable#including`, `Enumerable#excluding`
- Add document for `Array#including`, `Array#excluding`

### Other Information
cf. 
- [Enumerable#including](https://github.com/rails/rails/blob/04093884a1527777795ad1f17ef1c556e7db9429/activesupport/lib/active_support/core_ext/enumerable.rb#L107)
- [Enumerable#excluding](https://github.com/rails/rails/blob/04093884a1527777795ad1f17ef1c556e7db9429/activesupport/lib/active_support/core_ext/enumerable.rb#L127)
- [Array#including](https://github.com/rails/rails/blob/b89a3e7e638a50c648a17d09c48b49b707e1d90d/activesupport/lib/active_support/core_ext/array/access.rb#L36)
- [Array#excluding](https://github.com/rails/rails/blob/b89a3e7e638a50c648a17d09c48b49b707e1d90d/activesupport/lib/active_support/core_ext/array/access.rb#L47)
- [6_0_release_notes](https://edgeguides.rubyonrails.org/6_0_release_notes.html#active-support-notable-changes)
