### PR TITLE
Update code return value in debugging rails guide [ci skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -633,7 +633,7 @@ You can also inspect for an object method this way:
 
 ```
 (byebug) var instance Article.new
-@_start_transaction_state = {}
+@_start_transaction_state = nil
 @aggregation_cache = {}
 @association_cache = {}
 @attributes = #<ActiveRecord::AttributeSet:0x007fd0682a9b18 @attributes={"id"=>#<ActiveRecord::Attribute::FromDatabase:0x007fd0682a9a00 @name="id", @value_be...


### PR DESCRIPTION
### Summary

Update debugging rails guide.

Now `@_start_transaction_state` set to `nil` instead of empty hash from https://github.com/rails/rails/commit/b1458218c95d85c4ce911dd3e99da5ae7cf7aeee.
