### PR TITLE
Respect config.log_level in console

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -59,6 +59,7 @@ module ActiveRecord
       require "active_record/base"
       unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
         console = ActiveSupport::Logger.new(STDERR)
+        console.level = Rails.logger.level
         Rails.logger.extend ActiveSupport::Logger.broadcast console
       end
       ActiveRecord::Base.verbose_query_logs = false


### PR DESCRIPTION
### Summary

Fixes issue #37728 - more information and discussion is available in the issue.

I found no tests that applied to the railtie, so no tests are included.

### Other Information

Another solution to this would be to add a new configuration option `console_log_level` or similar. That could also be a resonable pattern to solve issue #15476.