### PR TITLE
Rendering objects that respond_to render_in uses class, not instance

### DIFF
--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -66,12 +66,12 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal "The secret is foo\n", content
   end
 
-  def test_render_component
+  def test_render_component_class
     renderer = ApplicationController.renderer
 
     assert_equal(
       %(<span title="my title">(Inline render)</span>),
-      renderer.render(TestComponent.new(title: "my title")).strip
+      renderer.render(TestComponent, locals: { title: "my title" }).strip
     )
   end
 

--- a/actionpack/test/lib/test_component.rb
+++ b/actionpack/test/lib/test_component.rb
@@ -6,6 +6,10 @@ class TestComponent < ActionView::Base
   validates :title, presence: true
   delegate :render, to: :view_context
 
+  def self.render_in(view_context, *args)
+    new(*args).render_in(view_context)
+  end
+
   def initialize(title:)
     @title = title
   end
@@ -17,7 +21,7 @@ class TestComponent < ActionView::Base
     rendered_template
   end
 
-  def format
+  def self.format
     :html
   end
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `RenderingHelper` supports rendering objects that `respond_to?` `:render_in` using class instead of instance.
+
+    *Joel Hawksley*
+
 *   `OptimizedFileSystemResolver` prefers template details in order of locale,
     formats, variants, handlers.
 

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -36,7 +36,7 @@ module ActionView
           end
         else
           if options.respond_to?(:render_in)
-            options.render_in(self, &block)
+            options.render_in(self, locals, &block)
           else
             view_renderer.render_partial(self, partial: options, locals: locals, &block)
           end

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -27,7 +27,7 @@ module ActionView
         render_partial_to_object(context, options)
       elsif options.key?(:object)
         object = options[:object]
-        AbstractRenderer::RenderedTemplate.new(object.render_in(context), object)
+        AbstractRenderer::RenderedTemplate.new(object.render_in(context, options[:locals]), object)
       else
         render_template_to_object(context, options)
       end

--- a/actionview/test/lib/test_component.rb
+++ b/actionview/test/lib/test_component.rb
@@ -6,6 +6,10 @@ class TestComponent < ActionView::Base
   validates :content, :title, presence: true
   delegate :render, to: :view_context
 
+  def self.render_in(view_context, *args, &block)
+    new(*args).render_in(view_context, &block)
+  end
+
   def initialize(title:)
     @title = title
   end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -678,13 +678,13 @@ module RenderTestCases
   def test_render_component
     assert_equal(
       %(<span title="my title">Hello, World! (Inline render)</span>),
-      @view.render(TestComponent.new(title: "my title")) { "Hello, World!" }.strip
+      @view.render(TestComponent, title: "my title") { "Hello, World!" }.strip
     )
   end
 
   def test_render_component_with_validation_error
     error = assert_raises(ActiveModel::ValidationError) do
-      @view.render(TestComponent.new(title: "my title")).strip
+      @view.render(TestComponent, title: "my title").strip
     end
 
     assert_match "Content can't be blank", error.message


### PR DESCRIPTION
### Summary

This change helps us more closely match the existing `render` API for templates/partials and gives us the ability to support existing features  like rendering collections.

As support for rendering objects that `respond_to` `render_in` has yet to be released, I don't think we need to make a backwards compatible change in this case.

### Details

Instead of:

```ruby
render(MyComponent.new(title: "Hello, World!")
```

In actionview, we now support:

```ruby
render(MyComponent, title: "Hello, World!")
```

And in actionpack, we now support:

```ruby
render(MyComponent, locals: { title: "Hello, World!" })
```

These syntaxes match the existing patterns for rendering templates/partials.

### Other Information

This PR is a follow up to:

https://github.com/rails/rails/pull/36388
https://github.com/rails/rails/pull/37919
