### PR TITLE
Reduce FILENAME_MAX_SIZE to accomodate large PIDs

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -16,7 +16,7 @@ module ActiveSupport
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"
-      FILENAME_MAX_SIZE = 228 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
+      FILENAME_MAX_SIZE = 226 # max filename size on file system is 255, minus room for timestamp, pid, and random characters appended by Tempfile (used by atomic write)
       FILEPATH_MAX_SIZE = 900 # max is 1024, plus some room
       GITKEEP_FILES = [".gitkeep", ".keep"].freeze
 


### PR DESCRIPTION
`FileStoreTest#test_filename_max_size` has been failing fairly regularly on my machine.

The max size here is designed around [Ruby's `Dir::Tmpname.create`](https://github.com/ruby/ruby/blob/master/lib/tmpdir.rb#L113-L137) which creates temporary filenames in the format

    $TIMESTAMP-$PID-$RANDOM

I believe the previous value of this field was based on the assumption that PIDs are 1-65535, which isn't necessarily the case on 64 bit Linux systems, which can be up to 2**22.

    $ uname -a
    Linux zergling 5.4.11-arch1-1 #1 SMP PREEMPT Sun, 12 Jan 2020 12:15:27 +0000 x86_64 GNU/Linux
    $ cat /proc/sys/kernel/pid_max
    4194304

I've chosen a new value based on what I believe the largest possible tempname is:

    255 - "20200117-4194304-#{0x100000000.to_s(36)}.lock".length #=> 226