### PR TITLE
Update fragment caching doc [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -24,7 +24,7 @@ module ActionView
       # This approach will assume that when a new topic is added, you'll touch
       # the project. The cache key generated from this call will be something like:
       #
-      #   views/template/action.html.erb:7a1156131a6928cb0026877f8b749ac9/projects/123
+      #   views/template/action:7a1156131a6928cb0026877f8b749ac9/projects/123
       #         ^template path           ^template tree digest            ^class   ^id
       #
       # This cache key is stable, but it's combined with a cache version derived from the project

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -88,19 +88,17 @@ When your application receives its first request to this page, Rails will write
 a new cache entry with a unique key. A key looks something like this:
 
 ```
-views/products/index.html.erb:bea67108094918eeba42cd4a6e786901/products/1
+views/products/index:bea67108094918eeba42cd4a6e786901/products/1
 ```
 
-`products/1` is a stable key but a cache version, derived from the product
-record, is stored in the cache entry. When the product `updated_at` is touched,
-the `cache_version` changes. Rails will check it when pulling the entry from the
-cache and write the new information to the same cache key. This is called recyclable
-key-based expiration.
-
 The string of characters in the middle is a template tree digest. It is a hash
-digest computed based on the contents of the entire template file. If
-you change the template file (e.g., the HTML changes), the digest will change,
+digest computed based on the contents of the view fragment you are caching. If
+you change the view fragment (e.g., the HTML changes), the digest will change,
 expiring the existing file.
+
+A cache version, derived from the product record, is stored in the cache entry.
+When the product is touched, the cache version changes, and any cached fragments
+that contain the previous version are ignored.
 
 TIP: Cache stores like Memcached will automatically delete old cache files.
 

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -88,21 +88,19 @@ When your application receives its first request to this page, Rails will write
 a new cache entry with a unique key. A key looks something like this:
 
 ```
-views/products/1-201505056193031061005000/bea67108094918eeba42cd4a6e786901
+views/products/index.html.erb:bea67108094918eeba42cd4a6e786901/products/1
 ```
 
-The number in the middle is the `product_id` followed by the timestamp value in
-the `updated_at` attribute of the product record. Rails uses the timestamp value
-to make sure it is not serving stale data. If the value of `updated_at` has
-changed, a new key will be generated. Then Rails will write a new cache to that
-key, and the old cache written to the old key will never be used again. This is
-called key-based expiration.
+`products/1` is a stable key but a cache version, derived from the product
+record, is stored in the cache entry. When the product `updated_at` is touched,
+the `cache_version` changes. Rails will check it when pulling the entry from the
+cache and write the new information to the same cache key. This is called recyclable
+key-based expiration.
 
-Cache fragments will also be expired when the view fragment changes (e.g., the
-HTML in the view changes). The string of characters at the end of the key is a
-template tree digest. It is a hash digest computed based on the contents of the
-view fragment you are caching. If you change the view fragment, the digest will
-change, expiring the existing file.
+The string of characters in the middle is a template tree digest. It is a hash
+digest computed based on the contents of the entire template file. If
+you change the template file (e.g., the HTML changes), the digest will change,
+expiring the existing file.
 
 TIP: Cache stores like Memcached will automatically delete old cache files.
 


### PR DESCRIPTION
### Summary

I updated Fragment Caching section according to the changes introduced in [Recyclable cache keys](https://github.com/rails/rails/pull/29092)
