### PR TITLE
make db:drop behaviour consistent when a DB does not exists

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -55,6 +55,9 @@ module ActiveRecord
       LOCAL_HOSTS = ["127.0.0.1", "localhost"]
 
       def check_protected_environments!
+
+        return unless adapter_instance(current_config).database_exists?
+
         unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]
           current = ActiveRecord::Base.connection.migration_context.current_environment
           stored  = ActiveRecord::Base.connection.migration_context.last_stored_environment
@@ -100,7 +103,7 @@ module ActiveRecord
       end
 
       def env
-        @env ||= Rails.env
+        @env ||= ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
       end
 
       def spec
@@ -462,6 +465,11 @@ module ActiveRecord
 
         def verbose?
           ENV["VERBOSE"] ? ENV["VERBOSE"] != "false" : true
+        end
+
+        def adapter_instance(configuration)
+          db_config = resolve_configuration(configuration)
+          database_adapter_for(db_config)
         end
 
         # Create a new instance for the specified db configuration object

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -67,6 +67,10 @@ module ActiveRecord
         run_cmd("mysql", args, "loading")
       end
 
+      def database_exists?
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(configuration_hash)
+      end
+
       private
         attr_reader :db_config, :configuration_hash
 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -86,6 +86,10 @@ module ActiveRecord
         run_cmd("psql", args, "loading")
       end
 
+      def database_exists?
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(configuration_hash)
+      end
+
       private
         attr_reader :db_config, :configuration_hash
 


### PR DESCRIPTION
### Summary

Resolves issue: #32914.

Provides consistent behaviour when using `rake db:drop`

With PostgreSQL and sqlite3 adapters running db:drop with a non-created DB acts as if the DB is there:
Dropped database '<env>'. As opposed to in case of mysql2 adapter: Database '<env>' does not exist.

The solution uses the new `database_exists?` method for the adapters to check if the `DB` before trying to get a connection t it.

If the `DB` does not exist it will return make avoiding the call to `ActiveRecord::Base.connection.migration_context.current_environment` which for some adapters it will create the DB and for others don't.

So finally when trying the `drop` the `DB` we will have the same consistent message across all adapters.

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/database_tasks.rb#L194-L195

```ruby
rescue ActiveRecord::NoDatabaseError
  $stderr.puts "Database '#{db_config.database}' does not exist"
```



