### PR TITLE
Reset the values of virtual columns when making a dup of a record

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -389,7 +389,8 @@ module ActiveRecord
     # :method: dup
     # Duped objects have no id assigned and are treated as new records. Note
     # that this is a "shallow" copy as it copies the object's attributes
-    # only, not its associations. The extent of a "deep" copy is application
+    # only, not its associations. Furthermore the attributes of the virtual columns
+    # are not copied over. The extent of a "deep" copy is application
     # specific and is therefore left to the application to implement according
     # to its need.
     # The dup method does not preserve the timestamps (created|updated)_(at|on).

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -399,6 +399,12 @@ module ActiveRecord
       @attributes = @attributes.deep_dup
       @attributes.reset(@primary_key)
 
+      if self.class.connection.supports_virtual_columns?
+        self.class.columns.select(&:virtual?).each do |column|
+          @attributes.reset(column.name)
+        end
+      end
+
       _run_initialize_callbacks
 
       @new_record               = true

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -20,7 +20,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
         t.virtual :name_length, type: :integer, as: "LENGTH(`name`)", stored: true
         t.virtual :name_octet_length, type: :integer, as: "OCTET_LENGTH(`name`)", stored: true
       end
-      VirtualColumn.create(name: "Rails")
+      @record = VirtualColumn.create(name: "Rails")
     end
 
     def teardown
@@ -58,6 +58,15 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
+    end
+
+    def test_record_dup_with_virtual_column
+      clone = @record.dup
+
+      assert_nil clone.upper_name
+      assert_nil clone.name_length
+      assert_nil clone.name_octet_length
+      assert clone.save
     end
   end
 end


### PR DESCRIPTION
This change makes sense for adapters which support "virtual" columns. That means
it only applies to MySQL adapter at the moment.

### Summary

Currently on MySQL if virtual column has a value, when we dup the corresponding record the value is not reset. That will cause an error to be raised when we try to save the clone.
In my PR there's a test example that demonstrates that.

I'm not familiar with the codebase good enough to judge if `ActiveRecord::Core#initialize_dup` is the right place to put such change. If it's not, then this PR might serve as a bug report.