### PR TITLE
Pass Benchmark.ms block through to realtime

### DIFF
--- a/activesupport/lib/active_support/core_ext/benchmark.rb
+++ b/activesupport/lib/active_support/core_ext/benchmark.rb
@@ -10,7 +10,7 @@ class << Benchmark
   #
   #   Benchmark.ms { User.all }
   #   # => 0.074
-  def ms
-    1000 * realtime { yield }
+  def ms(&block)
+    1000 * realtime(&block)
   end
 end


### PR DESCRIPTION
Avoids pushing an extra stack frame.