### PR TITLE
Workaroud to address apt-get update at GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,6 +14,7 @@ jobs:
         ruby-version: 2.6.x
     - name: Install required package
       run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
     - name: Cache gems


### PR DESCRIPTION
### Summary

This pull request addresses the following error at GitHub Actions.

https://github.com/rails/rails/pull/37950/checks?check_run_id=346759027

```
Reading package lists...
W: Conflicting distribution: https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic InRelease (expected bionic but got stable)
E: Repository 'https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic InRelease' changed its 'Origin' value from 'microsoft-ubuntu-bionic-prod bionic' to 'vscode stable'
E: Repository 'https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic InRelease' changed its 'Label' value from 'microsoft-ubuntu-bionic-prod bionic' to 'vscode stable'
E: Repository 'https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic InRelease' changed its 'Suite' value from 'bionic' to 'stable'
E: Repository 'https://packages.microsoft.com/repos/microsoft-ubuntu-bionic-prod bionic InRelease' changed its 'Codename' value from 'bionic' to 'stable'
W: Conflicting distribution: https://packages.microsoft.com/ubuntu/16.04/prod xenial InRelease (expected xenial but got stable)
E: Repository 'https://packages.microsoft.com/ubuntu/16.04/prod xenial InRelease' changed its 'Origin' value from 'microsoft-ubuntu-xenial-prod xenial' to 'vscode stable'
E: Repository 'https://packages.microsoft.com/ubuntu/16.04/prod xenial InRelease' changed its 'Label' value from 'microsoft-ubuntu-xenial-prod xenial' to 'vscode stable'
E: Repository 'https://packages.microsoft.com/ubuntu/16.04/prod xenial InRelease' changed its 'Suite' value from 'xenial' to 'stable'
E: Repository 'https://packages.microsoft.com/ubuntu/16.04/prod xenial InRelease' changed its 'Codename' value from 'xenial' to 'stable'
```

Refer:
https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
https://github.com/epatters/Catlab.jl/commit/3842b0b8a1e30818870d3adbe8e533c9cf44cf02

