### PR TITLE
Optimize class_attribute instance accessors

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -92,50 +92,54 @@ class Class
     instance_predicate: true,
     default: nil
   )
+    class_methods, methods = [], []
     attrs.each do |name|
-      singleton_class.silence_redefinition_of_method(name)
-      define_singleton_method(name) { default }
-
-      singleton_class.silence_redefinition_of_method("#{name}?")
-      define_singleton_method("#{name}?") { !!public_send(name) } if instance_predicate
-
-      ivar = "@#{name}".to_sym
-
-      singleton_class.silence_redefinition_of_method("#{name}=")
-      define_singleton_method("#{name}=") do |val|
-        redefine_singleton_method(name) { val }
-
-        if singleton_class?
-          class_eval do
-            redefine_method(name) do
-              if instance_variable_defined? ivar
-                instance_variable_get ivar
-              else
-                singleton_class.send name
-              end
-            end
-          end
-        end
-        val
+      unless name.is_a?(Symbol) || name.is_a?(String)
+        raise TypeError, "#{name.inspect} is not a symbol nor a string"
       end
 
-      if instance_reader
-        redefine_method(name) do
-          if instance_variable_defined?(ivar)
-            instance_variable_get ivar
-          else
-            self.class.public_send name
+      class_methods << <<~RUBY # In case the method exists and is not public
+        silence_redefinition_of_method def #{name}
+        end
+      RUBY
+
+      methods << <<~RUBY if instance_reader
+        silence_redefinition_of_method def #{name}
+          defined?(@#{name}) ? @#{name} : self.class.#{name}
+        end
+      RUBY
+
+
+      class_methods << <<~RUBY
+        silence_redefinition_of_method def #{name}=(value)
+          redefine_method(:#{name}) { value } if singleton_class?
+          redefine_singleton_method(:#{name}) { value }
+          value
+        end
+      RUBY
+
+      methods << <<~RUBY if instance_writer
+        silence_redefinition_of_method(:#{name}=)
+        attr_writer :#{name}
+      RUBY
+
+      if instance_predicate
+        class_methods << <<~RUBY
+          silence_redefinition_of_method def #{name}?
+            !!self.#{name}
           end
-        end
-
-        redefine_method("#{name}?") { !!public_send(name) } if instance_predicate
-      end
-
-      if instance_writer
-        redefine_method("#{name}=") do |val|
-          instance_variable_set ivar, val
-        end
+        RUBY
+        methods << <<~RUBY
+          silence_redefinition_of_method def #{name}?
+            !!self.#{name}
+          end
+        RUBY
       end
     end
+
+    location = caller_locations(1, 1).first
+    class_eval([";class << self", *class_methods, ";end", *methods].join(";").tr("\n", ";"), location.path, location.lineno)
+
+    attrs.each { |name| public_send("#{name}=", default) }
   end
 end

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -94,6 +94,16 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_equal "foo", object.setting
   end
 
+  test "works well with module singleton classes" do
+    @module = Module.new do
+      class << self
+        class_attribute :settings, default: 42
+      end
+    end
+
+    assert_equal 42, @module.settings
+  end
+
   test "setter returns set value" do
     val = @klass.send(:setting=, 1)
     assert_equal 1, val


### PR DESCRIPTION
### Improvement

Here's the benchmark I used: https://gist.github.com/casperisfine/1f37a7228f9133ba30441ff796fe0c1b

```
==== definition ====
 old     11.341k (±24.3%) i/s -     52.415k in   5.032040s
 new      1.708k (±18.9%) i/s -      8.300k in   5.058740s

==== class reader ====
 old     14.143M (± 1.7%) i/s -     70.951M in   5.018039s
 new     14.126M (± 1.4%) i/s -     70.956M in   5.024121s

==== class inherited reader ====
 old     14.196M (± 1.3%) i/s -     71.104M in   5.009397s
 new     13.852M (± 1.4%) i/s -     69.525M in   5.020324s

==== class writer ====
 old    721.934k (±22.4%) i/s -      3.375M in   5.074818s
 new    976.412k (±20.8%) i/s -      4.706M in   5.043937s

==== instance reader ====
 old      5.153M (± 0.9%) i/s -     25.763M in   5.000218s
 new      9.962M (± 1.5%) i/s -     50.054M in   5.025634s

==== instance writer ====
 old      9.411M (± 1.6%) i/s -     47.132M in   5.009605s
 new     21.748M (± 1.5%) i/s -    108.722M in   5.000272s
```

In short, the instance accessors are twice faster with this patch, and the class writer is marginally faster.

The downside is that the definition of the class variable is much slower. So this trade a bit of boot time performance for runtime performance. But it's not like the definition of `class_attribute` is really a hotspot.

### This implementation

Most of the gains are thanks to `class_eval` that allows to replace `instance_variable_defined?(:@foo)` by `defined?(@foo)`, `instance_variable_set(:@foo, value)` by `attr_writer`, and similar changes.

### Discarded implementations

Initially I was actually trying to reclaim some performance on the class accessors. I found an implementation based on `defined?(@foo) ? @foo : superclass.foo`, that was twice faster on the class itself, but then would slowly degrade when calling on child classes.

cc @rafaelfranca @Edouard-chin @etiennebarrie @paracycle @Morriar 