### PR TITLE
Add notification hooks for connection events

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add notification hooks for connection events
+
+    `connect.action_cable` and `disconnect.action_cable` notifications are added.
+
+    *Sergey Ponomarev*
+
 *   Subscription confirmations and rejections are now logged at the `DEBUG` level instead of `INFO`.
 
     *DHH*

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -168,7 +168,12 @@ module ActionCable
 
         def handle_open
           @protocol = websocket.protocol
-          connect if respond_to?(:connect)
+
+          payload = { connection_class: self.class.name, request: request }
+          ActiveSupport::Notifications.instrument("connect.action_cable", payload) do
+            connect if respond_to?(:connect)
+          end
+
           subscribe_to_internal_channel
           send_welcome_message
 
@@ -186,7 +191,10 @@ module ActionCable
           subscriptions.unsubscribe_from_all
           unsubscribe_from_internal_channel
 
-          disconnect if respond_to?(:disconnect)
+          payload = { connection_class: self.class.name, request: request }
+          ActiveSupport::Notifications.instrument("disconnect.action_cable", payload) do
+            disconnect if respond_to?(:disconnect)
+          end
         end
 
         def send_welcome_message

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -606,6 +606,20 @@ Action Cable
 | `:message`      | A hash of message    |
 | `:coder`        | The coder            |
 
+### connect.action_cable
+
+| Key                 | Value                        |
+| ------------------- | ---------------------------- |
+| `:connection_class` | Name of the connection class |
+| `:request`          | A connection request object  |
+
+### disconnect.action_cable
+
+| Key                 | Value                        |
+| ------------------- | ---------------------------- |
+| `:connection_class` | Name of the connection class |
+| `:request`          | A connection request object  |
+
 Active Storage
 --------------
 


### PR DESCRIPTION
Reopening instead of stale #36113 lost during Rails 6 race. 

In comparison to channels, the application-specific code doesn't have any way to instrument it yet. At the moment, if we want to measure performance, instrument connection code with APM  or gather any connect/disconnect statistics, it can only be done on the application code level or monkeypatching framework classes. 

`connect.action_cable` and `disconnect.action_cable` notifications were added in order to address the issue. 

Event payload consists of:
`connection_class` – name of the connection class since we can support multiple since #34714
`request` – the request that initiated the WebSocket connection. It provides access to the environment, cookies, etc.


cc @kaspth @palkan 