### PR TITLE
When all IPs are trusted, use the furthest away

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActionDispatch::Request.remote_ip` has ip address even when all sites are trusted.
+
+    Before, if all `X-Forwarded-For` sites were trusted, the `remote_ip` would default to `127.0.0.1`.
+    Now, the furthest proxy site is used. e.g.: It now gives an ip address when using curl from the load balancer.
+
+    *Keenan Brock*
 *   Fix possible information leak / session hijacking vulnerability.
 
     The `ActionDispatch::Session::MemcacheStore` is still vulnerable given it requires the

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -143,10 +143,11 @@ module ActionDispatch
         #   - X-Forwarded-For will be a list of IPs, one per proxy, or blank
         #   - Client-Ip is propagated from the outermost proxy, or is blank
         #   - REMOTE_ADDR will be the IP that made the request to Rack
-        ips = [forwarded_ips, client_ips, remote_addr].flatten.compact
+        ips = [forwarded_ips, client_ips].flatten.compact
 
-        # If every single IP option is in the trusted list, just return REMOTE_ADDR
-        filter_proxies(ips).first || remote_addr
+        # If every single IP option is in the trusted list, return the IP
+        # that's furthest away
+        filter_proxies(ips + [remote_addr]).first || ips.last || remote_addr
       end
 
       # Memoizes the value returned by #calculate_ip and returns it for

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -77,6 +77,10 @@ class RequestIP < BaseRequestTest
                            "HTTP_X_FORWARDED_FOR" => "3.4.5.6"
     assert_equal "3.4.5.6", request.remote_ip
 
+    request = stub_request "REMOTE_ADDR" => "127.0.0.1",
+                           "HTTP_X_FORWARDED_FOR" => "172.31.4.4, 10.0.0.1"
+    assert_equal "172.31.4.4", request.remote_ip
+
     request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6,unknown"
     assert_equal "3.4.5.6", request.remote_ip
 
@@ -89,6 +93,9 @@ class RequestIP < BaseRequestTest
     request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6,10.0.0.1"
     assert_equal "3.4.5.6", request.remote_ip
 
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "172.31.4.4, 10.0.0.1"
+    assert_equal "172.31.4.4", request.remote_ip
+
     request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6, 10.0.0.1, 10.0.0.1"
     assert_equal "3.4.5.6", request.remote_ip
 
@@ -96,7 +103,7 @@ class RequestIP < BaseRequestTest
     assert_equal "3.4.5.6", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "unknown,192.168.0.1"
-    assert_nil request.remote_ip
+    assert_equal "192.168.0.1", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "9.9.9.9, 3.4.5.6, 172.31.4.4, 10.0.0.1"
     assert_equal "3.4.5.6", request.remote_ip
@@ -161,7 +168,7 @@ class RequestIP < BaseRequestTest
     assert_equal "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "unknown,::1"
-    assert_nil request.remote_ip
+    assert_equal "::1", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "2001:0db8:85a3:0000:0000:8a2e:0370:7334, fe80:0000:0000:0000:0202:b3ff:fe1e:8329, ::1, fc00::, fc01::, fdff"
     assert_equal "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", request.remote_ip
@@ -207,7 +214,7 @@ class RequestIP < BaseRequestTest
     assert_equal "3.4.5.6", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "67.205.106.73,unknown"
-    assert_nil request.remote_ip
+    assert_equal "67.205.106.73", request.remote_ip # change
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "9.9.9.9, 3.4.5.6, 10.0.0.1, 67.205.106.73"
     assert_equal "3.4.5.6", request.remote_ip
@@ -226,10 +233,10 @@ class RequestIP < BaseRequestTest
 
     request = stub_request "REMOTE_ADDR" => "fe80:0000:0000:0000:0202:b3ff:fe1e:8329,::1",
                            "HTTP_X_FORWARDED_FOR" => "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
-    assert_equal "::1", request.remote_ip
+    assert_equal "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "unknown,fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
-    assert_nil request.remote_ip
+    assert_equal "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", request.remote_ip
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "fe80:0000:0000:0000:0202:b3ff:fe1e:8329,2001:0db8:85a3:0000:0000:8a2e:0370:7334"
     assert_equal "2001:0db8:85a3:0000:0000:8a2e:0370:7334", request.remote_ip


### PR DESCRIPTION
### Summary

This is a rebase of the stale https://github.com/rails/rails/pull/14600.

From reading the thread, it looked like no logic changes need to be made, it just needed style and merge updates.

/cc @indirect @jeremy @matthewd 

### Other Information

As far as I could tell, the merge conflicts were from an added test (bf14a8e23526) and style changes (e8ba0c0f21e2660 and 35b3de8021e68649c). I did move 2 asserts a few lines up, but besides that it should be unchanged.

Original PR Summary
----

Scenario: we have a REMOTE_ADDR of `127.0.0.1`, and X-Forwarded-For is
`A, B, C`.

Without any relevant trust, the `remote_ip` is `C`.

If `C` is trusted, then the `remote_ip` is `B`.

If `B` and `C` are trusted, then the `remote_ip` is `A`.

If all of `A`, `B`, and `C` are trusted, then the `remote_ip` should
still be `A`: if our trust was sufficient to get that far out before,
trusting something else should not have us fall back to `127.0.0.1`.

It is this last situation that we're correcting here:

We trust `A` to give us accurate X-Forwarded-For information, yet it has
chosen to leave it unset. Therefore, `A` is telling us that it is itself
the client.
