### PR TITLE
Use the single line editor in console test

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -137,14 +137,16 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   end
 
   def test_sandbox
-    spawn_console("--sandbox")
+    options = "--sandbox"
+    options += " -- --singleline --nocolorize" if RUBY_VERSION >= "2.7"
+    spawn_console(options)
 
     write_prompt "Post.count", "=> 0"
     write_prompt "Post.create"
     write_prompt "Post.count", "=> 1"
     @primary.puts "quit"
 
-    spawn_console("--sandbox")
+    spawn_console(options)
 
     write_prompt "Post.count", "=> 0"
     write_prompt "Post.transaction { Post.create; raise }"
@@ -164,7 +166,9 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   end
 
   def test_environment_option_and_irb_option
-    spawn_console("-e test -- --verbose")
+    options = "-e test -- --verbose"
+    options += " --singleline --nocolorize" if RUBY_VERSION >= "2.7"
+    spawn_console(options)
 
     write_prompt "a = 1", "a = 1"
     write_prompt "puts Rails.env", "puts Rails.env\r\ntest"

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -34,7 +34,9 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
     skip "PTY unavailable" unless available_pty?
 
     primary, replica = PTY.open
-    spawn_command("console", replica)
+    cmd = "console"
+    cmd += " --singleline" if RUBY_VERSION >= "2.7"
+    spawn_command(cmd, replica)
     assert_output(">", primary)
   ensure
     primary.puts "quit"


### PR DESCRIPTION
It's a bit difficult to deal properly with IRB's multi line and color, and I think we don't need to check it out in `rails console` tests.

