### PR TITLE
Document the return value of update_all [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -417,7 +417,7 @@ module ActiveRecord
     # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
     # statement and sends it straight to the database. It does not instantiate the involved models and it does not
     # trigger Active Record callbacks or validations. However, values passed to #update_all will still go through
-    # Active Record's normal type casting and serialization.
+    # Active Record's normal type casting and serialization. Returns the number of rows affected.
     #
     # Note: As Active Record callbacks are not triggered, this method will not automatically update +updated_at+/+updated_on+ columns.
     #


### PR DESCRIPTION
1. This return value is depended on throughout Rails itself. A couple of examples: [1](https://github.com/rails/rails/blob/2d7ff70b3f0ae7e25f766c7701eaebdaa3f2766a/activerecord/test/cases/relation/update_all_test.rb#L49), [2](https://github.com/rails/rails/blob/2d7ff70b3f0ae7e25f766c7701eaebdaa3f2766a/activerecord/lib/active_record/associations/has_many_through_association.rb#L140), [3](https://github.com/rails/rails/blob/2d7ff70b3f0ae7e25f766c7701eaebdaa3f2766a/activerecord/test/cases/persistence_test.rb#L522), etc.

2. `delete_all` and `delete_by` behave similarly and are [documented](https://github.com/rails/rails/blob/2d7ff70b3f0ae7e25f766c7701eaebdaa3f2766a/activerecord/lib/active_record/relation.rb#L564-L565) as [such](https://github.com/rails/rails/blob/2d7ff70b3f0ae7e25f766c7701eaebdaa3f2766a/activerecord/lib/active_record/relation.rb#L620).