### PR TITLE
Add exclude option for number of omission strings into truncate method in activesupport

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -152,5 +152,17 @@
 
     *Jordan Thomas*
 
+*   Add `exclude` option to `truncate` method. This option allows truncation by excluding
+    the number of strings in `omission` when executing the truncate method.
+    This `exclude` option can also be used with the `spearate` option without any problem.
+
+    Example:
+
+        'Hello World!'.truncate(10)
+        # => "Hello W..."
+        'Hello World!'.truncate(10, exclude: true)
+        # => "Hello Worl..."
+
+    *Teruhisa Fukumoto*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -58,6 +58,9 @@ class String
   #   'Once upon a time in a world far far away'.truncate(27, separator: /\s/)
   #   # => "Once upon a time in a..."
   #
+  #   'Once upon a time in a world far far away'.truncate(27, exclude: true)
+  #   # => "Once upon a time in a world..."
+  #
   # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "...")
   # for a total length not exceeding <tt>length</tt>:
   #
@@ -67,7 +70,13 @@ class String
     return dup unless length > truncate_at
 
     omission = options[:omission] || "..."
-    length_with_room_for_omission = truncate_at - omission.length
+    length_with_room_for_omission = \
+      if options[:exclude]
+        truncate_at
+      else
+        truncate_at - omission.length
+      end
+
     stop = \
       if options[:separator]
         rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -291,6 +291,12 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: /\s/)
   end
 
+  def test_truncate_with_exclude_option
+    assert_equal "Hello Big Wor...", "Hello Big World!".truncate(13, exclude: true)
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(14, omission: "[...]", exclude: false)
+    assert_equal "Hello Big[...]", "Hello Big World!".truncate(15, omission: "[...]", separator: /\s/, exclude: true)
+  end
+
   def test_truncate_returns_frozen_string
     assert_not "Hello World!".truncate(12).frozen?
     assert_not "Hello World!!".truncate(12).frozen?


### PR DESCRIPTION
### Summary
I added `exclude` option to the truncate method in ActiveSupport with this Pull.
That option makes it possible to truncate except the number of omission strings when executing the truncate method.
This option is useful for developers who do not want to pay attention to the number of characters of omission.

```
'Hello World!'.truncate(10)
    # => "Hello W..."
'Hello World!'.truncate(10, exclude: true)
    # => "Hello Worl..."
'Hello World!'.truncate(10, exclude: true, separator: /\s/)
    # => "Hello..."
```

### Use Case
Any developer who uses the truncate method may use this option. When considering the number of characters, calculating the number of characters in omission is cumbersome and not intuitive.

### Other Information
This exclude option is useful, for example, when Rails is responsible for the back end of a mobile app.Because the screen of the mobile application is very small, there are many opportunities to truncate strings.

In fact, I implemented a similar patch in Rails when sending mobile app push notifications from Rails.Especially in push notifications, the area that can be used to display characters is limited. 