### PR TITLE
Deprecate using `Range#include?` to check the inclusion of a value in a date time range

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate using `Range#include?` method to check the inclusion of a value
+    in a date time range. It is recommended to use `Range#cover?` method
+    instead of `Range#include?` to check the inclusion of a value
+    in a date time range.
+
+    *Vishal Telangre*
+
 *   Support added for a `round_mode` parameter, in all number helpers. (See: `BigDecimal::mode`.)
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/time_with_zone"
+require "active_support/deprecation"
 
 module ActiveSupport
   module IncludeTimeWithZone #:nodoc:
@@ -9,9 +10,13 @@ module ActiveSupport
     #   (1.hour.ago..1.hour.from_now).include?(Time.current) # => true
     #
     def include?(value)
-      if self.begin.is_a?(TimeWithZone)
-        cover?(value)
-      elsif self.end.is_a?(TimeWithZone)
+      if self.begin.is_a?(TimeWithZone) || self.end.is_a?(TimeWithZone)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Using `Range#include?` to check the inclusion of a value in
+          a date time range is deprecated.
+          It is recommended to use `Range#cover?` instead of `Range#include?` to
+          check the inclusion of a value in a date time range.
+        MSG
         cover?(value)
       else
         super

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -191,9 +191,21 @@ class RangeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_cover_on_time_with_zone
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Eastern Time (US & Canada)"], Time.utc(2006, 11, 28, 10, 30))
+    assert ((twz - 1.hour)..twz).cover?(twz)
+  end
+
   def test_include_on_time_with_zone
     twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Eastern Time (US & Canada)"], Time.utc(2006, 11, 28, 10, 30))
     assert ((twz - 1.hour)..twz).include?(twz)
+  end
+
+  def test_include_on_time_with_zone_deprecation
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Eastern Time (US & Canada)"], Time.utc(2006, 11, 28, 10, 30))
+    assert_deprecated do
+      ((twz - 1.hour)..twz).include?(twz)
+    end
   end
 
   def test_case_equals_on_time_with_zone


### PR DESCRIPTION
### Summary

The usage of the `Range#include?` method to check the inclusion of an argument in date-time with zone range is deprecated. This method is extended in `active_support/core_ext/range/include_time_with_zone` extension as of now.

As a replacement, it is recommended to use `Range#cover?` instead of `Range#include?` to check the inclusion of a value in a date-time range.

Reference: https://github.com/rails/rails/pull/36194#discussion_r363747761 cc: @rafaelfranca
