### PR TITLE
[regresion] Allow using mountable engine route helpers in System Tests (v6.0.1)

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -165,6 +165,7 @@ module ActionDispatch
           if ActionDispatch.test_app
             Class.new do
               include ActionDispatch.test_app.routes.url_helpers
+              include ActionDispatch.test_app.routes.mounted_helpers
 
               def url_options
                 default_url_options.reverse_merge(host: Capybara.app_host || Capybara.current_session.server_url)


### PR DESCRIPTION
# Summary

Fixes: https://github.com/rails/rails/issues/37754

After the System Tests refactor in Rails v6.0.1 https://github.com/rails/rails/commit/7982363, when you use a Rails mountable engine, and in your System Tests you try to use the route helpers (aka, engine_name.root_url), you get an undefined error.

### Other Information

This only affect tests that inherit from ActionDispatch::SystemTestCase (System Tests)...
Tests using ActionDispatch::IntegrationTest work just as expected...

I have no idea how to add a test for this, but I'm basically copy/pasting the same code that exists for the `IntegrationTest`:
https://github.com/chalofa/rails/blob/6-0-stable/actionpack/lib/action_dispatch/testing/integration.rb#L339-L340

Fix is for `6-0-stable` branch, it's a different line for `master`, but the change is basically the same
