### PR TITLE
Use multiline example blocks for improved readability [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1454,7 +1454,9 @@ This snippet means that when this file is loaded, it will encounter `ActiveRecor
 `ActiveSupport.on_load` is a mechanism that can be used to defer the loading of code until it is actually needed. The snippet above can be changed to:
 
 ```ruby
-ActiveSupport.on_load(:active_record) { include MyActiveRecordHelper }
+ActiveSupport.on_load(:active_record) do
+  include MyActiveRecordHelper
+end
 ```
 
 This new snippet will only include `MyActiveRecordHelper` when `ActiveRecord::Base` is loaded.
@@ -1476,7 +1478,11 @@ ActiveRecord::Base.include(MyActiveRecordHelper)
 becomes
 
 ```ruby
-ActiveSupport.on_load(:active_record) { include MyActiveRecordHelper } # self refers to ActiveRecord::Base here, so we can simply #include
+ActiveSupport.on_load(:active_record) do
+  # self refers to ActiveRecord::Base here,
+  # so we can call .include
+  include MyActiveRecordHelper
+end
 ```
 
 **Modifying calls to `prepend`**
@@ -1488,7 +1494,11 @@ ActionController::Base.prepend(MyActionControllerHelper)
 becomes
 
 ```ruby
-ActiveSupport.on_load(:action_controller_base) { prepend MyActionControllerHelper } # self refers to ActionController::Base here, so we can simply #prepend
+ActiveSupport.on_load(:action_controller_base) do
+  # self refers to ActionController::Base here,
+  # so we can call .prepend
+  prepend MyActionControllerHelper
+end
 ```
 
 **Modifying calls to class methods**
@@ -1500,7 +1510,10 @@ ActiveRecord::Base.include_root_in_json = true
 becomes
 
 ```ruby
-ActiveSupport.on_load(:active_record) { self.include_root_in_json = true } # self refers to ActiveRecord::Base here
+ActiveSupport.on_load(:active_record) do
+  # self refers to ActiveRecord::Base here
+  self.include_root_in_json = true
+end
 ```
 
 ### Available Load Hooks
@@ -1555,7 +1568,9 @@ Configuration hooks can be called in the Engine class.
 ```ruby
 module Blorgh
   class Engine < ::Rails::Engine
-    config.before_configuration { puts 'I am called before any initializers' }
+    config.before_configuration do
+      puts 'I am called before any initializers'
+    end
   end
 end
 ```


### PR DESCRIPTION
### Summary

Some 'ActiveSupport Load Hook' examples use a long one liner with `{}` blocks. Converting them to `do` blocks improves readability.

### Before
<img width="667" alt="image" src="https://user-images.githubusercontent.com/28561/71310058-e0a15400-240f-11ea-8260-172551c0959e.png">
<img width="651" alt="image" src="https://user-images.githubusercontent.com/28561/71310060-ea2abc00-240f-11ea-9128-791994eafaa5.png">
<img width="653" alt="image" src="https://user-images.githubusercontent.com/28561/71310061-f1ea6080-240f-11ea-801c-0d0260f6aaaf.png">
<img width="641" alt="image" src="https://user-images.githubusercontent.com/28561/71310064-fca4f580-240f-11ea-8c3b-cfbe4687a463.png">

### After

<img width="648" alt="image" src="https://user-images.githubusercontent.com/28561/71310069-075f8a80-2410-11ea-88a6-33a6d9b19dbb.png">
<img width="644" alt="image" src="https://user-images.githubusercontent.com/28561/71310072-10e8f280-2410-11ea-84dc-ca314839171a.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/28561/71310074-19d9c400-2410-11ea-889b-66aec5a888e8.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/28561/71310076-2231ff00-2410-11ea-8f63-3ccf8fdffacd.png">
