### PR TITLE
Should keep the original parts for zero duration

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -186,15 +186,15 @@ module ActiveSupport
         end
 
         parts = {}
-        remainder = value.to_f
+        remainder = value.round(9)
 
         PARTS.each do |part|
           unless part == :seconds
             part_in_seconds = PARTS_IN_SECONDS[part]
             parts[part] = remainder.div(part_in_seconds)
-            remainder = (remainder % part_in_seconds).round(9)
+            remainder %= part_in_seconds
           end
-        end
+        end unless value == 0
 
         parts[:seconds] = remainder
 
@@ -212,7 +212,7 @@ module ActiveSupport
     def initialize(value, parts) #:nodoc:
       @value, @parts = value, parts.to_h
       @parts.default = 0
-      @parts.reject! { |k, v| v.zero? }
+      @parts.reject! { |k, v| v.zero? } unless value == 0
     end
 
     def coerce(other) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -62,6 +62,7 @@ class DurationTest < ActiveSupport::TestCase
 
   def test_inspect
     assert_equal "0 seconds",                       0.seconds.inspect
+    assert_equal "0 days",                          0.days.inspect
     assert_equal "1 month",                         1.month.inspect
     assert_equal "1 month and 1 day",               (1.month + 1.day).inspect
     assert_equal "6 months and -2 days",            (6.months - 2.days).inspect
@@ -155,20 +156,29 @@ class DurationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::Duration, 13.months % 1.year
   end
 
+  def test_date_added_with_zero_days
+    assert_equal Date.civil(2017, 1, 1), Date.civil(2017, 1, 1) + 0.days
+    assert_instance_of Date, Date.civil(2017, 1, 1) + 0.days
+  end
+
   def test_date_added_with_multiplied_duration
     assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 1.day * 2
+    assert_instance_of Date, Date.civil(2017, 1, 1) + 1.day * 2
   end
 
   def test_date_added_with_multiplied_duration_larger_than_one_month
     assert_equal Date.civil(2017, 2, 15), Date.civil(2017, 1, 1) + 1.day * 45
+    assert_instance_of Date, Date.civil(2017, 1, 1) + 1.day * 45
   end
 
   def test_date_added_with_divided_duration
     assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 4.days / 2
+    assert_instance_of Date, Date.civil(2017, 1, 1) + 4.days / 2
   end
 
   def test_date_added_with_divided_duration_larger_than_one_month
     assert_equal Date.civil(2017, 2, 15), Date.civil(2017, 1, 1) + 90.days / 2
+    assert_instance_of Date, Date.civil(2017, 1, 1) + 90.days / 2
   end
 
   def test_plus_with_time


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/37849#issuecomment-560557239.

Without this, `0.days` is considered as `0.seconds` due to #31310.
We should not lose the original parts.