### PR TITLE
CredentialsCommand :edit/:show to use custom content_path and key_path

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -99,13 +99,34 @@ module Rails
           end
         end
 
-
         def content_path
-          @content_path ||= options[:environment] ? "config/credentials/#{options[:environment]}.yml.enc" : "config/credentials.yml.enc"
+          @content_path ||= get_environment_content_path || get_custom_credentials_content_path || "config/credentials.yml.enc"
         end
 
         def key_path
-          options[:environment] ? "config/credentials/#{options[:environment]}.key" : "config/master.key"
+          get_environment_key_path || get_custom_credentials_key_path || "config/master.key"
+        end
+
+        def get_custom_credentials_content_path
+          content_path = Rails.application.credentials.content_path
+          extract_relative_project_file_path_string(content_path) if content_path
+        end
+
+        def get_custom_credentials_key_path
+          key_path = Rails.application.credentials.key_path
+          extract_relative_project_file_path_string(key_path) if key_path
+        end
+
+        def extract_relative_project_file_path_string(path)
+          path.to_s.remove(Dir.pwd)[1..-1]
+        end
+
+        def get_environment_content_path
+          "config/credentials/#{options[:environment]}.yml.enc" if options[:environment]
+        end
+
+        def get_environment_key_path
+          "config/credentials/#{options[:environment]}.key" if options[:environment]
         end
 
         def extract_environment_from_path(path)

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -81,7 +81,7 @@ module Rails
           if options[:environment]
             encrypted_file_generator.add_encrypted_file_silently(content_path, key_path)
           else
-            credentials_generator.add_credentials_file_silently
+            credentials_generator.add_credentials_file_silently(content_path, key_path)
           end
         end
 
@@ -100,25 +100,19 @@ module Rails
         end
 
         def content_path
-          @content_path ||= get_environment_content_path || get_custom_credentials_content_path || "config/credentials.yml.enc"
+          @content_path ||= get_custom_credentials_content_path || get_environment_content_path || "config/credentials.yml.enc"
         end
 
         def key_path
-          get_environment_key_path || get_custom_credentials_key_path || "config/master.key"
+          @key_path ||= get_custom_credentials_key_path || get_environment_key_path || "config/master.key"
         end
 
         def get_custom_credentials_content_path
-          content_path = Rails.application.credentials.content_path
-          extract_relative_project_file_path_string(content_path) if content_path
+          Rails.application.credentials.content_path
         end
 
         def get_custom_credentials_key_path
-          key_path = Rails.application.credentials.key_path
-          extract_relative_project_file_path_string(key_path) if key_path
-        end
-
-        def extract_relative_project_file_path_string(path)
-          path.to_s.remove(Dir.pwd)[1..-1]
+          Rails.application.credentials.key_path
         end
 
         def get_environment_content_path

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -179,7 +179,10 @@ module Rails
       return if options[:pretend] || options[:dummy_app]
 
       require "rails/generators/rails/credentials/credentials_generator"
-      Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file_silently
+      Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file_silently(
+        Rails.application.credentials.content_path,
+        Rails.application.credentials.key_path
+      )
     end
 
     def database_yml

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -8,10 +8,8 @@ module Rails
   module Generators
     class CredentialsGenerator < Base # :nodoc:
       def add_credentials_file
-        unless credentials.content_path.exist?
-          template = credentials_template
-
-          say "Adding #{credentials.content_path} to store encrypted credentials."
+        unless @content_path.exist?
+          say "Adding #{@content_path} to store encrypted credentials."
           say ""
           say "The following content has been encrypted with the Rails master key:"
           say ""
@@ -25,23 +23,19 @@ module Rails
         end
       end
 
-      def add_credentials_file_silently(template = nil)
-        unless credentials.content_path.exist?
-          credentials.write(credentials_template)
+      def add_credentials_file_silently(content_path, key_path, template = nil)
+        unless content_path.exist?
+          ActiveSupport::EncryptedFile.new(
+            content_path: content_path,
+            key_path: key_path,
+            env_key: "RAILS_MASTER_KEY",
+            raise_if_missing_key: true
+          ).write(template)
         end
       end
 
       private
-        def credentials
-          ActiveSupport::EncryptedConfiguration.new(
-            config_path: "config/credentials.yml.enc",
-            key_path: "config/master.key",
-            env_key: "RAILS_MASTER_KEY",
-            raise_if_missing_key: true
-          )
-        end
-
-        def credentials_template
+        def template
           <<~YAML
             # aws:
             #   access_key_id: 123

--- a/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
@@ -6,10 +6,10 @@ require "active_support/encrypted_file"
 module Rails
   module Generators
     class EncryptedFileGenerator < Base # :nodoc:
-      def add_encrypted_file_silently(file_path, key_path, template = encrypted_file_template)
-        unless File.exist?(file_path)
+      def add_encrypted_file_silently(content_path, key_path, template = encrypted_file_template)
+        unless File.exist?(content_path)
           ActiveSupport::EncryptedFile.new(
-            content_path: file_path,
+            content_path: content_path,
             key_path: key_path,
             env_key: "RAILS_MASTER_KEY",
             raise_if_missing_key: true

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -57,11 +57,17 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
   end
 
   test "edit command modifies file specified by overridden content and key paths" do
-    assert_match(/access_key_id: 123/, run_edit_command)
-
     Dir.chdir(app_path) do
+      File.write("config/credentials.custom.yml.enc",
+        File.read("config/credentials.yml.enc"))
+
+      FileUtils.rm("config/credentials.yml.enc")
+
+      assert_match(/access_key_id: 123/, run_edit_command)
+
       assert File.exist?("config/master.key")
-      assert File.exist?("config/credentials.yml.enc")
+      assert File.exist?("config/credentials.custom.yml.enc")
+      assert_not File.exist?("config/credentials.yml.enc")
     end
   end
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -56,6 +56,15 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "edit command modifies file specified by overridden content and key paths" do
+    assert_match(/access_key_id: 123/, run_edit_command)
+
+    Dir.chdir(app_path) do
+      assert File.exist?("config/master.key")
+      assert File.exist?("config/credentials.yml.enc")
+    end
+  end
+
   test "edit command modifies file specified by environment option" do
     assert_match(/access_key_id: 123/, run_edit_command(environment: "production"))
     Dir.chdir(app_path) do


### PR DESCRIPTION
### Summary

Follows up on #37631 

As per the docs on credentials [here](https://edgeapi.rubyonrails.org/classes/Rails/Application.html#method-i-credentials), default behavior for credentials content_path and key_path can be overwritten by assigning to `Rails.application.config.credentials.content_path` and `Rails.application.config.credentials.key_path`.

Current implementation of `edit` and `show` methods in `Rails::Command::CredentialsCommand` uses the `content_path` and `key_path` methods that gets the path from the environment if that option was passed in, but then falls back directly to their original defaults not taking into account the overrides passed into `config.credentials`. This PR aims to address that issue by introducing an intermediate fallback that checks against the overrides too.

**_Currently stuck_**, I'm having quite a bit of difficulty trying to setup a mock for `Rails.application` inside of `railties/test/commands/credentials_test.rb` and I was wondering if I could get some pointers. `Rails.application` seems to always return `nil` in context of that test file - is there some support method that I could call somewhere? I've tried mocking out the credentials object like so:

```
expected_content_path = Pathname.new("/projects/rails_six/config/credentials.custom.yml.enc")
expected_key_path = Pathname.new("/projects/rails_six/config/master.custom.key")

mock_credentials = Minitest::Mock.new
mock_credentials.expect(:content_path, expected_content_path)
mock_credentials.expect(:key_path, expected_key_path)

Rails.application.config.stub(:credentials, mock_credentials) do
  assert_match(/access_key_id: 123/, run_edit_command)
end
```

Thanks in advance to any tips on how I can make this PR better! 😄 