### PR TITLE
Remove an unused connection handler in a test

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -12,9 +12,8 @@ module ActiveRecord
 
       def setup
         @handlers = { writing: ConnectionHandler.new }
-        @rw_handler = @handlers[:writing]
         @spec_name = "primary"
-        @writing_handler = ActiveRecord::Base.connection_handlers[:writing]
+        @writing_handler = @handlers[:writing]
       end
 
       def teardown


### PR DESCRIPTION
### Summary
There is an unused connection handler in a test and an extra
connection handler is made, so testing for sqlite3 makes an empty db
file as below.

```
$ bundle exec rake test:sqlite3
(snip)
$ git status
On branch test
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        db/
```
