### PR TITLE
Cleanup cache expanded_key

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -681,15 +681,15 @@ module ActiveSupport
           case key
           when Array
             if key.size > 1
-              key = key.collect { |element| expanded_key(element) }
+              key.collect { |element| expanded_key(element) }
             else
-              key = expanded_key(key.first)
+              expanded_key(key.first)
             end
           when Hash
-            key = key.sort_by { |k, _| k.to_s }.collect { |k, v| "#{k}=#{v}" }
-          end
-
-          key.to_param
+            key.collect { |k, v| "#{k}=#{v}" }.sort
+          else
+            key
+          end.to_param
         end
 
         def normalize_version(key, options = nil)


### PR DESCRIPTION
### Summary

This PR cleans up the implementation of Cache::Store#expanded_key.

It removes a few assignments and changes the order of collecting and sorting hash keys.

Benchmark for different key types can be found below.
```
==================================== String ====================================

/Users/viniciusstock/.gem/ruby/2.7.0/gems/activesupport-6.0.2.1/lib/active_support/cache.rb:463: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/viniciusstock/.gem/ruby/2.7.0/gems/activesupport-6.0.2.1/lib/active_support/cache.rb:738: warning: The called method `initialize' is defined here
Warming up --------------------------------------
        expanded_key   200.999k i/100ms
   fast_expanded_key   204.469k i/100ms
Calculating -------------------------------------
        expanded_key      3.686M (± 2.7%) i/s -     18.492M in   5.021381s
   fast_expanded_key      3.650M (± 2.8%) i/s -     18.402M in   5.045710s

Comparison:
        expanded_key:  3685719.1 i/s
   fast_expanded_key:  3650421.3 i/s - same-ish: difference falls within error


==================================== Array =====================================

Warming up --------------------------------------
        expanded_key    27.979k i/100ms
   fast_expanded_key    48.201k i/100ms
Calculating -------------------------------------
        expanded_key    302.252k (± 4.9%) i/s -      1.511M in   5.010378s
   fast_expanded_key    557.367k (± 5.0%) i/s -      2.796M in   5.028880s

Comparison:
   fast_expanded_key:   557367.3 i/s
        expanded_key:   302251.8 i/s - 1.84x  slower


===================================== Hash =====================================

Warming up --------------------------------------
        expanded_key    25.450k i/100ms
   fast_expanded_key    59.254k i/100ms
Calculating -------------------------------------
        expanded_key    271.573k (± 4.9%) i/s -      1.374M in   5.075396s
   fast_expanded_key    744.568k (± 2.0%) i/s -      3.733M in   5.015592s

Comparison:
   fast_expanded_key:   744567.8 i/s
        expanded_key:   271573.0 i/s - 2.74x  slower
```