### PR TITLE
Fix small typo inside `ActionCable` documentation [ci skip]

### DIFF
--- a/actioncable/app/javascript/action_cable/subscriptions.js
+++ b/actioncable/app/javascript/action_cable/subscriptions.js
@@ -1,7 +1,8 @@
 import Subscription from "./subscription"
 
-// Collection class for creating (and internally managing) channel subscriptions. The only method intended to be triggered by the user
-// us ActionCable.Subscriptions#create, and it should be called through the consumer like so:
+// Collection class for creating (and internally managing) channel subscriptions.
+// The only method intended to be triggered by the user is ActionCable.Subscriptions#create,
+// and it should be called through the consumer like so:
 //
 //   App = {}
 //   App.cable = ActionCable.createConsumer("ws://example.com/accounts/1")


### PR DESCRIPTION
Replace `us` with `is`, and change a bit line length for easier reading.
