### PR TITLE
Start delegating QC information to the pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -35,8 +35,7 @@ module ActiveRecord
     class NullPool # :nodoc:
       include ConnectionAdapters::AbstractPool
 
-      def query_cache_enabled
-      end
+      def query_cache_enabled?; false; end
 
       attr_accessor :schema_cache
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -35,6 +35,9 @@ module ActiveRecord
     class NullPool # :nodoc:
       include ConnectionAdapters::AbstractPool
 
+      def query_cache_enabled
+      end
+
       attr_accessor :schema_cache
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -41,15 +41,18 @@ module ActiveRecord
           connection.clear_query_cache if active_connection?
         end
 
-        def query_cache_enabled
+        def query_cache_enabled?
           @query_cache_enabled[connection_cache_key(current_thread)]
         end
+
+        alias :query_cache_enabled :query_cache_enabled?
+        deprecate :query_cache_enabled
       end
 
       attr_reader :query_cache
 
-      QC_ON  = Struct.new(:query_cache_enabled).new(true)
-      QC_OFF = Struct.new(:query_cache_enabled).new(false)
+      QC_ON  = Struct.new(:query_cache_enabled?).new(true)
+      QC_OFF = Struct.new(:query_cache_enabled?).new(false)
 
       def initialize(*)
         super
@@ -71,12 +74,11 @@ module ActiveRecord
       end
 
       def query_cache_enabled?
-        @query_cache_setting.query_cache_enabled
+        @query_cache_setting.query_cache_enabled?
       end
 
-      def query_cache_enabled
-        query_cache_enabled?
-      end
+      alias :query_cache_enabled :query_cache_enabled?
+      deprecate :query_cache_enabled
 
       def disable_query_cache!
         @query_cache_setting = QC_OFF

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -80,6 +80,7 @@ module ActiveRecord
       end
 
       def initialize(connection, logger = nil, config = {}) # :nodoc:
+        @pool                = ActiveRecord::ConnectionAdapters::NullPool.new
         super()
 
         @connection          = connection
@@ -87,7 +88,6 @@ module ActiveRecord
         @instrumenter        = ActiveSupport::Notifications.instrumenter
         @logger              = logger
         @config              = config
-        @pool                = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since          = Concurrent.monotonic_time
         @visitor = arel_visitor
         @statements = build_statement_pool

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       pools = []
 
       ActiveRecord::Base.connection_handlers.each do |key, handler|
-        pools.concat(handler.connection_pool_list.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
+        pools.concat(handler.connection_pool_list.reject { |p| p.query_cache_enabled? }.each { |p| p.enable_query_cache! })
       end
 
       pools

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1037,7 +1037,7 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_reload_via_querycache
     ActiveRecord::Base.connection.enable_query_cache!
     ActiveRecord::Base.connection.clear_query_cache
-    assert ActiveRecord::Base.connection.query_cache_enabled, "cache should be on"
+    assert ActiveRecord::Base.connection.query_cache_enabled?, "cache should be on"
     parrot = Parrot.create(name: "Shane")
 
     # populate the cache with the SELECT result

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -105,7 +105,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
         thread_1_connection = ActiveRecord::Base.connection
         ActiveRecord::Base.clear_active_connections!
-        assert_cache :off, thread_1_connection
+        assert_cache :empty, thread_1_connection
 
         started = Concurrent::Event.new
         checked = Concurrent::Event.new
@@ -138,7 +138,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         checked.set
         thread.join
 
-        assert_cache :off, thread_2_connection
+        assert_cache :empty, thread_2_connection
       }.call({})
 
       ActiveRecord::Base.connection_pool.connections.each do |conn|
@@ -580,6 +580,8 @@ class QueryCacheTest < ActiveRecord::TestCase
       when :dirty
         assert connection.query_cache_enabled, "cache should be on"
         assert_not connection.query_cache.empty?, "cache should be dirty"
+      when :empty
+        assert connection.query_cache.empty?, "cache should be empty"
       else
         raise "unknown state"
       end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -394,7 +394,7 @@ class LoadingTest < ActiveSupport::TestCase
         class OmgController < ActionController::Metal
           ActiveSupport.run_load_hooks(:action_controller, self)
           def show
-            if ActiveRecord::Base.connection.query_cache_enabled
+            if ActiveRecord::Base.connection.query_cache_enabled?
               self.response_body = ["Query cache is enabled."]
             else
               self.response_body = ["Expected ActiveRecord::Base.connection.query_cache_enabled to be true"]
@@ -427,7 +427,7 @@ class LoadingTest < ActiveSupport::TestCase
         class OmgController < ActionController::Metal
           ActiveSupport.run_load_hooks(:action_controller, self)
           def show
-            if ActiveRecord::Base.connection.query_cache_enabled
+            if ActiveRecord::Base.connection.query_cache_enabled?
               self.response_body = ["Query cache is enabled."]
             else
               self.response_body = ["Expected ActiveRecord::Base.connection.query_cache_enabled to be true"]


### PR DESCRIPTION
I would like to maintain a single source of truth with regard to enable / disable of the query cache.  Right now we store whether or not the QC is enabled on both the connection and the pool.  I'd like the connections to ask the pool so that we can store this info in one place.

This PR makes the connections delegate to the pool most of the time.  It allows users to override the QC setting on a per connection basis still.