### PR TITLE
Add missing parameter to ActionMailbox conductor

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -20,7 +20,7 @@ module Rails
 
     private
       def new_mail
-        Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body).to_h).tap do |mail|
+        Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :in_reply_to, :subject, :body, attachments: []).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
           params[:mail][:attachments].to_a.each do |attachment|
             mail.add_file(filename: attachment.original_filename, content: attachment.read)


### PR DESCRIPTION
When testing the ActionMailbox conductor found at
`/rails/conductor/action_mailbox/inbound_emails`, I encountered the
following issue upon submission of messages which include an attachment:

```
ActionController::UnpermittedParameters in Rails::Conductor::ActionMailbox::InboundEmailsController#create

found unpermitted parameter: :attachments
```

This commit allows `attachments` to be permitted.
