### PR TITLE
Show possible options for db:system:change command.

### DIFF
--- a/railties/lib/rails/commands/db/system/change/change_command.rb
+++ b/railties/lib/rails/commands/db/system/change/change_command.rb
@@ -8,7 +8,7 @@ module Rails
     module Db
       module System
         class ChangeCommand < Base # :nodoc:
-          class_option :to, desc: "The database system to switch to."
+          class_option :to, desc: "The database system to switch to. (options: #{Rails::Generators::Database::DATABASES.join('/')})"
 
           def perform
             Rails::Generators::Db::System::ChangeGenerator.start

--- a/railties/lib/rails/commands/db/system/change/change_command.rb
+++ b/railties/lib/rails/commands/db/system/change/change_command.rb
@@ -8,7 +8,7 @@ module Rails
     module Db
       module System
         class ChangeCommand < Base # :nodoc:
-          class_option :to, desc: "The database system to switch to. (options: #{Rails::Generators::Database::DATABASES.join('/')})"
+          class_option :to, desc: "The database system to switch to.", enum: Rails::Generators::Database::DATABASES
 
           def perform
             Rails::Generators::Db::System::ChangeGenerator.start


### PR DESCRIPTION
# before

```
Usage:
  rails change [options]

Options:
  [--to=TO]  # The database system to switch to.


```

# after

```
Usage:
  rails change [options]

Options:
  [--to=TO]  # The database system to switch to. (options: mysql/postgresql/sqlite3/oracle/frontbase/ibm_db/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)



```

:information_source:  _usage part seems weird, it shows `rails change` instead of `rails db:system:change`. I'll take a look at this as well._