### PR TITLE
Fix broken check on GitHub actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,6 +14,7 @@ jobs:
         ruby-version: 2.6.x
     - name: Install required package
       run: |
+        sudo apt-get update
         sudo apt-get install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
     - name: Cache gems
       uses: actions/cache@v1


### PR DESCRIPTION
Without it, it seems to be an error trying to install an older version.
Ref: https://github.com/rails/rails/commit/ea303d012e6638c99f528c68ee9144a83e836e27/checks?check_suite_id=321223550#step:4:29
