### PR TITLE
Fix typo in "Options for render" section [ci skip]

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -279,7 +279,7 @@ TIP: `send_file` is often a faster and better option if a layout isn't required.
 
 #### Options for `render`
 
-Calls to the `render` method generally accept five options:
+Calls to the `render` method generally accept six options:
 
 * `:content_type`
 * `:layout`


### PR DESCRIPTION
### Summary

The "2.2.12 Options for render" section of "Rails Layouts and Rendering" actually has six options, not five.

### Other Information

None.
