### PR TITLE
Add AC::TestSession#dig method like AD::Request::Session

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -202,6 +202,11 @@ module ActionController
       clear
     end
 
+    def dig(*keys)
+      keys = keys.map.with_index { |key, i| i.zero? ? key.to_s : key }
+      @data.dig(*keys)
+    end
+
     def fetch(key, *args, &block)
       @data.fetch(key.to_s, *args, &block)
     end

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -43,6 +43,12 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     assert_equal %w(1 2), session.values
   end
 
+  def test_dig
+    session = ActionController::TestSession.new(one: { two: { three: "3" } })
+    assert_equal("3", session.dig(:one, :two, :three))
+    assert_nil(session.dig(:ruby, :on, :rails))
+  end
+
   def test_fetch_returns_default
     session = ActionController::TestSession.new(one: "1")
     assert_equal("2", session.fetch(:two, "2"))


### PR DESCRIPTION
### Summary

`ActionDispatch::Request::Session#dig` has been introduced at 398267b14220c6659d6b1f8fdebf36ce7f8d58c9.
But `ActionController::TestSession` doesn't have `#dig`.

This breaks helper test.

helper:
``` ruby
def some_helper_method
  do_something_with session.dig(:foo, :bar)
end
```

test:
``` ruby
it 'some test' do
  expect(helper.some_helper_method).to be_something
end
```

Above test fails with exception:
```
NoMethodError: undefined method `dig' for #<ActionController::TestSession:***>
```
