### PR TITLE
Reduce allocations in set_callbacks

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -844,8 +844,18 @@ module ActiveSupport
             __callbacks[name.to_sym]
           end
 
-          def set_callbacks(name, callbacks) # :nodoc:
-            self.__callbacks = __callbacks.merge(name.to_sym => callbacks)
+          if Module.instance_method(:method_defined?).arity == 1 # Ruby 2.5 and older
+            def set_callbacks(name, callbacks) # :nodoc:
+              self.__callbacks = __callbacks.merge(name.to_sym => callbacks)
+            end
+          else # Ruby 2.6 and newer
+            def set_callbacks(name, callbacks) # :nodoc:
+              unless singleton_class.method_defined?(:__callbacks, false)
+                self.__callbacks = __callbacks.dup
+              end
+              self.__callbacks[name.to_sym] = callbacks
+              self.__callbacks
+            end
           end
       end
   end


### PR DESCRIPTION
This method is the source of many useless allocations:

```
allocated objects by location
-----------------------------------
     39568  ~/gems/rails-25a5b296a310/activesupport/lib/active_support/callbacks.rb:846

allocated memory by location
-----------------------------------
  17.11 MB  ~/gems/rails-25a5b296a310/activesupport/lib/active_support/callbacks.rb:846

retained memory by location
-----------------------------------
   1.03 MB  ~/gems/rails-25a5b296a310/activesupport/lib/active_support/callbacks.rb:846
```

However I'm really not very happy with this patch. `singleton_class.method_defined?(:__callbacks, false)` for checking wether the attribute is owned or inherited is very much coupled with the current implementation of `class_attribute`.

@rafaelfranca what do you think?

cc @Edouard-chin 