### PR TITLE
Prevent nesting failure screenshots into dirs

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Replaces (back)slashes in failure screenshot image paths with dashes.
+
+    If a failed test case contained a slash or a backslash, a screenshot would be created in a
+    nested directory, causing issues with `tmp:clear`.
+
+    *Damir Zekic*
+
 *   Add `params.member?` to mimic Hash behavior
 
     *Younes Serraj*

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -62,7 +62,8 @@ module ActionDispatch
           end
 
           def image_name
-            name = "#{unique}_#{method_name}"
+            sanitized_method_name = method_name.tr("/\\", "--")
+            name = "#{unique}_#{sanitized_method_name}"
             name[0...225]
           end
 

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -104,6 +104,15 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       assert_equal Rails.root.join("tmp/screenshots/0_x.png").to_s, @new_test.send(:image_path)
     end
   end
+
+  test "slashes and backslashes are replaced with dashes in paths" do
+    slash_test = DrivenBySeleniumWithChrome.new("x/y\\z")
+
+    Rails.stub :root, Pathname.getwd do
+      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z.png").to_s, slash_test.send(:image_path)
+      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z.html").to_s, slash_test.send(:html_path)
+    end
+  end
 end
 
 class RackTestScreenshotsTest < DrivenByRackTest


### PR DESCRIPTION
### Summary

When a failing test method name includes a slash (e.g. `test "signup on the /signup page"`) the screenshot is generated in the nested directory on systems that use slash as a directory separator (e.g. a screenshot called `signup_page.png` is generated within `failures_signup_on_the_`).

Nesting screenshots causes an issue with `tmp:clear` rake task:

```
== Removing old logs and tempfiles ==
rails aborted!
Errno::EISDIR: Is a directory @ apply2files - tmp/screenshots/failures_signup_on_the_
/var/lib/gems/2.5.0/gems/railties-5.2.3/lib/rails/tasks/tmp.rake:41:in `block (3 levels) in <top (required)>'
/var/lib/gems/2.5.0/gems/railties-5.2.3/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
...
Tasks: TOP => tmp:clear => tmp:screenshots:clear
```

While the error could be prevented by changing `tmp:clear` task, there's no reason to generate deep directory structures for tests using slashes.

To prevent a similar problem on Windows, backslashes are also "sanitized".

Replacing the problamatic characters with dashes seems to be a safe workaround, although dash is an arbitrary choice in this case.