### PR TITLE
Add origin to the payload for notifications to redirect_to Instrumentation

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -66,6 +66,7 @@ module ActionController
         result = super
         payload[:status]   = response.status
         payload[:location] = response.filtered_location
+        payload[:request] = request
         result
       end
     end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -180,11 +180,13 @@ INFO. Additional keys may be added by the caller.
 | ----------- | ------------------ |
 | `:status`   | HTTP response code |
 | `:location` | URL to redirect to |
+| `:request`  | The `ActionDispatch::Request` |
 
 ```ruby
 {
   status: 302,
-  location: "http://localhost:3000/posts/new"
+  location: "http://localhost:3000/posts/new",
+  request: #<ActionDispatch::Request:0x00007ff1cb9bd7b8>
 }
 ```
 


### PR DESCRIPTION
This change will allow subscribers to the notification to report on the full request

### Summary

This PR adds the full request to the payload for `redirect_to.action_controller` instrumentation so that subscribers can gather whatever information they need from it

### Other Information

This is valuable for people listening to redirects in an application.  A real world use case for this, we have a lot of developers in our code base and would like to know when someone is using redirect_to and dropping `utm_campaign` query params in the process.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
