### PR TITLE
Use singular, `instance`, in deprecation warning.

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -280,7 +280,7 @@ module ActionView #:nodoc:
         ActiveSupport::Deprecation.warn <<~eowarn.squish
           ActionView::Base instances must implement `compiled_method_container`
           or use the class method `with_empty_template_cache` for constructing
-          an ActionView::Base instances that has an empty cache.
+          an ActionView::Base instance that has an empty cache.
         eowarn
       end
 


### PR DESCRIPTION
### Summary

Grammar issue in deprecation message for `complied_method_container`.
