### PR TITLE
Switch to standardized argument name

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -57,22 +57,22 @@ module AbstractController
       # ==== Parameters
       # * <tt>method[, method]</tt> - A name or names of a method on the controller
       #   to be made available on the view.
-      def helper_method(*meths)
-        meths.flatten!
-        self._helper_methods += meths
+      def helper_method(*methods)
+        methods.flatten!
+        self._helper_methods += methods
 
         location = caller_locations(1, 1).first
         file, line = location.path, location.lineno
 
-        meths.each do |meth|
+        methods.each do |method|
           _helpers.class_eval <<-ruby_eval, file, line
-            def #{meth}(*args, **kwargs, &blk)                      # def current_user(*args, **kwargs, &blk)
-              if kwargs.empty?                                      #   if kwargs.empty?
-                controller.send(%(#{meth}), *args, &blk)            #     controller.send(:current_user, *args, &blk)
-              else                                                  #   else
-                controller.send(%(#{meth}), *args, **kwargs, &blk)  #     controller.send(:current_user, *args, **kwargs, &blk)
-              end                                                   #   end
-            end                                                     # end
+            def #{method}(*args, **kwargs, &blk)                     # def current_user(*args, **kwargs, &blk)
+              if kwargs.empty?                                       #   if kwargs.empty?
+                controller.send(%(#{method}), *args, &blk)           #     controller.send(:current_user, *args, &blk)
+              else                                                   #   else
+                controller.send(%(#{method}), *args, **kwargs, &blk) #     controller.send(:current_user, *args, **kwargs, &blk)
+              end                                                    #   end
+            end                                                      # end
           ruby_eval
         end
       end


### PR DESCRIPTION
### Summary

This is a small nit which updates the argument name for consistency. This is the only place in the codebase where `meths` was used instead of `methods`. Since the argument name shows up in [documentation](https://api.rubyonrails.org/classes/AbstractController/Helpers/ClassMethods.html#method-i-helper_method) it seemed worth updating.
