### PR TITLE
Add missing first title to AR Query Interface guide [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -18,7 +18,12 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
+What is the Active Record Query Interface?
+------------------------------------------
+
 If you're used to using raw SQL to find database records, then you will generally find that there are better ways to carry out the same operations in Rails. Active Record insulates you from the need to use SQL in most cases.
+
+Active Record will perform queries on the database for you and is compatible with most database systems, including MySQL, MariaDB, PostgreSQL, and SQLite. Regardless of which database system you're using, the Active Record method format will always be the same.
 
 Code examples throughout this guide will refer to one or more of the following models:
 
@@ -49,8 +54,6 @@ class Role < ApplicationRecord
   has_and_belongs_to_many :clients
 end
 ```
-
-Active Record will perform queries on the database for you and is compatible with most database systems, including MySQL, MariaDB, PostgreSQL, and SQLite. Regardless of which database system you're using, the Active Record method format will always be the same.
 
 Retrieving Objects from the Database
 ------------------------------------


### PR DESCRIPTION
### Summary
The Active Record Query Interface missed the first title (most other guides do have it, including the other AR guides).

The explanation about database compatibility seems more in place above the guide's code example usage.

### Before
<img width="694" alt="image" src="https://user-images.githubusercontent.com/28561/70847203-f89e3400-1e61-11ea-9660-32a9638a3489.png">

---------------------------------


### After
<img width="737" alt="image" src="https://user-images.githubusercontent.com/28561/70847210-14093f00-1e62-11ea-8255-f4e58b1016b4.png">
