### PR TITLE
Small doc fixes for ActiveJob::Exceptions::ClassMethods#retry_on

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -19,12 +19,12 @@ module ActiveJob
       # ==== Options
       # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
       #   as a computing proc that the number of executions so far as an argument, or as a symbol reference of
-      #   <tt>:exponentially_longer</tt>, which applies the wait algorithm of <tt><((executions**4) + (Kernel.rand((executions**4) * jitter))) + 2/tt>
+      #   <tt>:exponentially_longer</tt>, which applies the wait algorithm of <tt>((executions**4) + (Kernel.rand((executions**4) * jitter))) + 2</tt>
       #   (first wait ~3s, then ~18s, then ~83s, etc)
       # * <tt>:attempts</tt> - Re-enqueues the job the specified number of times (default: 5 attempts)
       # * <tt>:queue</tt> - Re-enqueues the job on a different queue
       # * <tt>:priority</tt> - Re-enqueues the job with a different priority
-      # * <tt>:jitter</tt> - A random delay of wait time used when calculating backoff. The default is 15%(0.15) which represents the upper bound of possible wait time (expressed as a percentage)
+      # * <tt>:jitter</tt> - A random delay of wait time used when calculating backoff. The default is 15% (0.15) which represents the upper bound of possible wait time (expressed as a percentage)
       #
       # ==== Examples
       #


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/31872

Particularly, the closing `</tt>` tag of the documented wait algorithm had a misplaced `<`.  Threw in a space between `15% (0.15)` for good measure.