### PR TITLE
Fixed typo in the class_names helper documentation

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -298,7 +298,7 @@ module ActionView
       #   class_names({ foo: true, bar: false })
       #    # => "foo"
       #   class_names(nil, false, 123, "", "foo", { bar: true })
-      #    # => "foo bar"
+      #    # => "123 foo bar"
       def class_names(*args)
         safe_join(build_tag_values(*args), " ")
       end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -347,6 +347,7 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "song", class_names(["song", { foo: false }])
     assert_equal "song play", class_names({ "song": true, "play": true })
     assert_equal "", class_names({ "song": false, "play": false })
+    assert_equal "123", class_names(nil, "", false, 123, { "song": false, "play": false })
   end
 
   def test_content_tag_with_data_attributes


### PR DESCRIPTION
Refer comment: https://github.com/rails/rails/pull/37918#discussion_r358095072

cc/ @joelhawksley I think it is a typo but in case it is not please feel free to close the PR. 