### PR TITLE
Fix  #37701 Autosave association bug with ActiveStorage::Attachments

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -179,6 +179,10 @@ module ActiveStorage
       @attachment_changes ||= {}
     end
 
+    def changed_for_autosave? #:nodoc:
+      super || attachment_changes.any?
+    end 
+
     def reload(*) #:nodoc:
       super.tap { @attachment_changes = nil }
     end

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -181,7 +181,7 @@ module ActiveStorage
 
     def changed_for_autosave? #:nodoc:
       super || attachment_changes.any?
-    end 
+    end
 
     def reload(*) #:nodoc:
       super.tap { @attachment_changes = nil }

--- a/activestorage/test/database/create_groups_migration.rb
+++ b/activestorage/test/database/create_groups_migration.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ActiveStorageCreateGroups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :groups do |t|
+    end
+  end
+end

--- a/activestorage/test/database/create_users_migration.rb
+++ b/activestorage/test/database/create_users_migration.rb
@@ -4,6 +4,7 @@ class ActiveStorageCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :name
+      t.integer :group_id
     end
   end
 end

--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "create_users_migration"
+require_relative "create_groups_migration"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.connection.migration_context.migrate
 ActiveStorageCreateUsers.migrate(:up)
+ActiveStorageCreateGroups.migrate(:up)

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -319,6 +319,14 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal 2736, @user.avatar.metadata[:height]
   end
 
+  test "updating an attachment as part of an autosave association" do
+    group = Group.create!(users: [@user])
+    @user.avatar = fixture_file_upload("racecar.jpg")
+    group.save!
+    @user.reload
+    assert @user.avatar.attached?
+  end
+
   test "attaching an existing blob to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach create_blob(filename: "funky.jpg")

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -126,6 +126,7 @@ end
 
 class Group < ActiveRecord::Base
   has_one_attached :avatar
+  has_many :users, autosave: true
 end
 
 require_relative "../../tools/test_common"


### PR DESCRIPTION
### Summary

Fixes #37701. Models with attached `ActiveStorage::Attachment`'s were not properly reporting changes to the `Attachment`'s as part of an autosave association.

This adds an extra check to `changed_for_autosave?` to report any attachment changes and have the autosave association models saved.