### PR TITLE
Fixed typo in documentation getting_started.md 

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -933,7 +933,7 @@ first method in the controller. Let's do it:
 ```ruby
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.all
+    @article = Article.all
   end
 
   def show


### PR DESCRIPTION
In line 36 the instance variable should be `@article` instead of `@articles`

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
