### PR TITLE
Activerecord ruby 2.7 warnings 6 0 stable batch 2

### DIFF
--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -10,14 +10,15 @@ module ActiveModel
 
       def register(type_name, klass = nil, **options, &block)
         block ||= proc { |_, *args| klass.new(*args) }
+        block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
         registrations << registration_klass.new(type_name, block, **options)
       end
 
-      def lookup(symbol, *args)
-        registration = find_registration(symbol, *args)
+      def lookup(symbol, *args, **kwargs)
+        registration = find_registration(symbol, *args, **kwargs)
 
         if registration
-          registration.call(self, symbol, *args)
+          registration.call(self, symbol, *args, **kwargs)
         else
           raise ArgumentError, "Unknown type #{symbol.inspect}"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -148,7 +148,7 @@ module ActiveRecord
         end
 
         if foreign_key
-          table.foreign_key(foreign_table_name, foreign_key_options)
+          table.foreign_key(foreign_table_name, **foreign_key_options)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -379,8 +379,8 @@ module ActiveRecord
         t1_ref, t2_ref = [table_1, table_2].map { |t| t.to_s.singularize }
 
         create_table(join_table_name, **options.merge!(id: false)) do |td|
-          td.references t1_ref, column_options
-          td.references t2_ref, column_options
+          td.references t1_ref, **column_options
+          td.references t2_ref, **column_options
           yield td if block_given?
         end
       end
@@ -902,7 +902,7 @@ module ActiveRecord
       #   add_reference(:products, :supplier, foreign_key: {to_table: :firms})
       #
       def add_reference(table_name, ref_name, **options)
-        ReferenceDefinition.new(ref_name, options).add_to(update_table_definition(table_name, self))
+        ReferenceDefinition.new(ref_name, **options).add_to(update_table_definition(table_name, self))
       end
       alias :add_belongs_to :add_reference
 
@@ -930,7 +930,7 @@ module ActiveRecord
             foreign_key_options = { to_table: reference_name }
           end
           foreign_key_options[:column] ||= "#{ref_name}_id"
-          remove_foreign_key(table_name, foreign_key_options)
+          remove_foreign_key(table_name, **foreign_key_options)
         end
 
         remove_column(table_name, "#{ref_name}_id")
@@ -1152,8 +1152,8 @@ module ActiveRecord
           options[:precision] = 6
         end
 
-        add_column table_name, :created_at, :datetime, options
-        add_column table_name, :updated_at, :datetime, options
+        add_column table_name, :created_at, :datetime, **options
+        add_column table_name, :updated_at, :datetime, **options
       end
 
       # Removes the timestamp columns (+created_at+ and +updated_at+) from the table definition.
@@ -1374,7 +1374,7 @@ module ActiveRecord
 
         def foreign_key_for(from_table, **options)
           return unless supports_foreign_keys?
-          foreign_keys(from_table).detect { |fk| fk.defined_for?(options) }
+          foreign_keys(from_table).detect { |fk| fk.defined_for?(**options) }
         end
 
         def foreign_key_for!(from_table, to_table: nil, **options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -247,7 +247,7 @@ module ActiveRecord
       def add_column(table_name, column_name, type, **options) #:nodoc:
         if invalid_alter_table_type?(type, options)
           alter_table(table_name) do |definition|
-            definition.column(column_name, type, options)
+            definition.column(column_name, type, **options)
           end
         else
           super

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -886,7 +886,12 @@ module ActiveRecord
           end
         end
         return super unless connection.respond_to?(method)
-        connection.send(method, *arguments, &block)
+        options = arguments.extract_options!
+        if options.empty?
+          connection.send(method, *arguments, &block)
+        else
+          connection.send(method, *arguments, **options, &block)
+        end
       end
     end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -97,7 +97,7 @@ module ActiveRecord
           end
         end
 
-        def create_table(table_name, options = {})
+        def create_table(table_name, **options)
           if connection.adapter_name == "Mysql2"
             super(table_name, options: "ENGINE=InnoDB", **options)
           else
@@ -119,7 +119,7 @@ module ActiveRecord
           alias :belongs_to :references
         end
 
-        def create_table(table_name, options = {})
+        def create_table(table_name, **options)
           if connection.adapter_name == "PostgreSQL"
             if options[:id] == :uuid && !options.key?(:default)
               options[:default] = "uuid_generate_v4()"

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -479,7 +479,9 @@ module ActiveRecord
 
       if touch
         names = touch if touch != true
-        touch_updates = klass.touch_attributes_with_time(*names)
+        names = Array(names)
+        options = names.extract_options!
+        touch_updates = klass.touch_attributes_with_time(*names, **options)
         updates.merge!(touch_updates) unless touch_updates.empty?
       end
 

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -60,15 +60,17 @@ module ActiveRecord
           return if method_defined?(method)
 
           if /\A[a-zA-Z_]\w*[!?]?\z/.match?(method)
+            definition = RUBY_VERSION >= "2.7" ? "..." : "*args, &block"
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{method}(*args, &block)
-                scoping { klass.#{method}(*args, &block) }
+              def #{method}(#{definition})
+                scoping { klass.#{method}(#{definition}) }
               end
             RUBY
           else
             define_method(method) do |*args, &block|
               scoping { klass.public_send(method, *args, &block) }
             end
+            ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
           end
         end
       end
@@ -107,6 +109,7 @@ module ActiveRecord
             super
           end
         end
+        ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
     end
 
     module ClassMethods # :nodoc:

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -31,7 +31,7 @@ module ActiveRecord
           version_options = connection.internal_string_options_for_primary_key
 
           connection.create_table(table_name, id: false) do |t|
-            t.string :version, version_options
+            t.string :version, **version_options
           end
         end
       end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -303,7 +303,7 @@ module ActiveRecord
 
     # See ActiveRecord::Transactions::ClassMethods for detailed documentation.
     def transaction(options = {}, &block)
-      self.class.transaction(options, &block)
+      self.class.transaction(**options, &block)
     end
 
     def destroy #:nodoc:

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -15,9 +15,9 @@ module ActiveRecord
           Registration
         end
 
-        def find_registration(symbol, *args)
+        def find_registration(symbol, *args, **kwargs)
           registrations
-            .select { |registration| registration.matches?(symbol, *args) }
+            .select { |registration| registration.matches?(symbol, *args, **kwargs) }
             .max
         end
     end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -851,7 +851,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_rollback_destructions_if_an_exception_occurred_while_saving_a_child
     # Stub the save method of the @pirate.ship instance to destroy and then raise an exception
     class << @pirate.ship
-      def save(*args)
+      def save(*, **)
         super
         destroy
         raise "Oh noes!"
@@ -914,7 +914,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   def test_should_rollback_destructions_if_an_exception_occurred_while_saving_a_parent
     # Stub the save method of the @ship.pirate instance to destroy and then raise an exception
     class << @ship.pirate
-      def save(*args)
+      def save(*, **)
         super
         destroy
         raise "Oh noes!"
@@ -1301,7 +1301,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
     # Stub the save method of the @pirate.ship instance to raise an exception
     class << @pirate.ship
-      def save(*args)
+      def save(*, **)
         super
         raise "Oh noes!"
       end
@@ -1338,7 +1338,7 @@ class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCas
     member = create_member_with_organization
 
     class << member.organization
-      def save(*args)
+      def save(*, **)
         super
         raise "Oh noes!"
       end
@@ -1359,7 +1359,7 @@ class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCas
     author = create_author_with_post_with_comment
 
     class << author.comment_on_first_post
-      def save(*args)
+      def save(*, **)
         super
         raise "Oh noes!"
       end
@@ -1449,7 +1449,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
 
     # Stub the save method of the @ship.pirate instance to raise an exception
     class << @ship.pirate
-      def save(*args)
+      def save(*, **)
         super
         raise "Oh noes!"
       end
@@ -1603,7 +1603,7 @@ module AutosaveAssociationOnACollectionAssociationTests
 
     # Stub the save method of the first child instance to raise an exception
     class << @pirate.send(@association_name).first
-      def save(*args)
+      def save(*, **)
         super
         raise "Oh noes!"
       end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -226,12 +226,6 @@ class EachTest < ActiveRecord::TestCase
     assert_equal special_posts_ids, posts.map(&:id)
   end
 
-  def test_find_in_batches_should_not_modify_passed_options
-    assert_nothing_raised do
-      Post.find_in_batches({ batch_size: 42, start: 1 }.freeze) { }
-    end
-  end
-
   def test_find_in_batches_should_use_any_column_as_primary_key
     nick_order_subscribers = Subscriber.order("nick asc")
     start_nick = nick_order_subscribers.second.nick
@@ -442,12 +436,6 @@ class EachTest < ActiveRecord::TestCase
       posts.concat(relation)
     end
     assert_equal special_posts_ids, posts.map(&:id)
-  end
-
-  def test_in_batches_should_not_modify_passed_options
-    assert_nothing_raised do
-      Post.in_batches({ of: 42, start: 1 }.freeze) { }
-    end
   end
 
   def test_in_batches_should_use_any_column_as_primary_key

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -78,7 +78,7 @@ class CoreTest < ActiveRecord::TestCase
        title: "The First Topic",
        author_name: "David",
        author_email_address: "david@loudthinking.com",
-       written_on: 2003-07-16 14:28:11 UTC,
+       written_on: 2003-07-16 14:28:11(?:\.2233)? UTC,
        bonus_time: 2000-01-01 14:28:00 UTC,
        last_read: Thu, 15 Apr 2004,
        content: "Have a nice day",

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -104,7 +104,11 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, "name: [FILTERED]"
+    if RUBY_VERSION >= "2.7"
+      assert_includes actual, 'name: "[FILTERED]"'
+    else
+      assert_includes actual, "name: [FILTERED]"
+    end
     assert_equal 1, actual.scan("[FILTERED]").length
   end
 
@@ -124,7 +128,11 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, "auth_token: [FILTERED]"
+    if RUBY_VERSION >= "2.7"
+      assert_includes actual, 'auth_token: "[FILTERED]"'
+    else
+      assert_includes actual, "auth_token: [FILTERED]"
+    end
     assert_includes actual, 'token: "[FILTERED]"'
   ensure
     User.remove_instance_variable(:@filter_attributes)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -382,9 +382,9 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
     # This isn't strictly necessary for the test, but a little bit of
     # knowledge of internals allows us to make failures far more likely.
-    model.define_singleton_method(:define_attribute) do |*args|
+    model.define_singleton_method(:define_attribute) do |*args, **kwargs|
       Thread.pass
-      super(*args)
+      super(*args, **kwargs)
     end
 
     threads = 4.times.map do


### PR DESCRIPTION
Followup https://github.com/rails/rails/pull/38037

This eliminate all warnings in the AR test suite with sqlite3 adatper (besides the tzinfo ones).

@rafaelfranca @Edouard-chin @kamipo 