### PR TITLE
Deprecate `connection_config`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The `connection_config` method has been deprecated, please use `connection_db_config` instead which will return a `DatabaseConfigurations::DatabaseConfig` instead of a `Hash`.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Retain explicit selections on the base model after applying `includes` and `joins`.
 
     Resolves #34889.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -199,6 +199,18 @@ module ActiveRecord
     def connection_config
       connection_pool.db_config.configuration_hash
     end
+    deprecate connection_config: "Use connection_db_config instead"
+
+    # Returns the db_config object from the associated connection:
+    #
+    #  ActiveRecord::Base.connection_db_config
+    #    #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
+    #      @spec_name="primary", @config={pool: 5, timeout: 5000, database: "db/development.sqlite3", adapter: "sqlite3"}>
+    #
+    # Use only for reading.
+    def connection_db_config
+      connection_pool.db_config
+    end
 
     def connection_pool
       connection_handler.retrieve_connection_pool(connection_specification_name) || raise(ConnectionNotEstablished)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -604,7 +604,7 @@ module ActiveRecord
       end
 
       def load_schema_if_pending!
-        current_config = Base.connection_config
+        current_db_config = Base.connection_db_config
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
@@ -621,7 +621,7 @@ module ActiveRecord
         end
 
         # Establish a new connection, the old database may be gone (db:test:prepare uses purge)
-        Base.establish_connection(current_config)
+        Base.establish_connection(current_db_config)
 
         check_pending!
       end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -80,14 +80,14 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
   task migrate: :load_config do
-    original_config = ActiveRecord::Base.connection_config
+    original_db_config = ActiveRecord::Base.connection_db_config
     ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
       ActiveRecord::Base.establish_connection(db_config)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     end
     db_namespace["_dump"].invoke
   ensure
-    ActiveRecord::Base.establish_connection(original_config)
+    ActiveRecord::Base.establish_connection(original_db_config)
   end
 
   # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -242,7 +242,7 @@ module ActiveRecord
         end
 
         # output
-        puts "\ndatabase: #{ActiveRecord::Base.connection_config[:database]}\n\n"
+        puts "\ndatabase: #{ActiveRecord::Base.connection_db_config.database}\n\n"
         puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
         puts "-" * 50
         ActiveRecord::Base.connection.migration_context.migrations_status.each do |status, version, name|

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -50,7 +50,7 @@ module ActiveRecord
     # Ensure, we can set connection params using the example of Generic
     # Query Optimizer (geqo). It is 'on' per default.
     def test_connection_options
-      params = ActiveRecord::Base.connection_config.dup
+      params = ActiveRecord::Base.connection_db_config.configuration_hash.dup
       params[:options] = "-c geqo=off"
       NonExistentTable.establish_connection(params)
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -389,7 +389,7 @@ module ActiveRecord
             ActiveRecord::Base.establish_connection(:arunit)
 
             pid2 = fork do
-              wr.write ActiveRecord::Base.connection_config[:database]
+              wr.write ActiveRecord::Base.connection_db_config.database
               wr.close
             end
 

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -14,8 +14,8 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
 
   teardown do
     return if in_memory_db?
-    config = ActiveRecord::Base.connection_config
-    ActiveRecord::Base.establish_connection(config)
+    db_config = ActiveRecord::Base.connection_db_config
+    ActiveRecord::Base.establish_connection(db_config)
   end
 
   unless in_memory_db?


### PR DESCRIPTION
The `connection_config` method returns a `Hash`, but since we're moving
toward a place where we're using `DatabaseConfiguration::DatabaseConfig`
objects everywhere, we're introducing a new method here to replace it
called `connection_db_config`.

Co-authored-by: eileencodes <eileencodes@gmail.com>