### PR TITLE
Fix multiparameter attribute assignment bypassing private attribute writer

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -49,7 +49,7 @@ module ActiveRecord
           else
             values = values_with_empty_parameters
           end
-          send("#{name}=", values)
+          public_send("#{name}=", values)
         rescue => ex
           errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
         end

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -79,7 +79,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     end
     assert_match("private method `last_read=' called", ex.message)
   ensure
-    Topic.private_method_defined?(:last_read=) and Topic.remove_method(:last_read=)
+    Topic.private_method_defined?(:last_read=) && Topic.remove_method(:last_read=)
   end
 
   def test_multiparameter_attributes_on_time
@@ -327,7 +327,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     end
     assert_match("private method `written_on=' called", ex.message)
   ensure
-    Topic.private_method_defined?(:written_on=) and Topic.remove_method(:written_on=)
+    Topic.private_method_defined?(:written_on=) && Topic.remove_method(:written_on=)
   end
 
   def test_multiparameter_attributes_setting_date_attribute


### PR DESCRIPTION
### Summary

Fixes #37790
Updates `execute_callstack_for_multiparameter_attributes` to use `Object#public_send` to respect private attribute writer.