### PR TITLE
Use correct filename for schema cache on load

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -128,7 +128,14 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.delete(:use_schema_cache_dump)
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
-            filename = File.join(app.config.paths["db"].first, "schema_cache.yml")
+            db_config = ActiveRecord::Base.configurations.configs_for(
+              env_name: Rails.env,
+              spec_name: "primary",
+            )
+            filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
+              db_config.spec_name,
+              schema_cache_path: db_config.schema_cache_path,
+            )
 
             if File.file?(filename)
               current_version = ActiveRecord::Migrator.current_version

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -134,7 +134,7 @@ class LoadingTest < ActiveSupport::TestCase
     setup_ar!
 
     initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord, "primary::SchemaMigration"].collect(&:to_s).sort
-    assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort
+    assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
     get "/load"
     assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial
     get "/unload"


### PR DESCRIPTION
### Summary

The initializer that loads the default schema cache on the default
connection doesn't account for the case where an app overrides the
default filename.

This relies on the `ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename` method  which handles the override logic and the default fallback.

### Other Information

The default value for the schema cache path can be overridden either via `ENV["SCHEMA_PATH"]`, or via the `:schema_cache_path` defined in the db config.

It might not be right to refer to the `ActiveRecord::Tasks::DatabaseTasks` from the rails initializer. If so, maybe the filename behavior needs to move somewhere else. I'm not sure what a good place for that would be.

Also, I'm not confident that I am accessing the current environment correctly to get the env name for the default db configuration.

Note that as discussed in #34449 this initializer doesn't work for applications using multiple databases, and this change doesn't fix that.
