### PR TITLE
Fix ActionController::TestSession#id to return Rack::Session::SessionId instance

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -176,12 +176,12 @@ module ActionController
 
   # Methods #destroy and #load! are overridden to avoid calling methods on the
   # @store object, which does not exist for the TestSession class.
-  class TestSession < Rack::Session::Abstract::SessionHash #:nodoc:
+  class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash #:nodoc:
     DEFAULT_OPTIONS = Rack::Session::Abstract::Persisted::DEFAULT_OPTIONS
 
     def initialize(session = {})
       super(nil, nil)
-      @id = SecureRandom.hex(16)
+      @id = Rack::Session::SessionId.new(SecureRandom.hex(16))
       @data = stringify_keys(session)
       @loaded = true
     end

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -65,6 +65,6 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
 
   def test_session_id
     session = ActionController::TestSession.new
-    assert_instance_of Rack::Session::SessionId, session.id
+    assert_instance_of String, session.id.public_id
   end
 end

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -62,4 +62,9 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     session = ActionController::TestSession.new(one: "1")
     assert_equal(2, session.fetch("2") { |key| key.to_i })
   end
+
+  def test_session_id
+    session = ActionController::TestSession.new
+    assert_instance_of Rack::Session::SessionId, session.id
+  end
 end

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -66,5 +66,6 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
   def test_session_id
     session = ActionController::TestSession.new
     assert_instance_of String, session.id.public_id
+    assert_equal(session.id.public_id, session["session_id"])
   end
 end


### PR DESCRIPTION
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
When testing with `ActionController::TestCase`, `session.id` returns a string value. With the update to rack v2.0.8, `session.id` now returns an instance of `Rack::Session::SessionId`. Therefore, fix `session.id` to return an instance of `Rack::Session::SessionId` when testing with `ActionController::TestCase`.
