### PR TITLE
Add ActiveJob::Base.default_retry_jitter config option to specify jitter value

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -807,6 +807,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.log_arguments` controls if the arguments of a job are logged. Defaults to `true`.
 
+* `config.active_job.default_retry_jitter` controls the amount of "jitter" (random variation) applied to the delay time calculated when retrying failed jobs. Defaults to `0.15`.
+
 ### Configuring Action Cable
 
 * `config.action_cable.url` accepts a string for the URL for where

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -156,6 +156,10 @@ module Rails
         when "6.1"
           load_defaults "6.0"
 
+          if respond_to?(:active_job)
+            active_job.default_retry_jitter = 0.15
+          end
+
           if respond_to?(:active_record)
             active_record.has_many_inversing = true
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2262,6 +2262,20 @@ module ApplicationTests
       end
     end
 
+    test "ActiveJob::Base.default_retry_jitter is 0.15 by default" do
+      app "development"
+
+      assert_equal 0.15, ActiveJob::Base.default_retry_jitter
+    end
+
+    test "ActiveJob::Base.default_retry_jitter can be set by config" do
+      app "development"
+
+      Rails.application.config.active_job.default_retry_jitter = 0.22
+
+      assert_equal 0.22, ActiveJob::Base.default_retry_jitter
+    end
+
     test "ActiveJob::Base.return_false_on_aborted_enqueue is true by default" do
       app "development"
 


### PR DESCRIPTION
# Problem

PR https://github.com/rails/rails/pull/31872 adds a `jitter:` option to `ActiveJob#retry_on` and the private `.determine_delay` method. Overall this is not an issue and serves to solve a valid problem, but it's caused a few minor issues for us at GitHub.

* First, we are currently opting not to use the jitter option which requires passing `jitter: 0.0` to all occurrances of `retry_on`.

* Second, we do make use of the private `determine_delay` method for which `jitter:` is now a required kwarg.

# Solution

This PR adds `ActiveJob::Base.default_retry_jitter` to define the jitter value and `Rails.application.config.active_job.default_retry_jitter` as a config option. This value defaults to `0.15` and will be used as the jitter value if no explicit value is passed with the `jitter:` kwarg.

This also makes `jitter:` optional for `determine_delay` and moves the responsibility of determining a default value from `retry_on` to `determine_delay`.

# Notes

* This PR adds tests to be sure that the config option correctly sets `ActiveJob::Base.default_retry_jitter` and that that value is used by `determine_delay`. If there are additional tests that we would benefit from I'm happy to add them.

* A description of `config.active_job.default_retry_jitter` was added to `guides/source/configuring.md`. If additional documentation should be present I'm happy to add it as well.

cc: @allcentury as the author of the original PR and @eileencodes for visibility