### PR TITLE
Add a host method to HashConfig

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         "#{adapter}_connection"
       end
 
+      def host
+        raise NotImplementedError
+      end
+
       def database
         raise NotImplementedError
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -53,6 +53,10 @@ module ActiveRecord
         configuration_hash[:migrations_paths]
       end
 
+      def host
+        configuration_hash[:host]
+      end
+
       def database
         configuration_hash[:database]
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -508,7 +508,7 @@ module ActiveRecord
         end
 
         def local_database?(db_config)
-          host = db_config.configuration_hash[:host]
+          host = db_config.host
           host.blank? || LOCAL_HOSTS.include?(host)
         end
 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -101,7 +101,7 @@ module ActiveRecord
         end
 
         def set_psql_env
-          ENV["PGHOST"]     = configuration_hash[:host]          if configuration_hash[:host]
+          ENV["PGHOST"]     = db_config.host                     if db_config.host
           ENV["PGPORT"]     = configuration_hash[:port].to_s     if configuration_hash[:port]
           ENV["PGPASSWORD"] = configuration_hash[:password].to_s if configuration_hash[:password]
           ENV["PGUSER"]     = configuration_hash[:username].to_s if configuration_hash[:username]


### PR DESCRIPTION
This is the last property that's used directly inside of Rails (in
`DatabaseTasks`) that doesn't have an accessor in `HashConfig`.

Adding this so that we can have a uniform interface for accessing
properties that Rails needs (that descend from
`DatabaseConfigurations::DatabaseConfig`)