### PR TITLE
Avoid making query when using `where(attr: out-of-range-value)`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -87,7 +87,14 @@ module ActiveRecord
       end
 
       def contradiction?
-        predicates.any? { |x| Arel::Nodes::In === x && Array === x.right && x.right.empty? }
+        predicates.any? do |x|
+          case x
+          when Arel::Nodes::In
+            Array === x.right && x.right.empty?
+          when Arel::Nodes::Equality
+            x.right.respond_to?(:unboundable?) && x.right.unboundable?
+          end
+        end
       end
 
       protected

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -905,14 +905,18 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_pick_one
     assert_equal "The First Topic", Topic.order(:id).pick(:heading)
-    assert_nil Topic.none.pick(:heading)
-    assert_nil Topic.where(id: 9999999999999999999).pick(:heading)
+    assert_no_queries do
+      assert_nil Topic.none.pick(:heading)
+      assert_nil Topic.where(id: 9999999999999999999).pick(:heading)
+    end
   end
 
   def test_pick_two
     assert_equal ["David", "david@loudthinking.com"], Topic.order(:id).pick(:author_name, :author_email_address)
-    assert_nil Topic.none.pick(:author_name, :author_email_address)
-    assert_nil Topic.where(id: 9999999999999999999).pick(:author_name, :author_email_address)
+    assert_no_queries do
+      assert_nil Topic.none.pick(:author_name, :author_email_address)
+      assert_nil Topic.where(id: 9999999999999999999).pick(:author_name, :author_email_address)
+    end
   end
 
   def test_pick_delegate_to_all

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -397,15 +397,24 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_with_large_number
-    assert_raises(ActiveRecord::RecordNotFound) { Topic.find("9999999999999999999999999999999") }
+    Topic.send(:load_schema)
+    assert_no_queries do
+      assert_raises(ActiveRecord::RecordNotFound) { Topic.find("9999999999999999999999999999999") }
+    end
   end
 
   def test_find_by_with_large_number
-    assert_nil Topic.find_by(id: "9999999999999999999999999999999")
+    Topic.send(:load_schema)
+    assert_no_queries do
+      assert_nil Topic.find_by(id: "9999999999999999999999999999999")
+    end
   end
 
   def test_find_by_id_with_large_number
-    assert_nil Topic.find_by_id("9999999999999999999999999999999")
+    Topic.send(:load_schema)
+    assert_no_queries do
+      assert_nil Topic.find_by_id("9999999999999999999999999999999")
+    end
   end
 
   def test_find_on_relation_with_large_number


### PR DESCRIPTION
Like as before Rails 6.0.

Closes #38309.