### PR TITLE
Make ActiveStorage::Filename#sanitized replacement character configurable

### DIFF
--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -53,9 +53,9 @@ class ActiveStorage::Filename
   #   ActiveStorage::Filename.new("foo:bar.jpg").sanitized # => "foo-bar.jpg"
   #   ActiveStorage::Filename.new("foo/bar.jpg").sanitized # => "foo-bar.jpg"
   #
-  # Characters considered unsafe for storage (e.g. \, $, and the RTL override character) are replaced with a dash.
+  # Characters considered unsafe for storage (e.g. \, $, and the RTL override character) are replaced with a dash (or specified via config.active_storage.sanitize_filename_with).
   def sanitized
-    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/\t\r\n\\", "-")
+    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/\t\r\n\\", ActiveStorage.sanitize_filename_with)
   end
 
   # Returns the sanitized version of the filename.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -65,6 +65,8 @@ module ActiveStorage
 
   mattr_accessor :replace_on_assign_to_many, default: false
 
+  mattr_accessor :sanitize_filename_with, default: "-"
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -82,6 +82,8 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
+
+        ActiveStorage.sanitize_filename_with = app.config.active_storage.sanitize_filename_with || "-"
       end
     end
 

--- a/activestorage/test/models/filename_test.rb
+++ b/activestorage/test/models/filename_test.rb
@@ -29,6 +29,18 @@ class ActiveStorage::FilenameTest < ActiveSupport::TestCase
     end
   end
 
+  test "with non-default ActiveStore.sanitize_filename_with" do
+    ActiveStorage.sanitize_filename_with = "_"
+
+    "%$|:;/\t\r\n\\".each_char do |character|
+      filename = ActiveStorage::Filename.new("foo#{character}bar.pdf")
+      assert_equal "foo_bar.pdf", filename.sanitized
+      assert_equal "foo_bar.pdf", filename.to_s
+    end
+  ensure
+    ActiveStorage.sanitize_filename_with = "-"
+  end
+
   test "sanitize transcodes to valid UTF-8" do
     { (+"\xF6").force_encoding(Encoding::ISO8859_1) => "ö",
       (+"\xC3").force_encoding(Encoding::ISO8859_1) => "Ã",

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -887,6 +887,8 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 * `config.active_storage.replace_on_assign_to_many` determines whether assigning to a collection of attachments declared with `has_many_attached` replaces any existing attachments or appends to them. The default is `true`.
 
+* `config.active_storage.sanitize_filename_with` determines which character to use for sanitizing a filename (default is dash `-`)
+
 * `config.active_storage.draw_routes` can be used to toggle Active Storage route generation. The default is `true`.
 
 ### Results of `load_defaults`


### PR DESCRIPTION
### Summary

Ability to configure the character that is used for replacing invalid characters in `ActiveStorage::Filename#sanitized`

Users migrating paperclip to activestorage have probably used `Paperclip::Attachment.cleanup_filename` that used an underscore by default.

By introducing this configurable option the migration is a lot easier (or makes it possible to just keep the behaviour of paperclip).