### PR TITLE
Fix Active Record attribute filtering test on Ruby 2.7

### DIFF
--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -104,7 +104,11 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, "name: [FILTERED]"
+    if RUBY_VERSION >= "2.7"
+      assert_includes actual, 'name: "[FILTERED]"'
+    else
+      assert_includes actual, "name: [FILTERED]"
+    end
     assert_equal 1, actual.scan("[FILTERED]").length
   end
 
@@ -124,7 +128,11 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, "auth_token: [FILTERED]"
+    if RUBY_VERSION >= "2.7"
+      assert_includes actual, 'auth_token: "[FILTERED]"'
+    else
+      assert_includes actual, "auth_token: [FILTERED]"
+    end
     assert_includes actual, 'token: "[FILTERED]"'
   ensure
     User.remove_instance_variable(:@filter_attributes)


### PR DESCRIPTION
As discussed here: https://github.com/rails/rails/pull/38034#issuecomment-567522175

I tried to figure out the root cause of this but couldn't find any related change in Ruby's `pp.rb`.

@rafaelfranca @kamipo @Edouard-chin 