### PR TITLE
Cache compiled view templates when running tests by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Cache compiled view templates when running tests by default
+
+    When generating a new app without `--skip-spring`, caching classes is 
+    disabled in `environments/test.rb`. This implicitly disables caching 
+    view templates too. This change will enable view template caching by 
+    adding this to the generated `environments/test.rb`: 
+
+    ````ruby
+    config.action_view.cache_template_loading = true
+    ````
+    
+    *Jorge Manrubia*
+
 *   Introduce middleware move operations
 
     With this change, you no longer need to delete and reinsert a middleware to

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -11,6 +11,7 @@ Rails.application.configure do
   <%-# Spring executes the reloaders when files change. %>
   <%- if spring_install? -%>
   config.cache_classes = false
+  config.action_view.cache_template_loading = true
   <%- else -%>
   config.cache_classes = true
   <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -836,6 +836,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "spring"
     assert_file("config/environments/test.rb") do |contents|
       assert_match("config.cache_classes = false", contents)
+      assert_match("config.action_view.cache_template_loading = true", contents)
     end
   end
 


### PR DESCRIPTION
### Summary

When generating a new app without `--skip-spring`, caching classes is disabled in `environments/test.rb`. This [implicitly disables caching view templates too](https://github.com/rails/rails/blob/88ee52f9d9cf2068bb400205e5a0c1d2e40169d1/actionview/lib/action_view/railtie.rb#L84-L88). This change enables template caching by adding this to the generated `environments/test.rb`:

```ruby
config.action_view.cache_template_loading = true
```

### Other Information

I think disabling compiled templates caching was an unintended side effect of [this commit](https://github.com/rails/rails/commit/65344f254cde87950c7f176cb7aa09c002a6f882).

We detected this problem because we were getting intermittent errors of this kind when running our suite of system tests:

```
undefined method `_app_views_layouts__nav_html_erb___3890178213482634628_149140
```

Investigating a little bit, we saw that the reason was that `ActionView::CacheExpiry` was [clearing the cache](https://github.com/rails/rails/blob/c81af6ae723ccfcd601032167d7b7f57c5449c33/actionview/lib/action_view/cache_expiry.rb#L27) when the list of view paths was modified during test execution.  This was happening when referencing a mailer class that was using `#append_view_path` (loading that class was modifying the list of paths). I haven't been able to reproduce this problem with a simple app yet (to open a bug), but this tweak fixed the issue for us and I believe it's a better default for Rails.

cc @kaspth 
