### PR TITLE
activerecord: Add missing require for compact_blank

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/enumerable"
+
 module ActiveRecord
   class DatabaseConfigurations
     # Expands a connection string into a hash.


### PR DESCRIPTION
### Summary

When active record is loaded with the DATABASE_URL environment variable set and active support not fully loaded, I am getting an exception from a use of `compact_blank` from active record trying to parse the DATABASE_URL.

I was able to reproduce this using `DATABASE_URL=mysql2://root@localhost bundle exec ruby -e 'require "active_record"; ActiveRecord::Base'` on rails master, which gave the following exception

```
Traceback (most recent call last):
	17: from -e:1:in `<main>'
	16: from -e:1:in `require'
	15: from /Users/dylansmith/src/rails/activerecord/lib/active_record/base.rb:17:in `<top (required)>'
	14: from /Users/dylansmith/src/rails/activerecord/lib/active_record/base.rb:267:in `<module:ActiveRecord>'
	13: from /Users/dylansmith/src/rails/activerecord/lib/active_record/base.rb:283:in `<class:Base>'
	12: from /Users/dylansmith/src/rails/activerecord/lib/active_record/base.rb:283:in `include'
	11: from /Users/dylansmith/src/rails/activesupport/lib/active_support/concern.rb:122:in `append_features'
	10: from /Users/dylansmith/src/rails/activesupport/lib/active_support/concern.rb:122:in `class_eval'
	 9: from /Users/dylansmith/src/rails/activerecord/lib/active_record/core.rb:53:in `block in <module:Core>'
	 8: from /Users/dylansmith/src/rails/activerecord/lib/active_record/core.rb:51:in `configurations='
	 7: from /Users/dylansmith/src/rails/activerecord/lib/active_record/core.rb:51:in `new'
	 6: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations.rb:19:in `initialize'
	 5: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations.rb:166:in `build_configs'
	 4: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations.rb:254:in `environment_url_config'
	 3: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations.rb:254:in `new'
	 2: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations/url_config.rb:38:in `initialize'
	 1: from /Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations/url_config.rb:48:in `build_url_hash'
/Users/dylansmith/src/rails/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb:36:in `to_hash': undefined method `compact_blank' for #<Hash:0x00007ff24e977e60> (NoMethodError)
```

I added `require "active_support/core_ext/enumerable"` to the file that made the `compact_blank` call to make sure that method is defined.