### PR TITLE
Fix ActiveStorage::Blob#service method redefined warning

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -33,7 +33,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
   store :metadata, accessors: [ :analyzed, :identified ], coder: ActiveRecord::Coders::JSON
 
   class_attribute :services, default: {}
-  class_attribute :service
+  class_attribute :service, instance_accessor: false
 
   has_many :attachments
 


### PR DESCRIPTION
### Summary

Fixes instance method redefinition warning in `ActiveStorage::Blob` caused by `class_attribute :service`. We don't want `blob.service=` to write to the class variable so I've removed that as well.

Eg. https://buildkite.com/rails/rails/builds/64896#dc86e6e0-e9c9-42e6-97a2-7bcb8d164d3c