### PR TITLE
Avoid allocating Binding instance in HWIA#convert_value

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -91,7 +91,7 @@ module ActiveSupport
     #
     # This value can be later fetched using either +:key+ or <tt>'key'</tt>.
     def []=(key, value)
-      regular_writer(convert_key(key), convert_value(value, for: :assignment))
+      regular_writer(convert_key(key), convert_value(value, conversion: :assignment))
     end
 
     alias_method :store, :[]=
@@ -357,7 +357,7 @@ module ActiveSupport
       set_defaults(_new_hash)
 
       each do |key, value|
-        _new_hash[key] = convert_value(value, for: :to_hash)
+        _new_hash[key] = convert_value(value, conversion: :to_hash)
       end
       _new_hash
     end
@@ -367,9 +367,7 @@ module ActiveSupport
         key.kind_of?(Symbol) ? key.to_s : key
       end
 
-      def convert_value(value, for: nil) # :doc:
-        conversion = binding.local_variable_get(:for)
-
+      def convert_value(value, conversion: nil) # :doc:
         if value.is_a? Hash
           if conversion == :to_hash
             value.to_hash
@@ -380,7 +378,7 @@ module ActiveSupport
           if conversion != :assignment || value.frozen?
             value = value.dup
           end
-          value.map! { |e| convert_value(e, for: conversion) }
+          value.map! { |e| convert_value(e, conversion: conversion) }
         else
           value
         end


### PR DESCRIPTION
`ActiveSupport::HashWithIndifferentAccess#convert_value` appeared quite high in some production profile so I took a look and found that weird `binding` access.

Digging into the git history to figure the reason, it seems it originate from https://github.com/rails/rails/pull/36758 and then https://github.com/rails/rails/commit/64a430129fbec2320054a8fc85672994f38a9ee0

The initial goal was to reduce the allocation in that hotspot by using keyword arguments. But since `for` is a keyword, `binding.get_local_variable` was used as a workaround. 

However `binding` does allocate a new `Binding` instance on each invocation, and is a quite slow method.

But since `convert_value` is a private method, I think we can simply rename the argument, and avoid all of that.

I adapted the benchmark from https://github.com/rails/rails/pull/36758: 

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  gem 'activesupport'
  gem 'benchmark-ips'
  gem 'memory_profiler'
end

require 'active_support/all'

class OptimizedHashWithIndifferentAccess < ActiveSupport::HashWithIndifferentAccess
  private

  EMPTY_HASH = {}.freeze

  # Convert to a regular hash with string keys.
  def to_hash
    _new_hash = Hash.new
    set_defaults(_new_hash)

    each do |key, value|
      _new_hash[key] = convert_value(value, conversion: :to_hash)
    end
    _new_hash
  end
  
  def []=(key, value)
    regular_writer(convert_key(key), convert_value(value, conversion: :assignment))
  end
  
  def convert_value(value, conversion: nil) # :doc:
    if value.is_a? Hash
      if conversion == :to_hash
        value.to_hash
      else
        value.nested_under_indifferent_access
      end
    elsif value.is_a?(Array)
      if conversion != :assignment || value.frozen?
        value = value.dup
      end
      value.map! { |e| convert_value(e, conversion: conversion) }
    else
      value
    end
  end
end

num_values = 25
source = num_values.times.each_with_object({}) { |i, result| result["Key#{i}"] = i }

Benchmark.ips do |x|
  x.report("original") { ActiveSupport::HashWithIndifferentAccess.new(source) }
  x.report("optimized") { OptimizedHashWithIndifferentAccess.new(source) }
  x.compare!
end

original_memory = MemoryProfiler.report do
  ActiveSupport::HashWithIndifferentAccess.new(source)
end

optimized_memory = MemoryProfiler.report do
  OptimizedHashWithIndifferentAccess.new(source)
end

puts "Memory Change: #{(original_memory.total_allocated_memsize - optimized_memory.total_allocated_memsize)} bytes"
```

Produce the following output:
```
Warming up --------------------------------------
            original    11.834k i/100ms
           optimized    12.398k i/100ms
Calculating -------------------------------------
            original    126.947k (±10.8%) i/s -    627.202k in   5.009570s
           optimized    128.584k (±11.3%) i/s -    644.696k in   5.084137s

Comparison:
           optimized:   128584.3 i/s
            original:   126946.7 i/s - same-ish: difference falls within error

Memory Change: 5800 bytes
```

@kaspth @rafaelfranca 

cc @etiennebarrie @Edouard-chin @paracycle @Morriar @ignacio-chiazzo