### PR TITLE
Fix typo guides/source/configuring.md

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -440,7 +440,7 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.per_form_csrf_tokens` configures whether CSRF tokens are only valid for the method/action they were generated for.
 
-* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController:Base`. This is false by default.
+* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController::Base`. This is false by default.
 
 * `config.action_controller.relative_url_root` can be used to tell Rails that you are [deploying to a subdirectory](configuring.html#deploy-to-a-subdirectory-relative-url-root). The default is `ENV['RAILS_RELATIVE_URL_ROOT']`.
 


### PR DESCRIPTION
### Summary

```Ruby
ActionController:Base
```

vs

```Ruby
ActionController::Base
```