### PR TITLE
Update explanation in comments of puma.rb.tt

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -27,7 +27,9 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
-# Use the `preload_app!` method when specifying a `workers` number.
+# Use the `preload_app!` method whenever the `workers` number is > 1 (so if you 
+# uncomment the line above and don't set WEB_CONCURRENCY to 1, make sure you 
+# preload_app!).
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.


### PR DESCRIPTION
Clarifies comments re: what it means to “specify” `workers` (the default via fetch would be 2 by uncommenting config line).

### Summary

The commentary in the Rails generated `config/puma.rb` file is great, but it could be a little clearer. In short, there’s a line that guides developers to `preload_app!` when “specifying” the `workers` variable. I think some people (e.g. novices, quick readers) are going to be a little confused about whether they need to `preload_app!` (they should) if they uncomment the line above — `workers ENV.fetch("WEB_CONCURRENCY") { 2 }` — but don’t specify `WEB_CONCURRENCY`.
