### PR TITLE
Remove deprecated non-symbol access to nested config_for hashes

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -75,6 +75,30 @@ To allow you to upgrade to new defaults one by one, the update task has created 
 Upgrading from Rails 6.0 to Rails 6.1
 -------------------------------------
 
+### `Rails.application.config_for` return value no longer supports access with String keys.
+
+Given a configuration file like this:
+
+```yaml
+# config/example.yml
+development:
+  options:
+    key: value
+```
+
+```ruby
+Rails.application.config_for(:example).options
+```
+
+This used to return a hash on which you could access values with String keys. That was deprecated in 6.0, and now doesn't work anymore.
+
+You can call `with_indifferent_access` on the return value of `config_for` if you still want to access values with String keys, e.g.:
+
+```ruby
+Rails.application.config_for(:example).with_indifferent_access.dig('options', 'key')
+```
+
+
 ### Response's Content-Type when using `respond_to#any`
 
 The Content-Type header returned in the response can differ from what Rails 6.0 returned,

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Remove access to values in nested hashes returned by `Rails.application.config_for` via String keys.
+
+    ```yaml
+    # config/example.yml
+    development:
+      options:
+        key: value
+    ```
+
+    ```ruby
+    Rails.application.config_for(:example).options
+    ```
+
+    This used to return a Hash on which you could access values with String keys. This was deprecated in 6.0, and now doesn't work anymore.
+
+    *Étienne Barrié*
+
 *   Configuration files for environments (`config/environments/*.rb`) are
     now able to modify `autoload_paths`, `autoload_once_paths`, and
     `eager_load_paths`.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1934,47 +1934,6 @@ module ApplicationTests
       assert_equal 1, Rails.application.config.my_custom_config[:foo][:bar][:baz]
     end
 
-    test "config_for loads nested custom configuration from yaml with deprecated non-symbol access" do
-      app_file "config/custom.yml", <<-RUBY
-      development:
-        foo:
-          bar:
-            baz: 1
-      RUBY
-
-      add_to_config <<-RUBY
-        config.my_custom_config = config_for('custom')
-      RUBY
-
-      app "development"
-
-      assert_deprecated do
-        assert_equal 1, Rails.application.config.my_custom_config["foo"]["bar"]["baz"]
-      end
-    end
-
-    test "config_for loads nested custom configuration inside array from yaml with deprecated non-symbol access" do
-      app_file "config/custom.yml", <<-RUBY
-      development:
-        foo:
-          bar:
-          - baz: 1
-      RUBY
-
-      add_to_config <<-RUBY
-        config.my_custom_config = config_for('custom')
-      RUBY
-
-      app "development"
-
-      config = Rails.application.config.my_custom_config
-      assert_instance_of Rails::Application::NonSymbolAccessDeprecatedHash, config[:foo][:bar].first
-
-      assert_deprecated do
-        assert_equal 1, config[:foo][:bar].first["baz"]
-      end
-    end
-
     test "config_for makes all hash methods available" do
       app_file "config/custom.yml", <<-RUBY
       development:
@@ -1997,87 +1956,6 @@ module ApplicationTests
       assert_equal({ foo: 0, bar: { baz: 1 } }, actual.to_h)
       assert_equal(0, actual[:foo])
       assert_equal({ baz: 1 }, actual[:bar])
-    end
-
-    test "config_for generates deprecation notice when nested hash methods are called with non-symbols" do
-      app_file "config/custom.yml", <<-RUBY
-      development:
-        foo:
-          bar: 1
-          baz: 2
-          qux:
-            boo: 3
-      RUBY
-
-      app "development"
-
-      actual = Rails.application.config_for("custom")[:foo]
-
-      # slice
-      assert_deprecated do
-        assert_equal({ bar: 1, baz: 2 }, actual.slice("bar", "baz"))
-      end
-
-      # except
-      assert_deprecated do
-        assert_equal({ qux: { boo: 3 } }, actual.except("bar", "baz"))
-      end
-
-      # dig
-      assert_deprecated do
-        assert_equal(3, actual.dig("qux", "boo"))
-      end
-
-      # fetch - hit
-      assert_deprecated do
-        assert_equal(1, actual.fetch("bar", 0))
-      end
-
-      # fetch - miss
-      assert_deprecated do
-        assert_equal(0, actual.fetch("does-not-exist", 0))
-      end
-
-      # fetch_values
-      assert_deprecated do
-        assert_equal([1, 2], actual.fetch_values("bar", "baz"))
-      end
-
-      # key? - hit
-      assert_deprecated do
-        assert(actual.key?("bar"))
-      end
-
-      # key? - miss
-      assert_deprecated do
-        assert_not(actual.key?("does-not-exist"))
-      end
-
-      # slice!
-      actual = Rails.application.config_for("custom")[:foo]
-
-      assert_deprecated do
-        slice = actual.slice!("bar", "baz")
-        assert_equal({ bar: 1, baz: 2 }, actual)
-        assert_equal({ qux: { boo: 3 } }, slice)
-      end
-
-      # extract!
-      actual = Rails.application.config_for("custom")[:foo]
-
-      assert_deprecated do
-        extracted = actual.extract!("bar", "baz")
-        assert_equal({ bar: 1, baz: 2 }, extracted)
-        assert_equal({ qux: { boo: 3 } }, actual)
-      end
-
-      # except!
-      actual = Rails.application.config_for("custom")[:foo]
-
-      assert_deprecated do
-        actual.except!("bar", "baz")
-        assert_equal({ qux: { boo: 3 } }, actual)
-      end
     end
 
     test "config_for uses the Pathname object if it is provided" do


### PR DESCRIPTION
### Summary

This fixes an issue with #37870 where nested hashes returned by `config_for` could return Hash subclasses instead of strictly a Hash when calling `to_hash`.

Since we changed the name of the `for` option in HashWithIndifferentAccess, and the class dealing with deprecations takes an options hash, there's no exception but the option is silently ignored, which in turn changes the behavior of `HashWithIndifferentAccess#to_hash`.

Instead of fixing the code, this removes the deprecation code, which also solves the issue.

```ruby
# before #37870 
Rails.application.config_for(:example)[:a_hash].to_hash[:other_hash]['key'] # => nil

# after #37870 
Rails.application.config_for(:example)[:a_hash].to_hash[:other_hash]['key']
# DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead. (called from <main> at (pry):1)
# => "value"

# after this PR
Rails.application.config_for(:example)[:a_hash].to_hash[:other_hash]['key'] # => nil
```

### Other Information

I used the `symbolize_names` option `YAML.load`, which seems to be the first usage of it in Rails. This required me to symbolize the environment name, and the `"shared"` special key.
Another possibility would be to use `deep_symbolize_keys` as was done before #35198, but since we're loading the configuration file ourselves, it felt like an unnecessary traversal of the whole data structure. Let me know if that was a mistake.

@rafaelfranca
cc @byroot @Edouard-chin @paracycle @Morriar