### PR TITLE
Ensure migration generator respects primary key config in references

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -22,6 +22,11 @@ module ActiveRecord
           ", id: :#{key_type}" if key_type
         end
 
+        def foreign_key_type
+          key_type = options[:primary_key_type]
+          ", type: :#{key_type}" if key_type
+        end
+
         def db_migrate_path
           if defined?(Rails.application) && Rails.application
             configured_migrate_path || default_migrate_path

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -6,6 +6,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
       t.string :password_digest<%= attribute.inject_options %>
 <% elsif attribute.token? -%>
       t.string :<%= attribute.name %><%= attribute.inject_options %>
+<% elsif attribute.reference? -%>
+      t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
 <% elsif !attribute.virtual? -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -3,7 +3,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
   def change
 <% attributes.each do |attribute| -%>
   <%- if attribute.reference? -%>
-    add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+    add_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
   <%- elsif attribute.token? -%>
     add_column :<%= table_name %>, :<%= attribute.name %>, :string<%= attribute.inject_options %>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>, unique: true
@@ -20,7 +20,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
     create_join_table :<%= join_tables.first %>, :<%= join_tables.second %> do |t|
     <%- attributes.each do |attribute| -%>
       <%- if attribute.reference? -%>
-      t.references :<%= attribute.name %><%= attribute.inject_options %>
+      t.references :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
       <%- elsif !attribute.virtual? -%>
       <%= '# ' unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>
       <%- end -%>
@@ -32,7 +32,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
 <% attributes.each do |attribute| -%>
 <%- if migration_action -%>
   <%- if attribute.reference? -%>
-    remove_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %>
+    remove_reference :<%= table_name %>, :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
   <%- else -%>
     <%- if attribute.has_index? -%>
     remove_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Ensure Rails migration generator respects system-wide primary key config
+
+    When rails is configured to use a specific primary key type:
+    ```
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
+    ```
+
+    Previously:
+
+    $ bin/rails g migration add_location_to_users location:references
+
+    The references line in the migration would not have `type: :uuid`.
+    This change causes the type to be applied appropriately.
+
+    *Louis-Michel Couture* *Dermot Haughey*
+
 *  Deprecate `Rails::DBConsole#config`
 
   `Rails::DBConsole#config` is deprecated without replacement. Use `Rails::DBConsole.db_config.configuration_hash` instead.

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -133,6 +133,17 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_remove_migration_with_references_removes_foreign_keys_when_primary_key_uuid
+    migration = "remove_references_from_books"
+    run_generator [migration, "author:belongs_to", "--primary_key_type=uuid"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_reference :books, :author,.*\sforeign_key: true, type: :uuid/, change)
+      end
+    end
+  end
+
   def test_add_migration_with_attributes_and_indices
     migration = "add_title_with_index_and_body_to_posts"
     run_generator [migration, "title:string:index", "body:text", "user_id:integer:uniq"]
@@ -291,6 +302,16 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_books.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/create_table :books, id: :uuid/, change)
+      end
+    end
+  end
+
+  def test_add_migration_with_references_options_when_primary_key_uuid
+    migration = "add_references_to_books"
+    run_generator [migration, "author:belongs_to", "--primary_key_type=uuid"]
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_reference :books, :author,.*\sforeign_key: true, type: :uuid/, change)
       end
     end
   end


### PR DESCRIPTION
### Summary

This is https://github.com/rails/rails/pull/32461, rebased and fixed.

When rails is configured to use a specific primary key type:
```
config.generators do |g|
  g.orm :active_record, primary_key_type: :uuid
end
```
Append the key `type` to `add_reference`(and similar)  in migrations.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Original author stated [here](https://github.com/rails/rails/pull/32461#issuecomment-435928976) that they weren't intending to complete the fix. I hope I followed the proper etiquette for completing an existing PR, happy to apply changes!

I fixed the existing logic to correctly append `type: :uuid` instead of `type: :, id: :uuid`
I made the `remove_reference` reversible and added a test for that.
Changelog indentation seemed wrong compared to other files, I reindented the entry that was already there.

Fixes: #23422
Closes: #32461

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
