### PR TITLE
Dump schema after running namespaced migrate tasks

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -112,6 +112,7 @@ db_namespace = namespace :db do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
         ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
+        db_namespace["_dump"].invoke
       end
     end
 


### PR DESCRIPTION
Namespaced migration tasks should dump the database
schema after being run (if dump_schema_after_migration
is set). This updates db:migrate:namespace to dump schema.