### PR TITLE
Allow #nulls_first and #nulls_last in PostgreSQL

### DIFF
--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -18,6 +18,7 @@ require "arel/nodes/false"
 # unary
 require "arel/nodes/unary"
 require "arel/nodes/grouping"
+require "arel/nodes/ordering"
 require "arel/nodes/ascending"
 require "arel/nodes/descending"
 require "arel/nodes/unqualified_column"

--- a/activerecord/lib/arel/nodes/ordering.rb
+++ b/activerecord/lib/arel/nodes/ordering.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class Ordering < Unary
+      def nulls_first
+        NullsFirst.new(self)
+      end
+
+      def nulls_last
+        NullsLast.new(self)
+      end
+    end
+
+    class NullsFirst < Ordering; end
+    class NullsLast < Ordering; end
+  end
+end

--- a/activerecord/lib/arel/nodes/unary.rb
+++ b/activerecord/lib/arel/nodes/unary.rb
@@ -36,7 +36,6 @@ module Arel # :nodoc: all
       Offset
       On
       OptimizerHints
-      Ordering
       RollUp
     }.each do |name|
       const_set(name, Class.new(Unary))

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -82,6 +82,16 @@ module Arel # :nodoc: all
           visit o.right, collector
         end
 
+        def visit_Arel_Nodes_NullsFirst(o, collector)
+          visit o.expr, collector
+          collector << " NULLS FIRST"
+        end
+
+        def visit_Arel_Nodes_NullsLast(o, collector)
+          visit o.expr, collector
+          collector << " NULLS LAST"
+        end
+
         # Used by Lateral visitor to enclose select queries in parentheses
         def grouping_parentheses(o, collector)
           if o.expr.is_a? Nodes::SelectStatement

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -315,6 +315,22 @@ module Arel
           _(sql).must_be_like %{ "users"."name" IS DISTINCT FROM NULL }
         end
       end
+
+      describe "Nodes::Ordering" do
+        it "should handle nulls first" do
+          test = Table.new(:users)[:first_name].desc.nulls_first
+          _(compile(test)).must_be_like %{
+            "users"."first_name" DESC NULLS FIRST
+          }
+        end
+
+        it "should handle nulls last" do
+          test = Table.new(:users)[:first_name].desc.nulls_last
+          _(compile(test)).must_be_like %{
+            "users"."first_name" DESC NULLS LAST
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When using PostgreSQL, it's useful to be able to specify NULLS FIRST and NULLS LAST on ordered columns. With this commit you can do that now, as in:

```ruby
User.arel_table[:first_name].desc.nulls_last
```