### PR TITLE
Upgrade listen to 3.2.1 for darwin fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,10 +239,10 @@ GEM
     faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.11.1)
-    ffi (1.11.1-java)
-    ffi (1.11.1-x64-mingw32)
-    ffi (1.11.1-x86-mingw32)
+    ffi (1.11.3)
+    ffi (1.11.3-java)
+    ffi (1.11.3-x64-mingw32)
+    ffi (1.11.3-x86-mingw32)
     fugit (1.3.3)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.1)
@@ -297,7 +297,7 @@ GEM
       mustache
       nokogiri
     libxml-ruby (3.1.0)
-    listen (3.2.0)
+    listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.3.0)


### PR DESCRIPTION
Pulls in a fix where the darwin adapter no longers create a `fsevent_watch` process
for each directory that Listen has been asked to watch.

### Summary

See https://github.com/guard/listen/commit/caf46a03b0625f8b1ec8a5dd0137de6dbc797927

Resolves: https://github.com/rails/rails/issues/26158, https://github.com/rails/rails/issues/37269

