### PR TITLE
Update guide missing "HTTP" of "HTTP Token authentication" [skip ci]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -900,7 +900,7 @@ end
 
 As seen in the example above, the `authenticate_or_request_with_http_digest` block takes only one argument - the username. And the block returns the password. Returning `false` or `nil` from the `authenticate_or_request_with_http_digest` will cause authentication failure.
 
-### Token authentication
+### HTTP Token authentication
 
 HTTP token authentication is a scheme to enable the usage of Bearer tokens in the HTTP `Authorization` header. There are many token formats available and describing them is outside the scope of this document.
 


### PR DESCRIPTION
### Summary
The title of "HTTP Token authentication" section added in the following PR was missing "HTTP"

https://github.com/rails/rails/pull/37683