### PR TITLE
Add download and delete methods for ActiveStorage::Variant

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -85,6 +85,16 @@ class ActiveStorage::Variant
   alias_method :service_url, :url
   deprecate service_url: :url
 
+  # Downloads the content of the variant from the service. See {ActiveStorage::Service#download} for details.
+  def download(&block)
+    service.download key, &block
+  end
+
+  # Deletes the variant from the service. See {ActiveStorage::Service#delete} for details.
+  def delete
+    service.delete key
+  end
+
   # Returns the receiving variant. Allows ActiveStorage::Variant and ActiveStorage::Preview instances to be used interchangeably.
   def image
     self

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -217,4 +217,22 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
       blob.variant(resize: "100x100").processed
     end
   end
+
+  test "download a variant" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    variant = blob.variant(resize: "100x100").processed
+
+    image = read_image(variant)
+
+    assert_equal image.to_blob, variant.download
+  end
+
+  test "delete a variant" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    variant = blob.variant(resize: "100x100").processed
+
+    variant.delete
+
+    assert_not variant.service.exist?(variant.key)
+  end
 end


### PR DESCRIPTION
### Summary

Adds `download` and `delete` methods to `ActiveStorage::Variant` that allow you to download or delete a variant from the backing service, respectively.
