### PR TITLE
Deprecate config in dbconsole

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*  Deprecate `Rails::DBConsole#config`
+
+  `Rails::DBConsole#config` is deprecated without replacement. Use `Rails::DBConsole.db_config.configuration_hash` instead.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 * `Rails.application.config_for` merges shared configuration deeply.
 
     ```yaml

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -16,6 +16,7 @@ module Rails
 
     def start
       ENV["RAILS_ENV"] ||= @options[:environment] || environment
+      config = db_config.configuration_hash
 
       case db_config.adapter
       when /^(jdbc)?mysql/
@@ -92,6 +93,7 @@ module Rails
     def config
       db_config.configuration_hash
     end
+    deprecate config: "please use db_config.configuration_hash"
 
     def db_config
       return @db_config if defined?(@db_config)

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -30,14 +30,14 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       }
     }
     app_db_config(config_sample) do
-      assert_equal config_sample["test"].symbolize_keys, Rails::DBConsole.new.config
+      assert_equal config_sample["test"].symbolize_keys, Rails::DBConsole.new.db_config.configuration_hash
     end
   end
 
   def test_config_with_no_db_config
     app_db_config(nil) do
       assert_raise(ActiveRecord::AdapterNotSpecified) {
-        Rails::DBConsole.new.config
+        Rails::DBConsole.new.db_config.configuration_hash
       }
     end
   end
@@ -56,7 +56,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     }.sort
 
     app_db_config(nil) do
-      assert_equal expected, Rails::DBConsole.new.config.sort
+      assert_equal expected, Rails::DBConsole.new.db_config.configuration_hash.sort
     end
   end
 
@@ -76,7 +76,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       }
     }
     app_db_config(sample_config) do
-      assert_equal host, Rails::DBConsole.new.config[:host]
+      assert_equal host, Rails::DBConsole.new.db_config.configuration_hash[:host]
     end
   end
 
@@ -213,7 +213,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     }
 
     app_db_config(sample_config) do
-      assert_equal "postgresql", Rails::DBConsole.new.config[:adapter]
+      assert_equal "postgresql", Rails::DBConsole.new.db_config.configuration_hash[:adapter]
     end
   end
 


### PR DESCRIPTION
This change deprecates config in dbconsole and updates usage in the
dbconsole tests so that we can remove an accessor on the
`configuration_hash`.

Eventually we want to pass objects around everywhere instead of
hashes. Callers can use `db_config` to access the hash if necessary.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>