### PR TITLE
Fix Ruby 2.7 warnings in Action View 6.0

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -274,7 +274,7 @@ module ActionView
         crossorigin = "anonymous" if crossorigin == true || (crossorigin.blank? && as_type == "font")
         nopush = options.delete(:nopush) || false
 
-        link_tag = tag.link({
+        link_tag = tag.link(**{
           rel: "preload",
           href: href,
           as: as_type,

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -166,7 +166,7 @@ module ActionView
       def cache(name = {}, options = {}, &block)
         if controller.respond_to?(:perform_caching) && controller.perform_caching
           name_options = options.slice(:skip_digest, :virtual_path)
-          safe_concat(fragment_for(cache_fragment_name(name, name_options), options, &block))
+          safe_concat(fragment_for(cache_fragment_name(name, **name_options), options, &block))
         else
           yield
         end

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -755,10 +755,10 @@ module ActionView
           output  = capture(builder, &block)
           options[:multipart] ||= builder.multipart?
 
-          html_options = html_options_for_form_with(url, model, options)
+          html_options = html_options_for_form_with(url, model, **options)
           form_tag_with_body(html_options, output)
         else
-          html_options = html_options_for_form_with(url, model, options)
+          html_options = html_options_for_form_with(url, model, **options)
           form_tag_html(html_options)
         end
       end

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -107,8 +107,8 @@ module ActionView
             true
           end
 
-          def method_missing(called, *args, &block)
-            tag_string(called, *args, &block)
+          def method_missing(called, *args, **options, &block)
+            tag_string(called, *args, **options, &block)
           end
       end
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -82,14 +82,14 @@ module ActionView
               html_safe_options[name] = ERB::Util.html_escape(value.to_s)
             end
           end
-          translation = I18n.translate(scope_key_by_partial(key), html_safe_options.merge(raise: i18n_raise))
+          translation = I18n.translate(scope_key_by_partial(key), **html_safe_options.merge(raise: i18n_raise))
           if translation.respond_to?(:map)
             translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
           else
             translation.respond_to?(:html_safe) ? translation.html_safe : translation
           end
         else
-          I18n.translate(scope_key_by_partial(key), options.merge(raise: i18n_raise))
+          I18n.translate(scope_key_by_partial(key), **options.merge(raise: i18n_raise))
         end
       rescue I18n::MissingTranslationData => e
         if remaining_defaults.present?

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -24,7 +24,7 @@ module ActionView
           @source,
           @identifer,
           @handler,
-          options
+          **options
         )
       end
   end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -62,7 +62,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def whole_form(action = "http://www.example.com", options = {})
-    out = form_text(action, options) + hidden_fields(options)
+    out = form_text(action, **options) + hidden_fields(options)
 
     if block_given?
       out << yield << "</form>"
@@ -168,7 +168,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
 end
 
 class FormWithActsLikeFormForTest < FormWithTest
-  def form_with(*)
+  def form_with(*, **)
     @output_buffer = super
   end
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -59,7 +59,7 @@ class TestERBTemplate < ActiveSupport::TestCase
 
   def new_template(body = "<%= hello %>", details = {})
     details = { format: :html, locals: [] }.merge details
-    ActionView::Template.new(body.dup, "hello template", details.delete(:handler) || ERBHandler, { virtual_path: "hello" }.merge!(details))
+    ActionView::Template.new(body.dup, "hello template", details.delete(:handler) || ERBHandler, **{ virtual_path: "hello" }.merge!(details))
   end
 
   def render(locals = {})

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -368,7 +368,7 @@ class TextHelperTest < ActionView::TestCase
   def test_word_wrap_does_not_modify_the_options_hash
     options = { line_width: 15 }
     passed_options = options.dup
-    word_wrap("some text", passed_options)
+    word_wrap("some text", **passed_options)
     assert_equal options, passed_options
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -562,13 +562,13 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_escaped_params
     @request = request_for_url("/category/administra%c3%a7%c3%a3o")
 
-    assert current_page?(controller: "foo", action: "category", category: "administração")
+    assert current_page?({ controller: "foo", action: "category", category: "administração" })
   end
 
   def test_current_page_with_escaped_params_with_different_encoding
     @request = request_for_url("/")
     @request.stub(:path, (+"/category/administra%c3%a7%c3%a3o").force_encoding(Encoding::ASCII_8BIT)) do
-      assert current_page?(controller: "foo", action: "category", category: "administração")
+      assert current_page?({ controller: "foo", action: "category", category: "administração" })
       assert current_page?("http://www.example.com/category/administra%c3%a7%c3%a3o")
     end
   end
@@ -576,7 +576,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_double_escaped_params
     @request = request_for_url("/category/administra%c3%a7%c3%a3o?callback_url=http%3a%2f%2fexample.com%2ffoo")
 
-    assert current_page?(controller: "foo", action: "category", category: "administração", callback_url: "http://example.com/foo")
+    assert current_page?({ controller: "foo", action: "category", category: "administração", callback_url: "http://example.com/foo" })
   end
 
   def test_current_page_with_trailing_slash


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/37935

There wasn't so many of them so I just did a single commit.

cc @rafaelfranca @Edouard-chin @kaspth 