### PR TITLE
Add test pattern ActiveSupport::Duration in DateTimeExtCalculationsTest#test_since

### DIFF
--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -152,6 +152,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2005, 2, 22, 11, 10, 10), DateTime.civil(2005, 2, 22, 10, 10, 10).since(3600)
     assert_equal DateTime.civil(2005, 2, 24, 10, 10, 10), DateTime.civil(2005, 2, 22, 10, 10, 10).since(86400 * 2)
     assert_equal DateTime.civil(2005, 2, 24, 11, 10, 35), DateTime.civil(2005, 2, 22, 10, 10, 10).since(86400 * 2 + 3600 + 25)
+    assert_equal DateTime.civil(2005, 2, 26, 10, 10, 10), DateTime.civil(2005, 2, 22, 10, 10, 10).since(4.days)
     assert_not_equal DateTime.civil(2005, 2, 22, 10, 10, 11), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.333)
     assert_not_equal DateTime.civil(2005, 2, 22, 10, 10, 12), DateTime.civil(2005, 2, 22, 10, 10, 10).since(1.667)
   end


### PR DESCRIPTION

### Summary

Add test pattern `ActiveSupport::Duration` in`DateTimeExtCalculationsTest#test_since`.
This test is for detecting the issue that may occur on ruby 2.5.x.
Passing `Duration` to `DateTime#since` will raise TypeError on ruby version 2.5.6.
But if you run this test on 2.6.5, the test succeeds.

### Other Information

See #37425
