### PR TITLE
The `AJ_ADAPTER` env needs to be set to run activejob integration test

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -5,7 +5,7 @@ require "support/job_buffer"
 
 GlobalID.app = "aj"
 
-@adapter = ENV["AJ_ADAPTER"] || "inline"
+@adapter = ENV["AJ_ADAPTER"] ||= "inline"
 puts "Using #{@adapter}"
 
 if ENV["AJ_INTEGRATION_TESTS"]


### PR DESCRIPTION
The `AJ_ADAPTER` env needs to be set:

- ActiveJob integration test can't be run otherwise because of
  https://github.com/rails/rails/blob/5bbf047debc8ceaa3833b777808150ad117f4d3b/activejob/test/support/integration/jobs_manager.rb#L8

cc/ @rafaelfranca @etiennebarrie @casperisfine