### PR TITLE
Fix translate method with default: nil

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActionView::Helpers::TranslationHelper#translate` should return nil when
+    passed `default: nil` and no translation is available, as `I18n#translate` does
+
+    *Stefan Wrobel*
+
 *   `OptimizedFileSystemResolver` prefers template details in order of locale,
     formats, variants, handlers.
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -59,7 +59,7 @@ module ActionView
       # they can provide HTML values for.
       def translate(key, options = {})
         options = options.dup
-        if options.has_key?(:default)
+        if options.has_key?(:default) && !options[:default].nil?
           remaining_defaults = Array.wrap(options.delete(:default)).compact
           options[:default] = remaining_defaults unless remaining_defaults.first.kind_of?(Symbol)
         end

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -241,6 +241,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal [], translation
   end
 
+  def test_translate_with_false_default
+    translation = translate(:'translations.missing', default: false)
+    assert_equal false, translation
+  end
+
+  def test_translate_with_nil_default
+    translation = translate(:'translations.missing', default: nil)
+    assert_nil translation
+  end
+
   def test_translate_does_not_change_options
     options = {}
     translate(:'translations.missing', options)


### PR DESCRIPTION
### Summary

`I18n.translate('missing.translation', default: nil)` will return `nil` but the wrapper in ActionView will actually change that default to `[]` which causes `translation missing` to be returned, which changes the expected underlying behavior of I18n. This fixes that scenario.

```ruby
I18n.translate('missing.translation', default: nil)
# => nil
helper.translate('missing.translation', default: nil)
# Before
# => "<span class=\"translation_missing\" title=\"translation missing: en.missing.translation\">Translation</span>"
# After
# => nil
```