### PR TITLE
[ci skip] Brazilian portuguese translation effort

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -178,6 +178,7 @@ Translation efforts we know about (various versions):
 * **Traditional Chinese** : [https://github.com/docrails-tw/guides](https://github.com/docrails-tw/guides)
 * **Russian** : [https://github.com/morsbox/rusrails](https://github.com/morsbox/rusrails)
 * **Japanese** : [https://github.com/yasslab/railsguides.jp](https://github.com/yasslab/railsguides.jp)
+* **Brazilian Portuguese** : [https://github.com/campuscode/rails-guides-pt-BR](https://github.com/campuscode/rails-guides-pt-BR)
 
 Contributing to the Rails Code
 ------------------------------


### PR DESCRIPTION
### Summary

For some time now an effort has been made to translate the documentation to pt-BR. Now that we have some important pages already translated we would like to insert the link in the official guide. Is it possible?

### Other Information

Translation is focused on Brazilian Portuguese but if other countries (Portugal, Mozambique, Angola, etc.) find the translation satisfactory we can switch to `Portuguese`.

To view the content you could look at [guiarails](https://www.guiarails.com.br/)
