### PR TITLE
Fix connection pools not shared between writer -> replica during tests:

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -130,6 +130,7 @@ module ActiveRecord
         # When connections are established in the future, begin a transaction too
         @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
           spec_name = payload[:spec_name] if payload.key?(:spec_name)
+          setup_shared_connection_pool
 
           if spec_name
             begin

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1399,13 +1399,6 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       rw_conn = ActiveRecord::Base.connection
       ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
 
-      assert_not_equal rw_conn, ro_conn
-
-      enlist_fixture_connections
-
-      rw_conn = ActiveRecord::Base.connection
-      ro_conn = ActiveRecord::Base.connection_handlers[:reading].connection_pool_list.first.connection
-
       assert_equal rw_conn, ro_conn
     end
   ensure


### PR DESCRIPTION
Fix connection pools not shared between writer -> replica during tests:

- ### Problem

  Connection pools are not properly shared. A replica can't see the
  data in the open transaction on the writing connection.
  ```ruby
  Dog.create!(name: 'bilou')

  AnimalsBase.connected_to(role: :reading) do
    Dog.find_by(name: 'bilou') # No result
  end
  ```

  The reason of this bug is because when test starts, we iterate
  over `AR::Base.connection_handlers` which only contains the `writing`
  handler since models haven't been loaded (app isn't eagerloaded
  test env).

  ### Solution

  Share connection pools as soon as a connection is established
  by creating a subcriber.

cc/ @rafaelfranca @casperisfine @eileencodes (FYI issue you saw in https://github.com/rails/rails/issues/37765#issuecomment-557253443 was related to this)