### PR TITLE
where statement with associated table name check if the value is asso…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `where statement with associated table name check if the value is association stuff.
+    Fixes #37531
+
+    *Hiroaki Osawa*
+
 *   `where(attr => [])` now loads an empty result without making a query.
 
     *John Hawthorn*

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -139,7 +139,7 @@ module ActiveRecord
       end
 
       def association_stuff?(value)
-        value.is_a?(Array) || value.is_a?(Base) || value.is_a?(Relation) || value.nil?
+        [Array, Base, Relation, NilClass].any? { |klass| value.is_a?(klass) }
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         attributes.flat_map do |key, value|
           if value.is_a?(Hash) && !table.has_column?(key)
             associated_predicate_builder(key).expand_from_hash(value)
-          elsif table.associated_with?(key)
+          elsif table.associated_with?(key) && association_stuff?(value)
             # Find the foreign key when using queries such as:
             # Post.where(author: author)
             #
@@ -136,6 +136,10 @@ module ActiveRecord
 
       def handler_for(object)
         @handlers.detect { |klass, _| klass === object }.last
+      end
+
+      def association_stuff?(value)
+        value.is_a?(Array) || value.is_a?(Base) || value.is_a?(Relation) || value.nil?
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -139,7 +139,11 @@ module ActiveRecord
       end
 
       def association_stuff?(value)
-        [Array, Base, Relation, NilClass].any? { |klass| value.is_a?(klass) }
+        case value
+        when Base, Relation, Array, NilClass then true
+        else
+          false
+        end
       end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -87,6 +87,17 @@ module ActiveRecord
       assert_equal Post.where(author_id: nil).to_sql, Post.where(author: nil).to_sql
     end
 
+    def test_association_stuff
+      sql = Post.where(author: 123).to_sql
+      if current_adapter?(:Mysql2Adapter)
+        assert_no_match(/`posts`\.`author_id`/, sql)
+        assert_match(/`posts`\.`author`/, sql)
+      else
+        assert_no_match(/"posts"\."author_id"/, sql)
+        assert_match(/"posts"\."author"/, sql)
+      end
+    end
+
     def test_belongs_to_array_value_where
       assert_equal Post.where(author_id: [1, 2]).to_sql, Post.where(author: [1, 2]).to_sql
     end


### PR DESCRIPTION
…ciation stuff

### Summary
fix #37531 

where statement with associated table name use associated table primary key now.
I think that This will not result in a sql error, potentially allowing a bug to exist which causes the query to return incorrect results too.