### PR TITLE
Allow sneaky params to be enabled via an option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow sneaky parameters to be enabled through a routing option
+
+    When :allow_sneaky is set to true, it is possible to configure routes like this:
+
+    ```
+    routes.draw do
+      resources :users, param: 'name/:sneaky', allow_sneaky: true
+    end
+    ```
+
+    *Stephen Downward*
+
 *   Bring back the feature that allows loading external route files from the router.
 
     This feature existed back in 2012 but got reverted with the incentive that

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1152,14 +1152,14 @@ module ActionDispatch
         # CANONICAL_ACTIONS holds all actions that does not need a prefix or
         # a path appended since they fit properly in their scope level.
         VALID_ON_OPTIONS  = [:new, :collection, :member]
-        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param, :concerns]
+        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param, :concerns, :allow_sneaky]
         CANONICAL_ACTIONS = %w(index create new show update destroy)
 
         class Resource #:nodoc:
           attr_reader :controller, :path, :param
 
           def initialize(entities, api_only, shallow, options = {})
-            if options[:param].to_s.include?(":")
+            if options[:param].to_s.include?(":") && !options[:allow_sneaky]
               raise ArgumentError, ":param option can't contain colons"
             end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "erb"
@@ -3377,6 +3378,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     }
 
     assert_match(/:param option can't contain colon/, ex.message)
+  end
+
+  def test_colon_containing_custom_param_with_sneaky_routes_enabled
+    draw do
+      resources :profiles, param: "username/:is_admin", allow_sneaky: true
+    end
+
+    get "/profiles/scd31/true"
+    assert_equal @request.params[:username], "scd31"
+    assert_equal @request.params[:is_admin], "true"
   end
 
   def test_action_from_path_is_frozen


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Partially reverts #30467. Disallowing sneaky params is still the default, but they can be turned on with the `:allow_sneaky` parameter:

```
routes.draw do
  resources :users, param: 'name/:sneaky', allow_sneaky: true
end
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

See #30467 for some examples of why sneaky params can be useful.
