### PR TITLE
Improve contributing guide for RDoc [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -133,9 +133,9 @@ Contributing to the Rails Documentation
 Ruby on Rails has two main sets of documentation: the guides, which help you
 learn about Ruby on Rails, and the API, which serves as a reference.
 
-You can help improve the Rails guides by making them more coherent, consistent, or readable, adding missing information, correcting factual errors, fixing typos, or bringing them up to date with the latest edge Rails.
+You can help improve the Rails guides or the API reference by making them more coherent, consistent, or readable, adding missing information, correcting factual errors, fixing typos, or bringing them up to date with the latest edge Rails.
 
-To do so, make changes to Rails guides source files (located [here](https://github.com/rails/rails/tree/master/guides/source) on GitHub). Then open a pull request to apply your
+To do so, make changes to Rails guides source files (located [here](https://github.com/rails/rails/tree/master/guides/source) on GitHub) or RDoc comments in source code. Then open a pull request to apply your
 changes to the master branch.
 
 When working with documentation, please take into account the [API Documentation Guidelines](api_documentation_guidelines.html) and the [Ruby on Rails Guides Guidelines](ruby_on_rails_guides_guidelines.html).


### PR DESCRIPTION
### Summary
The first line of contribution guide mentions both "the guides" and "the API reference".

> Ruby on Rails has two main sets of documentation: the guides, which help you
learn about Ruby on Rails, and the API, which serves as a reference.

However the following sentences were focusing on "the guides" only and missing the context for "the API". This PR is to add the context around that.

I made a change such that the guidance below is applicable to both Rails guide and the API reference.

> making them more coherent, consistent, or readable, adding missing information, correcting factual errors, fixing typos, or bringing them up to date

Please kindly let me know in case this is not in line with the intention. 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information 
To add some context, my colleague found [a typo in RDoc](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods/dirty.rb#L92) (this should be `will_save_change_to_attribute?("name")`) and was wondering if she should submit a PR for it. She was reluctant to do so as it felt like a cosmetic change that is mentioned in the [CONTRIBUTING.md](https://github.com/rails/rails/blob/master/CONTRIBUTING.md). However I thought it is rather fixing a factual error in documentation that is valuable rather than a cosmetic change. So I was looking for the relevant contribution guide for documentation, but it was missing the statement for RDoc. Hence I'm suggesting here to add the missing piece.

