### PR TITLE
Fix collection callbacks not terminating when abort is thrown

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -389,7 +389,9 @@ module ActiveRecord
         end
 
         def remove_records(existing_records, records, method)
-          records.each { |record| callback(:before_remove, record) }
+          catch(:abort) do
+            records.each { |record| callback(:before_remove, record) }
+          end || return
 
           delete_records(existing_records, method) if existing_records.any?
           @target -= records
@@ -445,7 +447,9 @@ module ActiveRecord
         end
 
         def replace_on_target(record, index, skip_callbacks)
-          callback(:before_add, record) unless skip_callbacks
+          catch(:abort) do
+            callback(:before_add, record)
+          end || return unless skip_callbacks
 
           set_inverse_instance(record)
 

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -62,6 +62,23 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
                   "after_adding#{@thinking.id}", "after_adding_proc#{@thinking.id}"], @david.post_log
   end
 
+  def test_has_many_callbacks_halt_execution_when_abort_is_trown_when_adding_to_association
+    author = Author.create!(name: "Roger")
+    post = Post.create!(title: "hello", body: "abc")
+    author.posts_with_thrown_callbacks << post
+
+    assert_empty(author.posts_with_callbacks)
+  end
+
+  def test_has_many_callbacks_halt_execution_when_abort_is_trown_when_removing_from_association
+    author = Author.create!(name: "Roger")
+    post = Post.create!(title: "hello", body: "abc", author: author)
+
+    assert_equal(1, author.posts_with_thrown_callbacks.size)
+    author.posts_with_thrown_callbacks.destroy(post.id)
+    assert_equal(1, author.posts_with_thrown_callbacks.size)
+  end
+
   def test_has_many_callbacks_with_create
     morten = Author.create name: "Morten"
     post = morten.posts_with_proc_callbacks.create! title: "Hello", body: "How are you doing?"

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -71,6 +71,10 @@ class Author < ActiveRecord::Base
            after_add: :log_after_adding,
            before_remove: :log_before_removing,
            after_remove: :log_after_removing
+  has_many :posts_with_thrown_callbacks, class_name: "Post", before_add: :throw_abort,
+           after_add: :ensure_not_called,
+           before_remove: :throw_abort,
+           after_remove: :ensure_not_called
   has_many :posts_with_proc_callbacks, class_name: "Post",
            before_add: Proc.new { |o, r| o.post_log << "before_adding#{r.id || '<new>'}" },
            after_add: Proc.new { |o, r| o.post_log << "after_adding#{r.id || '<new>'}" },
@@ -185,6 +189,14 @@ class Author < ActiveRecord::Base
   validates_presence_of :name
 
   private
+    def throw_abort(_)
+      throw(:abort)
+    end
+
+    def ensure_not_called(_)
+      raise
+    end
+
     def log_before_adding(object)
       @post_log << "before_adding#{object.id || '<new>'}"
     end


### PR DESCRIPTION
Cherry-picking tests from #37643.

Fixes #37273.

Closes #37643.