### PR TITLE
Use the 'What is FRAMEWORK?' title for all framework guides [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -15,8 +15,8 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+What is Action Cable?
+---------------------
 
 Action Cable seamlessly integrates
 [WebSockets](https://en.wikipedia.org/wiki/WebSocket) with the rest of your
@@ -57,8 +57,8 @@ As you can see, this is a fairly deep architectural stack. There's a lot of new
 terminology to identify the new pieces, and on top of that, you're dealing
 with both client and server side reflections of each unit.
 
-What is Pub/Sub
----------------
+What is Pub/Sub?
+----------------
 
 [Pub/Sub](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern), or
 Publish-Subscribe, refers to a message queue paradigm whereby senders of

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -15,8 +15,8 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+What is Action Mailbox?
+-----------------------
 
 Action Mailbox routes incoming emails to controller-like mailboxes for
 processing in Rails. It ships with ingresses for Mailgun, Mandrill, Postmark,

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -16,8 +16,8 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+What is Action Mailer?
+----------------------
 
 Action Mailer allows you to send emails from your application using mailer classes
 and views.

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -14,8 +14,8 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+What is Action Text?
+--------------------
 
 Action Text brings rich text content and editing to Rails. It includes
 the [Trix editor](https://trix-editor.org) that handles everything from formatting

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -16,8 +16,8 @@ After reading this guide, you will know:
 --------------------------------------------------------------------------------
 
 
-Introduction
-------------
+What is Active Job?
+-------------------
 
 Active Job is a framework for declaring jobs and making them run on a variety
 of queuing backends. These jobs can be everything from regularly scheduled

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -17,8 +17,8 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+What is Active Model?
+---------------------
 
 Active Model is a library containing various modules used in developing
 classes that need some features present on Active Record.


### PR DESCRIPTION
### Summary

Action View, Active Record and Active Storage use the 'What is
FRAMEWORK?' title for the framework introduction. The other frameworks
use 'Introduction'. The 'What is' form is more descriptive (and better
for SEO).

This change makes the titles more consistent by using the 'What is
FRAMEWORK?' title for the other frameworks.