### PR TITLE
Allow to remove ActiveStorage attachment with empty string value

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -50,7 +50,7 @@ module ActiveStorage
 
           def #{name}=(attachable)
             attachment_changes["#{name}"] =
-              if attachable.nil?
+              if attachable.blank?
                 ActiveStorage::Attached::Changes::DeleteOne.new("#{name}", self)
               else
                 ActiveStorage::Attached::Changes::CreateOne.new("#{name}", self, attachable)
@@ -119,6 +119,7 @@ module ActiveStorage
 
           def #{name}=(attachables)
             if ActiveStorage.replace_on_assign_to_many
+              attachables = attachables.reject(&:blank?) if attachables.respond_to?(:reject)
               attachment_changes["#{name}"] =
                 if Array(attachables).none?
                   ActiveStorage::Attached::Changes::DeleteMany.new("#{name}", self)

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -175,6 +175,14 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_not ActiveStorage::Blob.service.exist?(@user.highlights.second.key)
   end
 
+  test "updating an existing record with empty strings to detach existing blobs" do
+    @user.highlights.attach [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ]
+
+    @user.update! highlights: [@user.highlights.first.blob.signed_id, ""]
+    assert_equal "funky.jpg", @user.highlights.first.filename.to_s
+    assert @user.highlights.second.blank?
+  end
+
   test "replacing existing, dependent attachments on an existing record via assign and attach" do
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |old_blobs|
       @user.highlights.attach old_blobs

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -145,6 +145,13 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_not ActiveStorage::Blob.service.exist?(@user.avatar.key)
   end
 
+  test "updating an existing record with empty string to detach existing blob" do
+    @user.avatar.attach create_blob(filename: "funky.jpg")
+
+    @user.update! avatar: ""
+    assert_not @user.avatar.attached?
+  end
+
   test "successfully replacing an existing, dependent attachment on an existing record" do
     create_blob(filename: "funky.jpg").tap do |old_blob|
       @user.avatar.attach old_blob


### PR DESCRIPTION
### Summary

Currently there is no way to remove a `has_one_attached` attachment with `update` and `params`, because you don't have a way to pass `nil` in HTTP params.
It will be nice to have an ability to remove attached file for example with a checkbox on a form:

```
<%= f.file_field :avatar %>
<% if f.object.avatar.attached? %>
  <%= f.check_box :avatar, { id: 'remove-avatar', checked: false, include_hidden: false }, '' %>
  <%= label_tag 'remove-avatar', 'Remove' %>
<% end %>
```

Then in controller it would be translated to `@user.update(avatar: '')`, and it would purge an attachment.

Currently passing an empty string as a value will raise `ActiveSupport::MessageVerifier::InvalidSignature` error. In order to change this I've modified the check in the `has_one_attached` and `has_many_attached` methods to check against `blank?`.
