### PR TITLE
Set AJ `return_false_on_aborted_enqueue` true in the test suite:

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -13,6 +13,7 @@ if ENV["AJ_INTEGRATION_TESTS"]
 else
   ActiveJob::Base.logger = Logger.new(nil)
   ActiveJob::Base.skip_after_callbacks_if_terminated = true
+  ActiveJob::Base.return_false_on_aborted_enqueue = true
   require "adapters/#{@adapter}"
 end
 


### PR DESCRIPTION
Set AJ `return_false_on_aborted_enqueue` true in the test suite:

- Since this is going to be the default in 6.1, let's set it in the
  test suite to avoid deprecation warning.
  Otherwise one has to do `AS::Deprecation.silence { }` everytime we
  add a new test.

  Fix #38107

cc/ @rafaelfranca 