### PR TITLE
Change execute_batch to take array of statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -184,7 +184,7 @@ module ActiveRecord
 
       # Executes the truncate statement.
       def truncate(table_name, name = nil)
-        execute(build_truncate_statements(table_name), name)
+        execute(build_truncate_statement(table_name), name)
       end
 
       def truncate_tables(*table_names) # :nodoc:
@@ -194,9 +194,8 @@ module ActiveRecord
 
         with_multi_statements do
           disable_referential_integrity do
-            Array(build_truncate_statements(*table_names)).each do |sql|
-              execute_batch(sql, "Truncate Tables")
-            end
+            statements = build_truncate_statements(table_names)
+            execute_batch(statements, "Truncate Tables")
           end
         end
       end
@@ -365,14 +364,12 @@ module ActiveRecord
       def insert_fixtures_set(fixture_set, tables_to_delete = [])
         fixture_inserts = build_fixture_statements(fixture_set)
         table_deletes = tables_to_delete.map { |table| "DELETE FROM #{quote_table_name(table)}" }
-        total_sql = Array(combine_multi_statements(table_deletes + fixture_inserts))
+        statements = table_deletes + fixture_inserts
 
         with_multi_statements do
           disable_referential_integrity do
             transaction(requires_new: true) do
-              total_sql.each do |sql|
-                execute_batch(sql, "Fixtures Load")
-              end
+              execute_batch(statements, "Fixtures Load")
             end
           end
         end
@@ -408,8 +405,10 @@ module ActiveRecord
       end
 
       private
-        def execute_batch(sql, name = nil)
-          execute(sql, name)
+        def execute_batch(statements, name = nil)
+          statements.each do |statement|
+            execute(statement, name)
+          end
         end
 
         DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
@@ -469,11 +468,14 @@ module ActiveRecord
           end.compact
         end
 
-        def build_truncate_statements(*table_names)
-          truncate_tables = table_names.map do |table_name|
-            "TRUNCATE TABLE #{quote_table_name(table_name)}"
+        def build_truncate_statement(table_name)
+          "TRUNCATE TABLE #{quote_table_name(table_name)}"
+        end
+
+        def build_truncate_statements(table_names)
+          table_names.map do |table_name|
+            build_truncate_statement(table_name)
           end
-          combine_multi_statements(truncate_tables)
         end
 
         def with_multi_statements

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -82,8 +82,10 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         private
-          def execute_batch(sql, name = nil)
-            super
+          def execute_batch(statements, name = nil)
+            combine_multi_statements(statements).each do |statement|
+              execute(statement, name)
+            end
             @connection.abandon_results!
           end
 
@@ -97,14 +99,6 @@ module ActiveRecord
 
           def supports_set_server_option?
             @connection.respond_to?(:set_server_option)
-          end
-
-          def build_truncate_statements(*table_names)
-            if table_names.size == 1
-              super.first
-            else
-              super
-            end
           end
 
           def multi_statements_enabled?(flags)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -166,8 +166,12 @@ module ActiveRecord
         end
 
         private
-          def build_truncate_statements(*table_names)
-            "TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"
+          def execute_batch(statements, name = nil)
+            execute(combine_multi_statements(statements))
+          end
+
+          def build_truncate_statements(table_names)
+            ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
           end
 
           # Returns the current ID of a table's sequence.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -87,7 +87,9 @@ module ActiveRecord
         end
 
         private
-          def execute_batch(sql, name = nil)
+          def execute_batch(statements, name = nil)
+            sql = combine_multi_statements(statements)
+
             if preventing_writes? && write_query?(sql)
               raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
             end
@@ -112,11 +114,8 @@ module ActiveRecord
             end.compact
           end
 
-          def build_truncate_statements(*table_names)
-            truncate_tables = table_names.map do |table_name|
-              "DELETE FROM #{quote_table_name(table_name)}"
-            end
-            combine_multi_statements(truncate_tables)
+          def build_truncate_statement(table_name)
+            "DELETE FROM #{quote_table_name(table_name)}"
           end
       end
     end


### PR DESCRIPTION
Adapters don't necessarily have the ability to execute a batch of statements.

Previously execute_batch took a single string of statements separated by `;`, this meant that all adapters needed to be able to execute batch statements.

Instead, this commit changes the method to take an array of statements. Adapters which support batched queries can do the join there. For adapters which don't we provide a fallback implementation: executing each statement one at a time.

This also improves the implementation for the mysql2 adapter, which understands that there is a maximium query length. Previously the caller needed to split the statements before passing them to execute_batch, now execute_batch itself is responsible for splitting the queries.

cc @kamipo @tenderlove @eileencodes 