### PR TITLE
Add comment to BROWSER_LIKE_ACCEPTS regex

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -152,6 +152,8 @@ module ActionDispatch
       end
 
       private
+        # We use normal content negotiation unless you include */* in your list,
+        # in which case we assume you're a browser and send HTML.
         BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
 
         def params_readable? # :doc:


### PR DESCRIPTION
### Summary

I am adding the comment (based on the commit messages of the two commits mentioned) because it is far from obvious why this regex exists and what it does.

### Other Information

The concept of treating Accept header lists including `*/*` as identifying the request as coming from a browser, and allowing the mime negotiation to fall back to a HTML response, was introduced (several years ago) in commits 1310231c15742bf7d99e2f143d88b383c and dc5300adb6d46252c26e239ac67e3ca6e.