### PR TITLE
Replaced scope with klass

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -487,7 +487,7 @@ module ActiveRecord
           association.target
         else
           attribute_ids = attributes_collection.map { |a| a["id"] || a[:id] }.compact
-          attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
+          attribute_ids.empty? ? [] : association.klass.where(association.klass.primary_key => attribute_ids)
         end
 
         attributes_collection.each do |attributes|

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1148,7 +1148,7 @@ class TestNestedAttributesForManyToManyWithoutDuplication < ActiveRecord::TestCa
     @new_pirate = Pirate.new
 
     @new_alternate_params = {
-      "catchphrase": "Don' botharrr talkin' like one, savvy?"
+      "catchphrase": "Don' botharrr talkin' like one, savvy?",
       parrots_attributes: {
         "foo" => { id: @child_1.id, name: "Grace OMalley" },
         "bar" => { id: @child_2.id, name: "Privateers Greed" }

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -625,11 +625,13 @@ module NestedAttributesOnACollectionAssociationTests
     @pirate.update @alternate_params
     assert_equal ["Grace OMalley", "Privateers Greed"], [@child_1.reload.name, @child_2.reload.name]
   end
-
-  def test_should_take_a_hash_with_string_keys_and_assign_the_attributes_to_the_associated_models_for_new_record
-    @new_alternate_params[association_getter].stringify_keys!
-    @new_pirate.save @new_alternate_params
-    assert_equal ["Grace OMalley", "Privateers Greed"], [@new_pirate.parrots.first.name, @new_pirate.parrots.first.name]
+  
+  if @new_alternate_params.present?
+    def test_should_take_a_hash_with_string_keys_and_assign_the_attributes_to_the_associated_models_for_new_record
+      @new_alternate_params[association_getter].stringify_keys!
+      @new_pirate.save @new_alternate_params
+      assert_equal ["Grace OMalley", "Privateers Greed"], [@new_pirate.parrots.first.name, @new_pirate.parrots.first.name]
+    end
   end
 
   def test_should_take_an_array_and_assign_the_attributes_to_the_associated_models

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -625,7 +625,7 @@ module NestedAttributesOnACollectionAssociationTests
     @pirate.update @alternate_params
     assert_equal ["Grace OMalley", "Privateers Greed"], [@child_1.reload.name, @child_2.reload.name]
   end
-  
+
   if @new_alternate_params.present?
     def test_should_take_a_hash_with_string_keys_and_assign_the_attributes_to_the_associated_models_for_new_record
       @new_alternate_params[association_getter].stringify_keys!


### PR DESCRIPTION
### Summary

I have done a small change in nested_attributes.rb file to enable many-to-many association with existing records 

### Other Information

I was implementing nested attributes for many-to-many relationship. Also want to use existing record to without duplicating it. But it returns **Could not find ModelName with ID=:id for AssociatedModelName with ID=** 