### PR TITLE
Remove directory when file is deleted on DiskStorage service

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -50,7 +50,7 @@ module ActiveStorage
 
     def delete(key)
       instrument :delete, key: key do
-        File.delete path_for(key)
+        FileUtils.remove_dir folder_path_for(key), true
       rescue Errno::ENOENT
         # Ignore files already deleted
       end
@@ -147,6 +147,10 @@ module ActiveStorage
 
       def folder_for(key)
         [ key[0..1], key[2..3] ].join("/")
+      end
+
+      def folder_path_for(key)
+        File.join root, folder_for(key)
       end
 
       def make_path_for(key)


### PR DESCRIPTION
### Summary

DiskStorage only removes the attached file but leaves behind its empty parent directories.

This commit removes the parent directories as well.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
