### PR TITLE
Only enqueue analysis jobs when blob is analyzable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only enqueue analysis jobs for blobs with non-null analyzer classes.
+
+    *Gannon McGibbon*
+
 *   Previews are created on the same service as the original blob.
 
     *Peter Zhu*

--- a/activestorage/app/models/active_storage/blob/analyzable.rb
+++ b/activestorage/app/models/active_storage/blob/analyzable.rb
@@ -29,12 +29,16 @@ module ActiveStorage::Blob::Analyzable
     update! metadata: metadata.merge(extract_metadata_via_analyzer)
   end
 
-  # Enqueues an ActiveStorage::AnalyzeJob which calls #analyze.
+  # Enqueues an ActiveStorage::AnalyzeJob which calls #analyze, or calls #analyze inline based on analyzer class configuration.
   #
   # This method is automatically called for a blob when it's attached for the first time. You can call it to analyze a blob
   # again (e.g. if you add a new analyzer or modify an existing one).
   def analyze_later
-    ActiveStorage::AnalyzeJob.perform_later(self)
+    if analyzer_class.analyze_later?
+      ActiveStorage::AnalyzeJob.perform_later(self)
+    else
+      analyze
+    end
   end
 
   # Returns true if the blob has been analyzed.

--- a/activestorage/lib/active_storage/analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer.rb
@@ -12,6 +12,12 @@ module ActiveStorage
       false
     end
 
+    # Implement this method in concrete subclasses. It will determine if blob anlysis
+    # should be done in a job or performed inine. By default, analysis is enqueued in a job.
+    def self.analyze_later?
+      true
+    end
+
     def initialize(blob)
       @blob = blob
     end

--- a/activestorage/lib/active_storage/analyzer/null_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/null_analyzer.rb
@@ -6,6 +6,10 @@ module ActiveStorage
       true
     end
 
+    def self.analyze_later?
+      false
+    end
+
     def metadata
       {}
     end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -25,6 +25,18 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal 2736, blob.metadata[:height]
   end
 
+  test "attaching a un-analyzable blob" do
+    blob = create_blob(filename: "blank.txt")
+
+    assert_not_predicate blob, :analyzed?
+
+    assert_no_enqueued_jobs do
+      @user.highlights.attach(blob)
+    end
+
+    assert_predicate blob.reload, :analyzed?
+  end
+
   test "mirroring a directly-uploaded blob after attaching it" do
     with_service("mirror") do
       blob = directly_upload_file_blob


### PR DESCRIPTION
### Summary

Analyze inline when blob is analyzed with `NullAnalyzer`. I believe it is cheaper to do this as opposed to doing the no-op analysis in a job.

Fixes https://github.com/rails/rails/issues/37767.