### PR TITLE
Deprecate `database` kwarg from `connected_to` without replacement

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The `database` kwarg is deprecated without replacement because it can't be used for sharding and creates an issue if it's used during a request. Applications that need to create new connections should use `connects_to` instead.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Allow attributes to be fetched from Arel node groupings.
 
     *Jeff Emminger*, *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -95,27 +95,11 @@ module ActiveRecord
     #   ActiveRecord::Base.connected_to(role: :unknown_role) do
     #     # raises exception due to non-existent role
     #   end
-    #
-    # For cases where you may want to connect to a database outside of the model,
-    # you can use +connected_to+ with a +database+ argument. The +database+ argument
-    # expects a symbol that corresponds to the database key in your config.
-    #
-    #   ActiveRecord::Base.connected_to(database: :animals_slow_replica) do
-    #     Dog.run_a_long_query # runs a long query while connected to the +animals_slow_replica+
-    #   end
-    #
-    # This will connect to a new database for the queries inside the block. By
-    # default the `:writing` role will be used since all connections must be assigned
-    # a role. If you would like to use a different role you can pass a hash to database:
-    #
-    #   ActiveRecord::Base.connected_to(database: { readonly_slow: :animals_slow_replica }) do
-    #     # runs a long query while connected to the +animals_slow_replica+ using the readonly_slow role.
-    #     Dog.run_a_long_query
-    #   end
-    #
-    # When using the database key a new connection will be established every time. It is not
-    # recommended to use this outside of one-off scripts.
     def connected_to(database: nil, role: nil, prevent_writes: false, &blk)
+      if database
+        ActiveSupport::Deprecation.warn("The database key in `connected_to` is deprecated. It will be removed in Rails 6.2.0 without replacement.")
+      end
+
       if database && role
         raise ArgumentError, "connected_to can only accept a `database` or a `role` argument, but not both arguments."
       elsif database

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -156,16 +156,15 @@ module ActiveRecord
           previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
           previous_url, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgres://localhost/foo"
 
-          ActiveRecord::Base.connected_to(database: { writing: "postgres://localhost/bar" }) do
-            assert_equal :writing, ActiveRecord::Base.current_role
-            assert ActiveRecord::Base.connected_to?(role: :writing)
+          ActiveRecord::Base.connects_to(database: { writing: "postgres://localhost/bar" })
+          assert_equal :writing, ActiveRecord::Base.current_role
+          assert ActiveRecord::Base.connected_to?(role: :writing)
 
-            handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+          handler = ActiveRecord::Base.connection_handler
+          assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
-          end
+          assert_not_nil pool = handler.retrieve_connection_pool("primary")
+          assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
@@ -176,16 +175,15 @@ module ActiveRecord
           previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
           config = { adapter: "sqlite3", database: "db/readonly.sqlite3" }
 
-          ActiveRecord::Base.connected_to(database: { writing: config }) do
-            assert_equal :writing, ActiveRecord::Base.current_role
-            assert ActiveRecord::Base.connected_to?(role: :writing)
+          ActiveRecord::Base.connects_to(database: { writing: config })
+          assert_equal :writing, ActiveRecord::Base.current_role
+          assert ActiveRecord::Base.connected_to?(role: :writing)
 
-            handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+          handler = ActiveRecord::Base.connection_handler
+          assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config, pool.db_config.configuration_hash)
-          end
+          assert_not_nil pool = handler.retrieve_connection_pool("primary")
+          assert_equal(config, pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
@@ -193,7 +191,9 @@ module ActiveRecord
 
         def test_switching_connections_with_database_and_role_raises
           error = assert_raises(ArgumentError) do
-            ActiveRecord::Base.connected_to(database: :readonly, role: :writing) { }
+            assert_deprecated do
+              ActiveRecord::Base.connected_to(database: :readonly, role: :writing) { }
+            end
           end
           assert_equal "connected_to can only accept a `database` or a `role` argument, but not both arguments.", error.message
         end
@@ -216,16 +216,15 @@ module ActiveRecord
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
-          ActiveRecord::Base.connected_to(database: :animals) do
-            assert_equal :writing, ActiveRecord::Base.current_role
-            assert ActiveRecord::Base.connected_to?(role: :writing)
+          ActiveRecord::Base.connects_to(database: { writing: :animals })
+          assert_equal :writing, ActiveRecord::Base.current_role
+          assert ActiveRecord::Base.connected_to?(role: :writing)
 
-            handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+          handler = ActiveRecord::Base.connection_handler
+          assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["animals"], pool.db_config.configuration_hash)
-          end
+          assert_not_nil pool = handler.retrieve_connection_pool("primary")
+          assert_equal(config["default_env"]["animals"], pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -243,16 +242,15 @@ module ActiveRecord
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
-          ActiveRecord::Base.connected_to(database: { writing: :primary }) do
-            assert_equal :writing, ActiveRecord::Base.current_role
-            assert ActiveRecord::Base.connected_to?(role: :writing)
+          ActiveRecord::Base.connects_to(database: { writing: :primary })
+          assert_equal :writing, ActiveRecord::Base.current_role
+          assert ActiveRecord::Base.connected_to?(role: :writing)
 
-            handler = ActiveRecord::Base.connection_handler
-            assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
+          handler = ActiveRecord::Base.connection_handler
+          assert_equal handler, ActiveRecord::Base.connection_handlers[:writing]
 
-            assert_not_nil pool = handler.retrieve_connection_pool("primary")
-            assert_equal(config["default_env"]["primary"], pool.db_config.configuration_hash)
-          end
+          assert_not_nil pool = handler.retrieve_connection_pool("primary")
+          assert_equal(config["default_env"]["primary"], pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)


### PR DESCRIPTION
The `database` kwarg in `connected_to` has resulted in a lot of bug
reports that are trying to use it for sharding when that's not the
intent of the key. After considering where the database kwarg is used in
tests and thinking about usecases for it, we've determined it should be
removed.

There are plans to add sharding support and in the mean time the
database kwarg isn't the right solution for that. Applications that need
to create new connections can use establish_connection or connects_to.
Since the database key causes new connections to be established on every
call, that causes bugs if connected_to with a database kwarg is used
during a request or for any connection that's not a one-off.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>