### PR TITLE
Create Finisher initializer to warn for components used too early:

### DIFF
--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -46,6 +46,10 @@ module ActiveSupport
       @load_hooks[name] << [block, options]
     end
 
+    def loaded_components # :nodoc:
+      @loaded.select { |k, v| v.any? }
+    end
+
     def run_load_hooks(name, base = Object)
       @loaded[name] << base
       @load_hooks[name].each do |hook, options|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1451,6 +1451,23 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `add_builtin_route`: If the application is running under the development environment then this will append the route for `rails/info/properties` to the application routes. This route provides the detailed information such as Rails and Ruby version for `public/index.html` in a default Rails application.
 
+* `notify_early_loaded_component`: Loading Rails components inside initializers can cause issues and increate boot time of your application. This initializer checks if a Rails component was referenced too early and send a notification that you can subscribe to in order to take action:
+
+```ruby
+# config/environment.rb
+
+require_relative 'application'
+
+callback = ->(_, _, _, _, payload) do
+  raise("Rails components accessed too early: payload[:components]")
+end
+
+ActiveSupport::Notifications.subscribed(callback, 'components_loaded.rails') do
+  Rails.application.initialize!
+end
+```
+In order to fix this problem, use [lazy load hooks](https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html)
+
 * `build_middleware_stack`: Builds the middleware stack for the application, returning an object which has a `call` method which takes a Rack environment object for the request.
 
 * `eager_load!`: If `config.eager_load` is `true`, runs the `config.before_eager_load` hooks and then calls `eager_load!` which will load all `config.eager_load_namespaces`.

--- a/railties/test/boot_test.rb
+++ b/railties/test/boot_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+class BootTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  test "no rails components are loaded when running initializers" do
+    tweak_config
+
+    assert_nothing_raised do
+      app("development")
+    end
+  end
+
+  test "notification is sent when a Rails component is triggered when initializers are ran" do
+    tweak_config
+    app_file("config/initializers/000_my_initializer.rb", <<~RUBY)
+      ActiveRecord::Base
+      ActionController::Base
+    RUBY
+
+    error = assert_raises(RuntimeError) do
+      app("development")
+    end
+    assert_match("Here are the components that got loaded too early:", error.message)
+    assert_match("active_record, action_controller", error.message)
+  end
+
+  private
+    def tweak_config
+      remove_from_file("#{app_path}/config/environment.rb", "Rails.application.initialize!")
+
+      app_file("config/environment.rb", <<~RUBY, "a+")
+        block = ->(_, _, _, _, payload) do
+          raise(RuntimeError, <<~EOM)
+            One or many components were referenced too early during boot.
+            This is most likely due because an initializer make use of a component before this one had time to be loaded.
+            Here are the components that got loaded too early:
+
+            \#{payload[:components].join(', ')}
+          EOM
+        end
+
+        ActiveSupport::Notifications.subscribed(block, 'components_loaded.rails') do
+          Rails.application.initialize!
+        end
+      RUBY
+    end
+end


### PR DESCRIPTION
- ### Problem

  It's very common that application (or libraries) references Rails
  components too early during boot.
  This causes issue where applications or other libraries initializers
  can't set configuration values as they would get ignored.

  ```ruby
    # config/initializers/000_some_initializer.rb
    ActiveRecord::Base.configurations # Make use of AR::Base which hasn't been loaded yet

    # config/initializers/new_framework_defaults.rb
    Rails.application.config.active_record.belongs_to_required_by_default = "foo"
    # Setting this configuration won't do anything since ActiveRecord::Base is already
    # loaded and the `set_configs` initializer has already iterated over application
    # config (see https://github.com/rails/rails/blob/b67785a476cf346b09f5ebc71b4d61aae3ac27b3/activerecord/lib/active_record/railtie.rb#L192)

    puts ActiveRecord::Base.belongs_to_required_by_default # nil
  ```

  Moreover this causes performance penalty as it increase boot time.

  This issue is so common that even the Rails application itself and a
  dependency it requires on make the mistake.

  - [web-console](https://github.com/rails/web-console/blob/be84e6471c33bbbea17f6dfc9e5ed3c7c7c4bb57/lib/web_console/railtie.rb#L13) This ends up triggering the `ActionView::Base` constant.
  - [action_cable](https://github.com/rails/rails/blob/b67785a476cf346b09f5ebc71b4d61aae3ac27b3/actioncable/lib/action_cable/engine.rb#L48) This ends up triggering both ActionCable::Server::Base as well as ActionCable::Channel::Base

  ### Solution

  This PR doesn't solve the issue by itself but it will allow
  applications to have a way to be warned and take action
  when it happens as this thing can go unnoticed super easily.

  My idea on how to use the notification inside an application
  is to wrap the initialization process and either logs or raise
  when a component is accessed during boot.

  ```ruby
    # config/environment.rb

    require_relative 'application'

    block = ->(_, _, _, _, payload) do
      raise_or_output_to_stderr
    end

    ActiveSupport::Notifications.subscribed(block, 'components_loaded.rails') do
      Rails.application.initialize!
    end
  ```

cc/ @rafaelfranca @casperisfine