### PR TITLE
Address `DEPRECATED: use MT_CPU instead of N for parallel test runs`

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -16,7 +16,7 @@ end
 if ENV["TRAVIS"]
   PROCESS_COUNT = 0
 else
-  PROCESS_COUNT = (ENV["N"] || 4).to_i
+  PROCESS_COUNT = (ENV["MT_CPU"] || 4).to_i
 end
 
 require "active_support/testing/autorun"


### PR DESCRIPTION
### Summary

I have found this deprecate message while investigating #38094

* Steps to reproduce

```ruby
% cd actionpack
% N=0 bundle exec ruby -w -Itest test/controller/mime/accept_format_test.rb
DEPRECATED: use MT_CPU instead of N for parallel test runs
... snip ...
%
```

* minitest 5.12.0 deprecates ENV["N"] to specify the number of parallel test runners:

https://github.com/seattlerb/minitest/blob/master/History.rdoc#5120--2019-09-22
https://github.com/seattlerb/minitest/commit/4103a10eb4bb99bc60721b3245ee3a69988a214b

* No other code uses `ENV["N"]`
```
% git grep 'ENV\["N"\]'
actionpack/test/abstract_unit.rb:  PROCESS_COUNT = (ENV["N"] || 4).to_i
%
```

* Rails guide suggests using `PARALLEL_WORKERS` to specify the number of workers, not `N`
https://guides.rubyonrails.org/testing.html#parallel-testing

```ruby
PARALLEL_WORKERS=15 rails test
```
