### PR TITLE
Prevent generating tests with non-existent routes

### DIFF
--- a/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
@@ -6,6 +6,8 @@ module TestUnit # :nodoc:
   module Generators # :nodoc:
     class ControllerGenerator < Base # :nodoc:
       argument :actions, type: :array, default: [], banner: "action action"
+      class_option :skip_routes, type: :boolean
+
       check_class_collision suffix: "ControllerTest"
 
       def create_test_files

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
@@ -6,7 +6,7 @@ class <%= class_name %>ControllerTest < ActionDispatch::IntegrationTest
   include Engine.routes.url_helpers
 
 <% end -%>
-<% if actions.empty? -%>
+<% if actions.empty? || options[:skip_routes] -%>
   # test "the truth" do
   #   assert true
   # end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -75,6 +75,13 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_skip_routes_prevents_generating_tests_with_routes
+    run_generator ["account", "foo", "--skip-routes"]
+    assert_file "test/controllers/account_controller_test.rb" do |controller_test|
+      assert_no_match(/account_foo_(url|path)/, controller_test)
+    end
+  end
+
   def test_invokes_default_template_engine_even_with_no_action
     run_generator ["account"]
     assert_file "app/views/account"


### PR DESCRIPTION
This ensures generated tests are not broken by default when invoking the controller generator with one or more actions and "--skip-routes".
