### PR TITLE
fix db:schema dump generating incorrect create table information with options having entire raw create table string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -412,7 +412,7 @@ module ActiveRecord
         create_table_info = create_table_info(table_name)
 
         # strip create_definitions and partition_options
-        raw_table_options = create_table_info.sub(/\A.*\n\) /m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
+        raw_table_options = create_table_info.sub(/\A.*\n\)/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
 
         # strip AUTO_INCREMENT
         raw_table_options.sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')


### PR DESCRIPTION
fixes #37706 

**MySQL instance for Digital Ocean** gives SHOW CREATE TABLE in the below format: 
```sql
CREATE TABLE \"roles\" (\n  \"id\" bigint(20) NOT NULL AUTO_INCREMENT,\n  \"name\" varchar(255) DEFAULT NULL,\n  PRIMARY KEY (\"id\")\n)
```

Local MySQL Server gives SHOW CREATE TABLE Info in the below format: 
```sql
CREATE TABLE `roles` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `name` varchar(255) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8
```

Since these is no trailing space in the **Digital Ocean Create table info** its not getting matched resulting in wrong options value. So removed the extra space in the regex. 

We are already stripping all leading and trailing whitespace which handle it.
