### PR TITLE
Add :namespace option to generator `route` action

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -254,7 +254,12 @@ module Rails
       # Make an entry in Rails routing file <tt>config/routes.rb</tt>
       #
       #   route "root 'welcome#index'"
-      def route(routing_code)
+      #   route "root 'admin#index'", namespace: :admin
+      def route(routing_code, namespace: nil)
+        routing_code = Array(namespace).reverse.reduce(routing_code) do |code, ns|
+          "namespace :#{ns} do\n#{indent(code, 2)}\nend"
+        end
+
         log :route, routing_code
         sentinel = /\.routes\.draw do\s*\n/m
 
@@ -327,12 +332,7 @@ module Rails
         # Returns optimized string with indentation
         def optimize_indentation(value, amount = 0) # :doc:
           return "#{value}\n" unless value.is_a?(String)
-
-          if value.lines.size > 1
-            value.strip_heredoc.indent(amount)
-          else
-            "#{value.strip.indent(amount)}\n"
-          end
+          "#{value.strip_heredoc.indent(amount).chomp}\n"
         end
 
         # Indent the +Gemfile+ to the depth of @indentation

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -17,7 +17,8 @@ module Rails
       def add_routes
         return if options[:skip_routes]
         return if actions.empty?
-        route generate_routing_code
+        routing_code = actions.map { |action| "get '#{file_name}/#{action}'" }.join("\n")
+        route routing_code, namespace: regular_class_path
       end
 
       hook_for :template_engine, :test_framework, :helper, :assets do |generator|
@@ -31,45 +32,6 @@ module Rails
 
         def remove_possible_suffix(name)
           name.sub(/_?controller$/i, "")
-        end
-
-        # This method creates nested route entry for namespaced resources.
-        # For e.g. rails g controller foo/bar/baz index show
-        # Will generate -
-        # namespace :foo do
-        #   namespace :bar do
-        #     get 'baz/index'
-        #     get 'baz/show'
-        #   end
-        # end
-        def generate_routing_code
-          depth = 0
-          lines = []
-
-          # Create 'namespace' ladder
-          # namespace :foo do
-          #   namespace :bar do
-          regular_class_path.each do |ns|
-            lines << indent("namespace :#{ns} do\n", depth * 2)
-            depth += 1
-          end
-
-          # Create route
-          #     get 'baz/index'
-          #     get 'baz/show'
-          actions.each do |action|
-            lines << indent(%{get '#{file_name}/#{action}'\n}, depth * 2)
-          end
-
-          # Create `end` ladder
-          #   end
-          # end
-          until depth.zero?
-            depth -= 1
-            lines << indent("end\n", depth * 2)
-          end
-
-          lines.join
         end
     end
   end

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -16,32 +16,7 @@ module Rails
       #   end
       def add_resource_route
         return if options[:actions].present?
-
-        depth = 0
-        lines = []
-
-        # Create 'namespace' ladder
-        # namespace :foo do
-        #   namespace :bar do
-        regular_class_path.each do |ns|
-          lines << indent("namespace :#{ns} do\n", depth * 2)
-          depth += 1
-        end
-
-        # inserts the primary resource
-        # Create route
-        #     resources 'products'
-        lines << indent(%{resources :#{file_name.pluralize}\n}, depth * 2)
-
-        # Create `end` ladder
-        #   end
-        # end
-        until depth.zero?
-          depth -= 1
-          lines << indent("end\n", depth * 2)
-        end
-
-        route lines.join
+        route "resources :#{file_name.pluralize}", namespace: regular_class_path
       end
     end
   end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -525,6 +525,30 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file "config/routes.rb", content
   end
 
+  test "route with namespace option should nest route" do
+    run_generator
+    action :route, "get 'foo'\nget 'bar'", namespace: :baz
+    assert_routes <<~ROUTING_CODE.chomp
+      namespace :baz do
+        get 'foo'
+        get 'bar'
+      end
+    ROUTING_CODE
+  end
+
+  test "route with namespace option array should deeply nest route" do
+    run_generator
+    action :route, "get 'foo'\nget 'bar'", namespace: %w[baz qux]
+    assert_routes <<~ROUTING_CODE.chomp
+      namespace :baz do
+        namespace :qux do
+          get 'foo'
+          get 'bar'
+        end
+      end
+    ROUTING_CODE
+  end
+
   def test_readme
     run_generator
     assert_called(Rails::Generators::AppGenerator, :source_root, times: 2, returns: destination_root) do


### PR DESCRIPTION
I split this up into two commits because the first commit is mostly orthogonal, though the second commit relies on it.  I can resubmit the first commit as a separate PR, if desired.
