### PR TITLE
Address StarStarMimeControllerTest#test_javascript_with_no_format_only_star_star failure

### DIFF
--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+ActionView::Base.default_formats ||= Mime::SET.symbols
 
 class StarStarMimeController < ActionController::Base
   layout nil


### PR DESCRIPTION
### Summary

This pull request addresses StarStarMimeControllerTest#test_javascript_with_no_format_only_star_star failure.

Fix #38094

* Steps to reproduce:

```ruby
% cd actionpack
% MT_CPU=0 bundle exec ruby -w -Itest test/controller/mime/accept_format_test.rb -n "/^(?:MimeControllerLayoutsTest#(?:test_missing_layout_renders_properly)|StarStarMimeControllerTest#(?:test_javascript_with_no_format_only_star_star))$/" --verbose --seed 15759
```

* Actual result without this commit:

```ruby
% cd actionpack
% MT_CPU=0 bundle exec ruby -w -Itest test/controller/mime/accept_format_test.rb -n "/^(?:MimeControllerLayoutsTest#(?:test_missing_layout_renders_properly)|StarStarMimeControllerTest#(?:test_javascript_with_no_format_only_star_star))$/" --verbose --seed 15759
Run options: -n "/^(?:MimeControllerLayoutsTest#(?:test_missing_layout_renders_properly)|StarStarMimeControllerTest#(?:test_javascript_with_no_format_only_star_star))$/" --verbose --seed 15759

MimeControllerLayoutsTest#test_missing_layout_renders_properly = 0.18 s = .
StarStarMimeControllerTest#test_javascript_with_no_format_only_star_star = 0.00 s = E

Error:
StarStarMimeControllerTest#test_javascript_with_no_format_only_star_star:
ArgumentError: Invalid formats: :iphone
    /Users/yahonda/src/github.com/yahonda/rails/actionview/lib/action_view/lookup_context.rb:287:in `formats='
    /Users/yahonda/src/github.com/yahonda/rails/actionview/lib/action_view/view_paths.rb:11:in `formats='
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal/rendering.rb:29:in `process_action'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
    /Users/yahonda/src/github.com/yahonda/rails/activesupport/lib/active_support/callbacks.rb:98:in `run_callbacks'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/abstract_controller/callbacks.rb:41:in `process_action'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal/rescue.rb:22:in `process_action'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
    /Users/yahonda/src/github.com/yahonda/rails/activesupport/lib/active_support/notifications.rb:203:in `block in instrument'
    /Users/yahonda/src/github.com/yahonda/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /Users/yahonda/src/github.com/yahonda/rails/activesupport/lib/active_support/notifications.rb:203:in `instrument'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal/instrumentation.rb:33:in `process_action'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal/params_wrapper.rb:245:in `process_action'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/abstract_controller/base.rb:136:in `process'
    /Users/yahonda/src/github.com/yahonda/rails/actionview/lib/action_view/rendering.rb:39:in `process'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/metal.rb:190:in `dispatch'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/test_case.rb:512:in `process'
    /Users/yahonda/src/github.com/yahonda/rails/actionpack/lib/action_controller/test_case.rb:390:in `get'
    test/controller/mime/accept_format_test.rb:28:in `test_javascript_with_no_format_only_star_star'

rails test test/controller/mime/accept_format_test.rb:26

Finished in 0.180610s, 11.0736 runs/s, 11.0736 assertions/s.
2 runs, 2 assertions, 0 failures, 1 errors, 0 skips
%
```

* How to diagnose this error:

At first Restore `require "action_view/base"` to `actionpack/lib/action_dispatch/middleware/debug_exceptions.rb` addresses this error,
then isolated which lines are required then found this line is required.

https://github.com/rails/rails/blob/22483b86a6c779743b30e2f23bb46accfbf96b28/actionpack/lib/action_dispatch.rb#L117

```ruby
  ActionView::Base.default_formats ||= Mime::SET.symbols
```