### PR TITLE
Reflected association methods on relations

### DIFF
--- a/activerecord/test/cases/relation/reflection_methods_test.rb
+++ b/activerecord/test/cases/relation/reflection_methods_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+require "models/rating"
+
+module ActiveRecord
+  class ReflectionMethodsTest < ActiveRecord::TestCase
+    fixtures :posts, :comments, :ratings
+
+    test "Post -> Comment" do
+      assert_equal_ids Comment.all.ids, Post.all.comments.ids
+    end
+
+    test "Comment -> Post" do
+      assert_equal_ids Post.joins(:comments).distinct.pluck(:id),
+                       Comment.all.post.ids.uniq
+    end
+
+    test "Post -> Comment -> Rating" do
+      assert_equal_ids Rating.all.ids, Post.all.comments.ratings.ids
+    end
+
+    test "Rating -> Comment -> Post" do
+      assert_equal_ids Post.joins(comments: :ratings).distinct.pluck(:id),
+                       Rating.all.comment.post.ids.uniq
+    end
+
+    private
+      def assert_equal_ids(expected, actual)
+        assert_equal expected.sort, actual.sort
+      end
+  end
+end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -11,7 +11,7 @@ class Comment < ActiveRecord::Base
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }
 
-  belongs_to :post, counter_cache: true
+  belongs_to :post, inverse_of: :comments, counter_cache: true
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
 

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Rating < ActiveRecord::Base
-  belongs_to :comment
+  belongs_to :comment, inverse_of: :ratings
   has_many :taggings, as: :taggable
   has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"


### PR DESCRIPTION
Hi there!

This is a proof of concept of a variation of the first half of the API proposed in https://github.com/rails/rails/issues/37875. The idea here is to enable extra relation methods that mirror associations on the source model. First, an example:

```ruby
class Post < ApplicationRecord
  has_many :comments
end

class Comment < ApplicationRecord
  belongs_to :post
end

Post.where('id > ?', 42).comments
Post.all.comments.class
# => Comment::ActiveRecord_Relation

Post.where('id > ?', 42).comments.to_sql
# => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" IN (SELECT "posts"."id" FROM "posts" WHERE (id > 42))
```

It effectively allows the API @dhh was talking about wrt to relations, but doesn't yet take a look at bringing in the Many monad. It doesn't necessarily block that work - to me this PR is just taking care of the piece of it that relates to ActiveRecord. Then, if the Many monad gets brought in, you could easily subclass it here and have special proxying for ActiveRecord relations that does this logic.

Note that at the moment there's a bug where you have to call the method twice. I'm not sure why, but I'm sure it has to do with my unfamiliarity with the `GeneratedRelationMethods` module and its associated mutex. So if you're going to be looking at this call `Post.all.comments` twice.

I say this is work in progress because there are definitely other considerations here that I have yet to address (beyond just adding tests), including HABTM relations, has_many relations with non-standard scoping, etc. I would love to get some feedback on if this is a direction we'd like to go in though, and I can continue to address feedback here.