### PR TITLE
Action Text: Add method to confirm rich text content existence by adding ? after content name

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add method to confirm rich text content existence by adding `?` after content name.
+
+    *Kyohei Toyoda*
+
 *   The `fill_in_rich_text_area` system test helper locates a Trix editor and fills it in with the given HTML:
 
     ```ruby

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -13,6 +13,7 @@ module ActionText
       #   end
       #
       #   message = Message.create!(content: "<h1>Funny times!</h1>")
+      #   message.content? #=> true
       #   message.content.to_s # => "<h1>Funny times!</h1>"
       #   message.content.to_plain_text # => "Funny times!"
       #
@@ -27,6 +28,10 @@ module ActionText
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
             rich_text_#{name} || build_rich_text_#{name}
+          end
+
+          def #{name}?
+            rich_text_#{name}.present?
           end
 
           def #{name}=(body)

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -18,6 +18,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert message.content.nil?
     assert message.content.blank?
     assert message.content.empty?
+    assert_not message.content?
     assert_not message.content.present?
   end
 
@@ -26,6 +27,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_not message.content.nil?
     assert message.content.blank?
     assert message.content.empty?
+    assert_not message.content?
     assert_not message.content.present?
   end
 


### PR DESCRIPTION
### Summary

This is the pull request based on https://github.com/rails/rails/issues/37594

This change introduces a rich text object to make
it easier to confirm it context is existing or not.

### Other Information
If we have a class like below.

```
class Information < ApplicationRecord
  has_rich_text :notes
end
```

Before:
```
i = Information.new
i.notes? => NoMethodError
i.notes = "Some sample text"
i.notes.present? => true
```

After:
```
i = Information.new
i.notes? => false

i.notes = "Some sample text"
i.notes? => true
```

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
