### PR TITLE
Cache routes.url_helpers built modules

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -477,6 +477,14 @@ module ActionDispatch
       end
 
       def url_helpers(supports_path = true)
+        if supports_path
+          @url_helpers_with_paths ||= generate_url_helpers(true)
+        else
+          @url_helpers_without_paths ||= generate_url_helpers(false)
+        end
+      end
+
+      def generate_url_helpers(supports_path)
         routes = self
 
         Module.new do

--- a/actionpack/test/controller/route_helpers_test.rb
+++ b/actionpack/test/controller/route_helpers_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class RouteHelperIntegrationTest < ActionDispatch::IntegrationTest
+  def self.routes
+    @routes ||= ActionDispatch::Routing::RouteSet.new
+  end
+
+  class FakeACBase < ActionController::Base
+    # Normally done by app initialization to ActionController::Base
+    app = RouteHelperIntegrationTest
+    extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
+  end
+
+  class ApplicationController < FakeACBase
+  end
+
+  class FooController < ApplicationController
+  end
+
+  # We define many routes in these modules after they have been included into
+  # the controllers. For boot performance, it's important that we don't
+  # duplicate these modules an maked method cache invalidation expensive.
+  # https://github.com/rails/rails/pull/37927
+  test "only includes one module with route helpers" do
+    app = self.class
+
+    url_helpers_module = app.routes.named_routes.url_helpers_module
+    path_helpers_module = app.routes.named_routes.path_helpers_module
+
+    assert_operator FooController, :<, url_helpers_module
+    assert_operator ApplicationController, :<, url_helpers_module
+    assert_not_operator FakeACBase, :<, url_helpers_module
+
+    assert_operator FooController, :<, path_helpers_module
+    assert_operator ApplicationController, :<, path_helpers_module
+    assert_not_operator FakeACBase, :<, path_helpers_module
+
+    included_modules = FooController.ancestors.grep_v(Class)
+    included_modules -= [url_helpers_module, path_helpers_module]
+
+    modules_with_routes = included_modules.select do |mod|
+      mod < url_helpers_module || mod < path_helpers_module
+    end
+
+    assert_equal 1, modules_with_routes.size
+  end
+end


### PR DESCRIPTION
Previously, every time this was called it would return a new module.

Every time a new controller is built, it had one of these module included onto it (see [`AbstractController::Railties::RoutesHelper`](https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/railties/routes_helpers.rb)). Because each time this was a new module we would end up with a different copy being included on each controller. This would also include a different copy on a controller than on its superclass (ex. `ApplicationController`). Furthermore, each generated module also extended the url helper modules.

```
    +--------------+     +-------------+
    |              |     |             |
    | path_helpers |     | url_helpers | (named routes added here)
    |              |     |             |
    +------+----+--+     +----+--+-----+
           ^    ^             ^  ^
           |    |             |  |
           |  +---------------+  |
           |  | |                |
           |  | +-----------+    |
           |  |             |    |
    +------+--+---+      +--+----+-----+
    |             |      |             |
    | (singleton) +------+ url_helpers | (duplicated for each controller)
    |             |      |             |
    +-------------+      +-----+-------+
                               ^
                               |
                               |
                     +---------+-------+
                     |                 |
                     | UsersController |
                     |                 |
                     +-----------------+
```

The result of this is that when named routes were added to the two top-level modules, defining those methods became extremely slow because Ruby has to invalidate the class method caches on all of the generated modules as well as each controller. Furthermore because there were multiple paths up the inheritance chain (ex. one through UsersController's generated module and one through ApplicationController's generated module) it would end up invaliding the classes multiple times (ideally Ruby would be smarter about this, but it's much easier to solve in Rails).

Caching this module means that all controllers should include the same module and **defining these named routes should be 3-4x faster**. One caveat: this is only measurable with eager loading on, since the controllers being loaded is what causes the slow method definitions.

This method can generate two different modules, based on whether supports_path is truthy, so those are cached separately.

## Benchmark

``` ruby
require "action_controller/railtie"
require "rails"

class MyApp < Rails::Application
  config.eager_load = true
  config.secret_key_base = SecureRandom.hex
  initialize!
end

class ApplicationController < ActionController::Base
end

N = (ENV["N"] || 500).to_i
M = (ENV["M"] || 2000).to_i
N.times do |n|
  Object.const_set("Foo#{n}Controller", Class.new(ApplicationController))
end
puts "For #{N} controllers:"

MyApp.routes.draw do
  before = RubyVM.stat(:class_serial)
  get "/foo123", to: "home#index"
  after = RubyVM.stat(:class_serial)
  puts "  Class serial changed by #{after - before} per route"

  ms = Benchmark.ms {
    M.times do |n|
      get "/foo#{n}", to: "home#index"
    end
  }
  puts "  Defining #{M} routes took #{ms}ms"
end
```

**Before:**
```
For 500 controllers:
  Class serial changed by 13543 per route
  Defining 2000 routes took 1069.1329431720078ms
```

**After**
```
For 500 controllers:
  Class serial changed by 2028 per route
  Defining 2000 routes took 309.9443819373846ms
```

cc @tenderlove who helped ❤️
cc @casperisfine @Edouard-chin @rafaelfranca who were looking into `define_url_helper`'s performance in #37139. I'd love to know if this helps you too 🙇