### PR TITLE
Hide internal utility methods in the public API doc [ci skip]

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -363,11 +363,11 @@ module ActiveSupport
     end
 
     private
-      def convert_key(key) # :doc:
+      def convert_key(key)
         key.kind_of?(Symbol) ? key.to_s : key
       end
 
-      def convert_value(value, conversion: nil) # :doc:
+      def convert_value(value, conversion: nil)
         if value.is_a? Hash
           if conversion == :to_hash
             value.to_hash
@@ -384,7 +384,7 @@ module ActiveSupport
         end
       end
 
-      def set_defaults(target) # :doc:
+      def set_defaults(target)
         if default_proc
           target.default_proc = default_proc.dup
         else


### PR DESCRIPTION
I digged the history for the internal utility methods (`convert_key`,
`convert_value`, and `set_defaults`), I believe it is apparently not
intended to appear them in the public API doc.

* `convert_key`, `convert_value`: 71742114
* `set_defaults`: #20828

https://api.rubyonrails.org/v6.0.1/classes/ActiveSupport/HashWithIndifferentAccess.html

Since we sometimes makes breaking change for internal methods (e.g.
#37870), so that methods should not be leaked to the public API doc.