### PR TITLE
Removes the un-used function call for syntaxhighlighterConfig

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -1,8 +1,6 @@
 (function() {
   "use strict";
 
-  this.syntaxhighlighterConfig = { autoLinks: false };
-
   this.wrap = function(elem, wrapper) {
     elem.parentNode.insertBefore(wrapper, elem);
     wrapper.appendChild(elem);


### PR DESCRIPTION
### Summary
Followup for https://github.com/rails/rails/pull/37972
This PR removes the un-used function call for syntaxhighlighterConfig as after https://github.com/rails/rails/pull/37972 it is not needed.
/cc @p8 