### PR TITLE
Deprecate `#remove_connection` in favor of `#remove_connection_pool`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `#remove_connection` in favor of `#remove_connection_pool` when called on the handler.
+
+    `#remove_connection` is deprecated in order to support returning a `DatabaseConfig` object instead of a `Hash`. Use `#remove_connection_pool`, `#remove_connection` will be removed in 6.2.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Deprecate `#default_hash` and it's alias `#[]` on database configurations
 
     Applications should use `configs_for`. `#default_hash` and `#[]` will be removed in 6.2.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -232,7 +232,7 @@ module ActiveRecord
         self.connection_specification_name = nil
       end
 
-      connection_handler.remove_connection(name)
+      connection_handler.remove_connection_pool(name)
     end
 
     def clear_cache! # :nodoc:

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         assert_not_nil @handler.retrieve_connection_pool("readonly")
       ensure
         ActiveRecord::Base.configurations = old_config
-        @handler.remove_connection("readonly")
+        @handler.remove_connection_pool("readonly")
       end
 
       def test_establish_connection_using_3_levels_config
@@ -85,7 +85,7 @@ module ActiveRecord
 
           assert_not_deprecated do
             @handler.retrieve_connection("primary")
-            @handler.remove_connection("primary")
+            @handler.remove_connection_pool("primary")
           end
         ensure
           ActiveRecord::Base.configurations = old_config
@@ -99,7 +99,7 @@ module ActiveRecord
           ActiveRecord::Base.establish_connection(:primary)
 
           assert_deprecated { @handler.retrieve_connection("primary") }
-          assert_deprecated { @handler.remove_connection("primary") }
+          assert_deprecated { @handler.remove_connection_pool("primary") }
         ensure
           ActiveRecord::Base.configurations = old_config
           ActiveRecord::Base.establish_connection(:arunit)
@@ -151,6 +151,18 @@ module ActiveRecord
           ENV["RAILS_ENV"] = previous_env
           ActiveRecord::Base.establish_connection(:arunit)
           FileUtils.rm_rf "db"
+        end
+
+        def test_remove_connection_is_deprecated
+          expected = @handler.retrieve_connection_pool(@owner_name).db_config.configuration_hash
+
+          config_hash = assert_deprecated do
+            @handler.remove_connection(@owner_name)
+          end
+
+          assert_equal expected, config_hash
+        ensure
+          ActiveRecord::Base.establish_connection(:arunit)
         end
       end
 

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -62,7 +62,7 @@ module ActiveRecord
           @writing_handler.establish_connection(:primary, :pool_config_two)
 
           # remove default
-          @writing_handler.remove_connection("primary")
+          @writing_handler.remove_connection_pool("primary")
 
           assert_nil @writing_handler.retrieve_connection_pool("primary")
           assert_not_nil @writing_handler.retrieve_connection_pool("primary", :pool_config_two)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -154,7 +154,8 @@ if current_adapter?(:Mysql2Adapter)
 
     def using_strict(strict)
       connection = ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection connection.merge(strict: strict)
+      conn_hash = connection.configuration_hash
+      ActiveRecord::Base.establish_connection conn_hash.merge(strict: strict)
       yield
     ensure
       ActiveRecord::Base.remove_connection

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -9,7 +9,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
   def setup
     @per_test_teardown = []
-    @connection = ActiveRecord::Base.remove_connection
+    @connection = ActiveRecord::Base.remove_connection.configuration_hash
   end
 
   teardown do

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -454,7 +454,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       Task.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       ensure
-        ActiveRecord::Base.connection_handler.remove_connection(db_config.owner_name)
+        ActiveRecord::Base.connection_handler.remove_connection_pool(db_config.owner_name)
       end
     end
   end

--- a/activerecord/test/support/connection_helper.rb
+++ b/activerecord/test/support/connection_helper.rb
@@ -3,7 +3,7 @@
 module ConnectionHelper
   def run_without_connection
     original_connection = ActiveRecord::Base.remove_connection
-    yield original_connection
+    yield original_connection.configuration_hash
   ensure
     ActiveRecord::Base.establish_connection(original_connection)
   end


### PR DESCRIPTION
Calling `#remove_connection` on the handler is deprecated in favor of
`#remove_connection_pool`. This change was made to support changing the
return value from a hash to a `DatabaseConfig` object.
`#remove_connection` will be removed in 6.2.

NOTE: `#remove_connection` on `ActiveRecord::Base` will also now return
a `DatabaseConfig` object. We didn't use a deprecation here since
it's not documented that this method used to return a `Hash`.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>

---

cc/ @rafaelfranca @matthewd @jhawthorn @tenderlove we're not totally sure it's ok to change the return value of the `remove_connection` on AR Base, but it wasn't documented so we opted to change that one and deprecate the other one so we can pass objects around everywhere. The problem with returning a configuration hash is it results in Rails creating a new database configuration object if that returned hash was passed to `establish_connection`. Thoughts on changing the return value of this public method?