### PR TITLE
The return value of `ActiveSupport::Duration#inspect` is wrong when its parts are empty

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -375,7 +375,7 @@ module ActiveSupport
     alias :before :ago
 
     def inspect #:nodoc:
-      return "0 seconds" if parts.empty?
+      return "#{value} seconds" if parts.empty?
 
       parts.
         sort_by { |unit,  _ | PARTS.index(unit) }.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -74,6 +74,7 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "2 weeks",                         1.fortnight.inspect
     assert_equal "0 seconds",                       (10 % 5.seconds).inspect
     assert_equal "10 minutes",                      (10.minutes + 0.seconds).inspect
+    assert_equal "3600 seconds",                    (1.day / 24).inspect
   end
 
   def test_inspect_locale


### PR DESCRIPTION
```ruby
(1.day / 24).inspect   #=> "0 seconds"
(1.day / 24).to_i      #=> 3600
(1.day / 24) == 1.hour #=> true
(1.hour).inspect       #=> "1 hour"
(1.hour).parts         #=> {:hours=>1}
(1.day / 24).parts     #=> {}
```

Sometimes divisions of `ActiveSupport::Duration` make the instance's `parts` attribute empty. But these instances are not always 0 seconds.

Related to #31310 and #31302
