### PR TITLE
Update form examples [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -64,7 +64,7 @@ Then refer to this field in the form for the model:
 
 ```erb
 <%# app/views/messages/_form.html.erb %>
-<%= form_with(model: message) do |form| %>
+<%= form_with model: message do |form| %>
   <div class="field">
     <%= form.label :content %>
     <%= form.rich_text_area :content %>

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -793,13 +793,13 @@ Form helpers are designed to make working with models much easier compared to us
 
 There are two types of form helpers: those that specifically work with model attributes and those that don't. This helper deals with those that work with model attributes; to see an example of form helpers that don't work with model attributes, check the `ActionView::Helpers::FormTagHelper` documentation.
 
-The core method of this helper, `form_for`, gives you the ability to create a form for a model instance; for example, let's say that you have a model Person and want to create a new instance of it:
+The core method of this helper, `form_with`, gives you the ability to create a form for a model instance; for example, let's say that you have a model Person and want to create a new instance of it:
 
 ```html+erb
-# Note: a @person variable will have been created in the controller (e.g. @person = Person.new)
-<%= form_for @person, url: { action: "create" } do |f| %>
-  <%= f.text_field :first_name %>
-  <%= f.text_field :last_name %>
+<!-- Note: a @person variable will have been created in the controller (e.g. @person = Person.new) -->
+<%= form_with model: @person do |form| %>
+  <%= form.text_field :first_name %>
+  <%= form.text_field :last_name %>
   <%= submit_tag 'Create' %>
 <% end %>
 ```
@@ -837,10 +837,10 @@ check_box("article", "validated")
 
 #### fields_for
 
-Creates a scope around a specific model object like `form_for`, but doesn't create the form tags themselves. This makes `fields_for` suitable for specifying additional model objects in the same form:
+Creates a scope around a specific model object. This makes `fields_for` suitable for specifying additional model objects in the same form:
 
 ```html+erb
-<%= form_for @person, url: { action: "update" } do |person_form| %>
+<%= form_with model: @person do |person_form| %>
   First name: <%= person_form.text_field :first_name %>
   Last name : <%= person_form.text_field :last_name %>
 
@@ -859,16 +859,16 @@ file_field(:user, :avatar)
 # => <input type="file" id="user_avatar" name="user[avatar]" />
 ```
 
-#### form_for
+#### form_with
 
-Creates a form and a scope around a specific model object that is used as a base for questioning about values for the fields.
+Creates a form builder to work with. If a `model` argument is specified, form fields will be scoped to that model, and form field values will be prepopulated with corresponding model attributes.
 
 ```html+erb
-<%= form_for @article do |f| %>
-  <%= f.label :title, 'Title' %>:
-  <%= f.text_field :title %><br>
-  <%= f.label :body, 'Body' %>:
-  <%= f.text_area :body %><br>
+<%= form_with model: @article do |form| %>
+  <%= form.label :title, 'Title' %>:
+  <%= form.text_field :title %><br>
+  <%= form.label :body, 'Body' %>:
+  <%= form.text_area :body %><br>
 <% end %>
 ```
 
@@ -1203,7 +1203,7 @@ date_field("user", "dob")
 
 ### FormTagHelper
 
-Provides a number of methods for creating form tags that don't rely on an Active Record object assigned to the template like FormHelper does. Instead, you provide the names and values manually.
+Provides a number of methods for creating form tags that are not scoped to model objects. Instead, you provide the names and values manually.
 
 #### check_box_tag
 
@@ -1230,8 +1230,8 @@ Creates a field set for grouping HTML form elements.
 Creates a file upload field.
 
 ```html+erb
-<%= form_tag({ action: "post" }, multipart: true) do %>
-  <label for="file">File to Upload</label> <%= file_field_tag "file" %>
+<%= form_with url: new_account_avatar_path(@account), multipart: true do %>
+  <label for="file">Avatar:</label> <%= file_field_tag 'avatar' %>
   <%= submit_tag %>
 <% end %>
 ```
@@ -1241,17 +1241,6 @@ Example output:
 ```ruby
 file_field_tag 'attachment'
 # => <input id="attachment" name="attachment" type="file" />
-```
-
-#### form_tag
-
-Starts a form tag that points the action to a URL configured with `url_for_options` just like `ActionController::Base#url_for`.
-
-```html+erb
-<%= form_tag '/articles' do %>
-  <div><%= submit_tag 'Save' %></div>
-<% end %>
-# => <form action="/articles" method="post"><div><input type="submit" name="submit" value="Save" /></div></form>
 ```
 
 #### hidden_field_tag

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -287,7 +287,7 @@ email_contact.valid?     # => true
 email_contact.persisted? # => false
 ```
 
-Any class that includes `ActiveModel::Model` can be used with `form_for`,
+Any class that includes `ActiveModel::Model` can be used with `form_with`,
 `render` and any other Action View helper methods, just like Active Record
 objects.
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -555,7 +555,7 @@ directory at `app/views/blorgh/comments` and in it a new file called
 
 ```html+erb
 <h3>New comment</h3>
-<%= form_with(model: [@article, @article.comments.build], local: true) do |form| %>
+<%= form_with model: [@article, @article.comments.build], local: true do |form| %>
   <p>
     <%= form.label :text %><br>
     <%= form.text_area :text %>

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -54,10 +54,10 @@ One of the most basic forms you see on the web is a search form. This form conta
 To create this form you will use `form_with`, `label_tag`, `text_field_tag`, and `submit_tag`, respectively. Like this:
 
 ```erb
-<%= form_with(url: "/search", method: "get") do %>
-  <%= label_tag(:q, "Search for:") %>
-  <%= text_field_tag(:q) %>
-  <%= submit_tag("Search") %>
+<%= form_with url: "/search", method: :get do |form| %>
+  <%= form.label :q, "Search for:" %>
+  <%= form.text_field :q %>
+  <%= form.submit "Search" %>
 <% end %>
 ```
 
@@ -236,10 +236,10 @@ end
 The corresponding view `app/views/articles/new.html.erb` using `form_with` looks like this:
 
 ```erb
-<%= form_with model: @article, class: "nifty_form" do |f| %>
-  <%= f.text_field :title %>
-  <%= f.text_area :body, size: "60x12" %>
-  <%= f.submit "Create" %>
+<%= form_with model: @article, class: "nifty_form" do |form| %>
+  <%= form.text_field :title %>
+  <%= form.text_area :body, size: "60x12" %>
+  <%= form.submit "Create" %>
 <% end %>
 ```
 
@@ -629,12 +629,12 @@ A common task is uploading some sort of file, whether it's a picture of a person
 The following two forms both upload a file.
 
 ```erb
-<%= form_with(url: {action: :upload}, multipart: true) do %>
-  <%= file_field_tag 'picture' %>
+<%= form_with model: @person do |form| %>
+  <%= form.file_field :picture %>
 <% end %>
 
-<%= form_with model: @person do |f| %>
-  <%= f.file_field :picture %>
+<%= form_with url: "/uploads", multipart: true do |form| %>
+  <%= form.file_field 'picture' %>
 <% end %>
 ```
 
@@ -661,16 +661,16 @@ Customizing Form Builders
 The object yielded by `form_with` and `fields_for` is an instance of [`ActionView::Helpers::FormBuilder`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html). Form builders encapsulate the notion of displaying form elements for a single object. While you can write helpers for your forms in the usual way, you can also create subclass `ActionView::Helpers::FormBuilder` and add the helpers there. For example:
 
 ```erb
-<%= form_with model: @person do |f| %>
-  <%= text_field_with_label f, :first_name %>
+<%= form_with model: @person do |form| %>
+  <%= text_field_with_label form, :first_name %>
 <% end %>
 ```
 
 can be replaced with
 
 ```erb
-<%= form_with model: @person, builder: LabellingFormBuilder do |f| %>
-  <%= f.text_field :first_name %>
+<%= form_with model: @person, builder: LabellingFormBuilder do |form| %>
+  <%= form.text_field :first_name %>
 <% end %>
 ```
 
@@ -880,10 +880,10 @@ This creates an `addresses_attributes=` method on `Person` that allows you to cr
 The following form allows a user to create a `Person` and its associated addresses.
 
 ```html+erb
-<%= form_with model: @person do |f| %>
+<%= form_with model: @person do |form| %>
   Addresses:
   <ul>
-    <%= f.fields_for :addresses do |addresses_form| %>
+    <%= form.fields_for :addresses do |addresses_form| %>
       <li>
         <%= addresses_form.label :kind %>
         <%= addresses_form.text_field :kind %>
@@ -967,10 +967,10 @@ evaluates to `true` (e.g. 1, '1', true, or 'true') then the object will be destr
 This form allows users to remove addresses:
 
 ```erb
-<%= form_with model: @person do |f| %>
+<%= form_with model: @person do |form| %>
   Addresses:
   <ul>
-    <%= f.fields_for :addresses do |addresses_form| %>
+    <%= form.fields_for :addresses do |addresses_form| %>
       <li>
         <%= addresses_form.check_box :_destroy %>
         <%= addresses_form.label :kind %>

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1159,7 +1159,7 @@ it look as follows:
 ```html+erb
 <h1>Edit article</h1>
 
-<%= form_with(model: @article, local: true) do |form| %>
+<%= form_with model: @article, local: true do |form| %>
 
   <% if @article.errors.any? %>
     <div id="error_explanation">
@@ -1681,7 +1681,7 @@ So first, we'll wire up the Article show template
 </p>
 
 <h2>Add a comment:</h2>
-<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form| %>
+<%= form_with model: [ @article, @article.comments.build ], local: true do |form| %>
   <p>
     <%= form.label :commenter %><br>
     <%= form.text_field :commenter %>
@@ -1762,7 +1762,7 @@ add that to the `app/views/articles/show.html.erb`.
 <% end %>
 
 <h2>Add a comment:</h2>
-<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form| %>
+<%= form_with model: [ @article, @article.comments.build ], local: true do |form| %>
   <p>
     <%= form.label :commenter %><br>
     <%= form.text_field :commenter %>
@@ -1828,7 +1828,7 @@ following:
 <%= render @article.comments %>
 
 <h2>Add a comment:</h2>
-<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form| %>
+<%= form_with model: [ @article, @article.comments.build ], local: true do |form| %>
   <p>
     <%= form.label :commenter %><br>
     <%= form.text_field :commenter %>
@@ -1858,7 +1858,7 @@ Let us also move that new comment section out to its own partial. Again, you
 create a file `app/views/comments/_form.html.erb` containing:
 
 ```html+erb
-<%= form_with(model: [ @article, @article.comments.build ], local: true) do |form| %>
+<%= form_with model: [ @article, @article.comments.build ], local: true do |form| %>
   <p>
     <%= form.label :commenter %><br>
     <%= form.text_field :commenter %>

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -411,7 +411,7 @@ If a template with the specified format does not exist an `ActionView::MissingTe
 ##### The `:variants` Option
 
 This tells Rails to look for template variations of the same format.
-You can specify a list of variants by passing the `:variants` option with a symbol or an array. 
+You can specify a list of variants by passing the `:variants` option with a symbol or an array.
 
 An example of use would be this.
 
@@ -438,11 +438,11 @@ end
 private
 
 def determine_variant
-  variant = nil 
+  variant = nil
   # some code to determine the variant(s) to use
   variant = :mobile if session[:use_mobile]
-  
-  variant    
+
+  variant
 end
 ```
 
@@ -1097,9 +1097,9 @@ definitions for several similar resources:
 * `users/index.html.erb`
 
     ```html+erb
-    <%= render "shared/search_filters", search: @q do |f| %>
+    <%= render "shared/search_filters", search: @q do |form| %>
       <p>
-        Name contains: <%= f.text_field :name_contains %>
+        Name contains: <%= form.text_field :name_contains %>
       </p>
     <% end %>
     ```
@@ -1107,9 +1107,9 @@ definitions for several similar resources:
 * `roles/index.html.erb`
 
     ```html+erb
-    <%= render "shared/search_filters", search: @q do |f| %>
+    <%= render "shared/search_filters", search: @q do |form| %>
       <p>
-        Title contains: <%= f.text_field :title_contains %>
+        Title contains: <%= form.text_field :title_contains %>
       </p>
     <% end %>
     ```
@@ -1117,13 +1117,13 @@ definitions for several similar resources:
 * `shared/_search_filters.html.erb`
 
     ```html+erb
-    <%= form_for(search) do |f| %>
+    <%= form_with model: search do |form| %>
       <h1>Search form:</h1>
       <fieldset>
-        <%= yield f %>
+        <%= yield form %>
       </fieldset>
       <p>
-        <%= f.submit "Search" %>
+        <%= form.submit "Search" %>
       </p>
     <% end %>
     ```
@@ -1163,13 +1163,13 @@ You can also pass local variables into partials, making them even more powerful 
 * `_form.html.erb`
 
     ```html+erb
-    <%= form_for(zone) do |f| %>
+    <%= form_with model: zone do |form| %>
       <p>
         <b>Zone name</b><br>
-        <%= f.text_field :name %>
+        <%= form.text_field :name %>
       </p>
       <p>
-        <%= f.submit %>
+        <%= form.submit %>
       </p>
     <% end %>
     ```

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -912,7 +912,7 @@ resolve("Basket") { [:basket] }
 ```
 
 ``` erb
-<%= form_for @basket do |form| %>
+<%= form_with model: @basket do |form| %>
   <!-- basket form -->
 <% end %>
 ```

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -167,7 +167,7 @@ your form will be using Ajax. You can opt out of this behavior by
 passing the `:local` option `form_with`.
 
 ```erb
-<%= form_with(model: @article) do |f| %>
+<%= form_with model: @article do |form| %>
   ...
 <% end %>
 ```
@@ -338,8 +338,8 @@ This also works for links with `data-method` attribute.
 For example:
 
 ```erb
-<%= form_with(model: @article.new) do |f| %>
-  <%= f.submit data: { "disable-with": "Saving..." } %>
+<%= form_with model: @article.new do |form| %>
+  <%= form.submit data: { disable_with: "Saving..." } %>
 <%= end %>
 ```
 
@@ -429,10 +429,10 @@ The index view (`app/views/users/index.html.erb`) contains:
 
 <br>
 
-<%= form_with(model: @user) do |f| %>
-  <%= f.label :name %><br>
-  <%= f.text_field :name %>
-  <%= f.submit %>
+<%= form_with model: @user do |form| %>
+  <%= form.label :name %><br>
+  <%= form.text_field :name %>
+  <%= form.submit %>
 <% end %>
 ```
 


### PR DESCRIPTION
Convert examples to use `form_with` instead of `form_for` or `form_tag`, which have been soft-deprecated.  Also rename form variable in examples from `f` to `form`, as exemplified by 8ff7ca5d11.
