### PR TITLE
Fix doc code formatting [ci skip]

### DIFF
--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -51,7 +51,7 @@ module ActiveSupport
     # constant. Available behaviors are:
     #
     # [+raise+]   Raise <tt>ActiveSupport::DeprecationException</tt>.
-    # [+stderr+]  Log all deprecation warnings to +$stderr+.
+    # [+stderr+]  Log all deprecation warnings to <tt>$stderr</tt>.
     # [+log+]     Log all deprecation warnings to +Rails.logger+.
     # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
     # [+silence+] Do nothing.
@@ -78,7 +78,7 @@ module ActiveSupport
       # Available behaviors:
       #
       # [+raise+]   Raise <tt>ActiveSupport::DeprecationException</tt>.
-      # [+stderr+]  Log all deprecation warnings to +$stderr+.
+      # [+stderr+]  Log all deprecation warnings to <tt>$stderr</tt>.
       # [+log+]     Log all deprecation warnings to +Rails.logger+.
       # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
       # [+silence+] Do nothing.

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -42,7 +42,7 @@ module ActiveSupport
       end
 
       # Allow previously disallowed deprecation warnings within the block.
-      # <tt>allowed_warnings<tt> can be an array containing strings, symbols, or regular
+      # <tt>allowed_warnings</tt> can be an array containing strings, symbols, or regular
       # expressions. (Symbols are treated as strings). These are compared against
       # the text of deprecation warning messages generated within the block.
       # Matching warnings will be exempt from the rules set by


### PR DESCRIPTION
Fixes this:

![t9wrtvdaw0 2020-01-21 11-28-03](https://user-images.githubusercontent.com/308724/72823194-4bc58c80-3c41-11ea-8bc0-32cec0c0e46a.png)

and this:

![o5hsrokce6 2020-01-21 11-32-51](https://user-images.githubusercontent.com/308724/72823520-d8704a80-3c41-11ea-8e65-67389c58c3d4.png)
