### PR TITLE
Remove Resolver autoload

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -11,7 +11,6 @@ module ActiveRecord
     autoload :Column
     autoload :PoolConfig
     autoload :PoolManager
-    autoload :Resolver
 
     autoload_at "active_record/connection_adapters/abstract/schema_definitions" do
       autoload :IndexDefinition


### PR DESCRIPTION
This class has been removed in #37695 but I just noticed this lingering
around while doing some other work!

cc / @eileencodes 