### PR TITLE
Expose `klass.default_scoped` as public API

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -30,8 +30,7 @@ module ActiveRecord
               ActiveSupport::Deprecation.warn(<<~MSG.squish)
                 Class level methods will no longer inherit scoping from `#{scope._deprecated_scope_source}`
                 in Rails 6.1. To continue using the scoped relation, pass it into the block directly.
-                To instead access the full set of models, as Rails 6.1 will, use `#{name}.unscoped`,
-                or `#{name}.default_scoped` if a model has default scopes.
+                To instead access the full set of models, as Rails 6.1 will, use `#{name}.default_scoped`.
               MSG
             end
 
@@ -53,7 +52,8 @@ module ActiveRecord
           end
         end
 
-        def default_scoped(scope = relation) # :nodoc:
+        # Returns a scope for the model with default scopes.
+        def default_scoped(scope = relation)
           build_default_scope(scope) || scope
         end
 

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -95,6 +95,20 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_scoped_unscoped
+    DeveloperOrderedBySalary.where("salary = 9000").scoping do
+      assert_equal 11, DeveloperOrderedBySalary.first.id
+      assert_equal 1, DeveloperOrderedBySalary.unscoped.first.id
+    end
+  end
+
+  def test_scoped_default_scoped
+    DeveloperOrderedBySalary.where("salary = 9000").scoping do
+      assert_equal 11, DeveloperOrderedBySalary.first.id
+      assert_equal 2, DeveloperOrderedBySalary.default_scoped.first.id
+    end
+  end
+
   def test_scoped_find_all
     Developer.where("name = 'David'").scoping do
       assert_equal [developers(:david)], Developer.all


### PR DESCRIPTION
`default_scoped` is an only way to enforce returning a scope with
default scopes in a scoping, and it is needed for migration to avoid
leaking scope (#35280, #37727).

Closes #38241.