### PR TITLE
Fail loudly on missing git during `rails new`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -68,7 +68,7 @@ module Rails
 
     def version_control
       if !options[:skip_git] && !options[:pretend]
-        run "git init", capture: options[:quiet]
+        run "git init", capture: true
       end
     end
 


### PR DESCRIPTION
### Summary

Fix issue #38035 by allowing an Error::ENOENT error to bubble up from thor when the git executable is missing. Deciding to either install git or add `--skip-git` is left as an exercise to the user. At least it won't fail silently anymore.

### Other Information

New output (compare to example in original issue):

```
root@977db3d1d9df:/workspaces/rails# rm -rf ~/testapp ; bundle exec rails new ~/testapp
      create  
      create  README.md
      create  Rakefile
      create  .ruby-version
      create  config.ru
      create  .gitignore
      create  Gemfile
         run  git init from "."
bundler: failed to load command: rails (/usr/local/bundle/ruby/2.6.0/bin/rails)
Errno::ENOENT: No such file or directory - git
```