### PR TITLE
Also close PRs with no activity over 3 months

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,5 +24,10 @@ markComment: >
   Thank you for all your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
-# Limit to only `issues` or `pulls`
-only: issues
+
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs.
+
+    Thank you for your contributions.


### PR DESCRIPTION
Preparing to the beginning of the new decade, we will start to close all PRs with no activity for 90 days. We will have a grace period of 7 days before the bot close the PR so we can review if the PR is still valid and give users opportunity to update the PR.