### PR TITLE
Make warning/error more explicit for raw SQL arguments to query methods

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -145,17 +145,15 @@ module ActiveRecord
 
         if allow_unsafe_raw_sql == :deprecated
           ActiveSupport::Deprecation.warn(
-            "Dangerous query method (method whose arguments are used as raw " \
-            "SQL) called with non-attribute argument(s): " \
-            "#{unexpected.map(&:inspect).join(", ")}. Non-attribute " \
-            "arguments will be disallowed in Rails 6.1. This method should " \
-            "not be called with user-provided values, such as request " \
-            "parameters or model attributes. Known-safe values can be passed " \
-            "by wrapping them in Arel.sql()."
+            "Query method called with raw SQL as argument(s): " \
+            "#{unexpected.map(&:inspect).join(", ")}. String arguments " \
+            "containing anything other than column names and directions for ordering " \
+            "(ASC, DESC) will be disallowed in Rails 6.1. Known-safe arguments " \
+            "can be passed by wrapping them in Arel.sql()."
           )
         else
           raise(ActiveRecord::UnknownAttributeReference,
-            "Query method called with non-attribute argument(s): " +
+            "Query method called with raw SQL as argument(s): " +
             unexpected.map(&:inspect).join(", ")
           )
         end

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -207,7 +207,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "order: logs deprecation warning for unrecognized column" do
     with_unsafe_raw_sql_deprecated do
-      assert_deprecated(/Dangerous query method/) do
+      assert_deprecated(/Query method called with raw SQL/) do
         Post.order("REPLACE(title, 'misc', 'zzzz')")
       end
     end
@@ -327,7 +327,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
   test "pluck: logs deprecation warning" do
     with_unsafe_raw_sql_deprecated do
-      assert_deprecated(/Dangerous query method/) do
+      assert_deprecated(/Query method called with raw SQL/) do
         Post.includes(:comments).pluck(:title, "REPLACE(title, 'misc', 'zzzz')")
       end
     end


### PR DESCRIPTION
### Summary

This deprecation warning for "using raw sql expressions as arguments to query methods" was very confusing. In this PR, the warning says in more simple terms what isn't allowed and what is.

### More details

Changes:

- use "raw SQL argument" instead of "non-attribute argument", which is more in line with the method name in the underlying code
- don't claim that the query method is dangerous, because it isn't: the arguments are, potentially
- "user-provided values" is a specific instance of "raw SQL" that does not cover all [potential triggers](https://github.com/rails/rails/issues/38087) for this warning, so I chose to not include that
- the warning is only/mostly(*) generated for `.order()`, so the new warning just says what is actually allowed:
   1. column names, and
   2. directions for the ORDER clause (ASC, DESC)

Potential language regression: I use "column names" instead of "attribute names". Not sure if the latter may be more common in Rails docs. Maybe someone can weigh in on that. Because we're talking about SQL literals, "column names" may be more appropriate nevertheless.

(*) Note: there is [one reference](https://github.com/rails/rails/blob/5e6c33182337646c82640457f1ce9dabfcaeaf36/activerecord/lib/active_record/relation/calculations.rb#L190) to the `disallow_raw_sql!` method which does not pertain to `ORDER`, but instead is used in the `pluck` method. I'm not able to verify because I can't for the life of me figure out what `klass` is referring to on that line. However, the new warning should be fine even used in the context of `pluck`, because it is explicit about what is allowed.
