### PR TITLE
Add `page` generator

### DIFF
--- a/railties/lib/rails/generators/rails/page/page_generator.rb
+++ b/railties/lib/rails/generators/rails/page/page_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    class PageGenerator < NamedBase
+      class_option :root, type: :boolean, default: false,
+        desc: "Add root route"
+
+      def create_controller
+        invoke :controller, [name, ["index"]], { skip_routes: true, test_framework: false }
+      end
+
+      def add_route
+        route "get '#{file_name}', to: '#{file_name}#index'", namespace: regular_class_path
+      end
+
+      def add_root_route
+        return unless options[:root]
+        route "root to: '#{file_name}#index'"
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/page/page_generator.rb
+++ b/railties/lib/rails/generators/test_unit/page/page_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails/generators/test_unit"
+
+module TestUnit # :nodoc:
+  module Generators # :nodoc:
+    class PageGenerator < Base # :nodoc:
+      class_option :root, type: :boolean
+
+      check_class_collision suffix: "ControllerTest"
+
+      def create_test_files
+        template "functional_test.rb",
+                 File.join("test/controllers", class_path, "#{file_name}_controller_test.rb")
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/page/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/page/templates/functional_test.rb.tt
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+<% module_namespacing do -%>
+class <%= class_name %>ControllerTest < ActionDispatch::IntegrationTest
+<% if mountable_engine? -%>
+  include Engine.routes.url_helpers
+
+<% end -%>
+  test "should get index" do
+    get <%= url_helper_prefix %>_url
+    assert_response :success
+  end
+<% if options[:root] -%>
+
+  test "should get index via root route" do
+    get <%= url_helper_prefix %>_url
+    index_body = response.body
+    get root_url
+    assert_equal index_body, response.body
+  end
+<% end -%>
+end
+<% end -%>


### PR DESCRIPTION
The `page` generator generates one-off pages in an idiomatic way.  Specifically, a one-off page will have a corresponding route and a dedicated controller with `index` action and view.

---

I often see questions about the best practice for adding an e.g. "About Us" page to a Rails app.  Many answers recommend using a single controller with one or more non-REST action.  Some answers even recommend additional gems to manage one-off pages.

The `page` generator establishes and encourages a convention for one-off pages based on DHH's recommendations from a [podcast](http://www.fullstackradio.com/32) ([transcript of relevant portion](http://jeromedalbert.com/how-dhh-organizes-his-rails-controllers/)).  For example, `rails generate page about` will generate the `/about` route, `AboutController` with `index` action, index view, and integration tests.

(As a point of clarity, the `page` generator differs from the `controller` generator in that the `controller` generator generates routes as `/#{controller}/#{action}`, with tests to match.  So `rails generate controller about index` will generate an `/about/index` route and a test that invokes `about_index_url`.)

The `page` generator also provides a `--root` option to generate the root route.  For example, `rails generate page home --root` will additionally draw the `/` route to `HomeController#index`.

TODO:
- [ ] tests
