### PR TITLE
Add params.member? to mimic Hash behavior

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `params.member?` to mimic Hash behavior
+
+    *Younes Serraj*
+
 *   `process_action.action_controller` notifications now include the following in their payloads:
 
     * `:request` - the `ActionDispatch::Request`

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -181,6 +181,14 @@ module ActionController
     # Returns true if the given key is present in the parameters.
 
     ##
+    # :method: member?
+    #
+    # :call-seq:
+    #   member?(key)
+    #
+    # Returns true if the given key is present in the parameters.
+
+    ##
     # :method: keys
     #
     # :call-seq:
@@ -211,7 +219,7 @@ module ActionController
     #   values()
     #
     # Returns a new array of the values of the parameters.
-    delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?,
+    delegate :keys, :key?, :has_key?, :member?, :values, :has_value?, :value?, :empty?, :include?,
       :as_json, :to_s, :each_key, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -162,6 +162,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not @params.key?(:address)
   end
 
+  test "member? returns true if the given key is present in the params" do
+    assert @params.member?(:person)
+  end
+
+  test "member? returns false if the given key is not present in the params" do
+    assert_not @params.member?(:address)
+  end
+
   test "keys returns an array of the keys of the params" do
     assert_equal ["person"], @params.keys
     assert_equal ["age", "name", "addresses"], @params[:person].keys


### PR DESCRIPTION
### Summary

StrongParameters delegates `key?` method for `params` to behave kind of like a Hash.
I suggest we delegate `member?` as well.
