### PR TITLE
Avoid TypeError when Duration was passed to DateTime#since on ruby 2.5.x

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -110,7 +110,7 @@ class DateTime
   # instance time. Do not use this method in combination with x.months, use
   # months_since instead!
   def since(seconds)
-    self + Rational(seconds, 86400)
+    self + Rational(seconds.real, 86400)
   end
   alias :in :since
 


### PR DESCRIPTION
### Summary

On ruby 2.5.x, TypeError raised when Duration was passed to DateTime#since.

This patch fix https://github.com/rails/rails/issues/37425 and pass test added by https://github.com/rails/rails/pull/37777

### Other Information

See https://github.com/rails/rails/issues/37425 and https://github.com/rails/rails/pull/37777