### PR TITLE
Send notification when lazy load hooks are triggered:

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -25,11 +25,8 @@ module ActionController
 
     included do
       class_attribute :etag_with_template_digest, default: true
-
-      ActiveSupport.on_load :action_view, yield: true do
-        etag do |options|
-          determine_template_etag(options) if etag_with_template_digest
-        end
+      etag do |options|
+        determine_template_etag(options) if etag_with_template_digest
       end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -5,7 +5,6 @@ require "action_dispatch/middleware/exception_wrapper"
 require "action_dispatch/routing/inspector"
 
 require "action_view"
-require "action_view/base"
 
 module ActionDispatch
   # This middleware is responsible for logging exceptions and

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -71,18 +71,14 @@ module ActionView
     end
 
     initializer "action_view.caching" do |app|
-      ActiveSupport.on_load(:action_view) do
-        if app.config.action_view.cache_template_loading.nil?
-          ActionView::Resolver.caching = app.config.cache_classes
-        end
+      if app.config.action_view.cache_template_loading.nil?
+        ActionView::Resolver.caching = app.config.cache_classes
       end
     end
 
     initializer "action_view.per_request_digest_cache" do |app|
-      ActiveSupport.on_load(:action_view) do
-        unless ActionView::Resolver.caching?
-          app.executor.to_run ActionView::CacheExpiry::Executor.new(watcher: app.config.file_watcher)
-        end
+      unless ActionView::Resolver.caching?
+        app.executor.to_run ActionView::CacheExpiry::Executor.new(watcher: app.config.file_watcher)
       end
     end
 

--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/notifications"
+
 module ActiveSupport
   # lazy_load_hooks allows Rails to lazily load a lot of components and thus
   # making the app boot faster. Because of this feature now there is no need to
@@ -47,9 +49,11 @@ module ActiveSupport
     end
 
     def run_load_hooks(name, base = Object)
-      @loaded[name] << base
-      @load_hooks[name].each do |hook, options|
-        execute_hook(name, base, options, hook)
+      ActiveSupport::Notifications.instrument("run_load_hooks.active_support", name: name, base: base) do
+        @loaded[name] << base
+        @load_hooks[name].each do |hook, options|
+          execute_hook(name, base, options, hook)
+        end
       end
     end
 

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -174,6 +174,20 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
     assert_equal "Hulk Hogan", context.second_wrestler
   end
 
+  def test_hook_sends_a_notification
+    called = false
+    block = ->(_, _, _, _, payload) do
+      assert_equal(:my_hook, payload[:name])
+      called = true
+    end
+
+    ActiveSupport::Notifications.subscribed(block, "run_load_hooks.active_support") do
+      ActiveSupport.run_load_hooks(:my_hook)
+    end
+
+    assert(called)
+  end
+
 private
   def incr_amt
     5

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2191,6 +2191,8 @@ module ApplicationTests
 
     test "ActionView::Helpers::FormTagHelper.default_enforce_utf8 is false by default" do
       app "development"
+
+      ActionView::Base # Trigger autoloading
       assert_equal false, ActionView::Helpers::FormTagHelper.default_enforce_utf8
     end
 

--- a/railties/test/boot_test.rb
+++ b/railties/test/boot_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+class BootTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  test "no rails components are loaded at boot time in development" do
+    remove_from_file("#{app_path}/config/environment.rb", "Rails.application.initialize!")
+
+    app_file("config/environment.rb", <<~RUBY, "a+")
+      block = ->(_, _, _, _, payload) do
+        allowed_hooks = [:before_initialize, :after_initialize]
+        next if allowed_hooks.include?(payload[:name])
+
+        raise(<<~EOM)
+          The \#{payload[:base]} component was referenced too early during boot.
+          This is most likely due because an initializer make use of a component before this one had time to be loaded.
+        EOM
+      end
+
+      ActiveSupport::Notifications.subscribed(block, 'run_load_hooks.active_support') do
+        Rails.application.initialize!
+      end
+    RUBY
+
+    assert_nothing_raised do
+      app("development")
+    end
+  end
+end

--- a/railties/test/boot_test.rb
+++ b/railties/test/boot_test.rb
@@ -13,7 +13,7 @@ class BootTest < ActiveSupport::TestCase
 
     app_file("config/environment.rb", <<~RUBY, "a+")
       block = ->(_, _, _, _, payload) do
-        allowed_hooks = [:before_initialize, :after_initialize]
+        allowed_hooks = [:before_initialize, :after_initialize, :action_cable, :action_cable_channel]
         next if allowed_hooks.include?(payload[:name])
 
         raise(<<~EOM)


### PR DESCRIPTION
Send notification when lazy load hooks are triggered

- ### Problem

  It's very common that application (or libraries) references Rails
  components too early during boot.
  This causes issue where applications or other libraries initializers
  can't set configuration values as they would get ignored.

  ```ruby
    # config/initializers/000_some_initializer.rb
    ActiveRecord::Base.configurations # Make use of AR::Base which hasn't been loaded yet

    # config/initializers/new_framework_defaults.rb
    Rails.application.config.active_record.belongs_to_required_by_default = "foo"
    # Setting this configuration won't do anything since ActiveRecord::Base is already
    # loaded and the `set_configs` initializer has already iterated over application
    # config (see https://github.com/rails/rails/blob/b67785a476cf346b09f5ebc71b4d61aae3ac27b3/activerecord/lib/active_record/railtie.rb#L192)

    puts ActiveRecord::Base.belongs_to_required_by_default # nil
  ```

  Moreover this causes performance penalty as it increase boot time.

  This issue is so common that even the Rails application itself and a
  dependency it requires on make the mistake.

  - [web-console](https://github.com/rails/web-console/blob/be84e6471c33bbbea17f6dfc9e5ed3c7c7c4bb57/lib/web_console/railtie.rb#L13) This ends up triggering the `ActionView::Base` constant.
  - [action_cable](https://github.com/rails/rails/blob/b67785a476cf346b09f5ebc71b4d61aae3ac27b3/actioncable/lib/action_cable/engine.rb#L48) This ends up triggering both ActionCable::Server::Base as well as ActionCable::Channel::Base

  ### Solution

  This PR doesn't solve the issue by itself but it will allow
  applications to have a way to be warned and take action
  when it happens as this thing can go unnoticed super easily.

  My idea on how to use the notification inside an application
  is to wrap the initialization process and either logs or raise
  when a component is accessed during boot. This should however
  be done if eager_loading is disabled (so in dev/test basically).

  ```ruby
    # config/environment.rb

    require_relative 'application'

    block = ->(_, _, _, _, payload) do
      allowed_hooks = [:before_initialize, :after_initialize]
      next if Rails.env.production? || allowed_hooks.include?(payload[:name])

      raise_or_output_to_stderr
    end

    ActiveSupport::Notifications.subscribed(block, 'run_load_hooks.active_support') do
      Rails.application.initialize!
    end
  ```

cc/ @rafaelfranca @casperisfine