### PR TITLE
Fix ActionPack internal params being logged when using params_wrapper:

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -280,7 +280,7 @@ module ActionController
 
       def _perform_parameter_wrapping
         wrapped_hash = _wrap_parameters request.request_parameters
-        wrapped_keys = request.request_parameters.keys
+        wrapped_keys = request.request_parameters.except(*LogSubscriber::INTERNAL_PARAMS).keys
         wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
 
         # This will make the wrapped hash accessible from controller and view.

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -79,6 +79,14 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
+  def test_internal_parameters_are_filtered_out
+    with_default_wrapper_options do
+      @request.env["CONTENT_TYPE"] = "application/json"
+      post :parse, params: { "username" => "sikachu", "action" => "something" }
+      assert_equal({ "controller" => "params_wrapper_test/users", "action" => "parse", "username" => "sikachu", "user" => { "username" => "sikachu" } }, @request.filtered_parameters)
+    end
+  end
+
   def test_specify_wrapper_name
     with_default_wrapper_options do
       UsersController.wrap_parameters :person


### PR DESCRIPTION
Fix ActionPack internal params being logged when using params_wrapper:

- When using params wrapper, if a request parameters is reserved
  for Rails (like `action`, `format`...) it will be logged
  in case the controller uses param_wrapped.

  ```
  curl -d '{"action":"i_want_this_value"}' -H "Content-Type: application/json" https://foo.com/hooks/github

  Processing by GitHubHooksController#create as */*
    Parameters: {"github_hook"=>{"action"=>"create"}}
  ```

  When a controller is not using params_wrapper, internal parameters
  are not logged. We should do the same for controller that have
  params wrapper enabled

  Fix #37603

cc/ @rafaelfranca @casperisfine @etiennebarrie 