### PR TITLE
Fix Ruby 2.7 warnings on `MiddlewareStackProxy`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -90,8 +90,13 @@ module ActionDispatch
     end
 
     def unshift(klass, *args, &block)
-      middlewares.unshift(build_middleware(klass, args, block))
+      middlewares.unshift(
+        build_middleware(klass, args, block) do |app|
+          klass.new(app, *args, &block)
+        end
+      )
     end
+    ruby2_keywords(:unshift) if respond_to?(:ruby2_keywords, true)
 
     def initialize_copy(other)
       self.middlewares = other.middlewares.dup
@@ -99,8 +104,14 @@ module ActionDispatch
 
     def insert(index, klass, *args, &block)
       index = assert_index(index, :before)
-      middlewares.insert(index, build_middleware(klass, args, block))
+      middlewares.insert(
+        index,
+        build_middleware(klass, args, block) do |app|
+          klass.new(app, *args, &block)
+        end
+      )
     end
+    ruby2_keywords(:insert) if respond_to?(:ruby2_keywords, true)
 
     alias_method :insert_before, :insert
 
@@ -108,12 +119,14 @@ module ActionDispatch
       index = assert_index(index, :after)
       insert(index + 1, *args, &block)
     end
+    ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
 
     def swap(target, *args, &block)
       index = assert_index(target, :before)
       insert(index, *args, &block)
       middlewares.delete_at(index + 1)
     end
+    ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)
 
     def delete(target)
       middlewares.delete_if { |m| m.klass == target }

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -41,34 +41,39 @@ module Rails
       end
 
       def insert_before(*args, &block)
-        @operations << [__method__, args, block]
+        @operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
+      ruby2_keywords(:insert_before) if respond_to?(:ruby2_keywords, true)
 
       alias :insert :insert_before
 
       def insert_after(*args, &block)
-        @operations << [__method__, args, block]
+        @operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
+      ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
 
       def swap(*args, &block)
-        @operations << [__method__, args, block]
+        @operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
+      ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)
 
       def use(*args, &block)
-        @operations << [__method__, args, block]
+        @operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
+      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
       def delete(*args, &block)
-        @delete_operations << [__method__, args, block]
+        @delete_operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
 
       def unshift(*args, &block)
-        @operations << [__method__, args, block]
+        @operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
+      ruby2_keywords(:unshift) if respond_to?(:ruby2_keywords, true)
 
       def merge_into(other) #:nodoc:
-        (@operations + @delete_operations).each do |operation, args, block|
-          other.send(operation, *args, &block)
+        (@operations + @delete_operations).each do |operation|
+          operation.call(other)
         end
 
         other

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -16,13 +16,13 @@ module ApplicationTests
         list_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
         File.write("log/test.log", "zomg!")
 
-        assert_match "[]", list_tables.call
+        assert_equal "[]", list_tables.call
         assert_equal 5, File.size("log/test.log")
         assert_not File.exist?("tmp/restart.txt")
 
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/test.log")
-        assert_match '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
+        assert_equal '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end
@@ -44,17 +44,18 @@ module ApplicationTests
         # Ignore warnings such as `Psych.safe_load is deprecated`
         output.gsub!(/^warning:\s.*\n/, "")
 
-        assert_match(<<~OUTPUT, output)
+        assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==
           The Gemfile's dependencies are satisfied
 
           == Preparing database ==
-        OUTPUT
+          Created database 'app_development'
+          Created database 'app_test'
 
-        assert_match("Created database 'app_development'", output)
-        assert_match("Created database 'app_test'", output)
-        assert_match("== Removing old logs and tempfiles ==", output)
-        assert_match("== Restarting application server ==", output)
+          == Removing old logs and tempfiles ==
+
+          == Restarting application server ==
+        OUTPUT
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2441,7 +2441,7 @@ module ApplicationTests
       RUBY
 
       output = rails("routes", "-g", "active_storage")
-      assert_match <<~MESSAGE, output
+      assert_equal <<~MESSAGE, output
                            Prefix Verb URI Pattern                                                               Controller#Action
                rails_service_blob GET  /files/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
         rails_blob_representation GET  /files/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -420,8 +420,8 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
 
-        assert_match "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
-        assert_match "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
+        assert_equal "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
+        assert_equal "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
       end
 
       test "db:structure:dump does not dump schema information when no migrations are used" do
@@ -445,16 +445,16 @@ module ApplicationTests
 
         list_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
 
-        assert_match '["posts"]', list_tables[].to_s
+        assert_equal '["posts"]', list_tables[]
         rails "db:schema:load"
-        assert_match '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[].to_s
+        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[]
 
         app_file "db/structure.sql", <<-SQL
           CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
         SQL
 
         rails "db:structure:load"
-        assert_match '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[].to_s
+        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[]
       end
 
       test "db:schema:load with inflections" do
@@ -480,7 +480,7 @@ module ApplicationTests
         assert_match(/"geese"/, tables)
 
         columns = rails("runner", "p ActiveRecord::Base.connection.columns('geese').map(&:name)").strip
-        assert_includes columns, '["gooseid", "name"]'
+        assert_equal columns, '["gooseid", "name"]'
       end
 
       test "db:schema:load fails if schema.rb doesn't exist yet" do
@@ -539,8 +539,8 @@ module ApplicationTests
         test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip }
         development_environment = lambda { rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip }
 
-        assert_match "test", test_environment.call
-        assert_match "development", development_environment.call
+        assert_equal "test", test_environment.call
+        assert_equal "development", development_environment.call
 
         app_file "db/structure.sql", ""
         app_file "config/initializers/enable_sql_schema_format.rb", <<-RUBY
@@ -549,8 +549,8 @@ module ApplicationTests
 
         rails "db:setup"
 
-        assert_match "test", test_environment.call
-        assert_match "development", development_environment.call
+        assert_equal "test", test_environment.call
+        assert_equal "development", development_environment.call
       end
 
       test "db:test:prepare sets test ar_internal_metadata" do
@@ -559,7 +559,7 @@ module ApplicationTests
 
         test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip }
 
-        assert_match "test", test_environment.call
+        assert_equal "test", test_environment.call
 
         app_file "db/structure.sql", ""
         app_file "config/initializers/enable_sql_schema_format.rb", <<-RUBY
@@ -568,7 +568,7 @@ module ApplicationTests
 
         rails "db:test:prepare"
 
-        assert_match "test", test_environment.call
+        assert_equal "test", test_environment.call
       end
 
       test "db:seed:replant truncates all non-internal tables and loads the seeds" do

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -179,7 +179,7 @@ module ApplicationTests
 
       test "migration status when schema migrations table is not present" do
         output = rails("db:migrate:status", allow_failure: true)
-        assert_match "Schema migrations table does not exist yet.\n", output
+        assert_equal "Schema migrations table does not exist yet.\n", output
       end
 
       test "migration status" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -107,8 +107,8 @@ module ApplicationTests
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.connection.tables").strip }
 
-          assert_match '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
-          assert_match '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
+          assert_equal '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
+          assert_equal '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
         end
       end
 
@@ -380,7 +380,7 @@ module ApplicationTests
         RUBY
 
         output = rails("db:seed")
-        assert_includes output, "db/development.sqlite3"
+        assert_equal output, "db/development.sqlite3"
       ensure
         ENV["RAILS_ENV"] = @old_rails_env
         ENV["RACK_ENV"] = @old_rack_env

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -39,7 +39,7 @@ module ApplicationTests
 
     def test_should_set_argv_when_running_code
       output = rails("runner", "puts ARGV.join(',')", "--foo", "a1", "-b", "a2", "a3", "--moo")
-      assert_match "--foo,a1,-b,a2,a3,--moo", output.chomp
+      assert_equal "--foo,a1,-b,a2,a3,--moo", output.chomp
     end
 
     def test_should_run_file

--- a/railties/test/commands/notes_test.rb
+++ b/railties/test/commands/notes_test.rb
@@ -17,7 +17,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
-    assert_match <<~OUTPUT, run_notes_command
+    assert_equal <<~OUTPUT, run_notes_command
       app/controllers/some_controller.rb:
         * [  1] [OPTIMIZE] note in app directory
 
@@ -37,7 +37,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
   end
 
   test "`rails notes` displays an empty string when no results were found" do
-    assert_match "", run_notes_command
+    assert_equal "", run_notes_command
   end
 
   test "`rails notes --annotations` displays results for a single annotation without being prefixed by a tag" do
@@ -47,7 +47,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "app/controllers/some_controller.rb", "# OPTIMIZE: note in app directory"
     app_file "config/initializers/some_initializer.rb", "# TODO: note in config directory"
 
-    assert_match <<~OUTPUT, run_notes_command(["--annotations", "FIXME"])
+    assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FIXME"])
       db/some_seeds.rb:
         * [1] note in db directory
 
@@ -64,7 +64,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     app_file "test/some_test.rb", "# FIXME: note in test directory"
 
-    assert_match <<~OUTPUT, run_notes_command(["--annotations", "FOOBAR", "TODO"])
+    assert_equal <<~OUTPUT, run_notes_command(["--annotations", "FOOBAR", "TODO"])
       app/controllers/some_controller.rb:
         * [1] [FOOBAR] note in app directory
 
@@ -85,7 +85,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config "config.annotations.register_directories \"spec\""
 
-    assert_match <<~OUTPUT, run_notes_command
+    assert_equal <<~OUTPUT, run_notes_command
       db/some_seeds.rb:
         * [1] [FIXME] note in db directory
 
@@ -108,7 +108,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "app/assets/stylesheets/application.css.scss", "// TODO: note in scss"
     app_file "app/assets/stylesheets/application.css.sass", "// TODO: note in sass"
 
-    assert_match <<~OUTPUT, run_notes_command
+    assert_equal <<~OUTPUT, run_notes_command
       app/assets/stylesheets/application.css.sass:
         * [1] [TODO] note in sass
 
@@ -128,7 +128,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config 'config.annotations.register_tags "TESTME", "DEPRECATEME"'
 
-    assert_match <<~OUTPUT, run_notes_command
+    assert_equal <<~OUTPUT, run_notes_command
       app/controllers/hello_controller.rb:
         * [1] [DEPRECATEME] this action is no longer needed
 
@@ -149,7 +149,7 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
 
     add_to_config 'config.annotations.register_tags "TESTME", "DEPRECATEME"'
 
-    assert_match <<~OUTPUT, run_notes_command
+    assert_equal <<~OUTPUT, run_notes_command
       app/controllers/hello_controller.rb:
         * [1] [DEPRECATEME] this action is no longer needed
 

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -17,7 +17,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_match <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
+    assert_equal <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
                              Prefix Verb   URI Pattern                                             Controller#Action
                            new_post GET    /post/new(.:format)                                     posts#new
                           edit_post GET    /post/edit(.:format)                                    posts#edit
@@ -29,7 +29,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format) action_mailbox/ingresses/postmark/inbound_emails#create
     OUTPUT
 
-    assert_match <<~OUTPUT, run_routes_command([ "-c", "UserPermissionController" ])
+    assert_equal <<~OUTPUT, run_routes_command([ "-c", "UserPermissionController" ])
                     Prefix Verb   URI Pattern                     Controller#Action
        new_user_permission GET    /user_permission/new(.:format)  user_permissions#new
       edit_user_permission GET    /user_permission/edit(.:format) user_permissions#edit
@@ -50,7 +50,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_match <<~MESSAGE, run_routes_command([ "-g", "show" ])
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "show" ])
                              Prefix Verb URI Pattern                                                                              Controller#Action
                                cart GET  /cart(.:format)                                                                          cart#show
       rails_conductor_inbound_email GET  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
@@ -59,7 +59,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                  rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
     MESSAGE
 
-    assert_match <<~MESSAGE, run_routes_command([ "-g", "POST" ])
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "POST" ])
                                      Prefix Verb URI Pattern                                                         Controller#Action
                                             POST /cart(.:format)                                                     cart#create
               rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)             action_mailbox/ingresses/mandrill/inbound_emails#create
@@ -72,7 +72,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                        rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                      active_storage/direct_uploads#create
     MESSAGE
 
-    assert_match <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
            Prefix Verb URI Pattern            Controller#Action
       basketballs GET  /basketballs(.:format) basketball#index
     MESSAGE
@@ -89,24 +89,24 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
 
     expected_cart_output = "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n"
     output = run_routes_command(["-c", "cart"])
-    assert_match expected_cart_output, output
+    assert_equal expected_cart_output, output
 
     output = run_routes_command(["-c", "Cart"])
-    assert_match expected_cart_output, output
+    assert_equal expected_cart_output, output
 
     output = run_routes_command(["-c", "CartController"])
-    assert_match expected_cart_output, output
+    assert_equal expected_cart_output, output
 
     expected_perm_output = ["         Prefix Verb URI Pattern                Controller#Action",
                             "user_permission GET  /user_permission(.:format) user_permission#index\n"].join("\n")
     output = run_routes_command(["-c", "user_permission"])
-    assert_match expected_perm_output, output
+    assert_equal expected_perm_output, output
 
     output = run_routes_command(["-c", "UserPermission"])
-    assert_match expected_perm_output, output
+    assert_equal expected_perm_output, output
 
     output = run_routes_command(["-c", "UserPermissionController"])
-    assert_match expected_perm_output, output
+    assert_equal expected_perm_output, output
   end
 
   test "rails routes with namespaced controller search key" do
@@ -119,7 +119,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_match <<~OUTPUT, run_routes_command([ "-c", "Admin::PostController" ])
+    assert_equal <<~OUTPUT, run_routes_command([ "-c", "Admin::PostController" ])
                Prefix Verb   URI Pattern                Controller#Action
        new_admin_post GET    /admin/post/new(.:format)  admin/posts#new
       edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit
@@ -130,7 +130,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                       POST   /admin/post(.:format)      admin/posts#create
     OUTPUT
 
-    assert_match <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
+    assert_equal <<~OUTPUT, run_routes_command([ "-c", "PostController" ])
                              Prefix Verb   URI Pattern                                             Controller#Action
                      new_admin_post GET    /admin/post/new(.:format)                               admin/posts#new
                     edit_admin_post GET    /admin/post/edit(.:format)                              admin/posts#edit
@@ -153,8 +153,8 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
                                  POST   /admin/user_permission(.:format)      admin/user_permissions#create
     OUTPUT
 
-    assert_match expected_permission_output, run_routes_command([ "-c", "Admin::UserPermissionController" ])
-    assert_match expected_permission_output, run_routes_command([ "-c", "UserPermissionController" ])
+    assert_equal expected_permission_output, run_routes_command([ "-c", "Admin::UserPermissionController" ])
+    assert_equal expected_permission_output, run_routes_command([ "-c", "UserPermissionController" ])
   end
 
   test "rails routes displays message when no routes are defined" do
@@ -163,7 +163,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_match <<~MESSAGE, run_routes_command
+    assert_equal <<~MESSAGE, run_routes_command
                                      Prefix Verb   URI Pattern                                                                              Controller#Action
               rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
               rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
@@ -199,7 +199,7 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     end
 
     # rubocop:disable Layout/TrailingWhitespace
-    assert_match <<~MESSAGE, output
+    assert_equal <<~MESSAGE, output
       --[ Route 1 ]--------------
       Prefix            | cart
       Verb              | GET


### PR DESCRIPTION
Especially this is caused on `config.app_middleware.insert_after` in our
code base:

https://github.com/rails/rails/blob/2b9edb777b2a9567eac8e79e5dc44ce2ef28fe23/activerecord/lib/active_record/railtie.rb#L88-L90
https://github.com/rails/rails/blob/2b9edb777b2a9567eac8e79e5dc44ce2ef28fe23/activerecord/lib/active_record/migration.rb#L556-L557