### PR TITLE
Fix bug in configs_for

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -31,12 +31,14 @@ module ActiveRecord
     # * <tt>env_name:</tt> The environment name. Defaults to +nil+ which will collect
     #   configs for all environments.
     # * <tt>spec_name:</tt> The specification name (i.e. primary, animals, etc.). Defaults
-    #   to +nil+.
+    #   to +nil+. If no +env_name+ is specified the config for the default env and the
+    #   passed +spec_name+ will be returned.
     # * <tt>include_replicas:</tt> Determines whether to include replicas in
     #   the returned list. Most of the time we're only iterating over the write
     #   connection (i.e. migrations don't need to run for the write and read connection).
     #   Defaults to +false+.
     def configs_for(env_name: nil, spec_name: nil, include_replicas: false)
+      env_name ||= default_env if spec_name
       configs = env_with_configs(env_name)
 
       unless include_replicas
@@ -60,7 +62,7 @@ module ActiveRecord
     # return the first config hash for the environment.
     #
     #   { database: "my_db", adapter: "mysql2" }
-    def default_hash(env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s)
+    def default_hash(env = default_env)
       default = find_db_config(env)
       default.configuration_hash if default
     end
@@ -132,14 +134,17 @@ module ActiveRecord
       when Symbol
         resolve_symbol_connection(config, pool_name)
       when Hash, String
-        env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s
-        build_db_config_from_raw_config(env, "primary", config)
+        build_db_config_from_raw_config(default_env, "primary", config)
       else
         raise TypeError, "Invalid type for configuration. Expected Symbol, String, or Hash. Got #{config.inspect}"
       end
     end
 
     private
+      def default_env
+        ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s
+      end
+
       def env_with_configs(env = nil)
         if env
           configurations.select { |db_config| db_config.env_name == env }
@@ -160,13 +165,11 @@ module ActiveRecord
           end
         end
 
-        current_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s
-
         unless db_configs.find(&:for_current_env?)
-          db_configs << environment_url_config(current_env, "primary", {})
+          db_configs << environment_url_config(default_env, "primary", {})
         end
 
-        merge_db_environment_variables(current_env, db_configs.compact)
+        merge_db_environment_variables(default_env, db_configs.compact)
       end
 
       def walk_configs(env_name, config)
@@ -183,7 +186,7 @@ module ActiveRecord
           DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.spec_name, config)
         else
           raise AdapterNotSpecified, <<~MSG
-            The `#{env_name}` database is not configured for the `#{ActiveRecord::ConnectionHandling::DEFAULT_ENV.call}` environment.
+            The `#{env_name}` database is not configured for the `#{default_env}` environment.
 
               Available databases configurations are:
 

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -25,6 +25,17 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal ["arunit"], configs.map(&:env_name)
   end
 
+  def test_configs_for_getter_with_spec_name
+    previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit2"
+
+    config = ActiveRecord::Base.configurations.configs_for(spec_name: "primary")
+
+    assert_equal "arunit2", config.env_name
+    assert_equal "primary", config.spec_name
+  ensure
+    ENV["RAILS_ENV"] = previous_env
+  end
+
   def test_configs_for_getter_with_env_and_spec_name
     config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
 


### PR DESCRIPTION
If a spec name was provided without an env name, config_for would return
the first config that matched the spec, regardless of environment name.

Now configs_for will return the database config that matches the
default env and requested spec name.

Additionally this commit has moved the default env call into a method
because I'm tired of typing so many lines every single time.

We considered either returning all configs that match that spec name or
raising an error if only spec was passed, but this change has the least
impact on current behavior and matches Active Record's assumptions: that
if you ask for configs it will always consider the current environment.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>