### PR TITLE
Add scale support to ActiveRecord::Validations::NumericalityValidator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add scale support to `ActiveRecord::Validations::NumericalityValidator`.
+
+    *Gannon McGibbon*
+
 *   Find orphans by looking for missing relations through chaining `where.missing`:
 
     Before:

--- a/activerecord/lib/active_record/validations/numericality.rb
+++ b/activerecord/lib/active_record/validations/numericality.rb
@@ -3,14 +3,19 @@
 module ActiveRecord
   module Validations
     class NumericalityValidator < ActiveModel::Validations::NumericalityValidator # :nodoc:
-      def validate_each(record, attribute, value, precision: nil)
-        precision = [column_precision_for(attribute, record) || BigDecimal.double_fig, BigDecimal.double_fig].min
-        super
+      def validate_each(record, attribute, value, precision: nil, scale: nil)
+        precision = [column_precision_for(record, attribute) || BigDecimal.double_fig, BigDecimal.double_fig].min
+        scale     = column_scale_for(record, attribute)
+        super(record, attribute, value, precision: precision, scale: scale)
       end
 
       private
-        def column_precision_for(attribute, record)
+        def column_precision_for(record, attribute)
           record.class.type_for_attribute(attribute.to_s)&.precision
+        end
+
+        def column_scale_for(record, attribute)
+          record.class.type_for_attribute(attribute.to_s)&.scale
         end
     end
 

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -12,10 +12,10 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
   def test_column_with_precision
     model_class.validates_numericality_of(
-      :bank_balance, equal_to: 10_000_000.12
+      :unscaled_bank_balance, equal_to: 10_000_000.12
     )
 
-    subject = model_class.new(bank_balance: 10_000_000.121)
+    subject = model_class.new(unscaled_bank_balance: 10_000_000.121)
 
     assert_predicate subject, :valid?
   end
@@ -28,6 +28,16 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     subject = model_class.new(decimal_number_big_precision: 10_000_000.3)
 
     assert_predicate subject, :valid?
+  end
+
+  def test_column_with_scale
+    model_class.validates_numericality_of(
+      :bank_balance, greater_than: 10
+    )
+
+    subject = model_class.new(bank_balance: 10.001)
+
+    assert_not_predicate subject, :valid?
   end
 
   def test_no_column_precision
@@ -69,5 +79,27 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     subject = klass.new(bank_balance: 10_000_000.12)
 
     assert_predicate(subject, :valid?)
+  end
+
+  def test_virtual_attribute_with_precision
+    model_class.attribute(:virtual_decimal_number, :decimal, precision: 5)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, equal_to: 123.45
+    )
+
+    subject = model_class.new(virtual_decimal_number: 123.455)
+
+    assert_predicate subject, :valid?
+  end
+
+  def test_virtual_attribute_with_scale
+    model_class.attribute(:virtual_decimal_number, :decimal, scale: 2)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, greater_than: 1
+    )
+
+    subject = model_class.new(virtual_decimal_number: 1.001)
+
+    assert_not_predicate subject, :valid?
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -580,6 +580,7 @@ ActiveRecord::Schema.define do
   create_table :numeric_data, force: true do |t|
     t.decimal :bank_balance, precision: 10, scale: 2
     t.decimal :big_bank_balance, precision: 15, scale: 2
+    t.decimal :unscaled_bank_balance, precision: 10
     t.decimal :world_population, precision: 20, scale: 0
     t.decimal :my_house_population, precision: 2, scale: 0
     t.decimal :decimal_number


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/35426.

Adds scale truncation support to numericality validations.