### PR TITLE
Regex did not match CREATE TABLE in all cases

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -412,12 +412,13 @@ module ActiveRecord
         create_table_info = create_table_info(table_name)
 
         # strip create_definitions and partition_options
-        raw_table_options = create_table_info.sub(/\A.*\n\) /m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
+        # Be aware that `create_table_info` might not include any table options due to `NO_TABLE_OPTIONS` sql mode.
+        raw_table_options = create_table_info.sub(/\A.*\n\) ?/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
 
         # strip AUTO_INCREMENT
         raw_table_options.sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
 
-        table_options[:options] = raw_table_options
+        table_options[:options] = raw_table_options unless raw_table_options.blank?
 
         # strip COMMENT
         if raw_table_options.sub!(/ COMMENT='.+'/, "")

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -41,6 +41,25 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
     options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
     assert_match %r{COLLATE=utf8mb4_bin}, options
   end
+
+  test "schema dump works with NO_TABLE_OPTIONS sql mode" do
+    skip "As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated. It will be removed in a future version of MySQL." if @connection.database_version >= "5.7.22"
+
+    old_sql_mode = @connection.exec_query("SELECT @@session.sql_mode").first["@@session.sql_mode"]
+    new_sql_mode = old_sql_mode.split(",") + ["NO_TABLE_OPTIONS"]
+
+    begin
+      @connection.execute("SET @@session.sql_mode=\"#{new_sql_mode.join(",")}\"")
+
+      @connection.create_table "mysql_table_options", force: true
+      output  = dump_table_schema("mysql_table_options")
+      assert_no_match %r{options:}, output
+    rescue
+      assert(false, "Changing sql mode failed")
+    ensure
+      @connection.execute("SET @@session.sql_mode=\"#{old_sql_mode}\"")
+    end
+  end
 end
 
 class Mysql2DefaultEngineOptionSchemaDumpTest < ActiveRecord::Mysql2TestCase


### PR DESCRIPTION
The regular expression did not match CREATE TABLE statements printed out by AWS Aurora MySQL 5.6 instances, because they lack the required space at that position. Now it is optional.