### PR TITLE
Reduce number of created objects in Hash#to_json

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -93,7 +93,11 @@ module ActiveSupport
             when Numeric, NilClass, TrueClass, FalseClass
               value.as_json
             when Hash
-              Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
+              result = {}
+              value.each do |k, v|
+                result[jsonify(k)] = jsonify(v)
+              end
+              result
             when Array
               value.map { |v| jsonify(v) }
             else


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/38197.

Since the result of `as_json` is typically encoded with `to_json`, this patch should save the same number of allocations as the previous one.

### Benchmark

Modified version of the [benchmark](https://gist.github.com/apauly/3f547f06e83b66e4187e48519b426464) from https://github.com/rails/rails/pull/38197:

```ruby
require "bundler/inline"

gemfile(true) do
  gem "rails", git: "https://github.com/rails/rails.git"
end

require "json"
require "active_support/all"

module ActiveSupport
  module JSON
    module Encoding
      class JSONGemEncoder
        private
          def jsonify(value)
            case value
            when String
              EscapedString.new(value)
            when Numeric, NilClass, TrueClass, FalseClass
              value.as_json
            when Hash
              if $patched
                result = {}
                value.each do |k, v|
                  result[jsonify(k)] = jsonify(v)
                end
                result
              else
                Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
              end
            when Array
              value.map { |v| jsonify(v) }
            else
              jsonify value.as_json
            end
          end
      end
    end
  end
end

# Actual benchmark code

def build_random_hash(number, nesting=0)
  return number if nesting == 0
  number.times.to_h do |i|
    [i, build_random_hash(number, nesting - 1)]
  end
end

def compare(hash, label)
  GC.start
  $patched = false
  allocated_before = GC.stat(:total_allocated_objects)
  hash.to_json
  allocated_after = GC.stat(:total_allocated_objects)
  not_patched_allocations = allocated_after - allocated_before
  not_patched = "Object count before patch: #{not_patched_allocations}"

  GC.start
  $patched = true
  allocated_before = GC.stat(:total_allocated_objects)
  hash.to_json
  allocated_after = GC.stat(:total_allocated_objects)
  patched_allocations = allocated_after - allocated_before
  patched = "Object count after patch: #{patched_allocations}"

  puts label
  puts not_patched
  puts patched
  puts "Percentage difference: %.2f" % ((100.0 * patched_allocations / not_patched_allocations) - 100)
  puts "Absolute difference: #{patched_allocations - not_patched_allocations}"
  puts
end

build_random_hash(1, 1).to_json # warmup

compare build_random_hash(1, 1), ">> build_random_hash(1, 1)"
compare build_random_hash(1, 10), ">> build_random_hash(1, 10)"
compare build_random_hash(3, 3), ">> build_random_hash(3, 3)"
compare build_random_hash(5, 5), ">> build_random_hash(5, 5)"
```

### Result

```
>> build_random_hash(1, 1)
Object count before patch: 17
Object count after patch: 14
Percentage difference: -17.65
Absolute difference: -3

>> build_random_hash(1, 10)
Object count before patch: 116
Object count after patch: 86
Percentage difference: -25.86
Absolute difference: -30

>> build_random_hash(3, 3)
Object count before patch: 331
Object count after patch: 266
Percentage difference: -19.64
Absolute difference: -65

>> build_random_hash(5, 5)
Object count before patch: 30465
Object count after patch: 24998
Percentage difference: -17.95
Absolute difference: -5467
```