### PR TITLE
Fix adding non-null column to existing SQLite3 table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -365,7 +365,8 @@ module ActiveRecord
         # See: https://www.sqlite.org/lang_altertable.html
         # SQLite has an additional restriction on the ALTER TABLE statement
         def invalid_alter_table_type?(type, options)
-          type.to_sym == :primary_key || options[:primary_key]
+          type.to_sym == :primary_key || options[:primary_key] ||
+            options[:null] == false && options[:default].nil?
         end
 
         def alter_table(table_name, foreign_keys = foreign_keys(table_name), **options)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -324,6 +324,14 @@ module ActiveRecord
         end
       end
 
+      def test_add_column_with_not_null
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, number integer not null" do
+          assert_nothing_raised { @conn.add_column :ex, :name, :string, null: false }
+          column = @conn.columns("ex").find { |x| x.name == "name" }
+          assert_not column.null, "column should not be null"
+        end
+      end
+
       def test_indexes_logs
         with_example_table do
           assert_logged [["PRAGMA index_list(\"ex\")", "SCHEMA", []]] do


### PR DESCRIPTION
Forces adding the column by way of copying the table due to lack of support in SQLite3 adapter.

Fixes #38129

### Summary

See #38129

### Other Information

Test case added as well.