### PR TITLE
Remove unused requires

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
-require "yaml"
 require "active_support/benchmarkable"
 require "active_support/dependencies"
 require "active_support/descendants_tracker"
 require "active_support/time"
-require "active_support/core_ext/module/attribute_accessors"
-require "active_support/core_ext/array/extract_options"
-require "active_support/core_ext/hash/deep_merge"
-require "active_support/core_ext/hash/slice"
-require "active_support/core_ext/string/behavior"
-require "active_support/core_ext/kernel/singleton_class"
-require "active_support/core_ext/module/introspection"
 require "active_support/core_ext/class/subclasses"
 require "active_record/attribute_decorators"
 require "active_record/define_callbacks"


### PR DESCRIPTION
### Summary
`yaml` was removed at b2c9ce341a
`attribute_accessors` was removed at b2c9ce341a
`extract_options` was removed at ceb33f8493
`deep_merge` was removed at bed9179aa1
`slice` was removed at 24485b9ef0
`behavior` was removed at ceb33f8493
`singleton_class` was removed at ceb33f8493
`introspection` was removed at ceb33f8493
