### PR TITLE
Parallelize activesupport test suite

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -661,6 +661,10 @@ module ActiveSupport
             namespace = namespace.call
           end
 
+          if key && key.encoding != Encoding::UTF_8
+            key = key.dup.force_encoding(Encoding::UTF_8)
+          end
+
           if namespace
             "#{namespace}:#{key}"
           else

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -28,6 +28,8 @@ ActiveSupport.to_time_preserves_timezone = ENV["PRESERVE_TIMEZONES"] == "1"
 I18n.enforce_available_locales = false
 
 class ActiveSupport::TestCase
+  parallelize
+
   include ActiveSupport::Testing::MethodCallAssertions
 
   private

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -30,18 +30,41 @@ module CacheInstrumentationBehavior
 
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
     assert_equal :fetch_multi, events[0].payload[:super_operation]
+    assert_equal ["a", "b"], events[0].payload[:key]
     assert_equal ["b"], events[0].payload[:hits]
+  end
+
+  def test_instrumentation_empty_fetch_multi
+    events = with_instrumentation "read_multi" do
+      @cache.fetch_multi() { |key| key * 2 }
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal :fetch_multi, events[0].payload[:super_operation]
+    assert_equal [], events[0].payload[:key]
+    assert_equal [], events[0].payload[:hits]
   end
 
   def test_read_multi_instrumentation
     @cache.write("b", "bb")
 
     events = with_instrumentation "read_multi" do
-      @cache.read_multi("a", "b") { |key| key * 2 }
+      @cache.read_multi("a", "b")
     end
 
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal ["a", "b"], events[0].payload[:key]
     assert_equal ["b"], events[0].payload[:hits]
+  end
+
+  def test_empty_read_multi_instrumentation
+    events = with_instrumentation "read_multi" do
+      @cache.read_multi()
+    end
+
+    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
+    assert_equal [], events[0].payload[:key]
+    assert_equal [], events[0].payload[:hits]
   end
 
   private

--- a/activesupport/test/cache/behaviors/connection_pool_behavior.rb
+++ b/activesupport/test/cache/behaviors/connection_pool_behavior.rb
@@ -8,7 +8,7 @@ module ConnectionPoolBehavior
 
     emulating_latency do
       cache = ActiveSupport::Cache.lookup_store(*store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
-      cache.clear
+      cache.read("foo")
 
       assert_raises Timeout::Error do
         # One of the three threads will fail in 1 second because our pool size
@@ -33,7 +33,6 @@ module ConnectionPoolBehavior
 
     emulating_latency do
       cache = ActiveSupport::Cache.lookup_store(*store, store_options)
-      cache.clear
 
       assert_nothing_raised do
         # Default connection pool size is 5, assuming 10 will make sure that

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -6,7 +6,10 @@ require_relative "../behaviors"
 require "pathname"
 
 class FileStoreTest < ActiveSupport::TestCase
+  attr_reader :cache_dir
+
   def setup
+    @cache_dir = Dir.mktmpdir("file-store-")
     Dir.mkdir(cache_dir) unless File.exist?(cache_dir)
     @cache = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, expires_in: 60)
     @peek = ActiveSupport::Cache.lookup_store(:file_store, cache_dir, expires_in: 60)
@@ -19,10 +22,6 @@ class FileStoreTest < ActiveSupport::TestCase
   def teardown
     FileUtils.rm_r(cache_dir)
   rescue Errno::ENOENT
-  end
-
-  def cache_dir
-    File.join(Dir.pwd, "tmp_cache")
   end
 
   include CacheStoreBehavior

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -35,13 +35,17 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     MEMCACHE_UP = false
   end
 
+  def lookup_store(options = {})
+    ActiveSupport::Cache.lookup_store(*store, { namespace: @namespace }.merge(options))
+  end
+
   def setup
     skip "memcache server is not up" unless MEMCACHE_UP
 
-    @cache = ActiveSupport::Cache.lookup_store(*store, expires_in: 60)
-    @peek = ActiveSupport::Cache.lookup_store(*store)
+    @namespace = "test-#{SecureRandom.hex}"
+    @cache = lookup_store(expires_in: 60)
+    @peek = lookup_store
     @data = @cache.instance_variable_get(:@data)
-    @cache.clear
     @cache.silence!
     @cache.logger = ActiveSupport::Logger.new(File::NULL)
   end
@@ -56,23 +60,30 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   include ConnectionPoolBehavior
   include FailureSafetyBehavior
 
+  # Overrides test from LocalCacheBehavior in order to stub out the cache clear
+  # and replace it with a delete.
+  def test_clear_also_clears_local_cache
+    client = @cache.instance_variable_get(:@data)
+    key = "#{@namespace}:foo"
+    client.stub(:flush_all, -> { client.delete(key) }) do
+      super
+    end
+  end
+
   def test_raw_values
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true)
     cache.write("foo", 2)
     assert_equal "2", cache.read("foo")
   end
 
   def test_raw_values_with_marshal
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true)
     cache.write("foo", Marshal.dump([]))
     assert_equal [], cache.read("foo")
   end
 
   def test_local_cache_raw_values
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true)
     cache.with_local_cache do
       cache.write("foo", 2)
       assert_equal "2", cache.read("foo")
@@ -80,24 +91,21 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def test_increment_expires_in
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true, namespace: nil)
     assert_called_with cache.instance_variable_get(:@data), :incr, [ "foo", 1, 60 ] do
       cache.increment("foo", 1, expires_in: 60)
     end
   end
 
   def test_decrement_expires_in
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true, namespace: nil)
     assert_called_with cache.instance_variable_get(:@data), :decr, [ "foo", 1, 60 ] do
       cache.decrement("foo", 1, expires_in: 60)
     end
   end
 
   def test_local_cache_raw_values_with_marshal
-    cache = ActiveSupport::Cache.lookup_store(*store, raw: true)
-    cache.clear
+    cache = lookup_store(raw: true)
     cache.with_local_cache do
       cache.write("foo", Marshal.dump([]))
       assert_equal [], cache.read("foo")

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -14,7 +14,7 @@ Redis::Connection.drivers.append(driver)
 # Emulates a latency on Redis's back-end for the key latency to facilitate
 # connection pool testing.
 class SlowRedis < Redis
-  def get(key, options = {})
+  def get(key)
     if /latency/.match?(key)
       sleep 3
     else
@@ -109,7 +109,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
   class StoreTest < ActiveSupport::TestCase
     setup do
-      @namespace = "namespace"
+      @namespace = "test-#{SecureRandom.hex}"
 
       @cache = ActiveSupport::Cache::RedisCacheStore.new(timeout: 0.1, namespace: @namespace, expires_in: 60, driver: DRIVER)
       # @cache.logger = Logger.new($stdout)  # For test debugging
@@ -237,7 +237,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, UnavailableRedisClient)
 
-        yield ActiveSupport::Cache::RedisCacheStore.new
+        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
       ensure
         Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, old_client)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -131,6 +131,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include CacheIncrementDecrementBehavior
     include CacheInstrumentationBehavior
     include AutoloadingCacheBehavior
+    include EncodedKeyCacheBehavior
 
     def test_fetch_multi_uses_redis_mget
       assert_called(@cache.redis, :mget, returns: []) do
@@ -211,17 +212,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       def store_options
         { url: [ENV["REDIS_URL"] || "redis://localhost:6379/0"] * 2 }
       end
-  end
-
-  # Separate test class so we can omit the namespace which causes expected,
-  # appropriate complaints about incompatible string encodings.
-  class KeyEncodingSafetyTest < StoreTest
-    include EncodedKeyCacheBehavior
-
-    setup do
-      @cache = ActiveSupport::Cache::RedisCacheStore.new(timeout: 0.1, driver: DRIVER)
-      @cache.logger = nil
-    end
   end
 
   class StoreAPITest < StoreTest

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -85,7 +85,7 @@ class AtomicWriteTest < ActiveSupport::TestCase
 
   private
     def file_name
-      "atomic.file"
+      "atomic-#{Process.pid}.file"
     end
 
     def file_mode

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -5,9 +5,10 @@ require "active_support/encrypted_configuration"
 
 class EncryptedConfigurationTest < ActiveSupport::TestCase
   setup do
-    @credentials_config_path = File.join(Dir.tmpdir, "credentials.yml.enc")
+    @tmpdir = Dir.mktmpdir("config-")
+    @credentials_config_path = File.join(@tmpdir, "credentials.yml.enc")
 
-    @credentials_key_path = File.join(Dir.tmpdir, "master.key")
+    @credentials_key_path = File.join(@tmpdir, "master.key")
     File.write(@credentials_key_path, ActiveSupport::EncryptedConfiguration.generate_key)
 
     @credentials = ActiveSupport::EncryptedConfiguration.new(
@@ -17,8 +18,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   end
 
   teardown do
-    FileUtils.rm_rf @credentials_config_path
-    FileUtils.rm_rf @credentials_key_path
+    FileUtils.rm_rf @tmpdir
   end
 
   test "reading configuration by env key" do

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -7,9 +7,10 @@ class EncryptedFileTest < ActiveSupport::TestCase
   setup do
     @content = "One little fox jumped over the hedge"
 
-    @content_path = File.join(Dir.tmpdir, "content.txt.enc")
+    @tmpdir = Dir.mktmpdir("encrypted-file-test-")
+    @content_path = File.join(@tmpdir, "content.txt.enc")
 
-    @key_path = File.join(Dir.tmpdir, "content.txt.key")
+    @key_path = File.join(@tmpdir, "content.txt.key")
     File.write(@key_path, ActiveSupport::EncryptedFile.generate_key)
 
     @encrypted_file = encrypted_file(@content_path)
@@ -18,6 +19,7 @@ class EncryptedFileTest < ActiveSupport::TestCase
   teardown do
     FileUtils.rm_rf @content_path
     FileUtils.rm_rf @key_path
+    FileUtils.rm_rf @tmpdir
   end
 
   test "reading content by env key" do
@@ -56,7 +58,7 @@ class EncryptedFileTest < ActiveSupport::TestCase
   test "respects existing content_path symlink" do
     @encrypted_file.write(@content)
 
-    symlink_path = File.join(Dir.tmpdir, "content_symlink.txt.enc")
+    symlink_path = File.join(@tmpdir, "content_symlink.txt.enc")
     File.symlink(@encrypted_file.content_path, symlink_path)
 
     encrypted_file(symlink_path).write(@content)
@@ -68,7 +70,7 @@ class EncryptedFileTest < ActiveSupport::TestCase
   end
 
   test "creates new content_path symlink if it's dead" do
-    symlink_path = File.join(Dir.tmpdir, "content_symlink.txt.enc")
+    symlink_path = File.join(@tmpdir, "content_symlink.txt.enc")
     File.symlink(@content_path, symlink_path)
 
     encrypted_file(symlink_path).write(@content)


### PR DESCRIPTION
This updates the activesupport test suite to be run in parallel. ⚡️

**Before:** 127.87 seconds
**After:** 15.609 seconds (with `PARALLEL_WORKERS=16`)

This required a few changes to ensure that parallel tests didn't interfere with each other:
* Using random tmp directories instead of fixed locations
* Always configuring a namespace for cache clients being tested
* Avoiding calling `clear` on the memcache client, which would clear all namespaces

This also required one non-test change to allow [non-utf8 cache keys when a namespace was configured](8cc8edb91339e3c638a36133e7c4822cae1d6748). IMO that's a change we should make: having a namespace is a configuration change and shouldn't affect supported values.