### PR TITLE
Move `name` key on configuration hash into `DatabaseConfig`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,12 @@
+*   The `:name` key will no longer be returned as part of `DatabaseConfig#configuration_hash`. Please use `DatabaseConfig#owner_name` instead.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   ActiveRecord's `belongs_to_required_by_default` flag can now be set per model.
 
     You can now opt-out/opt-in specific models from having their associations required
     by default.
+
     This change is meant to ease the process of migrating all your models to have
     their association required.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1188,7 +1188,9 @@ module ActiveRecord
             raise AdapterNotFound, "database configuration specifies nonexistent #{db_config.adapter} adapter"
           end
 
-          ConnectionAdapters::PoolConfig.new(db_config.configuration_hash.delete(:name) || "primary", db_config)
+          pool_name = db_config.owner_name || "primary"
+          db_config.owner_name = nil
+          ConnectionAdapters::PoolConfig.new(pool_name, db_config)
         end
     end
   end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -253,7 +253,7 @@ module ActiveRecord
         self.connection_specification_name = pool_name
 
         db_config = Base.configurations.resolve(config_or_env, pool_name)
-        db_config.configuration_hash[:name] = pool_name
+        db_config.owner_name = pool_name
         db_config
       end
 

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -182,8 +182,10 @@ module ActiveRecord
         db_config = find_db_config(env_name)
 
         if db_config
-          config = db_config.configuration_hash.merge(name: pool_name.to_s)
-          DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.spec_name, config)
+          config = db_config.configuration_hash.dup
+          db_config = DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.spec_name, config)
+          db_config.owner_name = pool_name.to_s
+          db_config
         else
           raise AdapterNotSpecified, <<~MSG
             The `#{env_name}` database is not configured for the `#{default_env}` environment.

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -7,6 +7,7 @@ module ActiveRecord
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
       attr_reader :env_name, :spec_name
+      attr_accessor :owner_name
 
       def initialize(env_name, spec_name)
         @env_name = env_name

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -31,9 +31,9 @@ module ActiveRecord
         old_config = ActiveRecord::Base.configurations
         config = { "readonly" => { "adapter" => "sqlite3", "pool" => "5" } }
         ActiveRecord::Base.configurations = config
-        config_hash = ActiveRecord::Base.configurations.resolve(config["readonly"], "readonly").configuration_hash
-        config_hash[:name] = "readonly"
-        @handler.establish_connection(config_hash)
+        db_config = ActiveRecord::Base.configurations.resolve(config["readonly"], "readonly")
+        db_config.owner_name = "readonly"
+        @handler.establish_connection(db_config)
 
         assert_not_nil @handler.retrieve_connection_pool("readonly")
       ensure

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -22,9 +22,9 @@ module ActiveRecord
         configs.configs_for(env_name: env_name, spec_name: "primary")&.configuration_hash
       end
 
-      def resolve_spec(spec, config)
+      def resolve_db_config(spec, config)
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        configs.resolve(spec, spec).configuration_hash
+        configs.resolve(spec, spec)
       end
 
       def test_invalid_string_config
@@ -45,72 +45,85 @@ module ActiveRecord
 
       def test_resolver_with_database_uri_and_current_env_symbol_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
-        config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual   = resolve_spec(:default_env, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "default_env" }
-        assert_equal expected, actual
+        config = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual = resolve_db_config(:default_env, config)
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "default_env", actual.owner_name
       end
 
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rails_env
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         ENV["RAILS_ENV"]    = "foo"
 
-        config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
-        assert_equal expected, actual
+        config = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual = resolve_db_config(:foo, config)
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "foo", actual.owner_name
       end
 
       def test_resolver_with_nil_database_url_and_current_env
         ENV["RAILS_ENV"] = "foo"
         config = { "foo" => { "adapter" => "postgres", "url" => ENV["DATABASE_URL"] } }
-        actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgres", url: nil, name: "foo" }
-        assert_equal expected, actual
+        actual = resolve_db_config(:foo, config)
+        expected_config = { adapter: "postgres", url: nil }
+
+        assert_equal expected_config, actual.configuration_hash
+        assert_equal "foo", actual.owner_name
       end
 
       def test_resolver_with_database_uri_and_current_env_symbol_key_and_rack_env
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         ENV["RACK_ENV"]     = "foo"
 
-        config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
-        actual   = resolve_spec(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", name: "foo" }
-        assert_equal expected, actual
+        config = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual = resolve_db_config(:foo, config)
+        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "foo", actual.owner_name
       end
 
       def test_resolver_with_database_uri_and_known_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
-        config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
-        actual   = resolve_spec(:production, config)
-        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost", name: "production" }
-        assert_equal expected, actual
+        config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
+        actual = resolve_db_config(:production, config)
+        expected = { adapter: "not_postgres", database: "not_foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "production", actual.owner_name
       end
 
       def test_resolver_with_database_uri_and_multiple_envs
         ENV["DATABASE_URL"] = "postgres://localhost"
         ENV["RAILS_ENV"] = "test"
 
-        config   = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
-        actual   = resolve_spec(:test, config)
-        expected = { adapter: "postgresql", database: "foo_test", host: "localhost", name: "test" }
-        assert_equal expected, actual
+        config = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
+        actual = resolve_db_config(:test, config)
+        expected = { adapter: "postgresql", database: "foo_test", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "test", actual.owner_name
       end
 
       def test_resolver_with_database_uri_and_unknown_symbol_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         assert_raises AdapterNotSpecified do
-          resolve_spec(:production, config)
+          resolve_db_config(:production, config)
         end
       end
 
       def test_resolver_with_database_uri_and_supplied_url
         ENV["DATABASE_URL"] = "not-postgres://not-localhost/not_foo"
-        config   = { "production" => {  "adapter" => "also_not_postgres", "database" => "also_not_foo" } }
-        actual   = resolve_spec("postgres://localhost/foo", config)
+        config = { "production" => {  "adapter" => "also_not_postgres", "database" => "also_not_foo" } }
+        actual = resolve_db_config("postgres://localhost/foo", config)
         expected = { adapter: "postgresql", database: "foo", host: "localhost" }
-        assert_equal expected, actual
+
+        assert_equal expected, actual.configuration_hash
       end
 
       def test_jdbc_url
@@ -134,10 +147,12 @@ module ActiveRecord
 
       def test_url_with_hyphenated_scheme
         ENV["DATABASE_URL"] = "ibm-db://localhost/foo"
-        config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
-        actual   = resolve_spec(:default_env, config)
-        expected = { adapter: "ibm_db", database: "foo", host: "localhost", name: "default_env" }
-        assert_equal expected, actual
+        config = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
+        actual = resolve_db_config(:default_env, config)
+        expected = { adapter: "ibm_db", database: "foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+        assert_equal "default_env", actual.owner_name
       end
 
       def test_string_connection
@@ -165,10 +180,10 @@ module ActiveRecord
       end
 
       def test_url_removed_from_hash
-        config   = { "default_env" => { "url" => "postgres://localhost/foo" } }
-        actual   = resolve_spec(:default_env, config)
+        config = { "default_env" => { "url" => "postgres://localhost/foo" } }
+        actual = resolve_db_config(:default_env, config)
 
-        assert_not_includes actual, :url
+        assert_not_includes actual.configuration_hash, :url
       end
 
       def test_url_with_equals_in_query_value
@@ -400,16 +415,18 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
 
-        actual = resolve_spec(:production, config)
-        assert_equal config["production"].symbolize_keys.merge(name: "production"), actual
+        actual = resolve_db_config(:production, config)
+        assert_equal config["production"].symbolize_keys, actual.configuration_hash
+        assert_equal "production", actual.owner_name
 
-        actual = resolve_spec(:default_env, config)
+        actual = resolve_db_config(:default_env, config)
+
         assert_equal({
           host: "localhost",
           database: "foo",
           adapter: "postgresql",
-          name: "default_env"
-        }, actual)
+        }, actual.configuration_hash)
+        assert_equal "default_env", actual.owner_name
       end
     end
   end


### PR DESCRIPTION
`name` is used by Rails to find the configuration by connection
specification name, but database adapters don't need to use `name` in
order to establish a connection. This is part of our work to separate
what the database needs to connect (the configuration hash) and the
what Rails needs to find connections (everything else).

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>