### PR TITLE
Avoid using require_dependency is Zeitwerk is enabled

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -15,9 +15,11 @@
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveRecord::Base
-  require_dependency "active_storage/blob/analyzable"
-  require_dependency "active_storage/blob/identifiable"
-  require_dependency "active_storage/blob/representable"
+  unless Rails.autoloaders.zeitwerk_enabled?
+    require_dependency "active_storage/blob/analyzable"
+    require_dependency "active_storage/blob/identifiable"
+    require_dependency "active_storage/blob/representable"
+  end
 
   include Analyzable
   include Identifiable


### PR DESCRIPTION
### Context 

I'm trying to disable `config.add_autoload_paths_to_load_path` in our app, which cause `require_dependency` to straight up fail when called with an autoloaded path.

These were added in https://github.com/rails/rails/commit/1e55ee5a283df448c6cf4c4d3bb9c98e49927520 to workaround the classic autoloader limitations, but that's no longer a problem with Zeitwerk.

I'm not super happy with adding this kind of global config check in there, but I can't think of a better way.

@fxn, cc @eugeneius 

cc @rafaelfranca @Edouard-chin @etiennebarrie 
