### PR TITLE
Reestablish connection to previous database after migrating:

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -80,11 +80,14 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
+    original_config = ActiveRecord::Base.connection_config
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     end
     db_namespace["_dump"].invoke
+  ensure
+    ActiveRecord::Base.establish_connection(original_config)
   end
 
   # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -231,6 +231,23 @@ module ApplicationTests
         end
       end
 
+      test "db:migrate set back connection to its original state" do
+        Dir.chdir(app_path) do
+          dummy_task = <<~RUBY
+            task foo: :environment do
+              Book.first
+            end
+          RUBY
+          app_file('Rakefile', dummy_task, 'a+')
+
+          generate_models_for_animals
+
+          assert_nothing_raised do
+            rails("db:migrate", "foo")
+          end
+        end
+      end
+
       test "db:migrate and db:schema:dump and db:schema:load works on all databases" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load "schema"


### PR DESCRIPTION
Reestablish connection to previous database after migrating:

- The migrate task iterates and establish a connection over each db
  resulting in the last one to be used by subsequent rake tasks.
  We should reestablish a connection to the connection that was
  established before the migrate tasks was run
- Fix #37578

cc/ @casperisfine @etiennebarrie @rafaelfranca 