### PR TITLE
Backport Ruby 2.7 deprecation fix to Rails 6

### DIFF
--- a/activerecord/lib/active_record/railties/collection_cache_association_loading.rb
+++ b/activerecord/lib/active_record/railties/collection_cache_association_loading.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Railties # :nodoc:
     module CollectionCacheAssociationLoading #:nodoc:
       def setup(context, options, as, block)
-        @relation = relation_from_options(options)
+        @relation = relation_from_options(**options)
 
         super
       end


### PR DESCRIPTION
This backports 7b7c986e3ef38b466040c1a4938fc072f7ced820 to 6-0-stable.

I was seeing the following deprecation warning running my Rails app on 6-0-stable, but a fix for it already existed in master:

```
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/rails-5e0354b99908/activerecord/lib/active_record/railties/collection_cache_association_loading.rb:7: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/bundler/gems/rails-5e0354b99908/activerecord/lib/active_record/railties/collection_cache_association_loading.rb:12: warning: The called method `relation_from_options' is defined here
```

This fixes the last deprecation warning from Rails that I see in my app :)