### PR TITLE
Fix keyword arguments warnings in Active Job

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -619,6 +619,7 @@ module ActionMailer
           super
         end
       end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(method, include_all = false)
         action_methods.include?(method.to_s) || super

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -23,6 +23,7 @@ module ActionMailer
     def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
       mailer.constantize.public_send(mail_method, *args).send(delivery_method)
     end
+    ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
 
     private
       # "Deserialize" the mailer class name by hand in case another argument

--- a/actionmailer/lib/action_mailer/mail_delivery_job.rb
+++ b/actionmailer/lib/action_mailer/mail_delivery_job.rb
@@ -13,9 +13,14 @@ module ActionMailer
 
     rescue_from StandardError, with: :handle_exception_with_mailer_class
 
-    def perform(mailer, mail_method, delivery_method, args:, params: nil) #:nodoc:
+    def perform(mailer, mail_method, delivery_method, args:, kwargs: nil, params: nil)
       mailer_class = params ? mailer.constantize.with(params) : mailer.constantize
-      mailer_class.public_send(mail_method, *args).send(delivery_method)
+      message = if kwargs
+        mailer_class.public_send(mail_method, *args, **kwargs)
+      else
+        mailer_class.public_send(mail_method, *args)
+      end
+      message.send(delivery_method)
     end
 
     private

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -23,6 +23,7 @@ module ActionMailer
       @processed_mailer = nil
       @mail_message = nil
     end
+    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     # Method calls are delegated to the Mail::Message that's ready to deliver.
     def __getobj__ #:nodoc:
@@ -136,16 +137,14 @@ module ActionMailer
             "method*, or 3. use a custom Active Job instead of #deliver_later."
         else
           job = @mailer_class.delivery_job
-          args = arguments_for(job, delivery_method)
-          job.set(options).perform_later(*args)
-        end
-      end
 
-      def arguments_for(delivery_job, delivery_method)
-        if delivery_job <= MailDeliveryJob
-          [@mailer_class.name, @action.to_s, delivery_method.to_s, args: @args]
-        else
-          [@mailer_class.name, @action.to_s, delivery_method.to_s, *@args]
+          if job <= MailDeliveryJob
+            job.set(options).perform_later(
+              @mailer_class.name, @action.to_s, delivery_method.to_s, args: @args)
+          else
+            job.set(options).perform_later(
+              @mailer_class.name, @action.to_s, delivery_method.to_s, *@args)
+          end
         end
       end
   end

--- a/actionmailer/test/mailers/delayed_mailer.rb
+++ b/actionmailer/test/mailers/delayed_mailer.rb
@@ -22,6 +22,10 @@ class DelayedMailer < ActionMailer::Base
     mail(from: "test-sender@test.com", to: "test-receiver@test.com", subject: "Test Subject", body: "Test Body")
   end
 
+  def test_kwargs(argument:)
+    mail(from: "test-sender@test.com", to: "test-receiver@test.com", subject: "Test Subject", body: "Test Body")
+  end
+
   def test_raise(klass_name)
     raise klass_name.constantize, "boom"
   end

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -164,4 +164,11 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     assert_equal DelayedMailer, DelayedMailer.last_rescue_from_instance
     assert_equal "Error while trying to deserialize arguments: boom, missing find", DelayedMailer.last_error.message
   end
+
+  test "allows for keyword arguments" do
+    assert_performed_with(job: ActionMailer::MailDeliveryJob, args: ["DelayedMailer", "test_kwargs", "deliver_now", args: [argument: 1]]) do
+      message = DelayedMailer.test_kwargs(argument: 1)
+      message.deliver_later
+    end
+  end
 end

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -52,6 +52,8 @@ module ActiveJob
       # :nodoc:
       SYMBOL_KEYS_KEY = "_aj_symbol_keys"
       # :nodoc:
+      RUBY2_KEYWORDS_KEY = "_aj_ruby2_keywords"
+      # :nodoc:
       WITH_INDIFFERENT_ACCESS_KEY = "_aj_hash_with_indifferent_access"
       # :nodoc:
       OBJECT_SERIALIZER_KEY = "_aj_serialized"
@@ -60,10 +62,39 @@ module ActiveJob
       RESERVED_KEYS = [
         GLOBALID_KEY, GLOBALID_KEY.to_sym,
         SYMBOL_KEYS_KEY, SYMBOL_KEYS_KEY.to_sym,
+        RUBY2_KEYWORDS_KEY, RUBY2_KEYWORDS_KEY.to_sym,
         OBJECT_SERIALIZER_KEY, OBJECT_SERIALIZER_KEY.to_sym,
         WITH_INDIFFERENT_ACCESS_KEY, WITH_INDIFFERENT_ACCESS_KEY.to_sym,
       ]
-      private_constant :PERMITTED_TYPES, :RESERVED_KEYS, :GLOBALID_KEY, :SYMBOL_KEYS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
+      private_constant :PERMITTED_TYPES, :RESERVED_KEYS, :GLOBALID_KEY,
+        :SYMBOL_KEYS_KEY, :RUBY2_KEYWORDS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
+
+      unless Hash.respond_to?(:ruby2_keywords_hash?) && Hash.respond_to?(:ruby2_keywords_hash)
+        using Module.new {
+          refine Hash do
+            class << Hash
+              if RUBY_VERSION >= "2.7"
+                def ruby2_keywords_hash?(hash)
+                  !new(*[hash]).default.equal?(hash)
+                end
+              else
+                def ruby2_keywords_hash?(hash)
+                  false
+                end
+              end
+
+              def ruby2_keywords_hash(hash)
+                _ruby2_keywords_hash(**hash)
+              end
+
+              private def _ruby2_keywords_hash(*args)
+                args.last
+              end
+              ruby2_keywords(:_ruby2_keywords_hash) if respond_to?(:ruby2_keywords, true)
+            end
+          end
+        }
+      end
 
       def serialize_argument(argument)
         case argument
@@ -76,9 +107,14 @@ module ActiveJob
         when ActiveSupport::HashWithIndifferentAccess
           serialize_indifferent_hash(argument)
         when Hash
-          symbol_keys = argument.each_key.grep(Symbol).map(&:to_s)
+          symbol_keys = argument.each_key.grep(Symbol).map!(&:to_s)
+          aj_hash_key = if Hash.ruby2_keywords_hash?(argument)
+            RUBY2_KEYWORDS_KEY
+          else
+            SYMBOL_KEYS_KEY
+          end
           result = serialize_hash(argument)
-          result[SYMBOL_KEYS_KEY] = symbol_keys
+          result[aj_hash_key] = symbol_keys
           result
         when -> (arg) { arg.respond_to?(:permitted?) }
           serialize_indifferent_hash(argument.to_h)
@@ -132,6 +168,9 @@ module ActiveJob
           result = result.with_indifferent_access
         elsif symbol_keys = result.delete(SYMBOL_KEYS_KEY)
           result = transform_symbol_keys(result, symbol_keys)
+        elsif symbol_keys = result.delete(RUBY2_KEYWORDS_KEY)
+          result = transform_symbol_keys(result, symbol_keys)
+          result = Hash.ruby2_keywords_hash(result)
         end
         result
       end

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -10,9 +10,11 @@ module ActiveJob
     def perform_now(*args)
       @job_class.new(*args).perform_now
     end
+    ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
     def perform_later(*args)
       @job_class.new(*args).enqueue @options
     end
+    ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -86,6 +86,7 @@ module ActiveJob
       @executions = 0
       @exception_executions = {}
     end
+    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     # Returns a hash with the job data that can safely be passed to the
     # queuing adapter.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -21,11 +21,13 @@ module ActiveJob
       def perform_later(*args)
         job_or_instantiate(*args).enqueue
       end
+      ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
 
       private
         def job_or_instantiate(*args) # :doc:
           args.first.is_a?(self) ? args.first : new(*args)
         end
+        ruby2_keywords(:job_or_instantiate) if respond_to?(:ruby2_keywords, true)
     end
 
     # Enqueues the job to be performed by the queue adapter.

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -17,6 +17,7 @@ module ActiveJob
       def perform_now(*args)
         job_or_instantiate(*args).perform_now
       end
+      ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
       def execute(job_data) #:nodoc:
         ActiveJob::Callbacks.run_callbacks(:execute) do

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -170,7 +170,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   test "allows for keyword arguments" do
-    KwargsJob.perform_later(argument: 2)
+    KwargsJob.perform_now(argument: 2)
 
     assert_equal "Job with argument: 2", JobBuffer.last_value
   end


### PR DESCRIPTION
Reopened #38260.

Related #38053, #38187, #38105, #38260.

This is a reattempt to fix keyword arguments warnings in Active Job.

Now Ruby (master) has `Hash.ruby2_keywords_hash{?,}` and that will be
backported to 2.7.1.

https://github.com/ruby/ruby/pull/2818
https://bugs.ruby-lang.org/issues/16486

I've emulated that for 2.7.0 and older versions.
