### PR TITLE
Modify respond_to behaviour always setting the response's content type based on the request format

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,23 @@
+*  `respond_to#any` no longer returns a response's Content-Type based on the
+   request format but based on the block given.
+
+   Example:
+
+   ```ruby
+     def my_action
+       respond_to do |format|
+         format.any { render(json: { foo: 'bar' }) }
+       end
+     end
+
+     get('my_action.csv')
+   ```
+   The previous behaviour was to respond with a `text/csv` Content-Type which
+   is inaccurate since a JSON response is being rendered.
+   Now it correctly returns a `application/json` Content-Type.
+
+   * Edouard Chin*
+
 *   Add `params.member?` to mimic Hash behavior
 
     *Younes Serraj*

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -209,7 +209,7 @@ module ActionController #:nodoc:
           raise ActionController::RespondToMismatchError
         end
         _process_format(format)
-        _set_rendered_content_type format
+        _set_rendered_content_type(format) unless collector.any_response?
         response = collector.response
         response.call if response
       else
@@ -266,6 +266,10 @@ module ActionController #:nodoc:
         else
           VariantCollector.new(@variant)
         end
+      end
+
+      def any_response?
+        !@responses.fetch(format, false) && @responses[Mime::ALL]
       end
 
       def response

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -157,6 +157,13 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def handle_any_doesnt_set_request_content_type
+    respond_to do |type|
+      type.html { render body: "HTML" }
+      type.any { render json: { foo: "bar" } }
+    end
+  end
+
   def handle_any_any
     respond_to do |type|
       type.html { render body: "HTML" }
@@ -547,6 +554,12 @@ class RespondToControllerTest < ActionController::TestCase
     @request.accept = "text/xml"
     get :handle_any
     assert_equal "Either JS or XML", @response.body
+  end
+
+  def test_handle_any_doesnt_set_request_content_type
+    @request.accept = "text/csv"
+    get :handle_any_doesnt_set_request_content_type
+    assert_equal "application/json", @response.media_type
   end
 
   def test_handle_any_any

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -72,6 +72,37 @@ The new Rails version might have different configuration defaults than the previ
 
 To allow you to upgrade to new defaults one by one, the update task has created a file `config/initializers/new_framework_defaults.rb`. Once your application is ready to run with new defaults, you can remove this file and flip the `config.load_defaults` value.
 
+Upgrading from Rails 6.0 to Rails 6.1
+-------------------------------------
+
+### Response's Content-Type when using `respond_to#any`
+
+The Content-Type header returned in the response can differ from what Rails 6.0 returned,
+more specifically if your application uses `respond_to { |format| format.any }`.
+The Content-Type will now be based on the given block rather than the request's format.
+
+Example:
+
+```ruby
+  def my_action
+    respond_to do |format|
+      format.any { render(json: { foo: 'bar' }) }
+    end
+  end
+
+  get('my_action.csv')
+```
+
+Previous behaviour was returning a `text/csv` response's Content-Type which is inaccurate since a JSON response is being rendered.
+Current behaviour correctly returns a `application/json` response's Content-Type.
+
+If your application relies on the previous incorrect behaviour, you are encouraged to specify
+which formats your action accepts, i.e.
+
+```ruby
+   format.any(:xml, :json) { render request.format.to_sym => @people }
+```
+
 
 Upgrading from Rails 5.2 to Rails 6.0
 -------------------------------------


### PR DESCRIPTION
Modify respond_to behaviour always setting the request's content type:

- `respond_to any` doesn't allow to specify a content type and
  the content type in the response will be based on the request
  format.

  ```ruby
    def my_action
      respond_to do |format|
        format.html { render(html: 'hello') }
        format.any { render(json: { foo: 'bar'}) }
      end
    end

    get('my_action.csv')
    # Before this patch, content type was `text/csv'
    # Ather this patch, content type is correctly set to whateve we did in the `format.any` block
  ```

  If the client specify the type of data he wants but the server
  doesn't know how to handle it and return plain text (or whatever)
  I don't think it make sense to falsey claim that we are returning
  a `text/csv` a response where in fact we are returning something else.

  Fix #37345