### PR TITLE
Move records and loaded ivar up to load

### DIFF
--- a/activerecord/lib/active_record/relation/record_fetch_warning.rb
+++ b/activerecord/lib/active_record/relation/record_fetch_warning.rb
@@ -16,10 +16,10 @@ module ActiveRecord
       def exec_queries
         QueryRegistry.reset
 
-        super.tap do
+        super.tap do |records|
           if logger && warn_on_records_fetched_greater_than
-            if @records.length > warn_on_records_fetched_greater_than
-              logger.warn "Query fetched #{@records.size} #{@klass} records: #{QueryRegistry.queries.join(";")}"
+            if records.length > warn_on_records_fetched_greater_than
+              logger.warn "Query fetched #{records.size} #{@klass} records: #{QueryRegistry.queries.join(";")}"
             end
           end
         end


### PR DESCRIPTION
We should set the `@records` and `@loaded` ivar inside `#load` rather
than in `#exec_queries`. Since `#load` is running `#exec_queries` and
`@records` can only be assigned if `loaded?` is true and `@loaded` can
only be set if `loaded?` is true then `#load` should do the assignment.
This is cleaner but also we came across this while working on an
internal gem and realized that the ivar assignment was happening in the
wrong place.

Co-authored-by: Aaron Patterson <aaron.patterson@gmail.com>