### PR TITLE
Use new `...` syntax in Module#delegate if it's available

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -199,7 +199,13 @@ class Module
 
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.
-      definition = /[^\]]=$/.match?(method) ? "arg" : "*args, &block"
+      definition = if /[^\]]=$/.match?(method)
+        "arg"
+      elsif RUBY_VERSION >= "2.7"
+        "..."
+      else
+        "*args, &block"
+      end
 
       # The following generated method calls the target exactly once, storing
       # the returned value in a dummy variable.


### PR DESCRIPTION
It was added in https://bugs.ruby-lang.org/issues/16253

It allows to do blind delegation without having to worry
about ruby2_keywords, and supposedly is also a bit faster.

@rafaelfranca @Edouard-chin 