### PR TITLE
Make AS::Deprecation.silence block thread-local

### DIFF
--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -41,6 +41,7 @@ module ActiveSupport
       # By default, warnings are not silenced and debugging is off.
       self.silenced = false
       self.debug = false
+      @silenced_thread = Concurrent::ThreadLocalVar.new(false)
     end
   end
 end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   class Deprecation
     module Reporting
       # Whether to print a message (silent mode)
-      attr_accessor :silenced
+      attr_writer :silenced
       # Name of gem where method is deprecated
       attr_accessor :gem_name
 
@@ -33,11 +33,12 @@ module ActiveSupport
       #     ActiveSupport::Deprecation.warn('something broke!')
       #   end
       #   # => nil
-      def silence
-        old_silenced, @silenced = @silenced, true
-        yield
-      ensure
-        @silenced = old_silenced
+      def silence(&block)
+        @silenced_thread.bind(true, &block)
+      end
+
+      def silenced
+        @silenced || @silenced_thread.value
       end
 
       def deprecation_warning(deprecated_method_name, message = nil, caller_backtrace = nil)


### PR DESCRIPTION
Previouly `ActiveSupport::Deprecation.silence { ... }` would silence deprecations from all threads, which I think is surprising in a mutli-threaded environment.

This leaves `ActiveSupport::Deprecation.silenced=` as setting a global option, which might be a little confusing, but I think that these are used in different ways, and this best preserves how they are generally used. `silence {}` is used to silence a small section of code, `silenced=` is usually used to set a default in an initializer or test helper.

I somewhat think that `ActiveSupport::Deprecation.silenced=` should be deprecated in favour of `ActiveSupport::Deprecation.behavior = :silence` (but only somewhat and that's outside the scope of this PR)

cc @cpruitt who raised the issue ❤️