### PR TITLE
Call `MonitorMixin` initializer before use methods provided by `MonitorMixin`

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -136,11 +136,11 @@ module ActionController
       attr_accessor :ignore_disconnect
 
       def initialize(response)
+        super(response, SizedQueue.new(10))
         @error_callback = lambda { true }
         @cv = new_cond
         @aborted = false
         @ignore_disconnect = false
-        super(response, SizedQueue.new(10))
       end
 
       def write(string)


### PR DESCRIPTION
`MonitorMixin` setup internal variables in `initialize`, so need to call that before use. 
`ActionController::Live::Buffer` only use methods that do not depend on those
internal variables, so works expertly.

But since Ruby 2.7, methods that were not originally the case also depend on internal variables. As a result, some tests fail in Ruby 2.7.
https://buildkite.com/rails/rails/builds/65193#02e136eb-edea-4367-aee0-77e0a82f8531/990-1200

I'm not sure if this should be considered Ruby incompatible, but I fixed this because its usage is wrong.

Related to [Feature #16255: Make `monitor.rb` built-in](https://bugs.ruby-lang.org/issues/16255)

