### PR TITLE
Backport #36521 and #36532 to 6-0-stable

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   annotated_source_code returns an empty array so TemplateErrors without a
+    template in the backtrace are surfaced properly by DebugExceptions.
+
+    *Guilherme Mansur*, *Kasper Timm Hansen*
+
 *   Add autoload for SyntaxErrorInTemplate so syntax errors are correctly raised by DebugExceptions.
 
     *Guilherme Mansur*, *Gannon McGibbon*

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add autoload for SyntaxErrorInTemplate so syntax errors are correctly raised by DebugExceptions.
+
+    *Guilherme Mansur*, *Gannon McGibbon*
+
+
 ## Rails 6.0.2.1 (December 18, 2019) ##
 
 *   No changes.

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -77,6 +77,7 @@ module ActionView
       autoload :ActionViewError
       autoload :EncodingError
       autoload :TemplateError
+      autoload :SyntaxErrorInTemplate
       autoload :WrongEncodingError
     end
   end

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -81,8 +81,8 @@ module ActionView
         end
       end
 
-      def source_extract(indentation = 0, output = :console)
-        return unless num = line_number
+      def source_extract(indentation = 0)
+        return [] unless num = line_number
         num = num.to_i
 
         source_code = @template.source.split("\n")
@@ -91,9 +91,9 @@ module ActionView
         end_on_line   = [ num + SOURCE_CODE_RADIUS - 1, source_code.length].min
 
         indent = end_on_line.to_s.size + indentation
-        return unless source_code = source_code[start_on_line..end_on_line]
+        return [] unless source_code = source_code[start_on_line..end_on_line]
 
-        formatted_code_for(source_code, start_on_line, indent, output)
+        formatted_code_for(source_code, start_on_line, indent)
       end
 
       def sub_template_of(template_path)
@@ -122,15 +122,11 @@ module ActionView
           end + file_name
         end
 
-        def formatted_code_for(source_code, line_counter, indent, output)
-          start_value = (output == :html) ? {} : []
-          source_code.inject(start_value) do |result, line|
+        def formatted_code_for(source_code, line_counter, indent)
+          indent_template = "%#{indent}s: %s"
+          source_code.map do |line|
             line_counter += 1
-            if output == :html
-              result.update(line_counter.to_s => "%#{indent}s %s\n" % ["", line])
-            else
-              result << "%#{indent}s: %s" % [line_counter, line]
-            end
+            indent_template % [line_counter, line]
           end
         end
     end

--- a/actionview/test/template/template_error_test.rb
+++ b/actionview/test/template/template_error_test.rb
@@ -34,4 +34,20 @@ class TemplateErrorTest < ActiveSupport::TestCase
 
     assert_equal "#<ActionView::Template::Error: original>", error.inspect
   end
+
+  def test_annotated_source_code_returns_empty_array_if_source_cant_be_found
+    template = Class.new do
+      def identifier
+        "something"
+      end
+    end.new
+
+    error = begin
+      raise
+    rescue
+      raise ActionView::Template::Error.new(template) rescue $!
+    end
+
+    assert_equal [], error.annotated_source_code
+  end
 end


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/37512.

https://github.com/rails/rails/pull/36521 and https://github.com/rails/rails/pull/36532 both fix regressions in 6.0 (via https://github.com/rails/rails/pull/35308), so I think they should be backported.