### PR TITLE
PostgreSQL: Make detection of invalid plan locale-independent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -714,11 +714,10 @@ module ActiveRecord
         #
         # Check here for more details:
         # https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/cache/plancache.c#l573
-        CACHED_PLAN_HEURISTIC = "cached plan must not change result type"
         def is_cached_plan_failure?(e)
           pgerror = e.cause
-          code = pgerror.result.result_error_field(PG::PG_DIAG_SQLSTATE)
-          code == FEATURE_NOT_SUPPORTED && pgerror.message.include?(CACHED_PLAN_HEURISTIC)
+          pgerror.result.result_error_field(PG::PG_DIAG_SQLSTATE) == FEATURE_NOT_SUPPORTED &&
+            pgerror.result.result_error_field(PG::PG_DIAG_SOURCE_FUNCTION) == "RevalidateCachedQuery"
         rescue
           false
         end


### PR DESCRIPTION
The text of error messages from a PostgreSQL server depend on the setting `lc_messages` in `postgresql.conf`. The current detection of the particular error condition of an invalid
plan therefore works with English language setting on the server only. Other locale settings result in a wrong exception type, which lead to two test failures in ActiveRecord:
```
HotCompatibilityTest#test_cleans_up_after_prepared_statement_failure_in_a_transaction [test/cases/hot_compatibility_test.rb:75]:
[ActiveRecord::PreparedStatementCacheExpired] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"PG::FeatureNotSupported: FEHLER:  gecachter Plan darf den Ergebnistyp nicht ändern\n">
```
Here the German message wasn't recognized, so that a `StatementInvalid` is raised instead of `PreparedStatementCacheExpired`.

Using the `PG_DIAG_SOURCE_FUNCTION` is independent of the locale setting and fixes this. It is not guarantied to be stable across PostgreSQL versions, but it has been unchanged since PostgreSQL-9.2. On the other hand the text to be matched isn't guarantied to be stable either.
