### PR TITLE
Avoid assigning duplicate values to join_values

### DIFF
--- a/activerecord/lib/active_record/relation/from_clause.rb
+++ b/activerecord/lib/active_record/relation/from_clause.rb
@@ -18,6 +18,10 @@ module ActiveRecord
         value.nil?
       end
 
+      def ==(other)
+        other.is_a?(FromClause) && name == other.name && value == other.value
+      end
+
       def self.empty
         @empty ||= new(nil, nil).freeze
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -171,7 +171,7 @@ module ActiveRecord
     end
 
     def eager_load!(*args) # :nodoc:
-      self.eager_load_values += args
+      self.eager_load_values |= args
       self
     end
 
@@ -185,7 +185,7 @@ module ActiveRecord
     end
 
     def preload!(*args) # :nodoc:
-      self.preload_values += args
+      self.preload_values |= args
       self
     end
 
@@ -334,7 +334,7 @@ module ActiveRecord
     def group!(*args) # :nodoc:
       args.flatten!
 
-      self.group_values += args
+      self.group_values |= args
       self
     end
 
@@ -502,7 +502,7 @@ module ActiveRecord
     def joins!(*args) # :nodoc:
       args.compact!
       args.flatten!
-      self.joins_values += args
+      self.joins_values |= args
       self
     end
 
@@ -520,7 +520,7 @@ module ActiveRecord
     def left_outer_joins!(*args) # :nodoc:
       args.compact!
       args.flatten!
-      self.left_outer_joins_values += args
+      self.left_outer_joins_values |= args
       self
     end
 

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -138,5 +138,16 @@ module ActiveRecord
         author.top_posts.or(author.other_top_posts)
       end
     end
+
+    def test_structurally_incompatible_values
+      assert_nothing_raised do
+        Post.includes(:author).includes(:author).or(Post.includes(:author))
+        Post.eager_load(:author).eager_load(:author).or(Post.eager_load(:author))
+        Post.preload(:author).preload(:author).or(Post.preload(:author))
+        Post.group(:author_id).group(:author_id).or(Post.group(:author_id))
+        Post.joins(:author).joins(:author).or(Post.joins(:author))
+        Post.left_outer_joins(:author).left_outer_joins(:author).or(Post.left_outer_joins(:author))
+      end
+    end
   end
 end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -147,6 +147,7 @@ module ActiveRecord
         Post.group(:author_id).group(:author_id).or(Post.group(:author_id))
         Post.joins(:author).joins(:author).or(Post.joins(:author))
         Post.left_outer_joins(:author).left_outer_joins(:author).or(Post.left_outer_joins(:author))
+        Post.from("posts").or(Post.from("posts"))
       end
     end
   end


### PR DESCRIPTION
The ArgumentError occurs even though structures is compatible.
Because some query methods keep duplicate values.

For example, the behavior of `joins` method is as following:

```ruby
relation = Post.joins(:author).joins(:author)
relation.joins_values
#=> [:author, :author]
relation.or(Post.joins(:author))
#=> ArgumentError: Relation passed to #or must be structurally compatible. Incompatible values: [:joins]
```

This commit changes to not keep duplicate values.

Fixes #38052