### PR TITLE
Document how to add session middleware to an API app

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -333,25 +333,24 @@ will be:
 ```
 
 ### Using Session Middlewares
-The following middlewares are (by default) included for session management.  If one of your API clients is a browser, you might want to add one of these back in:
+The following middlewares, used for session management, are excluded from API apps since they normally don't need sessions.  If one of your API clients is a browser, you might want to add one of these back in:
 - `ActionDispatch::Session::CacheStore`
 - `ActionDispatch::Session::CookieStore`
 - `ActionDispatch::Session::MemCacheStore`
 
 The trick to adding these back in is that, by default, they are passed `session_options`
 when added (including the session key), so you can't just add a `session_store.rb` initializer, add
-`use ActionDispatch::Session::CookieStore` and have sessions functioning as normal.
+`use ActionDispatch::Session::CookieStore` and have sessions functioning as usual.  (To be clear: sessions
+may work, but your session options will be ignored - i.e the session key will default to `_session_id`)
 
-To be clear: sessions may work, but your session options will be ignored (i.e the session key will default
-to `_session_id`).  Instead of the initializer, you'll have to set the relevant options somewhere
-before your middleware is built (like `application.rb`) and pass them to your prefered middleware,
-like this:
+Instead of the initializer, you'll have to set the relevant options somewhere before your middleware is
+built (like `application.rb`) and pass them to your prefered middleware, like this:
 
 **application.rb:**
 ```ruby
-config.session_store :cookie_store, key: '_interslice_session'
-config.middleware.use ActionDispatch::Cookies # Required for all session management
-config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
+config.session_store :cookie_store, key: '_interslice_session' # <-- this also configures session_options for use below
+config.middleware.use ActionDispatch::Cookies # Required for all session management (regardless of session_store)
+config.middleware.use config.session_store, config.session_options
 ```
 
 ### Other Middleware

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -332,6 +332,28 @@ will be:
 { :person => { :firstName => "Yehuda", :lastName => "Katz" } }
 ```
 
+### Using Session Middlewares
+The following middlewares are (by default) included for session management.  If one of your API clients is a browser, you might want to add one of these back in:
+- `ActionDispatch::Session::CacheStore`
+- `ActionDispatch::Session::CookieStore`
+- `ActionDispatch::Session::MemCacheStore`
+
+The trick to adding these back in is that, by default, they are passed `session_options`
+when added (including the session key), so you can't just add a `session_store.rb` initializer, add
+`use ActionDispatch::Session::CookieStore` and have sessions functioning as normal.
+
+To be clear: sessions may work, but your session options will be ignored (i.e the session key will default
+to `_session_id`).  Instead of the initializer, you'll have to set the relevant options somewhere
+before your middleware is built (like `application.rb`) and pass them to your prefered middleware,
+like this:
+
+**application.rb:**
+```ruby
+config.session_store :cookie_store, key: '_interslice_session'
+config.middleware.use ActionDispatch::Cookies # Required for all session management
+config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
+```
+
 ### Other Middleware
 
 Rails ships with a number of other middleware that you might want to use in an
@@ -340,10 +362,6 @@ API application, especially if one of your API clients is the browser:
 - `Rack::MethodOverride`
 - `ActionDispatch::Cookies`
 - `ActionDispatch::Flash`
-- For session management
-    * `ActionDispatch::Session::CacheStore`
-    * `ActionDispatch::Session::CookieStore`
-    * `ActionDispatch::Session::MemCacheStore`
 
 Any of these middleware can be added via:
 


### PR DESCRIPTION
Reopening #28009 (after addressing comments on the closed PR)

Adds documentation to the guides about how to get session middleware back when using the api_only flag. Without this, it's not clear that session middleware has special cases to handle with the api_only flag.

Hopefully will help people avoid this problem: http://stackoverflow.com/questions/15342710/adding-cookie-session-store-back-to-rails-api-app/15363386#15363386