### PR TITLE
Deprecate config.assets.precompile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `Rails.application.config.assets.precompile`
+    in favor of `app/assets/config/manifest.js`
+
+    *Younes Serraj*
+
 *   Introduce middleware move operations
 
     With this change, you no longer need to delete and reinsert a middleware to

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -10,6 +10,7 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 <%- end -%>
 
+# DEPRECATED: use `app/assets/config/manifest.js` instead
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.


### PR DESCRIPTION
Deprecate `config.assets.precompile` in favor of `app/assets/config/manifest.js`

### Summary

https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs

Prior to Sprockets 4, we used to list top-level targets to compile using `Rails.application.config.assets.precompile` in `config/initializers/assets.rb`.

The preferred way is now `app/assets/config/manifest.js`.

I suggest we make this change more "official" by adding a deprecation comment in `config/initializers/assets.rb`.
