### PR TITLE
Updates configuring.md to be more clear on framework defaults

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -440,7 +440,7 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.per_form_csrf_tokens` configures whether CSRF tokens are only valid for the method/action they were generated for.
 
-* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController:Base`. This is false by default.
+* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController:Base`. For new applications, the default is true.
 
 * `config.action_controller.relative_url_root` can be used to tell Rails that you are [deploying to a subdirectory](configuring.html#deploy-to-a-subdirectory-relative-url-root). The default is `ENV['RAILS_RELATIVE_URL_ROOT']`.
 


### PR DESCRIPTION
### Summary

I was confused in looking through the documentation.  It seems that for brand new applications, `config.action_controller.default_protect_from_forgery` is `true`.  Only when upgrading, and before you flip the new framework defaults, it is `false`.

### Other Information

Currently, the docs say:
> config.action_controller.default_protect_from_forgery determines whether forgery protection is added on ActionController::Base. This is false by default.

However, a little bit further it says (in https://edgeguides.rubyonrails.org/configuring.html#with-5-2):

> config.action_controller.default_protect_from_forgery: true

Additionally, `config/initializers/new_framework_defaults_5_2.rb` says:

> This file contains migration options to ease your Rails 5.2 upgrade.
> Once upgraded flip defaults one by one to migrate to the new default.
...
> Rails.application.config.action_controller.default_protect_from_forgery = true

It seems to me that the default is actually `true`.