### PR TITLE
Backfill ActionView changelog for Rails 6.0

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -44,6 +44,11 @@
 
     *Edward Rudd*
 
+*   `ActionView::TemplateRender.render(file: )` now renders the file directly,
+    without using any handlers, using the new `Template::RawFile` class.
+
+    *John Hawthorn*, *Cliff Pruitt*
+
 
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -82,6 +82,11 @@
 
     *Mark Edmondson*
 
+*   Single arity template handlers are deprecated.  Template handlers must
+    now accept two parameters, the view object and the source for the view object.
+
+    *tenderlove*
+
 
 ## Rails 6.0.0.beta1 (January 18, 2019) ##
 

--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -304,6 +304,11 @@ Please refer to the [Changelog][action-view] for detailed changes.
     Paths should now be absolute.
     ([Pull Request](https://github.com/rails/rails/pull/35688))
 
+*   Deprecate single arity template handlers. The `call` method of
+    `ActionView::Template::Handlers` subclasses should now accept two parameters,
+    the view object and the source for the view object.
+    ([Pull Request](https://github.com/rails/rails/pull/35119))
+
 ### Notable changes
 
 *   Clear ActionView cache in development only on file changes, speeding up

--- a/guides/source/6_0_release_notes.md
+++ b/guides/source/6_0_release_notes.md
@@ -300,6 +300,10 @@ Please refer to the [Changelog][action-view] for detailed changes.
 *   Deprecate calling private model methods from the `options_from_collection_for_select` view helper.
     ([Pull Request](https://github.com/rails/rails/pull/33547))
 
+*   Deprecate `ActionView::TemplateRender.render(file: )` handling relative paths.
+    Paths should now be absolute.
+    ([Pull Request](https://github.com/rails/rails/pull/35688))
+
 ### Notable changes
 
 *   Clear ActionView cache in development only on file changes, speeding up
@@ -336,6 +340,10 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 *   Add I18n key style support for locale keys to submit tags.
     ([Pull Request](https://github.com/rails/rails/pull/26799))
+
+*   `ActionView::TemplateRender.render(file: )` now renders the file directly,
+    without using any handlers, using the new `Template::RawFile` class.
+    ([Pull Request](https://github.com/rails/rails/pull/35688))
 
 Action Mailer
 -------------


### PR DESCRIPTION
### Summary

This PR backfills the [Rails 6 Release Notes](https://edgeguides.rubyonrails.org/6_0_release_notes.html) and [Action View changelog](https://github.com/rails/rails/blob/6-0-stable/actionview/CHANGELOG.md) to include deprecations introduced in:

- https://github.com/rails/rails/pull/35688 `render(file: )` behaviour change
- https://github.com/rails/rails/pull/35119 Custom template handlers should accept two parameters

/cc @rafaelfranca 
