### PR TITLE
Api-docs validation defaults missing absence [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -12,6 +12,7 @@ module ActiveModel
       #
       # Examples of using the default rails validators:
       #
+      #   validates :username, absence: true
       #   validates :terms, acceptance: true
       #   validates :password, confirmation: true
       #   validates :username, exclusion: { in: %w(admin superuser) }


### PR DESCRIPTION
### Summary

The [validations api docs](https://api.rubyonrails.org/classes/ActiveModel/Validations/ClassMethods.html#method-i-validates) have got out of step with [those listed in the guide](https://guides.rubyonrails.org/active_record_validations.html#absence) - absence, for one, is missing.

This commit fixes that.

This appeared earlier in a previous, unmerged, pull request.
https://github.com/rails/rails/pull/35774#discussion_r359330882
