### PR TITLE
Add an option to disable logging for jobs with sensitive arguments

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add an option to disable logging of the job arguments when enqueuing and executing the job.
+
+        class SensitiveJob < ApplicationJob
+          self.log_arguments = false
+
+          def perform(my_sensitive_argument)
+          end
+        end
+
+    When dealing with sensitive arugments as password and tokens it is now possible to configure the job
+    to not put the sensitive argument in the logs.
+
+    *Rafael Mendonça França*
+
 *   Changes in `queue_name_prefix` of a job no longer affects all other jobs. Fixes #37084.
 
     *Lucas Mansur*

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -77,7 +77,7 @@ module ActiveJob
       end
 
       def args_info(job)
-        if job.arguments.any?
+        if job.class.log_arguments? && job.arguments.any?
           " with arguments: " +
             job.arguments.map { |arg| format(arg).inspect }.join(", ")
         else

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -10,6 +10,7 @@ module ActiveJob
 
     included do
       cattr_accessor :logger, default: ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
+      class_attribute :log_arguments, instance_accessor: false, default: true
 
       around_enqueue { |_, block| tag_logger(&block) }
       around_perform { |job, block| tag_logger(job.class.name, job.job_id, &block) }

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -9,6 +9,7 @@ require "jobs/overridden_logging_job"
 require "jobs/nested_job"
 require "jobs/rescue_job"
 require "jobs/retry_job"
+require "jobs/disable_log_job"
 require "models/person"
 
 class LoggingTest < ActiveSupport::TestCase
@@ -119,6 +120,18 @@ class LoggingTest < ActiveSupport::TestCase
       assert_match(/enqueued at /, @logger.messages)
       assert_match(/Dummy, here is it: Dummy/, @logger.messages)
       assert_match(/Performed LoggingJob \(Job ID: .*?\) from .*? in .*ms/, @logger.messages)
+    end
+  end
+
+  def test_perform_disabled_job_logging
+    perform_enqueued_jobs do
+      DisableLogJob.perform_later "Dummy"
+      assert_no_match(/Enqueued DisableLogJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
+      assert_no_match(/Performing DisableLogJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
+
+      assert_match(/enqueued at /, @logger.messages)
+      assert_match(/Dummy, here is it: Dummy/, @logger.messages)
+      assert_match(/Performed DisableLogJob \(Job ID: .*?\) from .*? in .*ms/, @logger.messages)
     end
   end
 

--- a/activejob/test/jobs/disable_log_job.rb
+++ b/activejob/test/jobs/disable_log_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DisableLogJob < ActiveJob::Base
+  self.log_arguments = false
+
+  def perform(dummy)
+    logger.info "Dummy, here is it: #{dummy}"
+  end
+
+  def job_id
+    "LOGGING-JOB-ID"
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -805,6 +805,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.return_false_on_aborted_enqueue` change the return value of `#enqueue` to false instead of the job instance when the enqueuing is aborted. Defaults to `false`.
 
+* `config.active_job.log_arguments` controls if the arguments of a job are logged. Defaults to `true`.
+
 ### Configuring Action Cable
 
 * `config.action_cable.url` accepts a string for the URL for where


### PR DESCRIPTION
    class SensitiveJob < ApplicationJob
      self.log_arguments = false

      def perform(my_sensitive_argument)
      end
    end

When dealing with sensitive arguments as password and tokens it is now possible to configure the job to not put the sensitive argument in the logs.

Closes #34438.