### PR TITLE
Allow relations with different SQL comments in the `or` method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1447,7 +1447,7 @@ module ActiveRecord
         end
       end
 
-      STRUCTURAL_OR_METHODS = Relation::VALUE_METHODS - [:extending, :where, :having, :unscope, :references]
+      STRUCTURAL_OR_METHODS = Relation::VALUE_METHODS - [:extending, :where, :having, :unscope, :references, :annotate, :optimizer_hints]
       def structurally_incompatible_values_for_or(other)
         values = other.values
         STRUCTURAL_OR_METHODS.reject do |method|

--- a/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
@@ -48,5 +48,24 @@ if supports_optimizer_hints?
         posts.unscope(:optimizer_hints).load
       end
     end
+
+    def test_optimizer_hints_with_or
+      assert_sql(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
+        Post.optimizer_hints("SeqScan(posts)").or(Post.all).load
+      end
+
+      queries = capture_sql do
+        Post.optimizer_hints("SeqScan(posts)").or(Post.optimizer_hints("IndexScan(posts)")).load
+      end
+      assert_equal 1, queries.length
+      assert_includes queries.first, "/*+ SeqScan(posts) */"
+      assert_not_includes queries.first, "/*+ IndexScan(posts) */"
+
+      queries = capture_sql do
+        Post.all.or(Post.optimizer_hints("IndexScan(posts)")).load
+      end
+      assert_equal 1, queries.length
+      assert_not_includes queries.first, "/*+ IndexScan(posts) */"
+    end
   end
 end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -139,6 +139,14 @@ module ActiveRecord
       end
     end
 
+    def test_or_with_annotate
+      quoted_posts = Regexp.escape(Post.quoted_table_name)
+      assert_match %r{#{quoted_posts} /\* foo \*/\z}, Post.annotate("foo").or(Post.all).to_sql
+      assert_match %r{#{quoted_posts} /\* foo \*/\z}, Post.annotate("foo").or(Post.annotate("foo")).to_sql
+      assert_match %r{#{quoted_posts} /\* foo \*/\z}, Post.annotate("foo").or(Post.annotate("bar")).to_sql
+      assert_match %r{#{quoted_posts} /\* foo \*/ /\* bar \*/\z}, Post.annotate("foo", "bar").or(Post.annotate("foo")).to_sql
+    end
+
     def test_structurally_incompatible_values
       assert_nothing_raised do
         Post.includes(:author).includes(:author).or(Post.includes(:author))


### PR DESCRIPTION
An error occurs when you pass a relation with SQL comments to the `or` method.

```ruby
class Post
  scope :active, -> { where(active: true).annotate("active posts") }
end

Post.where("created_at > ?", Time.current.beginning_of_month)
  .or(Post.active)
#=> ArgumentError (Relation passed to #or must be structurally compatible. Incompatible values: [:annotate])
```

In order to work without `ArgumentError`, it changes the `or` method to ignore SQL comments in the argument.

Ref: https://github.com/rails/rails/pull/38145#discussion_r363024376