### PR TITLE
Fix deprecation being thrown at boot time:

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -42,15 +42,6 @@ module ActiveJob
     # callbacks for +perform+ and +enqueue+ methods.
     module ClassMethods
       def inherited(klass)
-        unless skip_after_callbacks_if_terminated
-          ActiveSupport::Deprecation.warn(<<~EOM)
-            In Rails 6.2, ActiveJob's `after_enqueue` and `after_perform` callbacks will no longer run in case the
-            callback chain is halted (i.e. `throw(:abort)` is thrown in a before_enqueue callback).
-            To enable this behaviour right now, add in your application configuration file
-            `config.active_job.skip_after_callbacks_if_terminated = true`.
-          EOM
-        end
-
         klass.get_callbacks(:enqueue).config[:skip_after_callbacks_if_terminated] = skip_after_callbacks_if_terminated
         klass.get_callbacks(:perform).config[:skip_after_callbacks_if_terminated] = skip_after_callbacks_if_terminated
         super

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -63,6 +63,14 @@ module ActiveJob
       if successfully_enqueued
         self
       else
+        if !self.class.skip_after_callbacks_if_terminated && _enqueue_callbacks.any? { |c| c.kind == :after }
+          ActiveSupport::Deprecation.warn(<<~EOM)
+            In Rails 6.2, ActiveJob's `after_enqueue` callbacks will no longer run in case the
+            callback chain is halted (i.e. `throw(:abort)` is thrown in a before_enqueue callback).
+            To enable this behaviour right now, add in your application configuration file
+            `config.active_job.skip_after_callbacks_if_terminated = true`.
+          EOM
+        end
         if self.class.return_false_on_aborted_enqueue
           false
         else

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -12,6 +12,7 @@ if ENV["AJ_INTEGRATION_TESTS"]
   require "support/integration/helper"
 else
   ActiveJob::Base.logger = Logger.new(nil)
+  ActiveJob::Base.skip_after_callbacks_if_terminated = true
   require "adapters/#{@adapter}"
 end
 


### PR DESCRIPTION
-
  ### Problem

  In rails/rails@bbfab0b33ab I introduced a change which outputs
  a deprecation whenever a class inherits from ActiveJob::Base.

  This has the negative effect to trigger a massive amount of
  deprecation at boot time especially if your app is eagerloaded
  (like it's usually the case on CI).

  Another issue with this approach was that the deprecation will
  be output no matter if a job define a `after_perform` callbacks
  i.e.
  ```ruby
    class MyJob < AJ::Base
      before_enqueue { throw(:abort) }
    end

    # This shouldn't trigger a deprecation since no after callbacks are defined
    # The change in 6.2 will be already safe for the app.
  ```

  ### Solution

  Trigger the deprecation only when a job is abort
  (during enqueuing or performing) AND a `after_(perform/enqueue)`
  callback is defined on the job.

cc/ @kaspth @rafaelfranca 