### PR TITLE
Make VariantWithRecord create variant on the same service as original blob

### DIFF
--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -38,11 +38,11 @@ class ActiveStorage::VariantWithRecord
       blob.open do |input|
         if blob.content_type.in?(WEB_IMAGE_CONTENT_TYPES)
           variation.transform(input) do |output|
-            yield io: output, filename: blob.filename, content_type: blob.content_type
+            yield io: output, filename: blob.filename, content_type: blob.content_type, service_name: blob.service.name
           end
         else
           variation.transform(input, format: "png") do |output|
-            yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+            yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png", service_name: blob.service.name
           end
         end
       end

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -49,4 +49,11 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     assert_equal 100, image.width
     assert_equal 67, image.height
   end
+
+  test "variant of a blob is on the same service" do
+    blob = create_file_blob(filename: "racecar.jpg", service_name: "local_public")
+    variant = blob.variant(resize: "100x100").process
+
+    assert_equal "local_public", variant.image.blob.service_name
+  end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -67,8 +67,8 @@ class ActiveSupport::TestCase
       ActiveStorage::Blob.create_and_upload! key: key, io: StringIO.new(data), filename: filename, content_type: content_type, identify: identify, service_name: service_name, record: record
     end
 
-    def create_file_blob(key: nil, filename: "racecar.jpg", content_type: "image/jpeg", metadata: nil, record: nil)
-      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata, record: record
+    def create_file_blob(key: nil, filename: "racecar.jpg", content_type: "image/jpeg", metadata: nil, service_name: nil, record: nil)
+      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata, service_name: service_name, record: record
     end
 
     def create_blob_before_direct_upload(key: nil, filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain", record: nil)


### PR DESCRIPTION
### Summary
The new features in #37901 look really amazing, thanks a lot to @georgeclaghorn for working on it! However, I encountered an issue with it where the generated variant for a public blob became private (in the default service). This PR fixes this by creating the variant on the same service as the original blob.

cc. @georgeclaghorn 