### PR TITLE
Update "The Hard Way" setup for Arch Linux

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -127,7 +127,8 @@ To install all run:
 
 ```bash
 $ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2
-$ sudo systemctl start redis
+$ sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+$ sudo systemctl start redis mariadb memcached
 ```
 
 NOTE: If you are running Arch Linux, MySQL isn't supported anymore so you will need to


### PR DESCRIPTION
### Summary

MariaDB cannot be started on Arch Linux before running a command to create the database files

See https://wiki.archlinux.org/index.php/MariaDB#Installation

It also appears that memcached is not started by default on Arch Linux,
so it has been added to the systemctl startup step.

This PR adds those steps when setting up on Arch Linux