### PR TITLE
ActiveRecord::Querying::QUERYING_METHODS << :sample

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   ActiveRecord::Querying::QUERYING_METHODS << :sample
+
+    Allows for sampling directly on a model, so instead of Model.all.sample, one can simply do Model.sample.
+
+    *thoran*
+
 *   Adds support for `if_not_exists` to `add_column` and `if_exists` to `remove_column`.
 
     Applications can set their migrations to ignore exceptions raised when adding a column that already exists or when removing a column that does not exist.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
       :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,
-      :pluck, :pick, :ids
+      :pluck, :pick, :sample, :ids
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -219,6 +219,38 @@ module ActiveRecord
       limit(1).pluck(*column_names).first
     end
 
+    # Randomly select one record from the class by default and one or more with a supplied count of samples.
+    # It reflects the behaviour of Array#sample in that it will return a single object when no argument is supplied,
+    # but will return a collection containing one object when an explicit value of 1 is supplied.
+    #
+    # Also like #pluck, #sample will only load the actual value, not the entire record object, so it's also
+    # more efficient. The value is, again like with pluck, typecast by the column type.
+    #
+    #   Person.sample
+    #   # SELECT people.id FROM people
+    #   # SELECT * FROM people WHERE id = <randomly chosen id>
+    #   # => #<Person...>
+    #
+    #   Person.sample(1)
+    #   # SELECT people.id FROM people
+    #   # SELECT * FROM people WHERE id = (<randomly chosen id>)
+    #   # => [#<Person...>]
+    #
+    #   Person.sample(2)
+    #   # SELECT people.id FROM people
+    #   # SELECT * FROM people WHERE id = (<randomly chosen id>, <randomly chosen id>, ...)
+    #   # => [#<Person...>, #<Person...>]
+    def sample(sample_count = nil)
+      randomly_selected_ids = (
+        if sample_count.nil?
+          ids.sample # Returns a single id.
+        else
+          ids.sample(sample_count) # Returns a collection of ids.
+        end
+      )
+      klass.find(randomly_selected_ids)
+    end
+
     # Pluck all the ID's for the relation using the table's primary key
     #
     #   Person.ids # SELECT people.id FROM people

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -924,6 +924,36 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal cool_first.color, Minivan.pick(:color)
   end
 
+  def test_sample_one
+    assert_queries(2) do
+      assert_equal Reply, Reply.sample.class
+    end
+  end
+
+  def test_sample_two
+    assert_queries(2) do
+      assert_equal 1, Reply.sample(1).count
+    end
+  end
+
+  def test_sample_three
+    assert_queries(2) do
+      assert_equal Reply, Reply.sample(1).first.class
+    end
+  end
+
+  def test_sample_four
+    assert_queries(2) do
+      assert_equal 2, Reply.sample(2).count
+    end
+  end
+
+  def test_sample_five
+    assert_queries(2) do
+      assert_equal Reply, Reply.sample(2).first.class
+    end
+  end
+
   def test_grouped_calculation_with_polymorphic_relation
     part = ShipPart.create!(name: "has trinket")
     part.trinkets.create!


### PR DESCRIPTION
### Summary
`Model.sample` seems reasonable, since I am able to do `Model.pluck(:column_name)`, `Model.all.sample` and `Model.all.pluck(:column_name)`.  Filling in the gap of something which surprised me didn't work.
