### PR TITLE
Remove needless `require "pp"`

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -29,8 +29,6 @@ require "action_dispatch"
 require "active_support/dependencies"
 require "active_model"
 
-require "pp" # require 'pp' early to prevent hidden_methods from not picking up the pretty-print methods until too late
-
 module Rails
   class << self
     def env

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -24,8 +24,6 @@ require "active_support/dependencies"
 require "active_model"
 require "active_record"
 
-require "pp" # require 'pp' early to prevent hidden_methods from not picking up the pretty-print methods until too late
-
 ActiveSupport::Dependencies.hook!
 
 Thread.abort_on_exception = true

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "pp"
 require "active_support/dependencies"
 require "dependencies_test_helpers"
 

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -405,7 +405,6 @@ def start &blk
 
   if options[:debug]
     $DEBUG = true
-    require 'pp'
     p options[:server]
     pp wrapped_app
     pp app

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -483,10 +483,6 @@ module Rails
     end
 
     console do
-      require "pp"
-    end
-
-    console do
       unless ::Kernel.private_method_defined?(:y)
         require "psych/y"
       end


### PR DESCRIPTION
### Summary

In Ruby 2.5 and later, `Kernel#pp` is automatically loaded.
For details:

- https://bugs.ruby-lang.org/issues/14123

So, this PR remove the needless `require "pp"` s.