### PR TITLE
[GitHub Actions] Save few seconds on every build

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get -y install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
     - name: Install bundler
       run: |
-        gem install bundler:2.1.2
+        gem install bundler:2.1.2 --no-document
     - name: Cache gems
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
### Summary

Install bundler takes about 7-8s and without installing documentations takes about 3-4s.

### Other Information

<img width="1077" alt="スクリーンショット 2020-02-02 22 06 52" src="https://user-images.githubusercontent.com/1000669/73608613-83044800-4608-11ea-8053-d2c8b1bc50f9.png">

<img width="1083" alt="スクリーンショット 2020-02-02 22 07 18" src="https://user-images.githubusercontent.com/1000669/73608614-83044800-4608-11ea-9e0b-12ee81d03c9e.png">
