### PR TITLE
Use `assert_not` method from bug_report_template [ci skip]

### DIFF
--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -18,6 +18,6 @@ require "minitest/autorun"
 class BugTest < Minitest::Test
   def test_stuff
     assert "zomg".present?
-    refute "".present?
+    assert_not "".present?
   end
 end

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -17,6 +17,6 @@ require "minitest/autorun"
 class BugTest < Minitest::Test
   def test_stuff
     assert "zomg".present?
-    refute "".present?
+    assert_not "".present?
   end
 end


### PR DESCRIPTION
This PR changed method `refute` to `assert_not`.
I used this as reference!
> https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html
>
> **5.5.1 Follow the Coding Conventions**
> Rails follows a simple set of coding style conventions:
> -Use assert_not methods instead of refute.

