### PR TITLE
Fix configuring a cache store with ActiveSupport::OrderedOptions

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -56,6 +56,10 @@ module ActiveSupport
     def respond_to_missing?(name, include_private)
       true
     end
+
+    def extractable_options?
+      true
+    end
   end
 
   # +InheritableOptions+ provides a constructor to build an +OrderedOptions+

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -65,4 +65,13 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
     assert_kind_of(ActiveSupport::Cache::FileStore, store)
     assert_equal "/path/to/cache/directory", store.cache_path
   end
+
+  def test_redis_cache_store_with_ordered_options
+    options = ActiveSupport::OrderedOptions.new
+    options.update namespace: "foo"
+
+    store = ActiveSupport::Cache.lookup_store :redis_cache_store, options
+    assert_kind_of(ActiveSupport::Cache::RedisCacheStore, store)
+    assert_equal "foo", store.options[:namespace]
+  end
 end


### PR DESCRIPTION
9845cd6 broke configuring a cache store like so:

```ruby
config.cache_store = :redis_cache_store, config_for("redis/cache")
```

`Rails::Application#config_for` returns an `ActiveSupport::OrderedOptions`. By default, the `Array#extract_options!` core extension won't extract instances of `Hash` subclasses. Add `ActiveSupport::OrderedOptions#extractable_options?` and have it return true to fix.