### PR TITLE
guides -> active_job -> add que backend [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -166,6 +166,7 @@ Here is a noncomprehensive list of documentation:
 - [Sucker Punch](https://github.com/brandonhilkert/sucker_punch#active-job)
 - [Queue Classic](https://github.com/QueueClassic/queue_classic#active-job)
 - [Delayed Job](https://github.com/collectiveidea/delayed_job#active-job)
+- [Que](https://github.com/que-rb/que#additional-rails-specific-setup)
 
 Queues
 ------


### PR DESCRIPTION
### Summary

This is minor change to Rails Guides adding to the list of backends a project that has been developed over many years. It is the [que gem](https://github.com/que-rb/que), which [recently was transferred from a single owner to a small community](https://github.com/que-rb/que/issues/245).

I'm not directly involved with the development of Que, but last year I was evaluating some Active Job backends and I think Que is a very mature project that should appeal many people. It called my attention because it saves money: you can run your background jobs in Postgres, which for me is my primary database, hence I don't have to pay to provision Redis on my PaaS.

It is an alternative to [QueueClassic](https://github.com/QueueClassic/queue_classic) as [discussed here](https://www.reddit.com/r/ruby/comments/3poqc6/is_there_an_active_job_backend_that_uses_postgres/).

### Other Information

Again, I'm not directly involved with the development of the gem, but I recently got a notification about a release and I think doing this PR is a nice way to encourage the work the new team is doing.
