### PR TITLE
6-0 backport: Change execute_batch to take array of statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -73,8 +73,10 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         private
-          def execute_batch(sql, name = nil)
-            super
+          def execute_batch(statements, name = nil)
+            combine_multi_statements(statements).each do |statement|
+              execute(statement, name)
+            end
             @connection.abandon_results!
           end
 
@@ -88,14 +90,6 @@ module ActiveRecord
 
           def supports_set_server_option?
             @connection.respond_to?(:set_server_option)
-          end
-
-          def build_truncate_statements(*table_names)
-            if table_names.size == 1
-              super.first
-            else
-              super
-            end
           end
 
           def multi_statements_enabled?(flags)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -166,8 +166,12 @@ module ActiveRecord
         end
 
         private
-          def build_truncate_statements(*table_names)
-            "TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"
+          def execute_batch(statements, name = nil)
+            execute(combine_multi_statements(statements))
+          end
+
+          def build_truncate_statements(table_names)
+            ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
           end
 
           # Returns the current ID of a table's sequence.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -83,7 +83,9 @@ module ActiveRecord
 
 
         private
-          def execute_batch(sql, name = nil)
+          def execute_batch(statements, name = nil)
+            sql = combine_multi_statements(statements)
+
             if preventing_writes? && write_query?(sql)
               raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
             end
@@ -108,11 +110,8 @@ module ActiveRecord
             end.compact
           end
 
-          def build_truncate_statements(*table_names)
-            truncate_tables = table_names.map do |table_name|
-              "DELETE FROM #{quote_table_name(table_name)}"
-            end
-            combine_multi_statements(truncate_tables)
+          def build_truncate_statement(table_name)
+            "DELETE FROM #{quote_table_name(table_name)}"
           end
       end
     end


### PR DESCRIPTION
This backports https://github.com/rails/rails/pull/37707 to 6-0-stable to make it possible to use databases/connectors without enabling/supporting multiple statements.

I discussed the backport with @eileencodes 