### PR TITLE
Backport #31901 to Rails 5.0

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Fix minitest rails plugin. The custom reporters are added only if needed. This will fix conflicts with others plugins. *Kevin Robatel*
+
 ## Rails 5.0.7.2 (March 11, 2019) ##
 
 *   Generate random development secrets

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -38,10 +38,19 @@ module Minitest
       Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)
     end
 
+    self.plugin_rails_replace_reporters(reporter, options)
+  end
+
+  def self.plugin_rails_replace_reporters(minitest_reporter, options)
+    return unless minitest_reporter.kind_of?(Minitest::CompositeReporter)
+
     # Replace progress reporter for colors.
-    reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }
-    reporter << SuppressedSummaryReporter.new(options[:io], options)
-    reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+    if minitest_reporter.reporters.reject! { |reporter| reporter.kind_of?(SummaryReporter) } != nil
+      minitest_reporter << SuppressedSummaryReporter.new(options[:io], options)
+    end
+    if minitest_reporter.reporters.reject! { |reporter| reporter.kind_of?(ProgressReporter) } != nil
+      minitest_reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+    end
   end
 
   # Backwardscompatibility with Rails 5.0 generated plugin test scripts

--- a/railties/test/minitest/rails_plugin_test.rb
+++ b/railties/test/minitest/rails_plugin_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class Minitest::RailsPluginTest < ActiveSupport::TestCase
+  setup do
+    @options = Minitest.process_args []
+    @output = StringIO.new("".encode("UTF-8"))
+  end
+
+  test "default reporters are replaced" do
+    reporter = Minitest::CompositeReporter.new
+    reporter << Minitest::SummaryReporter.new(@output, @options)
+    reporter << Minitest::ProgressReporter.new(@output, @options)
+    reporter << Minitest::Reporter.new(@output, @options)
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+
+    assert_equal 3, reporter.reporters.count
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(Minitest::SuppressedSummaryReporter) }
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(::Rails::TestUnitReporter) }
+    assert reporter.reporters.any? { |candidate| candidate.kind_of?(Minitest::Reporter) }
+  end
+
+  test "no custom reporters are added if nothing to replace" do
+    reporter = Minitest::CompositeReporter.new
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+
+    assert_equal 0, reporter.reporters.count
+  end
+
+  test "handle the case when reporter is not CompositeReporter" do
+    reporter = Minitest::Reporter.new
+
+    Minitest::plugin_rails_replace_reporters(reporter, {})
+  end
+end


### PR DESCRIPTION
#31901 fixes an issue where there's mixed output when running tests when the [minitest-reporters](https://github.com/kern/minitest-reporters) is imported.

I know that 5.0 is not actively maintained anymore, and I'm fine if you decide to close this PR. But this is a trivial fix to backport, so I think it may be worth it.

/cc @Kevinrob