### PR TITLE
Easy to show `bundle exec rubocop` output at GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -23,8 +23,9 @@ jobs:
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gem-
-    - name: Build and run RuboCop
+    - name: Install gems
       run: |
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
-        bundle exec rubocop --parallel
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel


### PR DESCRIPTION
### Summary

When pull requests have RuboCop offenses they need to click the "Build and run RuboCop" section and scroll about 200 lines to skip `bundle install` output.

This change splits "Build and run RuboCop" into two parts. then the "Run RuboCop" section only shows `bundle exec rubocop --parallel` output.
