### PR TITLE
Cache gems for GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,15 @@ jobs:
     - name: Install required package
       run: |
         sudo apt-get install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
+    - name: Cache gems
+      uses: actions/cache@preview
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
     - name: Build and run RuboCop
       run: |
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rubocop --parallel


### PR DESCRIPTION
### Summary
This pull request adds cache for GitHub Actions

Follows up #37582

GitHub Actions cache requires `path:` parameter to configure which directory to be cached. It looks there is no easy way to retrieve path information using bundler command then workaround implemented to use `vendor/bundle`.

Thanks to https://github.com/actions/cache/pull/4
