### PR TITLE
Previews are created on the same service as the original blob

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Previews are created on the same service as the original blob.
+
+    *Peter Zhu*
+
 *   Remove unused `disposition` and `content_type` query parameters for `DiskService`.
 
     *Peter Zhu*

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -74,7 +74,7 @@ class ActiveStorage::Preview
     end
 
     def process
-      previewer.preview do |attachable|
+      previewer.preview(service_name: blob.service_name) do |attachable|
         ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
           image.attach(attachable)
         end

--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -18,8 +18,9 @@ module ActiveStorage
     end
 
     # Override this method in a concrete subclass. Have it yield an attachable preview image (i.e.
-    # anything accepted by ActiveStorage::Attached::One#attach).
-    def preview
+    # anything accepted by ActiveStorage::Attached::One#attach). Pass the additional options to
+    # the underlying blob that is created.
+    def preview(**options)
       raise NotImplementedError
     end
 

--- a/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
@@ -20,10 +20,10 @@ module ActiveStorage
       end
     end
 
-    def preview
+    def preview(**options)
       download_blob_to_tempfile do |input|
         draw_first_page_from input do |output|
-          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png", **options
         end
       end
     end

--- a/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
@@ -18,10 +18,10 @@ module ActiveStorage
       end
     end
 
-    def preview
+    def preview(**options)
       download_blob_to_tempfile do |input|
         draw_first_page_from input do |output|
-          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png"
+          yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png", **options
         end
       end
     end

--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -6,10 +6,10 @@ module ActiveStorage
       blob.video?
     end
 
-    def preview
+    def preview(**options)
       download_blob_to_tempfile do |input|
         draw_relevant_frame_from input do |output|
-          yield io: output, filename: "#{blob.filename.base}.jpg", content_type: "image/jpeg"
+          yield io: output, filename: "#{blob.filename.base}.jpg", content_type: "image/jpeg", **options
         end
       end
     end

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -48,4 +48,18 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
     assert blob.reload.preview_image.attached?
   end
+
+  test "preview of PDF is created on the same service" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf", service_name: "local_public")
+    preview = blob.preview(resize: "640x280").processed
+
+    assert_equal "local_public", preview.image.blob.service_name
+  end
+
+  test "preview of MP4 video is created on the same service" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4", service_name: "local_public")
+    preview = blob.preview(resize: "640x280").processed
+
+    assert_equal "local_public", preview.image.blob.service_name
+  end
 end


### PR DESCRIPTION
### Summary

Previews will now be created on the same service as the original blob. See https://github.com/rails/rails/pull/37906#issuecomment-565134065.

cc. @georgeclaghorn 
