### PR TITLE
Don't recursive call for value local variable that type is Array in `ActiveSupport::ParameterFilter::CompiledFilter#value_for_key`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't recursive call for value local variable that type is Array in `ActiveSupport::ParameterFilter::CompiledFilter#value_for_key`
+
+    *Yuji Kamijima*
+
 *   Add block support to `ActiveSupport::Testing::TimeHelpers#travel_back`.
 
     *Tim Masliuchenko*

--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -118,7 +118,7 @@ module ActiveSupport
           # If we don't pop the current parent it will be duplicated as we
           # process each array value.
           parents.pop if deep_regexps
-          value = value.map { |v| value_for_key(key, v, parents, original_params) }
+          value = value.map { |v| v.is_a?(Hash) ? value_for_key(key, v, parents, original_params) : v }
           # Restore the parent stack after processing the array.
           parents.push(key) if deep_regexps
         elsif blocks.any?

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -36,8 +36,8 @@ class ParameterFilterTest < ActiveSupport::TestCase
       before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world" } } }
       after_filter["barg"]  = { :bargain => "niag", "blah" => "[FILTERED]", "bar" => { "bargain" => { "blah" => "[FILTERED]", "hello" => "world!" } } }
 
-      before_filter["array_elements"] = %w(element1 element2)
-      after_filter["array_elements"] = %w(ELEMENT1 ELEMENT2)
+      before_filter["array_elements"] = ["element1", ["element2"], [["element3"]], [{ name: "element4" }], { name: "element5" }]
+      after_filter["array_elements"] = ["element1", ["element2"], [["element3"]], [{ name: "element4" }], { name: "element5" }]
 
       assert_equal after_filter, parameter_filter.filter(before_filter)
     end


### PR DESCRIPTION
### Summary
After Rails6, ParameterFilter has been added a breaking change that recursive call for Array object. Why don't we return to the behavior to Rails 5.2type??

```rb
###### less than or equal to Rails5.2.x ######
# ref: https://github.com/rails/rails/blob/v5.2.3/actionpack/lib/action_dispatch/http/parameter_filter.rb#L70

def call(original_params, parents = [])
  filtered_params = original_params.class.new

  original_params.each do |key, value|
    parents.push(key) if deep_regexps
    if regexps.any? { |r| key =~ r }
      value = FILTERED
    elsif deep_regexps && (joined = parents.join(".")) && deep_regexps.any? { |r| joined =~ r }
      value = FILTERED
    elsif value.is_a?(Hash)
      value = call(value, parents)
    elsif value.is_a?(Array)
      ### WARNING ###
      # Return a inside object in `value` if the inside object's type is not Hash
      value = value.map { |v| v.is_a?(Hash) ? call(v, parents) : v }
    elsif blocks.any?
      key = key.dup if key.duplicable?
      value = value.dup if value.duplicable?
      blocks.each { |b| b.call(key, value) }
    end
    parents.pop if deep_regexps

    filtered_params[key] = value
  end

  filtered_params
end

###### after Rails6 ######
# ref: https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/parameter_filter.rb#L116

def value_for_key(key, value, parents = [], original_params = nil)
  parents.push(key) if deep_regexps
  if regexps.any? { |r| r.match?(key) }
    value = @mask
  elsif deep_regexps && (joined = parents.join(".")) && deep_regexps.any? { |r| r.match?(joined) }
    value = @mask
  elsif value.is_a?(Hash)
    value = call(value, parents, original_params)
  elsif value.is_a?(Array)
    # If we don't pop the current parent it will be duplicated as we
    # process each array value.
    parents.pop if deep_regexps
    ### WARNING ###
    # executed recursive call...
    value = value.map { |v| value_for_key(key, v, parents, original_params) }
    # Restore the parent stack after processing the array.
    parents.push(key) if deep_regexps
  elsif blocks.any?
    key = key.dup if key.duplicable?
    value = value.dup if value.duplicable?
    blocks.each { |b| b.arity == 2 ? b.call(key, value) : b.call(key, value, original_params) }
  end
  parents.pop if deep_regexps
  value
end
```


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Nothing in this time.