### PR TITLE
Deprecate schema dump marshaling behavior

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -134,6 +134,7 @@ module ActiveRecord
         @version = connection.migration_context.current_version
         [@version, @columns, {}, @primary_keys, @data_sources, @indexes, database_version]
       end
+      deprecate :marshal_dump, "Please use :encode_with instead, e.g. by using YAML.dump."
 
       def marshal_load(array)
         @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version = array
@@ -141,6 +142,7 @@ module ActiveRecord
 
         derive_columns_hash_and_deduplicate_values
       end
+      deprecate :marshal_load, "Please use :init_with instead, e.g. by using YAML.load."
 
       private
         def derive_columns_hash_and_deduplicate_values

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -122,7 +122,9 @@ module ActiveRecord
         @cache.primary_keys("posts")
         @cache.indexes("posts")
 
-        @cache = Marshal.load(Marshal.dump(@cache))
+        assert_deprecated do
+          @cache = Marshal.load(Marshal.dump(@cache))
+        end
 
         assert_no_queries do
           assert_equal 12, @cache.columns("posts").size

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -116,11 +116,7 @@ module ActiveRecord
       end
 
       def test_dump_and_load
-        @cache.columns("posts")
-        @cache.columns_hash("posts")
-        @cache.data_sources("posts")
-        @cache.primary_keys("posts")
-        @cache.indexes("posts")
+        @cache.add("posts")
 
         assert_deprecated do
           @cache = Marshal.load(Marshal.dump(@cache))


### PR DESCRIPTION
In 2016, with Rails 5.1 YAML has been used to serialize the schema cache. This was added in 4c00c6e. The marshaling behavior was removed in March 2019 (65f2eea), and then reintroduced in e5f1b36 the next day.

I was unable to find a discussion about this, so it's not clear what broke, or why the marshal behavior is still necessary. Rather than removing it outright, with this PR I'm suggesting to deprecate it, so that it can be removed in Rails 6.2.