### PR TITLE
Remove accidental git merge marker [ci skip]

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -353,7 +353,6 @@ module Rails
 
       super()
       ...
->>>>>>> c5102225a36d254dc067c6d5a606856233d46e99
     end
 
     private


### PR DESCRIPTION
### Summary

Removes a tiny leftover from a git merge:
`>>>>>>> c5102225a36d254dc067c6d5a606856233d46e99`