### PR TITLE
Update ActionText docs [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -45,9 +45,31 @@ happens after every keystroke, and avoids the need to use execCommand at all.
 
 ## Installation
 
-Run `rails action_text:install` to add the Yarn package and copy over the necessary migration.
-Also, you need to set up Active Storage for embedded images and other attachments.
-Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
+Run `rails action_text:install` to add the Yarn package and copy over the necessary migration. Also, you need to set up Active Storage for embedded images and other attachments. Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
+
+### Installation with Webpacker 
+
+Both `trix` and `@rails/actiontext` should be required in your JavaScript pack.
+
+```js
+// application.js
+require("trix")
+require("@rails/actiontext")
+```
+
+In order for the built-in CSS styles to work, you'll need to use webpack-compatible import syntax within the generated `actiontext.scss` file.
+
+```scss
+@import "trix/dist/trix";
+```
+
+Additionally you'll also need to ensure that the `actiontext.scss` file is imported into your stylesheet pack.
+
+```
+// application.scss
+@import "./actiontext.scss";
+```
+
 
 ## Examples
 
@@ -59,6 +81,8 @@ class Message < ApplicationRecord
   has_rich_text :content
 end
 ```
+
+Note that you don't need to add a `content` field to your `messages` table.
 
 Then refer to this field in the form for the model:
 

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -47,9 +47,9 @@ happens after every keystroke, and avoids the need to use execCommand at all.
 
 Run `rails action_text:install` to add the Yarn package and copy over the necessary migration. Also, you need to set up Active Storage for embedded images and other attachments. Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
 
-### Installation with Webpacker 
+After the installation is complete, a Rails app using Webpacker should have the following changes:
 
-Both `trix` and `@rails/actiontext` should be required in your JavaScript pack.
+1. Both `trix` and `@rails/actiontext` should be required in your JavaScript pack.
 
 ```js
 // application.js
@@ -57,13 +57,13 @@ require("trix")
 require("@rails/actiontext")
 ```
 
-In order for the built-in CSS styles to work, you'll need to use webpack-compatible import syntax within the generated `actiontext.scss` file.
+2. The`trix` stylesheet should be imported into `actiontext.scss`.
 
 ```scss
 @import "trix/dist/trix";
 ```
 
-Additionally you'll also need to ensure that the `actiontext.scss` file is imported into your stylesheet pack.
+Additionally this `actiontext.scss` file should be imported into your stylesheet pack.
 
 ```
 // application.scss


### PR DESCRIPTION
- Added guidance on installation with `webpacker`. I always like having a reference as to how things should be connected rather than depending on installers, which often don't work in projects with non-standard structures.
- Clarify confusion about whether `content` attribute in database is needed.