### PR TITLE
Save a string allocation for each attribute method call

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -375,6 +375,7 @@ module ActiveModel
           end
 
           mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
+            # frozen_string_literal: true
             #{defn}
               #{body}
             end


### PR DESCRIPTION
I noticed that the attribute method proxy call would systematically instantiate the same string over and over:

```ruby
[10] pry(main)> MemoryProfiler.report { s.name? }.pretty_print
# ...
Allocated String Report
-----------------------------------
         1  "name"
         1  ~/gems/rails-1d1991430dc5/activemodel/lib/active_model/attribute_methods.rb:380
```

It's not a lot per say, but it can easily add up.

### Backward compatibility 

It's possible that there are attribute methods out there that mutate the received attribute name, but IMHO it's quite an edge case and easy to fix.

cc @rafaelfranca @Edouard-chin 