### PR TITLE
Add to the log format "*/*" if using a not found format:

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -11,6 +11,7 @@ module ActionController
       params  = payload[:params].except(*INTERNAL_PARAMS)
       format  = payload[:format]
       format  = format.to_s.upcase if format.is_a?(Symbol)
+      format  = "*/*" if format.nil?
 
       info "Processing by #{payload[:controller]}##{payload[:action]} as #{format}"
       info "  Parameters: #{params.inspect}" unless params.empty?

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -121,6 +121,20 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal "Processing by Another::LogSubscribersController#show as HTML", logs.first
   end
 
+  def test_start_processing_as_json
+    get :show, format: "json"
+    wait
+    assert_equal 2, logs.size
+    assert_equal "Processing by Another::LogSubscribersController#show as JSON", logs.first
+  end
+
+  def test_start_processing_as_non_exten
+    get :show, format: "noext"
+    wait
+    assert_equal 2, logs.size
+    assert_equal "Processing by Another::LogSubscribersController#show as */*", logs.first
+  end
+
   def test_halted_callback
     get :never_executed
     wait


### PR DESCRIPTION
The rendering template is processing as */* but in the log is
  "Processing by Controller#action as "

This change add the */* for the log and showing as
  "Processing by Controller#action as */*"
when there not founds for the extension of format.
