### PR TITLE
Do not re-parse PATH_INFO when validating authenticity token

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -381,7 +381,7 @@ module ActionController #:nodoc:
         if per_form_csrf_tokens
           correct_token = per_form_csrf_token(
             session,
-            normalize_action_path(request.fullpath),
+            request.fullpath.chomp("/"),
             request.request_method
           )
 


### PR DESCRIPTION
PATH_INFO will never contain query parameters (that is the contract with
the webserver), so there is no reason to call URI.parse on it.  In
addition, clients can send garbage paths that raise an exception when
being parsed rather than just failing the auth token check.

We're seeing exceptions in our app because people are sending garbage URLs and hitting this codepath.  I was going to escape the paths, but then I realized we probably shouldn't be parsing them in the first place since the webserver has already done so.  We might be able to eliminate the `normalize_action_path` method, but I haven't investigated that closely.