### PR TITLE
Fix title capitalization in guides according to guidelines [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1212,7 +1212,7 @@ Imagine you have a server which mirrors the production environment but is only u
 That environment is no different than the default ones, start a server with `rails server -e staging`, a console with `rails console -e staging`, `Rails.env.staging?` works, etc.
 
 
-### Deploy to a subdirectory (relative URL root)
+### Deploy to a Subdirectory (relative URL root)
 
 By default Rails expects that your application is running at the root
 (e.g. `/`). This section explains how to run your application inside a directory.

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -356,7 +356,7 @@ $ bundle exec ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_lay
 
 The `-n` option allows you to run a single method instead of the whole file.
 
-#### Running tests with a specific seed
+#### Running Tests with a Specific Seed
 
 Test execution is randomized with a randomization seed. If you are experiencing random
 test failures you can more accurately reproduce a failing test scenario by specifically
@@ -609,7 +609,7 @@ the same way that you appreciate feedback on your patches.
 
 It's entirely possible that the feedback you get will suggest changes. Don't get discouraged: the whole point of contributing to an active open source project is to tap into the knowledge of the community. If people are encouraging you to tweak your code, then it's worth making the tweaks and resubmitting. If the feedback is that your code doesn't belong in the core, you might still think about releasing it as a gem.
 
-#### Squashing commits
+#### Squashing Commits
 
 One of the things that we may ask you to do is to "squash your commits", which
 will combine all of your commits into a single commit. We prefer pull requests
@@ -632,7 +632,7 @@ $ git push fork my_new_branch --force-with-lease
 You should be able to refresh the pull request on GitHub and see that it has
 been updated.
 
-#### Updating a pull request
+#### Updating a Pull Request
 
 Sometimes you will be asked to make some changes to the code you have
 already committed. This can include amending existing commits. In this

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -956,7 +956,7 @@ For further information on how to install Valgrind and use with Ruby, refer to
 [Valgrind and Ruby](https://blog.evanweaver.com/2008/02/05/valgrind-and-ruby/)
 by Evan Weaver.
 
-### Find a memory leak
+### Find a Memory Leak
 There is an excellent article about detecting and fixing memory leaks at Derailed, [which you can read here](https://github.com/schneems/derailed_benchmarks#is-my-app-leaking-memory).
 
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -18,7 +18,7 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-What are engines?
+What are Engines?
 -----------------
 
 Engines can be considered miniature applications that provide functionality to
@@ -69,7 +69,7 @@ Finally, engines would not have been possible without the work of James Adam,
 Piotr Sarnacki, the Rails Core Team, and a number of other people. If you ever
 meet them, don't forget to say thanks!
 
-Generating an engine
+Generating an Engine
 --------------------
 
 To generate an engine, you will need to run the plugin generator and pass it
@@ -328,7 +328,7 @@ integration tests for the engine should be placed. Other directories can be
 created in the `test` directory as well. For example, you may wish to create a
 `test/models` directory for your model tests.
 
-Providing engine functionality
+Providing Engine Functionality
 ------------------------------
 
 The engine that this guide covers provides submitting articles and commenting
@@ -707,7 +707,7 @@ you specify custom helpers (such as `devise_for`) in the routes. These helpers
 do exactly the same thing, mounting pieces of the engines's functionality at a
 pre-defined path which may be customizable.
 
-### Engine setup
+### Engine Setup
 
 The engine contains migrations for the `blorgh_articles` and `blorgh_comments`
 table which need to be created in the application's database so that the
@@ -1031,7 +1031,7 @@ application. The same thing goes if you want to use a standard initializer.
 For locales, simply place the locale files in the `config/locales` directory,
 just like you would in an application.
 
-Testing an engine
+Testing an Engine
 -----------------
 
 When an engine is generated, there is a smaller dummy application created inside
@@ -1094,7 +1094,7 @@ there, rather than the application's one.
 This also ensures that the engine's URL helpers will work as expected in your
 tests.
 
-Improving engine functionality
+Improving Engine Functionality
 ------------------------------
 
 This section explains how to add and/or override engine MVC functionality in the

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -389,7 +389,7 @@ create and read. The form for doing this will look like this:
 It will look a little basic for now, but that's ok. We'll look at improving the
 styling for it afterwards.
 
-### Laying down the groundwork
+### Laying down the Groundwork
 
 Firstly, you need a place within the application to create a new article. A
 great place for that would be at `/articles/new`. With the route already
@@ -591,7 +591,7 @@ NOTE: By default `form_with` submits forms using Ajax thereby skipping full page
 redirects. To make this guide easier to get into we've disabled that with
 `local: true` for now.
 
-### Creating articles
+### Creating Articles
 
 To make the "Unknown action" go away, you can define a `create` action within
 the `ArticlesController` class in `app/controllers/articles_controller.rb`,
@@ -643,7 +643,7 @@ This action is now displaying the parameters for the article that are coming in
 from the form. However, this isn't really all that helpful. Yes, you can see the
 parameters but nothing in particular is being done with them.
 
-### Creating the Article model
+### Creating the Article Model
 
 Models in Rails use a singular name, and their corresponding database tables
 use a plural name. Rails provides a generator for creating models, which most
@@ -725,7 +725,7 @@ command will apply to the database defined in the `development` section of your
 environment, for instance in production, you must explicitly pass it when
 invoking the command: `rails db:migrate RAILS_ENV=production`.
 
-### Saving data in the controller
+### Saving Data in the Controller
 
 Back in `ArticlesController`, we need to change the `create` action
 to use the new `Article` model to save the data in the database.
@@ -870,7 +870,7 @@ Visit <http://localhost:3000/articles/new> and give it a try!
 
 ![Show action for articles](images/getting_started/show_action_for_articles.png)
 
-### Listing all articles
+### Listing all Articles
 
 We still need a way to list all our articles, so let's do that.
 The route for this as per output of `rails routes` is:
@@ -926,7 +926,7 @@ And then finally, add the view for this action, located at
 Now if you go to <http://localhost:3000/articles> you will see a list of all the
 articles that you have created.
 
-### Adding links
+### Adding Links
 
 You can now create, show, and list articles. Now let's add some links to
 navigate through pages.

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -537,7 +537,7 @@ So that would give you:
 
 TIP: Right now you might need to add some more date/time formats in order to make the I18n backend work as expected (at least for the 'pirate' locale). Of course, there's a great chance that somebody already did all the work by **translating Rails' defaults for your locale**. See the [rails-i18n repository at GitHub](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) for an archive of various locale files. When you put such file(s) in `config/locales/` directory, they will automatically be ready for use.
 
-### Inflection Rules For Other Locales
+### Inflection Rules for Other Locales
 
 Rails allows you to define inflection rules (such as rules for singularization and pluralization) for locales other than English. In `config/initializers/inflections.rb`, you can define these rules for multiple locales. The initializer contains a default example for specifying additional rules for English; follow that format for other locales as you see fit.
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -405,7 +405,7 @@ The comments resource here will have the following routes generated for it:
 | PATCH/PUT | /comments/:id(.:format)                      | comments#update   | sekret_comment_path         |
 | DELETE    | /comments/:id(.:format)                      | comments#destroy  | sekret_comment_path         |
 
-### Routing concerns
+### Routing Concerns
 
 Routing concerns allow you to declare common routes that can be reused inside other resources and routes. To define a concern:
 
@@ -448,7 +448,7 @@ namespace :articles do
 end
 ```
 
-### Creating Paths and URLs From Objects
+### Creating Paths and URLs from Objects
 
 In addition to using the routing helpers, Rails can also create paths and URLs from an array of parameters. For example, suppose you have this set of routes:
 
@@ -868,7 +868,7 @@ end
 root to: "home#index"
 ```
 
-### Unicode character routes
+### Unicode Character Routes
 
 You can specify unicode character routes directly. For example:
 
@@ -876,7 +876,7 @@ You can specify unicode character routes directly. For example:
 get 'こんにちは', to: 'welcome#index'
 ```
 
-### Direct routes
+### Direct Routes
 
 You can create custom URL helpers directly. For example:
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1171,7 +1171,7 @@ Environmental Security
 
 It is beyond the scope of this guide to inform you on how to secure your application code and environments. However, please secure your database configuration, e.g. `config/database.yml`, master key for `credentials.yml`, and other unencrypted secrets. You may want to further restrict access, using environment-specific versions of these files and any others that may contain sensitive information.
 
-### Custom credentials
+### Custom Credentials
 
 Rails stores secrets in `config/credentials.yml.enc`, which is encrypted and hence cannot be edited directly. Rails uses `config/master.key` or alternatively looks for environment variable `ENV["RAILS_MASTER_KEY"]` to encrypt the credentials file. The credentials file can be stored in version control, as long as master key is kept safe.
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -224,7 +224,7 @@ we ensured that our test passes. This approach to software development is
 referred to as
 [_Test-Driven Development_ (TDD)](http://c2.com/cgi/wiki?TestDrivenDevelopment).
 
-#### What an error looks like
+#### What an Error Looks Like
 
 To see how an error gets reported, here's a test containing an error:
 
@@ -470,7 +470,7 @@ Parallel testing allows you to parallelize your test suite. While forking proces
 default method, threading is supported as well. Running tests in parallel reduces the time it
 takes your entire test suite to run.
 
-### Parallel testing with processes
+### Parallel Testing with Processes
 
 The default parallelization method is to fork processes using Ruby's DRb system. The processes
 are forked based on the number of workers provided. The default number is the actual core count
@@ -522,7 +522,7 @@ end
 
 These methods are not needed or available when using parallel testing with threads.
 
-### Parallel testing with threads
+### Parallel Testing with Threads
 
 If you prefer using threads or are using JRuby, a threaded parallelization option is provided. The threaded
 parallelizer is backed by Minitest's `Parallel::Executor`.
@@ -574,7 +574,7 @@ For good tests, you'll need to give some thought to setting up test data.
 In Rails, you can handle this by defining and customizing fixtures.
 You can find comprehensive documentation in the [Fixtures API documentation](https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html).
 
-#### What Are Fixtures?
+#### What are Fixtures?
 
 _Fixtures_ is a fancy word for sample data. Fixtures allow you to populate your testing database with predefined data before your tests run. Fixtures are database independent and written in YAML. There is one file per model.
 
@@ -787,7 +787,7 @@ Rails.
 The `take_screenshot` helper method can be included anywhere in your tests to
 take a screenshot of the browser.
 
-### Implementing a system test
+### Implementing a System Test
 
 Now we're going to add a system test to our blog application. We'll demonstrate
 writing a system test by visiting the index page and creating a new blog article.
@@ -832,7 +832,7 @@ rails test:system
 NOTE: By default, running `rails test` won't run your system tests.
 Make sure to run `rails test:system` to actually run them.
 
-#### Creating articles system test
+#### Creating Articles System Test
 
 Now let's test the flow for creating a new article in our blog.
 
@@ -1710,7 +1710,7 @@ your jobs are performed inline. It will also ensure that all previously performe
 and enqueued jobs are cleared before any test run so you can safely assume that
 no jobs have already been executed in the scope of each test.
 
-### Custom Assertions And Testing Jobs Inside Other Components
+### Custom Assertions and Testing Jobs inside Other Components
 
 Active Job ships with a bunch of custom assertions that can be used to lessen the verbosity of tests. For a full list of available assertions, see the API documentation for [`ActiveJob::TestHelper`](https://api.rubyonrails.org/classes/ActiveJob/TestHelper.html).
 

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -142,7 +142,7 @@ follow this pattern.
 Built-in Helpers
 ----------------
 
-### Remote elements
+### Remote Elements
 
 Rails provides a bunch of view helper methods written in Ruby to assist you
 in generating HTML. Sometimes, you want to add a little Ajax to those elements,
@@ -253,7 +253,7 @@ this generates
 
 Since it's just a `<form>`, all of the information on `form_with` also applies.
 
-### Customize remote elements
+### Customize Remote Elements
 
 It is possible to customize the behavior of elements with a `data-remote`
 attribute without writing a line of JavaScript. You can specify extra `data-`


### PR DESCRIPTION
### Summary
According to the guide guidelines, all words except for prepositions,
conjunctions, internal articles, and forms of the verb "to be" should be
capitalized. This commit fixes some titles.