### PR TITLE
Bump gem versions in bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.0.0"
+  gem "rails", "6.0.2"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activejob", "6.0.0"
+  gem "activejob", "6.0.2"
 end
 
 require "minitest/autorun"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "6.0.0"
+  gem "activerecord", "6.0.2"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "6.0.0"
+  gem "activerecord", "6.0.2"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.0.0"
+  gem "rails", "6.0.2"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activesupport", "6.0.0"
+  gem "activesupport", "6.0.2"
 end
 
 require "active_support"


### PR DESCRIPTION
### Summary

Updated each gem version in bug report templates from 6.0.0 to 6.0.2.

### Other Information

I confirmed all tests in these templates succeed on ruby 2.6.5p114.

```
ruby guides/bug_report_templates/action_controller_gem.rb
ruby guides/bug_report_templates/active_job_gem.rb
ruby guides/bug_report_templates/active_record_gem.rb
ruby guides/bug_report_templates/active_record_migrations_gem.rb
ruby guides/bug_report_templates/active_storage_gem.rb
ruby guides/bug_report_templates/generic_gem.rb
```