### PR TITLE
Fix yarn issues on CI

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -20,10 +20,7 @@ module ApplicationTests
     def precompile!(env = nil)
       with_env env.to_h do
         quietly do
-          precompile_task = "bin/rails assets:precompile --trace 2>&1"
-          output = Dir.chdir(app_path) { %x[ #{precompile_task} ] }
-          assert $?.success?, output
-          output
+          rails ["assets:precompile", "--trace"]
         end
       end
     end
@@ -37,7 +34,7 @@ module ApplicationTests
 
     def clean_assets!
       quietly do
-        assert Dir.chdir(app_path) { system("bin/rails assets:clobber") }
+        rails ["assets:clobber"]
       end
     end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -528,7 +528,15 @@ Module.new do
       sh "yarn install"
     end
   end
-  FileUtils.cp("#{assets_path}/package.json", "#{app_template_path}/package.json")
+
+  # Fix relative file paths
+  package_json = File.read("#{assets_path}/package.json")
+  package_json.gsub!(%r{"file:(\.\./[^"]+)"}) do
+    path = Pathname.new($1).expand_path(assets_path).relative_path_from(Pathname.new(app_template_path))
+    "\"file:#{path}\""
+  end
+  File.write("#{app_template_path}/package.json", package_json)
+
   FileUtils.cp("#{assets_path}/config/webpacker.yml", "#{app_template_path}/config/webpacker.yml")
   FileUtils.cp_r("#{assets_path}/config/webpack", "#{app_template_path}/config/webpack")
   FileUtils.ln_s("#{assets_path}/node_modules", "#{app_template_path}/node_modules")

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -502,28 +502,39 @@ end
 Module.new do
   extend TestHelpers::Paths
 
+  def self.sh(cmd)
+    output = `#{cmd}`
+    raise "Command #{cmd.inspect} failed. Output:\n#{output}" unless $?.success?
+  end
+
   # Build a rails app
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
 
-  `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install`
+  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
     f.puts "require 'rails/all'"
   end
 
   unless File.exist?("#{RAILS_FRAMEWORK_ROOT}/actionview/lib/assets/compiled/rails-ujs.js")
-    Dir.chdir("#{RAILS_FRAMEWORK_ROOT}/actionview") { `yarn build` }
+    Dir.chdir("#{RAILS_FRAMEWORK_ROOT}/actionview") do
+      sh "yarn build"
+    end
   end
 
   assets_path = "#{RAILS_FRAMEWORK_ROOT}/railties/test/isolation/assets"
   unless Dir.exist?("#{assets_path}/node_modules")
-    Dir.chdir(assets_path) { `yarn install` }
+    Dir.chdir(assets_path) do
+      sh "yarn install"
+    end
   end
   FileUtils.cp("#{assets_path}/package.json", "#{app_template_path}/package.json")
   FileUtils.cp("#{assets_path}/config/webpacker.yml", "#{app_template_path}/config/webpacker.yml")
   FileUtils.cp_r("#{assets_path}/config/webpack", "#{app_template_path}/config/webpack")
   FileUtils.ln_s("#{assets_path}/node_modules", "#{app_template_path}/node_modules")
-  FileUtils.chdir(app_template_path) { `bin/rails webpacker:binstubs` }
+  FileUtils.chdir(app_template_path) do
+    sh "bin/rails webpacker:binstubs"
+  end
 
   # Fake 'Bundler.require' -- we run using the repo's Gemfile, not an
   # app-specific one: we don't want to require every gem that lists.

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -541,6 +541,7 @@ Module.new do
   FileUtils.cp_r("#{assets_path}/config/webpack", "#{app_template_path}/config/webpack")
   FileUtils.ln_s("#{assets_path}/node_modules", "#{app_template_path}/node_modules")
   FileUtils.chdir(app_template_path) do
+    sh "yarn install"
     sh "bin/rails webpacker:binstubs"
   end
 


### PR DESCRIPTION
~Just trying to get output for what's going wrong for now 🤔~

I believe I figured the cause. The way our app template worked involved copying a `package.json` and `node_modules` into an "app template" dir. And we would copy that directory for use in each test using an app.

The app template didn't have a yarn.lock and wasn't necessarily up-to-date so it needed to re-install on each run. The copied package.json had the wrong relative paths so this failed. Furthermore, parallel invocations of yarn or _something_ 😬 ended up with yarn having corrupted packages _surprisingly_ reliably. Running `yarn install` in the app template directory on boot solves this.

This also adds more assertions that when we are setting up the shell commands we run actually succeed.