### PR TITLE
Get rid of Rack deprecation warning

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0", ">= 2.0.8"
+  s.add_dependency "rack",      "~> 2.0", ">= 2.1.0"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -17,7 +17,7 @@ module ActionDispatch
   class FileHandler
     def initialize(root, index: "index", headers: {})
       @root          = root.chomp("/").b
-      @file_server   = ::Rack::File.new(@root, headers)
+      @file_server   = ::Rack::Files.new(@root, headers)
       @index         = index
     end
 

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord",  version
 
   s.add_dependency "marcel", "~> 0.3.1"
+  s.add_dependency "rack", "~> 2.0", ">= 2.1.0"
 end

--- a/activestorage/app/controllers/concerns/active_storage/file_server.rb
+++ b/activestorage/app/controllers/concerns/active_storage/file_server.rb
@@ -3,7 +3,7 @@
 module ActiveStorage::FileServer # :nodoc:
   private
     def serve_file(path, content_type:, disposition:)
-      Rack::File.new(nil).serving(request, path).tap do |(status, headers, body)|
+      Rack::Files.new(nil).serving(request, path).tap do |(status, headers, body)|
         self.status = status
         self.response_body = body
 


### PR DESCRIPTION
### Summary

Rack has added a deprecation message when `Rack::File` is used https://github.com/rack/rack/blob/110b5475005ca48689ef69e33859bb912331c5fc/lib/rack/file.rb#L6
It has been released in Rack 2.1.0.

    Rack::File is deprecated, please use Rack::Files instead.

This results in [build failures](https://travis-ci.org/rspec/rspec-rails/jobs/635434487) for projects that keep themselves warn-free.