### PR TITLE
Fix many ruby 2.7 warnings for the 6.0 stable branch

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -52,12 +52,12 @@ module ActiveSupport
       #
       #   ActiveSupport::Cache.lookup_store(MyOwnCacheStore.new)
       #   # => returns MyOwnCacheStore.new
-      def lookup_store(*store_option)
-        store, *parameters = *Array.wrap(store_option).flatten
+      def lookup_store(*store_args, **store_options)
+        store, *parameters = *Array.wrap(store_args).flatten
 
         case store
         when Symbol
-          retrieve_store_class(store).new(*parameters)
+          retrieve_store_class(store).new(*parameters, **store_options)
         when nil
           ActiveSupport::Cache::MemoryStore.new
         else

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -318,7 +318,7 @@ module ActiveSupport
 
           entry = nil
           instrument(:read, name, options) do |payload|
-            cached_entry = read_entry(key, options) unless options[:force]
+            cached_entry = read_entry(key, **options) unless options[:force]
             entry = handle_expired_entry(cached_entry, key, options)
             entry = nil if entry && entry.mismatched?(normalize_version(name, options))
             payload[:super_operation] = :fetch if payload
@@ -326,9 +326,9 @@ module ActiveSupport
           end
 
           if entry
-            get_entry_value(entry, name, options)
+            get_entry_value(entry, name, **options)
           else
-            save_block_result_to_cache(name, options) { |_name| yield _name }
+            save_block_result_to_cache(name, **options) { |_name| yield _name }
           end
         elsif options && options[:force]
           raise ArgumentError, "Missing block: Calling `Cache#fetch` with `force: true` requires a block."
@@ -352,11 +352,11 @@ module ActiveSupport
         version = normalize_version(name, options)
 
         instrument(:read, name, options) do |payload|
-          entry = read_entry(key, options)
+          entry = read_entry(key, **options)
 
           if entry
             if entry.expired?
-              delete_entry(key, options)
+              delete_entry(key, **options)
               payload[:hit] = false if payload
               nil
             elsif entry.mismatched?(version)
@@ -384,7 +384,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument :read_multi, names, options do |payload|
-          read_multi_entries(names, options).tap do |results|
+          read_multi_entries(names, **options).tap do |results|
             payload[:hits] = results.keys
           end
         end
@@ -396,10 +396,10 @@ module ActiveSupport
 
         instrument :write_multi, hash, options do |payload|
           entries = hash.each_with_object({}) do |(name, value), memo|
-            memo[normalize_key(name, options)] = Entry.new(value, options.merge(version: normalize_version(name, options)))
+            memo[normalize_key(name, options)] = Entry.new(value, **options.merge(version: normalize_version(name, options)))
           end
 
-          write_multi_entries entries, options
+          write_multi_entries entries, **options
         end
       end
 
@@ -438,7 +438,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument :read_multi, names, options do |payload|
-          reads   = read_multi_entries(names, options)
+          reads   = read_multi_entries(names, **options)
           writes  = {}
           ordered = names.each_with_object({}) do |name, hash|
             hash[name] = reads.fetch(name) { writes[name] = yield(name) }
@@ -447,7 +447,7 @@ module ActiveSupport
           payload[:hits] = reads.keys
           payload[:super_operation] = :fetch_multi
 
-          write_multi(writes, options)
+          write_multi(writes, **options)
 
           ordered
         end
@@ -460,8 +460,8 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument(:write, name, options) do
-          entry = Entry.new(value, options.merge(version: normalize_version(name, options)))
-          write_entry(normalize_key(name, options), entry, options)
+          entry = Entry.new(value, **options.merge(version: normalize_version(name, options)))
+          write_entry(normalize_key(name, options), entry, **options)
         end
       end
 
@@ -472,7 +472,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument(:delete, name) do
-          delete_entry(normalize_key(name, options), options)
+          delete_entry(normalize_key(name, options), **options)
         end
       end
 
@@ -483,7 +483,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument(:exist?, name) do
-          entry = read_entry(normalize_key(name, options), options)
+          entry = read_entry(normalize_key(name, options), **options)
           (entry && !entry.expired? && !entry.mismatched?(normalize_version(name, options))) || false
         end
       end
@@ -556,28 +556,28 @@ module ActiveSupport
 
         # Reads an entry from the cache implementation. Subclasses must implement
         # this method.
-        def read_entry(key, options)
+        def read_entry(key, **options)
           raise NotImplementedError.new
         end
 
         # Writes an entry to the cache implementation. Subclasses must implement
         # this method.
-        def write_entry(key, entry, options)
+        def write_entry(key, entry, **options)
           raise NotImplementedError.new
         end
 
         # Reads multiple entries from the cache implementation. Subclasses MAY
         # implement this method.
-        def read_multi_entries(names, options)
+        def read_multi_entries(names, **options)
           results = {}
           names.each do |name|
             key     = normalize_key(name, options)
             version = normalize_version(name, options)
-            entry   = read_entry(key, options)
+            entry   = read_entry(key, **options)
 
             if entry
               if entry.expired?
-                delete_entry(key, options)
+                delete_entry(key, **options)
               elsif entry.mismatched?(version)
                 # Skip mismatched versions
               else
@@ -590,15 +590,15 @@ module ActiveSupport
 
         # Writes multiple entries to the cache implementation. Subclasses MAY
         # implement this method.
-        def write_multi_entries(hash, options)
+        def write_multi_entries(hash, **options)
           hash.each do |key, entry|
-            write_entry key, entry, options
+            write_entry key, entry, **options
           end
         end
 
         # Deletes an entry from the cache implementation. Subclasses must
         # implement this method.
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           raise NotImplementedError.new
         end
 
@@ -699,7 +699,7 @@ module ActiveSupport
               entry.expires_at = Time.now + race_ttl
               write_entry(key, entry, expires_in: race_ttl * 2)
             else
-              delete_entry(key, options)
+              delete_entry(key, **options)
             end
             entry = nil
           end
@@ -711,7 +711,7 @@ module ActiveSupport
           entry.value
         end
 
-        def save_block_result_to_cache(name, options)
+        def save_block_result_to_cache(name, **options)
           result = instrument(:generate, name, options) do
             yield(name)
           end

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -43,8 +43,8 @@ module ActiveSupport
       def cleanup(options = nil)
         options = merged_options(options)
         search_dir(cache_path) do |fname|
-          entry = read_entry(fname, options)
-          delete_entry(fname, options) if entry && entry.expired?
+          entry = read_entry(fname, **options)
+          delete_entry(fname, **options) if entry && entry.expired?
         end
       end
 
@@ -66,13 +66,13 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           search_dir(cache_path) do |path|
             key = file_path_key(path)
-            delete_entry(path, options) if key.match(matcher)
+            delete_entry(path, **options) if key.match(matcher)
           end
         end
       end
 
       private
-        def read_entry(key, options)
+        def read_entry(key, **options)
           if File.exist?(key)
             File.open(key) { |f| Marshal.load(f) }
           end
@@ -81,14 +81,14 @@ module ActiveSupport
           nil
         end
 
-        def write_entry(key, entry, options)
+        def write_entry(key, entry, **options)
           return false if options[:unless_exist] && File.exist?(key)
           ensure_cache_path(File.dirname(key))
           File.atomic_write(key, cache_path) { |f| Marshal.dump(entry, f) }
           true
         end
 
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           if File.exist?(key)
             begin
               File.delete(key)

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -28,7 +28,7 @@ module ActiveSupport
       # Provide support for raw values in the local cache strategy.
       module LocalCacheWithRaw # :nodoc:
         private
-          def read_entry(key, options)
+          def read_entry(key, **options)
             entry = super
             if options[:raw] && local_cache && entry
               entry = deserialize_entry(entry.value)
@@ -36,11 +36,11 @@ module ActiveSupport
             entry
           end
 
-          def write_entry(key, entry, options)
+          def write_entry(key, entry, **options)
             if options[:raw] && local_cache
               raw_entry = Entry.new(entry.value.to_s)
               raw_entry.expires_at = entry.expires_at
-              super(key, raw_entry, options)
+              super(key, raw_entry, **options)
             else
               super
             end
@@ -142,12 +142,12 @@ module ActiveSupport
 
       private
         # Read an entry from the cache.
-        def read_entry(key, options)
+        def read_entry(key, **options)
           rescue_error_with(nil) { deserialize_entry(@data.with { |c| c.get(key, options) }) }
         end
 
         # Write an entry to the cache.
-        def write_entry(key, entry, options)
+        def write_entry(key, entry, **options)
           method = options && options[:unless_exist] ? :add : :set
           value = options[:raw] ? entry.value.to_s : entry
           expires_in = options[:expires_in].to_i
@@ -156,12 +156,12 @@ module ActiveSupport
             expires_in += 5.minutes
           end
           rescue_error_with false do
-            @data.with { |c| c.send(method, key, value, expires_in, options) }
+            @data.with { |c| c.send(method, key, value, expires_in, **options) }
           end
         end
 
         # Reads multiple entries from the cache implementation.
-        def read_multi_entries(names, options)
+        def read_multi_entries(names, **options)
           keys_to_names = Hash[names.map { |name| [normalize_key(name, options), name] }]
 
           raw_values = @data.with { |c| c.get_multi(keys_to_names.keys) }
@@ -179,7 +179,7 @@ module ActiveSupport
         end
 
         # Delete an entry from the cache.
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           rescue_error_with(false) { @data.with { |c| c.delete(key) } }
         end
 

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -51,7 +51,7 @@ module ActiveSupport
           keys = synchronize { @data.keys }
           keys.each do |key|
             entry = @data[key]
-            delete_entry(key, options) if entry && entry.expired?
+            delete_entry(key, **options) if entry && entry.expired?
           end
         end
       end
@@ -67,7 +67,7 @@ module ActiveSupport
           instrument(:prune, target_size, from: @cache_size) do
             keys = synchronize { @key_access.keys.sort { |a, b| @key_access[a].to_f <=> @key_access[b].to_f } }
             keys.each do |key|
-              delete_entry(key, options)
+              delete_entry(key, **options)
               return if @cache_size <= target_size || (max_time && Concurrent.monotonic_time - start_time > max_time)
             end
           end
@@ -98,7 +98,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           keys = synchronize { @data.keys }
           keys.each do |key|
-            delete_entry(key, options) if key.match(matcher)
+            delete_entry(key, **options) if key.match(matcher)
           end
         end
       end
@@ -120,7 +120,7 @@ module ActiveSupport
           key.to_s.bytesize + entry.size + PER_ENTRY_OVERHEAD
         end
 
-        def read_entry(key, options)
+        def read_entry(key, **options)
           entry = @data[key]
           synchronize do
             if entry
@@ -134,7 +134,7 @@ module ActiveSupport
           entry
         end
 
-        def write_entry(key, entry, options)
+        def write_entry(key, entry, **options)
           entry.dup_value!
           synchronize do
             old_entry = @data[key]
@@ -151,7 +151,7 @@ module ActiveSupport
           end
         end
 
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           synchronize do
             @key_access.delete(key)
             entry = @data.delete(key)

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -33,14 +33,14 @@ module ActiveSupport
       end
 
       private
-        def read_entry(key, options)
+        def read_entry(key, **options)
         end
 
-        def write_entry(key, entry, options)
+        def write_entry(key, entry, **options)
           true
         end
 
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           false
         end
     end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -74,7 +74,7 @@ module ActiveSupport
       # Support raw values in the local cache strategy.
       module LocalCacheWithRaw # :nodoc:
         private
-          def read_entry(key, options)
+          def read_entry(key, **options)
             entry = super
             if options[:raw] && local_cache && entry
               entry = deserialize_entry(entry.value)
@@ -82,24 +82,24 @@ module ActiveSupport
             entry
           end
 
-          def write_entry(key, entry, options)
+          def write_entry(key, entry, **options)
             if options[:raw] && local_cache
               raw_entry = Entry.new(serialize_entry(entry, raw: true))
               raw_entry.expires_at = entry.expires_at
-              super(key, raw_entry, options)
+              super(key, raw_entry, **options)
             else
               super
             end
           end
 
-          def write_multi_entries(entries, options)
+          def write_multi_entries(entries, **options)
             if options[:raw] && local_cache
               raw_entries = entries.map do |key, entry|
                 raw_entry = Entry.new(serialize_entry(entry, raw: true))
                 raw_entry.expires_at = entry.expires_at
               end.to_h
 
-              super(raw_entries, options)
+              super(raw_entries, **options)
             else
               super
             end
@@ -346,13 +346,13 @@ module ActiveSupport
 
         # Store provider interface:
         # Read an entry from the cache.
-        def read_entry(key, options = nil)
+        def read_entry(key, **options)
           failsafe :read_entry do
             deserialize_entry redis.with { |c| c.get(key) }
           end
         end
 
-        def read_multi_entries(names, _options)
+        def read_multi_entries(names, **options)
           if mget_capable?
             read_multi_mget(*names)
           else

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -50,27 +50,27 @@ module ActiveSupport
             @data.clear
           end
 
-          def read_entry(key, options)
+          def read_entry(key, **options)
             @data[key]
           end
 
-          def read_multi_entries(keys, options)
+          def read_multi_entries(keys, **options)
             values = {}
 
             keys.each do |name|
-              entry = read_entry(name, options)
+              entry = read_entry(name, **options)
               values[name] = entry.value if entry
             end
 
             values
           end
 
-          def write_entry(key, value, options)
+          def write_entry(key, value, **options)
             @data[key] = value
             true
           end
 
-          def delete_entry(key, options)
+          def delete_entry(key, **options)
             !!@data.delete(key)
           end
 
@@ -92,34 +92,34 @@ module ActiveSupport
             local_cache_key)
         end
 
-        def clear(options = nil) # :nodoc:
+        def clear(**options) # :nodoc:
           return super unless cache = local_cache
           cache.clear(options)
           super
         end
 
-        def cleanup(options = nil) # :nodoc:
+        def cleanup(**options) # :nodoc:
           return super unless cache = local_cache
           cache.clear
           super
         end
 
-        def increment(name, amount = 1, options = nil) # :nodoc:
+        def increment(name, amount = 1, **options) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache { super }
-          write_cache_value(name, value, options)
+          write_cache_value(name, value, **options)
           value
         end
 
-        def decrement(name, amount = 1, options = nil) # :nodoc:
+        def decrement(name, amount = 1, **options) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache { super }
-          write_cache_value(name, value, options)
+          write_cache_value(name, value, **options)
           value
         end
 
         private
-          def read_entry(key, options)
+          def read_entry(key, **options)
             if cache = local_cache
               cache.fetch_entry(key) { super }
             else
@@ -127,42 +127,42 @@ module ActiveSupport
             end
           end
 
-          def read_multi_entries(keys, options)
+          def read_multi_entries(keys, **options)
             return super unless local_cache
 
-            local_entries = local_cache.read_multi_entries(keys, options)
+            local_entries = local_cache.read_multi_entries(keys, **options)
             missed_keys = keys - local_entries.keys
 
             if missed_keys.any?
-              local_entries.merge!(super(missed_keys, options))
+              local_entries.merge!(super(missed_keys, **options))
             else
               local_entries
             end
           end
 
-          def write_entry(key, entry, options)
+          def write_entry(key, entry, **options)
             if options[:unless_exist]
-              local_cache.delete_entry(key, options) if local_cache
+              local_cache.delete_entry(key, **options) if local_cache
             else
-              local_cache.write_entry(key, entry, options) if local_cache
+              local_cache.write_entry(key, entry, **options) if local_cache
             end
 
             super
           end
 
-          def delete_entry(key, options)
-            local_cache.delete_entry(key, options) if local_cache
+          def delete_entry(key, **options)
+            local_cache.delete_entry(key, **options) if local_cache
             super
           end
 
-          def write_cache_value(name, value, options)
+          def write_cache_value(name, value, **options)
             name = normalize_key(name, options)
             cache = local_cache
             cache.mute do
               if value
-                cache.write(name, value, options)
+                cache.write(name, value, **options)
               else
-                cache.delete(name, options)
+                cache.delete(name, **options)
               end
             end
           end

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -121,7 +121,7 @@ module ActiveSupport
     #        (Backtrace information…)
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
     class DeprecatedConstantProxy < Module
-      def self.new(*args, &block)
+      def self.new(*args, **kwargs, &block)
         object = args.first
 
         return object unless object

--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -94,7 +94,7 @@ module ActiveSupport
       end
 
       def handle_missing_key
-        raise MissingKeyError, key_path: key_path, env_key: env_key if raise_if_missing_key
+        raise MissingKeyError.new(key_path: key_path, env_key: env_key) if raise_if_missing_key
       end
   end
 end

--- a/activesupport/lib/active_support/locale/en.rb
+++ b/activesupport/lib/active_support/locale/en.rb
@@ -4,7 +4,8 @@
   en: {
     number: {
       nth: {
-        ordinals: lambda do |_key, number:, **_options|
+        ordinals: lambda do |_key, options|
+          number = options[:number]
           case number
           when 1; "st"
           when 2; "nd"
@@ -22,7 +23,8 @@
           end
         end,
 
-        ordinalized: lambda do |_key, number:, **_options|
+        ordinalized: lambda do |_key, options|
+          number = options[:number]
           "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
         end
       }

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -172,7 +172,7 @@ module ActiveSupport
         iv = cipher.random_iv
         cipher.auth_data = "" if aead_mode?
 
-        encrypted_data = cipher.update(Messages::Metadata.wrap(@serializer.dump(value), metadata_options))
+        encrypted_data = cipher.update(Messages::Metadata.wrap(@serializer.dump(value), **metadata_options))
         encrypted_data << cipher.final
 
         blob = "#{::Base64.strict_encode64 encrypted_data}--#{::Base64.strict_encode64 iv}"

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -172,8 +172,8 @@ module ActiveSupport
     #
     #   other_verifier = ActiveSupport::MessageVerifier.new 'd1ff3r3nt-s3Krit'
     #   other_verifier.verify(signed_message) # => ActiveSupport::MessageVerifier::InvalidSignature
-    def verify(*args)
-      verified(*args) || raise(InvalidSignature)
+    def verify(*args, **options)
+      verified(*args, **options) || raise(InvalidSignature)
     end
 
     # Generates a signed message for the provided value.

--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -20,12 +20,12 @@ module ActiveSupport
         def decrypt_and_verify(*args, on_rotation: nil, **options)
           super
         rescue MessageEncryptor::InvalidMessage, MessageVerifier::InvalidSignature
-          run_rotations(on_rotation) { |encryptor| encryptor.decrypt_and_verify(*args, options) } || raise
+          run_rotations(on_rotation) { |encryptor| encryptor.decrypt_and_verify(*args, **options) } || raise
         end
 
         private
           def build_rotation(secret = @secret, sign_secret = @sign_secret, options)
-            self.class.new(secret, sign_secret, options)
+            self.class.new(secret, sign_secret, **options)
           end
       end
 
@@ -33,12 +33,12 @@ module ActiveSupport
         include Rotator
 
         def verified(*args, on_rotation: nil, **options)
-          super || run_rotations(on_rotation) { |verifier| verifier.verified(*args, options) }
+          super || run_rotations(on_rotation) { |verifier| verifier.verified(*args, **options) }
         end
 
         private
           def build_rotation(secret = @secret, options)
-            self.class.new(secret, options)
+            self.class.new(secret, **options)
           end
       end
 

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -122,7 +122,7 @@ module ActiveSupport #:nodoc:
       #
       #   'こんにちは'.mb_chars.limit(7).to_s # => "こん"
       def limit(limit)
-        truncate_bytes(limit, omission: nil)
+        chars(@wrapped_string.truncate_bytes(limit, omission: nil))
       end
 
       # Capitalizes the first letter of every word, when possible.

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -161,12 +161,12 @@ module ActiveSupport
           options
         end
 
-        def translate_number_value_with_default(key, i18n_options = {})
-          I18n.translate(key, { default: default_value(key), scope: :number }.merge!(i18n_options))
+        def translate_number_value_with_default(key, **i18n_options)
+          I18n.translate(key, **{default: default_value(key), scope: :number}.merge!(i18n_options))
         end
 
-        def translate_in_locale(key, i18n_options = {})
-          translate_number_value_with_default(key, { locale: options[:locale] }.merge(i18n_options))
+        def translate_in_locale(key, **i18n_options)
+          translate_number_value_with_default(key, **{locale: options[:locale]}.merge(i18n_options))
         end
 
         def default_value(key)

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -162,11 +162,11 @@ module ActiveSupport
         end
 
         def translate_number_value_with_default(key, **i18n_options)
-          I18n.translate(key, **{default: default_value(key), scope: :number}.merge!(i18n_options))
+          I18n.translate(key, **{ default: default_value(key), scope: :number }.merge!(i18n_options))
         end
 
         def translate_in_locale(key, **i18n_options)
-          translate_number_value_with_default(key, **{locale: options[:locale]}.merge(i18n_options))
+          translate_number_value_with_default(key, **{ locale: options[:locale] }.merge(i18n_options))
         end
 
         def default_value(key)

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -400,7 +400,7 @@ module CacheStoreBehavior
 
   def test_race_condition_protection_skipped_if_not_defined
     @cache.write("foo", "bar")
-    time = @cache.send(:read_entry, @cache.send(:normalize_key, "foo", {}), {}).expires_at
+    time = @cache.send(:read_entry, @cache.send(:normalize_key, "foo", {}), **{}).expires_at
 
     Time.stub(:now, Time.at(time)) do
       result = @cache.fetch("foo") do
@@ -529,8 +529,8 @@ module CacheStoreBehavior
         assert_equal value, @cache.read("uncompressed")
       end
 
-      actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "actual", {}), {})
-      uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "uncompressed", {}), {})
+      actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "actual", {}), **{})
+      uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "uncompressed", {}), **{})
 
       actual_size = Marshal.dump(actual_entry).bytesize
       uncompressed_size = Marshal.dump(uncompressed_entry).bytesize

--- a/activesupport/test/cache/behaviors/connection_pool_behavior.rb
+++ b/activesupport/test/cache/behaviors/connection_pool_behavior.rb
@@ -7,7 +7,7 @@ module ConnectionPoolBehavior
     threads = []
 
     emulating_latency do
-      cache = ActiveSupport::Cache.lookup_store(*store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
+      cache = ActiveSupport::Cache.lookup_store(*store, **{ pool_size: 2, pool_timeout: 1 }.merge(store_options))
       cache.clear
 
       assert_raises Timeout::Error do
@@ -32,7 +32,7 @@ module ConnectionPoolBehavior
     threads = []
 
     emulating_latency do
-      cache = ActiveSupport::Cache.lookup_store(*store, store_options)
+      cache = ActiveSupport::Cache.lookup_store(*store, **store_options)
       cache.clear
 
       assert_nothing_raised do

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -6,7 +6,7 @@ require "active_support/cache"
 class CacheKeyTest < ActiveSupport::TestCase
   def test_entry_legacy_optional_ivars
     legacy = Class.new(ActiveSupport::Cache::Entry) do
-      def initialize(value, options = {})
+      def initialize(value, **options)
         @value = value
         @expires_in = nil
         @created_at = nil

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -106,7 +106,7 @@ class FileStoreTest < ActiveSupport::TestCase
 
   def test_log_exception_when_cache_read_fails
     File.stub(:exist?, -> { raise StandardError.new("failed") }) do
-      @cache.send(:read_entry, "winston", {})
+      @cache.send(:read_entry, "winston", **{})
       assert_predicate @buffer.string, :present?
     end
   end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -90,7 +90,7 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
   end
 
   def test_pruning_is_capped_at_a_max_time
-    def @cache.delete_entry(*args)
+    def @cache.delete_entry(*args, **options)
       sleep(0.01)
       super
     end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -53,7 +53,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
     verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", serializer: JSONSerializer.new)
-    message = verifier.generate(:foo => 123, "bar" => Time.utc(2010))
+    message = verifier.generate({ :foo => 123, "bar" => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, verifier.verified(message)
     assert_equal exp, verifier.verify(message)
@@ -115,7 +115,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
   end
 
   def test_on_rotation_is_called_and_verified_returns_message
-    older_message = ActiveSupport::MessageVerifier.new("older", digest: "SHA1").generate(encoded: "message")
+    older_message = ActiveSupport::MessageVerifier.new("older", digest: "SHA1").generate({ encoded: "message" })
 
     verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA512")
     verifier.rotate "old",   digest: "SHA256"
@@ -142,7 +142,7 @@ class MessageVerifierMetadataTest < ActiveSupport::TestCase
   include SharedMessageMetadataTests
 
   setup do
-    @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", verifier_options)
+    @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", **verifier_options)
   end
 
   def test_verify_raises_when_purpose_differs
@@ -162,11 +162,11 @@ class MessageVerifierMetadataTest < ActiveSupport::TestCase
 
   private
     def generate(message, **options)
-      @verifier.generate(message, options)
+      @verifier.generate(message, **options)
     end
 
     def parse(message, **options)
-      @verifier.verified(message, options)
+      @verifier.verified(message, **options)
     end
 
     def verifier_options

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "fileutils"
-require "open-uri"
 require "tmpdir"
 
 module MultibyteTestHelpers
@@ -11,7 +10,7 @@ module MultibyteTestHelpers
         unless File.exist?(File.dirname(to))
           system "mkdir -p #{File.dirname(to)}"
         end
-        open(from) do |source|
+        URI.open(from) do |source|
           File.open(to, "w") do |target|
             source.each_line do |l|
               target.write l


### PR DESCRIPTION
When possible I simply cherry-picked fixes from the master branch, but sometimes I had to redo them manually.

Here I started with ActiveSupport, I'm not sure I eliminated them all yet because the test suite is segfaulting on my machine. 

This is still a work in progress, but opening a PR give me a CI run which is helpful.

cc @rafaelfranca @Edouard-chin 