### PR TITLE
Fix input value not properly applied:

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -94,7 +94,7 @@ module ActionView
         def tag_option(key, value, escape)
           case value
           when Array, Hash
-            value = build_tag_values(value)
+            value = build_tag_values(value) if key.to_s == "class"
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
@@ -109,14 +109,14 @@ module ActionView
 
             args.each do |tag_value|
               case tag_value
-              when String
-                tag_values << tag_value if tag_value.present?
               when Hash
                 tag_value.each do |key, val|
                   tag_values << key if val
                 end
               when Array
                 tag_values << build_tag_values(*tag_value).presence
+              else
+                tag_values << tag_value.to_s if tag_value.present?
               end
             end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -37,6 +37,24 @@ class TagHelperTest < ActionView::TestCase
     assert_match(/class="elsewhere"/, str)
   end
 
+  def test_tag_options_with_array_of_numeric
+    str = tag(:input, value: [123, 456])
+
+    assert_equal("<input value=\"123 456\" />", str)
+  end
+
+  def test_tag_options_with_array_of_random_objects
+    klass = Class.new do
+      def to_s
+        "hello"
+      end
+    end
+
+    str = tag(:input, value: [klass.new])
+
+    assert_equal("<input value=\"hello\" />", str)
+  end
+
   def test_tag_options_rejects_nil_option
     assert_equal "<p />", tag("p", ignored: nil)
   end
@@ -261,6 +279,18 @@ class TagHelperTest < ActionView::TestCase
 
     str = content_tag("p", "limelight", class: ["song", { foo: false }])
     assert_equal "<p class=\"song\">limelight</p>", str
+
+    str = content_tag("p", "limelight", class: [1, 2, 3])
+    assert_equal "<p class=\"1 2 3\">limelight</p>", str
+
+    klass = Class.new do
+      def to_s
+        "1"
+      end
+    end
+
+    str = content_tag("p", "limelight", class: [klass.new])
+    assert_equal "<p class=\"1\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: { "song": true, "play": true })
     assert_equal "<p class=\"song play\">limelight</p>", str


### PR DESCRIPTION
Fix input value not properly applied:

- #37872 introduced a regression and you can't do

  ```html.erb
    hidden_field_tag('token', value: [1, 2, 3])
  ```

  This will result in a `<input type="hidden" value=""`>.

  I chose `hidden_field_tag` and the `value` attribute as an example
  but this issue applies to any tag helper and any attributes.

  I don't know if this PR is the right fix since https://github.com/rails/rails/pull/37872#issuecomment-561806468
  specifies that the feature should only apply for "class" attribute.

cc/ @rafaelfranca @tenderlove @joelhawksley 