### PR TITLE
Backport ActiveStorage Ruby 2.7 deprecation warning fixes to Rails 6.0

### DIFF
--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -5,7 +5,7 @@
 # the blob that was created up front.
 class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
   def create
-    blob = ActiveStorage::Blob.create_before_direct_upload!(blob_args)
+    blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
     render json: direct_upload_json(blob)
   end
 

--- a/activestorage/app/models/active_storage/blob/identifiable.rb
+++ b/activestorage/app/models/active_storage/blob/identifiable.rb
@@ -26,6 +26,6 @@ module ActiveStorage::Blob::Identifiable
     end
 
     def update_service_metadata
-      service.update_metadata key, service_metadata if service_metadata.any?
+      service.update_metadata key, **service_metadata if service_metadata.any?
     end
 end

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -59,7 +59,7 @@ class ActiveStorage::Preview
   # a stable URL that redirects to the short-lived URL returned by this method.
   def service_url(**options)
     if processed?
-      variant.service_url(options)
+      variant.service_url(**options)
     else
       raise UnprocessedError
     end

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -58,7 +58,7 @@ module ActiveStorage
             filename: attachable.original_filename,
             content_type: attachable.content_type
         when Hash
-          ActiveStorage::Blob.build_after_unfurling(attachable)
+          ActiveStorage::Blob.build_after_unfurling(**attachable)
         when String
           ActiveStorage::Blob.find_signed(attachable)
         else

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -82,8 +82,8 @@ module ActiveStorage
       raise NotImplementedError
     end
 
-    def open(*args, &block)
-      ActiveStorage::Downloader.new(self).open(*args, &block)
+    def open(*args, **options, &block)
+      ActiveStorage::Downloader.new(self).open(*args, **options, &block)
     end
 
     # Delete the file at the +key+.


### PR DESCRIPTION
### Summary

Cherry-picked dea19d4ead79fe0d7a1c81eb0be1c8958c80659e back to 6-0-stable to fix deprecation warnings I was seeing in ActiveStorage on Ruby 2.7.
