### PR TITLE
Reload schema after ignored_columns reassignment

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -288,6 +288,7 @@ module ActiveRecord
       # Sets the columns names the model should ignore. Ignored columns won't have attribute
       # accessors defined, and won't be referenced in SQL queries.
       def ignored_columns=(columns)
+        reload_schema_from_cache
         @ignored_columns = columns.map(&:to_s)
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1503,6 +1503,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "Developer: name", loaded_developer.name
   end
 
+  test "when assigning new ignored columns it invalidates cache for column names" do
+    assert_not_includes ColumnNamesCachedDeveloper.column_names, "name"
+  end
+
   test "ignored columns not included in SELECT" do
     query = Developer.all.to_sql.downcase
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -303,3 +303,8 @@ class AttributedDeveloper < ActiveRecord::Base
 
   self.ignored_columns += ["name"]
 end
+
+class ColumnNamesCachedDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  self.ignored_columns += ["name"] if column_names.include?("name")
+end


### PR DESCRIPTION
### Problem

Assignments to `ignored_columns` do not impact `column_names` if `column_names` was already called before.

### Example

```ruby
self.ignored_columns = %w(name) if column_names.include?('name')

# a few moments later...
self.column_names.include?('name') # expected: false, actual: true
```

When we evaluate the condition, `column_names` gets memoized. Therefore, even after assigning a new value to `ignored_columns`, ActiveRecord doesn't actually ignore it.

### Solution

@doctolib we were wondering if it would be a good idea to actually call `reload_schema_from_cache` after every reassignment of `ignored_columns`.

Please let us know if that is something you'd be willing to incorporate in the codebase. Anything we should change? Any missing tests? ❤️ 