### PR TITLE
Add ActionText installer rake task

### DIFF
--- a/actiontext/lib/tasks/actiontext.rake
+++ b/actiontext/lib/tasks/actiontext.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc "Copy over the migration, stylesheet, and JavaScript files"
+task "action_text:install" do
+  Rails::Command.invoke :generate, ["action_text:install"]
+end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -160,7 +160,8 @@ module Rails
             "#{css}:scaffold",
             "#{css}:assets",
             "css:assets",
-            "css:scaffold"
+            "css:scaffold",
+            "action_text:install"
           ]
         end
       end


### PR DESCRIPTION
After changes in #35085

While I was debugging this #37818, I faced with the issue where `rails action_text:install` as mentioned in the documentation was not working. After debugging for long it landed me to this PR: #35085 

PR moved the ActionText installer from task to generator. The documentation and warning message where user was suggested to run generator was not updated. This PR update the mention on ActionText installer.

I am not confident about changes in `tasks/release` file. Please do let me know if we need to revert it.