### PR TITLE
Update docs of String methods using ActiveSupport::Inflector [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -160,7 +160,7 @@ class String
   #   '::Inflections'.demodulize                         # => "Inflections"
   #   ''.demodulize                                      # => ''
   #
-  # See ActiveSupport::Inflector.demodulize
+  # See ActiveSupport::Inflector.demodulize.
   #
   # See also +deconstantize+.
   def demodulize

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -262,7 +262,7 @@ class String
   #   '_id'.humanize                                # => "Id"
   #   'author_id'.humanize(keep_id_suffix: true)    # => "Author Id"
   #
-  # See ActiveSupport::Inflector.humanize
+  # See ActiveSupport::Inflector.humanize.
   def humanize(capitalize: true, keep_id_suffix: false)
     ActiveSupport::Inflector.humanize(self, capitalize: capitalize, keep_id_suffix: keep_id_suffix)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -56,7 +56,7 @@ class String
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
   #
-  # See ActiveSupport::Inflector.singularize
+  # See ActiveSupport::Inflector.singularize.
   def singularize(locale = :en)
     ActiveSupport::Inflector.singularize(self, locale)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -31,7 +31,7 @@ class String
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
   #
-  # See ActiveSupport::Inflector.pluralize
+  # See ActiveSupport::Inflector.pluralize.
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
     if count == 1

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -148,7 +148,7 @@ class String
   #
   #   'puni_puni'.dasherize # => "puni-puni"
   #
-  # See ActiveSupport::Inflector.dasherize
+  # See ActiveSupport::Inflector.dasherize.
   def dasherize
     ActiveSupport::Inflector.dasherize(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -215,7 +215,7 @@ class String
   #   <%= link_to(@person.name, person_path) %>
   #   # => <a href="/person/1-Donald-E-Knuth">Donald E. Knuth</a>
   #
-  # See ActiveSupport::Inflector.parameterize
+  # See ActiveSupport::Inflector.parameterize.
   def parameterize(separator: "-", preserve_case: false, locale: nil)
     ActiveSupport::Inflector.parameterize(self, separator: separator, preserve_case: preserve_case, locale: locale)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -30,6 +30,8 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
+  #
+  # See ActiveSupport::Inflector.pluralize
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
     if count == 1
@@ -53,28 +55,34 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
+  #
+  # See ActiveSupport::Inflector.singularize
   def singularize(locale = :en)
     ActiveSupport::Inflector.singularize(self, locale)
   end
 
   # +constantize+ tries to find a declared constant with the name specified
   # in the string. It raises a NameError when the name is not in CamelCase
-  # or is not initialized.  See ActiveSupport::Inflector.constantize
+  # or is not initialized.
   #
   #   'Module'.constantize  # => Module
   #   'Class'.constantize   # => Class
   #   'blargle'.constantize # => NameError: wrong constant name blargle
+  #
+  # See ActiveSupport::Inflector.constantize
   def constantize
     ActiveSupport::Inflector.constantize(self)
   end
 
   # +safe_constantize+ tries to find a declared constant with the name specified
   # in the string. It returns +nil+ when the name is not in CamelCase
-  # or is not initialized.  See ActiveSupport::Inflector.safe_constantize
+  # or is not initialized.
   #
   #   'Module'.safe_constantize  # => Module
   #   'Class'.safe_constantize   # => Class
   #   'blargle'.safe_constantize # => nil
+  #
+  # See ActiveSupport::Inflector.safe_constantize
   def safe_constantize
     ActiveSupport::Inflector.safe_constantize(self)
   end
@@ -88,6 +96,10 @@ class String
   #   'active_record'.camelize(:lower)        # => "activeRecord"
   #   'active_record/errors'.camelize         # => "ActiveRecord::Errors"
   #   'active_record/errors'.camelize(:lower) # => "activeRecord::Errors"
+  #
+  # +camelize+ is also aliased as +camelcase+.
+  #
+  # See ActiveSupport::Inflector.camelize
   def camelize(first_letter = :upper)
     case first_letter
     when :upper
@@ -108,11 +120,13 @@ class String
   # optional parameter +keep_id_suffix+ to true.
   # By default, this parameter is false.
   #
-  # +titleize+ is also aliased as +titlecase+.
-  #
   #   'man from the boondocks'.titleize                       # => "Man From The Boondocks"
   #   'x-men: the last stand'.titleize                        # => "X Men: The Last Stand"
   #   'string_ending_with_id'.titleize(keep_id_suffix: true)  # => "String Ending With Id"
+  #
+  # +titleize+ is also aliased as +titlecase+.
+  #
+  # See ActiveSupport::Inflector.titleize
   def titleize(keep_id_suffix: false)
     ActiveSupport::Inflector.titleize(self, keep_id_suffix: keep_id_suffix)
   end
@@ -124,6 +138,8 @@ class String
   #
   #   'ActiveModel'.underscore         # => "active_model"
   #   'ActiveModel::Errors'.underscore # => "active_model/errors"
+  #
+  # See ActiveSupport::Inflector.underscore
   def underscore
     ActiveSupport::Inflector.underscore(self)
   end
@@ -131,6 +147,8 @@ class String
   # Replaces underscores with dashes in the string.
   #
   #   'puni_puni'.dasherize # => "puni-puni"
+  #
+  # See ActiveSupport::Inflector.dasherize
   def dasherize
     ActiveSupport::Inflector.dasherize(self)
   end
@@ -141,6 +159,8 @@ class String
   #   'Inflections'.demodulize                           # => "Inflections"
   #   '::Inflections'.demodulize                         # => "Inflections"
   #   ''.demodulize                                      # => ''
+  #
+  # See ActiveSupport::Inflector.demodulize
   #
   # See also +deconstantize+.
   def demodulize
@@ -154,6 +174,8 @@ class String
   #   'String'.deconstantize      # => ""
   #   '::String'.deconstantize    # => ""
   #   ''.deconstantize            # => ""
+  #
+  # See ActiveSupport::Inflector.deconstantize
   #
   # See also +demodulize+.
   def deconstantize
@@ -192,6 +214,8 @@ class String
   #
   #   <%= link_to(@person.name, person_path) %>
   #   # => <a href="/person/1-Donald-E-Knuth">Donald E. Knuth</a>
+  #
+  # See ActiveSupport::Inflector.parameterize
   def parameterize(separator: "-", preserve_case: false, locale: nil)
     ActiveSupport::Inflector.parameterize(self, separator: separator, preserve_case: preserve_case, locale: locale)
   end
@@ -202,6 +226,8 @@ class String
   #   'RawScaledScorer'.tableize # => "raw_scaled_scorers"
   #   'ham_and_egg'.tableize     # => "ham_and_eggs"
   #   'fancyCategory'.tableize   # => "fancy_categories"
+  #
+  # See ActiveSupport::Inflector.tableize
   def tableize
     ActiveSupport::Inflector.tableize(self)
   end
@@ -212,6 +238,8 @@ class String
   #
   #   'ham_and_eggs'.classify # => "HamAndEgg"
   #   'posts'.classify        # => "Post"
+  #
+  # See ActiveSupport::Inflector.classify
   def classify
     ActiveSupport::Inflector.classify(self)
   end
@@ -233,6 +261,8 @@ class String
   #   'author_id'.humanize(capitalize: false)       # => "author"
   #   '_id'.humanize                                # => "Id"
   #   'author_id'.humanize(keep_id_suffix: true)    # => "Author Id"
+  #
+  # See ActiveSupport::Inflector.humanize
   def humanize(capitalize: true, keep_id_suffix: false)
     ActiveSupport::Inflector.humanize(self, capitalize: capitalize, keep_id_suffix: keep_id_suffix)
   end
@@ -242,6 +272,8 @@ class String
   #   'what a Lovely Day'.upcase_first # => "What a Lovely Day"
   #   'w'.upcase_first                 # => "W"
   #   ''.upcase_first                  # => ""
+  #
+  # See ActiveSupport::Inflector.upcase_first
   def upcase_first
     ActiveSupport::Inflector.upcase_first(self)
   end
@@ -253,6 +285,8 @@ class String
   #   'Message'.foreign_key        # => "message_id"
   #   'Message'.foreign_key(false) # => "messageid"
   #   'Admin::Post'.foreign_key    # => "post_id"
+  #
+  # See ActiveSupport::Inflector.foreign_key
   def foreign_key(separate_class_name_and_id_with_underscore = true)
     ActiveSupport::Inflector.foreign_key(self, separate_class_name_and_id_with_underscore)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -227,7 +227,7 @@ class String
   #   'ham_and_egg'.tableize     # => "ham_and_eggs"
   #   'fancyCategory'.tableize   # => "fancy_categories"
   #
-  # See ActiveSupport::Inflector.tableize
+  # See ActiveSupport::Inflector.tableize.
   def tableize
     ActiveSupport::Inflector.tableize(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -273,7 +273,7 @@ class String
   #   'w'.upcase_first                 # => "W"
   #   ''.upcase_first                  # => ""
   #
-  # See ActiveSupport::Inflector.upcase_first
+  # See ActiveSupport::Inflector.upcase_first.
   def upcase_first
     ActiveSupport::Inflector.upcase_first(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -69,7 +69,7 @@ class String
   #   'Class'.constantize   # => Class
   #   'blargle'.constantize # => NameError: wrong constant name blargle
   #
-  # See ActiveSupport::Inflector.constantize
+  # See ActiveSupport::Inflector.constantize.
   def constantize
     ActiveSupport::Inflector.constantize(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -82,7 +82,7 @@ class String
   #   'Class'.safe_constantize   # => Class
   #   'blargle'.safe_constantize # => nil
   #
-  # See ActiveSupport::Inflector.safe_constantize
+  # See ActiveSupport::Inflector.safe_constantize.
   def safe_constantize
     ActiveSupport::Inflector.safe_constantize(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -139,7 +139,7 @@ class String
   #   'ActiveModel'.underscore         # => "active_model"
   #   'ActiveModel::Errors'.underscore # => "active_model/errors"
   #
-  # See ActiveSupport::Inflector.underscore
+  # See ActiveSupport::Inflector.underscore.
   def underscore
     ActiveSupport::Inflector.underscore(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -99,7 +99,7 @@ class String
   #
   # +camelize+ is also aliased as +camelcase+.
   #
-  # See ActiveSupport::Inflector.camelize
+  # See ActiveSupport::Inflector.camelize.
   def camelize(first_letter = :upper)
     case first_letter
     when :upper

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -239,7 +239,7 @@ class String
   #   'ham_and_eggs'.classify # => "HamAndEgg"
   #   'posts'.classify        # => "Post"
   #
-  # See ActiveSupport::Inflector.classify
+  # See ActiveSupport::Inflector.classify.
   def classify
     ActiveSupport::Inflector.classify(self)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -286,7 +286,7 @@ class String
   #   'Message'.foreign_key(false) # => "messageid"
   #   'Admin::Post'.foreign_key    # => "post_id"
   #
-  # See ActiveSupport::Inflector.foreign_key
+  # See ActiveSupport::Inflector.foreign_key.
   def foreign_key(separate_class_name_and_id_with_underscore = true)
     ActiveSupport::Inflector.foreign_key(self, separate_class_name_and_id_with_underscore)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -126,7 +126,7 @@ class String
   #
   # +titleize+ is also aliased as +titlecase+.
   #
-  # See ActiveSupport::Inflector.titleize
+  # See ActiveSupport::Inflector.titleize.
   def titleize(keep_id_suffix: false)
     ActiveSupport::Inflector.titleize(self, keep_id_suffix: keep_id_suffix)
   end

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -175,7 +175,7 @@ class String
   #   '::String'.deconstantize    # => ""
   #   ''.deconstantize            # => ""
   #
-  # See ActiveSupport::Inflector.deconstantize
+  # See ActiveSupport::Inflector.deconstantize.
   #
   # See also +demodulize+.
   def deconstantize


### PR DESCRIPTION
### Summary

* Add references to methods defined in `ActiveSupport::Inflector`
* Add document of aliased method (`#camelcase`)
