### PR TITLE
Fix NumericalityValidator when precision is too high:

### DIFF
--- a/activerecord/lib/active_record/validations/numericality.rb
+++ b/activerecord/lib/active_record/validations/numericality.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Validations
     class NumericalityValidator < ActiveModel::Validations::NumericalityValidator # :nodoc:
       def validate_each(record, attribute, value, precision: nil)
-        precision = column_precision_for(attribute, record) || Float::DIG
+        precision = [column_precision_for(attribute, record) || BigDecimal.double_fig, BigDecimal.double_fig].min
         super
       end
 

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -20,12 +20,22 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     assert_predicate subject, :valid?
   end
 
-  def test_no_column_precision
+  def test_column_with_precision_higher_than_double_fig
     model_class.validates_numericality_of(
-      :decimal_number, equal_to: 1_000_000_000.12345
+      :decimal_number_big_precision, equal_to: 10_000_000.3
     )
 
-    subject = model_class.new(decimal_number: 1_000_000_000.123454)
+    subject = model_class.new(decimal_number_big_precision: 10_000_000.3)
+
+    assert_predicate subject, :valid?
+  end
+
+  def test_no_column_precision
+    model_class.validates_numericality_of(
+      :decimal_number, equal_to: 1_000_000_000.123454
+    )
+
+    subject = model_class.new(decimal_number: 1_000_000_000.1234545)
 
     assert_predicate subject, :valid?
   end
@@ -33,10 +43,10 @@ class NumericalityValidationTest < ActiveRecord::TestCase
   def test_virtual_attribute
     model_class.attribute(:virtual_decimal_number, :decimal)
     model_class.validates_numericality_of(
-      :virtual_decimal_number, equal_to: 1_000_000_000.12345
+      :virtual_decimal_number, equal_to: 1_000_000_000.123454
     )
 
-    subject = model_class.new(virtual_decimal_number: 1_000_000_000.123454)
+    subject = model_class.new(virtual_decimal_number: 1_000_000_000.1234545)
 
     assert_predicate subject, :valid?
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -585,6 +585,7 @@ ActiveRecord::Schema.define do
     t.decimal :decimal_number
     t.decimal :decimal_number_with_default, precision: 3, scale: 2, default: 2.78
     t.float   :temperature
+    t.decimal :decimal_number_big_precision, precision: 20
     # Oracle/SQLServer supports precision up to 38
     if current_adapter?(:OracleAdapter, :SQLServerAdapter)
       t.decimal :atoms_in_universe, precision: 38, scale: 0


### PR DESCRIPTION
Fix NumericalityValidator when precision is too high:

- When a column with a precision that is higher than what the system
  allows, it would result in an error:

  ```sh
    require "bigdecimal/util"

    123.4.to_d(20) => ArgumentError, precision is too high
  ```

  To fix that problem we need to check what the max number of digits
  a Float is allowed to have, we can achieve that with `BigDecimal.double_fig`

  Fix #38209

cc/ @rafael @gmcgibbon @casperisfine