### PR TITLE
Fix documentation regarding X-Frame-Options values

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1045,7 +1045,7 @@ config.action_dispatch.default_headers.clear
 
 Here is a list of common headers:
 
-* **X-Frame-Options:** _'SAMEORIGIN' in Rails by default_ - allow framing on same domain. Set it to 'DENY' to deny framing at all or 'ALLOWALL' if you want to allow framing for all website.
+* **X-Frame-Options:** _'SAMEORIGIN' in Rails by default_ - allow framing on same domain. Set it to 'DENY' to deny framing at all or remove this header completely if you want to allow framing on all websites.
 * **X-XSS-Protection:** _'1; mode=block' in Rails by default_ - use XSS Auditor and block page if XSS attack is detected. Set it to '0;' if you want to switch XSS Auditor off(useful if response contents scripts from request parameters)
 * **X-Content-Type-Options:** _'nosniff' in Rails by default_ - stops the browser from guessing the MIME type of a file.
 * **X-Content-Security-Policy:** [A powerful mechanism for controlling which sites certain content types can be loaded from](http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html)


### PR DESCRIPTION
### Summary

There are two possible directives for X-Frame-Options:

```
X-Frame-Options: deny
X-Frame-Options: sameorigin
```

`ALLOWALL` is not a valid value and using it can sometimes be interpreted as `DENY`.

### Other Information

This documentation has been this way (at least) since Rails 4.0 and should be fixed for all versions.
