### PR TITLE
Put dev dependencies in generated plugin Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -21,8 +21,4 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   <%= '# ' if options.dev? || options.edge? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
-<% unless options[:skip_active_record] -%>
-
-  spec.add_development_dependency "<%= gem_for_database[0] %>"
-<% end -%>
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -4,21 +4,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 <% if options[:skip_gemspec] -%>
 <%= '# ' if options.dev? || options.edge? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
 <% else -%>
-# Declare your gem's dependencies in <%= name %>.gemspec.
-# Bundler will treat runtime dependencies like base dependencies, and
-# development dependencies will be added by default to the :development group.
+# Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec
 <% end -%>
+<% unless options[:skip_active_record] -%>
 
-<% if options[:skip_gemspec] -%>
 group :development do
   gem '<%= gem_for_database[0] %>'
 end
-<% else -%>
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
 <% end -%>
 
 <% if options.dev? || options.edge? -%>


### PR DESCRIPTION
The Gemfile offers more flexibility than the gemspec in terms of gem groups and platforms.  Putting the default development dependencies in the Gemfile encourages users to add their own development dependencies to the Gemfile.  This is similar to the current behavior of the `bundle gem` command (see bundler/bundler#7222).

This change also fixes a corner case where using the "--skip-gemspec" and "--skip-active-record" options together would incorrectly generate a "sqlite3" dependency in the Gemfile.
