### PR TITLE
perform_caching config affects collection caching

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   `ActionView::CollectionCaching#cache_collection_render` now respects
+    `config.action_controller.perform_caching`
+
+    ```
+    <%= render partial: 'products/product', collection: @products, cached: true %>
+    ```
+
+    Before:
+      It would always return the cached partial.
+      Even if `config.action_controller.perform_caching == false`
+    After:
+      It will return the cached partial only if `config.action_controller.perform_caching == true`
+
+    *Santiago Bartesaghi*
+
 *   `ActionView::Helpers::FormOptionsHelper#select` should mark option for `nil` as selected.
 
     ```ruby

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -12,7 +12,7 @@ module ActionView
 
     private
       def cache_collection_render(instrumentation_payload, view, template)
-        return yield unless @options[:cached]
+        return yield unless @options[:cached] && view.controller.respond_to?(:perform_caching) && view.controller.perform_caching
 
         # Result is a hash with the key represents the
         # key used for cache lookup and the value is the item

--- a/actionview/test/activerecord/multifetch_cache_test.rb
+++ b/actionview/test/activerecord/multifetch_cache_test.rb
@@ -22,6 +22,10 @@ class MultifetchCacheTest < ActiveRecordTestCase
         [ :views, key ]
       end
     end.with_view_paths(view_paths, {})
+
+    controller = ActionController::Base.new
+    controller.perform_caching = true
+    @view.controller = controller
   end
 
   def test_only_preloading_for_records_that_miss_the_cache

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -198,6 +198,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def test_render_collection_template
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_cache_controller
+
       @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
       wait
 
@@ -208,6 +210,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def test_render_collection_with_implicit_path
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_cache_controller
+
       @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
       wait
 
@@ -218,6 +222,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def test_render_collection_template_without_path
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_cache_controller
+
       @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
       wait
 
@@ -229,6 +235,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   def test_render_collection_with_cached_set
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
       set_view_cache_dependencies
+      set_cache_controller
 
       @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
         locals: { greeting: "hi" })

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -21,6 +21,8 @@ module RenderTestCases
     end.with_view_paths(paths, @assigns)
 
     controller = TestController.new
+    controller.perform_caching = true
+    @view.controller = controller
 
     @controller_view = controller.view_context_class.with_empty_template_cache.new(
       controller.lookup_context,
@@ -786,6 +788,30 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
 
     assert_not_equal "Cached",
       @view.render(partial: "test/customer", collection: [customer])
+  end
+
+  test "collection caching does not cache if controller doesn't respond to perform_caching" do
+    @view.controller = nil
+
+    customer = Customer.new("david", 1)
+    key = cache_key(customer, "test/_customer")
+
+    ActionView::PartialRenderer.collection_cache.write(key, "Cached")
+
+    assert_not_equal "Cached",
+      @view.render(partial: "test/customer", collection: [customer], cached: true)
+  end
+
+  test "collection caching does not cache if perform_caching is disabled" do
+    @view.controller.perform_caching = false
+
+    customer = Customer.new("david", 1)
+    key = cache_key(customer, "test/_customer")
+
+    ActionView::PartialRenderer.collection_cache.write(key, "Cached")
+
+    assert_not_equal "Cached",
+      @view.render(partial: "test/customer", collection: [customer], cached: true)
   end
 
   test "collection caching with partial that doesn't use fragment caching" do


### PR DESCRIPTION
### Summary

The goal of this PR is make the `config.action_controller.perform_caching` option more robust. 

Currently that option exists and will prevent caching from happening when calling the `cache` methods from a controller or using the view helper. But there are some other ways of caching that don't respect the configuration, for example when doing something like `<%= render partial: 'programs', collection: @programs, cached: true %>`. With this PR, if the `perform_caching` config is turned off we'll respect it on collection caching.

### Other Information

All this originated as a request for a production app where we want to be able to turn off fragment caching instantaneously with and ENV VAR in case something goes wrong and we detect we are serving bad data.