### PR TITLE
Fix fallout from recent back ports

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -30,13 +30,8 @@
 
     *Patrick Rebsch*
 
-<<<<<<< HEAD
 
 ## Rails 6.0.2.1 (December 18, 2019) ##
-=======
-    Applications should use `configs_for`. `#default_hash` and `#[]` will be removed in 6.2.
-=======
->>>>>>> 59d54b350d... Merge pull request #38235 from eileencodes/fix-advisory-lock
 
 *   No changes.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -393,7 +393,7 @@ module ActiveRecord
         indexes << [column_name, options]
       end
 
-      def foreign_key(table_name, options = {}) # :nodoc:
+      def foreign_key(table_name, **options) # :nodoc:
         foreign_keys << [table_name, options]
       end
 
@@ -476,7 +476,7 @@ module ActiveRecord
         @foreign_key_drops << name
       end
 
-      def add_column(name, type, options)
+      def add_column(name, type, **options)
         name = name.to_s
         type = type.to_sym
         @adds << AddColumnDefinition.new(@td.new_column_definition(name, type, **options))
@@ -630,6 +630,7 @@ module ActiveRecord
       #   t.remove_index(:branch_id)
       #   t.remove_index(column: [:branch_id, :party_id])
       #   t.remove_index(name: :by_branch_party)
+      #   t.remove_index(:branch_id, name: :by_branch_party)
       #
       # See {connection.remove_index}[rdoc-ref:SchemaStatements#remove_index]
       def remove_index(options = {})
@@ -705,8 +706,8 @@ module ActiveRecord
       #  t.foreign_key(:authors) unless t.foreign_key_exists?(:authors)
       #
       # See {connection.foreign_key_exists?}[rdoc-ref:SchemaStatements#foreign_key_exists?]
-      def foreign_key_exists?(*args, **options)
-        @base.foreign_key_exists?(name, *args, **options)
+      def foreign_key_exists?(*args)
+        @base.foreign_key_exists?(name, *args)
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -587,7 +587,7 @@ module ActiveRecord
       #  # ALTER TABLE "shapes" ADD "triangle" polygon
       def add_column(table_name, column_name, type, **options)
         at = create_alter_table table_name
-        at.add_column(column_name, type, options)
+        at.add_column(column_name, type, **options)
         execute schema_creation.accept at
       end
 
@@ -595,10 +595,14 @@ module ActiveRecord
       #
       #   remove_columns(:suppliers, :qualification, :experience)
       #
-      def remove_columns(table_name, *column_names)
+      # +type+ and other column options can be passed to make migration reversible.
+      #
+      #    remove_columns(:suppliers, :qualification, :experience, type: :string, null: false)
+      def remove_columns(table_name, *column_names, **options)
         raise ArgumentError.new("You must specify at least one column name. Example: remove_columns(:people, :first_name)") if column_names.empty?
+        type = options.delete(:type)
         column_names.each do |column_name|
-          remove_column(table_name, column_name)
+          remove_column(table_name, column_name, type, **options)
         end
       end
 
@@ -988,7 +992,7 @@ module ActiveRecord
       #   Action that happens <tt>ON UPDATE</tt>. Valid values are +:nullify+, +:cascade+ and +:restrict+
       # [<tt>:validate</tt>]
       #   (PostgreSQL only) Specify whether or not the constraint should be validated. Defaults to +true+.
-      def add_foreign_key(from_table, to_table, options = {})
+      def add_foreign_key(from_table, to_table, **options)
         return unless supports_foreign_keys?
 
         options = foreign_key_options(from_table, to_table, options)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1374,7 +1374,7 @@ module ActiveRecord
 
       def with_advisory_lock
         lock_id = generate_migrator_advisory_lock_id
-        AdvisoryLockBase.establish_connection(ActiveRecord::Base.connection_db_config) unless AdvisoryLockBase.connected?
+        AdvisoryLockBase.establish_connection(ActiveRecord::Base.connection_config) unless AdvisoryLockBase.connected?
         connection = AdvisoryLockBase.connection
         got_lock = connection.get_advisory_lock(lock_id)
         raise ConcurrentMigrationError unless got_lock

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -303,6 +303,13 @@ module ActiveRecord
         end
       end
 
+      def test_remove_drops_multiple_columns_when_column_options_are_given
+        with_change_table do |t|
+          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz, type: :string, null: false]
+          t.remove :bar, :baz, type: :string, null: false
+        end
+      end
+
       def test_remove_index_removes_index_with_options
         with_change_table do |t|
           @connection.expect :remove_index, nil, [:delete_me, { unique: true }]


### PR DESCRIPTION
### Summary

* there's no connection_db_config in Rails 6.0
* remove_column and friends "options" changes.
* merge conflict markers in activerecord/CHANGELOG.md

Noticed while running tests for JRuby's AR-JDBC. While the Rails tests
where running fine, our local ones broke during migration tests.
Fixes are basically from master.

Fixes #38315 
