### PR TITLE
Removed unnecessary words from Getting Started docs

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -400,7 +400,7 @@ error:
 ![Another routing error, uninitialized constant ArticlesController](images/getting_started/routing_error_no_controller.png)
 
 This error occurs because the route needs to have a controller defined in order
-to serve the request. The solution to this particular problem is simple: create
+to serve the request. The solution to this particular problem is to create
 a controller called `ArticlesController`. You can do this by running this
 command:
 
@@ -416,7 +416,7 @@ class ArticlesController < ApplicationController
 end
 ```
 
-A controller is simply a class that is defined to inherit from
+A controller is a class that is defined to inherit from
 `ApplicationController`.
 It's inside this class that you'll define methods that will become the actions
 for this controller. These actions will perform CRUD operations on the articles
@@ -525,7 +525,6 @@ method called `form_with`. To use this method, add this code into
 ```
 
 If you refresh the page now, you'll see the exact same form from our example above.
-Building forms in Rails is really just that easy!
 
 When you call `form_with`, you pass it an identifying scope for this
 form. In this case, it's the symbol `:article`. This tells the `form_with`
@@ -609,7 +608,7 @@ end
 
 If you re-submit the form now, you may not see any change on the page. Don't worry!
 This is because Rails by default returns `204 No Content` response for an action if
-we don't specify what the response should be. We just added the `create` action
+we don't specify what the response should be. We added the `create` action
 but didn't specify anything about how the response should be. In this case, the
 `create` action should save our new article to the database.
 
@@ -624,7 +623,7 @@ def create
 end
 ```
 
-The `render` method here is taking a very simple hash with a key of `:plain` and
+The `render` method here is taking a hash with a key of `:plain` and
 value of `params[:article].inspect`. The `params` method is the object which
 represents the parameters (or fields) coming in from the form. The `params`
 method returns an `ActionController::Parameters` object, which
@@ -672,7 +671,7 @@ models, as that will be done automatically by Active Record.
 
 As we've just seen, `rails generate model` created a _database migration_ file
 inside the `db/migrate` directory. Migrations are Ruby classes that are
-designed to make it simple to create and modify database tables. Rails uses
+designed to create and modify database tables. Rails uses
 rake commands to run migrations, and it's possible to undo a migration after
 it's been applied to your database. Migration filenames include a timestamp to
 ensure that they're processed in the order that they were created.
@@ -1119,7 +1118,7 @@ with class `field_with_errors`. You can define a CSS rule to make them
 standout.
 
 Now you'll get a nice error message when saving an article without a title when
-you attempt to do just that on the new article form
+you attempt to do that on the new article form
 <http://localhost:3000/articles/new>:
 
 ![Form With Errors](images/getting_started/form_with_errors.png)
@@ -1347,7 +1346,7 @@ content:
 ```
 
 Everything except for the `form_with` declaration remained the same.
-The reason we can use this shorter, simpler `form_with` declaration
+The reason we can use this shorter `form_with` declaration
 to stand in for either of the other forms is that `@article` is a *resource*
 corresponding to a full set of RESTful routes, and Rails is able to infer
 which URI and method to use.
@@ -1996,7 +1995,7 @@ Security
 If you were to publish your blog online, anyone would be able to add, edit and
 delete articles or delete comments.
 
-Rails provides a very simple HTTP authentication system that will work nicely in
+Rails provides an HTTP authentication system that will work nicely in
 this situation.
 
 In the `ArticlesController` we need to have a way to block access to the


### PR DESCRIPTION
[ci skip]

### Summary

This PR removes some uses of "simple" and "just" from the getting started documentation.

### Other Information
Using "simple" and "just" in documentation is very tempting! It is there to show enthusiasm and to encourage new people to try out the thing the author loves. In this case, Rails. However, if you are following documentation and struggle with it, reading these words can be a source of frustration.

Also: using fewer words can make the instructions more clear and can reduce ambiguity.
