### PR TITLE
Handle when JS passes `content_type` equals blank string

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -204,7 +204,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   def unfurl(io, identify: true) #:nodoc:
     self.checksum     = compute_checksum_in_chunks(io)
-    self.content_type = extract_content_type(io) if content_type.nil? || identify
+    self.content_type = extract_content_type(io) if content_type.blank? || identify
     self.byte_size    = io.size
     self.identified   = true
   end


### PR DESCRIPTION
I've been running a digital documents marketplace with `ActiveStorage` enabled for the last few months and noticed that sometimes JS sets the `file.content_type` as `""`, especially for some (but definitely not all) `docx` files. However these files are beyond identifying — the backend code in `ActiveStorage::Blob::Identifiable` is able to identify the files correctly as `"application/vnd.openxmlformats-officedocument.wordprocessingml.document"`.

The issue is that this backend never gets called, because, the ways things are, a blank string is treated as an explicit and desired `content_type`. I propose running `identify` in this case as well.