### PR TITLE
Maintain the consistency between `parts` and `value` of `AS::Duration`

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -75,7 +75,10 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "2 weeks",                         1.fortnight.inspect
     assert_equal "0 seconds",                       (10 % 5.seconds).inspect
     assert_equal "10 minutes",                      (10.minutes + 0.seconds).inspect
-    assert_equal "3600 seconds",                    (1.day / 24).inspect
+    assert_equal "1 hour",                          (1.day / 24).inspect
+    assert_equal "1 hour and 30 minutes",           (3.hours / 2).inspect
+    assert_equal "31 minutes",                      ((1.hour + 2.minutes) / 2).inspect
+    assert_equal "1 hour and 1 minute",             ((2.hour + 2.minutes) / 2).inspect
   end
 
   def test_inspect_locale


### PR DESCRIPTION
In #37839 and #37849, we have modified to use `AS::Duration#value` instead of `parts` when `parts` is empty. Now, however, I think it's better to keep `parts` not to be empty when `value` isn't zero.

Besides, the return value of `inspect` and `to_i` seems not to be consistent when the division had a remainder.

```ruby
(3.minutes / 2).inspect #=> "1 minute"
(3.minutes / 2).to_i    #=> 90
```

To prevent these inconsistencies, we can rebuild the instance using `AS::Duration.build` when the division has a remainder.