### PR TITLE
Backport #37834 to 6-0-stable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     rails (6.0.2.1)
       actioncable (= 6.0.2.1)
       actionmailbox (= 6.0.2.1)

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -40,6 +40,9 @@ module ActionDispatch
   class IllegalStateError < StandardError
   end
 
+  class MissingController < NameError
+  end
+
   eager_autoload do
     autoload_under "http" do
       autoload :ContentSecurityPolicy

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -98,7 +98,7 @@ module ActionDispatch
 
         def binary_params_for?(controller, action)
           controller_class_for(controller).binary_params_for?(action)
-        rescue NameError
+        rescue MissingController
           false
         end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -85,7 +85,15 @@ module ActionDispatch
       if name
         controller_param = name.underscore
         const_name = "#{controller_param.camelize}Controller"
-        ActiveSupport::Dependencies.constantize(const_name)
+        begin
+          ActiveSupport::Dependencies.constantize(const_name)
+        rescue NameError => error
+          if error.missing_name == const_name || const_name.start_with?("#{error.missing_name}::")
+            raise MissingController.new(error.message, error.name)
+          else
+            raise
+          end
+        end
       else
         PASS_NOT_FOUND
       end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 1.1"
   s.add_dependency "minitest",        "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
-  s.add_dependency "zeitwerk",        "~> 2.2"
+  s.add_dependency "zeitwerk",        "~> 2.2", ">= 2.2.2"
 end


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/38060.

https://github.com/rails/rails/pull/37834 fixes a problem that's new in Rails 6.0, so I think it should be backported as a bug fix.