### PR TITLE
Use optimized subclass of StringInquirer for Rails.env

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/string/inquiry.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/string_inquirer"
+require "active_support/environment_inquirer"
 
 class String
   # Wraps the current string in the <tt>ActiveSupport::StringInquirer</tt> class,

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  # This is a special case of StringInquirer that defines the three default
+  # environments at construction time based on the environment string.
+  class EnvironmentInquirer < StringInquirer
+    DEFAULT_ENVIRONMENTS = ["development", "test", "production"]
+    def initialize(env)
+      super(env)
+
+      DEFAULT_ENVIRONMENTS.each do |default_env|
+        singleton_class.define_method(:"#{env}?", (env == default_env).method(:itself))
+      end
+    end
+  end
+end

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -70,14 +70,14 @@ module Rails
     #   Rails.env.development? # => true
     #   Rails.env.production? # => false
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+      @_env ||= ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
     end
 
     # Sets the Rails environment.
     #
     #   Rails.env = "staging" # => "staging"
     def env=(environment)
-      @_env = ActiveSupport::StringInquirer.new(environment)
+      @_env = ActiveSupport::EnvironmentInquirer.new(environment)
     end
 
     # Returns all Rails groups for loading based on:


### PR DESCRIPTION
### Summary
This adds a StringInquirer subclass EnvironmentInquirer that
predefines the three default environments as query methods, in
order to avoid dispatching through `method_missing` for every call
to those methods. The original StringInquirer was not modified due
to the side effects of having new env-related methods on it. This
new class was not implemented using lazy method definition to
avoid the open-ended possibility of defining a new method for all
query calls. The three default environments should cover a high
percentage of real-world uses, and users with custom environments
could add their own to this class.

Fixes #37803.

I am open to discussion about the following points:

* Whether to lazily define all queries as they are called. Concerns include: runaway method definition, complexity.
* Whether to do these methods on StringInquirer itself, which currently is only used for `Rails.env` in the Rails codebase (but may be used for other purposes in userland code). Concerns include: new predefined env-related methods on what previously only had custom `*_missing` methods.

### Other Information

Using the following benchmark, `EnvironmentInquirer` is over 10x faster than plain `StringInquirer` on CRuby 2.6.4.

```ruby
require 'benchmark/ips'

require 'active_support/core_ext/string/inquiry'

Benchmark.ips do |ips|
  si = ActiveSupport::StringInquirer.new('development')
  env = ActiveSupport::EnvironmentInquirer.new('development')

  ips.report('StringInquirer') do |i|
    while i > 0
      si.development?
      i-=1
    end
  end

  ips.report('EnvironmentInquirer') do |i|
    while i > 0
      env.development?
      i-=1
    end
  end
end
```

Results:

```
Warming up --------------------------------------
      StringInquirer   145.978k i/100ms
 EnvironmentInquirer   367.087k i/100ms
Calculating -------------------------------------
      StringInquirer      2.332M (±10.8%) i/s -     11.532M in   5.019755s
 EnvironmentInquirer     27.333M (± 3.4%) i/s -    136.556M in   5.001554s
```