### PR TITLE
Allow to specify attribute methods arity to avoid arguments splating

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -9,7 +9,7 @@ module ActiveModel
     include ActiveModel::AttributeMethods
 
     included do
-      attribute_method_suffix "="
+      attribute_method_suffix "=", arity: 1
       class_attribute :attribute_types, :_default_attributes, instance_accessor: false
       self.attribute_types = Hash.new(Type.default_value)
       self._default_attributes = AttributeSet.new({})

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -123,9 +123,10 @@ module ActiveModel
     include ActiveModel::AttributeMethods
 
     included do
-      attribute_method_suffix "_changed?", "_change", "_will_change!", "_was"
-      attribute_method_suffix "_previously_changed?", "_previous_change", "_previously_was"
-      attribute_method_affix prefix: "restore_", suffix: "!"
+      attribute_method_suffix "_change", "_will_change!", "_previous_change", arity: 0
+      attribute_method_suffix "_previously_was", "_was", arity: 0
+      attribute_method_suffix "_changed?", "_previously_changed?", arity: -1
+      attribute_method_affix prefix: "restore_", suffix: "!", arity: 0
     end
 
     def initialize_dup(other) # :nodoc:

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -6,7 +6,7 @@ class Topic
   include ActiveModel::AttributeMethods
   include ActiveSupport::NumberHelper
 
-  attribute_method_suffix "_before_type_cast"
+  attribute_method_suffix "_before_type_cast", arity: 0
   define_attribute_method :price
 
   def self._validates_default_keys

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -29,8 +29,8 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        attribute_method_suffix "_before_type_cast"
-        attribute_method_suffix "_came_from_user?"
+        attribute_method_suffix "_before_type_cast", arity: 0
+        attribute_method_suffix "_came_from_user?", arity: 0
       end
 
       # Returns the value of the attribute identified by +attr_name+ before

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -17,13 +17,13 @@ module ActiveRecord
         class_attribute :partial_writes, instance_writer: false, default: true
 
         # Attribute methods for "changed in last call to save?"
-        attribute_method_affix(prefix: "saved_change_to_", suffix: "?")
-        attribute_method_prefix("saved_change_to_")
-        attribute_method_suffix("_before_last_save")
+        attribute_method_affix(prefix: "saved_change_to_", suffix: "?", arity: -1)
+        attribute_method_prefix("saved_change_to_", arity: 0)
+        attribute_method_suffix("_before_last_save", arity: 0)
 
         # Attribute methods for "will change if I call save?"
-        attribute_method_affix(prefix: "will_save_change_to_", suffix: "?")
-        attribute_method_suffix("_change_to_be_saved", "_in_database")
+        attribute_method_affix(prefix: "will_save_change_to_", suffix: "?", arity: -1)
+        attribute_method_suffix("_change_to_be_saved", "_in_database", arity: 0)
       end
 
       # <tt>reload</tt> the record and clears changed attributes.

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        attribute_method_suffix "?"
+        attribute_method_suffix "?", arity: 0
       end
 
       def query_attribute(attr_name)

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        attribute_method_suffix "="
+        attribute_method_suffix "=", arity: 1
       end
 
       module ClassMethods # :nodoc:


### PR DESCRIPTION
This is kind of a followup to https://github.com/rails/rails/pull/38355

Every attribute method call incurs an extra array allocation because arguments are forwarded with `*args`.

However most of the attribute methods defined by Rails core have a fixed number of arguments, so if we specify the method arity, we can avoid allocating that array.

I think it's worth it here because attribute methods can easily end up in tight loops, but maybe the added complexity isn't justified.

This is fully backward compatible since if arity is not specified, it falls back to the old splat args behavior.

Also note that I haven't updated the documentation, but let me know if I should.

cc @rafaelfranca @Edouard-chin and @tenderlove (since you merged #38355)