### PR TITLE
Issue 37507: Make assert_changes use minitest diffing

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -187,7 +187,7 @@ module ActiveSupport
         error = "#{expression.inspect} didn't change"
         error = "#{error}. It was already #{to}" if before == to
         error = "#{message}.\n#{error}" if message
-        assert before != after, error
+        wont_equal before, after, error
 
         unless to == UNTRACKED
           error = "#{expression.inspect} didn't change to as expected\n"


### PR DESCRIPTION
### Summary

This PR addresses the issue raised here:  https://github.com/rails/rails/issues/37507

We made an attempt to work on improve the potential output of the assertion failure. Can you please give some guidance @kaspth if we're on the right track.



