### PR TITLE
Defaults content_type to application/octet-stream in blob_record.js

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -550,7 +550,7 @@
       this.file = file;
       this.attributes = {
         filename: file.name,
-        content_type: file.type,
+        content_type: file.type || "application/octet-stream",
         byte_size: file.size,
         checksum: checksum
       };

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -6,7 +6,7 @@ export class BlobRecord {
 
     this.attributes = {
       filename: file.name,
-      content_type: file.type,
+      content_type: file.type || "application/octet-stream",
       byte_size: file.size,
       checksum: checksum
     }


### PR DESCRIPTION
### Summary

Defaults content_type to application/octet-stream in blob_record.js in order to resolve https://github.com/rails/rails/issues/38123.

@cushingw recommended this solution here https://github.com/rails/rails/issues/36514#issuecomment-503221829.

Closes https://github.com/rails/rails/issues/38123

