### PR TITLE
Remove stacktrace from ActiveJob logging callback halts

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -10,7 +10,7 @@ module ActiveJob
 
       if ex
         error do
-          "Failed enqueuing #{job.class.name} to #{queue_name(event)}: #{ex.class} (#{ex.message}):\n" + Array(ex.backtrace).join("\n")
+          "Failed enqueuing #{job.class.name} to #{queue_name(event)}: #{ex.class} (#{ex.message})"
         end
       elsif event.payload[:aborted]
         info do
@@ -29,7 +29,7 @@ module ActiveJob
 
       if ex
         error do
-          "Failed enqueuing #{job.class.name} to #{queue_name(event)}: #{ex.class} (#{ex.message}):\n" + Array(ex.backtrace).join("\n")
+          "Failed enqueuing #{job.class.name} to #{queue_name(event)}: #{ex.class} (#{ex.message})"
         end
       elsif event.payload[:aborted]
         info do


### PR DESCRIPTION
### Summary

ActiveJob will log the entire backtrace when one of the enqueue
callbacks fail. This is not necessary and increases noise. When there is
an Exception object, the object gets bubbled up eventually anyways.

### Solution

Remove `Array(ex.backtrace).join("\n")` from `def enqueue` and `def
enqueue_at`.

These were recently added in https://github.com/rails/rails/commit/0d3aec496955f38c21bf8042d2510d5b3ade8a00

I'm only removing the backtrace part. Since backtrace was never tested in the first place, there are no additional tests for this PR.

The actual exceptions bubble up and will be caught higher in the stack. This can be seen from here: https://github.com/rails/rails/blob/538424a5ca1026f1359d17ed7ab74e89c991d109/activejob/test/cases/logging_test.rb#L199

There are valid cases where enqueue can fail. In our application, we check if a job has already been enqueued and fail to enqueue it twice. This is a valid case and we trap the error and simply log a single line. Before this PR, we are seeing very long backtrace of the error and no way to skip it.

Since the exceptions bubble up, it can be easily logged if someone wants to.
Or otherwise, there should be a better way of opting in or out of having the exceptions in the log.