### PR TITLE
Add support for basic CTEs by introducing Relation#with.

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -99,6 +99,7 @@ module ActiveRecord
       autoload :SpawnMethods
       autoload :Batches
       autoload :Delegation
+      autoload :With
     end
 
     autoload :Result

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       :create_or_find_by, :create_or_find_by!,
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
-      :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
+      :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins, :with,
       :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -444,6 +444,7 @@ module ActiveRecord
       stmt.offset(arel.offset)
       stmt.order(*arel.orders)
       stmt.wheres = arel.constraints
+      stmt.with = arel.ast.with
 
       if updates.is_a?(Hash)
         if klass.locking_enabled? &&
@@ -586,6 +587,7 @@ module ActiveRecord
       stmt.offset(arel.offset)
       stmt.order(*arel.orders)
       stmt.wheres = arel.constraints
+      stmt.with = arel.ast.with
 
       affected = @klass.connection.delete(stmt, "#{@klass} Destroy")
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   class Relation
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
                             :order, :joins, :left_outer_joins, :references,
-                            :extending, :unscope, :optimizer_hints, :annotate]
+                            :extending, :unscope, :optimizer_hints, :annotate, :with]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering,
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
@@ -16,7 +16,7 @@ module ActiveRecord
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 
     include Enumerable
-    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation, With
 
     attr_reader :table, :klass, :loaded, :predicate_builder
     attr_accessor :skip_preloading_value

--- a/activerecord/lib/active_record/relation/with.rb
+++ b/activerecord/lib/active_record/relation/with.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module With
+    def with_values
+      @values[:with] || []
+    end
+
+    def with_values=(values)
+      raise ImmutableRelation if @loaded
+      @values[:with] = values
+    end
+
+    def with(opts = :chain, *rest)
+      if opts.blank?
+        self
+      else
+        spawn.with!(opts, *rest)
+      end
+    end
+
+    def with!(opts = :chain, *rest) # :nodoc:
+      self.with_values += [opts] + rest
+      self
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/delete_statement.rb
+++ b/activerecord/lib/arel/nodes/delete_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class DeleteStatement < Arel::Nodes::Node
-      attr_accessor :left, :right, :orders, :limit, :offset, :key
+      attr_accessor :left, :right, :orders, :limit, :offset, :key, :with
 
       alias :relation :left
       alias :relation= :left=
@@ -18,6 +18,7 @@ module Arel # :nodoc: all
         @limit = nil
         @offset = nil
         @key = nil
+        @with = nil
       end
 
       def initialize_copy(other)
@@ -27,7 +28,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [self.class, @left, @right, @orders, @limit, @offset, @key].hash
+        [self.class, @left, @right, @orders, @limit, @offset, @key, @with].hash
       end
 
       def eql?(other)
@@ -37,7 +38,8 @@ module Arel # :nodoc: all
           self.orders == other.orders &&
           self.limit == other.limit &&
           self.offset == other.offset &&
-          self.key == other.key
+          self.key == other.key &&
+          self.with == other.with
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :values, :orders, :limit, :offset, :key, :with
 
       def initialize
         @relation = nil
@@ -13,6 +13,7 @@ module Arel # :nodoc: all
         @limit    = nil
         @offset   = nil
         @key      = nil
+        @with     = nil
       end
 
       def initialize_copy(other)
@@ -22,7 +23,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @offset, @key, @with].hash
       end
 
       def eql?(other)
@@ -33,7 +34,8 @@ module Arel # :nodoc: all
           self.orders == other.orders &&
           self.limit == other.limit &&
           self.offset == other.offset &&
-          self.key == other.key
+          self.key == other.key &&
+          self.with == other.with
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -36,6 +36,10 @@ module Arel # :nodoc: all
         @ast.wheres << expr
         self
       end
+
+      def with=(expr)
+        @ast.with = expr
+      end
     end
 
     attr_reader :ast

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -59,10 +59,10 @@ module Arel # :nodoc: all
         end
 
         # In the simple case, MySQL allows us to place JOINs directly into the UPDATE
-        # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
+        # query. However, this does not allow for LIMIT, OFFSET, ORDER and WITH.To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.offset || has_join_sources?(o) && has_limit_or_offset_or_orders?(o)
+          if o.offset || o.with || has_join_sources?(o) && has_limit_or_offset_or_orders?(o)
             super
           else
             o

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -825,6 +825,7 @@ module Arel # :nodoc: all
           stmt.limit       = o.limit
           stmt.offset      = o.offset
           stmt.orders      = o.orders
+          stmt.with        = o.with
           stmt
         end
 

--- a/activerecord/test/cases/associations/with_test.rb
+++ b/activerecord/test/cases/associations/with_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+
+if ActiveRecord::Base.connection.supports_common_table_expressions?
+  class WithTest < ActiveRecord::TestCase
+    fixtures :posts, :comments
+
+    def test_with
+      result = Comment.with(my_posts: Post.where(author_id: 1)).joins("JOIN my_posts ON my_posts.id = comments.post_id")
+      assert_match(/^WITH/, result.to_sql)
+      assert_equal 10, result.count
+    end
+
+    def test_multiple_with
+      result = Comment.with(my_posts: Post.where(author_id: 1), their_posts: Post.where(author_id: 2)).load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/my_posts/, sql)
+      assert_match(/their_posts/, sql)
+    end
+
+    def test_multiple_with_calls
+      result = Comment.with(my_posts: Post.where(author_id: 1)).with(their_posts: Post.where(author_id: 2)).load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/my_posts/, sql)
+      assert_match(/their_posts/, sql)
+    end
+
+    def test_with_with_arel
+      arel_table = Arel::Table.new("posts")
+      arel_manager = arel_table.project(arel_table[:author_id])
+      result = Comment.with(arel_posts: arel_manager).load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/arel_posts/, sql)
+    end
+
+    def test_with_with_string
+      result = Comment.with(Arel.sql("sql_posts AS (SELECT * FROM posts where author_id = 1)")).load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/sql_posts/, sql)
+    end
+
+    def test_with_with_hash_string
+      result = Comment.with(sql_posts: Arel.sql("SELECT * FROM posts where author_id = 1")).load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/sql_posts/, sql)
+    end
+
+    def test_merge_with
+      result = Comment.all.merge(Post.with(my_posts: Post.where(author_id: 7))).joins("JOIN my_posts ON my_posts.id = comments.post_id").load
+      sql = result.to_sql
+
+      assert_match(/^WITH/, sql)
+      assert_match(/my_posts/, sql)
+    end
+  end
+end

--- a/activerecord/test/cases/associations/with_test.rb
+++ b/activerecord/test/cases/associations/with_test.rb
@@ -10,6 +10,7 @@ if ActiveRecord::Base.connection.supports_common_table_expressions?
 
     def test_with
       result = Comment.with(my_posts: Post.where(author_id: 1)).joins("JOIN my_posts ON my_posts.id = comments.post_id")
+
       assert_match(/^WITH/, result.to_sql)
       assert_equal 10, result.count
     end
@@ -64,6 +65,16 @@ if ActiveRecord::Base.connection.supports_common_table_expressions?
 
       assert_match(/^WITH/, sql)
       assert_match(/my_posts/, sql)
+    end
+
+    def test_with_delete_all
+      result = Comment.with(my_posts: Post.where(author_id: 1)).joins("JOIN my_posts ON my_posts.id = comments.post_id").delete_all
+      assert_equal 10, result
+    end
+
+    def test_with_update_all
+      result = Comment.with(my_posts: Post.where(author_id: 1)).joins("JOIN my_posts ON my_posts.id = comments.post_id").update_all(author_id: 999)
+      assert_equal 10, result
     end
   end
 end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -56,7 +56,8 @@ module ActiveRecord
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
-        :destroy_all, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by
+        :destroy_all, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by,
+        :with
       ]
 
     def test_delegate_querying_methods


### PR DESCRIPTION
I'm using CTEs quite often in Rails applications and I think they deserve to be first class citizens in Active Record.

This is initial port of https://github.com/kmurph73/ctes_in_my_pg (which is based on https://github.com/DavyJonesLocker/postgres_ext) with removed `PG` dependency and without recursive support. Recursive support can be added later if needed, but I'm not sure about the API for now.

:information_source: ~~There is [one known problem](https://github.com/kmurph73/ctes_in_my_pg/issues/6), I'll take a look if it is still present and try to fix it as well.~~ fixed in this PR