### PR TITLE
Skip keeps option shouldn't restrict from creating empty directories

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -81,8 +81,8 @@ module Rails
 
       empty_directory_with_keep_file "app/assets/images"
 
-      empty_directory_with_keep_file "app/controllers/concerns"
-      empty_directory_with_keep_file "app/models/concerns"
+      keep_file  "app/controllers/concerns"
+      keep_file  "app/models/concerns"
     end
 
     def bin

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -79,10 +79,10 @@ module Rails
     def app
       directory "app"
 
-      keep_file "app/assets/images"
+      empty_directory_with_keep_file "app/assets/images"
 
-      keep_file  "app/controllers/concerns"
-      keep_file  "app/models/concerns"
+      empty_directory_with_keep_file "app/controllers/concerns"
+      empty_directory_with_keep_file "app/models/concerns"
     end
 
     def bin

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -117,7 +117,8 @@ module SharedGeneratorTests
     assert_file ".gitignore" do |content|
       assert_no_match(/\.keep/, content)
     end
-
+    assert_directory("app/assets/images")
+    assert_directory("app/models/concerns")
     assert_no_file("app/models/concerns/.keep")
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -118,7 +118,6 @@ module SharedGeneratorTests
       assert_no_match(/\.keep/, content)
     end
     assert_directory("app/assets/images")
-    assert_directory("app/models/concerns")
     assert_no_file("app/models/concerns/.keep")
   end
 


### PR DESCRIPTION
--skip-keeps option in rails generator is used for skipping creating .keep files in the project. But it also skips on creating assets/images, models/concerns and controllers/concerns folders.
When we create a new rails app with this option as in the issue https://github.com/rails/rails/issues/38222 it gives 500 error because config/manifest.js file reference to images folder which doesn't exist.

Code of config/manifest.js file.
```
//= link_tree ../images

//= link_directory ../stylesheets .css
```

