### PR TITLE
Use --assume-yes to install the dependencies for Github's workflows:

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install required package
       run: |
         sudo apt-get update
-        sudo apt-get install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
+        sudo apt-get -y install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
     - name: Install bundler
       run: |
         gem install bundler:2.1.2


### PR DESCRIPTION
This could prevent not install if require a confirmation action on
system were is run the workflow.