### PR TITLE
Fix Ruby 2.7 warnings in Action Pack 6.0

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -63,9 +63,13 @@ module AbstractController
 
         meths.each do |meth|
           _helpers.class_eval <<-ruby_eval, __FILE__, __LINE__ + 1
-            def #{meth}(*args, &blk)                               # def current_user(*args, &blk)
-              controller.send(%(#{meth}), *args, &blk)             #   controller.send(:current_user, *args, &blk)
-            end                                                    # end
+            def #{meth}(*args, **kwargs, &blk)                      # def current_user(*args, **kwargs, &blk)
+              if kwargs.empty?                                      #   if kwargs.empty?
+                controller.send(%(#{meth}), *args, &blk)            #     controller.send(:current_user, *args, &blk)
+              else                                                  #   else
+                controller.send(%(#{meth}), *args, **kwargs, &blk)  #     controller.send(:current_user, *args, **kwargs, &blk)
+              end                                                   #   end
+            end                                                     # end
           ruby_eval
         end
       end

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -19,7 +19,7 @@ module AbstractController
         options[:default] = defaults.flatten
         key = "#{path}.#{action_name}#{key}"
       end
-      I18n.translate(key, options)
+      I18n.translate(key, **options)
     end
     alias :t :translate
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -571,7 +571,8 @@ module ActionDispatch
         secret = request.key_generator.generate_key(request.signed_cookie_salt)
         @verifier = ActiveSupport::MessageVerifier.new(secret, digest: signed_cookie_digest, serializer: SERIALIZER)
 
-        request.cookies_rotations.signed.each do |*secrets, **options|
+        request.cookies_rotations.signed.each do |(*secrets)|
+          options = secrets.extract_options!
           @verifier.rotate(*secrets, serializer: SERIALIZER, **options)
         end
       end
@@ -584,7 +585,7 @@ module ActionDispatch
         end
 
         def commit(name, options)
-          options[:value] = @verifier.generate(serialize(options[:value]), cookie_metadata(name, options))
+          options[:value] = @verifier.generate(serialize(options[:value]), **cookie_metadata(name, options))
 
           raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
         end
@@ -630,7 +631,7 @@ module ActionDispatch
         end
 
         def commit(name, options)
-          options[:value] = @encryptor.encrypt_and_sign(serialize(options[:value]), cookie_metadata(name, options))
+          options[:value] = @encryptor.encrypt_and_sign(serialize(options[:value]), **cookie_metadata(name, options))
 
           raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
         end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -44,8 +44,8 @@ module ActionDispatch
 
       # Performs a HEAD request with the given parameters. See ActionDispatch::Integration::Session#process
       # for more details.
-      def head(path, *args)
-        process(:head, path, *args)
+      def head(path, **args)
+        process(:head, path, **args)
       end
 
       # Follow a single redirect response. If the last response was not a
@@ -349,15 +349,19 @@ module ActionDispatch
       end
 
       %w(get post patch put head delete cookies assigns follow_redirect!).each do |method|
-        define_method(method) do |*args|
+        define_method(method) do |*args, **options|
           # reset the html_document variable, except for cookies/assigns calls
           unless method == "cookies" || method == "assigns"
             @html_document = nil
           end
 
-          integration_session.__send__(method, *args).tap do
-            copy_session_variables!
+          result = if options.any?
+            integration_session.__send__(method, *args, **options)
+          else
+            integration_session.__send__(method, *args)
           end
+          copy_session_variables!
+          result
         end
       end
 
@@ -650,8 +654,8 @@ module ActionDispatch
           @@app = app
         end
 
-        def register_encoder(*args)
-          RequestEncoder.register_encoder(*args)
+        def register_encoder(*args, **options)
+          RequestEncoder.register_encoder(*args, **options)
         end
       end
 

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -177,9 +177,9 @@ class Rack::TestCase < ActionDispatch::IntegrationTest
     end
   end
 
-  def get(thing, *args)
+  def get(thing, *args, **kwargs)
     if thing.is_a?(Symbol)
-      super("#{self.class.testing}/#{thing}", *args)
+      super("#{self.class.testing}/#{thing}", *args, **kwargs)
     else
       super
     end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -362,13 +362,12 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
   private
     # Overwrite get to send SessionSecret in env hash
-    def get(path, *args)
-      args[0] ||= {}
-      args[0][:env] ||= {}
-      args[0][:env]["action_dispatch.key_generator"] ||= Generator
-      args[0][:env]["action_dispatch.cookies_rotations"] = Rotations
-      args[0][:env]["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
-      super(path, *args)
+    def get(path, **options)
+      options[:env] ||= {}
+      options[:env]["action_dispatch.key_generator"] ||= Generator
+      options[:env]["action_dispatch.cookies_rotations"] = Rotations
+      options[:env]["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
+      super(path, **options)
     end
 
     def with_test_route_set

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -899,7 +899,7 @@ class CookiesTest < ActionController::TestCase
 
     key_generator = @request.env["action_dispatch.key_generator"]
     old_secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
-    old_value = ActiveSupport::MessageVerifier.new(old_secret).generate(bar: "baz")
+    old_value = ActiveSupport::MessageVerifier.new(old_secret).generate({ bar: "baz" })
 
     @request.headers["Cookie"] = "foo=#{old_value}"
     get :get_signed_cookie

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -123,7 +123,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       encryptor = ActiveSupport::MessageEncryptor.new("A" * 32, cipher: "aes-256-gcm", serializer: Marshal)
 
-      cookies[SessionKey] = encryptor.encrypt_and_sign("foo" => "bar", "session_id" => "abc")
+      cookies[SessionKey] = encryptor.encrypt_and_sign({ "foo" => "bar", "session_id" => "abc" })
 
       get "/get_session_value"
 
@@ -380,10 +380,9 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
 
   private
     # Overwrite get to send SessionSecret in env hash
-    def get(path, *args)
-      args[0] ||= {}
-      args[0][:headers] ||= {}
-      args[0][:headers].tap do |config|
+    def get(path, **options)
+      options[:headers] ||= {}
+      options[:headers].tap do |config|
         config["action_dispatch.secret_key_base"] = SessionSecret
         config["action_dispatch.authenticated_encrypted_cookie_salt"] = SessionSalt
         config["action_dispatch.use_authenticated_cookie_encryption"] = true
@@ -392,7 +391,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
         config["action_dispatch.cookies_rotations"] ||= Rotations
       end
 
-      super(path, *args)
+      super
     end
 
     def with_test_route_set(options = {})

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -9,7 +9,7 @@ class SSLTest < ActionDispatch::IntegrationTest
 
   def build_app(headers: {}, ssl_options: {})
     headers = HEADERS.merge(headers)
-    ActionDispatch::SSL.new lambda { |env| [200, headers, []] }, ssl_options.reverse_merge(hsts: { subdomains: true })
+    ActionDispatch::SSL.new lambda { |env| [200, headers, []] }, **ssl_options.reverse_merge(hsts: { subdomains: true })
   end
 end
 

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -95,7 +95,7 @@ module ActionView
             end
           rescue ActionView::MissingTemplate
             all_details = @details.merge(formats: @lookup_context.default_formats)
-            raise unless template_exists?(layout, nil, false, [], all_details)
+            raise unless template_exists?(layout, nil, false, [], **all_details)
           end
         when Proc
           resolve_layout(layout.call(@lookup_context, formats), keys, formats)


### PR DESCRIPTION
There are a few left that I couldn't figure out:

```
rails/actionpack/lib/action_dispatch/middleware/cookies.rb:574: warning: The last argument is used as the keyword parameter
rails/actionpack/lib/action_dispatch/middleware/cookies.rb:574: warning: for method defined here; maybe ** should be added to the call?
rails/actionpack/lib/action_dispatch/middleware/cookies.rb:574: warning: The last argument is used as the keyword parameter
rails/actionpack/lib/action_dispatch/middleware/cookies.rb:574: warning: for method defined here; maybe ** should be added to the call?
rails/actionview/lib/action_view/renderer/abstract_renderer.rb:20: warning: The last argument is used as the keyword parameter
rails/actionview/lib/action_view/lookup_context.rb:142: warning: for `template_exists?' defined here; maybe ** should be added to the call?
rails/actionview/lib/action_view/renderer/abstract_renderer.rb:20: warning: The last argument is used as the keyword parameter
rails/actionview/lib/action_view/lookup_context.rb:142: warning: for `template_exists?' defined here; maybe ** should be added to the call?
```

cc @rafaelfranca @Edouard-chin @kamipo 