### PR TITLE
Restores ability to eager load manually

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -90,7 +90,7 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
 
 * `config.disable_sandbox` controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to false.
 
-* `config.eager_load` when `true`, eager loads all registered `config.eager_load_namespaces`. This includes your application, engines, Rails frameworks, and any other registered namespace.
+* `config.eager_load` when `true`, eager loads everything in `config.eager_load_namespaces`. This includes your application, engines, Rails frameworks, and any other registered namespace. Please, note that 3rd party code can eager load regardless of this config setting.
 
 * `config.eager_load_namespaces` registers namespaces that are eager loaded when `config.eager_load` is `true`. All namespaces in the list must respond to the `eager_load!` method.
 
@@ -1325,7 +1325,7 @@ Rails has 5 initialization events which can be hooked into (listed in the order 
 
 * `to_prepare`: Run after the initializers are run for all Railties (including the application itself), but before eager loading and the middleware stack is built. More importantly, will run upon every request in `development`, but only once (during boot-up) in `production` and `test`.
 
-* `before_eager_load`: This is run directly before eager loading occurs, which is the default behavior for the `production` environment and not for the `development` environment.
+* `before_eager_load`: This is run directly before eager loading occurs, which is the default behavior for the `production` environment and not for the `development` environment. Since this is an initialization event,the hook is not invoked if the application is eager loaded manually by calling `eager_load!` directly.
 
 * `after_initialize`: Run directly after the initialization of the application, after the application initializers in `config/initializers` are run.
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -113,15 +113,8 @@ module Rails
         app.reloader.prepare!
       end
 
-      initializer :eager_load! do
-        if config.eager_load
-          ActiveSupport.run_load_hooks(:before_eager_load, self)
-          # Checks defined?(Zeitwerk) instead of zeitwerk_enabled? because we
-          # want to eager load any dependency managed by Zeitwerk regardless of
-          # the autoloading mode of the application.
-          Zeitwerk::Loader.eager_load_all if defined?(Zeitwerk)
-          config.eager_load_namespaces.each(&:eager_load!)
-        end
+      initializer :eager_load! do |app|
+        app.eager_load! if config.eager_load
       end
 
       # All initialization is done, including eager loading in production


### PR DESCRIPTION
This is a draft just for the sake of discussing with concrete code.

Rails 6 does not provide an encapsulated way to eager load applications, because it was considered that the public interface to eager loading is `config.eager_load`.

This patch is an attempt to restore that functionality, and it presents the caveats that motivated the change in Rails 6.

1. You tell the user the config endpoint can be officially overridden, so they really have no control. How can you configure something whose validity is uncertain?
3. If this method becomes public API, we need to define when can it be called.
2. 3rd party code that relies on the `:before_eager_load` initializer hook does not get their code executed if `config.eager_load` is false, because a manual call is not part of the initialization process.
4. In `classic` mode, if `config.eager_load` is false Rails unhooks AS::Dependencies after eager loading in the `:disable_dependency_loading` initializer, manual eager loading would not do that.
4. Let me also note that, since Rails 6 in `zeitwerk` mode allows applications to have autoloaded paths that are not eager loaded (because Zeitwerk is thread-safe autoloading), eager loading does not generally solve the problem of being aware of all classes and modules present in the application, which is a use case for manual eager loads.