### PR TITLE
Test extensions to Mail gem

### DIFF
--- a/actionmailbox/test/unit/mail_ext/addresses_test.rb
+++ b/actionmailbox/test/unit/mail_ext/addresses_test.rb
@@ -3,13 +3,18 @@
 require_relative "../../test_helper"
 
 module MailExt
-  class RecipientsTest < ActiveSupport::TestCase
+  class AddressesTest < ActiveSupport::TestCase
     setup do
       @mail = Mail.new \
+        from: "sally@example.com",
         to: "david@basecamp.com",
         cc: "jason@basecamp.com",
         bcc: "andrea@basecamp.com",
         x_original_to: "ryan@basecamp.com"
+    end
+
+    test "from address uses address object" do
+      assert_equal "example.com", @mail.from_address.domain
     end
 
     test "recipients include everyone from to, cc, bcc, and x-original-to" do
@@ -30,6 +35,10 @@ module MailExt
 
     test "bcc addresses use address objects" do
       assert_equal "basecamp.com", @mail.bcc_addresses.first.domain
+    end
+
+    test "x_original_to addresses use address objects" do
+      assert_equal "basecamp.com", @mail.x_original_to_addresses.first.domain
     end
   end
 end


### PR DESCRIPTION
The from_address method is added to Mail::Message, but is not used
internally to ActionMailbox, nor tested (even implicitly). As it is part
of the public API, it feels important to at least have a basic test of
it.

Similarly, the x_original_to_addresses was only implicitly tested via
the recipients_addresses method. Given other similar methods are
explicitly tested, it feels like an oversight not to test it as well.

As the test for from_address didn't align with the naming of
RecipientsTest, which was testing methods both from addresses.rb and
recipients.rb, I split the existing test into two separate ones that
matched the name of the file the were testing. I thought this was
cleaner than introducing a new test just for the from_address method.