### PR TITLE
test: Show diffs in assert_no_changes

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -219,9 +219,8 @@ module ActiveSupport
         retval = assert_nothing_raised(&block)
         after = exp.call
 
-        error = "#{expression.inspect} did change to #{after}"
-        error = "#{message}.\n#{error}" if message
-        assert before == after, error
+        error = message ? "#{message}.\n#{error}" : nil
+        assert_equal before, after, error
 
         retval
       end

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -219,8 +219,7 @@ module ActiveSupport
         retval = assert_nothing_raised(&block)
         after = exp.call
 
-        error = message ? "#{message}.\n#{error}" : nil
-        assert_equal before, after, error
+        assert_equal before, after, message
 
         retval
       end

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -219,7 +219,10 @@ module ActiveSupport
         retval = assert_nothing_raised(&block)
         after = exp.call
 
-        assert_equal before, after, message
+        error = "#{expression.inspect} changed"
+        error = "#{message}.\n#{error}" if message
+
+        assert_equal before, after, error
 
         retval
       end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -293,7 +293,8 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "@object.num should not change.\n\"@object.num\" did change to 1", error.message
+    assert_equal "@object.num should not change.\n\"@object.num\" changed.\nExpected: 0\n  Actual: 1", error.message
+    error.message
   end
 end
 


### PR DESCRIPTION
### Summary

An attempt to improve the error message for assert_no_changes by printing out minitest's assert_equals diff instead of the full changed object. Fixes https://github.com/rails/rails/issues/37507

### Other Information
Example error after this fix:
```
Failure:
JavascriptPackageTest#test_compiled_code_is_in_sync_with_source_code [/vagrant/rails/actioncable/test/javascript_package_test.rb:9]:
#<Proc:0x00005640a0bbde88@/vagrant/rails/actioncable/test/javascript_package_test.rb:9 (lambda)> changed.
--- expected
+++ actual
@@ -4,7 +4,8 @@
   \"use strict\";
   var adapters = {
     logger: self.console,
-    WebSocket: self.WebSocket
+    WebSocket: self.WebSocket,
+    props: \"\"
   };
   var logger = {
     log: function log() {
```


I chose not to differentiate between `nil` comparisons as done in the referenced commit (https://github.com/rails/rails/commit/bbe437faecca5fd6bdc2327a4bc7a31ba21afe2e) as it seems the output is pretty benign:
```
Failure:
JavascriptPackageTest#test_compiled_code_is_in_sync_with_source_code [(byebug):1]:
# ...
Expected: nil
  Actual: "..."
```