### PR TITLE
Fix making an extra db file after testing for sqlite3

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       fixtures :people
 
       def setup
-        @writing_handler = ActiveRecord::Base.connection_handlers[:writing]
+        @writing_handler = ConnectionHandler.new
       end
 
       def teardown


### PR DESCRIPTION
### Summary
Testing for sqlite3 makes an extra db file `primary.sqlite3` as below.
```
$ bundle exec rake test:sqlite3
(snip)
$ git status
On branch test
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        db/
```

However, I don't really understand why this happens. I just referenced another code. If my correction is misplaced, could you give me advice or close this and correct it?
