### PR TITLE
Fix bug when requesting for variants in public disk controller

### DIFF
--- a/activestorage/app/controllers/active_storage/public_disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/public_disk_controller.rb
@@ -7,9 +7,9 @@ class ActiveStorage::PublicDiskController < ActiveStorage::BaseController
   skip_forgery_protection
 
   def show
-    if blob = ActiveStorage::Blob.find_by(key: params[:key])
+    if blob = ActiveStorage::Blob.find_by(key: extract_blob_key)
       if blob.service.public?
-        serve_file blob.service.path_for(blob.key), content_type: blob.content_type, disposition: :inline
+        serve_file blob.service.path_for(params[:key]), content_type: blob.content_type, disposition: :inline
       else
         head :unauthorized
       end
@@ -17,4 +17,13 @@ class ActiveStorage::PublicDiskController < ActiveStorage::BaseController
       head :not_found
     end
   end
+
+  private
+    def extract_blob_key
+      if params[:key].start_with? "variant"
+        params[:key].split("/")[1]
+      else
+        params[:key]
+      end
+    end
 end

--- a/activestorage/test/controllers/public_disk_controller_test.rb
+++ b/activestorage/test/controllers/public_disk_controller_test.rb
@@ -30,4 +30,14 @@ class ActiveStorage::PublicDiskControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
   end
+
+  test "showing public blob variant" do
+    with_service("local_public") do
+      blob = create_file_blob.variant(resize_to_limit: [100, 100]).processed
+
+      get blob.url
+      assert_response :ok
+      assert_equal "image/jpeg", response.headers["Content-Type"]
+    end
+  end
 end


### PR DESCRIPTION
### Summary

There's a bug when requesting for a variant in `PublicDiskController` because the variant sets a different [`key` attribute](https://github.com/rails/rails/blob/master/activestorage/app/models/active_storage/variant.rb#L73) that causes `ActiveStorage::Blob.find_by` to fail and thus it returns a 404 not found. This PR extracts the key of the blob from the URL parameter in order to find the blob.
