### PR TITLE
Update a tag for missing <dl> in guides

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -52,7 +52,7 @@
           <a href="index.html" id="guidesMenu" class="guides-index-item nav-item">Guides Index</a>
           <div id="guides" class="clearfix" style="display: none;">
             <hr />
-            <div class="guides-section-container">
+            <dl class="guides-section-container">
               <% documents_by_section.each do |section| %>
                 <div class="guides-section">
                   <dt><%= section['name'] %></dt>
@@ -61,7 +61,7 @@
                   <% end %>
                 </div>
               <% end %>
-            </div>
+            </dl>
           </div>
         </li>
         <li><a class="nav-item" href="contributing_to_ruby_on_rails.html">Contribute</a></li>


### PR DESCRIPTION
### Summary
The errors below happens in executing `bundle exec rake
guides:validate`.

```
$ bundle exec rake guides:generate:html
(snip)
$ bundle exec rake guides:validate
(snip)
  ./output/active_record_querying.html has 57 validation error(s):

    ERROR; line 55: Element “dt” not allowed as child of element
    “div” in this context. (Suppressing further errors from this
    subtree.)
(snip)
```

