### PR TITLE
Fix BigDecimal.new deprecation in rounding number helper

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -48,7 +48,7 @@ module ActiveSupport
         end
 
         def calculate_rounded_number(multiplier)
-          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+          (number / BigDecimal(multiplier.to_f.to_s)).round * multiplier
         end
 
         def digit_count(number)

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -34,7 +34,7 @@ module ActiveSupport
           return 0 if number.zero?
           digits = digit_count(number)
           multiplier = 10**(digits - precision)
-          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+          (number / BigDecimal(multiplier.to_f.to_s)).round * multiplier
         end
 
         def convert_to_decimal(number)


### PR DESCRIPTION
### Summary

This fixes:
```
activesupport-5.1.7/lib/active_support/number_helper/rounding_helper.rb:37:
  warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```
