### PR TITLE
Writes should always clear the query cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
               def #{method_name}(*)
-                ActiveRecord::Base.clear_query_caches_for_current_thread if @query_cache_enabled
+                ActiveRecord::Base.clear_query_caches_for_current_thread
                 super
               end
             end_code


### PR DESCRIPTION
It shouldn't matter whether or not QC is enabled, inserts, updates, etc
(anything that modifies the state of the DB) should invalidate the
cache.