### PR TITLE
Render objects that respond_to render_in in controllers

### DIFF
--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "test_component"
 
 class RendererTest < ActiveSupport::TestCase
   test "action controller base has a renderer" do
@@ -63,6 +64,15 @@ class RendererTest < ActiveSupport::TestCase
                                assigns: { secret: "foo" }
 
     assert_equal "The secret is foo\n", content
+  end
+
+  def test_render_component
+    renderer = ApplicationController.renderer
+
+    assert_equal(
+      %(<span title="my title">(Inline render)</span>),
+      renderer.render(TestComponent.new(title: "my title")).strip
+    )
   end
 
   test "rendering with custom env" do

--- a/actionpack/test/lib/test_component.rb
+++ b/actionpack/test/lib/test_component.rb
@@ -10,14 +10,15 @@ class TestComponent < ActionView::Base
     @title = title
   end
 
-  # Entrypoint for rendering. Called by ActionView::RenderingHelper#render.
-  #
-  # Returns ActionView::OutputBuffer.
   def render_in(view_context)
     self.class.compile
     @view_context = view_context
     validate!
     rendered_template
+  end
+
+  def format
+    :html
   end
 
   def self.template

--- a/actionpack/test/lib/test_component.rb
+++ b/actionpack/test/lib/test_component.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class TestComponent < ActionView::Base
+  include ActiveModel::Validations
+
+  validates :title, presence: true
+  delegate :render, to: :view_context
+
+  def initialize(title:)
+    @title = title
+  end
+
+  # Entrypoint for rendering. Called by ActionView::RenderingHelper#render.
+  #
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context)
+    self.class.compile
+    @view_context = view_context
+    validate!
+    rendered_template
+  end
+
+  def self.template
+    <<~'erb'
+    <span title="<%= title %>">(<%= render(plain: "Inline render") %>)</span>
+    erb
+  end
+
+  def self.compile
+    @compiled ||= nil
+    return if @compiled
+
+    class_eval(
+      "def rendered_template; @output_buffer = ActionView::OutputBuffer.new; " +
+      ActionView::Template::Handlers::ERB.erb_implementation.new(template, trim: true).src +
+      "; end"
+    )
+
+    @compiled = true
+  end
+
+private
+  attr_reader :title, :view_context
+end

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -25,6 +25,9 @@ module ActionView
     def render_to_object(context, options) # :nodoc:
       if options.key?(:partial)
         render_partial_to_object(context, options)
+      elsif options.key?(:object)
+        object = options[:object]
+        AbstractRenderer::RenderedTemplate.new(object.render_in(context), object)
       else
         render_template_to_object(context, options)
       end

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -144,6 +144,8 @@ module ActionView
         else
           if action.respond_to?(:permitted?) && action.permitted?
             options = action
+          elsif action.respond_to?(:render_in)
+            options[:object] = action
           else
             options[:partial] = action
           end


### PR DESCRIPTION
In #36388, we supported passing objects that `respond_to` `render_in`
to `render`, but _only_ in views.

This change does the same for controllers, as Rails
generally gives the expectation that `render` behaves
the same in both contexts.

Co-authored-by: Aaron Patterson <tenderlove@github.com>