### PR TITLE
Fix belongs_to associations with missing FKs or missing models

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -89,6 +89,16 @@ module ActiveRecord
         end
 
         def find_target?
+          # Here we only check for the presence of the foreign key attribute, which
+          # returns false even when the FK column does not exist at all.
+          # Perhaps we should check first whether foreign_key_column_present?
+          # and raise an error?
+
+          # For the other scenario where the model class is gone / not defined anymore,
+          # I think the simple fix would be to justk check for 'klass' before checking
+          # for 'foreign_key_present?'. This makes sure that the checking for klass definition
+          # takes precedence and the error is raised.
+
           !loaded? && foreign_key_present? && klass
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1365,6 +1365,41 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_raise_error_when_foreign_key_missing
+    client = AccountWithInvalidAssociations.new
+
+    error = assert_raises { client.topic }
+    assert_equal "foreign key column clients.topic_id does not exist", error.message
+  end
+
+  def test_with_custom_association_name_raise_error_when_foreign_key_missing
+    client = AccountWithInvalidAssociations.new
+
+    error = assert_raises { client.other_topic }
+    assert_equal "foreign key column clients.other_topic_id does not exist", error.message
+  end
+
+  def test_with_configured_foreign_key_name_raise_error_when_foreign_key_missing
+    client = AccountWithInvalidAssociations.new
+
+    error = assert_raises { client.other_topic_2 }
+    assert_equal "foreign key column clients.topic_id does not exist", error.message
+  end
+
+  def test_raise_error_when_association_model_class_not_defined
+    client = AccountWithInvalidAssociations.new
+
+    error = assert_raises { client.bar }
+    assert_equal "uninitialized constant AccountWithInvalidAssociations::Bar", error.message
+  end
+
+  def test_raise_error_when_configured_model_class_for_association_not_defined
+    client = AccountWithInvalidAssociations.new
+
+    error = assert_raises { client.other_bar }
+    assert_equal "uninitialized constant AccountWithInvalidAssociations::Bar", error.message
+  end
 end
 
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/models/account.rb
+++ b/activerecord/test/models/account.rb
@@ -44,3 +44,17 @@ class SubAccount < Account
   end
   private_class_method :instantiate_instance_of
 end
+
+class AccountWithInvalidAssociations < Account
+  # Should raise an error since the :topic_id FK column does not exist
+  belongs_to :topic, required: false
+  # Should raise an error since the :other_bar_id FK column does not exist
+  belongs_to :other_topic, class_name: "Topic", required: false
+  # Should raise an error since the :topic_id FK column does not exist
+  belongs_to :other_topic_2, class_name: "Topic", foreign_key: "topic_id", required: false
+
+  # Should raise an error of AccountWithInvalidAssociations::Bar not found
+  belongs_to :bar, required: false
+  # Should raise an error of AccountWithInvalidAssociations::Bar not found
+  belongs_to :other_bar, class_name: "Bar", required: false
+end


### PR DESCRIPTION
I noticed something very strange with `belongs_to` association and don't know if it's by design.

If I have a model `Foo` that belongs to  `:bar`, but `Foo` does not have the `bar_id` FK column defined, it returns `nil` on `foo.bar`.

```rb
class Foo < ApplicationRecord
  # FK column bar_id does not exist
  belongs_to :bar
end

Foo.new.bar # => returns nil
```

To me that is very weird, since the FK attribute does not exist at all. Would expect an error to be raised. This could lead to hidden bugs, in the scenario where someone removes the FK `foos.bar_id` with a migration but forgets about the AR association somehow.

Imho the ideal would be to fail loud in this case, since this is a (most probably unintentional) mistake during the task of removing the column.

It also lacks consistency, given that for `has_many` associations, an error is raised:

```rb
class Foo < ApplicationRecord
  has_many :bars
end

Foo.new.bars # => raises an error at the query/DB level, since the FK bars.foo_id does not exist
```

It gets even more weird in another other scenario, example:

Someone removes the `bars / Bar` table / model but forgets to remove some of the `belongs_to :bar` associations. Next time the code hits `foo.bar`, the FK `bar_id` is still there but the table and model class are gone. Instead of raising something like `unitiliazed constant Bar` it just silently returns `nil`.

```rb
class Foo < ApplicationRecord
  # FK column still exists but table and model bars/Bar are gone
  belongs_to :bar
end

Foo.new.bar # => returns nil
```

(assuming here that the `foos.bar_id` column didn't have a FK constraint set)

Imo this is also another source of bugs which goes unnoticed.

NOTE: Could have created an issue, but I've investigated the code-base alread and know possible solutions. Just wanted to trigger a discussion and check if it makes sense to proceed with this PR.