### PR TITLE
Minor fix to correctly identify the entire scope of the loopback adress range

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -33,7 +33,7 @@ module ActionDispatch
     # not be the ultimate client IP in production, and so are discarded. See
     # https://en.wikipedia.org/wiki/Private_network for details.
     TRUSTED_PROXIES = [
-      "127.0.0.1",      # localhost IPv4
+      "127.0.0.0/8",    # localhost IPv4 range, per RFC-3330
       "::1",            # localhost IPv6
       "fc00::/7",       # private IPv6 range fc00::/7
       "10.0.0.0/8",     # private IPv4 range 10.x.x.x


### PR DESCRIPTION
### Summary

Updating the way this code identifies whether or not part of the XFF chain is from the loopback address.  The old code assumed `127.0.0.1` was the only available loopback address.  [RFC-3330](https://tools.ietf.org/html/rfc3330) indicates that `127.0.0.0/8` is the full network for loopback.  I changed that line of code to reflect the RFC.