### PR TITLE
Avoid unnecessary SQL query when calling ActiveRecord::Relation#cache_key

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -317,7 +317,7 @@ module ActiveRecord
       query_signature = ActiveSupport::Digest.hexdigest(to_sql)
       key = "#{klass.model_name.cache_key}/query-#{query_signature}"
 
-      if cache_version(timestamp_column)
+      if collection_cache_versioning
         key
       else
         "#{key}-#{compute_cache_version(timestamp_column)}"

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -113,6 +113,13 @@ module ActiveRecord
       assert_no_queries { developers.cache_key }
     end
 
+    test "it doesn't trigger any query if collection_cache_versioning is enabled" do
+      with_collection_cache_versioning do
+        developers = Developer.where(name: "David")
+        assert_no_queries { developers.cache_key }
+      end
+    end
+
     test "relation cache_key changes when the sql query changes" do
       developers = Developer.where(name: "David")
       other_relation = Developer.where(name: "David").where("1 = 1")


### PR DESCRIPTION
With collection_cache_versioning enabled, a collection's volatile info (size & max updated_at timestamp) is included in `ActiveRecord::Relation#cache_version`, not `#cache_key`.

Avoid the SQL query to used determine this volatile info when generating an un-versioned cache key. This query does not need to be executed unless `#cache_version` is called separately.