### PR TITLE
Remove unused requires

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -4,8 +4,6 @@ require "active_support/concern"
 require "active_support/descendants_tracker"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/class/attribute"
-require "active_support/core_ext/kernel/reporting"
-require "active_support/core_ext/kernel/singleton_class"
 require "active_support/core_ext/string/filters"
 require "thread"
 


### PR DESCRIPTION
### Summary
`reporting` was removed at 7e75dc5d86.
`singleton_class` was removed at b342d2baef.
