### PR TITLE
Track Active Storage variants in the database

### DIFF
--- a/actionmailbox/test/dummy/db/migrate/20180212164506_create_active_storage_tables.active_storage.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180212164506_create_active_storage_tables.active_storage.rb
@@ -24,5 +24,13 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
   end
 end

--- a/actiontext/test/dummy/db/migrate/20180212164506_create_active_storage_tables.rb
+++ b/actiontext/test/dummy/db/migrate/20180212164506_create_active_storage_tables.rb
@@ -24,5 +24,13 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
   end
 end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -44,6 +44,12 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_on_blob_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.string "subject"
     t.datetime "created_at", precision: 6, null: false
@@ -69,4 +75,5 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Variants are tracked in the database to avoid existence checks in the storage service.
+
+    *George Claghorn*
+
 *   Deprecate `service_url` methods in favour of `url`.
 
     Deprecate `Variant#service_url` and `Preview#service_url` to instead use

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -4,6 +4,9 @@ module ActiveStorage::Blob::Representable
   extend ActiveSupport::Concern
 
   included do
+    has_many :variant_records, class_name: "ActiveStorage::VariantRecord", dependent: false
+    before_destroy { variant_records.destroy_all if ActiveStorage.track_variants }
+
     has_one_attached :preview_image
   end
 
@@ -27,7 +30,7 @@ module ActiveStorage::Blob::Representable
   # variable, call ActiveStorage::Blob#variable?.
   def variant(transformations)
     if variable?
-      ActiveStorage::Variant.new(self, transformations)
+      variant_class.new(self, transformations)
     else
       raise ActiveStorage::InvariableError
     end
@@ -90,4 +93,9 @@ module ActiveStorage::Blob::Representable
   def representable?
     variable? || previewable?
   end
+
+  private
+    def variant_class
+      ActiveStorage.track_variants ? ActiveStorage::VariantWithRecord : ActiveStorage::Variant
+    end
 end

--- a/activestorage/app/models/active_storage/variant_record.rb
+++ b/activestorage/app/models/active_storage/variant_record.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ActiveStorage::VariantRecord < ActiveRecord::Base
+  self.table_name = "active_storage_variant_records"
+
+  belongs_to :blob
+  has_one_attached :image
+end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class ActiveStorage::VariantWithRecord
+  WEB_IMAGE_CONTENT_TYPES = %w[ image/png image/jpeg image/jpg image/gif ]
+
+  attr_reader :blob, :variation
+
+  def initialize(blob, variation)
+    @blob, @variation = blob, ActiveStorage::Variation.wrap(variation)
+  end
+
+  def processed
+    process
+    self
+  end
+
+  def process
+    transform_blob { |image| create_or_find_record(image: image) } unless processed?
+  end
+
+  def processed?
+    record.present?
+  end
+
+  def image
+    record&.image
+  end
+
+  def url(**options)
+    image&.url(**options)
+  end
+
+  alias_method :service_url, :url
+  deprecate service_url: :url
+
+  private
+    def transform_blob
+      blob.open do |input|
+        if blob.content_type.in?(WEB_IMAGE_CONTENT_TYPES)
+          variation.transform(input) do |output|
+            yield io: output, filename: blob.filename, content_type: blob.content_type
+          end
+        else
+          variation.transform(input, format: "png") do |output|
+            yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+          end
+        end
+      end
+    end
+
+    def create_or_find_record(image:)
+      @record =
+        ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+          blob.variant_records.create_or_find_by!(variation_digest: variation.digest) do |record|
+            record.image.attach(image)
+          end
+        end
+    end
+
+    def record
+      @record ||= blob.variant_records.find_by(variation_digest: variation.digest)
+    end
+end

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -58,6 +58,10 @@ class ActiveStorage::Variation
     self.class.encode(transformations)
   end
 
+  def digest
+    Digest::SHA1.base64digest Marshal.dump(transformations)
+  end
+
   private
     def transformer
       if ActiveStorage.variant_processor

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -23,5 +23,13 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
   end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,0 +1,11 @@
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -63,6 +63,7 @@ module ActiveStorage
   mattr_accessor :draw_routes, default: true
 
   mattr_accessor :replace_on_assign_to_many, default: false
+  mattr_accessor :track_variants, default: false
 
   module Transformers
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -84,6 +84,7 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
+        ActiveStorage.track_variants = app.config.active_storage.track_variants || false
       end
     end
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -5,6 +5,14 @@ require "database/setup"
 require "minitest/mock"
 
 class ActiveStorage::VariantTest < ActiveSupport::TestCase
+  setup do
+    @was_tracking, ActiveStorage.track_variants = ActiveStorage.track_variants, false
+  end
+
+  teardown do
+    ActiveStorage.track_variants = @was_tracking
+  end
+
   test "variations have the same key for different types of the same transformation" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant_a = blob.variant(resize: "100x100")

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
+  setup do
+    @was_tracking, ActiveStorage.track_variants = ActiveStorage.track_variants, true
+  end
+
+  teardown do
+    ActiveStorage.track_variants = @was_tracking
+  end
+
+  test "generating a resized variation of a JPEG blob" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(resize: "100x100")
+
+    assert_difference -> { blob.variant_records.count }, +1 do
+      variant.process
+    end
+
+    assert_match(/racecar\.jpg/, variant.url)
+
+    image = read_image(variant.image)
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+
+    record = blob.variant_records.last
+    assert_equal variant.variation.digest, record.variation_digest
+  end
+
+  test "serving a previously-generated resized variation of a JPEG blob" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    assert_difference -> { blob.variant_records.count } do
+      blob.variant(resize: "100x100").process
+    end
+
+    variant = blob.variant(resize: "100x100")
+
+    assert_no_difference -> { blob.variant_records.count } do
+      variant.process
+    end
+
+    assert_match(/racecar\.jpg/, variant.url)
+
+    image = read_image(variant.image)
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -889,11 +889,18 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 * `config.active_storage.replace_on_assign_to_many` determines whether assigning to a collection of attachments declared with `has_many_attached` replaces any existing attachments or appends to them. The default is `true`.
 
+* `config.active_storage.track_variants` determines whether variants are recorded in the database. The default is `true`.
+
 * `config.active_storage.draw_routes` can be used to toggle Active Storage route generation. The default is `true`.
 
 ### Results of `config.load_defaults`
 
 `config.load_defaults` sets new defaults up to and including the version passed. Such that passing, say, '6.0' also gets the new defaults from every version before it.
+
+#### For '6.1', new defaults from previous versions below and:
+
+- `config.active_record.has_many_inversing`: `true`
+- `config.active_storage.track_variants`: `true`
 
 #### For '6.0', new defaults from previous versions below and:
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -159,6 +159,10 @@ module Rails
           if respond_to?(:active_record)
             active_record.has_many_inversing = true
           end
+
+          if respond_to?(:active_storage)
+            active_storage.track_variants = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -8,3 +8,6 @@
 
 # Support for inversing belongs_to -> has_many Active Record associations.
 # Rails.application.config.active_record.has_many_inversing = true
+
+# Track Active Storage variants in the database.
+# Rails.application.config.active_storage.track_variants = true


### PR DESCRIPTION
Currently, when a variant is requested, we check whether it exists in the service. If it doesn’t, we generate it on-demand and store it for reuse.

The existence check can add unacceptable latency to variant serving. We’ve seen existence checks to third-party services take upwards of 500ms in normal circumstances. Further, checking whether an object exists at a particular key before uploading it [triggers eventual consistency](https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel) in S3:

> Amazon S3 provides read-after-write consistency for PUTS of new objects in your S3 bucket in all Regions with one caveat. The caveat is that if you make a HEAD or GET request to the key name (to find if the object exists) before creating the object, Amazon S3 provides eventual consistency for read-after-write.

This means that when a variant is requested for the first time, generated, and stored in S3, subsequent redirects to the variant’s service URL can fail indefinitely thereafter. The result is sporadically broken images.

This PR addresses the above concerns by doing away with the existence check. When a variant is requested for the first time, we generate it, store it, and track it in the application database. Now we can know whether we’ve already generated a variant without making a remote call to the storage service.