### PR TITLE
Revert "Workaroud to address apt-get update at GitHub Actions"

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,7 +14,6 @@ jobs:
         ruby-version: 2.6.x
     - name: Install required package
       run: |
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
     - name: Cache gems


### PR DESCRIPTION
This pull request reverts rails/rails#37953 because the original issue has been addressed https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/m-p/41199#M4529