### PR TITLE
Add first & last_id segments to collection cache_version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Include the IDs of the first and last records of a collection when
+    generating cache keys for Active Record relations using a limit or
+    offset. Update signatures of `ActiveRecord::Relation#cache_version`,
+    `ActiveRecord::Relation#cache_key` and related methods to use keyword
+    arguments instead of positional arguments, add deprecation notices where
+    appropriate. Fixes #31996, #34408 and #37555.
+
+    *Aaron Lipman*
+
 *   Connections can be granularly switched for abstract classes when `connected_to` is called.
 
     This change allows `connected_to` to switch a `role` and/or `shard` for a single abstract class instead of all classes globally. Applications that want to use the new feature need to set `config.active_record.legacy_connection_handling` to `false` in their application configuration.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -597,6 +597,17 @@ module ActiveRecord
       def check_version # :nodoc:
       end
 
+      def cache_version_query(collection, id_column: nil, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.table[timestamp_column])
+        select_values = "COUNT(*) AS collection_size, MAX(#{timestamp_col}) AS timestamp"
+        query = collection.unscope(:order)
+        query.select_values = [select_values]
+        query.arel
+      end
+
+      def set_cache_version_vars # :nodoc:
+      end
+
       private
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -461,6 +461,36 @@ module ActiveRecord
         end
       end
 
+      def cache_version_query(collection, id_column: collection.primary_key, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.table[timestamp_column])
+        id_col = visitor.compile(collection.table[id_column])
+
+        if collection.has_limit_or_offset?
+          collection_table = Arel::Table.new("cache_key_collection")
+          aggregates_table = Arel::Table.new("cache_key_aggregates")
+          query = collection.select("#{id_col} AS collection_cache_key_id, #{timestamp_col} AS collection_cache_key_timestamp")
+          collection_query = Arel::Nodes::SqlLiteral.new "(#{ query.to_sql })"
+          aggregates_query = collection_table.project("COUNT(*) AS collection_size, MAX(collection_cache_key_timestamp) AS timestamp")
+          collection_common_table_expr = Arel::Nodes::As.new(collection_table, collection_query)
+          aggregates_common_table_expr = Arel::Nodes::As.new(aggregates_table, aggregates_query)
+          collection_size_minus_one = Arel::Nodes::Subtraction.new(aggregates_table[:collection_size], 1)
+          last_id_offset = Arel::Nodes::NamedFunction.new("GREATEST", [collection_size_minus_one, 0])
+
+          select_values = [
+            aggregates_table[:collection_size],
+            aggregates_table[:timestamp],
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).as("first_id"),
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).skip(last_id_offset).as("last_id")
+          ]
+
+          aggregates_table
+            .project(select_values)
+            .with(collection_common_table_expr, aggregates_common_table_expr)
+        else
+          super
+        end
+      end
+
       private
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -159,8 +159,8 @@ module ActiveRecord
         end
       end
 
-      def collection_cache_key(collection = all, timestamp_column = :updated_at) # :nodoc:
-        collection.send(:compute_cache_key, timestamp_column)
+      def collection_cache_key(collection = all, id_column: primary_key, timestamp_column: :updated_at) # :nodoc:
+        collection.send(:compute_cache_key, id_column: id_column, timestamp_column: timestamp_column)
       end
     end
 

--- a/activerecord/test/fixtures/movies.yml
+++ b/activerecord/test/fixtures/movies.yml
@@ -5,3 +5,7 @@ first:
 second:
   movieid: 2
   name: Gladiator
+
+second:
+  movieid: 3
+  name: Ghostbusters

--- a/activerecord/test/models/bagel.rb
+++ b/activerecord/test/models/bagel.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Bagel < ActiveRecord::Base
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -89,6 +89,11 @@ ActiveRecord::Schema.define do
     t.integer     :value
   end
 
+  create_table :bagels, force: true do |t|
+    t.string :topping
+    t.timestamps null: false
+  end
+
   create_table :binaries, force: true do |t|
     t.string :name
     t.binary :data
@@ -635,6 +640,7 @@ ActiveRecord::Schema.define do
   create_table :movies, force: true, id: false do |t|
     t.primary_key :movieid
     t.string      :name
+    t.timestamps null: false
   end
 
   create_table :notifications, force: true do |t|


### PR DESCRIPTION
### Summary

In collections with a limit, including the IDs of the first and last records when generating a collection's cache version ensures correct cache key expiration after a record is deleted. Prior to this commit, collection cache versions only include the collection's size and maximum updated_at timestamp, e.g.:

    "#{collection_size}-#{max_updated_at_timestamp}"

To demonstrate why this isn't robust enough, consider the following database table:

    Employee.all

    SELECT * FROM employees;
    +----+-------+---------------------+---------------------+
    | id | name  | created_at          | updated_at          |
    +----+-------+---------------------+---------------------+
    |  1 | alice | 2019-11-01 00:00:00 | 2019-11-01 00:00:00 |
    |  2 | carol | 2019-11-02 00:00:00 | 2019-11-02 00:00:00 |
    |  3 | doug  | 2019-11-03 00:00:00 | 2019-11-03 00:00:00 |
    |  4 | bob   | 2019-11-04 00:00:00 | 2019-11-04 00:00:00 |
    +----+-------+---------------------+---------------------+

Select the first three employees sorted alphabetically:

    employees = Employee.order(:name).limit(3)

    SELECT * FROM employees ORDER BY name ASC LIMIT 3;
    +----+-------+---------------------+---------------------+
    | id | name  | created_at          | updated_at          |
    +----+-------+---------------------+---------------------+
    |  1 | alice | 2019-11-01 00:00:00 | 2019-11-01 00:00:00 |
    |  4 | bob   | 2019-11-04 00:00:00 | 2019-11-04 00:00:00 |
    |  2 | carol | 2019-11-02 00:00:00 | 2019-11-02 00:00:00 |
    +----+-------+---------------------+---------------------+

Note the collection's size (3) and max updated_at timestamp (2019-11-04 00:00:00), both of which are used to compose the cache version:

    employees.cache_version
    # => "3-20191104000000"

Now, delete an employee:

    Employee.find_by(name: "alice").destroy

    DELETE FROM employees WHERE name = "alice";

Re-run the original query:

    employees = Employee.order(:name).limit(3)

    SELECT * FROM employees ORDER BY name ASC LIMIT 3;
    +----+-------+---------------------+---------------------+
    | id | name  | created_at          | updated_at          |
    +----+-------+---------------------+---------------------+
    |  4 | bob   | 2019-11-04 00:00:00 | 2019-11-04 00:00:00 |
    |  2 | carol | 2019-11-02 00:00:00 | 2019-11-02 00:00:00 |
    |  3 | doug  | 2019-11-03 00:00:00 | 2019-11-03 00:00:00 |
    +----+-------+---------------------+---------------------+

Note that while the collection's contents have changed, its size and maximum updated_at timestamp remain the same, resulting in the cache_version failing to correctly expire:

    employees.cache_version
    # => "3-20191104000000"

Including the ID of the first and last record in a collection fixes this problem - when deleting a record from a collection with a limit (or some other combination of inserts/updates/deletes), either the collection size will shrink, its max updated_at timestamp will increase, or one of its bounding IDs will change.

If a collection is loaded, determining the IDs of its first and last records is straightforward:

    employees = Employee.limit(3)
    first_id = employees.size > 0 ? employees.first.id : nil
    last_id = employees.size > 0 ? employees.last.id : nil

If a collection isn't loaded, this commit uses SQL common table expressions (for SQLite and PostgreSQL databases) or user-defined variables (for MySQL databases) to determine the last record's ID. Example SQL queries below (table aliases shortened for readability):

    -- PostgreSQL/SQLite
    WITH
      col AS
        (SELECT id, updated_at FROM employees ORDER BY name ASC LIMIT 3),
      agg AS
        (SELECT COUNT(*) AS size, MAX(updated_at) AS timestamp FROM col)
    SELECT
      size,
      timestamp,
      (SELECT id FROM col LIMIT 1) AS first_id,
      (SELECT id FROM col LIMIT 1 OFFSET
        GREATEST((SELECT size FROM agg) - 1, 0)) AS last_id
    FROM agg;

    -- MySQL
    SET @first_id := NULL, @last_id := NULL;
    SELECT
      COUNT(*) AS collection_size,
      MAX(updated_at) AS timestamp,
      @first_id AS first_id,
      @last_id AS last_id
    FROM (
      SELECT
        @first_id := COALESCE(@first_id, id),
        @last_id := id,
        updated_at
      FROM employees
      ORDER BY name ASC LIMIT 3
    ) col;

    +------+---------------------+----------+---------+
    | size | timestamp           | first_id | last_id |
    +------+---------------------+----------+---------+
    |    3 | 2019-11-04 00:00:00 |        4 |       3 |
    +------+---------------------+----------+---------+

Fixes #31996, #34408 and #37555.

### Benchmarks

This change has a negligible impact on common use-cases (e.g. paginating records). For very large collections (~100k+ records for Postgres, ~10k+ for MySQL), generating cache_versions takes an estimated 1.75 times longer for Postgres, and 2.75 for MySQL. However, this change should not impact the overall time complexity which should remain linear in regard to the limit/collection size.

Here are some charts (with linear and logarithmic x axes) visualizing the results of my benchmarking (full script and raw results further below):

https://docs.google.com/spreadsheets/d/1d9u7vPh7AD8ArD4krRY7esWsvoBP1eK925prOH4c1uU/edit?folder=0AL-x-3mNk-iPUk9PVA#gid=1452480752

Log charts:

![postgres log chart](https://docs.google.com/spreadsheets/d/e/2PACX-1vTvSS1smbMOibaMpOLHr1ryO6aun0VZzTsJsDe4M2gWGdWZ6BywGZtGvDA_neH1-7rhK77A9NqQS9WB/pubchart?oid=1118001582&format=image)

![mysql log chart](https://docs.google.com/spreadsheets/d/e/2PACX-1vTvSS1smbMOibaMpOLHr1ryO6aun0VZzTsJsDe4M2gWGdWZ6BywGZtGvDA_neH1-7rhK77A9NqQS9WB/pubchart?oid=345571619&format=image)

Linear charts:

![postgres log chart](https://docs.google.com/spreadsheets/d/e/2PACX-1vTvSS1smbMOibaMpOLHr1ryO6aun0VZzTsJsDe4M2gWGdWZ6BywGZtGvDA_neH1-7rhK77A9NqQS9WB/pubchart?oid=133526580&format=image)

![mysql log chart](https://docs.google.com/spreadsheets/d/e/2PACX-1vTvSS1smbMOibaMpOLHr1ryO6aun0VZzTsJsDe4M2gWGdWZ6BywGZtGvDA_neH1-7rhK77A9NqQS9WB/pubchart?oid=1389627901&format=image)

### Other changes

This commit updates the signatures of `ActiveRecord::Relation#cache_version`, `#cache_key` and related methods to use keyword instead of positional arguments, as said methods now accept multiple optional arguments. In order to avoid breaking changes, both methods still accept positional arguments, but will raise deprecation warnings if passed.

### Other considered solutions

In writing this commit, I reviewed other potential solutions to this issue, particularly https://github.com/rails/rails/pull/21503. Most other solutions detected changes to a collection via either a checksum of its IDs, or a hash digest of a string of concatenated IDs. I leaned away from this approach for several reasons:

1. SQLite doesn't have an MD5 function.
2. It's inefficient for very large collections, taking about four times longer than the current approach. (Although the overall time complexity appears equivalent.)
3. For HABTM relations where neither model's updated_at columns are touched when associations are created or destroyed, an ID checksum covers one additional use case: On a query like `@project.employees`, an ID checksum would detect changes to a project's employees even when the collection size, max updated_at timestamp and bounding IDs remain the same. However, an ID checksum *won't* cover the most basic use case of Russian doll caching: consider a cached collection of projects each with an inner-nested cached collection of employees - changes to a project's employees fails to expire the outer cached fragment. Thus, I don't find that the ID checksum approach provides a comprehensive advantage.

### Benchmarking Script + results

For the purposes of Benchmarking, I provisioned Postgres and MySQL databases through Heroku's add-ons. For Postgres, I used a "Standard-0" tier DB with 4 GB ram. For MySQL, I used a JawsSB "Whitetip" tier DB with 1 GB of ram. (Both services are backed by AWS.)

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
  gem "pg"
  gem "mysql2"
end

require "active_record"
require "logger"

ActiveRecord::Base.establish_connection({
  # redacted
})

ActiveRecord::Base.collection_cache_versioning = true

class ActiveRecord::Relation
  def cache_version_new(deprecated_timestamp_column = nil, id_column: primary_key, timestamp_column: :updated_at)
    if deprecated_timestamp_column
      ActiveSupport::Deprecation.warn("Passing a timestamp column as a positional argument to ActiveRecord::Relation#cache_version is deprecated. Please use a `:timestamp_column` keyword argument instead.")
      timestamp_column = deprecated_timestamp_column
    end

    if collection_cache_versioning
      @cache_versions_new ||= {}
      @cache_versions_new[[id_column, timestamp_column]] ||= compute_cache_version_new(id_column: id_column, timestamp_column: timestamp_column)
    end
  end

  def compute_cache_version_new(id_column: primary_key, timestamp_column: :updated_at) # :nodoc:
    size = 0
    first_id = nil
    last_id = nil
    timestamp = nil

    if loaded? || distinct_value
      size = records.size

      if size > 0
        timestamp = max_by(&timestamp_column)._read_attribute(timestamp_column).utc.to_s(cache_timestamp_format)

        if has_limit_or_offset?
          first_id = first._read_attribute(id_column)
          last_id = last._read_attribute(id_column)
        end
      end
    else
      collection = eager_loading? ? apply_join_dependency : self
      timestamp_col = connection.visitor.compile(arel_attribute(timestamp_column))
      id_col = connection.visitor.compile(arel_attribute(id_column))

      if collection.has_limit_or_offset?
        case connection.adapter_name
        when "PostgreSQL", "SQLite"
          collection_table = Arel::Table.new("cache_key_collection")
          aggregates_table = Arel::Table.new("cache_key_aggregates")
          query = collection.select("#{id_col} AS collection_cache_key_id, #{timestamp_col} AS collection_cache_key_timestamp")
          collection_query = Arel::Nodes::SqlLiteral.new "(#{ query.to_sql })"
          aggregates_query = collection_table.project("COUNT(*) AS collection_size, MAX(collection_cache_key_timestamp) AS timestamp")
          collection_common_table_expr = Arel::Nodes::As.new(collection_table, collection_query)
          aggregates_common_table_expr = Arel::Nodes::As.new(aggregates_table, aggregates_query)

          collection_size_minus_one = Arel::Nodes::Subtraction.new(aggregates_table[:collection_size], 1)
          last_id_offset = connection.adapter_name == "PostgreSQL" ?
            Arel::Nodes::NamedFunction.new("GREATEST", [collection_size_minus_one, 0]) :
            aggregates_table.project(collection_size_minus_one)

          select_values = [
            aggregates_table[:collection_size],
            aggregates_table[:timestamp],
            collection_table.project(collection_table[:collection_cache_key_id]).take(1).as("first_id"),
            collection_table.project(collection_table[:collection_cache_key_id]).take(1).skip(last_id_offset).as("last_id")
          ]

          arel = aggregates_table
            .project(select_values)
            .with(collection_common_table_expr, aggregates_common_table_expr)
        when "Mysql2"
          select_values = "COUNT(*) AS collection_size, @first_id AS first_id, @last_id AS last_id, MAX(collection_cache_key_timestamp) AS timestamp"
          query = collection.select("COALESCE(@first_id, @first_id := #{id_col}), @last_id := #{id_col}, #{timestamp_col} AS collection_cache_key_timestamp")
          subquery_alias = "subquery_for_cache_key"
          arel = query.build_subquery(subquery_alias, select_values)
        else
          select_values = "COUNT(*) AS collection_size, MAX(#{timestamp_col}) AS timestamp"
          query = collection.select("#{timestamp_col} AS collection_cache_key_timestamp")
          subquery_alias = "subquery_for_cache_key"
          arel = query.build_subquery(subquery_alias, select_values)
        end
      else
        select_values = "COUNT(*) AS collection_size, MAX(#{timestamp_col}) AS timestamp"
        query = collection.unscope(:order)
        query.select_values = [select_values]
        arel = query.arel
      end

      result = nil

      connection_pool.with_connection do
        if connection.adapter_name == "Mysql2" && collection.has_limit_or_offset?
          connection.execute("SET @first_id := @last_id := NULL")
        end

        result = connection.select_one(arel, nil)
      end

      if result
        column_type = klass.type_for_attribute(timestamp_column)
        size = result["collection_size"]

        if size > 0
          first_id = result["first_id"]
          last_id = result["last_id"]
          timestamp = column_type.deserialize(result["timestamp"]).utc.to_s(cache_timestamp_format)
        end
      end
    end

    [size, first_id, last_id, timestamp].reject(&:blank?).join("-")
  end
  private :compute_cache_version_new
end

ActiveRecord::Schema.define do
  create_table :users, if_not_exists: true do |t|
    t.string :name
    t.timestamps
  end
end

class User < ActiveRecord::Base
end

# Seed database with two million records
if User.first.nil?
  r = 2_000_000
  t = 5.years.ago.to_i
  now = Time.now.to_i
  pct = 0.0

  puts "initializing test records"

  (1..r).map { |n| {
    id: n,
    name: SecureRandom.alphanumeric(5 + rand(12)),
    created_at: Time.at(t += (now - t) / (1 + r - n)),
    updated_at: Time.at(rand(t..now+1))
  } }.each_slice(20_000) { |slice|
    puts "seeding DB" if pct == 0.0
    User.insert_all(slice)
    puts "#{pct+=1}%"
  }
end

Benchmark.ips do |benchmark|
  benchmark.config(warmup: 0, time: 120)

  limits = [10, 100, 1000, 10000, 100000, 200000, 400000, 600000, 800000, 1000000]
  orders = [:asc, :desc]
  offsets = (0..1_000_000).step(250_000)

  limits.each do |limit|
    benchmark.report("current cache_version, limit #{limit}") do
      orders.each do |order|
        offsets.each do |offset|
          User.order(id: order).limit(limit).offset(offset).cache_version
        end
      end
    end

    benchmark.report("w/ first & last ID, limit #{limit}") do
      orders.each do |order|
        offsets.each do |offset|
          User.order(id: order).limit(limit).offset(offset).cache_version_new
        end
      end
    end
  end
end
```

results:

```
Postgres
Calculating -------------------------------------
current cache_version, limit 10
                          0.457  (± 0.0%) i/s -     53.000  in 120.940372s
w/ first & last ID, limit 10
                          0.630  (± 0.0%) i/s -     74.000  in 120.222423s
current cache_version, limit 100
                          0.555  (± 0.0%) i/s -     66.000  in 121.112922s
w/ first & last ID, limit 100
                          0.622  (± 0.0%) i/s -     71.000  in 120.100475s
current cache_version, limit 1000
                          0.473  (± 0.0%) i/s -     55.000  in 120.244607s
w/ first & last ID, limit 1000
                          0.627  (± 0.0%) i/s -     71.000  in 120.659220s
current cache_version, limit 10000
                          0.442  (± 0.0%) i/s -     52.000  in 121.285019s
w/ first & last ID, limit 10000
                          0.561  (± 0.0%) i/s -     64.000  in 120.059518s
current cache_version, limit 100000
                          0.431  (± 0.0%) i/s -     51.000  in 121.234291s
w/ first & last ID, limit 100000
                          0.410  (± 0.0%) i/s -     48.000  in 120.316814s
current cache_version, limit 200000
                          0.406  (± 0.0%) i/s -     49.000  in 121.883819s
w/ first & last ID, limit 200000
                          0.303  (± 0.0%) i/s -     37.000  in 122.960886s
current cache_version, limit 400000
                          0.315  (± 0.0%) i/s -     38.000  in 121.148364s
w/ first & last ID, limit 400000
                          0.223  (± 0.0%) i/s -     27.000  in 121.430635s
current cache_version, limit 600000
                          0.266  (± 0.0%) i/s -     32.000  in 120.808200s
w/ first & last ID, limit 600000
                          0.168  (± 0.0%) i/s -     21.000  in 125.029394s
current cache_version, limit 800000
                          0.236  (± 0.0%) i/s -     29.000  in 123.167375s
w/ first & last ID, limit 800000
                          0.140  (± 0.0%) i/s -     17.000  in 121.361332s
current cache_version, limit 1000000
                          0.208  (± 0.0%) i/s -     26.000  in 125.224578s
w/ first & last ID, limit 1000000
                          0.120  (± 0.0%) i/s -     15.000  in 125.416142s

MySQL
current cache_version, limit 10
                          0.400  (± 0.0%) i/s -     46.000  in 120.437852s
w/ first & last ID, limit 10
                          0.429  (± 0.0%) i/s -     51.000  in 121.507532s
current cache_version, limit 100
                          0.380  (± 0.0%) i/s -     45.000  in 122.325720s
w/ first & last ID, limit 100
                          0.426  (± 0.0%) i/s -     51.000  in 122.081295s
current cache_version, limit 1000
                          0.436  (± 0.0%) i/s -     50.000  in 121.347133s
w/ first & last ID, limit 1000
                          0.422  (± 0.0%) i/s -     50.000  in 120.497030s
current cache_version, limit 10000
                          0.424  (± 0.0%) i/s -     49.000  in 120.461740s
w/ first & last ID, limit 10000
                          0.395  (± 0.0%) i/s -     46.000  in 120.202285s
current cache_version, limit 100000
                          0.304  (± 0.0%) i/s -     35.000  in 120.550654s
w/ first & last ID, limit 100000
                          0.198  (± 0.0%) i/s -     24.000  in 122.127827s
current cache_version, limit 200000
                          0.215  (± 0.0%) i/s -     26.000  in 122.966909s
w/ first & last ID, limit 200000
                          0.150  (± 0.0%) i/s -     18.000  in 120.493927s
current cache_version, limit 400000
                          0.173  (± 0.0%) i/s -     21.000  in 121.901465s
w/ first & last ID, limit 400000
                          0.100  (± 0.0%) i/s -     12.000  in 120.903169s
current cache_version, limit 600000
                          0.156  (± 0.0%) i/s -     19.000  in 122.053916s
w/ first & last ID, limit 600000
                          0.079  (± 0.0%) i/s -     10.000  in 126.504833s
current cache_version, limit 800000
                          0.147  (± 0.0%) i/s -     18.000  in 123.154995s
w/ first & last ID, limit 800000
                          0.062  (± 0.0%) i/s -      8.000  in 128.516317s
current cache_version, limit 1000000
                          0.129  (± 0.0%) i/s -     16.000  in 124.396169s
w/ first & last ID, limit 1000000
                          0.048  (± 0.0%) i/s -      6.000  in 126.030320s
```