### PR TITLE
Extend Relation#to_sql to handle delete_all and update_all.

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -721,6 +721,30 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 
+  def test_to_sql_default
+    sql = Post.all.to_sql
+    assert_includes sql, "SELECT"
+  end
+
+  def test_to_sql_select
+    sql = Post.all.to_sql(:select)
+    assert_includes sql, "SELECT"
+  end
+
+  def test_to_sql_delete_all
+    sql = Post.all.to_sql(:delete_all)
+    assert_includes sql, "DELETE FROM"
+  end
+
+  def test_to_sql_update_all
+    sql = Post.all.to_sql(:update_all, title: "deleted")
+    assert_includes sql, "UPDATE"
+  end
+
+  def test_to_sql_unknown
+    assert_raises(ArgumentError) { Post.all.to_sql(:insert) }
+  end
+
   def test_to_sql_on_eager_join
     expected = capture_sql {
       Post.eager_load(:last_comment).order("comments.id DESC").to_a


### PR DESCRIPTION
Just got an idea to be able to inspect queries for `delete_all` and `update_all` on relations.

# examples

```ruby
Post.all.to_sql # unchanged
#=> "SELECT \"posts\".* FROM \"posts\""

Post.all.to_sql(:select)
#=> "SELECT \"posts\".* FROM \"posts\""

Post.all.to_sql(:delete_all)
#=> "DELETE FROM \"posts\""

Post.all.to_sql(:update_all, title: 'deleted')
#=> "UPDATE \"posts\" SET \"title\" = 'deleted'"
```

In case this is welcomed, I'll need to update documentation as well, just ping me.