### PR TITLE
Improve escape_javascript performance.

### DIFF
--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -29,7 +29,7 @@ module ActionView
         if javascript.empty?
           result = ""
         else
-          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) { |match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u, JS_ESCAPE_MAP)
         end
         javascript.html_safe? ? result.html_safe : result
       end


### PR DESCRIPTION
### Summary

#34405 introduced a performance regression when calling `escape_javascript` (see #38071). This is a simple work-around to avoid the [`gsub` with block](https://github.com/rails/rails/blob/49d1b5a98dc50ca59bbfb817f90eb5c2c2645d30/activesupport/lib/active_support/core_ext/string/output_safety.rb#L267-L276) monkey patch.

Not sure if it's important that `escape_javascript` follow that same code path.

Thanks!

Before

<img width="1157" alt="before" src="https://user-images.githubusercontent.com/133809/71328394-f5b4da80-2516-11ea-8b9b-bc2d6ff33b05.png">

After

<img width="1215" alt="after" src="https://user-images.githubusercontent.com/133809/71328395-ffd6d900-2516-11ea-9163-0659f3f270a2.png">

