### PR TITLE
Fix ActionMailer assertions don't work for parameterized mail with legacy delivery job

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix ActionMailer assertions don't work for parameterized mail with legacy delivery job.
+
+    *bogdanvlviv*
+
 *   Added `email_address_with_name` to properly escape addresses with names.
 
     *Sunny Ripert*

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -155,7 +155,8 @@ module ActionMailer
       def delivery_job_filter(job)
         job_class = job.is_a?(Hash) ? job.fetch(:job) : job.class
 
-        Base.descendants.map(&:delivery_job).include?(job_class)
+        Base.descendants.map(&:delivery_job).include?(job_class) ||
+          ActionMailer::Parameterized::DeliveryJob == job_class
       end
   end
 end

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -206,6 +206,20 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
+  def test_assert_enqueued_emails_with_legacy_delivery_job
+    previous_delivery_job = TestHelperMailer.delivery_job
+    TestHelperMailer.delivery_job = ActionMailer::DeliveryJob
+    assert_nothing_raised do
+      assert_enqueued_emails 1 do
+        silence_stream($stdout) do
+          TestHelperMailer.test.deliver_later
+        end
+      end
+    end
+  ensure
+    TestHelperMailer.delivery_job = previous_delivery_job
+  end
+
   def test_assert_enqueued_parameterized_emails
     assert_nothing_raised do
       assert_enqueued_emails 1 do
@@ -214,6 +228,20 @@ class TestHelperMailerTest < ActionMailer::TestCase
         end
       end
     end
+  end
+
+  def test_assert_enqueued_parameterized_emails_with_legacy_delivery_job
+    previous_delivery_job = TestHelperMailer.delivery_job
+    TestHelperMailer.delivery_job = ActionMailer::DeliveryJob
+    assert_nothing_raised do
+      assert_enqueued_emails 1 do
+        silence_stream($stdout) do
+          TestHelperMailer.with(a: 1).test.deliver_later
+        end
+      end
+    end
+  ensure
+    TestHelperMailer.delivery_job = previous_delivery_job
   end
 
   def test_assert_enqueued_emails_too_few_sent


### PR DESCRIPTION

We should backport this to `6-0-stable`.

Fixes https://github.com/rails/rails/issues/37605
