### PR TITLE
Reduce the number of records loaded when preloading across a `has_one`

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -27,39 +27,41 @@ module ActiveRecord
         end
 
         def records_by_owner
-          # owners can be duplicated when a relation has a collection association join
-          # #compare_by_identity makes such owners different hash keys
-          @records_by_owner ||= preloaded_records.each_with_object({}.compare_by_identity) do |record, result|
-            owners_by_key[convert_key(record[association_key_name])].each do |owner|
-              (result[owner] ||= []) << record
-            end
-          end
+          load_records unless defined?(@records_by_owner)
+
+          @records_by_owner
         end
 
         def preloaded_records
-          return @preloaded_records if defined?(@preloaded_records)
+          load_records unless defined?(@preloaded_records)
 
-          raw_records = owner_keys.empty? ? [] : records_for(owner_keys)
-          seen_records_by_owner = {}.compare_by_identity
-
-          @preloaded_records = raw_records.select do |record|
-            assignments = []
-
-            owners_by_key[convert_key(record[association_key_name])].each do |owner|
-              entries = (seen_records_by_owner[owner] ||= [])
-
-              if reflection.collection? || entries.empty?
-                entries << record
-                assignments << record
-              end
-            end
-
-            !assignments.empty?
-          end
+          @preloaded_records
         end
 
         private
           attr_reader :owners, :reflection, :preload_scope, :model, :klass
+
+          def load_records
+            # owners can be duplicated when a relation has a collection association join
+            # #compare_by_identity makes such owners different hash keys
+            @records_by_owner = {}.compare_by_identity
+            raw_records = owner_keys.empty? ? [] : records_for(owner_keys)
+
+            @preloaded_records = raw_records.select do |record|
+              assignments = []
+
+              owners_by_key[convert_key(record[association_key_name])].each do |owner|
+                entries = (@records_by_owner[owner] ||= [])
+
+                if reflection.collection? || entries.empty?
+                  entries << record
+                  assignments << record
+                end
+              end
+
+              !assignments.empty?
+            end
+          end
 
           # The name of the key on the associated records
           def association_key_name

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -160,6 +160,9 @@ class Author < ActiveRecord::Base
   has_many :posts_with_signature, ->(record) { where("posts.title LIKE ?", "%by #{record.name.downcase}%") }, class_name: "Post"
   has_many :posts_mentioning_author, ->(record = nil) { where("posts.body LIKE ?", "%#{record&.name&.downcase}%") }, class_name: "Post"
 
+  has_one :recent_post, -> { order(id: :desc) }, class_name: "Post"
+  has_one :recent_response, through: :recent_post, source: :comments
+
   has_many :posts_with_extension, -> { order(:title) }, class_name: "Post" do
     def extension_method; end
   end


### PR DESCRIPTION
### Summary

Some configurations of associations can cause Rails preloading to generate SQL queries that retrieve large amounts of data that is then discarded (before application code is involved). This change aims to alleviate this for `has_one` associations, by proactively discarding records that would not be bound to an association.

For context, this behaviour came up in the context of `has_one` associations built from orderings; background operations attempted to preload several layers of associations on the "far side" of this `has_one`, and we ultimately found ourselves with unanticipated load. Debugging led to `Preloader::Association#run` performing filtering when assigning an association, but all retrieved records being returned to the invoking `Preloader`, which results in preloading into these eventually-unbound records (and so on down the tree).

### Other Information

I'm a little doubtful of the fusion of the two public methods here. The primary motivation was the dramatically increased complexity of `preloaded_records`, to effectively execute `records_by_owner` in passing. Although I think the reduced surface is worthwhile, I've separated that commit here.