### PR TITLE
Fix IRB deprecation warning on tab-completion on Ruby <= 2.5:

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -147,7 +147,7 @@ module ActiveSupport
 
       # Don't give a deprecation warning on methods that IRB may invoke
       # during tab-completion.
-      delegate :hash, :instance_methods, to: :target
+      delegate :hash, :instance_methods, :name, to: :target
 
       # Returns the class of the new constant.
       #


### PR DESCRIPTION
Fix IRB deprecation warning on tab-completion on Ruby <= 2.5:

- Similar fix as https://github.com/rails/rails/pull/37100/ which
  solved the issue only for ruby 2.6.

  Fix #37775

cc/ @rafaelfranca @casperisfine