### PR TITLE
Don't parse DB specific locking docs as code

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -53,8 +53,12 @@ module ActiveRecord
     #   end
     #
     # Database-specific information on row locking:
-    #   MySQL: https://dev.mysql.com/doc/refman/en/innodb-locking-reads.html
-    #   PostgreSQL: https://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
+    #
+    # [MySQL]
+    #   https://dev.mysql.com/doc/refman/en/innodb-locking-reads.html
+    #
+    # [PostgreSQL]
+    #   https://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
     module Pessimistic
       # Obtain a row lock on this record. Reloads the record to obtain the requested
       # lock. Pass an SQL locking clause to append the end of the SELECT statement


### PR DESCRIPTION
### Summary

It was showing the two links as code with weird parsing.

<img width="767" alt="image" src="https://user-images.githubusercontent.com/1051/68682992-517a6400-0566-11ea-94c0-02534a62a7a9.png">

https://api.rubyonrails.org/v6.0.0/classes/ActiveRecord/Locking/Pessimistic.html