### PR TITLE
Address `no implicit conversion of Arel::Attributes::Attribute into String`

### DIFF
--- a/activerecord/lib/arel/visitors/oracle.rb
+++ b/activerecord/lib/arel/visitors/oracle.rb
@@ -104,7 +104,7 @@ module Arel # :nodoc: all
           return o if o.orders.empty?
           return o unless o.cores.any? do |core|
             core.projections.any? do |projection|
-              /FIRST_VALUE/.match?(projection)
+              /FIRST_VALUE/ === projection
             end
           end
           # Previous version with join and split broke ORDER BY clause


### PR DESCRIPTION
### Summary

This pull request addresses the following `TypeError: no implicit conversion of Arel::Attributes::Attribute into String`error reported by https://github.com/rsim/oracle-enhanced/issues/1943

https://github.com/rails/rails/commit/4a9ef5e1202cdab1882989eb561b0dc854c9891b triggers this failure.

```ruby
$ bundle exec rspec ./spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:92
==> Loading config from ENV or use default
==> Running specs with MRI version 2.6.5
==> Effective ActiveRecord version 6.1.0.alpha
... snip ...
Run options: include {:locations=>{"./spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb"=>[92]}}
F

Failures:

  1) OracleEnhancedAdapter context index on single table should create single VARCHAR2 column index
     Failure/Error: expect(Post.contains(:title, word).to_a).to eq([@post2, @post1])

     TypeError:
       no implicit conversion of Arel::Attributes::Attribute into String
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:107:in `match?'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:107:in `block (2 levels) in order_hacks'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:106:in `any?'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:106:in `block in order_hacks'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:105:in `any?'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:105:in `order_hacks'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/oracle.rb:8:in `visit_Arel_Nodes_SelectStatement'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/visitor.rb:30:in `visit'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/visitor.rb:11:in `accept'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:10:in `accept'
     # /home/yahonda/git/rails/activerecord/lib/arel/visitors/to_sql.rb:18:in `compile'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:25:in `to_sql_and_binds'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:63:in `select_all'
     # /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:107:in `select_all'
     # /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:46:in `find_by_sql'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:826:in `block in exec_queries'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:844:in `skip_query_cache_if_necessary'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:811:in `exec_queries'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:629:in `load'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:250:in `records'
     # /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:245:in `to_ary'
     # ./spec/active_record/connection_adapters/oracle_enhanced/context_index_spec.rb:95:in `block (4 levels) in <top (required)>'
     ... snip ...
```
