### PR TITLE
Remove extra `the` in preloader docs

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -58,7 +58,7 @@ module ActiveRecord
       # == Parameters
       # +records+ is an array of ActiveRecord::Base. This array needs not be flat,
       # i.e. +records+ itself may also contain arrays of records. In any case,
-      # +preload_associations+ will preload the all associations records by
+      # +preload_associations+ will preload all associations records by
       # flattening +records+.
       #
       # +associations+ specifies one or more associations that you want to


### PR DESCRIPTION
### Summary
This is a very minimal contribution that fixes a small error in the docs for the Preloader class.
There was an extra `the` in the docs, it's pretty self-explained in the file changes in this commit.