### PR TITLE
Improve deprecation message for leaking scope

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -30,7 +30,8 @@ module ActiveRecord
               ActiveSupport::Deprecation.warn(<<~MSG.squish)
                 Class level methods will no longer inherit scoping from `#{scope._deprecated_scope_source}`
                 in Rails 6.1. To continue using the scoped relation, pass it into the block directly.
-                To instead access the full set of models, as Rails 6.1 will, use `#{name}.unscoped`.
+                To instead access the full set of models, as Rails 6.1 will, use `#{name}.unscoped`,
+                or `#{name}.default_scoped` if a model has default scopes.
               MSG
             end
 


### PR DESCRIPTION
Follow up of #35280.

If a model has default scopes, vanilla `klass.all` is not the same with
`klass.unscoped`.

In that case, we should use `klass.default_scoped` instead.