### PR TITLE
Fix numericality validator when defined on abstract class:

### DIFF
--- a/activerecord/lib/active_record/validations/numericality.rb
+++ b/activerecord/lib/active_record/validations/numericality.rb
@@ -3,21 +3,14 @@
 module ActiveRecord
   module Validations
     class NumericalityValidator < ActiveModel::Validations::NumericalityValidator # :nodoc:
-      def initialize(options)
-        super
-        @klass = options[:class]
-      end
-
       def validate_each(record, attribute, value, precision: nil)
-        precision = column_precision_for(attribute) || Float::DIG
+        precision = column_precision_for(attribute, record) || Float::DIG
         super
       end
 
       private
-        def column_precision_for(attribute)
-          if @klass < ActiveRecord::Base
-            @klass.type_for_attribute(attribute.to_s)&.precision
-          end
+        def column_precision_for(attribute, record)
+          record.class.type_for_attribute(attribute.to_s)&.precision
         end
     end
 

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -40,4 +40,24 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     assert_predicate subject, :valid?
   end
+
+  def test_on_abstract_class
+    abstract_class = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+      validates(:bank_balance, numericality: { equal_to: 10_000_000.12 })
+    end
+
+    klass = Class.new(abstract_class) do
+      def self.table_name
+        "numeric_data"
+      end
+
+      def self.name
+        "MyClass"
+      end
+    end
+    subject = klass.new(bank_balance: 10_000_000.12)
+
+    assert_predicate(subject, :valid?)
+  end
 end


### PR DESCRIPTION
Fix numericality validator when defined on abstract class:

- ### Problem

  It's no longer possible to define a numeric validation on abstract
  class:

  ```ruby
    class AnimalsBase < ApplicationRecord
      self.abstract_class = true

      validates :age, numericality: { min: 18 }
    end

    class Dog < AnimalsBase
    end

    Dog.create!(age: 0) => ActiveRecord::TableNotSpecified: AnimalsBase has no table configured. Set one with AnimalsBase.table_name=
  ```

  ### Solution

  Instead of trying to get the type for attribute on the class
  defining the validation, get it from the record being validated.

cc/ @rafaelfranca @casperisfine @gmcgibbon 