### PR TITLE
Add missing require to PathSet

### DIFF
--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/module/deprecation"
+
 module ActionView #:nodoc:
   # = Action View PathSet
   #


### PR DESCRIPTION
### Summary

In some circumstances PathSet would complain about a missing deprecate method.
