### PR TITLE
Deduplicate empty `@if` and `@unless` arrays in Active Support callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -297,8 +297,8 @@ module ActiveSupport
           @kind    = kind
           @filter  = filter
           @key     = compute_identifier filter
-          @if      = check_conditionals(Array(options[:if]))
-          @unless  = check_conditionals(Array(options[:unless]))
+          @if      = check_conditionals(options[:if])
+          @unless  = check_conditionals(options[:unless])
         end
 
         def filter; @key; end
@@ -349,7 +349,13 @@ module ActiveSupport
         end
 
         private
+          EMPTY_ARRAY = [].freeze
+          private_constant :EMPTY_ARRAY
+
           def check_conditionals(conditionals)
+            return EMPTY_ARRAY if conditionals.blank?
+
+            conditionals = Array(conditionals)
             if conditionals.any? { |c| c.is_a?(String) }
               raise ArgumentError, <<-MSG.squish
                 Passing string to be evaluated in :if and :unless conditional
@@ -358,7 +364,7 @@ module ActiveSupport
               MSG
             end
 
-            conditionals
+            conditionals.freeze
           end
 
           def compute_identifier(filter)


### PR DESCRIPTION
I noticed a surprising amount of memory being retained in `callbacks.rb`:

```
retained memory by file
-----------------------------------
   7.45 MB  ~/gems/rails-25a5b296a310/activesupport/lib/active_support/callbacks.rb
```

After some investigation, about 15% of that is empty arrays:

```ruby
[23] pry(main)> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).count
=> 17034
[24] pry(main)> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).select { |c| c.instance_variable_get(:@if).empty? }.count
=> 12657
[25] pry(main)> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).select { |c| c.instance_variable_get(:@unless).empty? }.count
=> 16685
[26] pry(main)> (12657 + 16685) * ObjectSpace.memsize_of([])
=> 1173680 # 1.12 MB
```

Of course the savings are heavily dependent on the app size. For
instance on Redmine:

```ruby
>> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).count
=> 1210
>> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).select { |c| c.instance_variable_get(:@if).empty? }.count
=> 725
>> ObjectSpace.each_object(ActiveSupport::Callbacks::Callback).select { |c| c.instance_variable_get(:@unless).empty? }.count
=> 1184
>> (725 + 1184) * ObjectSpace.memsize_of([])
=> 76360 # 74.6 KB
```

cc @rafaelfranca @Edouard-chin 