### PR TITLE
WIP: Allow switching between old and new validations errors implementation

### DIFF
--- a/activemodel/lib/active_model/legacy_errors.rb
+++ b/activemodel/lib/active_model/legacy_errors.rb
@@ -1,0 +1,601 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/array/conversions"
+require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/string/filters"
+
+module ActiveModel
+  # == Active \Model \Errors
+  #
+  # Provides a modified +Hash+ that you can include in your object
+  # for handling error messages and interacting with Action View helpers.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     # Required dependency for ActiveModel::Errors
+  #     extend ActiveModel::Naming
+  #
+  #     def initialize
+  #       @errors = ActiveModel::Errors.new(self)
+  #     end
+  #
+  #     attr_accessor :name
+  #     attr_reader   :errors
+  #
+  #     def validate!
+  #       errors.add(:name, :blank, message: "cannot be nil") if name.nil?
+  #     end
+  #
+  #     # The following methods are needed to be minimally implemented
+  #
+  #     def read_attribute_for_validation(attr)
+  #       send(attr)
+  #     end
+  #
+  #     def self.human_attribute_name(attr, options = {})
+  #       attr
+  #     end
+  #
+  #     def self.lookup_ancestors
+  #       [self]
+  #     end
+  #   end
+  #
+  # The last three methods are required in your object for +Errors+ to be
+  # able to generate error messages correctly and also handle multiple
+  # languages. Of course, if you extend your object with <tt>ActiveModel::Translation</tt>
+  # you will not need to implement the last two. Likewise, using
+  # <tt>ActiveModel::Validations</tt> will handle the validation related methods
+  # for you.
+  #
+  # The above allows you to do:
+  #
+  #   person = Person.new
+  #   person.validate!            # => ["cannot be nil"]
+  #   person.errors.full_messages # => ["name cannot be nil"]
+  #   # etc..
+  class LegacyErrors
+    include Enumerable
+
+    CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
+    MESSAGE_OPTIONS = [:message]
+
+    class << self
+      attr_accessor :i18n_customize_full_message # :nodoc:
+    end
+    self.i18n_customize_full_message = false
+
+    attr_reader :messages, :details
+
+    # Pass in the instance of the object that is using the errors object.
+    #
+    #   class Person
+    #     def initialize
+    #       @errors = ActiveModel::Errors.new(self)
+    #     end
+    #   end
+    def initialize(base)
+      @base     = base
+      @messages = apply_default_array({})
+      @details = apply_default_array({})
+    end
+
+    def initialize_dup(other) # :nodoc:
+      @messages = other.messages.dup
+      @details  = other.details.deep_dup
+      super
+    end
+
+    # Copies the errors from <tt>other</tt>.
+    #
+    # other - The ActiveModel::Errors instance.
+    #
+    # Examples
+    #
+    #   person.errors.copy!(other)
+    def copy!(other) # :nodoc:
+      @messages = other.messages.dup
+      @details  = other.details.dup
+    end
+
+    # Merges the errors from <tt>other</tt>.
+    #
+    # other - The ActiveModel::Errors instance.
+    #
+    # Examples
+    #
+    #   person.errors.merge!(other)
+    def merge!(other)
+      @messages.merge!(other.messages) { |_, ary1, ary2| ary1 + ary2 }
+      @details.merge!(other.details) { |_, ary1, ary2| ary1 + ary2 }
+    end
+
+    # Removes all errors except the given keys. Returns a hash containing the removed errors.
+    #
+    #   person.errors.keys                  # => [:name, :age, :gender, :city]
+    #   person.errors.slice!(:age, :gender) # => { :name=>["cannot be nil"], :city=>["cannot be nil"] }
+    #   person.errors.keys                  # => [:age, :gender]
+    def slice!(*keys)
+      keys = keys.map(&:to_sym)
+      @details.slice!(*keys)
+      @messages.slice!(*keys)
+    end
+
+    # Clear the error messages.
+    #
+    #   person.errors.full_messages # => ["name cannot be nil"]
+    #   person.errors.clear
+    #   person.errors.full_messages # => []
+    def clear
+      messages.clear
+      details.clear
+    end
+
+    # Returns +true+ if the error messages include an error for the given key
+    # +attribute+, +false+ otherwise.
+    #
+    #   person.errors.messages        # => {:name=>["cannot be nil"]}
+    #   person.errors.include?(:name) # => true
+    #   person.errors.include?(:age)  # => false
+    def include?(attribute)
+      attribute = attribute.to_sym
+      messages.key?(attribute) && messages[attribute].present?
+    end
+    alias :has_key? :include?
+    alias :key? :include?
+
+    # Delete messages for +key+. Returns the deleted messages.
+    #
+    #   person.errors[:name]        # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
+    #   person.errors[:name]        # => []
+    def delete(key)
+      attribute = key.to_sym
+      details.delete(attribute)
+      messages.delete(attribute)
+    end
+
+    # When passed a symbol or a name of a method, returns an array of errors
+    # for the method.
+    #
+    #   person.errors[:name]  # => ["cannot be nil"]
+    #   person.errors['name'] # => ["cannot be nil"]
+    def [](attribute)
+      messages[attribute.to_sym]
+    end
+
+    # Iterates through each error key, value pair in the error messages hash.
+    # Yields the attribute and the error for that attribute. If the attribute
+    # has more than one error message, yields once for each error message.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.each do |attribute, error|
+    #     # Will yield :name and "can't be blank"
+    #   end
+    #
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.each do |attribute, error|
+    #     # Will yield :name and "can't be blank"
+    #     # then yield :name and "must be specified"
+    #   end
+    def each
+      messages.each_key do |attribute|
+        messages[attribute].each { |error| yield attribute, error }
+      end
+    end
+
+    # Returns the number of error messages.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.size # => 1
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.size # => 2
+    def size
+      values.flatten.size
+    end
+    alias :count :size
+
+    # Returns all message values.
+    #
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.values   # => [["cannot be nil", "must be specified"]]
+    def values
+      messages.select do |key, value|
+        !value.empty?
+      end.values
+    end
+
+    # Returns all message keys.
+    #
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.keys     # => [:name]
+    def keys
+      messages.select do |key, value|
+        !value.empty?
+      end.keys
+    end
+
+    # Returns +true+ if no errors are found, +false+ otherwise.
+    # If the error message is a string it can be empty.
+    #
+    #   person.errors.full_messages # => ["name cannot be nil"]
+    #   person.errors.empty?        # => false
+    def empty?
+      size.zero?
+    end
+    alias :blank? :empty?
+
+    # Returns an xml formatted representation of the Errors hash.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.to_xml
+    #   # =>
+    #   #  <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    #   #  <errors>
+    #   #    <error>name can't be blank</error>
+    #   #    <error>name must be specified</error>
+    #   #  </errors>
+    def to_xml(options = {})
+      to_a.to_xml({ root: "errors", skip_types: true }.merge!(options))
+    end
+
+    # Returns a Hash that can be used as the JSON representation for this
+    # object. You can pass the <tt>:full_messages</tt> option. This determines
+    # if the json object should contain full messages or not (false by default).
+    #
+    #   person.errors.as_json                      # => {:name=>["cannot be nil"]}
+    #   person.errors.as_json(full_messages: true) # => {:name=>["name cannot be nil"]}
+    def as_json(options = nil)
+      to_hash(options && options[:full_messages])
+    end
+
+    # Returns a Hash of attributes with their error messages. If +full_messages+
+    # is +true+, it will contain full messages (see +full_message+).
+    #
+    #   person.errors.to_hash       # => {:name=>["cannot be nil"]}
+    #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
+    def to_hash(full_messages = false)
+      if full_messages
+        messages.each_with_object({}) do |(attribute, array), messages|
+          messages[attribute] = array.map { |message| full_message(attribute, message) }
+        end
+      else
+        without_default_proc(messages)
+      end
+    end
+
+    # Adds +message+ to the error messages and used validator type to +details+ on +attribute+.
+    # More than one error can be added to the same +attribute+.
+    # If no +message+ is supplied, <tt>:invalid</tt> is assumed.
+    #
+    #   person.errors.add(:name)
+    #   # => ["is invalid"]
+    #   person.errors.add(:name, :not_implemented, message: "must be implemented")
+    #   # => ["is invalid", "must be implemented"]
+    #
+    #   person.errors.messages
+    #   # => {:name=>["is invalid", "must be implemented"]}
+    #
+    #   person.errors.details
+    #   # => {:name=>[{error: :not_implemented}, {error: :invalid}]}
+    #
+    # If +message+ is a symbol, it will be translated using the appropriate
+    # scope (see +generate_message+).
+    #
+    # If +message+ is a proc, it will be called, allowing for things like
+    # <tt>Time.now</tt> to be used within an error.
+    #
+    # If the <tt>:strict</tt> option is set to +true+, it will raise
+    # ActiveModel::StrictValidationFailed instead of adding the error.
+    # <tt>:strict</tt> option can also be set to any other exception.
+    #
+    #   person.errors.add(:name, :invalid, strict: true)
+    #   # => ActiveModel::StrictValidationFailed: Name is invalid
+    #   person.errors.add(:name, :invalid, strict: NameIsInvalid)
+    #   # => NameIsInvalid: Name is invalid
+    #
+    #   person.errors.messages # => {}
+    #
+    # +attribute+ should be set to <tt>:base</tt> if the error is not
+    # directly associated with a single attribute.
+    #
+    #   person.errors.add(:base, :name_or_email_blank,
+    #     message: "either name or email must be present")
+    #   person.errors.messages
+    #   # => {:base=>["either name or email must be present"]}
+    #   person.errors.details
+    #   # => {:base=>[{error: :name_or_email_blank}]}
+    def add(attribute, message = :invalid, options = {})
+      message = message.call if message.respond_to?(:call)
+      detail  = normalize_detail(message, options)
+      message = normalize_message(attribute, message, options)
+      if exception = options[:strict]
+        exception = ActiveModel::StrictValidationFailed if exception == true
+        raise exception, full_message(attribute, message)
+      end
+
+      details[attribute.to_sym]  << detail
+      messages[attribute.to_sym] << message
+    end
+
+    # Returns +true+ if an error on the attribute with the given message is
+    # present, or +false+ otherwise. +message+ is treated the same as for +add+.
+    #
+    #   person.errors.add :name, :blank
+    #   person.errors.added? :name, :blank           # => true
+    #   person.errors.added? :name, "can't be blank" # => true
+    #
+    # If the error message requires options, then it returns +true+ with
+    # the correct options, or +false+ with incorrect or missing options.
+    #
+    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.added? :name, :too_long, count: 25                     # => true
+    #   person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
+    #   person.errors.added? :name, :too_long, count: 24                     # => false
+    #   person.errors.added? :name, :too_long                                # => false
+    #   person.errors.added? :name, "is too long"                            # => false
+    def added?(attribute, message = :invalid, options = {})
+      message = message.call if message.respond_to?(:call)
+
+      if message.is_a? Symbol
+        details[attribute.to_sym].include? normalize_detail(message, options)
+      else
+        self[attribute].include? message
+      end
+    end
+
+    # Returns +true+ if an error on the attribute with the given message is
+    # present, or +false+ otherwise. +message+ is treated the same as for +add+.
+    #
+    #   person.errors.add :age
+    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.of_kind? :age                                            # => true
+    #   person.errors.of_kind? :name                                           # => false
+    #   person.errors.of_kind? :name, :too_long                                # => true
+    #   person.errors.of_kind? :name, "is too long (maximum is 25 characters)" # => true
+    #   person.errors.of_kind? :name, :not_too_long                            # => false
+    #   person.errors.of_kind? :name, "is too long"                            # => false
+    def of_kind?(attribute, message = :invalid)
+      message = message.call if message.respond_to?(:call)
+
+      if message.is_a? Symbol
+        details[attribute.to_sym].map { |e| e[:error] }.include? message
+      else
+        self[attribute].include? message
+      end
+    end
+
+    # Returns all the full error messages in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :address, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create(address: '123 First St.')
+    #   person.errors.full_messages
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank", "Email can't be blank"]
+    def full_messages
+      map { |attribute, message| full_message(attribute, message) }
+    end
+    alias :to_a :full_messages
+
+    # Returns all the full error messages for a given attribute in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create()
+    #   person.errors.full_messages_for(:name)
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
+    def full_messages_for(attribute)
+      attribute = attribute.to_sym
+      messages[attribute].map { |message| full_message(attribute, message) }
+    end
+
+    # Returns a full message for a given attribute.
+    #
+    #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
+    #
+    # The `"%{attribute} %{message}"` error format can be overridden with either
+    #
+    # * <tt>activemodel.errors.models.person/contacts/addresses.attributes.street.format</tt>
+    # * <tt>activemodel.errors.models.person/contacts/addresses.format</tt>
+    # * <tt>activemodel.errors.models.person.attributes.name.format</tt>
+    # * <tt>activemodel.errors.models.person.format</tt>
+    # * <tt>errors.format</tt>
+    def full_message(attribute, message)
+      return message if attribute == :base
+      attribute = attribute.to_s
+
+      if self.class.i18n_customize_full_message && @base.class.respond_to?(:i18n_scope)
+        attribute = attribute.remove(/\[\d\]/)
+        parts = attribute.split(".")
+        attribute_name = parts.pop
+        namespace = parts.join("/") unless parts.empty?
+        attributes_scope = "#{@base.class.i18n_scope}.errors.models"
+
+        if namespace
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
+            ]
+          end
+        else
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
+            ]
+          end
+        end
+
+        defaults.flatten!
+      else
+        defaults = []
+      end
+
+      defaults << :"errors.format"
+      defaults << "%{attribute} %{message}"
+
+      attr_name = attribute.tr(".", "_").humanize
+      attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
+
+      I18n.t(defaults.shift,
+        default:  defaults,
+        attribute: attr_name,
+        message:   message)
+    end
+
+    # Translates an error message in its default scope
+    # (<tt>activemodel.errors.messages</tt>).
+    #
+    # Error messages are first looked up in <tt>activemodel.errors.models.MODEL.attributes.ATTRIBUTE.MESSAGE</tt>,
+    # if it's not there, it's looked up in <tt>activemodel.errors.models.MODEL.MESSAGE</tt> and if
+    # that is not there also, it returns the translation of the default message
+    # (e.g. <tt>activemodel.errors.messages.MESSAGE</tt>). The translated model
+    # name, translated attribute name and the value are available for
+    # interpolation.
+    #
+    # When using inheritance in your models, it will check all the inherited
+    # models too, but only if the model itself hasn't been found. Say you have
+    # <tt>class Admin < User; end</tt> and you wanted the translation for
+    # the <tt>:blank</tt> error message for the <tt>title</tt> attribute,
+    # it looks for these translations:
+    #
+    # * <tt>activemodel.errors.models.admin.attributes.title.blank</tt>
+    # * <tt>activemodel.errors.models.admin.blank</tt>
+    # * <tt>activemodel.errors.models.user.attributes.title.blank</tt>
+    # * <tt>activemodel.errors.models.user.blank</tt>
+    # * any default you provided through the +options+ hash (in the <tt>activemodel.errors</tt> scope)
+    # * <tt>activemodel.errors.messages.blank</tt>
+    # * <tt>errors.attributes.title.blank</tt>
+    # * <tt>errors.messages.blank</tt>
+    def generate_message(attribute, type = :invalid, options = {})
+      type = options.delete(:message) if options[:message].is_a?(Symbol)
+      value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
+
+      options = {
+        model: @base.model_name.human,
+        attribute: @base.class.human_attribute_name(attribute),
+        value: value,
+        object: @base
+      }.merge!(options)
+
+      if @base.class.respond_to?(:i18n_scope)
+        i18n_scope = @base.class.i18n_scope.to_s
+        defaults = @base.class.lookup_ancestors.flat_map do |klass|
+          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+        end
+        defaults << :"#{i18n_scope}.errors.messages.#{type}"
+
+        catch(:exception) do
+          translation = I18n.translate(defaults.first, options.merge(default: defaults.drop(1), throw: true))
+          return translation unless translation.nil?
+        end unless options[:message]
+      else
+        defaults = []
+      end
+
+      defaults << :"errors.attributes.#{attribute}.#{type}"
+      defaults << :"errors.messages.#{type}"
+
+      key = defaults.shift
+      defaults = options.delete(:message) if options[:message]
+      options[:default] = defaults
+
+      I18n.translate(key, options)
+    end
+
+    def marshal_dump # :nodoc:
+      [@base, without_default_proc(@messages), without_default_proc(@details)]
+    end
+
+    def marshal_load(array) # :nodoc:
+      @base, @messages, @details = array
+      apply_default_array(@messages)
+      apply_default_array(@details)
+    end
+
+    def init_with(coder) # :nodoc:
+      coder.map.each { |k, v| instance_variable_set(:"@#{k}", v) }
+      @details ||= {}
+      apply_default_array(@messages)
+      apply_default_array(@details)
+    end
+
+  private
+    def normalize_message(attribute, message, options)
+      case message
+      when Symbol
+        generate_message(attribute, message, options.except(*CALLBACKS_OPTIONS))
+      else
+        message
+      end
+    end
+
+    def normalize_detail(message, options)
+      { error: message }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
+    end
+
+    def without_default_proc(hash)
+      hash.dup.tap do |new_h|
+        new_h.default_proc = nil
+      end
+    end
+
+    def apply_default_array(hash)
+      hash.default_proc = proc { |h, key| h[key] = [] }
+      hash
+    end
+  end
+
+  # Raised when a validation cannot be corrected by end users and are considered
+  # exceptional.
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #
+  #     attr_accessor :name
+  #
+  #     validates_presence_of :name, strict: true
+  #   end
+  #
+  #   person = Person.new
+  #   person.name = nil
+  #   person.valid?
+  #   # => ActiveModel::StrictValidationFailed: Name can't be blank
+  class StrictValidationFailed < StandardError
+  end
+
+  # Raised when attribute values are out of range.
+  class RangeError < ::RangeError
+  end
+
+  # Raised when unknown attributes are supplied via mass assignment.
+  #
+  #   class Person
+  #     include ActiveModel::AttributeAssignment
+  #     include ActiveModel::Validations
+  #   end
+  #
+  #   person = Person.new
+  #   person.assign_attributes(name: 'Gorby')
+  #   # => ActiveModel::UnknownAttributeError: unknown attribute 'name' for Person.
+  class UnknownAttributeError < NoMethodError
+    attr_reader :record, :attribute
+
+    def initialize(record, attribute)
+      @record = record
+      @attribute = attribute
+      super("unknown attribute '#{attribute}' for #{@record.class}.")
+    end
+  end
+end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -299,7 +299,11 @@ module ActiveModel
     #   person.valid? # => false
     #   person.errors # => #<ActiveModel::Errors:0x007fe603816640 @messages={name:["can't be blank"]}>
     def errors
-      @errors ||= Errors.new(self)
+      @errors ||= if Rails.application.config.validation_error_as_object
+        Errors.new(self)
+      else
+        LegacyErrors.new(self)
+      end
     end
 
     # Runs all the specified validations and returns +true+ if no errors were

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -32,6 +32,7 @@ require "yaml"
 require "active_record/version"
 require "active_model/attribute_set"
 require "active_record/errors"
+require "active_record/legacy_errors"
 
 module ActiveRecord
   extend ActiveSupport::Autoload

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -19,6 +19,7 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
+                    :validation_error_as_object,
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path
 
       attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
@@ -67,6 +68,7 @@ module Rails
         @credentials.content_path                = default_credentials_content_path
         @credentials.key_path                    = default_credentials_key_path
         @autoloader                              = :classic
+        @validation_error_as_object              = false
         @disable_sandbox                         = false
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_2.rb.tt
@@ -1,0 +1,11 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.2 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Switch to new model validation errors implementation,
+# representing each error as an object.
+# Rails.application.config.active_record.validation_error_as_object = true


### PR DESCRIPTION
### Summary

Rails 6.2 [re-implemented](https://github.com/rails/rails/pull/32313) model validation errors in an OO way, which caused some incompatibility. To allow more graceful upgrade, this PR adds a `validation_error_as_object` flag, which would determine whether the old or the new implementation would be used.

### Other Information

The default would use the old behavior. User would need to uncomment the option in `new_framework_defaults_6_2.rb` to switch to new behavior.

Part of https://github.com/rails/rails/issues/37081