### PR TITLE
Suppress deprecation warning in generating the guide `index.html`

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -163,7 +163,7 @@ module RailsGuides
 
           # Generate the special pages like the home.
           # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
-          result = view.render(layout: layout, formats: [$1.to_sym], file: $`)
+          result = view.render(layout: layout, formats: [$1.to_sym], template: $`)
         else
           body = File.read("#{@source_dir}/#{guide}")
           result = RailsGuides::Markdown.new(


### PR DESCRIPTION
### Summary
In generating the guide `index.html`, the warning below happens.

```
$ bundle exec rake guides:generate:html
/Users/tnakata/.rbenv/versions/2.6.5/bin/ruby rails_guides.rb
Generating index.html.erb as index.html
DEPRECATION WARNING: render file: should be given the absolute path to a file (called from render at /Users/tnakata/workspace/rails/actionview/lib/action_view/renderer/template_renderer.rb:7)
Generating layout.html.erb as layout.html
Generating _welcome.html.erb as _welcome.html
Generating _license.html.erb as _license.html
```
