### PR TITLE
Allow log_tags to take a hash for a tagged logger

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -23,8 +23,7 @@ module Rails
         request = ActionDispatch::Request.new(env)
 
         if logger.respond_to?(:tagged)
-          tags = compute_tags(request)
-          logger.tagged(tags) { call_app(request, env) }
+          logger.tagged(compute_tags(request)) { call_app(request, env) }
         else
           call_app(request, env)
         end

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -5,6 +5,7 @@ require "active_support/testing/autorun"
 require "active_support/test_case"
 require "rails/rack/logger"
 require "logger"
+require "minitest/mock"
 
 module Rails
   module Rack
@@ -89,6 +90,24 @@ module Rails
             logger.call("REQUEST_METHOD" => "GET")
           end
         end
+      end
+
+      def test_log_tags_can_be_a_hash
+        trace_id = "abc123"
+        remote_ip = "127.0.0.1"
+        log_tags = {
+          ip: :remote_ip,
+          trace_id: ->(request) { trace_id },
+        }
+        expected_tags = {
+          ip: remote_ip,
+          trace_id: trace_id,
+        }
+        log = MiniTest::Mock.new
+        logger = TestLogger.new(log, taggers: log_tags) { }
+
+        log.expect(:tagged, true, [expected_tags])
+        logger.call("REQUEST_METHOD" => "GET", "REMOTE_ADDR" => remote_ip)
       end
     end
   end


### PR DESCRIPTION
### Summary

Tagged loggers like `ActiveSupport::TaggedLogging` make logging both named
and unnamed tags visible for better application debugging. Prior to this
change, log_tags only supported an array of tags such as:

```ruby
config.log_tags = [
  :remote_ip,
  ->(request) { some_computed_value }
]
```

However as this list gets long it has two issues:

1.  Parsing JSON logs requires positional references (ie remote_ip will
always be at some index)
2.  Some tags look similar and are hard to discern in a log message.
For example a datadog trace id and epoch time look indistinguishable to a
human reading those logs

This change allows users to instead pass in a hash like object to
`#log_tags`:

```ruby
config.log_tags = {
  remote_ip: :remote_ip,
  trace_id: ->(request) { some_computed_value }
}
```

### Other Information

- I still need to update the changelog if folks like this.
