### PR TITLE
Allow updating the database selector context with the response and not only the request

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -59,11 +59,14 @@ module ActiveRecord
           context = context_klass.call(request)
           resolver = resolver_klass.call(context, options)
 
-          if reading_request?(request)
+          response = if reading_request?(request)
             resolver.read(&blk)
           else
             resolver.write(&blk)
           end
+
+          resolver.update_context(response)
+          response
         end
 
         def reading_request?(request)

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -43,6 +43,10 @@ module ActiveRecord
           write_to_primary(&blk)
         end
 
+        def update_context(response)
+          context.save(response)
+        end
+
         private
           def read_from_primary(&blk)
             ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role, prevent_writes: true) do

--- a/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
@@ -38,6 +38,9 @@ module ActiveRecord
           def update_last_write_timestamp
             session[:last_write] = self.class.convert_time_to_timestamp(Time.now)
           end
+
+          def save(response)
+          end
         end
       end
     end


### PR DESCRIPTION
### Summary

This pull request allows the resolver in the `DatabaseSelector` middleware (`ActiveRecord::Middleware::DatabaseSelector`) to have access to the response computed in the middleware and use it to update the context if necessary.

Currently, in the default resolver (`ActiveRecord::Middleware::DatabaseSelector::Resolver`) and default context (`ActiveRecord::Middleware::DatabaseSelector::Resolver::Session`) this is not necessary because the context is stored in the `session`, which can be modified via the `request` and gets automatically set in the `response`. This is not the case for other cookies. 

### Our use case

We'd like to set a cookie that can be accessed outside Rails when the primary DB is used, mirroring `session[:last_write]` that we can't read.

We could have done this with another middleware but thought about supporting this directly since [this is a case mentioned in the guides](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-connection-switching) and defining our own resolver and context, to use a cookie for example. The current implementation allows the resolver to decide whether to read or write based on other cookies (from the request) but not to persist that in the response.

This PR reflects the solution we ended up with, in our particular case, but I'm happy to change it completely if you think it'd be more useful or it'd make more sense to support this differently. 