### PR TITLE
Encode template source before extracting lines

### DIFF
--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -85,7 +85,7 @@ module ActionView
         return [] unless num = line_number
         num = num.to_i
 
-        source_code = @template.source.split("\n")
+        source_code = @template.encode!.split("\n")
 
         start_on_line = [ num - SOURCE_CODE_RADIUS - 1, 0 ].max
         end_on_line   = [ num + SOURCE_CODE_RADIUS - 1, source_code.length].min


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/38056.

Before 2169bd3d2a9d2f331a5dd6e41d9d638e0da6117c, a template's source was encoded in place when it was compiled, and the `source_extract` method could rely on `Template#source` to return a properly encoded string.

Now that `Template#source` always returns a new copy of the template source with no encoding, `source_extract` should call `encode!` itself.