### PR TITLE
Add unwhere method to clear where conditions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -674,6 +674,18 @@ module ActiveRecord
       unscope(where: conditions.keys).where(conditions)
     end
 
+    # Returns a relation, without all where conditions
+    #
+    #    Post.where("id = 1").unwhere
+    #    # SELECT `posts`.* FROM `posts`
+    #    Post.where("id = 1").unwhere.where(trashed: false)
+    #    # SELECT `posts`.* FROM `posts` WHERE `trashed` = 0
+    #
+    def unwhere
+      self.where_clause.clear
+      self
+    end
+
     # Returns a new relation, which is the logical union of this relation and the one passed as an
     # argument.
     #

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   class Relation
     class WhereClause # :nodoc:
-      delegate :any?, :empty?, to: :predicates
+      delegate :any?, :empty?, :clear, to: :predicates
 
       def initialize(predicates)
         @predicates = predicates

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -103,5 +103,19 @@ module ActiveRecord
 
       assert_equal Post.where(comments_count: 3..5), relation
     end
+
+    def test_unwhere
+      relation = Post.where(title: "hello").where(body: "world").unwhere
+      expected = Post.all
+
+      assert_equal expected, relation
+    end
+
+    def test_unwhere_with_where_after_it
+      relation = Post.where(title: "hello").where(body: "world").unwhere.where(title: "hello")
+      expected = Post.where(title: "hello")
+
+      assert_equal expected, relation
+    end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -432,5 +432,15 @@ module ActiveRecord
     def test_where_with_unsupported_arguments
       assert_raises(ArgumentError) { Author.where(42) }
     end
+
+    def test_unwhere_with_joins
+      relation = Comment.joins(post: :author).where(authors: { id: "2-foo" }).unwhere
+      expected = Comment.joins(post: :author)
+      assert_equal expected, relation
+
+      relation = Comment.joins(post: :author).where(authors: { id: "2-foo" }).unwhere.where("comments.id = 1")
+      expected = Comment.joins(post: :author).where("comments.id = 1")
+      assert_equal expected, relation
+    end
   end
 end


### PR DESCRIPTION
### Summary

I need to have a nice way to return a list of total records in DB regardless passed where conditions.
Currently, I'm building a scope with joins, order, etc and then making a "dup" of it and then adding where conditions. This is inconvenient and looks like overhead. So I think having a simple shortcut to clear passed "where" conditions would be nice.