### PR TITLE
Update list of middleware for API-only in Guides

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -199,6 +199,7 @@ Choosing Middleware
 
 An API application comes with the following middleware by default:
 
+- `ActionDispatch::HostAuthorization`
 - `Rack::Sendfile`
 - `ActionDispatch::Static`
 - `ActionDispatch::Executor`
@@ -209,6 +210,7 @@ An API application comes with the following middleware by default:
 - `Rails::Rack::Logger`
 - `ActionDispatch::ShowExceptions`
 - `ActionDispatch::DebugExceptions`
+- `ActionDispatch::ActionableExceptions`
 - `ActionDispatch::Reloader`
 - `ActionDispatch::Callbacks`
 - `ActiveRecord::Migration::CheckPending`


### PR DESCRIPTION
### Summary

In **Using Rails for API-only Applications**, the list of default middleware that comes with an API-only application is listed in the Choosing Middleware section of the guide. I noticed that it's missing two middleware when I compared it to the middleware of my freshly created API-only application.

Missing middleware:

* ActionDispatch::HostAuthorization
* ActionDispatch::ActionableExceptions

This change adds these two to the list while preserving the order of the middleware as they were printed by the `rails middleware` command.

### Other Information

Steps taken to verify the missing middleware:

```
$ rails new basic_api --api -d postgresql
$ cd basic_api
$ rails middleware
use ActionDispatch::HostAuthorization
use Rack::Sendfile
use ActionDispatch::Static
use ActionDispatch::Executor
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use ActionDispatch::RequestId
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use ActionDispatch::ActionableExceptions
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
run BasicApi::Application.routes
```
