### PR TITLE
Highlight code with Prism on 'turbolinks:load' [ci skip]

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -29,6 +29,8 @@
   if (window.location.protocol === "file:") Turbolinks.supported = false;
 
   document.addEventListener("turbolinks:load", function() {
+    Prism.highlightAll();
+
     var guidesMenu = document.getElementById("guidesMenu");
     var guides     = document.getElementById("guides");
 


### PR DESCRIPTION
### Summary

In #37972 I broke highlighting under turbolinks. Highlighting is only shown when reloading a guides page. `Prism.highlightAll()` should be called in the 'turbolinks:load' EventListener.