### PR TITLE
Add falcon to the available rack servers

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -96,7 +96,7 @@ module Rails
 
       # Hard-coding a bunch of handlers here as we don't have a public way of
       # querying them from the Rack::Handler registry.
-      RACK_SERVERS = %w(cgi fastcgi webrick lsws scgi thin puma unicorn)
+      RACK_SERVERS = %w(cgi fastcgi webrick lsws scgi thin puma unicorn falcon)
 
       DEFAULT_PORT = 3000
       DEFAULT_PIDFILE = "tmp/pids/server.pid"


### PR DESCRIPTION
This PR adds `falcon` to RACK_SERVERS. This option has been [added in Rack 2.1](https://github.com/rack/rack/blob/master/lib/rack/handler.rb#L48)

