### PR TITLE
Fix indentation in `configuring.md` [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -459,7 +459,7 @@ The schema dumper adds two additional configuration options:
     Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
     ```
 
-  By default it is set to `false` which results in following output:
+    By default it is set to `false` which results in following output:
 
     ```
     Rendered messages/_message.html.erb in 1.2 ms [cache hit]


### PR DESCRIPTION
### Summary
before
<img width="675" alt="スクリーンショット 2019-11-07 9 17 27" src="https://user-images.githubusercontent.com/17407489/68349137-73777f00-013f-11ea-9ce2-9552cce07744.png">

after
<img width="639" alt="スクリーンショット 2019-11-07 9 17 49" src="https://user-images.githubusercontent.com/17407489/68349150-7d997d80-013f-11ea-8cf4-a4e8a69a5c32.png">

