### PR TITLE
Additionally order by primary key if implicit_order_column is not uniq

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Specifying `implicit_order_column` now subsorts the records by primary key if available to ensure deterministic results.
+
+    *Paweł Urbanek*
+
 *   `where(attr => [])` now loads an empty result without making a query.
 
     *John Hawthorn*

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -115,8 +115,8 @@ module ActiveRecord
     #
     # Sets the column to sort records by when no explicit order clause is used
     # during an ordered finder call. Useful when the primary key is not an
-    # auto-incrementing integer, for example when it's a UUID. Note that using
-    # a non-unique column can result in non-deterministic results.
+    # auto-incrementing integer, for example when it's a UUID. Records are subsorted
+    # by the primary key if it exists to ensure deterministic results.
     included do
       mattr_accessor :primary_key_prefix_type, instance_writer: false
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -560,7 +560,11 @@ module ActiveRecord
 
       def ordered_relation
         if order_values.empty? && (implicit_order_column || primary_key)
-          order(arel_attribute(implicit_order_column || primary_key).asc)
+          if implicit_order_column && primary_key && implicit_order_column != primary_key
+            order(arel_attribute(implicit_order_column).asc, arel_attribute(primary_key).asc)
+          else
+            order(arel_attribute(implicit_order_column || primary_key).asc)
+          end
         else
           self
         end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1117,6 +1117,7 @@ ActiveRecord::Schema.define do
 
   create_table :non_primary_keys, force: true, id: false do |t|
     t.integer :id
+    t.datetime :created_at
   end
 end
 


### PR DESCRIPTION
As mentioned here https://github.com/rails/rails/pull/34480/files#r234781773 the current implementation of `implicit_order_column` does not guarantee that the objects will always be returned in the same order if `implicit_order_column` contains duplicate values. 

This patch adds a secondary sort by primary key (if it's not set as a `implicit_order_column` already) to guarantee the consistent output.