### PR TITLE
Switch to double quotes to satisfy RuboCop

### DIFF
--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -238,7 +238,7 @@ module ApplicationTests
               Book.first
             end
           RUBY
-          app_file('Rakefile', dummy_task, 'a+')
+          app_file("Rakefile", dummy_task, "a+")
 
           generate_models_for_animals
 


### PR DESCRIPTION
Example failure: https://github.com/rails/rails/pull/37621/checks#step:6:208