### PR TITLE
Rails::Application#config_for merges shared configuration deeply

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,27 @@
+* `Rails.application.config_for` merges shared configuration deeply.
+
+    ```yaml
+    # config/example.yml
+    shared:
+      foo:
+        bar:
+          baz: 1
+    development:
+      foo:
+        bar:
+          qux: 2
+    ```
+
+    ```ruby
+    # Previously
+    Rails.application.config_for(:example)[:foo][:bar] #=> { qux: 2 }
+
+    # Now
+    Rails.application.config_for(:example)[:foo][:bar] #=> { baz: 1, qux: 2 }
+    ```
+
+    *Yuhei Kiriyama*
+
 *   Remove access to values in nested hashes returned by `Rails.application.config_for` via String keys.
 
     ```yaml

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -229,7 +229,7 @@ module Rails
       if yaml.exist?
         require "erb"
         config = YAML.load(ERB.new(yaml.read).result, symbolize_names: true) || {}
-        config = (config[:shared] || {}).merge(config[env.to_sym] || {})
+        config = (config[:shared] || {}).deep_merge(config[env.to_sym] || {})
 
         ActiveSupport::OrderedOptions.new.tap do |options|
           options.update(config)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2034,6 +2034,27 @@ module ApplicationTests
       assert_equal(:bar, Rails.application.config.my_custom_config[:foo])
     end
 
+    test "config_for merges shared configuration deeply" do
+      app_file "config/custom.yml", <<-RUBY
+      shared:
+        foo:
+          bar:
+            baz: 1
+      development:
+        foo:
+          bar:
+            qux: 2
+      RUBY
+
+      add_to_config <<-RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal({ baz: 1, qux: 2 }, Rails.application.config.my_custom_config[:foo][:bar])
+    end
+
     test "config_for with empty file returns an empty hash" do
       app_file "config/custom.yml", <<-RUBY
       RUBY


### PR DESCRIPTION
### Summary

I'm using some gems to manage environment specific configurations, but I'd like to migrate to the Rails features. However, my configurations are nested deeply, and `Rails::Application#config_for` doesn't merge deeply.

```yaml
# config/application.yml
shared:
  foo:
    bar:
      baz: 1
development:
  foo:
    bar:
      qux: 2
```

```ruby
# currently
config_for(:application)[:foo][:bar] #=> { qux: 2 }
# I expect
config_for(:application)[:foo][:bar] #=> { baz: 1, qux: 2 }
```

I know it's a breaking change. If changing the default behavior is difficult, for instance, how about controlling it by an option?