### PR TITLE
Fix keyward arguments warning in `MiddlewareStack#build`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -8,10 +8,11 @@ module ActionDispatch
     class Middleware
       attr_reader :args, :block, :klass
 
-      def initialize(klass, args, block)
+      def initialize(klass, args, block, &build_block)
         @klass = klass
         @args  = args
         @block = block
+        @build_block = build_block
       end
 
       def name; klass.name; end
@@ -34,7 +35,7 @@ module ActionDispatch
       end
 
       def build(app)
-        klass.new(app, *args, &block)
+        @build_block&.call(app) || klass.new(app, *args, &block)
       end
 
       def build_instrumented(app)
@@ -119,8 +120,13 @@ module ActionDispatch
     end
 
     def use(klass, *args, &block)
-      middlewares.push(build_middleware(klass, args, block))
+      middlewares.push(
+        build_middleware(klass, args, block) do |app|
+          klass.new(app, *args, &block)
+        end
+      )
     end
+    ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)
@@ -140,8 +146,8 @@ module ActionDispatch
         i
       end
 
-      def build_middleware(klass, args, block)
-        Middleware.new(klass, args, block)
+      def build_middleware(klass, args, block, &build_block)
+        Middleware.new(klass, args, block, &build_block)
       end
   end
 end


### PR DESCRIPTION
This is an alternative of 6b633a2823feb09f51daac57f410ee559a56195a.

`ActionDispatch::Static` middleware requires to be passed `**kwargs`.

https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/railties/lib/rails/application/default_middleware_stack.rb#L27
https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/actionpack/lib/action_dispatch/middleware/static.rb#L112-L116

But `ActionDispatch::Session::CookieStore` middleware requires to be
passed actual `session_options` to `options.merge!(cookie_only: true)`
destructively.

(Ideally passed args should not be mutated, but for now the middleware
intentionally murate the args and testing that.)

https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/railties/lib/rails/application/default_middleware_stack.rb#L65
https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb#L59-L61
https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/railties/test/application/configuration_test.rb#L1557-L1563
https://github.com/rails/rails/blob/0b3c710d35199d187dbfddaefbb9ab2752ea6498/railties/test/application/middleware/session_test.rb#L337-L341

To address both case, we need to evaluate args for building app in the
`use` method context (that method args in the context have last args
whether kwargs or hash).
