### PR TITLE
Revert "Use `app.config.file_watcher` for watcher in `RoutesReloader`"

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -341,7 +341,7 @@ module Rails
     end
 
     def routes_reloader #:nodoc:
-      @routes_reloader ||= RoutesReloader.new(file_watcher: config.file_watcher)
+      @routes_reloader ||= RoutesReloader.new
     end
 
     # Returns an array of file paths appended with a hash of

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -9,11 +9,10 @@ module Rails
       attr_accessor :eager_load
       delegate :execute_if_updated, :execute, :updated?, to: :updater
 
-      def initialize(file_watcher: ActiveSupport::FileUpdateChecker)
+      def initialize
         @paths      = []
         @route_sets = []
         @eager_load = false
-        @file_watcher = file_watcher
       end
 
       def reload!
@@ -27,7 +26,7 @@ module Rails
 
     private
       def updater
-        @updater ||= @file_watcher.new(paths) { reload! }
+        @updater ||= ActiveSupport::FileUpdateChecker.new(paths) { reload! }
       end
 
       def clear!

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -184,8 +184,11 @@ class LoadingTest < ActiveSupport::TestCase
   test "does not reload constants on development if custom file watcher always returns false" do
     add_to_config <<-RUBY
       config.cache_classes = false
-      config.file_watcher = Class.new(ActiveSupport::FileUpdateChecker) do
+      config.file_watcher = Class.new do
+        def initialize(*); end
         def updated?; false; end
+        def execute; end
+        def execute_if_updated; false; end
       end
     RUBY
 


### PR DESCRIPTION
This reverts commit 28e44f472d1cd6853726f85eeb7623e5901c4d37.

A limitation of Listen is that it currently only supports watching directories.
Therefore, watching `config/routes.rb` will end up watching the entire `config` directory
if we use the evented file watcher. This causes problems especially if symlinks are present
in the `config` directory.

