### PR TITLE
Prevent a route be written more than once

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent a route be written more than once
+
+    If you have a second route that is commented
+    the generator will not write to it
+
+    *thiaguerd*
+
 *   Cache compiled view templates when running tests by default
 
     When generating a new app without `--skip-spring`, caching classes is 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -260,7 +260,7 @@ module Rails
         end
 
         log :route, routing_code
-        sentinel = /^\s*\w.*\.routes\.draw do\s*\n/m
+        sentinel = /^\s*[A-Z]\S*\.routes.draw\s*do\s*\n/m
 
         in_root do
           inject_into_file "config/routes.rb", optimize_indentation(routing_code, 2), after: sentinel, verbose: false, force: false

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -260,7 +260,7 @@ module Rails
         end
 
         log :route, routing_code
-        sentinel = /\.routes\.draw do\s*\n/m
+        sentinel = /^\s*\w.*\.routes\.draw do\s*\n/m
 
         in_root do
           inject_into_file "config/routes.rb", optimize_indentation(routing_code, 2), after: sentinel, verbose: false, force: false

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -539,6 +539,20 @@ class ActionsTest < Rails::Generators::TestCase
     ROUTING_CODE
   end
 
+  def test_does_not_write_multiple_times_same_route
+    run_generator
+    route_path = File.expand_path("config/routes.rb", destination_root)
+    content = File.read(route_path)
+    comments = content.gsub(/^/, "#") + content.gsub(/^/, "# ")
+    File.write(route_path, comments, mode: "a")
+    route_command = "root 'welcome#index'"
+    action :route, route_command
+    assert_file("config/routes.rb") do |routes|
+      assert_routes route_command
+      assert_equal 1, routes.scan(/root\ 'welcome\#index'/).size
+    end
+  end
+
   def test_readme
     run_generator
     assert_called(Rails::Generators::AppGenerator, :source_root, times: 2, returns: destination_root) do

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -82,16 +82,6 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_does_not_write_multiple_times_same_route
-    route_path = File.expand_path("config/routes.rb", destination_root)
-    content = File.read(route_path)
-    File.write(route_path, content.gsub(/^/, "#"), mode: "a")
-    run_generator ["account", "foo"]
-    assert_file("config/routes.rb") do |routes|
-      assert_equal 1, routes.scan(/get 'account\/foo'/).size
-    end
-  end
-
   def test_invokes_default_template_engine_even_with_no_action
     run_generator ["account"]
     assert_file "app/views/account"

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -82,6 +82,16 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_does_not_write_multiple_times_same_route
+    route_path = File.expand_path("config/routes.rb", destination_root)
+    content = File.read(route_path)
+    File.write(route_path, content.gsub(/^/, "#"), mode: "a")
+    run_generator ["account", "foo"]
+    assert_file("config/routes.rb") do |routes|
+      assert_equal 1, routes.scan(/get 'account\/foo'/).size
+    end
+  end
+
   def test_invokes_default_template_engine_even_with_no_action
     run_generator ["account"]
     assert_file "app/views/account"


### PR DESCRIPTION
### Summary

Currently the route generator writes to routes that are commented

I updated the sentinel to verify that it is not commented

### Other Information

Example initial

```
Rails.application.routes.draw do
  # ...
end
# Rails.application.routes.draw do
#   # ...
# end
```

**On write any route**

Before

```
Rails.application.routes.draw do
  get 'controller/action'
  # ..
end
# Rails.application.routes.draw do
  get 'controller/action'
#  # ..
# end
```

After

```
Rails.application.routes.draw do
  get 'controller/action'
  # ..
end
# Rails.application.routes.draw do
#  # ..
# end
```