### PR TITLE
ActionText installer should not fail for JS dependency 

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -12,8 +12,7 @@ module ActionText
         run "rake app:update:bin"
 
         say "Installing JavaScript dependencies"
-        run "yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}",
-          abort_on_failure: true, capture: true
+        run "yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}"
       end
 
       def append_dependencies_to_package_file


### PR DESCRIPTION
While I was debugging this #37818, the ActionText installer failed on Rails master branch because `@rails/actiontext` version `^6.1.0-alpha`  is not yet released.
```
error Couldn't find any versions for "@rails/actiontext" that matches "^6.1.0-alpha"
```
So I tried adding `@rails/actiontext` version `6.0.1` and tried running the installer again but it still failed with the same error.

Previously, the task did not fail and would prompt that `@rails/actiontext` version was not found. Ref: https://github.com/rails/rails/pull/35085/files#diff-7e2078bf029f66dc871d69d9cec4ea35L22
```
Couldn't find any versions for "@rails/actiontext" that matches "^6.1.0-alpha"
? Please choose a version of "@rails/actiontext" from this list:
```

**Before changes:**
<img width="614" alt="37181-after-action-text-install" src="https://user-images.githubusercontent.com/7736232/69779092-d4d5bf80-11cc-11ea-83e4-b4f94d3b289a.png">


**After changes:** 
<img width="784" alt="37181-before-action-text-install" src="https://user-images.githubusercontent.com/7736232/69779003-87595280-11cc-11ea-82de-5ac4006d10a7.png">