### PR TITLE
ActiveRecord PostgreSQL adapter: parse quoted values in range output

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -69,11 +69,30 @@ module ActiveRecord
             def extract_bounds(value)
               from, to = value[1..-2].split(",", 2)
               {
-                from:          (from == "" || from == "-infinity") ? infinity(negative: true) : from,
-                to:            (to == "" || to == "infinity") ? infinity : to,
+                from:          (from == "" || from == "-infinity") ? infinity(negative: true) : unquote(from),
+                to:            (to == "" || to == "infinity") ? infinity : unquote(to),
                 exclude_start: value.start_with?("("),
                 exclude_end:   value.end_with?(")")
               }
+            end
+
+            # When formatting the bound values of range types, PostgreSQL quotes
+            # the bound value using double-quotes in certain conditions. Within
+            # a double-quoted string, literal " and \ characters are themselves
+            # escaped. In input, PostgreSQL accepts multiple escape styles for "
+            # (either \" or "") but in output always uses "".
+            # See:
+            # * https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO
+            # * https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-IO-SYNTAX
+            def unquote(value)
+              if value.start_with?('"') && value.end_with?('"')
+                unquoted_value = value[1..-2]
+                unquoted_value.gsub!('""', '"')
+                unquoted_value.gsub!('\\\\', '\\')
+                unquoted_value
+              else
+                value
+              end
             end
 
             def infinity(negative: false)


### PR DESCRIPTION
### Summary

When formatting the bound values of range types, PostgreSQL quotes the value using double-quotes in certain conditions: if its formatted representation contains parentheses, commas, double quotes, backslashes or whitespace (manual section 8.17.5, 8.16.6).

In particular this affects timestamps, which include whitespace and so will be formatted with double-quotes, for example `["2018-01-01 00:00:00",)`.

However, the parser for range values in `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range#cast_value` doesn't check for or extract quoted values. This results in a string potentially containing nested quotes being passed to the parser for the subtype.

In the case of timestamp ranges (where the subtype is `OID::DateTime`), this causes two problems:
 * The special-case handling for BCE in `DateTime#cast_value` is bypassed, resulting in incorrect positive instead of negative year values (Issue #37647).
 * `ActiveModel::Type::DateTime`'s `fast_string_to_time` parser can't be used and falls back to the `fallback_string_to_time` parser using `Date._parse`.

This change updates `Range#extract_bounds` to extract nested quoted values.

Fixes #37647