### PR TITLE
Fix small typo in activejob changelog (arugments -> arguments)

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -7,7 +7,7 @@
           end
         end
 
-    When dealing with sensitive arugments as password and tokens it is now possible to configure the job
+    When dealing with sensitive arguments as password and tokens it is now possible to configure the job
     to not put the sensitive argument in the logs.
 
     *Rafael Mendonça França*


### PR DESCRIPTION
Spotted a small typo in activejob changelog while viewing some recent merges.