### PR TITLE
Add missing require in action_dispatch/http/parameters

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_dispatch/http/mime_type"
+
 module ActionDispatch
   module Http
     module Parameters


### PR DESCRIPTION
### Summary

`ActionDispatch::Http::Parameters` is depending on a `ActionDispatch::Http::Mime` and cannot be required if the latter has not been required before. I see no indication that this is a private API and cannot be used on it's own (I stumbled upon it trying to do it myself), so I think that requirement shall be explicitly stated.

Here's a script to replicate the problem:

```ruby
require 'bundler/inline'

gemfile do
  gem 'actionpack', git: 'https://github.com/rails/rails.git'
  gem 'activesupport', git: 'https://github.com/rails/rails.git'
end

require 'active_support/concern'
require 'action_dispatch/http/parameters'
```

**Expected output**

None

**Actual output**

```
Traceback (most recent call last):
        5: from dispatch-http.rb:9:in `<main>'
        4: from dispatch-http.rb:9:in `require'
        3: from /Users/pawel.swiatkowski/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/rails-f207e00eb25b/actionpack/lib/action_dispatch/http/parameters.rb:3:in `<top (required)>'
        2: from /Users/pawel.swiatkowski/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/rails-f207e00eb25b/actionpack/lib/action_dispatch/http/parameters.rb:4:in `<module:ActionDispatch>'
        1: from /Users/pawel.swiatkowski/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/rails-f207e00eb25b/actionpack/lib/action_dispatch/http/parameters.rb:5:in `<module:Http>'
/Users/pawel.swiatkowski/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/rails-f207e00eb25b/actionpack/lib/action_dispatch/http/parameters.rb:11:in `<module:Parameters>': uninitialized constant ActionDispatch::Http::Parameters::Mime (NameError)
```

I know this might be considered a cosmetic change, but I submit it anyway.

### Other Information

I also relies on `ActiveSupport::Concern`, which is also not required. I'm not sure if it should be added as well.
