### PR TITLE
Remove an empty line from generated migration

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -37,7 +37,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
     <%- if attribute.has_index? -%>
     remove_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
     <%- end -%>
-    <%- if !attribute.virtual? %>
+    <%- if !attribute.virtual? -%>
     remove_column :<%= table_name %>, :<%= attribute.name %>, :<%= attribute.type %><%= attribute.inject_options %>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
Currently, if you run `rails g migration remove_column_from_models`, there is an empty line before `remove_column` line because we forgot to use `-%>` in the template:

```console
$ bin/rails g migration remove_title_from_posts title:string
      invoke  active_record
      create    db/migrate/20200114061235_remove_title_from_posts.rb

$ cat db/migrate/20200114061235_remove_title_from_posts.rb
class RemoveTitleFromPosts < ActiveRecord::Migration[6.1]
  def change

    remove_column :posts, :title, :string
  end
end
```

This commit adds the missing `-` in front of `-%>` to make it removes the empty line.