### PR TITLE
Fix inconsisteny between view and controller [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -66,7 +66,7 @@ Then refer to this field in the form for the model:
 <%# app/views/messages/_form.html.erb %>
 <%= form_with(model: message) do |form| %>
   <div class="field">
-    <%= form.label :content %>
+    <%= form.label :title %>
     <%= form.rich_text_area :content %>
   </div>
 <% end %>


### PR DESCRIPTION
### Summary
Fixed inconsistency between form fields and permitted parameters.
```erb
<%= form.label :content %>
<%= form.rich_text_area :content %>
```
```ruby
message = Message.create! params.require(:message).permit(:title, :content)
```
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
