### PR TITLE
Introduce class_names helper

### DIFF
--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -338,6 +338,17 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p class=\"song play>\">limelight</p>", str
   end
 
+  def test_class_names
+    assert_equal "song play", class_names(["song", { "play": true }])
+    assert_equal "song", class_names({ "song": true, "play": false })
+    assert_equal "song", class_names([{ "song": true }, { "play": false }])
+    assert_equal "song", class_names({ song: true, play: false })
+    assert_equal "song", class_names([{ song: true }, nil, false])
+    assert_equal "song", class_names(["song", { foo: false }])
+    assert_equal "song play", class_names({ "song": true, "play": true })
+    assert_equal "", class_names({ "song": false, "play": false })
+  end
+
   def test_content_tag_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       content_tag("p", "limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })


### PR DESCRIPTION
As a follow-up to https://github.com/rails/rails/pull/37872,
this change introduces a class_names view helper
to make it easier to conditionally apply class names
in views.

Before:
`<div class="<%= item.for_sale? ? 'active' : '' %>">`

After:
`<div class="<%= class_names(active: item.for_sale?) %>">`

We've been using this helper in the GitHub monolith
since 2016.

Co-authored-by: Aaron Patterson <tenderlove@github.com>