### PR TITLE
Memoize regex when checking missing route keys

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -125,19 +125,10 @@ module ActionDispatch
           routes
         end
 
-        module RegexCaseComparator
-          DEFAULT_INPUT = /[-_.a-zA-Z0-9]+\/[-_.a-zA-Z0-9]+/
-          DEFAULT_REGEX = /\A#{DEFAULT_INPUT}\Z/
-
-          def self.===(regex)
-            DEFAULT_INPUT == regex
-          end
-        end
-
         # Returns an array populated with missing keys if any are present.
         def missing_keys(route, parts)
           missing_keys = nil
-          tests = route.path.requirements
+          tests = route.path.requirements_for_missing_keys_check
           route.required_parts.each { |key|
             case tests[key]
             when nil
@@ -145,13 +136,8 @@ module ActionDispatch
                 missing_keys ||= []
                 missing_keys << key
               end
-            when RegexCaseComparator
-              unless RegexCaseComparator::DEFAULT_REGEX.match?(parts[key])
-                missing_keys ||= []
-                missing_keys << key
-              end
             else
-              unless /\A#{tests[key]}\Z/.match?(parts[key])
+              unless tests[key].match?(parts[key])
                 missing_keys ||= []
                 missing_keys << key
               end

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -177,6 +177,12 @@ module ActionDispatch
           @re ||= regexp_visitor.new(@separators, @requirements).accept spec
         end
 
+        def requirements_for_missing_keys_check
+          @requirements_for_missing_keys_check ||= requirements.each_with_object({}) do |(key, regex), hash|
+            hash[key] = /\A#{regex}\Z/
+          end
+        end
+
         private
           def regexp_visitor
             @anchored ? AnchoredRegexp : UnanchoredRegexp

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -289,6 +289,37 @@ module ActionDispatch
           named_captures = { "action" => "list", "format" => "rss" }
           assert_equal named_captures, match.named_captures
         end
+
+        def test_requirements_for_missing_keys_check
+          name_regex = /test/
+
+          path = Pattern.build(
+            "/page/:name",
+            { name: name_regex },
+            SEPARATORS,
+            true
+          )
+
+          transformed_regex = path.requirements_for_missing_keys_check[:name]
+          assert_not_nil transformed_regex
+          assert_equal(transformed_regex, /\A#{name_regex}\Z/)
+        end
+
+        def test_requirements_for_missing_keys_check_memoization
+          name_regex = /test/
+
+          path = Pattern.build(
+            "/page/:name",
+            { name: name_regex },
+            SEPARATORS,
+            true
+          )
+
+          first_call = path.requirements_for_missing_keys_check[:name]
+          second_call = path.requirements_for_missing_keys_check[:name]
+
+          assert_equal(first_call.object_id, second_call.object_id)
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

When the route definition has parameters, we can supply a regex for
validation purposes (constraint):

    get "/a/:b" => "test#index", constraints: { b: /abc/ }, as: test

This regex is going to be used to check the supplied values during
link generation:

    test_path("abc") # check "abc" against /abc/ regex

The link generation code checks each parameter. To properly validate the
parameter, it creates a new regex with start and end of string modifiers:

    /\A#{original_regex}\Z/

This means, for each link generation the code stringifies the existing
regex and creates a new one. When a new regex is created, it needs to be
compiled, for large regexes this can take quite a bit of time.

This change memoizes the generated regex for each route when constrains
are given. It also removes the RegexCaseComparator class since it is not
in use anymore.

### Other Information

Relevant method: [missing_keys](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/journey/formatter.rb#L154)

#### Performance test

Before:

```
       user     system      total        real
test_path 12.841376   0.132328  12.973704 ( 13.057241)
```

After:

```
       user     system      total        real
test_path  2.069745   0.005842   2.075587 (  2.075645)
```

Benchmark script (place it to rails root): 

```ruby
# frozen_string_literal: true

require "bundler/inline"
require "benchmark"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
end

require "action_controller/railtie"

NAMESPACE_ID_REGEX = /(?-mix:(?!((?i-mx:\-|\.well\-known|404\.html|422\.html|500\.html|502\.html|503\.html|abuse_reports|admin|api|apple\-touch\-icon\-precomposed\.png|apple\-touch\-icon\.png|assets|autocomplete|ci|dashboard|deploy\.html|explore|favicon\.ico|favicon\.png|files|groups|health_check|help|import|invites|jwt|login|notification_settings|oauth|profile|projects|public|robots\.txt|s|search|sent_notifications|slash\-command\-logo\.png|snippets|unsubscribes|uploads|users|v2))\/)(?-mix:(?:[a-zA-Z0-9_\.][a-zA-Z0-9_\-\.]*[a-zA-Z0-9_\-]|[a-zA-Z0-9_])(?-mix:(?<!\.git|\.atom))))(?:\/(?!(?i-mx:\-|badges|blame|blob|builds|commits|create|create_dir|edit|environments\/folders|files|find_file|gitlab\-lfs\/objects|info\/lfs\/objects|new|preview|raw|refs|tree|update|wikis)\/)(?-mix:(?:[a-zA-Z0-9_\.][a-zA-Z0-9_\-\.]*[a-zA-Z0-9_\-]|[a-zA-Z0-9_])(?-mix:(?<!\.git|\.atom))))*/.freeze

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/namespace/:namespace_id" => "test#index", constraints: { namespace_id: NAMESPACE_ID_REGEX }, as: :test
  end
end

include Rails.application.routes.url_helpers

N = 100000

Benchmark.bm do |x|
  x.report("test_path") do
    N.times do
      test_path("path1/path2/path3")
    end
  end
end
```

`ruby test_script.rb`

Call graph:

![missing_keys](https://user-images.githubusercontent.com/705206/71957402-f5daf880-31ed-11ea-8275-3b2cb2df515f.png)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
