### PR TITLE
Fix NoMethodError on ActiveSupport::Cache::RedisCacheStore#clear with…

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -246,10 +246,14 @@ module ActiveSupport
             pattern = namespace_key(matcher, options)
             cursor = "0"
             # Fetch keys in batches using SCAN to avoid blocking the Redis server.
-            begin
-              cursor, keys = c.scan(cursor, match: pattern, count: SCAN_BATCH_SIZE)
-              c.del(*keys) unless keys.empty?
-            end until cursor == "0"
+            nodes = c.respond_to?(:nodes) ? c.nodes : [c]
+
+            nodes.each do |node|
+              begin
+                cursor, keys = node.scan(cursor, match: pattern, count: SCAN_BATCH_SIZE)
+                node.del(*keys) unless keys.empty?
+              end until cursor == "0"
+            end
           end
         end
       end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -301,5 +301,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_not @cache.exist?("foo")
       assert @cache.redis.exists("fu")
     end
+
+    test "clear all cache key with Redis::Distributed" do
+      cache = ActiveSupport::Cache::RedisCacheStore.new(
+        url: %w[redis://localhost:6379/0, redis://localhost:6379/1],
+        timeout: 0.1, namespace: @namespace, expires_in: 60, driver: DRIVER)
+      cache.write("foo", "bar")
+      cache.write("fu", "baz")
+      cache.clear
+      assert_not cache.exist?("foo")
+      assert_not cache.exist?("fu")
+    end
   end
 end


### PR DESCRIPTION
… Redis::Distributed

### Summary

ActiveSupport::Cache::RedisCacheStore#clear raises NoMethodError when RedisCacheStore is configured with both multiple URLs and a namespace.

This patch fixes #38178

### Other Information

https://github.com/rails/rails/issues/38178
