### PR TITLE
Rename a test method to not conflict with a deprecated method

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -117,7 +117,7 @@ module ActiveRecord
 
     def test_current_database
       if @connection.respond_to?(:current_database)
-        assert_equal ARTest.connection_config["arunit"]["database"], @connection.current_database
+        assert_equal ARTest.test_configuration_hashes["arunit"]["database"], @connection.current_database
       end
     end
 
@@ -147,7 +147,7 @@ module ActiveRecord
         assert_nothing_raised do
           ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"].except(:database))
 
-          config = ARTest.connection_config
+          config = ARTest.test_configuration_hashes
           ActiveRecord::Base.connection.execute(
             "SELECT #{config['arunit']['database']}.pirates.*, #{config['arunit2']['database']}.courses.* " \
             "FROM #{config['arunit']['database']}.pirates, #{config['arunit2']['database']}.courses"

--- a/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb
@@ -21,7 +21,7 @@ if ActiveRecord::Base.connection.supports_foreign_tables?
       @connection = ActiveRecord::Base.connection
       enable_extension!("postgres_fdw", @connection)
 
-      foreign_db_config = ARTest.connection_config["arunit2"]
+      foreign_db_config = ARTest.test_configuration_hashes["arunit2"]
       @connection.execute <<~SQL
         CREATE SERVER foreign_server
           FOREIGN DATA WRAPPER postgres_fdw

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -11,7 +11,7 @@ module ARTest
     ENV["ARCONN"] || config["default_connection"]
   end
 
-  def self.connection_config
+  def self.test_configuration_hashes
     config.fetch("connections").fetch(connection_name) do
       puts "Connection #{connection_name.inspect} not found. Available connections: #{config['connections'].keys.join(', ')}"
       exit 1
@@ -22,7 +22,7 @@ module ARTest
     puts "Using #{connection_name}"
     ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
     ActiveRecord::Base.connection_handlers = { ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler }
-    ActiveRecord::Base.configurations = connection_config
+    ActiveRecord::Base.configurations = test_configuration_hashes
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2
   end


### PR DESCRIPTION
This method in test has a confusing name that also is the same as a
method with a different behavior on `ActiveRecord::Base` so we're just
renaming it to avoid confusion between the two!

Co-authored-by: eileencodes <eileencodes@gmail.com>