### PR TITLE
Correctly deprecate where.not working as NOR for relations:

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -64,7 +64,10 @@ module ActiveRecord
 
       private
         def not_behaves_as_nor?(opts)
-          opts.is_a?(Hash) && opts.size > 1
+          return false unless opts.is_a?(Hash)
+
+          opts.any? { |k, v| v.is_a?(Hash) && v.size > 1 } ||
+            opts.size > 1
         end
     end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -181,6 +181,18 @@ module ActiveRecord
       assert_equal all - expected, only.sort_by(&:id).map(&:estimate_of)
     end
 
+    def test_where_not_association_as_nor_is_deprecated
+      treasure = Treasure.create!(name: "my_treasure")
+      PriceEstimate.create!(estimate_of: treasure, price: 2, currency: "USD")
+      PriceEstimate.create(estimate_of: treasure, price: 2, currency: "EUR")
+
+      assert_deprecated do
+        result = Treasure.joins(:price_estimates).where.not(price_estimates: { price: 2, currency: "USD" })
+
+        assert_predicate result, :empty?
+      end
+    end
+
     def test_polymorphic_nested_array_where
       treasure = Treasure.new
       treasure.id = 1

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -746,6 +746,7 @@ ActiveRecord::Schema.define do
     t.string :estimate_of_type
     t.integer :estimate_of_id
     t.integer :price
+    t.string :currency
   end
 
   create_table :products, force: true do |t|


### PR DESCRIPTION
Correctly deprecate where.not working as NOR for relations:

- 12a9664ff60 deprecated where.not working as NOR, however
  doing a relation query like this `where.not(relation: { })`
  wouldn't be properly deprecated and where.not would work as
  NAND instead

cc/ @casperisfine @rafaelfranca @kamipo