### PR TITLE
Revert "Fix keyward arguments warning in `MiddlewareStack#build`"

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -34,13 +34,7 @@ module ActionDispatch
       end
 
       def build(app)
-        args = @args.dup
-        options = args.extract_options!
-        if options.empty?
-          klass.new(app, *args, &block)
-        else
-          klass.new(app, *args, **options, &block)
-        end
+        klass.new(app, *args, &block)
       end
 
       def build_instrumented(app)


### PR DESCRIPTION
This reverts commit 6b633a2823feb09f51daac57f410ee559a56195a.

@kamipo This was breaking CI (with I believe a consistent legitimate failure)

```
Failure:
ApplicationTests::ConfigurationTest#test_default_session_store_initializer_sets_session_store_to_cookie_store [test/application/configuration_test.rb:1562]:
--- expected
+++ actual
@@ -1 +1 @@
-{:key=>"_myapp_session", :cookie_only=>true}
+{:key=>"_myapp_session"}
```

I don't think it's safe to `options = args.extract_options!` and assume that the options were intended to be `kwargs`, as `some_method(foo: true)` can be kwargs but `some_method({ foo: true })` can't.

What we probably need to do is accept them and store them separately in the top method the user is calling (here I think `Middleware#use`).
