### PR TITLE
Fire JS event on ActionText upload error

### DIFF
--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -20,7 +20,7 @@ export class AttachmentUpload {
 
   directUploadDidComplete(error, attributes) {
     if (error) {
-      var uploadFailed = new CustomEvent("actiontext-attachment-error", {"detail": {"error": error }});
+      var uploadFailed = new CustomEvent("trix-attachment-error", {"detail": {"error": error }});
       this.element.dispatchEvent(uploadFailed);
     } else {
       this.attachment.setAttributes({

--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -20,7 +20,7 @@ export class AttachmentUpload {
 
   directUploadDidComplete(error, attributes) {
     if (error) {
-      let uploadFailed = new CustomEvent("trix-attachment-error", {"detail": {"error": error }})
+      let uploadFailed = new CustomEvent("trix-attachment-error", {"detail": {"error": error, "attachment": this.attachment }})
       this.element.dispatchEvent(uploadFailed)
     } else {
       this.attachment.setAttributes({

--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -21,13 +21,13 @@ export class AttachmentUpload {
   directUploadDidComplete(error, attributes) {
     if (error) {
       var uploadFailed = new CustomEvent("actiontext-attachment-error", {"detail": {"error": error }});
-      document.dispatchEvent(uploadFailed);
+      this.element.dispatchEvent(uploadFailed);
+    } else {
+      this.attachment.setAttributes({
+        sgid: attributes.attachable_sgid,
+        url: this.createBlobUrl(attributes.signed_id, attributes.filename)
+      })
     }
-
-    this.attachment.setAttributes({
-      sgid: attributes.attachable_sgid,
-      url: this.createBlobUrl(attributes.signed_id, attributes.filename)
-    })
   }
 
   createBlobUrl(signedId, filename) {

--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -20,8 +20,8 @@ export class AttachmentUpload {
 
   directUploadDidComplete(error, attributes) {
     if (error) {
-      var uploadFailed = new CustomEvent("trix-attachment-error", {"detail": {"error": error }});
-      this.element.dispatchEvent(uploadFailed);
+      let uploadFailed = new CustomEvent("trix-attachment-error", {"detail": {"error": error }})
+      this.element.dispatchEvent(uploadFailed)
     } else {
       this.attachment.setAttributes({
         sgid: attributes.attachable_sgid,

--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -20,7 +20,8 @@ export class AttachmentUpload {
 
   directUploadDidComplete(error, attributes) {
     if (error) {
-      throw new Error(`Direct upload failed: ${error}`)
+      var uploadFailed = new CustomEvent("actiontext-attachment-error", {"detail": {"error": error }});
+      document.dispatchEvent(uploadFailed);
     }
 
     this.attachment.setAttributes({

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -1,5 +1,6 @@
 (function(global, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : factory(global.ActiveStorage = {});
+  typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : (global = global || self, 
+  factory(global.ActiveStorage = {}));
 })(this, function(exports) {
   "use strict";
   function createCommonjsModule(fn, module) {
@@ -12,7 +13,7 @@
       {
         module.exports = factory();
       }
-    })(function(undefined) {
+    })(function(undefined$1) {
       var hex_chr = [ "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" ];
       function md5cycle(x, k) {
         var a = x[0], b = x[1], c = x[2], d = x[3];
@@ -243,7 +244,7 @@
           }
           ArrayBuffer.prototype.slice = function(from, to) {
             var length = this.byteLength, begin = clamp(from, length), end = length, num, target, targetArray, sourceArray;
-            if (to !== undefined) {
+            if (to !== undefined$1) {
               end = clamp(to, length);
             }
             if (begin > end) {
@@ -510,7 +511,7 @@
       root = document;
     }
     var elements = root.querySelectorAll(selector);
-    return toArray$1(elements);
+    return toArray(elements);
   }
   function findElement(root, selector) {
     if (typeof root == "string") {
@@ -534,7 +535,7 @@
     }
     return event;
   }
-  function toArray$1(value) {
+  function toArray(value) {
     if (Array.isArray(value)) {
       return value;
     } else if (Array.from) {
@@ -609,12 +610,12 @@
       }
     }, {
       key: "status",
-      get: function get$$1() {
+      get: function get() {
         return this.xhr.status;
       }
     }, {
       key: "response",
-      get: function get$$1() {
+      get: function get() {
         var _xhr = this.xhr, responseType = _xhr.responseType, response = _xhr.response;
         if (responseType == "json") {
           return response;
@@ -795,7 +796,7 @@
       }
     }, {
       key: "url",
-      get: function get$$1() {
+      get: function get() {
         return this.input.getAttribute("data-direct-upload-url");
       }
     } ]);
@@ -839,7 +840,7 @@
       value: function createDirectUploadControllers() {
         var controllers = [];
         this.inputs.forEach(function(input) {
-          toArray$1(input.files).forEach(function(file) {
+          toArray(input.files).forEach(function(file) {
             var controller = new DirectUploadController(input, file);
             controllers.push(controller);
           });
@@ -934,8 +935,8 @@
     }
   }
   setTimeout(autostart, 1);
-  exports.start = start;
   exports.DirectUpload = DirectUpload;
+  exports.start = start;
   Object.defineProperty(exports, "__esModule", {
     value: true
   });

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -1,6 +1,5 @@
 (function(global, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : (global = global || self, 
-  factory(global.ActiveStorage = {}));
+  typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : factory(global.ActiveStorage = {});
 })(this, function(exports) {
   "use strict";
   function createCommonjsModule(fn, module) {
@@ -13,7 +12,7 @@
       {
         module.exports = factory();
       }
-    })(function(undefined$1) {
+    })(function(undefined) {
       var hex_chr = [ "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f" ];
       function md5cycle(x, k) {
         var a = x[0], b = x[1], c = x[2], d = x[3];
@@ -244,7 +243,7 @@
           }
           ArrayBuffer.prototype.slice = function(from, to) {
             var length = this.byteLength, begin = clamp(from, length), end = length, num, target, targetArray, sourceArray;
-            if (to !== undefined$1) {
+            if (to !== undefined) {
               end = clamp(to, length);
             }
             if (begin > end) {
@@ -511,7 +510,7 @@
       root = document;
     }
     var elements = root.querySelectorAll(selector);
-    return toArray(elements);
+    return toArray$1(elements);
   }
   function findElement(root, selector) {
     if (typeof root == "string") {
@@ -535,7 +534,7 @@
     }
     return event;
   }
-  function toArray(value) {
+  function toArray$1(value) {
     if (Array.isArray(value)) {
       return value;
     } else if (Array.from) {
@@ -610,12 +609,12 @@
       }
     }, {
       key: "status",
-      get: function get() {
+      get: function get$$1() {
         return this.xhr.status;
       }
     }, {
       key: "response",
-      get: function get() {
+      get: function get$$1() {
         var _xhr = this.xhr, responseType = _xhr.responseType, response = _xhr.response;
         if (responseType == "json") {
           return response;
@@ -796,7 +795,7 @@
       }
     }, {
       key: "url",
-      get: function get() {
+      get: function get$$1() {
         return this.input.getAttribute("data-direct-upload-url");
       }
     } ]);
@@ -840,7 +839,7 @@
       value: function createDirectUploadControllers() {
         var controllers = [];
         this.inputs.forEach(function(input) {
-          toArray(input.files).forEach(function(file) {
+          toArray$1(input.files).forEach(function(file) {
             var controller = new DirectUploadController(input, file);
             controllers.push(controller);
           });

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -936,6 +936,7 @@
   }
   setTimeout(autostart, 1);
   exports.DirectUpload = DirectUpload;
+  exports.dispatchEvent = dispatchEvent;
   exports.start = start;
   Object.defineProperty(exports, "__esModule", {
     value: true

--- a/activestorage/app/javascript/activestorage/index.js
+++ b/activestorage/app/javascript/activestorage/index.js
@@ -1,6 +1,7 @@
 import { start } from "./ujs"
 import { DirectUpload } from "./direct_upload"
-export { start, DirectUpload }
+import { dispatchEvent } from "./helpers"
+export { start, DirectUpload, dispatchEvent }
 
 function autostart() {
   if (window.ActiveStorage) {


### PR DESCRIPTION
### Summary

This is to allow the clean handling of when an upload fails using the Trix editor, by way of creating an event we can listen for and handle appropriately. 

See #37793 For more info

