### PR TITLE
prevent helper_method from calling to_hash

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -66,13 +66,10 @@ module AbstractController
 
         methods.each do |method|
           _helpers.class_eval <<-ruby_eval, file, line
-            def #{method}(*args, **kwargs, &blk)                     # def current_user(*args, **kwargs, &blk)
-              if kwargs.empty?                                       #   if kwargs.empty?
-                controller.send(%(#{method}), *args, &blk)           #     controller.send(:current_user, *args, &blk)
-              else                                                   #   else
-                controller.send(%(#{method}), *args, **kwargs, &blk) #     controller.send(:current_user, *args, **kwargs, &blk)
-              end                                                    #   end
-            end                                                      # end
+            def #{method}(*args, &blk)                     # def current_user(*args, &blk)
+              controller.send(%(#{method}), *args, &blk)   #   controller.send(:current_user, *args, &blk)
+            end                                            # end
+            ruby2_keywords(%(#{method})) if respond_to?(:ruby2_keywords, true)
           ruby_eval
         end
       end


### PR DESCRIPTION
`helper_method` was taking `**kwargs` on all definitions by default.
ruby will assume that this means you want keyword args and call
`to_hash` on what you pass if the object responds to `to_hash`. Instead
we should only take keyword args if the helper method defined intends
to pass keyword args.

This also fixes a warning when you pass a hash to your helper method,

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

Also, this would be a good candidate for using `...`, but since `send`
requires the method as the first argument, we can't use it here.