### PR TITLE
Do not define instance predicate if the instance reader isn't as well

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -120,7 +120,9 @@ class Class
 
       if instance_predicate
         class_methods << "silence_redefinition_of_method def #{name}?; !!self.#{name}; end"
-        methods       << "silence_redefinition_of_method def #{name}?; !!self.#{name}; end"
+        if instance_reader
+          methods << "silence_redefinition_of_method def #{name}?; !!self.#{name}; end"
+        end
       end
     end
 

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -68,24 +68,31 @@ class ClassAttributeTest < ActiveSupport::TestCase
   test "disabling instance writer" do
     object = Class.new { class_attribute :setting, instance_writer: false }.new
     assert_raise(NoMethodError) { object.setting = "boom" }
+    assert_not_respond_to object, :setting=
   end
 
   test "disabling instance reader" do
     object = Class.new { class_attribute :setting, instance_reader: false }.new
     assert_raise(NoMethodError) { object.setting }
+    assert_not_respond_to object, :setting
     assert_raise(NoMethodError) { object.setting? }
+    assert_not_respond_to object, :setting?
   end
 
   test "disabling both instance writer and reader" do
     object = Class.new { class_attribute :setting, instance_accessor: false }.new
     assert_raise(NoMethodError) { object.setting }
+    assert_not_respond_to object, :setting
     assert_raise(NoMethodError) { object.setting? }
+    assert_not_respond_to object, :setting?
     assert_raise(NoMethodError) { object.setting = "boom" }
+    assert_not_respond_to object, :setting=
   end
 
   test "disabling instance predicate" do
     object = Class.new { class_attribute :setting, instance_predicate: false }.new
     assert_raise(NoMethodError) { object.setting? }
+    assert_not_respond_to object, :setting?
   end
 
   test "works well with singleton classes" do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/37903

This regressed in 49d1b5a98dc50ca59bbfb817f90eb5c2c2645d30.

I didn't notice it because the method would be defined but would
raise a NoMethodError.

Sorry :/

cc @kaspth @rafaelfranca @paracycle @Edouard-chin 