### PR TITLE
Reduce number of created objects in Hash#as_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -169,7 +169,11 @@ class Hash
       self
     end
 
-    Hash[subset.map { |k, v| [k.to_s, options ? v.as_json(options.dup) : v.as_json] }]
+    result = {}
+    subset.each do |k, v|
+      result[k.to_s] = options ? v.as_json(options.dup) : v.as_json
+    end
+    result
   end
 end
 


### PR DESCRIPTION
### Summary

Reduce the number of objects allocated in `Hash#as_json` by 2 for every time `Hash#as_json` is being called.

### Other Information
In order to benchmark this, I wrote a small script 
-> https://gist.github.com/apauly/3f547f06e83b66e4187e48519b426464

The difference is of course highly coupled to the actual size of the hash. The output of the gist will look something like this:

```
>> compare build_random_hash(1, 1)
Object count after patch: 3
Object count before patch: 7

>> compare build_random_hash(1, 10)
Object count after patch: 30
Object count before patch: 60

>> compare build_random_hash(3, 3)
Object count after patch: 91
Object count before patch: 156

>> compare build_random_hash(5, 5)
Object count after patch: 8591
Object count before patch: 14058
```
