### PR TITLE
Prevent deadlocks from touch callbacks on chained associations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -372,7 +372,7 @@ module ActiveRecord
       end
 
       def <=>(other)
-        by_depth(other) || by_table(other) || by_id(other) || 0
+        by_depth(other) || by_table(other) || by_id(other)
       end
 
       private
@@ -385,7 +385,7 @@ module ActiveRecord
         end
 
         def by_id(other)
-          (object.id <=> other.object.id)&.nonzero?
+          (object.id <=> other.object.id) || 0
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -116,7 +116,9 @@ module ActiveRecord
       end
 
       def before_commit_records
-        records.uniq.each(&:before_committed!) if records && @run_commit_callbacks
+        return unless records && @run_commit_callbacks
+
+        records.uniq.sort_by(&DeadlockPreventionOrder).each(&:before_committed!)
       end
 
       def commit_records
@@ -331,6 +333,59 @@ module ActiveRecord
           return unless transaction.is_a?(RealTransaction)
           return unless error.is_a?(ActiveRecord::PreparedStatementCacheExpired)
           @connection.clear_cache!
+        end
+    end
+
+    class DeadlockPreventionOrder
+      include Comparable
+
+      def self.to_proc
+        method(:new).to_proc
+      end
+
+      def self.association_depth(model, stack: [])
+        @association_depth ||= {}
+        @association_depth.fetch(model.name) do |key|
+          stack << model
+          depths = model.reflect_on_all_associations(:belongs_to).lazy
+            .select { |belonging| belonging.options[:touch] }
+            .map { |belonging|
+              if belonging.polymorphic?
+                1
+              elsif stack.include?(belonging.klass) || belonging.table_name == model.table_name
+                0
+              else
+                association_depth(belonging.klass, stack: stack) + 1
+              end
+            }
+
+          @association_depth[key] = depths.max || 0
+        end
+      end
+
+      delegate :association_depth, to: :class
+
+      attr_reader :object
+
+      def initialize(record)
+        @object = record
+      end
+
+      def <=>(other)
+        by_depth(other) || by_table(other) || by_id(other) || 0
+      end
+
+      private
+        def by_depth(other)
+          (association_depth(other.object.class) <=> association_depth(object.class)).nonzero?
+        end
+
+        def by_table(other)
+          (object.class.table_name <=> other.object.class.table_name).nonzero?
+        end
+
+        def by_id(other)
+          (object.id <=> other.object.id)&.nonzero?
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -346,7 +346,6 @@ module ActiveRecord
       def self.association_depth(model, stack: [])
         @association_depth ||= {}
         @association_depth.fetch(model.name) do |key|
-          stack << model
           depths = model.reflect_on_all_associations(:belongs_to)
             .select { |belonging| belonging.options[:touch] }
             .map { |belonging|
@@ -355,7 +354,7 @@ module ActiveRecord
               elsif stack.include?(belonging.klass) || belonging.table_name == model.table_name
                 0
               else
-                association_depth(belonging.klass, stack: stack) + 1
+                association_depth(belonging.klass, stack: [model].concat(stack)) + 1
               end
             }
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -347,7 +347,7 @@ module ActiveRecord
         @association_depth ||= {}
         @association_depth.fetch(model.name) do |key|
           stack << model
-          depths = model.reflect_on_all_associations(:belongs_to).lazy
+          depths = model.reflect_on_all_associations(:belongs_to)
             .select { |belonging| belonging.options[:touch] }
             .map { |belonging|
               if belonging.polymorphic?


### PR DESCRIPTION
Even with great care to arrange our model updates consistently within
transaction blocks, ActiveRecord could still cause deadlocks based on the
sequence of models needing to touch associations before commit.

The order that records are appended to the transaction callback array should be
sorted in a sequence that is:

1. Consistent between different transactions operating on the same tables, and
2. Least likely to conflict with the order of statements across different tables

Consider a simple hierarchy of Child belongs to Parent with touch: true. We can
easily create a situation where the deferred touches are listed out of order on
transaction records, based on different data conditions:

Transaction A

    Child.nice.each(&:send_gifts)
    # => [
    #   #<Child id: 1, parent_id: 1>,
    #   #<Child id: 2, parent_id: 2>
    # ]
    current_transaction.records
    # => [
    #   #<Parent id: 1>
    #   #<Parent id: 2>
    # ]

Transaction B

    Child.naughty.each(&:send_coal)
    # => [
    #   #<Child id: 3, parent_id: 2>,
    #   #<Child id: 4, parent_id: 1>
    # ]
    current_transaction.records
    # => [
    #   #<Parent id: 2>
    #   #<Parent id: 1>
    # ]

If these two transactions were to run concurrently, the `before_commit` callback
sequence could end up as:

|     | Transaction A             | Transaction B             |               |
| --- | ---                       | ---                       | ---           |
| 1   | UPDATE parents WHERE id=1 |                           | A locks row 1 |
| 2   |                           | UPDATE parents WHERE id=2 | B locks row 2 |
| 3   | UPDATE parents WHERE id=2 |                           | A waits for B |
| 4   |                           | UPDATE parents WHERE id=1 | B waits for A |

As each transaction is holding a row lock and waiting on the other to complete,
the database has no choice but to ROLLBACK one of these transactions with a
corresponding deadlock error.

To prevent this, we sort the transaction callback records in order of:

1. *Greatest depth* so when different associations reference a parent through
different paths, the deepest dependencies are applied first. This mostly mimics
the current implementation as associations get traversed upwards. (Polymorphic
associations are not counted for depth since they are indeterminate.)
2. *Table name* so different models that refer to the same table are applied
together in sequence, and not interleaved with other models.
3. *Primary key* as records from the same table can be listed for touch
callbacks in different order, they need to be updated in sequence.