### PR TITLE
Unscope support or and string

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -27,8 +27,8 @@ module ActiveRecord
         )
       end
 
-      def except(*columns)
-        WhereClause.new(except_predicates(columns))
+      def except(*columns_or_scope)
+        WhereClause.new(except_predicates(columns_or_scope))
       end
 
       def or(other)
@@ -145,9 +145,14 @@ module ActiveRecord
           end
         end
 
-        def except_predicates(columns)
+        def except_predicates(columns_or_scope)
           predicates.reject do |node|
-            Arel.fetch_attribute(node) { |attr| columns.include?(attr.name.to_s) }
+            case node
+            when String
+              columns_or_scope.include?(node)
+            else
+              Arel.fetch_attribute(node) { |attr| columns_or_scope.include?(attr.name.to_s) }
+            end
           end
         end
 

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -58,8 +58,12 @@ module Arel
       end
     when Arel::Nodes::Or
       fetch_attribute(value.left, &block) && fetch_attribute(value.right, &block)
+    when Arel::Nodes::And
+      fetch_attribute(value.left, &block)
     when Arel::Nodes::Grouping
       fetch_attribute(value.expr, &block)
+    when String
+      value
     end
   end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -104,6 +104,30 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal expected, received
   end
 
+  def test_unscope_overrides_a_stringified_scope
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = Developer.named_david_or_jamis_stringified.unscope(where: "name = 'David' OR name = 'Jamis'").collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_overrides_or_on_same_column
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = Developer.named_david_or_jamis_operator.unscope(where: :name).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_overrides_and_on_different_column
+    expected = Developer.all.where(salary: 100000).collect { |dev| [dev.name, dev.id] }
+    received = Developer.fixture_3_with_salary_100000.unscope(where: :name).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
+  def test_unscope_overrides_or_on_same_column_with_between
+    expected = Developer.all.collect { |dev| [dev.name, dev.id] }
+    received = Developer.with_id_1_or_between_3_and_7.unscope(where: :id).collect { |dev| [dev.name, dev.id] }
+    assert_equal expected, received
+  end
+
   def test_unscope_after_reordering_and_combining
     expected = Developer.order("id DESC, name DESC").collect { |dev| [dev.name, dev.id] }
     received = DeveloperOrderedBySalary.reorder("name DESC").unscope(:order).order("id DESC, name DESC").collect { |dev| [dev.name, dev.id] }

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -62,6 +62,10 @@ class Developer < ActiveRecord::Base
   has_many :contracted_projects, class_name: "Project"
 
   scope :jamises, -> { where(name: "Jamis") }
+  scope :named_david_or_jamis_stringified, -> { where("name = 'David' OR name = 'Jamis'") }
+  scope :named_david_or_jamis_operator, -> { where(name: 'David').or(where(name: 'Jamis')) }
+  scope :fixture_3_with_salary_100000, -> { where(name: 'fixture_3', salary: 100000) }
+  scope :with_id_1_or_between_3_and_7, -> { where(id: 3..7).or(where(id: 1)) }
 
   validates_inclusion_of :salary, in: 50000..200000
   validates_length_of    :name, within: 3..20

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -63,8 +63,8 @@ class Developer < ActiveRecord::Base
 
   scope :jamises, -> { where(name: "Jamis") }
   scope :named_david_or_jamis_stringified, -> { where("name = 'David' OR name = 'Jamis'") }
-  scope :named_david_or_jamis_operator, -> { where(name: 'David').or(where(name: 'Jamis')) }
-  scope :fixture_3_with_salary_100000, -> { where(name: 'fixture_3', salary: 100000) }
+  scope :named_david_or_jamis_operator, -> { where(name: "David").or(where(name: "Jamis")) }
+  scope :fixture_3_with_salary_100000, -> { where(name: "fixture_3", salary: 100000) }
   scope :with_id_1_or_between_3_and_7, -> { where(id: 3..7).or(where(id: 1)) }
 
   validates_inclusion_of :salary, in: 50000..200000


### PR DESCRIPTION
Fixes #37934

```ruby
class Post < ActiveRecord::Base
  scope :added_by_dhh_or_about_rails_7,  -> { where(author_name: 'DHH').or(where(title: 'Rails 7')) }
  scope :added_by_eileen_or_about_rails,  -> { where("author_name = 'Eileen' OR title= 'Rails'") }
end


class BugTest < Minitest::Test
  def test_association_stuff
    Post.create!(title: "Racing", author_name: "DHH")
    Post.create!(title: "Rails 7", author_name: "DHH")
    Post.create!(title: "Boxing", author_name: "Harry")
    Post.create!(title: "Rails", author_name: "Jeremy")
    Post.create!(title: "Rails 7", author_name: "Aaron Patterson")
    Post.create!(title: "HTTP3", author_name: "Eileen")

    
    posts_by_dhh_or_rails_7 = Post.all.added_by_dhh_or_about_rails_7
    #SELECT `posts`.* FROM `posts` WHERE (`posts`.`author_name` = 'DHH' OR `posts`.`title` = 'Rails 7 Ideas')

    posts_about_rails_7 = posts_by_dhh_or_rails_7.unscope(where: :author_name)
    #Should Have removed OR:
    # SELECT `posts`.* FROM `posts` WHERE (`posts`.`title` = 'Rails 7 Ideas')
    #But Its still same:
    # #SELECT `posts`.* FROM `posts` WHERE (`posts`.`author_name` = 'DHH' OR `posts`.`title` = 'Rails 7 Ideas')


    posts_by_elieen_or_rails = Post.all.added_by_eileen_or_about_rails
    #SELECT `posts`.* FROM `posts` WHERE (author_name = 'Eileen' OR title= 'Rails')
    all_posts = posts_by_elieen_or_rails.unscope(where: "author_name = 'Eileen' OR title= 'Rails'")
    #SELECT `posts`.* FROM `posts` WHERE (author_name = 'Eileen' OR title= 'Rails')
    
    assert_equal 2, posts_about_rails_7.count
    assert_equal 6, all_posts.count
  end
end

```
### Fix
Fix allows to unscope the a scope or where with OR operator. Example:

```sql
Post.all.added_by_eileen_or_about_rails.unscope(where: "author_name = 'Eileen' OR title= 'Rails'")
#SELECT `posts`.* FROM `posts`

Post.all.added_by_dhh_or_about_rails_7.unscope(where: :author_name)
#SELECT `posts`.* FROM `posts` WHERE (`posts`.`title` = 'Rails 7 Ideas')
```
