### PR TITLE
Clear callback triggers when transaction completes

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -339,7 +339,7 @@ module ActiveRecord
         _run_commit_callbacks
       end
     ensure
-      @_committed_already_called = false
+      @_committed_already_called = @_trigger_update_callback = @_trigger_destroy_callback = false
     end
 
     # Call the #after_rollback callbacks. The +force_restore_state+ argument indicates if the record
@@ -352,6 +352,7 @@ module ActiveRecord
     ensure
       restore_transaction_record_state(force_restore_state)
       clear_transaction_record_state
+      @_trigger_update_callback = @_trigger_destroy_callback = false if force_restore_state
     end
 
     # Executes +method+ within a transaction and captures its return value as a


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/36934.

The `_trigger_update_callback` and `_trigger_destroy_callback` attributes were added in https://github.com/rails/rails/pull/35920 to avoid running transactional callbacks when an attempt to modify a record fails inside a transaction due to the record being invalid, for example.

However the values weren't being reset between transactions, which meant they leaked from one transaction to another and caused false positives where unsuccessful modifications still triggered callbacks. Clearing them when a transaction commits or is rolled back fixes the problem.