### PR TITLE
Fix typo colection -> collection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,7 +6,7 @@
     *Edouard Chin*
 
 *   Fix the preloader when one record is fetched using `after_initialize`
-    but not the entire colection.
+    but not the entire collection.
 
     *Bradley Price*
 


### PR DESCRIPTION
`colection` -> `collection`

**NOTE:** This PR is raised on `6-0-2` branch and not on `master`.