### PR TITLE
Set autocomplete to off for _method tag

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -722,7 +722,7 @@ module ActionView
         end
 
         def method_tag(method)
-          tag("input", type: "hidden", name: "_method", value: method.to_s)
+          tag("input", type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
         end
 
         # Returns an array of hashes each containing :name and :value keys


### PR DESCRIPTION
Firefox can _sometimes_ set this field's value to the authenticity token. This option tells Firefox (and other browsers) not to do this.

Here's a screenshot of Firefox doing this weird thing:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/2687/68630840-b7ea8c80-053c-11ea-8aa4-939e006de577.png">