### PR TITLE
Use transform_values to build hash_rows

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -145,21 +145,32 @@ module ActiveRecord
             # used as keys in ActiveRecord::Base's @attributes hash
             columns = @columns.map(&:-@)
             length  = columns.length
+            template = nil
 
             @rows.map { |row|
-              # In the past we used Hash[columns.zip(row)]
-              #  though elegant, the verbose way is much more efficient
-              #  both time and memory wise cause it avoids a big array allocation
-              #  this method is called a lot and needs to be micro optimised
-              hash = {}
+              if template
+                # We use transform_values to build subsequent rows from the
+                # hash of the first row. This is faster because we avoid any
+                # reallocs and in Ruby 2.7+ avoid hashing entirely.
+                index = -1
+                template.transform_values do
+                  row[index += 1]
+                end
+              else
+                # In the past we used Hash[columns.zip(row)]
+                #  though elegant, the verbose way is much more efficient
+                #  both time and memory wise cause it avoids a big array allocation
+                #  this method is called a lot and needs to be micro optimised
+                hash = {}
 
-              index = 0
-              while index < length
-                hash[columns[index]] = row[index]
-                index += 1
+                index = 0
+                while index < length
+                  hash[columns[index]] = row[index]
+                  index += 1
+                end
+
+                template = hash
               end
-
-              hash
             }
           end
       end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -169,7 +169,11 @@ module ActiveRecord
                   index += 1
                 end
 
-                template = hash
+                # It's possible to select the same column twice, in which case
+                # we can't use a template
+                template = hash if hash.length == length
+
+                hash
               end
             }
           end


### PR DESCRIPTION
This commit changes hash_rows to build the first row as it did before, and then to use transform_values to build subsequent rows, using the first as a template.

In Ruby 2.4+ (first version to include transform_values) this is a tiny bit faster because the hash will never be realloc'd and the hash update logic is probably slightly simpler than add.

In Ruby 2.7+ this is a fair bit faster because transform_values is able to run without hashing the keys and only iterates over the values list.

In the case that we only have one row this is only one extra lvar set/read and the condition.


## Benchmark

```
# frozen_string_literal: true
require "active_support/all"

columns = %w[id author_id section_id title byline body published_at created_at updated_at].map(&:-@)

row = [1, 2, 3, "Top 10 tricks to speed up hashes", "by John Hawthorn", "transform_values is quick and even faster in Ruby 2.7. Try it today!", Time.now, Time.now, Time.now]
rows = [row] * ENV.fetch('N', 10).to_i

def hash_like_rails_6_0(columns, row)
  length = columns.length
  hash = {}

  index = 0
  while index < length
    hash[columns[index]] = row[index]
    index += 1
  end

  hash
end

Benchmark.ips do |x|
  x.report "Rails 6.0" do
    rows.map { |row| hash_like_rails_6_0(columns, row) }
  end

  x.report "transform_values" do
    template = nil
    rows.map do |row|
      if template
        index = -1
        template.transform_values do
          row[index += 1]
        end
      else
        template = hash_like_rails_6_0(columns, row)
      end
    end
  end
end
```

I made a graph to show the current Rails 6.0 implementation vs transform_values on Ruby 2.6 and 2.7. Interestingly, the current Rails 6.0 implementation is actually slower on Ruby 2.7 (a regression I'm looking into), but that shouldn't affect the motivation for this change.

<img width="917" alt="Screen Shot 2019-10-31 at 00 23 51" src="https://user-images.githubusercontent.com/131752/67967483-e70b1080-fbc2-11e9-8544-81773df8e046.png">

This is about 7% faster on Ruby 2.6 and Ruby 2.7+transform_values is 25% faster than Ruby 2.6+current implementation (using this measurement because Ruby 2.7's hash perf regression)