### PR TITLE
implicitly translate flash messages with redirect_to

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -47,7 +47,7 @@ module ActionController #:nodoc:
       def redirect_to(options = {}, response_options_and_flash = {}) #:doc:
         self.class._flash_types.each do |flash_type|
           if type = response_options_and_flash.delete(flash_type)
-            flash[flash_type] = type
+            flash[flash_type] = type == true ? t(".#{flash_type}") : type
           end
         end
 

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -80,6 +80,14 @@ class FlashTest < ActionController::TestCase
       redirect_to "/somewhere", notice: "Good luck in the somewheres!"
     end
 
+    def redirect_with_alert_implicitly_translated
+      redirect_to "/nowhere", alert: true
+    end
+
+    def redirect_with_notice_implicitly_translated
+      redirect_to "/somewhere", notice: true
+    end
+
     def render_with_flash_now_alert
       flash.now.alert = "Beware the nowheres now!"
       render inline: "hello"
@@ -100,6 +108,21 @@ class FlashTest < ActionController::TestCase
   end
 
   tests TestController
+
+  setup do
+    I18n.backend.store_translations(:en,
+      flash_test: {
+        test: {
+          redirect_with_alert_implicitly_translated: {
+            alert: "Beware the implicitly translated nowheres!"
+          },
+          redirect_with_notice_implicitly_translated: {
+            notice: "Good luck in the implicitly translated somewheres!"
+          }
+        }
+      }
+    )
+  end
 
   def test_flash
     get :set_flash
@@ -195,6 +218,16 @@ class FlashTest < ActionController::TestCase
   def test_redirect_to_with_notice
     get :redirect_with_notice
     assert_equal "Good luck in the somewheres!", @controller.send(:flash)[:notice]
+  end
+
+  def test_redirect_to_with_alert_implicitly_translated
+    get :redirect_with_alert_implicitly_translated
+    assert_equal "Beware the implicitly translated nowheres!", @controller.send(:flash)[:alert]
+  end
+
+  def test_redirect_to_with_notice_implicitly_translated
+    get :redirect_with_notice_implicitly_translated
+    assert_equal "Good luck in the implicitly translated somewheres!", @controller.send(:flash)[:notice]
   end
 
   def test_render_with_flash_now_alert


### PR DESCRIPTION
### Summary

analogous to how `form.text_field :foo, placeholder: true` will enable and implicitly lookup the proper translation of the field's placeholder, do so with `redirect_to foo_path, notice: true` as well and give me the proper translated flash from `I18n`.

yesterday is was getting sick of typing over and over again:

```rb
redirect_to foo_path, notice: t(".notice")
# and
redirect_to foo_path, alert: t(".alert")
```

so i got around implementing this:

```rb
redirect_to foo_path, notice: true
# and
redirect_to foo_path, alert: true
```

**Notes**
- this makes `AC::Flash` implicitly dependent upon `AbstractController::Translation`
- this only works for "known" flash types (by default `notice` and `alert`) and such added with `add_flash_types`
- it only kicks in if the flash value is `true`, otherwise keeps the original behavior
