### PR TITLE
Added "each" method for AR classes

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,
-      :pluck, :pick, :ids
+      :pluck, :pick, :ids, :each
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1096,4 +1096,9 @@ class CalculationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test "#each works as class method" do
+    assert_respond_to Account, :each
+    assert Account.each.is_a?(Enumerable)
+  end
 end


### PR DESCRIPTION
### Summary

I want to reduce a little code by removing the calling method "all" on ActiveRecord classes. 

Instead of `Account.all.each ...` just call `Account.each ...`.

I think it's more readable and clear for a developer about how this code works.