### PR TITLE
Allow a proc to be used in addition to a static value for cookies_same_site_protection

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -438,13 +438,7 @@ module ActionDispatch
 
           options[:path]      ||= "/"
 
-          same_site_protection = if request.cookies_same_site_protection.is_a?(Proc)
-            request.cookies_same_site_protection.call(request)
-          else
-            request.cookies_same_site_protection
-          end
-
-          options[:same_site] ||= same_site_protection
+          options[:same_site] ||= request.cookies_same_site_protection.call(request)
           options[:same_site] = false if options[:same_site] == :none # TODO: Remove when rack 2.1.0 is out.
 
           if options[:domain] == :all || options[:domain] == "all"

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -70,7 +70,7 @@ module ActionDispatch
     end
 
     def cookies_same_site_protection
-      get_header Cookies::COOKIES_SAME_SITE_PROTECTION
+      get_header Cookies::COOKIES_SAME_SITE_PROTECTION || Proc.new {}
     end
 
     def cookies_digest
@@ -438,7 +438,7 @@ module ActionDispatch
 
           options[:path]      ||= "/"
 
-          options[:same_site] ||= request.cookies_same_site_protection.call(request)
+          options[:same_site] ||= request.cookies_same_site_protection&.call(request)
           options[:same_site] = false if options[:same_site] == :none # TODO: Remove when rack 2.1.0 is out.
 
           if options[:domain] == :all || options[:domain] == "all"

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -437,7 +437,14 @@ module ActionDispatch
           end
 
           options[:path]      ||= "/"
-          options[:same_site] ||= request.cookies_same_site_protection
+
+          same_site_protection = if request.cookies_same_site_protection.is_a?(Proc)
+            request.cookies_same_site_protection.call(request)
+          else
+            request.cookies_same_site_protection
+          end
+
+          options[:same_site] ||= same_site_protection
           options[:same_site] = false if options[:same_site] == :none # TODO: Remove when rack 2.1.0 is out.
 
           if options[:domain] == :all || options[:domain] == "all"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -245,6 +245,12 @@ module Rails
     # will be used by middlewares and engines to configure themselves.
     def env_config
       @app_env_config ||= begin
+        same_site_protection = config.action_dispatch.cookies_same_site_protection
+
+        unless same_site_protection.respond_to?(:call)
+          same_site_protection = -> (_) { same_site_protection }
+        end
+
         super.merge(
           "action_dispatch.parameter_filter" => config.filter_parameters,
           "action_dispatch.redirect_filter" => config.filter_redirect,
@@ -265,7 +271,7 @@ module Rails
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,
           "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest,
           "action_dispatch.cookies_rotations" => config.action_dispatch.cookies_rotations,
-          "action_dispatch.cookies_same_site_protection" => config.action_dispatch.cookies_same_site_protection,
+          "action_dispatch.cookies_same_site_protection" => same_site_protection,
           "action_dispatch.use_cookies_with_metadata" => config.action_dispatch.use_cookies_with_metadata,
           "action_dispatch.content_security_policy" => config.content_security_policy,
           "action_dispatch.content_security_policy_report_only" => config.content_security_policy_report_only,


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

The cookies_same_site_protection configuration option is great, but our team has had trouble adopting it because it does not allow us to change which `SameSite` property value (if any) to use for a particular request. This PR adds the ability to specify a `Proc` that will determine which SameSite property value to use at run time.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->


