### PR TITLE
Duplicate the cached value before writing it in the local cache

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -64,8 +64,9 @@ module ActiveSupport
             values
           end
 
-          def write_entry(key, value, **options)
-            @data[key] = value
+          def write_entry(key, entry, **options)
+            entry.dup_value!
+            @data[key] = entry
             true
           end
 

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -150,6 +150,25 @@ module LocalCacheBehavior
     end
   end
 
+  def test_initial_object_mutation_after_write
+    @cache.with_local_cache do
+      initial = +"bar"
+      @cache.write("foo", initial)
+      initial << "baz"
+      assert_equal "bar", @cache.read("foo")
+    end
+  end
+
+  def test_initial_object_mutation_after_fetch
+    @cache.with_local_cache do
+      initial = +"bar"
+      @cache.fetch("foo") { initial }
+      initial << "baz"
+      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.fetch("foo")
+    end
+  end
+
   def test_middleware
     app = lambda { |env|
       result = @cache.write("foo", "bar")


### PR DESCRIPTION
Discovered by @eljojo.

I think the test case showcase the bug somewhat properly. In short it was already protecting itself from mutation of returned values, but not from mutation of the original value, e.g.:


```ruby
my_string = "foo"
cache.write('key', my_string)
my_string << "bar"
cache.read('key') # => "foobar"
```

@rafaelfranca @camilo @etiennebarrie @Edouard-chin 