### PR TITLE
Fix ActiveRecord cache on queries with limit/offset

### DIFF
--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -13,60 +13,68 @@ module ActiveRecord
     fixtures :developers, :projects, :developers_projects, :topics, :comments, :posts
 
     test "collection_cache_key on model" do
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, Developer.collection_cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, Developer.collection_cache_key)
     end
 
     test "cache_key for relation" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc)
       last_developer_timestamp = developers.first.updated_at
+      first_developer_timestamp = developers.last.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $4
     end
 
     test "cache_key for relation with limit" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5)
       last_developer_timestamp = developers.first.updated_at
+      first_developer_timestamp = developers.last.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $4
     end
 
     test "cache_key for relation with custom select and limit" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5)
       developers_with_select = developers.select("developers.*")
       last_developer_timestamp = developers.first.updated_at
+      first_developer_timestamp = developers.last.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers_with_select.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers_with_select.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers_with_select.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/ =~ developers_with_select.cache_key
 
       assert_equal ActiveSupport::Digest.hexdigest(developers_with_select.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $4
     end
 
     test "cache_key for loaded relation" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5).load
       last_developer_timestamp = developers.first.updated_at
+      first_developer_timestamp = developers.last.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $4
     end
 
     test "cache_key for relation with table alias" do
@@ -81,24 +89,26 @@ module ActiveRecord
       )
       developers = developers.where(salary: 100000).order(updated_at: :desc)
       last_developer_timestamp = developers.first.updated_at
+      first_developer_timestamp = developers.last.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
       assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $4
     end
 
     test "cache_key for relation with includes" do
       comments = Comment.includes(:post).where("posts.type": "Post")
-      assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)\z/, comments.cache_key)
+      assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, comments.cache_key)
     end
 
     test "cache_key for loaded relation with includes" do
       comments = Comment.includes(:post).where("posts.type": "Post").load
-      assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)\z/, comments.cache_key)
+      assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, comments.cache_key)
     end
 
     test "it triggers at most one query" do
@@ -138,7 +148,7 @@ module ActiveRecord
 
     test "collection proxy provides a cache_key" do
       developers = projects(:active_record).developers
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
 
     test "cache_key for loaded collection with zero size" do
@@ -157,19 +167,19 @@ module ActiveRecord
     test "cache_key with a relation having selected columns" do
       developers = Developer.select(:salary)
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
 
     test "cache_key with a relation having distinct and order" do
       developers = Developer.distinct.order(:salary).limit(5)
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
 
     test "cache_key with a relation having custom select and order" do
       developers = Developer.select("name AS dev_name").order("dev_name DESC").limit(5)
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
 
     test "cache_key should be stable when using collection_cache_versioning" do
@@ -188,13 +198,15 @@ module ActiveRecord
       with_collection_cache_versioning do
         developers = Developer.where(salary: 100000).order(updated_at: :desc)
         last_developer_timestamp = developers.first.updated_at
+        first_developer_timestamp = developers.last.updated_at
 
-        assert_match(/(\d+)-(\d+)\z/, developers.cache_version)
+        assert_match(/(\d+)-(\d+)-(\d+)\z/, developers.cache_version)
 
-        /(\d+)-(\d+)\z/ =~ developers.cache_version
+        /(\d+)-(\d+)-(\d+)\z/ =~ developers.cache_version
 
         assert_equal developers.count.to_s, $1
         assert_equal last_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $2
+        assert_equal first_developer_timestamp.to_s(ActiveRecord::Base.cache_timestamp_format), $3
       end
     end
 


### PR DESCRIPTION
### Summary
This PR fixes an old problem with the caching of queries with limit.
The correction can be tested using the sample app submitted by @marckohlbrugge in #37555 (the most recent issue on the subject).

Before this change the cache_version format would be:

**"count-max_timestamp (usually updated_at)"**
ex: **"3-20191111224826321158"**

But in [some scenarios](https://github.com/rails/rails/issues/37555) involving limit and specific ordering
this data wasn't enough to invalidate the cache correctly, so
this PR changes the format to:

**"count-max_timestamp-min_timestamp"**
ex: **"3-20191111224826321158-20191111224826321030"**

### Benchmarks
The benchmarks were conducted using this script:
https://gist.github.com/victor-am/2a4302c8878b56221aceb613d001609c

Any suggestions on different scenarios for the benchmarks would be appreciated 😄 

**❗️Since this problem seems to occur almost exclusively with limit queries we could only apply this change on those scenarios to avoid messing with the non-limit queries. The downside would be to have two formats of cache_version (`count-timestamp` and `count-timestamp-timestamp`). Let me know if this is preferable 🤔**

And the results are as following:
```
========================= Query with limit 3 and order =========================

Warming up --------------------------------------
       Before change     1.000  i/100ms
        After change     1.000  i/100ms
Calculating -------------------------------------
       Before change     12.590  (±23.8%) i/s -     59.000  in   5.036258s
        After change     13.194  (± 7.6%) i/s -     66.000  in   5.037225s

Comparison:
        After change:       13.2 i/s
       Before change:       12.6 i/s - same-ish: difference falls within error


====================== Query with limit 100_000 and order ======================

Warming up --------------------------------------
       Before change     1.000  i/100ms
        After change     1.000  i/100ms
Calculating -------------------------------------
       Before change      6.656  (± 0.0%) i/s -     34.000  in   5.120976s
        After change      6.204  (±16.1%) i/s -     31.000  in   5.060640s

Comparison:
       Before change:        6.7 i/s
        After change:        6.2 i/s - same-ish: difference falls within error


============================== Query with limit 3 ==============================

Warming up --------------------------------------
       Before change   242.000  i/100ms
        After change   240.000  i/100ms
Calculating -------------------------------------
       Before change      2.582k (± 9.2%) i/s -     12.826k in   5.026062s
        After change      1.955k (±12.5%) i/s -      9.600k in   5.002996s

Comparison:
       Before change:     2582.0 i/s
        After change:     1954.6 i/s - 1.32x  slower


=========================== Query with limit 100_000 ===========================

Warming up --------------------------------------
       Before change     5.000  i/100ms
        After change     5.000  i/100ms
Calculating -------------------------------------
       Before change     62.924  (±14.3%) i/s -    310.000  in   5.018337s
        After change     54.579  (± 7.3%) i/s -    275.000  in   5.064948s

Comparison:
       Before change:       62.9 i/s
        After change:       54.6 i/s - same-ish: difference falls within error


======================= Query without limit (30 results) =======================

Warming up --------------------------------------
       Before change   204.000  i/100ms
        After change   154.000  i/100ms
Calculating -------------------------------------
       Before change      1.826k (±31.1%) i/s -      7.752k in   5.106217s
        After change      2.054k (±17.0%) i/s -      9.856k in   5.012670s

Comparison:
        After change:     2054.1 i/s
       Before change:     1826.0 i/s - same-ish: difference falls within error


==================== Query without limit (500_000 results) =====================

Warming up --------------------------------------
       Before change     1.000  i/100ms
        After change     1.000  i/100ms
Calculating -------------------------------------
       Before change     20.596  (± 9.7%) i/s -    103.000  in   5.036099s
        After change     19.041  (± 5.3%) i/s -     95.000  in   5.012132s

Comparison:
       Before change:       20.6 i/s
        After change:       19.0 i/s - same-ish: difference falls within error
```