### PR TITLE
Add EXPLAIN support for JSON format when available.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -155,6 +155,10 @@ module ActiveRecord
         exec_query(sql, name)
       end
 
+      def explain_json(arel, binds = []) # :nodoc:
+        raise NotImplementedError
+      end
+
       # Executes an INSERT query and returns the new record's ID
       #
       # +id_value+ will be returned unless the value is +nil+, in

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -299,6 +299,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support explain in JSON format?
+      def supports_explain_json?
+        false
+      end
+
       # Does this adapter support setting the isolation level for a transaction?
       def supports_transaction_isolation?
         false

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -84,6 +84,10 @@ module ActiveRecord
         true
       end
 
+      def supports_explain_json?
+        true
+      end
+
       def supports_indexes_in_create?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -37,6 +37,11 @@ module ActiveRecord
           MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
         end
 
+        def explain_json(arel, binds = [])
+          sql = "EXPLAIN FORMAT=JSON #{to_sql(arel, binds)}"
+          exec_query(sql, "EXPLAIN", binds).rows[0][0]
+        end
+
         # Executes the SQL statement in the context of this connection.
         def execute(sql, name = nil)
           if preventing_writes? && write_query?(sql)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -9,6 +9,11 @@ module ActiveRecord
           PostgreSQL::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", binds))
         end
 
+        def explain_json(arel, binds = [])
+          sql = "EXPLAIN (FORMAT JSON) #{to_sql(arel, binds)}"
+          exec_query(sql, "EXPLAIN", binds).rows[0][0]
+        end
+
         # The internal PostgreSQL identifier of the money data type.
         MONEY_COLUMN_TYPE_OID = 790 #:nodoc:
         # The internal PostgreSQL identifier of the BYTEA data type.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -334,6 +334,10 @@ module ActiveRecord
         true
       end
 
+      def supports_explain_json?
+        true
+      end
+
       def supports_extensions?
         true
       end

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -39,7 +39,8 @@ module ActiveRecord
         queries.map do |sql, binds|
           [[sql, binds.map { |attr| render_bind(attr) }], JSON.parse(connection.explain_json(sql, binds))]
         end.to_h
-      else raise "Unsupported explain format."
+      else
+        raise ArgumentError, "\"#{format}\" is unsupported explain format. Only :text and :json formats are supported."
       end
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -234,9 +234,14 @@ module ActiveRecord
     # Note that this method actually runs the queries, since the results of some
     # are needed by the next ones when eager loading is going on.
     #
+    #
+    # ==== Parameters
+    #
+    # * +format+ - :text (default text output) or :json (returns a Hash)
+    #
     # Please see further details in the
     # {Active Record Query Interface guide}[https://guides.rubyonrails.org/active_record_querying.html#running-explain].
-    def explain(format = :text)
+    def explain(format: :text)
       exec_explain(collecting_queries_for_explain { exec_queries }, format)
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -236,8 +236,8 @@ module ActiveRecord
     #
     # Please see further details in the
     # {Active Record Query Interface guide}[https://guides.rubyonrails.org/active_record_querying.html#running-explain].
-    def explain
-      exec_explain(collecting_queries_for_explain { exec_queries })
+    def explain(format = :text)
+      exec_explain(collecting_queries_for_explain { exec_queries }, format)
     end
 
     # Converts relation objects to Array.

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -17,7 +17,7 @@ if ActiveRecord::Base.connection.supports_explain?
 
     if ActiveRecord::Base.connection.supports_explain_json?
       def test_exec_explain_json
-        explain = Car.where(name: "honda").explain(:json)
+        explain = Car.where(name: "honda").explain(format: :json)
         sql, binds = explain.keys.first
         explain_plan = explain.values.first
 
@@ -31,12 +31,12 @@ if ActiveRecord::Base.connection.supports_explain?
       end
     else
       def test_exec_explain_json_raise
-        assert_raise(NotImplementedError) { Car.where(name: "honda").explain(:json) }
+        assert_raise(NotImplementedError) { Car.where(name: "honda").explain(format: :json) }
       end
     end
 
     def test_exec_explain_unknown
-      assert_raise { Car.where(name: "honda").explain(:xml) }
+      assert_raise(ArgumentError) { Car.where(name: "honda").explain(format: :xml) }
     end
 
     def test_relation_explain

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -15,6 +15,30 @@ if ActiveRecord::Base.connection.supports_explain?
       base.connection
     end
 
+    if ActiveRecord::Base.connection.supports_explain_json?
+      def test_exec_explain_json
+        explain = Car.where(name: "honda").explain(:json)
+        sql, binds = explain.keys.first
+        explain_plan = explain.values.first
+
+        assert_match "SELECT", sql
+
+        if binds.any?
+          assert_equal [["name", "honda"]], binds
+        end
+
+        assert explain_plan
+      end
+    else
+      def test_exec_explain_json_raise
+        assert_raise(NotImplementedError) { Car.where(name: "honda").explain(:json) }
+      end
+    end
+
+    def test_exec_explain_unknown
+      assert_raise { Car.where(name: "honda").explain(:xml) }
+    end
+
     def test_relation_explain
       message = Car.where(name: "honda").explain
       assert_match(/^EXPLAIN for:/, message)


### PR DESCRIPTION
Hello, I found out useful to use EXPLAIN output sometimes. For example in PostgreSQL it is possible to get estimated rows and in combination with `find_in_batches` it can be used to show estimated progress.

Currently it is needed to parse `explain` message or use lower level API:

```ruby
# postgresql example
JSON.parse(ActiveRecord::Base.connection.exec_query("EXPLAIN (FORMAT json) #{relation.to_sql}").to_a[0].values[0]
#=> [{"Plan"=>{"Node Type"=>"Result", "Parallel Aware"=>false, "Startup Cost"=>0.0, "Total Cost"=>0.01, "Plan Rows"=>1, "Plan Width"=>4}}]
```
In this pull request I'm introducing new optional argument to `relation.explain` and support `:text` (current and also default option) and new `:json` which will return JSON version of explain output already parsed to `Hash` by `JSON.parse`. It returns  explains of all queries including binds (where possible) in following hash:

```ruby
{ [sql, binds] => explain_plan_hash, ... }
```

:information_source: _This is initial simple and naive implementation just to share some code and start discussion. I still need to check if all supported PostgreSQL and MySQL versions support this. Also I think some refactorings can be done, for example `ActiveRecord::Explain#exec_explain` can be split to two private methods and so on..._

PostgreSQL example:

```ruby
pp Car.where(name: "honda").explain(:json)
{["SELECT \"cars\".* FROM \"cars\" WHERE \"cars\".\"name\" = $1",
  [["name", "honda"]]]=>
  [{"Plan"=>
     {"Node Type"=>"Seq Scan",
      "Parallel Aware"=>false,
      "Relation Name"=>"cars",
      "Alias"=>"cars",
      "Startup Cost"=>0.0,
      "Total Cost"=>19.75,
      "Plan Rows"=>4,
      "Plan Width"=>76,
      "Filter"=>"((name)::text = 'honda'::text)"}}]}
```

MySQL usage:

```ruby
pp Car.where(name: "honda").explain(:json)
{["SELECT `cars`.* FROM `cars` WHERE `cars`.`name` = 'honda'", []]=>                         
  {"query_block"=>                                                                             
    {"select_id"=>1,                                                                           
     "table"=>
      {"table_name"=>"cars",
       "access_type"=>"ALL",            
       "rows"=>2,
       "filtered"=>100,
       "attached_condition"=>"cars.`name` = 'honda'"}}}}
```

SQLite3 usage (not supported):

```ruby
pp Car.where(name: "honda").explain(:json)
#=> NotImplementedError
```