### PR TITLE
Fix RSpec capitalization typo ("Rspec" -> "RSpec")

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -621,7 +621,7 @@ See [#19034](https://github.com/rails/rails/pull/19034) for more details.
 continue using these methods in your controller tests, add `gem 'rails-controller-testing'` to
 your `Gemfile`.
 
-If you are using Rspec for testing, please see the extra configuration required in the gem's
+If you are using RSpec for testing, please see the extra configuration required in the gem's
 documentation.
 
 #### New behavior when uploading files


### PR DESCRIPTION
### Summary

Change `Rspec` -> `RSpec`.

RSpec is written with a capital `R` and `S` elsewhere in the guides, as well as on its website [rspec.info/](https://rspec.info/). Change the upgrade guide to match this style.

### Other Information

I was searching through the docs for an unrelated RSpec configuration change, 
and noticed this small inconsistency in capitalization. I'm sure if anyone wants to change
old upgrade documentation, but I figured I'd open a PR just in case.

