### PR TITLE
Remove week from iso8601 parts [continuation of 34683]

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   When an instance of `ActiveSupport::Duration` is converted to an `iso8601` duration string, if `weeks` are mixed with `date` parts, the `week` part will be converted to days.
+    This keeps the parser and serializer on the same page.
+
+    ```ruby
+    duration = ActiveSupport::Duration.build(1000000)
+    # 1 week, 4 days, 13 hours, 46 minutes, and 40.0 seconds
+
+    duration_iso = duration.iso8601
+    # P11DT13H46M40S
+
+    ActiveSupport::Duration.parse(duration_iso)
+    # 11 days, 13 hours, 46 minutes, and 40 seconds
+
+    duration = ActiveSupport::Duration.build(604800)
+    # 1 week
+
+    duration_iso = duration.iso8601
+    # P1W
+
+    ActiveSupport::Duration.parse(duration_iso)
+    # 1 week
+    ```
+
+    *Abhishek Sarkar*
+
 *   Add block support to `ActiveSupport::Testing::TimeHelpers#travel_back`.
 
     *Tim Masliuchenko*

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -6,6 +6,8 @@ module ActiveSupport
   class Duration
     # Serializes duration to string according to ISO 8601 Duration format.
     class ISO8601Serializer # :nodoc:
+      DATE_COMPONENTS = %i(years months days)
+
       def initialize(duration, precision: nil)
         @duration = duration
         @precision = precision
@@ -19,8 +21,8 @@ module ActiveSupport
         output = +"P"
         output << "#{parts[:years]}Y"   if parts.key?(:years)
         output << "#{parts[:months]}M"  if parts.key?(:months)
-        output << "#{parts[:weeks]}W"   if parts.key?(:weeks)
         output << "#{parts[:days]}D"    if parts.key?(:days)
+        output << "#{parts[:weeks]}W"   if parts.key?(:weeks)
         time = +""
         time << "#{parts[:hours]}H"     if parts.key?(:hours)
         time << "#{parts[:minutes]}M"   if parts.key?(:minutes)
@@ -40,6 +42,12 @@ module ActiveSupport
           parts = @duration.parts.each_with_object(Hash.new(0)) do |(k, v), p|
             p[k] += v  unless v.zero?
           end
+
+          # Convert weeks to days and remove weeks if mixed with date parts
+          if week_mixed_with_date?(parts)
+            parts[:days] += parts.delete(:weeks) * SECONDS_PER_WEEK / SECONDS_PER_DAY
+          end
+
           # If all parts are negative - let's make a negative duration
           sign = ""
           if parts.values.all? { |v| v < 0 }
@@ -47,6 +55,10 @@ module ActiveSupport
             parts.transform_values!(&:-@)
           end
           [parts, sign]
+        end
+
+        def week_mixed_with_date?(parts)
+          parts.key?(:weeks) && (parts.keys & DATE_COMPONENTS).any?
         end
     end
   end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -573,6 +573,9 @@ class DurationTest < ActiveSupport::TestCase
     expectations = [
       ["P1Y",           1.year                           ],
       ["P1W",           1.week                           ],
+      ["P4W",           4.week                           ],
+      ["P1Y7D",         1.year + 1.week                  ],
+      ["P1Y1M21D",      1.year + 1.month + 3.week        ],
       ["P1Y1M",         1.year + 1.month                 ],
       ["P1Y1M1D",       1.year + 1.month + 1.day         ],
       ["-P1Y1D",        -1.year - 1.day                  ],


### PR DESCRIPTION
This is a continuation of #34683 and should fix #34655.

I've rebased it on master and addressed the feedback in the original PR.

### Summary

It converts the week part into days and removes it from the final result.

```ruby
# copied from a comment of original PR

duration = ActiveSupport::Duration.build(1000000)
# 1 week, 4 days, 13 hours, 46 minutes, and 40.0 seconds

duration_iso = duration.iso8601
# P11DT13H46M40S

ActiveSupport::Duration.parse(duration_iso)
# 11 days, 13 hours, 46 minutes, and 40 seconds
```