### PR TITLE
6-0 Backport: Fix Messages::Metadata#fresh? to handle parse_json_times = true

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Update `ActiveSupport::Messages::Metadata#fresh?` to work for cookies with expiry set when
+    `ActiveSupport.parse_json_times = true`.
+
+    *Christian Gregg*
+
 ## Rails 6.0.2 (December 13, 2019) ##
 
 *   Eager load translations during initialization.

--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -64,7 +64,7 @@ module ActiveSupport
         end
 
         def fresh?
-          @expires_at.nil? || Time.now.utc < Time.iso8601(@expires_at)
+          @expires_at.nil? || Time.now.utc < @expires_at
         end
     end
   end

--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -6,7 +6,8 @@ module ActiveSupport
   module Messages #:nodoc:
     class Metadata #:nodoc:
       def initialize(message, expires_at = nil, purpose = nil)
-        @message, @expires_at, @purpose = message, expires_at, purpose
+        @message, @purpose = message, purpose
+        @expires_at = expires_at.is_a?(String) ? Time.iso8601(expires_at) : expires_at
       end
 
       def as_json(options = {})

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -61,6 +61,15 @@ class MessageVerifierTest < ActiveSupport::TestCase
     ActiveSupport.use_standard_json_time_format = prev
   end
 
+  def test_verify_with_parse_json_times
+    previous = [ ActiveSupport.parse_json_times, Time.zone ]
+    ActiveSupport.parse_json_times, Time.zone = true, "UTC"
+
+    assert_equal "hi", @verifier.verify(@verifier.generate("hi", expires_at: Time.now.utc + 10))
+  ensure
+    ActiveSupport.parse_json_times, Time.zone = previous
+  end
+
   def test_raise_error_when_argument_class_is_not_loaded
     # To generate the valid message below:
     #


### PR DESCRIPTION
Backport of #37502 into `6-0-stable`

We are currently running some monkey-patches for this 😄 
Would be nice to be able to get rid of them!