### PR TITLE
Revert revert ec sqlite3 connection transaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -74,19 +74,37 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
+        def begin_isolated_db_transaction(isolation) #:nodoc
+          raise ArgumentError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
+          raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
+
+          Thread.current.thread_variable_set("read_uncommitted", @connection.get_first_value("PRAGMA read_uncommitted"))
+          @connection.read_uncommitted = true
+          begin_db_transaction
+        end
+
         def begin_db_transaction #:nodoc:
           log("begin transaction", "TRANSACTION") { @connection.transaction }
         end
 
         def commit_db_transaction #:nodoc:
           log("commit transaction", "TRANSACTION") { @connection.commit }
+          reset_read_uncommitted
         end
 
         def exec_rollback_db_transaction #:nodoc:
           log("rollback transaction", "TRANSACTION") { @connection.rollback }
+          reset_read_uncommitted
         end
 
         private
+          def reset_read_uncommitted
+            read_uncommitted = Thread.current.thread_variable_get("read_uncommitted")
+            return unless read_uncommitted
+
+            @connection.read_uncommitted = read_uncommitted
+          end
+
           def execute_batch(statements, name = nil)
             sql = combine_multi_statements(statements)
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -75,7 +75,7 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         def begin_isolated_db_transaction(isolation) #:nodoc
-          raise ArgumentError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
+          raise TransactionIsolationError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
           raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
 
           Thread.current.thread_variable_set("read_uncommitted", @connection.get_first_value("PRAGMA read_uncommitted"))

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       # Allow database path relative to Rails.root, but only if the database
       # path is not the special path that tells sqlite to build a database only
       # in memory.
-      if ":memory:" != config[:database]
+      if ":memory:" != config[:database] && !config[:database].to_s.starts_with?("file:")
         config[:database] = File.expand_path(config[:database], Rails.root) if defined?(Rails.root)
         dirname = File.dirname(config[:database])
         Dir.mkdir(dirname) unless File.directory?(dirname)
@@ -113,6 +113,10 @@ module ActiveRecord
       end
 
       def supports_savepoints?
+        true
+      end
+
+      def supports_transaction_isolation?
         true
       end
 
@@ -323,6 +327,10 @@ module ActiveRecord
         end
 
         sql
+      end
+
+      def shared_cache? # :nodoc:
+        @config.fetch(:flags, 0).anybits?(::SQLite3::Constants::Open::SHAREDCACHE)
       end
 
       def get_database_version # :nodoc:

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -19,7 +19,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   test "raises when trying to open a transaction in a isolation level other than `read_uncommitted`" do
     with_connection do |conn|
-      assert_raises(ArgumentError) do
+      assert_raises(ActiveRecord::TransactionIsolationError) do
         conn.transaction(requires_new: true, isolation: :something) do
           conn.transaction_manager.materialize_transactions
         end

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
+  test "shared_cached? is true when cache-mode is enabled" do
+    with_connection(flags: shared_cache_flags) do |conn|
+      assert_predicate(conn, :shared_cache?)
+    end
+  end
+
+  test "shared_cached? is false when cache-mode is disabled" do
+    flags =::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
+
+    with_connection(flags: flags) do |conn|
+      assert_not_predicate(conn, :shared_cache?)
+    end
+  end
+
+  test "raises when trying to open a transaction in a isolation level other than `read_uncommitted`" do
+    with_connection do |conn|
+      assert_raises(ArgumentError) do
+        conn.transaction(requires_new: true, isolation: :something) do
+          conn.transaction_manager.materialize_transactions
+        end
+      end
+    end
+  end
+
+  test "raises when trying to open a read_uncommitted transaction but shared-cache mode is turned off" do
+    with_connection do |conn|
+      error = assert_raises(StandardError) do
+        conn.transaction(requires_new: true, isolation: :read_uncommitted) do
+          conn.transaction_manager.materialize_transactions
+        end
+      end
+
+      assert_match("You need to enable the shared-cache mode", error.message)
+    end
+  end
+
+  test "opens a `read_uncommitted` transaction" do
+    with_connection(flags: shared_cache_flags) do |conn1|
+      conn1.create_table(:zines) { |t| t.column(:title, :string) } if in_memory_db?
+      conn1.transaction do
+        conn1.transaction_manager.materialize_transactions
+        conn1.execute("INSERT INTO zines (title) VALUES ('foo')")
+
+        with_connection(flags: shared_cache_flags) do |conn2|
+          conn2.transaction(joinable: false, isolation: :read_uncommitted) do
+            assert_not_empty(conn2.execute("SELECT * FROM zines WHERE title = 'foo'"))
+          end
+        end
+
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+  test "reset the read_uncommitted PRAGMA when transactions is rolled back" do
+    with_connection(flags: shared_cache_flags) do |conn|
+      conn.transaction(joinable: false, isolation: :read_uncommitted) do
+        assert_not(read_uncommitted?(conn))
+        conn.transaction_manager.materialize_transactions
+        assert(read_uncommitted?(conn))
+
+        raise ActiveRecord::Rollback
+      end
+
+      assert_not(read_uncommitted?(conn))
+    end
+  end
+
+  test "reset the read_uncommitted PRAGMA when transactions is commited" do
+    with_connection(flags: shared_cache_flags) do |conn|
+      conn.transaction(joinable: false, isolation: :read_uncommitted) do
+        assert_not(read_uncommitted?(conn))
+        conn.transaction_manager.materialize_transactions
+        assert(read_uncommitted?(conn))
+      end
+
+      assert_not(read_uncommitted?(conn))
+    end
+  end
+
+  test "set the read_uncommited PRAGMA to its previous value" do
+    with_connection(flags: shared_cache_flags) do |conn|
+      conn.transaction(joinable: false, isolation: :read_uncommitted) do
+        conn.instance_variable_get(:@connection).read_uncommitted = true
+        assert(read_uncommitted?(conn))
+        conn.transaction_manager.materialize_transactions
+        assert(read_uncommitted?(conn))
+      end
+
+      assert(read_uncommitted?(conn))
+    end
+  end
+
+  private
+    def read_uncommitted?(conn)
+      conn.instance_variable_get(:@connection).get_first_value("PRAGMA read_uncommitted") != 0
+    end
+
+    def shared_cache_flags
+      ::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE | ::SQLite3::Constants::Open::SHAREDCACHE | ::SQLite3::Constants::Open::URI
+    end
+
+    def with_connection(options = {})
+      conn_options = options.reverse_merge(
+        database: in_memory_db? ? "file::memory:" : ActiveRecord::Base.configurations["arunit"][:database]
+      )
+      conn = ActiveRecord::Base.sqlite3_connection(conn_options)
+
+      yield(conn)
+    ensure
+      conn.disconnect! if conn
+    end
+end

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-unless ActiveRecord::Base.connection.supports_transaction_isolation?
+unless ActiveRecord::Base.connection.supports_transaction_isolation? && !current_adapter?(:SQLite3Adapter)
   class TransactionIsolationUnsupportedTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
@@ -10,6 +10,8 @@ unless ActiveRecord::Base.connection.supports_transaction_isolation?
     end
 
     test "setting the isolation level raises an error" do
+      skip if current_adapter?(:SQLite3Adapter)
+
       assert_raises(ActiveRecord::TransactionIsolationError) do
         Tag.transaction(isolation: :serializable) { Tag.connection.materialize_transactions }
       end

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -10,8 +10,6 @@ unless ActiveRecord::Base.connection.supports_transaction_isolation? && !current
     end
 
     test "setting the isolation level raises an error" do
-      skip if current_adapter?(:SQLite3Adapter)
-
       assert_raises(ActiveRecord::TransactionIsolationError) do
         Tag.transaction(isolation: :serializable) { Tag.connection.materialize_transactions }
       end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1127,7 +1127,7 @@ class TransactionsWithTransactionalFixturesTest < ActiveRecord::TestCase
   end
 end if Topic.connection.supports_savepoints?
 
-if ActiveRecord::Base.connection.supports_transaction_isolation?
+if ActiveRecord::Base.connection.supports_transaction_isolation? && !in_memory_db?
   class ConcurrentTransactionTest < TransactionTest
     # This will cause transactions to overlap and fail unless they are performed on
     # separate database connections.

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1127,7 +1127,7 @@ class TransactionsWithTransactionalFixturesTest < ActiveRecord::TestCase
   end
 end if Topic.connection.supports_savepoints?
 
-if ActiveRecord::Base.connection.supports_transaction_isolation? && !in_memory_db?
+if ActiveRecord::Base.connection.supports_transaction_isolation? && !current_adapter?(:SQLite3Adapter)
   class ConcurrentTransactionTest < TransactionTest
     # This will cause transactions to overlap and fail unless they are performed on
     # separate database connections.


### PR DESCRIPTION
Don't run concurrent transaction test on sqlite3:

- #37798 had to be reverted because a new flakyness appeared ([see
  CI build](https://buildkite.com/rails/rails/builds/65467#efaa1dd5-aaf4-43a1-a204-d1c42abf614d))

  This failure isn't related to the change itself.
  If you apply this diff, the test will some time to time fail.
  Even without my changes.

```diff
  diff --git a/activerecord/test/cases/transactions_test.rb b/activerecord/test/cases/transactions_test.rb
index b5c1cac3d9..09fe0ddd7f 100644
--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1127,7 +1127,6 @@ def test_no_automatic_savepoint_for_inner_transaction
   end
 end if Topic.connection.supports_savepoints?

-if ActiveRecord::Base.connection.supports_transaction_isolation?
   class ConcurrentTransactionTest < TransactionTest
     # This will cause transactions to overlap and fail unless they are performed on
     # separate database connections.
@@ -1198,4 +1197,3 @@ def test_transaction_isolation__read_committed
       assert_equal original_salary, Developer.find(1).salary
     end
   end
-end
```

  SQlite3 isn't safe to run in a multi threaded environment unless
  sqlite is compiled with a special flag which isn't our case.
  Ref https://www.sqlite.org/threadsafe.html

cc/ @eileencodes @rafaelfranca @casperisfine