### PR TITLE
Correct default value of `unknown_asset_fallback` [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -570,7 +570,7 @@ config.assets.unknown_asset_fallback = false
 ```
 
 If "asset fallback" is enabled then when an asset cannot be found the path will be
-output instead and no error raised. The asset fallback behavior is enabled by default.
+output instead and no error raised. The asset fallback behavior is disabled by default.
 
 ### Turning Digests Off
 


### PR DESCRIPTION
### Summary
`unknown_asset_fallback` defaults to `false`.
Refer to 6813b480a1.

In addition, I also referred to https://github.com/rails/rails/blob/master/railties/lib/rails/application/configuration.rb#L95.
