### PR TITLE
Fix ActiveStorage::Blob → ActionText::TrixAttachment conversion

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -29,6 +29,10 @@ module ActionText
         def attachable_plain_text_representation(caption = nil)
           "[#{caption || filename}]"
         end
+
+        def to_trix_content_attachment_partial_path
+          nil
+        end
       end
     end
 

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -32,8 +32,8 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal attachable.byte_size, trix_attachment.attributes["filesize"]
     assert_equal "Captioned", trix_attachment.attributes["caption"]
 
-    assert_not_nil attachable.to_trix_content_attachment_partial_path
-    assert_not_nil trix_attachment.attributes["content"]
+    assert_nil attachable.to_trix_content_attachment_partial_path
+    assert_nil trix_attachment.attributes["content"]
   end
 
   test "converts to TrixAttachment with content" do


### PR DESCRIPTION
A regression introduced in 764803e07a5c89c931df9a1c4fe730f73b7571e6 caused blobs to appear as HTML content attachments instead of file / image attachments when editing rich text content. This change restores the original intended behavior.

References: https://github.com/rails/rails/pull/35485, https://github.com/basecamp/trix/issues/706