### PR TITLE
Fix #38041 (Rounding issue using BigDecimal/DateTime)

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -110,7 +110,7 @@ class DateTime
   # instance time. Do not use this method in combination with x.months, use
   # months_since instead!
   def since(seconds)
-    self + Rational(seconds, 86400)
+    self + Rational(Rational(seconds), 86400)
   end
   alias :in :since
 

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -430,4 +430,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 0, DateTime.civil(2000).subsec
     assert_equal Rational(1, 2), DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 2)).subsec
   end
+
+  def test_compute_with_decimal_durations
+    assert_equal DateTime.civil(2019, 12, 19, 9), DateTime.civil(2019, 12, 19, 10) - BigDecimal(1).hour
+    assert_equal DateTime.civil(2019, 12, 19, 11), DateTime.civil(2019, 12, 19, 10) + BigDecimal(1).hour
+  end
 end


### PR DESCRIPTION
We should rationalize the numerator alone before we rationalize the whole value.

```
irb(2019-12-19T10:00:00+00:00):005:0> Rational(BigDecimal(1) * 3600, 3600)
=> 0.1e1
irb(2019-12-19T10:00:00+00:00):006:0> Rational(Rational(BigDecimal(1) * 3600), 3600)
=> (1/1)
```


This fixes #38041
