### PR TITLE
Don't encourage using octals for dates and times

### DIFF
--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -76,7 +76,7 @@ class MessageDeliveryTest < ActiveSupport::TestCase
   end
 
   test "should enqueue a delivery with a delay" do
-    travel_to Time.new(2004, 11, 24, 01, 04, 44) do
+    travel_to Time.new(2004, 11, 24, 1, 4, 44) do
       assert_performed_with(job: ActionMailer::MailDeliveryJob, at: Time.current + 10.minutes, args: ["DelayedMailer", "test_message", "deliver_now", args: [1, 2, 3]]) do
         @mail.deliver_later wait: 10.minutes
       end

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -86,7 +86,7 @@ module ActiveSupport
       # The stubs are automatically removed at the end of the test.
       #
       #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
-      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+      #   travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
       #   Time.current     # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #   Date.current     # => Wed, 24 Nov 2004
       #   DateTime.current # => Wed, 24 Nov 2004 01:04:44 -0500
@@ -108,7 +108,7 @@ module ActiveSupport
       # state at the end of the block:
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
-      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44) do
+      #   travel_to Time.zone.local(2004, 11, 24, 1, 4, 44) do
       #     Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
@@ -165,7 +165,7 @@ module ActiveSupport
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #
-      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+      #   travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
       #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #
       #   travel_back
@@ -175,7 +175,7 @@ module ActiveSupport
       #
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #
-      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+      #   travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
       #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
       #
       #   travel_back do

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -43,7 +43,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to
     Time.stub(:now, Time.now) do
-      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44)
       travel_to expected_time
 
       assert_equal expected_time, Time.now
@@ -56,7 +56,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to_with_block
     Time.stub(:now, Time.now) do
-      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44)
 
       travel_to expected_time do
         assert_equal expected_time, Time.now
@@ -86,7 +86,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_back
     Time.stub(:now, Time.now) do
-      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44)
 
       travel_to expected_time
       assert_equal expected_time, Time.now
@@ -104,7 +104,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_back_with_block
     Time.stub(:now, Time.now) do
-      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44)
 
       travel_to expected_time
       assert_equal expected_time, Time.now
@@ -127,8 +127,8 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to_with_nested_calls_with_blocks
     Time.stub(:now, Time.now) do
-      outer_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
-      inner_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
+      outer_expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+      inner_expected_time = Time.new(2004, 10, 24, 1, 4, 44)
       travel_to outer_expected_time do
         e = assert_raises(RuntimeError) do
           travel_to(inner_expected_time) do
@@ -142,8 +142,8 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to_with_nested_calls
     Time.stub(:now, Time.now) do
-      outer_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
-      inner_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
+      outer_expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+      inner_expected_time = Time.new(2004, 10, 24, 1, 4, 44)
       travel_to outer_expected_time do
         assert_nothing_raised do
           travel_to(inner_expected_time)
@@ -156,8 +156,8 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_travel_to_with_subsequent_calls
     Time.stub(:now, Time.now) do
-      initial_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
-      subsequent_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
+      initial_expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+      subsequent_expected_time = Time.new(2004, 10, 24, 1, 4, 44)
       assert_nothing_raised do
         travel_to initial_expected_time
         travel_to subsequent_expected_time


### PR DESCRIPTION
This could result in confusing errors or inconsistency for 08 and 09

### Summary

Although aesthetically pleasing, prefixing dates and times with zeroes creates octal digits which some programmers may be unaware of. This leads to either inconsistency or syntax errors when 08 and 09 are needed.