### PR TITLE
Use path instead of fullpath on validating authenticity token

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -381,7 +381,7 @@ module ActionController #:nodoc:
         if per_form_csrf_tokens
           correct_token = per_form_csrf_token(
             session,
-            request.fullpath.chomp("/"),
+            request.path.chomp("/"),
             request.request_method
           )
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -835,6 +835,18 @@ class PerFormTokensControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_accepts_token_with_path_with_query_params
+    get :index
+    form_token = assert_presence_and_fetch_form_csrf_token
+    assert_matches_session_token_on_server form_token
+
+    @request.env["PATH_INFO"] = "/per_form_tokens/post_one"
+    @request.env["QUERY_STRING"] = "key=value"
+    assert_nothing_raised do
+      post :post_one, params: { custom_authenticity_token: form_token }
+    end
+  end
+
   def test_rejects_garbage_path
     get :index
 


### PR DESCRIPTION
### Summary

PR #38211 introduced a bug where URLs with query_params
will fail to validate authenticity token.

This PR changes the `fullpath` to `path` as fullpath contains query_params.

### Other Information

There is more detail about why #38211 causes issues in the comments [here](https://github.com/rails/rails/pull/38211#issuecomment-577388931) and [here](https://github.com/rails/rails/pull/38211#issuecomment-577395277)
