### PR TITLE
Conform `bin` files to rails style guide

### DIFF
--- a/actionmailbox/test/dummy/bin/bundle
+++ b/actionmailbox/test/dummy/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/actionmailbox/test/dummy/bin/rails
+++ b/actionmailbox/test/dummy/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/actionmailbox/test/dummy/bin/rake
+++ b/actionmailbox/test/dummy/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+# frozen_string_literal: true
+
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/actionmailbox/test/dummy/bin/setup
+++ b/actionmailbox/test/dummy/bin/setup
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+# frozen_string_literal: true
+
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,24 +15,24 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  # system "bin/yarn"
 
   # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
+  # unless File.exist?("config/database.yml")
+  #   cp "config/database.yml.sample", "config/database.yml"
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/actionmailbox/test/dummy/bin/update
+++ b/actionmailbox/test/dummy/bin/update
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+# frozen_string_literal: true
+
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,19 +15,19 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  # system "bin/yarn"
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/actionmailbox/test/dummy/bin/yarn
+++ b/actionmailbox/test/dummy/bin/yarn
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
-APP_ROOT = File.expand_path('..', __dir__)
+# frozen_string_literal: true
+
+APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg", *ARGV
+rescue Errno::ENOENT
+  $stderr.puts "Yarn executable was not detected in the system."
+  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/actiontext/test/dummy/bin/bundle
+++ b/actiontext/test/dummy/bin/bundle
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/actiontext/test/dummy/bin/rails
+++ b/actiontext/test/dummy/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/actiontext/test/dummy/bin/rake
+++ b/actiontext/test/dummy/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+# frozen_string_literal: true
+
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/actiontext/test/dummy/bin/setup
+++ b/actiontext/test/dummy/bin/setup
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+# frozen_string_literal: true
+
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,24 +15,24 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  # system "bin/yarn"
 
   # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
+  # unless File.exist?("config/database.yml")
+  #   cp "config/database.yml.sample", "config/database.yml"
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/actiontext/test/dummy/bin/update
+++ b/actiontext/test/dummy/bin/update
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+# frozen_string_literal: true
+
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -13,19 +15,19 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  # system "bin/yarn"
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/actiontext/test/dummy/bin/webpack
+++ b/actiontext/test/dummy/bin/webpack
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"]  ||= "development"

--- a/actiontext/test/dummy/bin/webpack-dev-server
+++ b/actiontext/test/dummy/bin/webpack-dev-server
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"]  ||= "development"

--- a/actiontext/test/dummy/bin/yarn
+++ b/actiontext/test/dummy/bin/yarn
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
-APP_ROOT = File.expand_path('..', __dir__)
+# frozen_string_literal: true
+
+APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg", *ARGV
+rescue Errno::ENOENT
+  $stderr.puts "Yarn executable was not detected in the system."
+  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,7 +1,9 @@
-require 'fileutils'
+# frozen_string_literal: true
+
+require "fileutils"
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -12,28 +14,28 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 <% unless options.skip_javascript? -%>
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  # system "bin/yarn"
 <% end -%>
 <% unless options.skip_active_record? -%>
 
   # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
+  # unless File.exist?("config/database.yml")
+  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+  system! "bin/rails db:prepare"
 <% end -%>
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end


### PR DESCRIPTION
### Summary

I noticed that new rails apps have inconsistent style in some of the auto-generated bin files.
I dug up a little and saw there are some bin files that are being skipped on rubocop run.

Also, template file [`railties/lib/rails/generators/rails/app/templates/bin/setup.tt`](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/bin/setup.tt) is not being linted, as rubocop can't parse that file.

I've manually edited that file.

### Other Information

It's odd to see that `actionmailbox` and `actiontext` `dummy` directory are skipped (https://github.com/rails/rails/blob/master/.rubocop.yml#L16-L17), but, for example `activestorage`'s [`dummy`](https://github.com/rails/rails/tree/master/activestorage/test/dummy/bin) directory is not skipped.
Perhaps all should be skipped or all should be linted?

Here are repro steps to automatically run the changes I've run on dummy folders:
`rubocop -a actionmailbox/test/dummy/bin/* actiontext/test/dummy/bin/*`

To get the full diff (of `setup.tt` you can run this):
`git revert HEAD`
`rubocop -a actionmailbox/test/dummy/bin/* actiontext/test/dummy/bin/*`
`git diff HEAD HEAD~2`
Here's the result of that diff (rubocop-only vs rubocop+manual changes):
https://github.com/vfonic/rails/compare/rails-bin-style...vfonic:rails-bin-files

EDIT: Upon further investigation, there are more files that use single quotes. For example: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/bin/rails.tt

I guess a good way to find all of these would be to create a new rails app and run rubocop the files generated.

Does it make sense to change all of these or is this just becoming too much of a bikeshedding? :)
