### PR TITLE
Return unfrozen strings from to_sentence

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `Array#to_sentence` no longer returns a frozen string.
+
+    Before:
+        ['one', 'two'].to_sentence.frozen?
+        # => true
+
+    After:
+        ['one', 'two'].to_sentence.frozen?
+        # => false
+
+    *Nicolas Dular*
+
 *   When an instance of `ActiveSupport::Duration` is converted to an `iso8601` duration string, if `weeks` are mixed with `date` parts, the `week` part will be converted to days.
     This keeps the parser and serializer on the same page.
 

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -74,13 +74,13 @@ class Array
 
     case length
     when 0
-      ""
+      +""
     when 1
-      "#{self[0]}"
+      +"#{self[0]}"
     when 2
-      "#{self[0]}#{options[:two_words_connector]}#{self[1]}"
+      +"#{self[0]}#{options[:two_words_connector]}#{self[1]}"
     else
-      "#{self[0...-1].join(options[:words_connector])}#{options[:last_word_connector]}#{self[-1]}"
+      +"#{self[0...-1].join(options[:words_connector])}#{options[:last_word_connector]}#{self[-1]}"
     end
   end
 

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -68,6 +68,13 @@ class ToSentenceTest < ActiveSupport::TestCase
     assert_instance_of String, [ActiveSupport::SafeBuffer.new("one"), "two"].to_sentence
     assert_instance_of String, [ActiveSupport::SafeBuffer.new("one"), "two", "three"].to_sentence
   end
+
+  def test_returns_no_frozen_string
+    assert_not [].to_sentence.frozen?
+    assert_not ["one"].to_sentence.frozen?
+    assert_not ["one", "two"].to_sentence.frozen?
+    assert_not ["one", "two", "three"].to_sentence.frozen?
+  end
 end
 
 class ToSTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

Fixes issue https://github.com/rails/rails/issues/38044 where the author mentioned that 
```ruby
['foo', 'bar'].to_sentence.frozen?
````
unexpectedly returned a frozen string.

