### PR TITLE
Use `app.config.file_watcher` for watcher in `RoutesReloader`

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -341,7 +341,7 @@ module Rails
     end
 
     def routes_reloader #:nodoc:
-      @routes_reloader ||= RoutesReloader.new
+      @routes_reloader ||= RoutesReloader.new(file_watcher: config.file_watcher)
     end
 
     # Returns an array of file paths appended with a hash of

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -9,10 +9,11 @@ module Rails
       attr_accessor :eager_load
       delegate :execute_if_updated, :execute, :updated?, to: :updater
 
-      def initialize
+      def initialize(file_watcher: ActiveSupport::FileUpdateChecker)
         @paths      = []
         @route_sets = []
         @eager_load = false
+        @file_watcher = file_watcher
       end
 
       def reload!
@@ -26,7 +27,7 @@ module Rails
 
     private
       def updater
-        @updater ||= ActiveSupport::FileUpdateChecker.new(paths) { reload! }
+        @updater ||= @file_watcher.new(paths) { reload! }
       end
 
       def clear!

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -184,11 +184,8 @@ class LoadingTest < ActiveSupport::TestCase
   test "does not reload constants on development if custom file watcher always returns false" do
     add_to_config <<-RUBY
       config.cache_classes = false
-      config.file_watcher = Class.new do
-        def initialize(*); end
+      config.file_watcher = Class.new(ActiveSupport::FileUpdateChecker) do
         def updated?; false; end
-        def execute; end
-        def execute_if_updated; false; end
       end
     RUBY
 


### PR DESCRIPTION
### Summary

Use `config.file_watcher` to determine which class to use as the watcher for `Rails::Application::RoutesReloader`. Currently it is being hardcoded to `ActiveSupport::FileUpdateChecker`.

