### PR TITLE
Fix interleaved logging line when using parallel tests:

### DIFF
--- a/railties/lib/rails/parallelization_log.rb
+++ b/railties/lib/rails/parallelization_log.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_support/testing/parallelization"
+require "fileutils"
+
+module ParallelizationLog
+  ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
+    logfile = Rails.application.config.paths['log'].first
+    logfile += "-#{i}"
+    f = File.open(logfile, "a")
+    f.binmode
+    f.sync = true
+
+    Rails.logger.reopen(f)
+  end
+
+  ActiveSupport::Testing::Parallelization.run_cleanup_hook do |i|
+    main_logfile = Rails.application.config.paths['log'].first
+    process_logfile = main_logfile + "-#{i}"
+
+    File.open(main_logfile, 'ab') do |f|
+      f.flock(File::LOCK_EX)
+      f.write(File.read(process_logfile))
+    end
+    FileUtils.rm(process_logfile)
+  end
+end

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -11,6 +11,11 @@ require "action_dispatch/testing/integration"
 require "rails/generators/test_case"
 
 require "active_support/testing/autorun"
+require "rails/parallelization_log"
+
+ActiveSupport.on_load(:active_support_test_case) do
+  include ParallelizationLog
+end
 
 if defined?(ActiveRecord::Base)
   begin


### PR DESCRIPTION
Fix interleaved logging line when using parallel tests:

- @cjlarose proposed to fix https://github.com/rails/rails/issues/37372
  by appending the worker id to each line of log. I think it's a
  bit hard to follow especially if your have 4 processes.

  What I propose in this PR is to have one logfile per process,
  and when a process no longer have tests in the queue, we write
  the content of the logfile process in the main logfile (test.log).

  Advantages:

  - Developers don't get confused with X logfiles.
  - Simple to implement

  Con:

  - The main logfile won't have any log until the process is finished.
    Developers can still follow the log of the process logfile
    but it might be confusing

cc/ @eileencodes @rafaelfranca 

