### PR TITLE
Do not stringify attributes in assign_attributes

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -26,13 +26,12 @@ module ActiveModel
     #   cat.name # => 'Gorby'
     #   cat.status # => 'sleeping'
     def assign_attributes(new_attributes)
-      if !new_attributes.respond_to?(:stringify_keys)
+      unless new_attributes.respond_to?(:stringify_keys)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
       end
       return if new_attributes.empty?
 
-      attributes = new_attributes.stringify_keys
-      _assign_attributes(sanitize_for_mass_assignment(attributes))
+      _assign_attributes(sanitize_for_mass_assignment(new_attributes))
     end
 
     alias attributes= assign_attributes
@@ -49,7 +48,7 @@ module ActiveModel
         if respond_to?(setter)
           public_send(setter, v)
         else
-          raise UnknownAttributeError.new(self, k)
+          raise UnknownAttributeError.new(self, k.to_s)
         end
       end
   end


### PR DESCRIPTION
### Summary

This PR stops stringifying attributes before mass assignment. The method `sanitize_for_mass_assignment` doesn't seem to have any requirements concerning key types and we can just `to_s` inside the assignment loop when needed. Also, the variable `setter` is built with string interpolation, so invoking `to_s` there is not needed.

I also took the opportunity to change `if !condition` to `unless condition`.

### Benchmark script
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
end

module ActiveModel
  module AttributeAssignment
    def fast_assign_attributes(new_attributes)
      if !new_attributes.respond_to?(:stringify_keys)
        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
      end
      return if new_attributes.empty?

      _assign_attributes(sanitize_for_mass_assignment(new_attributes))
    end

    alias attributes= assign_attributes

    private
    def _assign_attributes(attributes)
      attributes.each do |k, v|
        _fast_assign_attribute(k, v)
      end
    end

    def _fast_assign_attribute(k, v)
      setter = :"#{k}="
      if respond_to?(setter)
        public_send(setter, v)
      else
        raise UnknownAttributeError.new(self, k.to_s)
      end
    end
  end
end

class Post
  include ActiveModel::AttributeAssignment
  attr_accessor :title, :author, :published, :score, :tags, :content
end

post = Post.new
attributes = {
  title: "My post",
  author: "John",
  published: true,
  score: 500,
  tags: "Software development,Web development",
  content: "random text" * 100
}

action_controller_params = ActionController::Parameters.new(attributes)
action_controller_params.permit!

SCENARIOS = {
  "Simple hash" => attributes,
  "ActionController params" => action_controller_params
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("assign_attributes")      { post.assign_attributes(value) }
    x.report("fast_assign_attributes") { post.fast_assign_attributes(value) }
    x.compare!
  end
end
```
### Results
```
================================= Simple hash ==================================

Warming up --------------------------------------
   assign_attributes    24.446k i/100ms
fast_assign_attributes
                        33.541k i/100ms
Calculating -------------------------------------
   assign_attributes    270.450k (± 1.8%) i/s -      1.369M in   5.063520s
fast_assign_attributes
                        375.572k (± 1.6%) i/s -      1.878M in   5.002558s

Comparison:
fast_assign_attributes:   375571.9 i/s
   assign_attributes:   270450.4 i/s - 1.39x  slower


=========================== ActionController params ============================

Warming up --------------------------------------
   assign_attributes     5.125k i/100ms
fast_assign_attributes
                         6.947k i/100ms
Calculating -------------------------------------
   assign_attributes     55.890k (± 7.2%) i/s -    281.875k in   5.068153s
fast_assign_attributes
                         75.672k (± 6.1%) i/s -    382.085k in   5.067397s

Comparison:
fast_assign_attributes:    75671.6 i/s
   assign_attributes:    55890.3 i/s - 1.35x  slower
```