### PR TITLE
### Summary

### DIFF
--- a/actionview/lib/action_view/helpers.rb
+++ b/actionview/lib/action_view/helpers.rb
@@ -15,6 +15,7 @@ module ActionView #:nodoc:
     autoload :ControllerHelper
     autoload :CspHelper
     autoload :CsrfHelper
+    autoload :CssHelper
     autoload :DateHelper
     autoload :DebugHelper
     autoload :FormHelper

--- a/actionview/lib/action_view/helpers/css_helper.rb
+++ b/actionview/lib/action_view/helpers/css_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActionView
+  # = Action View CSS Helper
+  module Helpers #:nodoc:
+    module CssHelper
+
+      # helper method to assign conditional CSS classes.
+      def css_classes(*classes)
+        classes.map do |css_class|
+          if css_class.is_a? Hash
+            css_class.find_all(&:last).map { |c| c.first.to_s.dasherize }
+          else
+            css_class.to_s.dasherize
+          end
+        end.flatten.join(' ')
+      end
+    end
+  end
+end

--- a/actionview/test/template/css_helper_test.rb
+++ b/actionview/test/template/css_helper_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class CssHelperTest < ActionView::TestCase
+  tests ActionView::Helpers::CssHelper
+
+  def test_css_classes
+    assert_equal "class-1", css_classes("class-1")
+    assert_equal "class-1", css_classes("class_1")
+    assert_equal "class-1", css_classes(:class_1)
+    assert_equal "class-1 class-2", css_classes(:class_1, :class_2)
+    assert_equal "class-1 class-2", css_classes('class-1', 'class-2')
+    assert_equal "class-1 class-2 class-3", css_classes('class-1', 'class-2', class_3: true)
+    assert_equal "class-1 class-2 class-4", css_classes('class-1', 'class-2', class_3: false, class_4: true)
+  end
+end


### PR DESCRIPTION
This PR introduces a new ActionView helper called `css_classes`.
The aim of this helper is to simplify writing of CSS classes in ERB templates.

Take the following:

```erb
<div class="class-1 class-2 <%= "class-3" if condition3? %>>
```

can be written as:
```erb
<div class="<%= css_classes('class-1', 'class-2', 'class-3' => condition3?) %>">
```

or

```erb
<div class="<%= css_classes(:class_1, :class_2', class_3: condition3?) %>">
```