### PR TITLE
Database URL supports query value with equal sign

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     *Jeff Emminger*, *Gannon McGibbon*
 
+*   A database URL can now contain a querystring value that contains an equal sign. This is needed to support passing PostgresSQL `options`.
+
+    *Joshua Flanagan*
+
 *   Calling methods like `establish_connection` with a `Hash` which is invalid (eg: no `adapter`) will now raise an error the same way as connections defined in `config/database.yml`.
 
     *John Crepezzi*

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -57,7 +57,7 @@ module ActiveRecord
         #   "localhost"
         #   # => {}
         def query_hash
-          Hash[(@query || "").split("&").map { |pair| pair.split("=") }].symbolize_keys
+          Hash[(@query || "").split("&").map { |pair| pair.split("=", 2) }].symbolize_keys
         end
 
         def raw_config

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -171,6 +171,13 @@ module ActiveRecord
         assert_not_includes actual, :url
       end
 
+      def test_url_with_equals_in_query_value
+        config   = { "default_env" => { "url" => "postgresql://localhost/foo?options=-cmyoption=on" } }
+        actual   = resolve_config(config)
+        expected = { options: "-cmyoption=on", adapter: "postgresql", database: "foo", host: "localhost" }
+        assert_equal expected, actual
+      end
+
       def test_hash
         config = { "production" => { "adapter" => "postgres", "database" => "foo" } }
         actual = resolve_config(config, "production")


### PR DESCRIPTION
### Summary

A querystring value should be allowed to include an equal sign `=`.

This is necessary to support passing `options` for a PostgresSQL connection, using the database URL format.

### Example

```
# config/database.yml

development:
  url: postgresql://localhost/railsdevapp_development?options=-cmysetting.debug=on
```

Before this PR, attempting to start the rails process with that configuration would result in an error:

```
> bundle exec rails console
Traceback (most recent call last):
	49: from bin/rails:4:in `<main>'
	48: from bin/rails:4:in `require'
...
	 1: from /rails/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb:58:in `query_hash'
/rails/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb:58:in `[]': invalid number of elements (3 for 1..2) (ArgumentError)
```

After this PR, rails can properly parse the configuration:

```
> bundle exec rails console
Loading development environment (Rails 6.1.0.alpha)
2.6.5 :001 > ActiveRecord::Base.connection.select_all("show mysetting.debug").to_a
   (0.4ms)  show mysetting.debug
 => [{"mysetting.debug"=>"on"}]
```