### PR TITLE
[ci skip] Document caveat for create_or_find_by/!

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -206,6 +206,7 @@ module ActiveRecord
     # (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted
     # and failed due to validation errors it won't be persisted, you get what #create returns in
     # such situation.
+    # This means an uniquness validation over the unique constraint on the table cannot be set.
     def create_or_find_by(attributes, &block)
       transaction(requires_new: true) { create(attributes, &block) }
     rescue ActiveRecord::RecordNotUnique


### PR DESCRIPTION
### Summary

The following test fails due to uniquness validation.
Added documetation pointing out this caveat.

- failure
```
Error:
BugTest#test_association_stuff:
ActiveRecord::RecordInvalid: Validation failed: Body has already been taken
```

- test case
```ruby
# frozen_string_literal: true
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "rails", github: "rails/rails"
  gem "sqlite3"
end
require "active_record"
require "minitest/autorun"
require "logger"
# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :body
    t.index [:body], unique: true
  end
  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end
class Post < ActiveRecord::Base
  has_many :comments
  validates :body, uniqueness: true
end
class Comment < ActiveRecord::Base
  belongs_to :post
end
class BugTest < Minitest::Test
  def test_association_stuff
    Post.create!(body: 'foo')
    Post.create_or_find_by!(body: 'foo')
  end
end
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
