### PR TITLE
Separate with space between table name and columns list in SQL of insert_all

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -122,7 +122,7 @@ module ActiveRecord
         end
 
         def into
-          "INTO #{model.quoted_table_name}(#{columns_list})"
+          "INTO #{model.quoted_table_name} (#{columns_list})"
         end
 
         def values_list


### PR DESCRIPTION
### Summary

In arel, there is a space between the table name and columns list when INSERT.
https://github.com/rails/rails/blob/3c28e79b615f6937f5abdc433ff634d15cf2466f/activerecord/lib/arel/visitors/to_sql.rb#L56

```ruby
# create_table :users do |t|
#   t.string :name
# end

User.create!(name: "foo")
# INSERT INTO `users` (`name`) VALUES ('foo')
              ^^^^^^^^^^^^^^^^
```

But SQL of insert_all is not separated.

```ruby
User.insert_all!([{name: "foo"}])
# INSERT INTO `users`(`name`) VALUES ('foo')
              ^^^^^^^^^^^^^^^
```

This is not a problem (because it is correct as SQL), but fixing this will make unified behavior.


### Other Information

A known issue is that database_rewinder fails to parse table name on insert_all.
https://github.com/amatsuda/database_rewinder/blob/v0.9.1/lib/database_rewinder.rb#L51-L54

```ruby
statement = "INSERT INTO `users`(`name`) VALUES ('foo')"
match = statement.match(/\A\s*INSERT(?:\s+IGNORE)?(?:\s+INTO)?\s+(?:\.*[`"]?([^.\s`"]+)[`"]?)*/i)
# => #<MatchData "INSERT INTO `users`(`name`)" 1:")">
# Expected behavior is
# => #<MatchData "INSERT INTO `users`" 1:"users">
```
