### PR TITLE
Avoid using `require_dependency` in `modules_for_helpers` if Zeitwerk is enabled

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 $:.unshift File.expand_path("lib", __dir__)
-$:.unshift File.expand_path("fixtures/helpers", __dir__)
-$:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)
 
 require "active_support/core_ext/kernel/reporting"
 
@@ -34,6 +32,11 @@ module Rails
     def root; end
   end
 end
+
+ActiveSupport::Dependencies.autoload_paths += [
+  File.expand_path("fixtures/helpers", __dir__),
+  File.expand_path("fixtures/alternate_helpers", __dir__),
+]
 
 ActiveSupport::Dependencies.hook!
 

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -52,7 +52,7 @@ class HelpersPathsController < ActionController::Base
   paths = ["helpers2_pack", "helpers1_pack"].map do |path|
     File.join(File.expand_path("../fixtures", __dir__), path)
   end
-  $:.unshift(*paths)
+  ActiveSupport::Dependencies.autoload_paths += paths
 
   self.helpers_path = paths
   helper :all

--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 
 ActionController::Base.helpers_path = File.expand_path("../../fixtures/helpers", __dir__)
+ActiveSupport::Dependencies.autoload_paths += [File.expand_path("../../fixtures/helpers", __dir__)]
 
 module AbstractController
   module Testing
@@ -54,7 +55,7 @@ module AbstractController
       include ActionController::Helpers
 
       path = File.expand_path("../../fixtures/helpers_missing", __dir__)
-      $:.unshift(path)
+      ActiveSupport::Dependencies.autoload_paths += [path]
       self.helpers_path = path
     end
 
@@ -111,7 +112,7 @@ module AbstractController
     class InvalidHelpersTest < ActiveSupport::TestCase
       def test_controller_raise_error_about_real_require_problem
         e = assert_raise(LoadError) { AbstractInvalidHelpers.helper(:invalid_require) }
-        assert_equal "No such file to load -- very_invalid_file_name.rb", e.message
+        assert_equal "cannot load such file -- very_invalid_file_name", e.message
       end
 
       def test_controller_raise_error_about_missing_helper


### PR DESCRIPTION
Followup to: https://github.com/rails/rails/pull/37599

### Context

I'm trying to disable [`config.add_autoload_paths_to_load_path`](https://github.com/rails/rails/commit/668673f7793be1ce318a32bb622ed411029d00a9) in our app, which cause `require_dependency` to straight up fail when called with an autoloaded path.

### This change

This is the last `require_dependency` usage. With this patch I'm able to boot our app with `config.add_autoload_paths_to_load_path = false`.

Again, I'm not super happy with accessing `Rails.autoloaders.zeitwerk_enabled?` from there, but I can't see a better alternative.

@fxn, @rafaelfranca 

cc @Edouard-chin @etiennebarrie 