### PR TITLE
Fix regression, enforce fresh ETag header after collection contents change

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Enforce fresh ETag header after a collection's contents change by adding
+    ActiveRecord::Relation#cache_key_with_version. This method will be used by
+    ActionController::ConditionalGet to ensure that when collection cache versioning
+    is enabled, requests using ConditionalGet don't return the same ETag header
+    after a collection is modified. Fixes #38078.
+
+    *Aaron Lipman*
+
 *   Skip test database when running `db:create` or `db:drop` in development
     with `DATABASE_URL` set.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -385,6 +385,15 @@ module ActiveRecord
     end
     private :compute_cache_version
 
+    # Returns a cache key along with the version.
+    def cache_key_with_version
+      if version = cache_version
+        "#{cache_key}-#{version}"
+      else
+        cache_key
+      end
+    end
+
     # Scope all queries to the current scope.
     #
     #   Comment.where(post_id: 1).scoping do

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -198,6 +198,16 @@ module ActiveRecord
       end
     end
 
+    test "cache_key_with_version contains key and version regardless of collection_cache_versioning setting" do
+      key_with_version_1 = Developer.all.cache_key_with_version
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, key_with_version_1)
+
+      with_collection_cache_versioning do
+        key_with_version_2 = Developer.all.cache_key_with_version
+        assert_equal(key_with_version_1, key_with_version_2)
+      end
+    end
+
     def with_collection_cache_versioning(value = true)
       @old_collection_cache_versioning = ActiveRecord::Base.collection_cache_versioning
       ActiveRecord::Base.collection_cache_versioning = value


### PR DESCRIPTION
Add `ActiveRecord::Relation#cache_key_with_version`. This method will be used by ActionController::ConditionalGet to ensure that when collection cache versioning is enabled, requests using ConditionalGet don't return the same ETag header after a collection is modified.

Prior to the introduction of collection cache versioning in 4f2ac80d4cdb01c4d3c1765637bed76cc91c1e35, `ActiveRecord::Relation#cache_key` was suitable for the purposes of ConditionalGet as all cache keys included a version. However, with collection cache versioning enabled, keys remain constant. In turn, ETag headers remain constant, rendering them ineffective.

This commit takes the `cache_key_with_version` logic used for individual Active Record objects (from aa8749eb52d7919a438940c9218cad98d892f9ad), abstracts it into a module, and applies it to both individual Active Record objects and collections.

Fixes #38078