### PR TITLE
Deprecate and replace `#default_hash` and `#[]`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `#default_hash` and it's alias `#[]` on database configurations
+
+    Applications should use `configs_for`. `#default_hash` and `#[]` will be removed in 6.2.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Add scale support to `ActiveRecord::Validations::NumericalityValidator`.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -67,6 +67,7 @@ module ActiveRecord
       default.configuration_hash if default
     end
     alias :[] :default_hash
+    deprecate "[]": "Use configs_for", default_hash: "Use configs_for"
 
     # Returns a single DatabaseConfig object based on the requested environment.
     #

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -467,7 +467,7 @@ db_namespace = namespace :db do
       end
     ensure
       if should_reconnect
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.default_hash(ActiveRecord::Tasks::DatabaseTasks.env))
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: "primary"))
       end
     end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -145,7 +145,8 @@ module ActiveRecord
 
       def test_not_specifying_database_name_for_cross_database_selects
         assert_nothing_raised do
-          ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"].except(:database))
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          ActiveRecord::Base.establish_connection(db_config.configuration_hash.except(:database))
 
           config = ARTest.test_configuration_hashes
           ActiveRecord::Base.connection.execute(

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -22,7 +22,8 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_bad_connection
     assert_raise ActiveRecord::NoDatabaseError do
-      configuration = ActiveRecord::Base.configurations["arunit"].merge(database: "inexistent_activerecord_unittest")
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      configuration = db_config.configuration_hash.merge(database: "inexistent_activerecord_unittest")
       connection = ActiveRecord::Base.mysql2_connection(configuration)
       connection.drop_table "ex", if_exists: true
     end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -18,7 +18,8 @@ module ActiveRecord
 
       def test_bad_connection
         assert_raise ActiveRecord::NoDatabaseError do
-          configuration = ActiveRecord::Base.configurations["arunit"].merge(database: "should_not_exist-cinco-dog-db")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          configuration = db_config.configuration_hash.merge(database: "should_not_exist-cinco-dog-db")
           connection = ActiveRecord::Base.postgresql_connection(configuration)
           connection.exec_query("SELECT 1")
         end
@@ -31,9 +32,9 @@ module ActiveRecord
       end
 
       def test_database_exists_returns_true_when_the_database_exists
-        config = ActiveRecord::Base.configurations["arunit"]
-        assert ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),
-          "expected database #{config[:database]} to exist"
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        assert ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(db_config.configuration_hash),
+          "expected database #{db_config.database} to exist"
       end
 
       def test_primary_key
@@ -476,7 +477,8 @@ module ActiveRecord
         end
 
         def connection_without_insert_returning
-          ActiveRecord::Base.postgresql_connection(ActiveRecord::Base.configurations["arunit"].merge(insert_returning: false))
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          ActiveRecord::Base.postgresql_connection(db_config.configuration_hash.merge(insert_returning: false))
         end
     end
   end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -35,10 +35,10 @@ module ActiveRecord
           "expected non_extant_db to not exist"
       end
 
-      def test_database_exists_returns_true_when_databae_exists
-        config = ActiveRecord::Base.configurations["arunit"]
-        assert SQLite3Adapter.database_exists?(config),
-          "expected #{config[:database]} to exist"
+      def test_database_exists_returns_true_when_database_exists
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        assert SQLite3Adapter.database_exists?(db_config.configuration_hash),
+          "expected #{db_config.database} to exist"
       end
 
       unless in_memory_db?
@@ -545,7 +545,9 @@ module ActiveRecord
       end
 
       def test_statement_closed
-        db = ::SQLite3::Database.new(ActiveRecord::Base.configurations["arunit"][:database])
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db = ::SQLite3::Database.new(db_config.database)
+
         statement = ::SQLite3::Statement.new(db,
                                            "CREATE TABLE statement_test (number integer not null)")
         statement.stub(:step, -> { raise ::SQLite3::BusyException.new("busy") }) do

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -106,8 +106,9 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     end
 
     def with_connection(options = {})
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
       conn_options = options.reverse_merge(
-        database: in_memory_db? ? "file::memory:" : ActiveRecord::Base.configurations["arunit"][:database]
+        database: in_memory_db? ? "file::memory:" : db_config.database
       )
       conn = ActiveRecord::Base.sqlite3_connection(conn_options)
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -13,7 +13,8 @@ module ActiveRecord
       def setup
         @handler = ConnectionHandler.new
         @owner_name = "ActiveRecord::Base"
-        @pool = @handler.establish_connection(ActiveRecord::Base.configurations["arunit"])
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        @pool = @handler.establish_connection(db_config)
       end
 
       def test_default_env_fall_back_to_default_env_when_rails_env_or_rack_env_is_empty_string

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -15,8 +15,9 @@ module ActiveRecord
         @rw_handler = @handlers[:writing]
         @ro_handler = @handlers[:reading]
         @owner_name = "ActiveRecord::Base"
-        @rw_pool = @handlers[:writing].establish_connection(ActiveRecord::Base.configurations["arunit"])
-        @ro_pool = @handlers[:reading].establish_connection(ActiveRecord::Base.configurations["arunit"])
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        @rw_pool = @handlers[:writing].establish_connection(db_config)
+        @ro_pool = @handlers[:reading].establish_connection(db_config)
       end
 
       def teardown

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -47,7 +47,9 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     original_rails_env = ENV["RAILS_ENV"]
     ENV["RAILS_ENV"] = "arunit"
 
-    assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").configuration_hash, ActiveRecord::Base.configurations.default_hash
+    assert_deprecated do
+      assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").configuration_hash, ActiveRecord::Base.configurations.default_hash
+    end
   ensure
     ENV["RAILS_ENV"] = original_rails_env
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -81,7 +81,8 @@ class QueryCacheTest < ActiveRecord::TestCase
     }
 
     ActiveRecord::Base.connected_to(role: :reading) do
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      ActiveRecord::Base.establish_connection(db_config)
     end
 
     mw = middleware { |env|
@@ -104,7 +105,8 @@ class QueryCacheTest < ActiveRecord::TestCase
       }
 
       ActiveRecord::Base.connected_to(role: :reading) do
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        ActiveRecord::Base.establish_connection(db_config)
       end
 
       rd, wr = IO.pipe
@@ -588,7 +590,8 @@ class QueryCacheTest < ActiveRecord::TestCase
       }
 
       ActiveRecord::Base.connected_to(role: :reading) do
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations["arunit"])
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        ActiveRecord::Base.establish_connection(db_config)
       end
 
       mw = middleware { |env|

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1056,7 +1056,8 @@ module ActiveRecord
         assert_operator AuthorAddress.count, :>, 0
 
         old_configurations = ActiveRecord::Base.configurations
-        configurations = { development: ActiveRecord::Base.configurations["arunit"] }
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        configurations = { development: db_config.configuration_hash }
         ActiveRecord::Base.configurations = configurations
 
         ActiveRecord::Tasks::DatabaseTasks.stub(:root, nil) do

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -95,7 +95,7 @@ module Rails
 
     # The name of the database adapter for the current environment.
     property "Database adapter" do
-      ActiveRecord::Base.configurations[Rails.env]["adapter"]
+      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary").adapter
     end
 
     property "Database schema version" do

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -236,7 +236,9 @@ module ApplicationTests
       orig_rails_env, Rails.env = Rails.env, "development"
       ActiveRecord::Base.establish_connection
       assert ActiveRecord::Base.connection
-      assert_match(/#{ActiveRecord::Base.configurations[Rails.env]['database']}/, ActiveRecord::Base.connection_db_config.database)
+      assert_match(/#{ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary").database}/, ActiveRecord::Base.connection_db_config.database)
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+      assert_match(/#{db_config.database}/, ActiveRecord::Base.connection_db_config.database)
     ensure
       ActiveRecord::Base.remove_connection
       ENV["DATABASE_URL"] = orig_database_url if orig_database_url

--- a/railties/test/application/initializers/hooks_test.rb
+++ b/railties/test/application/initializers/hooks_test.rb
@@ -52,14 +52,13 @@ module ApplicationTests
     end
 
     test "after_initialize runs after frameworks have been initialized" do
-      $activerecord_configurations = nil
+      $activerecord_configuration = nil
       add_to_config <<-RUBY
-        config.after_initialize { $activerecord_configurations = ActiveRecord::Base.configurations }
+        config.after_initialize { $activerecord_configuration = ActiveRecord::Base.configurations.configs_for(env_name: "development", spec_name: "primary") }
       RUBY
 
       require "#{app_path}/config/environment"
-      assert $activerecord_configurations
-      assert $activerecord_configurations["development"]
+      assert $activerecord_configuration
     end
 
     test "after_initialize happens after to_prepare in development" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -51,7 +51,8 @@ module ApplicationTests
 
       test "db:create and db:drop without database URL" do
         require "#{app_path}/config/environment"
-        db_create_and_drop ActiveRecord::Base.configurations[Rails.env][:database]
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_create_and_drop db_config.database
       end
 
       test "db:create and db:drop with database URL" do
@@ -332,7 +333,8 @@ module ApplicationTests
 
       test "db:migrate and db:migrate:status without database_url" do
         require "#{app_path}/config/environment"
-        db_migrate_and_status ActiveRecord::Base.configurations[Rails.env][:database]
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_migrate_and_status db_config.database
       end
 
       test "db:migrate and db:migrate:status with database_url" do
@@ -372,7 +374,8 @@ module ApplicationTests
 
       test "db:fixtures:load without database_url" do
         require "#{app_path}/config/environment"
-        db_fixtures_load ActiveRecord::Base.configurations[Rails.env][:database]
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_fixtures_load db_config.database
       end
 
       test "db:fixtures:load with database_url" do
@@ -407,7 +410,8 @@ module ApplicationTests
 
       test "db:structure:dump and db:structure:load without database_url" do
         require "#{app_path}/config/environment"
-        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
+        db_config = ActiveRecord::Base.connection_db_config
+        db_structure_dump_and_load db_config.database
       end
 
       test "db:structure:dump and db:structure:load with database_url" do
@@ -418,7 +422,8 @@ module ApplicationTests
 
       test "db:structure:dump and db:structure:load set ar_internal_metadata" do
         require "#{app_path}/config/environment"
-        db_structure_dump_and_load ActiveRecord::Base.configurations[Rails.env][:database]
+        db_config = ActiveRecord::Base.connection_db_config
+        db_structure_dump_and_load db_config.database
 
         assert_equal "test", rails("runner", "-e", "test", "puts ActiveRecord::InternalMetadata[:environment]").strip
         assert_equal "development", rails("runner", "puts ActiveRecord::InternalMetadata[:environment]").strip
@@ -497,8 +502,8 @@ module ApplicationTests
           require "#{app_path}/app/models/book"
           # if structure is not loaded correctly, exception would be raised
           assert_equal 0, Book.count
-          assert_match ActiveRecord::Base.configurations["test"][:database],
-            ActiveRecord::Base.connection_db_config.database
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", spec_name: "primary")
+          assert_match db_config.database, ActiveRecord::Base.connection_db_config.database
         end
       end
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -966,7 +966,7 @@ module ApplicationTests
 
           class EnvironmentTest < ActiveSupport::TestCase
             def test_environment
-              test_db = ActiveRecord::Base.configurations[#{env.dump}][:database]
+              test_db = ActiveRecord::Base.configurations.configs_for(env_name: #{env.dump}, spec_name: "primary").database
               db_file = ActiveRecord::Base.connection_db_config.database
               assert_match(test_db, db_file)
               assert_equal #{env.dump}, ENV["RAILS_ENV"]


### PR DESCRIPTION
Database configurations are now objects almost everywhere, so we don't
need to fake access to a hash with `#default_hash` or its alias `#[]`.
Applications should `configs_for` and pass `env_name` and `spec_name` to
get the database config object. If you're looking for the default for
the test environment you can pass `configs_for(env_name: "test", spec_name:
"primary")`. Change test to development to get the dev config, etc.

`#default_hash` and `#[]` will be removed in 6.2.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>