### PR TITLE
Fix unscoped grouped where

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow attributes to be fetched from Arel node groupings.
+
+    *Jeff Emminger*, *Gannon McGibbon*
+
 *   Calling methods like `establish_connection` with a `Hash` which is invalid (eg: no `adapter`) will now raise an error the same way as connections defined in `config/database.yml`.
 
     *John Crepezzi*

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -46,10 +46,20 @@ module Arel
     value.is_a?(Arel::Node) || value.is_a?(Arel::Attribute) || value.is_a?(Arel::Nodes::SqlLiteral)
   end
 
-  def self.fetch_attribute(value) # :nodoc:
+  def self.fetch_attribute(value, &block) # :nodoc:
     case value
-    when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
-      yield value.left.is_a?(Arel::Attributes::Attribute) ? value.left : value.right
+    when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality,
+         Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual,
+         Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
+      if value.left.is_a?(Arel::Attributes::Attribute)
+        yield value.left
+      else
+        yield value.right
+      end
+    when Arel::Nodes::Or
+      fetch_attribute(value.left, &block) && fetch_attribute(value.right, &block)
+    when Arel::Nodes::Grouping
+      fetch_attribute(value.expr, &block)
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2050,6 +2050,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, posts.unscope(where: :body).count
   end
 
+  def test_unscope_grouped_where
+    posts = Post.where(
+      title: ["Welcome to the weblog", "So I was thinking", nil]
+    )
+
+    assert_equal 2, posts.count
+    assert_equal Post.count, posts.unscope(where: :title).count
+  end
+
   def test_locked_should_not_build_arel
     posts = Post.locked
     assert_predicate posts, :locked?


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/pull/34679.

Correctly unscopes on node groupings. An easy way to create a grouping is to do a `where` with an array including a `nil` value like `Post.where(title: ["Welcome to the weblog", "So I was thinking", nil])`, and then unscope it with `.unscope(where: :title)`. Currently, this doesn't work because ARel can't find the attribute in the expression. This fixes that.