### PR TITLE
Backport Database URL supports query value with equal sign

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   A database URL can now contain a querystring value that contains an equal sign. This is needed to support passing PostgresSQL `options`.
+
+     *Joshua Flanagan*
+
 *   Retain explicit selections on the base model after applying `includes` and `joins`.
 
     Resolves #34889.

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -72,7 +72,7 @@ module ActiveRecord
           #   "localhost"
           #   # => {}
           def query_hash
-            Hash[(@query || "").split("&").map { |pair| pair.split("=") }]
+            Hash[(@query || "").split("&").map { |pair| pair.split("=", 2) }]
           end
 
           def raw_config

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -160,6 +160,13 @@ module ActiveRecord
         assert_equal expected, actual
       end
 
+      def test_url_with_equals_in_query_value
+         config   = { "default_env" => { "url" => "postgresql://localhost/foo?options=-cmyoption=on" } }
+         actual   = resolve_config(config)
+         expected = { "default_env" => { "options" => "-cmyoption=on", "adapter" => "postgresql", "database" => "foo", "host" => "localhost" } }
+         assert_equal expected, actual
+       end
+
       def test_hash
         config = { "production" => { "adapter" => "postgres", "database" => "foo" } }
         actual = resolve_config(config)


### PR DESCRIPTION
Backports https://github.com/rails/rails/pull/37738 to 6.0.

A querystring value should be allowed to include an equal sign =.

This is necessary to support passing options for a PostgresSQL connection,
using the database URL format.