### PR TITLE
Default HSTS max-age directive to 2 years

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -29,7 +29,7 @@ module ActionDispatch
   #
   #    * +expires+: How long, in seconds, these settings will stick. The minimum
   #      required to qualify for browser preload lists is 1 year. Defaults to
-  #      1 year (recommended).
+  #      2 years (recommended).
   #
   #    * +subdomains+: Set to +true+ to tell the browser to apply these settings
   #      to all subdomains. This protects your cookies from interception by a
@@ -49,8 +49,8 @@ module ActionDispatch
   class SSL
     # :stopdoc:
 
-    # Default to 1 year, the minimum for browser preload lists.
-    HSTS_EXPIRES_IN = 31536000
+    # Default to 2 years as recommended on hstspreload.org.
+    HSTS_EXPIRES_IN = 63072000
 
     def self.default_hsts_options
       { expires: HSTS_EXPIRES_IN, subdomains: true, preload: false }

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -98,8 +98,8 @@ class RedirectSSLTest < SSLTest
 end
 
 class StrictTransportSecurityTest < SSLTest
-  EXPECTED = "max-age=31536000"
-  EXPECTED_WITH_SUBDOMAINS = "max-age=31536000; includeSubDomains"
+  EXPECTED = "max-age=63072000"
+  EXPECTED_WITH_SUBDOMAINS = "max-age=63072000; includeSubDomains"
 
   def assert_hsts(expected, url: "https://example.org", hsts: { subdomains: true }, headers: {})
     self.app = build_app ssl_options: { hsts: hsts }, headers: headers


### PR DESCRIPTION
### Summary

Updates the default [HTTP Strict Transport Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (HSTS) `max-age` directive to 2 years as recommended on [hstspreload.org](https://hstspreload.org).

### Other Information

Under [Deployment Recommendations](https://hstspreload.org/#deployment-recommendations), hstspreload.org recommends increasing the `max-age` to 2 years. Furthermore, Mozilla also recommends two years on their [Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS) MozillaWiki page. See https://github.com/rails/rails/pull/31720 for an earlier pull request updating the default to 1 year.