### PR TITLE
Disable ActiveJob retry jitter when given zero/falsey value

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -133,13 +133,17 @@ module ActiveJob
 
         case seconds_or_duration_or_algorithm
         when :exponentially_longer
-          ((executions**4) + (Kernel.rand((executions**4) * jitter))) + 2
+          delay = executions**4
+          delay_jitter = jitter > 0 ? Kernel.rand((executions**4) * jitter) : jitter
+          delay + delay_jitter + 2
         when ActiveSupport::Duration
           duration = seconds_or_duration_or_algorithm.to_i
-          duration + Kernel.rand(duration * jitter)
+          duration_jitter = jitter > 0 ? Kernel.rand(duration * jitter) : jitter
+          duration + duration_jitter
         when Integer
           seconds = seconds_or_duration_or_algorithm
-          seconds + (Kernel.rand(seconds * jitter).ceil)
+          seconds_jitter = jitter > 0 ? Kernel.rand(seconds * jitter) : jitter
+          seconds + seconds_jitter
         when Proc
           algorithm = seconds_or_duration_or_algorithm
           algorithm.call(executions)

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -134,22 +134,23 @@ module ActiveJob
         case seconds_or_duration_or_algorithm
         when :exponentially_longer
           delay = executions**4
-          delay_jitter = jitter > 0 ? Kernel.rand((executions**4) * jitter) : jitter
+          delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter + 2
-        when ActiveSupport::Duration
-          duration = seconds_or_duration_or_algorithm.to_i
-          duration_jitter = jitter > 0 ? Kernel.rand(duration * jitter) : jitter
-          duration + duration_jitter
-        when Integer
-          seconds = seconds_or_duration_or_algorithm
-          seconds_jitter = jitter > 0 ? Kernel.rand(seconds * jitter) : jitter
-          seconds + seconds_jitter
+        when ActiveSupport::Duration, Integer
+          delay = seconds_or_duration_or_algorithm.to_i
+          delay_jitter = determine_jitter_for_delay(delay, jitter)
+          delay + delay_jitter
         when Proc
           algorithm = seconds_or_duration_or_algorithm
           algorithm.call(executions)
         else
           raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
         end
+      end
+
+      def determine_jitter_for_delay(delay, jitter)
+        return 0.0 if jitter == 0
+        Kernel.rand(delay * jitter)
       end
 
       def executions_for(exceptions)

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -150,7 +150,7 @@ module ActiveJob
       end
 
       def determine_jitter_for_delay(delay, jitter)
-        return 0.0 if jitter == 0
+        return 0.0 if jitter.zero?
         Kernel.rand(delay * jitter)
       end
 

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -53,7 +53,7 @@ module ActiveJob
       #      # Might raise Net::OpenTimeout or Timeout::Error when the remote service is down
       #    end
       #  end
-      def retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: nil)
+      def retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: JITTER_DEFAULT)
         rescue_from(*exceptions) do |error|
           executions = executions_for(exceptions)
           if executions < attempts
@@ -126,8 +126,11 @@ module ActiveJob
     end
 
     private
-      def determine_delay(seconds_or_duration_or_algorithm:, executions:, jitter: nil)
-        jitter ||= self.class.retry_jitter
+      JITTER_DEFAULT = Object.new
+
+      def determine_delay(seconds_or_duration_or_algorithm:, executions:, jitter: JITTER_DEFAULT)
+        jitter = jitter == JITTER_DEFAULT ? self.class.retry_jitter : (jitter || 0.0)
+
         case seconds_or_duration_or_algorithm
         when :exponentially_longer
           ((executions**4) + (Kernel.rand((executions**4) * jitter))) + 2

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -127,6 +127,7 @@ module ActiveJob
 
     private
       JITTER_DEFAULT = Object.new
+      private_constant :JITTER_DEFAULT
 
       def determine_delay(seconds_or_duration_or_algorithm:, executions:, jitter: JITTER_DEFAULT)
         jitter = jitter == JITTER_DEFAULT ? self.class.retry_jitter : (jitter || 0.0)

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -158,16 +158,12 @@ class ExceptionsTest < ActiveSupport::TestCase
    travel_to Time.now
 
    Kernel.stub(:rand, ->(arg) { arg }) do
-     RetryJob.perform_later "DisabledJitterError", 5, :log_scheduled_at
+     RetryJob.perform_later "DisabledJitterError", 3, :log_scheduled_at
 
      assert_equal [
        "Raised DisabledJitterError for the 1st time",
        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Raised DisabledJitterError for the 2nd time",
-       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
-       "Raised DisabledJitterError for the 3rd time",
-       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
-       "Raised DisabledJitterError for the 4th time",
        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Successfully completed job"
      ], JobBuffer.values

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -155,19 +155,19 @@ class ExceptionsTest < ActiveSupport::TestCase
   end
 
   test "disable retry jitter" do
-   travel_to Time.now
+    travel_to Time.now
 
-   Kernel.stub(:rand, ->(arg) { arg }) do
-     RetryJob.perform_later "DisabledJitterError", 3, :log_scheduled_at
+    Kernel.stub(:rand, ->(arg) { arg }) do
+      RetryJob.perform_later "DisabledJitterError", 3, :log_scheduled_at
 
-     assert_equal [
-       "Raised DisabledJitterError for the 1st time",
-       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
-       "Raised DisabledJitterError for the 2nd time",
-       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
-       "Successfully completed job"
-     ], JobBuffer.values
-   end
+      assert_equal [
+        "Raised DisabledJitterError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
+        "Raised DisabledJitterError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
   end
 
   test "custom wait retrying job" do

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -154,7 +154,7 @@ class ExceptionsTest < ActiveSupport::TestCase
     ActiveJob::Base.retry_jitter = old_jitter
   end
 
-  test "disable retry jitter" do
+  test "retry jitter disabled with nil" do
     travel_to Time.now
 
     Kernel.stub(:rand, ->(arg) { arg }) do
@@ -164,6 +164,22 @@ class ExceptionsTest < ActiveSupport::TestCase
         "Raised DisabledJitterError for the 1st time",
         "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
         "Raised DisabledJitterError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+  end
+
+  test "retry jitter disabled with zero" do
+    travel_to Time.now
+
+    Kernel.stub(:rand, ->(arg) { arg }) do
+      RetryJob.perform_later "ZeroJitterError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised ZeroJitterError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
+        "Raised ZeroJitterError for the 2nd time",
         "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
         "Successfully completed job"
       ], JobBuffer.values

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -164,11 +164,11 @@ class ExceptionsTest < ActiveSupport::TestCase
        "Raised DisabledJitterError for the 1st time",
        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Raised DisabledJitterError for the 2nd time",
-       "Next execution scheduled at #{(Time.now + 6.seconds).to_f}",
+       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Raised DisabledJitterError for the 3rd time",
-       "Next execution scheduled at #{(Time.now + 9.seconds).to_f}",
+       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Raised DisabledJitterError for the 4th time",
-       "Next execution scheduled at #{(Time.now + 12.seconds).to_f}",
+       "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
        "Successfully completed job"
      ], JobBuffer.values
    end

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -4,6 +4,7 @@ require_relative "../support/job_buffer"
 require "active_support/core_ext/integer/inflections"
 
 class DefaultsError < StandardError; end
+class DisabledJitterError < StandardError; end
 class FirstRetryableErrorOfTwo < StandardError; end
 class SecondRetryableErrorOfTwo < StandardError; end
 class LongWaitError < StandardError; end
@@ -18,6 +19,7 @@ class CustomDiscardableError < StandardError; end
 
 class RetryJob < ActiveJob::Base
   retry_on DefaultsError
+  retry_on DisabledJitterError, jitter: nil
   retry_on FirstRetryableErrorOfTwo, SecondRetryableErrorOfTwo, attempts: 4
   retry_on LongWaitError, wait: 1.hour, attempts: 10
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/integer/inflections"
 
 class DefaultsError < StandardError; end
 class DisabledJitterError < StandardError; end
+class ZeroJitterError < StandardError; end
 class FirstRetryableErrorOfTwo < StandardError; end
 class SecondRetryableErrorOfTwo < StandardError; end
 class LongWaitError < StandardError; end
@@ -20,6 +21,7 @@ class CustomDiscardableError < StandardError; end
 class RetryJob < ActiveJob::Base
   retry_on DefaultsError
   retry_on DisabledJitterError, jitter: nil
+  retry_on ZeroJitterError, jitter: 0.0
   retry_on FirstRetryableErrorOfTwo, SecondRetryableErrorOfTwo, attempts: 4
   retry_on LongWaitError, wait: 1.hour, attempts: 10
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10


### PR DESCRIPTION
This PR updates the `ActiveJob` `retry_on` and `determine_delay` methods to accept `nil` / `falsey` values for `jitter:` and treat them as `0.0` which effectively disables jitter randomization.

This also fixes the https://github.com/rails/rails/issues/37990 bug which caused a random fraction of a second to be added to the delay when a jitter value of `0.0` was used.

### Refactoring `determine_delay`

This PR refactors `determine_delay` a bit. It combines the `ActiveSupport::Duration` and `Integer` cases as they were identical with the exception of variable names and a call to `.to_i` which is a no-op for `Integer`. If this is undesirable for any reason I can break it back apart.

This also pulls calculation for jitter out into a private `determine_jitter_for_delay(delay, jitter)` method.

Thanks @kaspth for posting code for a starting point in https://github.com/rails/rails/pull/37923#discussion_r357445670

cc @eileencodes for visibility