### PR TITLE
Add the ability to customize ActionDispatch::RequestId http header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add the ability to customize `ActionDispatch::RequestId` http header and generator.
+
+    *Nikolay Kondratyev*
+
 *   `redirect_to.action_controller` notifications now include the `ActionDispatch::Request` in
     their payloads as `:request`.
 

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -6,25 +6,26 @@ require "active_support/core_ext/string/access"
 module ActionDispatch
   # Makes a unique request id available to the +action_dispatch.request_id+ env variable (which is then accessible
   # through <tt>ActionDispatch::Request#request_id</tt> or the alias <tt>ActionDispatch::Request#uuid</tt>) and sends
-  # the same id to the client via the X-Request-Id header.
+  # the same id to the client via the +http_header+ which default value is X-Request-Id.
   #
-  # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated
+  # The unique request id is either based on the +http_header+ in the request, which would typically be generated
   # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the
   # header is accepted from the outside world, we sanitize it to a max of 255 chars and alphanumeric and dashes only.
   #
   # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
   # from multiple pieces of the stack.
   class RequestId
-    X_REQUEST_ID = "X-Request-Id" #:nodoc:
-
-    def initialize(app)
+    def initialize(app, http_header: nil, generator: nil)
+      @http_header = http_header || "X-Request-Id"
+      @http_header_key = http_header_key(@http_header)
+      @generator = generator || SecureRandom.method(:uuid)
       @app = app
     end
 
     def call(env)
-      req = ActionDispatch::Request.new env
-      req.request_id = make_request_id(req.x_request_id)
-      @app.call(env).tap { |_status, headers, _body| headers[X_REQUEST_ID] = req.request_id }
+      req = ActionDispatch::Request.new(env)
+      req.request_id = make_request_id(req.get_header(@http_header_key))
+      @app.call(env).tap { |_status, headers, _body| headers[@http_header] = req.request_id }
     end
 
     private
@@ -32,12 +33,12 @@ module ActionDispatch
         if request_id.presence
           request_id.gsub(/[^\w\-@]/, "").first(255)
         else
-          internal_request_id
+          @generator.call
         end
       end
 
-      def internal_request_id
-        SecureRandom.uuid
+      def http_header_key(header)
+        "HTTP_#{header.upcase.tr("-", "_")}"
       end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -237,7 +237,7 @@ Every Rails application comes with a standard set of middleware which it uses in
 * `Rack::Runtime` sets an `X-Runtime` header, containing the time (in seconds) taken to execute the request.
 * `Rails::Rack::Logger` notifies the logs that the request has begun. After request is complete, flushes all the logs.
 * `ActionDispatch::ShowExceptions` rescues any exception returned by the application and renders nice exception pages if the request is local or if `config.consider_all_requests_local` is set to `true`. If `config.action_dispatch.show_exceptions` is set to `false`, exceptions will be raised regardless.
-* `ActionDispatch::RequestId` makes a unique X-Request-Id header available to the response and enables the `ActionDispatch::Request#uuid` method.
+* `ActionDispatch::RequestId` makes a unique X-Request-Id header available to the response and enables the `ActionDispatch::Request#uuid` method. Configurable with the `config.action_dispatch.request_id_http_header`, and `config.action_dispatch.request_id_generator` options.
 * `ActionDispatch::RemoteIp` checks for IP spoofing attacks and gets valid `client_ip` from request headers. Configurable with the `config.action_dispatch.ip_spoofing_check`, and `config.action_dispatch.trusted_proxies` options.
 * `Rack::Sendfile` intercepts responses whose body is being served from a file and replaces it with a server specific X-Sendfile header. Configurable with `config.action_dispatch.x_sendfile_header`.
 * `ActionDispatch::Callbacks` runs the prepare callbacks before serving the request.

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -43,7 +43,7 @@ module Rails
 
           middleware.use ::Rack::Runtime
           middleware.use ::Rack::MethodOverride unless config.api_only
-          middleware.use ::ActionDispatch::RequestId
+          middleware.use ::ActionDispatch::RequestId, http_header: config.action_dispatch.request_id_http_header, generator: config.action_dispatch.request_id_generator
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           middleware.use ::Rails::Rack::Logger, config.log_tags


### PR DESCRIPTION
### Summary

There should be able to set HTTP header for request id instead of [deprecated](https://tools.ietf.org/html/rfc6648) X-Request-Id or in case of custom HTTP header passed by load balancer.

It may also be useful to change random request id generator from UUID to [ULID](https://github.com/ulid/spec) or something else.