### PR TITLE
Update sqlite3 to avoid Ruby 2.7 warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.4.2)
     stackprof (0.2.13)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Ref: https://github.com/sparklemotion/sqlite3-ruby/pull/277

This will get rid of the thousands of warnings in Active Record test suite:

```
/usr/local/lib/ruby/gems/2.7.0/gems/sqlite3-1.4.1/lib/sqlite3/statement.rb:108: warning: rb_tainted_str_new is deprecated and will be removed in Ruby 3.2.
```

cc @rafaelfranca @kaspth @Edouard-chin 