### PR TITLE
Fix addition of two Active support durations

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -304,6 +304,42 @@ module ActiveSupport
       Duration == klass || value.instance_of?(klass)
     end
 
+    def minutes #:nodoc:
+      self.class.new(value, minutes: value / SECONDS_PER_MINUTE)
+    end
+
+    alias :minute :minutes
+
+    def hours #:nodoc:
+      self.class.new(value, hours: value / SECONDS_PER_HOUR)
+    end
+
+    alias :hour :hours
+
+    def days #:nodoc:
+      self.class.new(value, days: value / SECONDS_PER_DAY)
+    end
+
+    alias :day :days
+
+    def weeks #:nodoc:
+      self.class.new(value, weeks: value / SECONDS_PER_WEEK)
+    end
+
+    alias :week :weeks
+
+    def months #:nodoc:
+      self.class.new(value, months: value / SECONDS_PER_MONTH)
+    end
+
+    alias :month :months
+
+    def years #:nodoc:
+      self.class.new(value, years: value / SECONDS_PER_YEAR)
+    end
+
+    alias :year :years
+
     # Returns +true+ if +other+ is also a Duration instance with the
     # same +value+, or if <tt>other == value</tt>.
     def ==(other)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -695,8 +695,9 @@ class DurationTest < ActiveSupport::TestCase
 
   def test_addition_of_durations
     ninty_minutes = (1.hour + 30.minutes).minutes
-    assert_equal "90", ninty_minutes.to_s
+    assert_equal "90 minutes", ninty_minutes.inspect
     assert ninty_minutes.instance_of?(ActiveSupport::Duration)
+    assert_equal "95 minutes", (ninty_minutes + 5.minutes).inspect
   end
 
   private

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -694,7 +694,7 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_addition_of_durations
-    assert_equal '90', (1.hour + 30.minutes).minutes.to_s
+    assert_equal "90", (1.hour + 30.minutes).minutes.to_s
   end
 
   private

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -693,6 +693,10 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "can't build an ActiveSupport::Duration from a NilClass", error.message
   end
 
+  def test_addition_of_durations
+    assert_equal '90', (1.hour + 30.minutes).minutes.to_s
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -694,7 +694,9 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_addition_of_durations
-    assert_equal "90", (1.hour + 30.minutes).minutes.to_s
+    ninty_minutes = (1.hour + 30.minutes).minutes
+    assert_equal "90", ninty_minutes.to_s
+    assert ninty_minutes.instance_of?(ActiveSupport::Duration)
   end
 
   private


### PR DESCRIPTION
This fixes https://github.com/rails/rails/issues/37749.
When we write 8.hours it creates ActiveSupport::Duration object https://github.com/rails/rails/blob/f78fb42b51c2226b5e87d5c637604f1d85b68b14/activesupport/lib/active_support/core_ext/numeric/time.rb#L29 which multiples with number of seconds it contains thus multiplying 8 * 60 * 60 setting attribute `value` as 28800.
When we call minutes on this object, since ActiveSupport::Duration doesn't have any instance method `minutes` it goes to method missing defined here https://github.com/rails/rails/blob/f78fb42b51c2226b5e87d5c637604f1d85b68b14/activesupport/lib/active_support/duration.rb#L429

This method call method `minutes` on the value of the current instance which is `28800` which is of numeric class and respond from https://github.com/rails/rails/blob/f78fb42b51c2226b5e87d5c637604f1d85b68b14/activesupport/lib/active_support/core_ext/numeric/time.rb#L21 where it creates ActiveSupport::Duration minutes object with argument 28800 which is same as calling 28800.minutes

Therefore added instance methods minutes, hours, days, weeks, months and years thus using value of the current instance dividing with seconds it contains , for example for hours it will divide with 3600, for minutes dividing with 60 returning our expected result.


They are two ways to fix it, either modify method missing method implemented for ActiveSupport::Duration or add these methods to the class. In this pull request I have added methods but alternative approach would fix it too.

Now calling methods like minutes, hours gives more consistent results.

```
Before Change:
1.hour 
=> 1 hour
1.hour.minutes 
=> 3600 minutes
1.hour.minutes.minutes 
=> 216000 minutes

After Change:
1.hour 
=> 1 hour
1.hour.minutes 
=> 60 minutes
1.hour.minutes.minutes 
=> 60.minutes
1.hour.minutes.minutes.minutes
=> 60.minutes
```