### PR TITLE
Allow AR::Enum definitions with boolean values

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -123,12 +123,12 @@ module ActiveRecord
       end
 
       def cast(value)
-        return if value.blank?
-
         if mapping.has_key?(value)
           value.to_s
         elsif mapping.has_value?(value)
           mapping.key(value)
+        elsif value.blank?
+          nil
         else
           assert_valid_value(value)
         end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -231,6 +231,11 @@ class EnumTest < ActiveRecord::TestCase
     assert_nil @book.status
   end
 
+  test "assign nil value to enum which defines nil value to hash" do
+    @book.read_status = nil
+    assert_equal "forgotten", @book.read_status
+  end
+
   test "assign empty string value" do
     @book.status = ""
     assert_nil @book.status

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -236,6 +236,16 @@ class EnumTest < ActiveRecord::TestCase
     assert_nil @book.status
   end
 
+  test "assign false value to a field defined as not boolean" do
+    @book.status = false
+    assert_nil @book.status
+  end
+
+  test "assign false value to a field defined as boolean" do
+    @book.boolean_status = false
+    assert_equal "disabled", @book.boolean_status
+  end
+
   test "assign long empty string value" do
     @book.status = "   "
     assert_nil @book.status

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -10,6 +10,7 @@ awdr:
   illustrator_visibility: :visible
   font_size: :medium
   difficulty: :medium
+  boolean_status: :enabled
 
 rfr:
   author_id: 1

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -18,6 +18,7 @@ class Book < ActiveRecord::Base
   enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
   enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
+  enum boolean_status: { enabled: true, disabled: false }
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -117,6 +117,7 @@ ActiveRecord::Schema.define do
     t.column :cover, :string, default: "hard"
     t.string :isbn, **case_sensitive_options
     t.datetime :published_on
+    t.boolean :boolean_status
     t.index [:author_id, :name], unique: true
     t.index :isbn, where: "published_on IS NOT NULL", unique: true
   end


### PR DESCRIPTION
### Summary

If `AR::Enum` is used for boolean field, it would be not expected behavior for us.

fixes #38075

### Problem

In case of using boolean for enum, we can set with string (hash key)
to instance, but we cannot set with actual value (hash value).

```ruby
class Post < ActiveRecord::Base
  enum status: { enabled: true, disabled: false }
end

post.status = 'enabled'
post.status # 'enabled'

post.status = true
post.status # 'enabled'

post.status = 'disabled'
post.status # 'disabled'

post.status = false
post.status # nil (This is not expected behavior)
```

After looking into `AR::Enum::EnumType#cast`, I found that `blank?` method converts from false value to nil (it seems it may not intentional behavior).

https://github.com/rails/rails/blob/1421ad5c81910026ae54477fe244a40ed666122d/activerecord/lib/active_record/enum.rb#L125-L135

In this patch, I improved that if it defines enum with boolean, it returns reasonable behavior.

### Importance (Why it would be better to merge this patch)

- I am working on a legacy project that has enums with booleans as their values.
- The project's team had never noticed this behavior before because they had been assigning values using the enum key strings, i.e. `post.status = 'disabled'`.
- I stumbled upon this behavior when I wrote a test that called `post.disabled!`.
- The assertion at [assert_valid_enum_definition_values](https://github.com/rails/rails/blob/f4fbdb1b4ed47a45f8c1c63756af0b6f6873196b/activerecord/lib/active_record/enum.rb#L162) permits boolean-valued hashes, which tells me that this is a feature that we may want to support, so I made these changes to reflect that.

*^ This messages are translated by my co-worker @rastamhadi*