### PR TITLE
Pass env_name as a string in test databases

### DIFF
--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -5,7 +5,7 @@ require "active_support/testing/parallelization"
 module ActiveRecord
   module TestDatabases # :nodoc:
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
-      create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym)
+      create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
     end
 
     def self.create_and_load_schema(i, env_name:)
@@ -20,7 +20,12 @@ module ActiveRecord
           db_config.configuration_hash.merge(database: database)
         )
 
+        # Reconstruct with the new configuration
         ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config_copy, ActiveRecord::Base.schema_format, nil)
+
+        # Replace the original configuration with our replacement
+        ActiveRecord::Base.configurations.configurations.delete(db_config)
+        ActiveRecord::Base.configurations.configurations.push(db_config_copy)
       end
     ensure
       ActiveRecord::Base.establish_connection(ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym)

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_record/test_databases"
 
 class TestDatabasesTest < ActiveRecord::TestCase
   unless in_memory_db?
     def test_databases_are_created
       previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
+      prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
+        "arunit" => {
+          "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+        }
+      }
 
       base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
       expected_database = "#{base_db_config.database}-2"
@@ -16,6 +22,34 @@ class TestDatabasesTest < ActiveRecord::TestCase
         ActiveRecord::TestDatabases.create_and_load_schema(2, env_name: "arunit")
       end
     ensure
+      ActiveRecord::Base.configurations = prev_configs
+      ActiveRecord::Base.establish_connection(:arunit)
+      ENV["RAILS_ENV"] = previous_env
+    end
+
+    def test_create_databases_after_fork
+      previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
+      prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
+        "arunit" => {
+          "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+        }
+      }
+
+      idx = 42
+      base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      expected_database = "#{base_db_config.database}-#{idx}"
+
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
+        assert_equal expected_database, db_config.database
+      }) do
+        ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }
+      end
+
+      # Updates the databse configuration
+      assert_equal expected_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").database
+    ensure
+      ActiveRecord::Base.configurations = prev_configs
+      ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
     end
   end


### PR DESCRIPTION
In 154abca we switched from using `Rails.env` to fetch the `env_name` to
`ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym` which
changed the type from a `String` to a `Symbol`.

This commit brings things back to the original state, so we can find the
configurations correctly!

It also modifies the configuration in the configurations array, so that
future connections can find the database with the updated keyword value.

Closes #38104

cc / @mcgregordan @eileencodes @rafaelfranca @khustochka 