### PR TITLE
Modify ActiveRecord::TestFixtures to not rely on AS::TestCase:

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -42,7 +42,7 @@ module ActiveRecord
         if fixture_set_names.first == :all
           raise StandardError, "No fixture path found. Please set `#{self}.fixture_path`." if fixture_path.blank?
           fixture_set_names = Dir[::File.join(fixture_path, "{**,*}/*.{yml}")].uniq
-          fixture_set_names.reject! { |f| f.starts_with?(file_fixture_path.to_s) } if file_fixture_path
+          fixture_set_names.reject! { |f| f.starts_with?(file_fixture_path.to_s) } if defined?(file_fixture_path) && file_fixture_path
           fixture_set_names.map! { |f| f[fixture_path.to_s.size..-5].delete_prefix("/") }
         else
           fixture_set_names = fixture_set_names.flatten.map(&:to_s)
@@ -98,7 +98,7 @@ module ActiveRecord
 
     def run_in_transaction?
       use_transactional_tests &&
-        !self.class.uses_transaction?(method_name)
+        !self.class.uses_transaction?(name)
     end
 
     def setup_fixtures(config = ActiveRecord::Base)

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "tempfile"
+require "fileutils"
+require "models/zine"
 
 class TestFixturesTest < ActiveRecord::TestCase
   setup do
@@ -16,5 +19,42 @@ class TestFixturesTest < ActiveRecord::TestCase
     @klass.use_transactional_tests = "foobar"
 
     assert_equal "foobar", @klass.use_transactional_tests
+  end
+
+  unless in_memory_db?
+    def test_doesnt_rely_on_active_support_test_case_specific_methods
+      tmp_dir = Dir.mktmpdir
+      File.write(File.join(tmp_dir, "zines.yml"), <<~YML)
+      going_out:
+        title: Hello
+    YML
+
+      klass = Class.new(Minitest::Test) do
+        include ActiveRecord::TestFixtures
+
+        self.fixture_path = tmp_dir
+        self.use_transactional_tests = true
+
+        fixtures :all
+
+        def test_run_successfuly
+          assert_equal("Hello", Zine.first.title)
+          assert_equal("Hello", zines(:going_out).title)
+        end
+      end
+
+      old_handlers = ActiveRecord::Base.connection_handlers
+      old_handler = ActiveRecord::Base.connection_handler
+      ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+      ActiveRecord::Base.connection_handlers = {}
+      ActiveRecord::Base.establish_connection(:arunit)
+
+      test_result = klass.new("test_run_successfuly").run
+      assert_predicate(test_result, :passed?)
+    ensure
+      ActiveRecord::Base.connection_handler = old_handler
+      ActiveRecord::Base.connection_handlers = old_handlers
+      FileUtils.rm_r(tmp_dir)
+    end
   end
 end


### PR DESCRIPTION
- ### Problem

  If one wants to use ActiveRecord::TestFixtures it is mandatory for
  the test suite to inherit from `ActiveSupport::TestCase`.
  TestFixtures makes use of specific method from AS::TestCase
  (`file_fixture_path` and `method_name`).

  ### Solution

  This PR fixes that by not making use of method_name and file_fixture_path.

cc/ @rafaelfranca 