### PR TITLE
Remove method encode from url_test in Actionmailer:

### DIFF
--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -57,10 +57,6 @@ class ActionMailerUrlTest < ActionMailer::TestCase
     end
   end
 
-  def encode(text, charset = "UTF-8")
-    quoted_printable(text, charset)
-  end
-
   def new_mail(charset = "UTF-8")
     mail = Mail.new
     mail.mime_version = "1.0"


### PR DESCRIPTION
This method is introduced in c064802d but at this moment is not
use anymore.

