### PR TITLE
Add first & last IDs to collection cache versions (via connection adapters)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Include the IDs of the first and last records of a collection when
+    generating cache keys for Active Record relations using a limit or
+    offset. Update signatures of `ActiveRecord::Relation#cache_version`,
+    `ActiveRecord::Relation#cache_key` and related methods to use keyword
+    arguments instead of positional arguments, add deprecation notices where
+    appropriate. Fixes #31996, #34408 and #37555.
+
+    *Aaron Lipman*
+
 *   Add `ActiveRecord::Validations::NumericalityValidator` with
     support for casting floats using a database columns' precision value.
 
@@ -7,7 +16,7 @@
     ActiveRecord::Relation#cache_key_with_version. This method will be used by
     ActionController::ConditionalGet to ensure that when collection cache versioning
     is enabled, requests using ConditionalGet don't return the same ETag header
-    after a collection is modified. Fixes #38078.
+    after a collection is modified. Fixes #38078
 
     *Aaron Lipman*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -590,6 +590,17 @@ module ActiveRecord
       def check_version # :nodoc:
       end
 
+      def cache_version_query(collection, id_column: nil, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.arel_attribute(timestamp_column))
+        select_values = "COUNT(*) AS collection_size, MAX(#{timestamp_col}) AS timestamp"
+        query = collection.unscope(:order)
+        query.select_values = [select_values]
+        query.arel
+      end
+
+      def set_cache_version_vars # :nodoc:
+      end
+
       private
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -122,6 +122,22 @@ module ActiveRecord
         @connection = nil
       end
 
+      def cache_version_query(collection, id_column: collection.primary_key, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.arel_attribute(timestamp_column))
+        id_col = visitor.compile(collection.arel_attribute(id_column))
+
+        if collection.has_limit_or_offset?
+          query = collection.select("COALESCE(@first_id, @first_id := #{id_col}), @last_id := #{id_col}, #{timestamp_col} AS collection_cache_key_timestamp")
+          Arel::Nodes::SqlLiteral.new "SELECT COUNT(*) AS collection_size, @first_id AS first_id, @last_id AS last_id, MAX(collection_cache_key_timestamp) AS timestamp FROM (#{query.to_sql}) AS subquery_for_cache_key"
+        else
+          super
+        end
+      end
+
+      def set_cache_version_vars # :nodoc:
+        execute("SET @first_id := @last_id := NULL")
+      end
+
       private
         def connect
           @connection = Mysql2::Client.new(@config)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -463,6 +463,36 @@ module ActiveRecord
         end
       end
 
+      def cache_version_query(collection, id_column: collection.primary_key, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.arel_attribute(timestamp_column))
+        id_col = visitor.compile(collection.arel_attribute(id_column))
+
+        if collection.has_limit_or_offset?
+          collection_table = Arel::Table.new("cache_key_collection")
+          aggregates_table = Arel::Table.new("cache_key_aggregates")
+          query = collection.select("#{id_col} AS collection_cache_key_id, #{timestamp_col} AS collection_cache_key_timestamp")
+          collection_query = Arel::Nodes::SqlLiteral.new "(#{ query.to_sql })"
+          aggregates_query = collection_table.project("COUNT(*) AS collection_size, MAX(collection_cache_key_timestamp) AS timestamp")
+          collection_common_table_expr = Arel::Nodes::As.new(collection_table, collection_query)
+          aggregates_common_table_expr = Arel::Nodes::As.new(aggregates_table, aggregates_query)
+          collection_size_minus_one = Arel::Nodes::Subtraction.new(aggregates_table[:collection_size], 1)
+          last_id_offset = Arel::Nodes::NamedFunction.new("GREATEST", [collection_size_minus_one, 0])
+
+          select_values = [
+            aggregates_table[:collection_size],
+            aggregates_table[:timestamp],
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).as("first_id"),
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).skip(last_id_offset).as("last_id")
+          ]
+
+          aggregates_table
+            .project(select_values)
+            .with(collection_common_table_expr, aggregates_common_table_expr)
+        else
+          super
+        end
+      end
+
       private
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -343,6 +343,36 @@ module ActiveRecord
         end
       end
 
+      def cache_version_query(collection, id_column: collection.primary_key, timestamp_column: :updated_at) # :nodoc:
+        timestamp_col = visitor.compile(collection.arel_attribute(timestamp_column))
+        id_col = visitor.compile(collection.arel_attribute(id_column))
+
+        if collection.has_limit_or_offset?
+          collection_table = Arel::Table.new("cache_key_collection")
+          aggregates_table = Arel::Table.new("cache_key_aggregates")
+          query = collection.select("#{id_col} AS collection_cache_key_id, #{timestamp_col} AS collection_cache_key_timestamp")
+          collection_query = Arel::Nodes::SqlLiteral.new "(#{ query.to_sql })"
+          aggregates_query = collection_table.project("COUNT(*) AS collection_size, MAX(collection_cache_key_timestamp) AS timestamp")
+          collection_common_table_expr = Arel::Nodes::As.new(collection_table, collection_query)
+          aggregates_common_table_expr = Arel::Nodes::As.new(aggregates_table, aggregates_query)
+          collection_size_minus_one = Arel::Nodes::Subtraction.new(aggregates_table[:collection_size], 1)
+          last_id_offset = aggregates_table.project(collection_size_minus_one)
+
+          select_values = [
+            aggregates_table[:collection_size],
+            aggregates_table[:timestamp],
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).as("first_id"),
+            collection_table.project(collection_table[:collection_cache_key_id]).take(1).skip(last_id_offset).as("last_id")
+          ]
+
+          aggregates_table
+            .project(select_values)
+            .with(collection_common_table_expr, aggregates_common_table_expr)
+        else
+          super
+        end
+      end
+
       private
         # See https://www.sqlite.org/limits.html,
         # the default value is 999 when not configured.

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -161,8 +161,8 @@ module ActiveRecord
         end
       end
 
-      def collection_cache_key(collection = all, timestamp_column = :updated_at) # :nodoc:
-        collection.send(:compute_cache_key, timestamp_column)
+      def collection_cache_key(collection = all, id_column: primary_key, timestamp_column: :updated_at) # :nodoc:
+        collection.send(:compute_cache_key, id_column: id_column, timestamp_column: timestamp_column)
       end
     end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -304,83 +304,137 @@ module ActiveRecord
     #    Product.where("name like ?", "%Cosmic Encounter%").cache_key
     #    # => "products/query-1850ab3d302391b85b8693e941286659-1-20150714212553907087000"
     #
-    # You can also pass a custom timestamp column to fetch the timestamp of the
-    # last updated record.
+    # You can pass a custom timestamp column to fetch the timestamp of the
+    # most-recently updated record.
     #
-    #   Product.where("name like ?", "%Game%").cache_key(:last_reviewed_at)
-    def cache_key(timestamp_column = :updated_at)
+    #    Product.where("name like ?", "%Game%").cache_key(timestamp_column: :last_reviewed_at)
+    #
+    # You can also specify a column other than a model's primary ID to generate
+    # the first & last ID segments of the cache_version for collections using a
+    # limit or offset.
+    #
+    #    Product.where("name like ?", "%Game%").cache_key(id_column: :upc)
+    def cache_key(deprecated_timestamp_column = nil, id_column: primary_key, timestamp_column: :updated_at)
+      if deprecated_timestamp_column
+        ActiveSupport::Deprecation.warn("Passing a timestamp column as a positional argument to ActiveRecord::Relation#cache_key is deprecated. Please use a `:timestamp_column` keyword argument instead.")
+        timestamp_column = deprecated_timestamp_column
+      end
+
       @cache_keys ||= {}
-      @cache_keys[timestamp_column] ||= klass.collection_cache_key(self, timestamp_column)
+      @cache_keys[[id_column, timestamp_column]] ||= klass.collection_cache_key(self, id_column: id_column, timestamp_column: timestamp_column)
     end
 
-    def compute_cache_key(timestamp_column = :updated_at) # :nodoc:
+    def compute_cache_key(id_column: primary_key, timestamp_column: :updated_at) # :nodoc:
       query_signature = ActiveSupport::Digest.hexdigest(to_sql)
       key = "#{klass.model_name.cache_key}/query-#{query_signature}"
 
       if collection_cache_versioning
         key
       else
-        "#{key}-#{compute_cache_version(timestamp_column)}"
+        "#{key}-#{compute_cache_version(id_column: id_column, timestamp_column: timestamp_column)}"
       end
     end
     private :compute_cache_key
 
     # Returns a cache version that can be used together with the cache key to form
     # a recyclable caching scheme. The cache version is built with the number of records
-    # matching the query, and the timestamp of the last updated record. When a new record
-    # comes to match the query, or any of the existing records is updated or deleted,
-    # the cache version changes.
+    # matching the query, and the timestamp of the last updated record. When a
+    # new record comes to match the query, or any of the existing records is updated or
+    # deleted, the cache version changes.
     #
     # If the collection is loaded, the method will iterate through the records
     # to generate the timestamp, otherwise it will trigger one SQL query like:
     #
-    #    SELECT COUNT(*), MAX("products"."updated_at") FROM "products" WHERE (name like '%Cosmic Encounter%')
-    def cache_version(timestamp_column = :updated_at)
+    #    SELECT COUNT(*), MAX(products.updated_at) FROM products WHERE (name like '%Cosmic Encounter%')
+    #
+    # If the collection uses a limit or offset, the cache version will include the
+    # collection's first and last IDs to ensure proper expiration. When using Postgres
+    # or SQLite, first & last IDs will be determined via common table expressions:
+    #
+    #    WITH
+    #      cache_key_collection AS (SELECT id AS collection_cache_key_id, updated_at AS collection_cache_key_timestamp FROM products ORDER BY name ASC LIMIT 5),
+    #      cache_key_aggregates AS (SELECT COUNT(*) AS collection_size, MAX(collection_cache_key_timestamp) AS timestamp FROM cache_key_collection)
+    #    SELECT
+    #      collection_size,
+    #      timestamp,
+    #      (SELECT collection_cache_key_id FROM cache_key_collection LIMIT 1) AS first_id,
+    #      (SELECT collection_cache_key_id FROM cache_key_collection LIMIT 1 OFFSET GREATEST(collection_size - 1, 0) AS last_id
+    #    FROM cache_key_aggregates
+    #
+    # When using MySQL, first and last IDs will be determined via user variables:
+    #
+    #    SET @first_id := @last_id := NULL;
+    #    SELECT
+    #      COUNT(*) AS collection_size,
+    #      MAX(collection_cache_key_timestamp) AS timestamp,
+    #      @first_id AS first_id,
+    #      @last_id AS last_id
+    #    FROM (
+    #      SELECT
+    #        COALESCE(@first_id, @first_id := id),
+    #        @last_id := id,
+    #        updated_at AS collection_cache_key_timestamp
+    #      FROM products
+    #      ORDER BY name ASC LIMIT 5
+    #    ) subquery_for_cache_key
+    def cache_version(deprecated_timestamp_column = nil, id_column: primary_key, timestamp_column: :updated_at)
+      if deprecated_timestamp_column
+        ActiveSupport::Deprecation.warn("Passing a timestamp column as a positional argument to ActiveRecord::Relation#cache_version is deprecated. Please use a `:timestamp_column` keyword argument instead.")
+        timestamp_column = deprecated_timestamp_column
+      end
+
       if collection_cache_versioning
         @cache_versions ||= {}
-        @cache_versions[timestamp_column] ||= compute_cache_version(timestamp_column)
+        @cache_versions[[id_column, timestamp_column]] ||= compute_cache_version(id_column: id_column, timestamp_column: timestamp_column)
       end
     end
 
-    def compute_cache_version(timestamp_column) # :nodoc:
+    def compute_cache_version(id_column: primary_key, timestamp_column: :updated_at) # :nodoc:
+      size = 0
+      first_id = nil
+      last_id = nil
+      timestamp = nil
+
       if loaded? || distinct_value
         size = records.size
+
         if size > 0
-          timestamp = max_by(&timestamp_column)._read_attribute(timestamp_column)
+          timestamp = max_by(&timestamp_column)._read_attribute(timestamp_column).utc.to_s(cache_timestamp_format)
+
+          if has_limit_or_offset?
+            first_id = first._read_attribute(id_column)
+            last_id = last._read_attribute(id_column)
+          end
         end
       else
         collection = eager_loading? ? apply_join_dependency : self
+        arel = connection.cache_version_query(collection, id_column: id_column, timestamp_column: timestamp_column)
+        result = nil
 
-        column = connection.visitor.compile(arel_attribute(timestamp_column))
-        select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
-
-        if collection.has_limit_or_offset?
-          query = collection.select("#{column} AS collection_cache_key_timestamp")
-          subquery_alias = "subquery_for_cache_key"
-          subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
-          arel = query.build_subquery(subquery_alias, select_values % subquery_column)
-        else
-          query = collection.unscope(:order)
-          query.select_values = [select_values % column]
-          arel = query.arel
+        connection_pool.with_connection do
+          connection.set_cache_version_vars if has_limit_or_offset?
+          result = connection.select_one(arel, nil)
         end
-
-        result = connection.select_one(arel, nil)
 
         if result
           column_type = klass.type_for_attribute(timestamp_column)
-          timestamp = column_type.deserialize(result["timestamp"])
-          size = result["size"]
-        else
-          timestamp = nil
-          size = 0
+          size = result["collection_size"]
+
+          if size > 0
+            first_id = result["first_id"]
+            last_id = result["last_id"]
+            timestamp = column_type.deserialize(result["timestamp"]).utc.to_s(cache_timestamp_format)
+          end
         end
       end
 
-      if timestamp
-        "#{size}-#{timestamp.utc.to_s(cache_timestamp_format)}"
+      case
+      when size.zero?
+        "0"
+      when first_id
+        "#{size}-#{first_id}-#{last_id}-#{timestamp}"
       else
-        "#{size}"
+        "#{size}-#{timestamp}"
       end
     end
     private :compute_cache_version

--- a/activerecord/test/fixtures/movies.yml
+++ b/activerecord/test/fixtures/movies.yml
@@ -5,3 +5,7 @@ first:
 second:
   movieid: 2
   name: Gladiator
+
+second:
+  movieid: 3
+  name: Ghostbusters

--- a/activerecord/test/models/bagel.rb
+++ b/activerecord/test/models/bagel.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Bagel < ActiveRecord::Base
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -89,6 +89,11 @@ ActiveRecord::Schema.define do
     t.integer     :value
   end
 
+  create_table :bagels, force: true do |t|
+    t.string :topping
+    t.timestamps null: false
+  end
+
   create_table :binaries, force: true do |t|
     t.string :name
     t.binary :data
@@ -571,6 +576,7 @@ ActiveRecord::Schema.define do
   create_table :movies, force: true, id: false do |t|
     t.primary_key :movieid
     t.string      :name
+    t.timestamps null: false
   end
 
   create_table :notifications, force: true do |t|


### PR DESCRIPTION
This draft pull request is a refactored version of #37724. In this refactored version, logic specific to Postgres/MySQL/Sqlite3 is moved to the respective connection adapter.