### PR TITLE
Add `Rails::Application::Configuration#database_configuration=`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `Rails::Application::Configuration#database_configuration=`.
+
+    This is useful if you'd like to set database config without config/database.yml file.
+
+    ```ruby
+    Rails.configuration.database_configuration = {
+      "development" => {
+        "adapter" => "sqlite3",
+        "database" => ":memory:"
+      }
+    }
+    ```
+
+    *Ryo Nakamura*
+
 *   Remove access to values in nested hashes returned by `Rails.application.config_for` via String keys.
 
     ```yaml

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1704,6 +1704,19 @@ module ApplicationTests
       assert_kind_of Hash, Rails.application.config.database_configuration
     end
 
+    test "config.database_configuration can be set" do
+      app "development"
+      database_configuration = {
+        "development" => {
+          "adapter" => "sqlite3",
+          "database" => ":memory:"
+        }
+      }
+      Rails.configuration.database_configuration = database_configuration
+
+      assert_equal database_configuration, Rails.configuration.database_configuration
+    end
+
     test "autoload paths do not include asset paths" do
       app "development"
       ActiveSupport::Dependencies.autoload_paths.each do |path|


### PR DESCRIPTION
### Summary

I added the following changes:

- Added `Rails::Application::Configuration#database_configuration=`
- Changed `Rails::Application::Configuration#database_configuration`

so that we can set database configuration without config/database.yml or `ENV["DATABASE_URL"]`.

```ruby
Rails.configuration.database_configuration = {
  "development" => {
    "adapter" => "sqlite3",
    "database" => ":memory:"
  }
}
```

### Other Information

I needed this API at https://github.com/rails/rails/pull/37888/files#diff-1d52fed1aa29d830cc0d3c9c4fa97c8dR38.