### PR TITLE
Fixes for isolation tests

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -200,7 +200,7 @@ module ActionDispatch
       end
 
       class Expanded < Base
-        def initialize(width: IO.console_size.second)
+        def initialize(width: IO.console_size[1])
           @width = width
           super()
         end

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/array/access"
 
 module BareMetalTest
   class BareController < ActionController::Metal

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -3,6 +3,9 @@
 require "abstract_unit"
 require "active_support/ordered_options"
 
+require "action_dispatch"
+ActionView::Template::Types.delegate_to Mime
+
 class AssetTagHelperTest < ActionView::TestCase
   tests ActionView::Helpers::AssetTagHelper
 


### PR DESCRIPTION
These seem to have been failing since [#38026 (see comment)](https://github.com/rails/rails/pull/38026#issuecomment-567907402) not due to anything wrong with that change, but just because these tests relied on some behaviour which came from that.

This makes our tests stable when run in isolation by fixing some issues with `Array#second` in actionpack tests and by ensuring mime types from action_dispatch are loaded when testing asset tag helpers.