### PR TITLE
Switch to the writer DB to generate ASt previews

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -74,7 +74,11 @@ class ActiveStorage::Preview
     end
 
     def process
-      previewer.preview { |attachable| image.attach(attachable) }
+      previewer.preview do |attachable|
+        ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+          image.attach(attachable)
+        end
+      end
     end
 
     def variant

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -37,4 +37,15 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
       blob.preview resize: "640x280"
     end
   end
+
+  test "previewing on the writer DB" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+
+    # Simulate a selector middleware switching to a read-only replica.
+    ActiveRecord::Base.connection_handler.while_preventing_writes do
+      blob.preview(resize: "640x280").processed
+    end
+
+    assert blob.reload.preview_image.attached?
+  end
 end


### PR DESCRIPTION
Fixes that preview generation would fail in apps using Active Record multi-DB support to default GET requests to a read-only replica DB. Preview requests are necessarily GETs and need to use the writer.