### PR TITLE
Fix CI error with minitest 5.14

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -101,8 +101,14 @@ module ActiveSupport
               begin
                 queue.record(reporter, result)
               rescue DRb::DRbConnError
-                result.failures.each do |failure|
-                  failure.send(:initialize, DRb::DRbRemoteError.new(failure.exception))
+                result.failures.map! do |failure|
+                  if failure.respond_to?(:error)
+                    # minitest >5.14.0
+                    error = DRb::DRbRemoteError.new(failure.error)
+                  else
+                    error = DRb::DRbRemoteError.new(failure.exception)
+                  end
+                  Minitest::UnexpectedError.new(error)
                 end
                 queue.record(reporter, result)
               end


### PR DESCRIPTION
Follow up to 2bf1c17c20b3a2d053cba8db74b91acacaa62308, which still left this one failure. Minitest 5.14 uses error instead of exception, so exception had been changed to just be the same `UnexpectedError` instance and losing us the actual error message.

This also switches to initializing a new `UnexpectedError` instance because previously, for reasons I can't quite figure out, reusing the same instance would still give us a `DRbConnError`.