### PR TITLE
Add missing languages for guides code blocks [ci skip]

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -60,7 +60,7 @@ module RailsGuides
 
         def class_for(code_type)
           case code_type
-          when "ruby", "sql", "plain", "js"
+          when "ruby", "sql", "plain", "js", "yaml"
             code_type
           when "erb", "html+erb"
             "erb"

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -397,7 +397,7 @@ Rails.application.config.session_store :cookie_store, key: '_your_app_session', 
 
 Rails sets up (for the CookieStore) a secret key used for signing the session data in `config/credentials.yml.enc`. This can be changed with `rails credentials:edit`.
 
-```ruby
+```yaml
 # aws:
 #   access_key_id: 123
 #   secret_access_key: 345

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -443,7 +443,7 @@ You can also consider using the [append_view_path](https://guides.rubyonrails.or
 
 You can perform fragment caching in mailer views like in application views using the `cache` method.
 
-```
+```html+erb
 <% cache do %>
   <%= @company.name %>
 <% end %>
@@ -451,8 +451,8 @@ You can perform fragment caching in mailer views like in application views using
 
 And in order to use this feature, you need to configure your application with this:
 
-```
-  config.action_mailer.perform_caching = true
+```ruby
+config.action_mailer.perform_caching = true
 ```
 
 Fragment caching is also supported in multipart emails.
@@ -542,13 +542,13 @@ Because of this behavior you cannot use any of the `*_path` helpers inside of
 an email. Instead you will need to use the associated `*_url` helper. For example
 instead of using
 
-```
+```html+erb
 <%= link_to 'welcome', welcome_path %>
 ```
 
 You will need to use:
 
-```
+```html+erb
 <%= link_to 'welcome', welcome_url %>
 ```
 

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -1556,7 +1556,7 @@ with the value of the `name`.
 
 would roughly output something like:
 
-```
+```html
 <form method="post" action="/sessions" class="button_to">
   <input type="submit" value="Sign in" />
 </form>

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -133,7 +133,7 @@ Rails 6.0 ships with all the rails tasks you need to use multiple databases in R
 
 You can run `rails -T` to see all the commands you're able to run. You should see the following:
 
-```
+```bash
 $ rails -T
 rails db:create                          # Creates the database from DATABASE_URL or config/database.yml for the ...
 rails db:create:animals                  # Create animals database for current environment
@@ -166,7 +166,7 @@ For example the `animals` database would look in the `db/animals_migrate` direct
 `primary` would look in `db/migrate`. Rails generators now take a `--database` option
 so that the file is generated in the correct directory. The command can be run like so:
 
-```
+```bash
 $ rails g migration CreateDogs name:string --database animals
 ```
 

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1808,7 +1808,7 @@ Client.pluck(:name)
 
 You are not limited to querying fields from a single table, you can query multiple tables as well.
 
-```
+```ruby
 Client.joins(:comments, :categories).pluck("clients.email, comments.title, categories.name")
 ```
 
@@ -2004,7 +2004,7 @@ User.where(id: 1).joins(:articles).explain
 
 may yield
 
-```
+```sql
 EXPLAIN for: SELECT `users`.* FROM `users` INNER JOIN `articles` ON `articles`.`user_id` = `users`.`id` WHERE `users`.`id` = 1
 +----+-------------+----------+-------+---------------+
 | id | select_type | table    | type  | possible_keys |
@@ -2028,7 +2028,7 @@ Active Record performs a pretty printing that emulates that of the
 corresponding database shell. So, the same query running with the
 PostgreSQL adapter would yield instead
 
-```
+```sql
 EXPLAIN for: SELECT "users".* FROM "users" INNER JOIN "articles" ON "articles"."user_id" = "users"."id" WHERE "users"."id" = 1
                                   QUERY PLAN
 ------------------------------------------------------------------------------
@@ -2051,7 +2051,7 @@ User.where(id: 1).includes(:articles).explain
 
 yields
 
-```
+```sql
 EXPLAIN for: SELECT `users`.* FROM `users`  WHERE `users`.`id` = 1
 +----+-------------+-------+-------+---------------+
 | id | select_type | table | type  | possible_keys |

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1283,7 +1283,7 @@ Furthermore, if you use the Rails form helpers to generate your forms, when
 a validation error occurs on a field, it will generate an extra `<div>` around
 the entry.
 
-```
+```html
 <div class="field_with_errors">
  <input id="article_title" name="article[title]" size="30" type="text" value="">
 </div>
@@ -1292,7 +1292,7 @@ the entry.
 You can then style this div however you'd like. The default scaffold that
 Rails generates, for example, adds this CSS rule:
 
-```
+```css
 .field_with_errors {
   padding: 2px;
   background-color: red;

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -447,7 +447,7 @@ available configuration options in [Configuring Rails Applications](configuring.
 If you need to create a link from outside of controller/view context (Background
 jobs, Cronjobs, etc.), you can access the rails_blob_path like this:
 
-```
+```ruby
 Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true)
 ```
 

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -238,7 +238,7 @@ namespace as in `<tt>ActiveRecord::Base</tt>`.
 
 You can quickly test the RDoc output with the following command:
 
-```
+```bash
 $ echo "+:to_param+" | rdoc --pipe
 # => <p><code>:to_param</code></p>
 ```

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -951,7 +951,7 @@ https://explainshell.com/explain?cmd=curl+-I+http%3A%2F%2Fwww.example.com). You
 can request the headers from both your server and your CDN to verify they are
 the same:
 
-```
+```bash
 $ curl -I http://www.example/assets/application-
 d0e099e021c95eb0de3615fd1d8c4d83.css
 HTTP/1.1 200 OK
@@ -967,7 +967,7 @@ Via: 1.1 vegur
 
 Versus the CDN copy.
 
-```
+```bash
 $ curl -I http://mycdnsubdomain.fictional-cdn.com/application-
 d0e099e021c95eb0de3615fd1d8c4d83.css
 HTTP/1.1 200 OK Server: Cowboy Last-

--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -94,7 +94,7 @@ By default, the autoload paths of an application consist of all the subdirectori
 
 For example, if `UsersHelper` is implemented in `app/helpers/users_helper.rb`, the module is autoloadable, you do not need (and should not write) a `require` call for it:
 
-```
+```bash
 $ bin/rails runner 'p UsersHelper'
 UsersHelper
 ```
@@ -133,7 +133,7 @@ In a Rails console there is no file watcher active regardless of the value of `c
 
 However, you can force a reload in the console executing `reload!`:
 
-```
+```bash
 $ bin/rails c
 Loading development environment (Rails 6.0.0)
 irb(main):001:0> User.object_id

--- a/guides/source/autoloading_and_reloading_constants_classic_mode.md
+++ b/guides/source/autoloading_and_reloading_constants_classic_mode.md
@@ -411,7 +411,7 @@ Autoloading Availability
 Rails is always able to autoload provided its environment is in place. For
 example the `runner` command autoloads:
 
-```
+```bash
 $ rails runner 'p User.column_names'
 ["id", "email", "created_at", "updated_at"]
 ```
@@ -485,7 +485,7 @@ See also [Autoloading in the Test Environment](#autoloading-in-the-test-environm
 The value of `autoload_paths` can be inspected. In a just-generated application
 it is (edited):
 
-```
+```bash
 $ rails r 'puts ActiveSupport::Dependencies.autoload_paths'
 .../app/assets
 .../app/channels
@@ -1185,7 +1185,7 @@ up the constant in `Hotel` and its ancestors. If `app/models/image.rb` has
 been loaded but `app/models/hotel/image.rb` hasn't, Ruby does not find `Image`
 in `Hotel`, but it does in `Object`:
 
-```
+```bash
 $ rails r 'Image; p Hotel::Image' 2>/dev/null
 Image # NOT Hotel::Image!
 ```

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -967,7 +967,7 @@ The `config/database.yml` file contains sections for three different environment
 
 If you wish, you can manually specify a URL inside of your `config/database.yml`
 
-```
+```yaml
 development:
   url: postgresql://localhost/blog_development?pool=5
 ```
@@ -984,7 +984,7 @@ Since there are two ways to configure your connection (using `config/database.ym
 
 If you have an empty `config/database.yml` file but your `ENV['DATABASE_URL']` is present, then Rails will connect to the database via your environment variable:
 
-```
+```bash
 $ cat config/database.yml
 
 $ echo $DATABASE_URL
@@ -993,7 +993,7 @@ postgresql://localhost/my_database
 
 If you have a `config/database.yml` but no `ENV['DATABASE_URL']` then this file will be used to connect to your database:
 
-```
+```bash
 $ cat config/database.yml
 development:
   adapter: postgresql
@@ -1007,7 +1007,7 @@ If you have both `config/database.yml` and `ENV['DATABASE_URL']` set then Rails 
 
 When duplicate connection information is provided the environment variable will take precedence:
 
-```
+```bash
 $ cat config/database.yml
 development:
   adapter: sqlite3
@@ -1033,7 +1033,7 @@ Here the adapter, host, and database match the information in `ENV['DATABASE_URL
 
 If non-duplicate information is provided you will get all unique values, environment variable still takes precedence in cases of any conflicts.
 
-```
+```bash
 $ cat config/database.yml
 development:
   adapter: sqlite3
@@ -1058,7 +1058,7 @@ Since pool is not in the `ENV['DATABASE_URL']` provided connection information i
 
 The only way to explicitly not use the connection information in `ENV['DATABASE_URL']` is to specify an explicit URL connection using the `"url"` sub key:
 
-```
+```bash
 $ cat config/database.yml
 development:
   url: sqlite3:NOT_my_database
@@ -1082,7 +1082,7 @@ Here the connection information in `ENV['DATABASE_URL']` is ignored, note the di
 
 Since it is possible to embed ERB in your `config/database.yml` it is best practice to explicitly show you are using the `ENV['DATABASE_URL']` to connect to your database. This is especially useful in production since you should not commit secrets like your database password into your source control (such as Git).
 
-```
+```bash
 $ cat config/database.yml
 production:
   url: <%= ENV['DATABASE_URL'] %>
@@ -1156,7 +1156,7 @@ production:
 
 If enabled, Active Record will create up to `1000` prepared statements per database connection by default. To modify this behavior you can set `statement_limit` to a different value:
 
-```
+```yaml
 production:
   adapter: postgresql
   statement_limit: 200

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -111,7 +111,9 @@ security features which in turn may weaken the strength of the key.
 
 In test and development applications get a `secret_key_base` derived from the app name. Other environments must use a random key present in `config/credentials.yml.enc`, shown here in its decrypted state:
 
-    secret_key_base: 492f...
+```yaml
+secret_key_base: 492f...
+```
 
 WARNING: If your application's secrets may have been exposed, strongly consider changing them. Changing `secret_key_base` will expire currently active sessions.
 
@@ -1181,8 +1183,10 @@ By default, this file contains the application's
 The secrets kept in credentials file are accessible via `Rails.application.credentials`.
 For example, with the following decrypted `config/credentials.yml.enc`:
 
-    secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
-    some_api_key: SOMEKEY
+```yaml
+secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
+some_api_key: SOMEKEY
+```
 
 `Rails.application.credentials.some_api_key` returns `SOMEKEY` in any environment.
 


### PR DESCRIPTION
### Summary
Following up on #37972 I noticed some code examples were missing the language used for code highlighting.