### PR TITLE
Add explain to abstract database statements.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -155,6 +155,10 @@ module ActiveRecord
         exec_query(sql, name)
       end
 
+      def explain(arel, binds = []) # :nodoc:
+        raise NotImplementedError
+      end
+
       # Executes an INSERT query and returns the new record's ID
       #
       # +id_value+ will be returned unless the value is +nil+, in


### PR DESCRIPTION
While working on #37970 I have found out that `explain` is implemented in all adapters, but it is not defined in abstract one. I'm not sure if there's any reason for that. Also I'm not sure if documentation is needed, for now I have marked it as `nodoc`.