### PR TITLE
i18n.md: Remove Rails versions from Traco link

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1186,7 +1186,7 @@ Several gems can help with this:
 
 * [Globalize](https://github.com/globalize/globalize): Store translations on separate translation tables, one for each translated model
 * [Mobility](https://github.com/shioyama/mobility): Provides support for storing translations in many formats, including translation tables, json columns (PostgreSQL), etc.
-* [Traco](https://github.com/barsoom/traco): Translatable columns for Rails 3 and 4, stored in the model table itself
+* [Traco](https://github.com/barsoom/traco): Translatable columns stored in the model table itself
 
 Conclusion
 ----------


### PR DESCRIPTION
It is not intended to be limited to only Rails 3 and 4, and currently runs specs against Rails 4.2 to to 5.2: https://github.com/barsoom/traco/blob/master/.travis.yml
