### PR TITLE
Adds support to wrap aliased attributed in object hash in params wrapper

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -107,10 +107,14 @@ module ActionController
 
           unless super || exclude
             if m.respond_to?(:attribute_names) && m.attribute_names.any?
+              self.include = m.attribute_names
+
               if m.respond_to?(:stored_attributes) && !m.stored_attributes.empty?
-                self.include = m.attribute_names + m.stored_attributes.values.flatten.map(&:to_s)
-              else
-                self.include = m.attribute_names
+                self.include += m.stored_attributes.values.flatten.map(&:to_s)
+              end
+
+              if m.respond_to?(:attribute_aliases) && m.attribute_aliases.any?
+                self.include += m.attribute_aliases.keys
               end
 
               if m.respond_to?(:nested_attributes_options) && m.nested_attributes_options.keys.any?

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -293,6 +293,10 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
     def self.attribute_names
       ["username"]
     end
+
+    def self.attribute_aliases
+      { "nick" => "username" }
+    end
   end
 
   class SampleTwo
@@ -322,6 +326,19 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
         @request.env["CONTENT_TYPE"] = "application/json"
         post :parse, params: { "username" => "sikachu", "title" => "Developer" }
         assert_parameters("username" => "sikachu", "title" => "Developer", "user" => { "username" => "sikachu" })
+      end
+    ensure
+      Admin.send :remove_const, :User
+    end
+  end
+
+  def test_namespace_lookup_from_model_alias
+    Admin.const_set(:User, Class.new(SampleOne))
+    begin
+      with_default_wrapper_options do
+        @request.env["CONTENT_TYPE"] = "application/json"
+        post :parse, params: { "nick" => "sikachu", "title" => "Developer" }
+        assert_parameters({ "nick" => "sikachu", "title" => "Developer", "user" => { "nick" => "sikachu" } })
       end
     ensure
       Admin.send :remove_const, :User


### PR DESCRIPTION
- Adds support to wrap aliased attributed in object hash in params wrapper

Fixes #24213. Updates and Closes #24338



I don't see a changelog on something [related](https://github.com/rails/rails/pull/28056), so din't think this does too