### PR TITLE
Improve zeitwerk:check warning message [CI skip]

### DIFF
--- a/railties/lib/rails/tasks/zeitwerk.rake
+++ b/railties/lib/rails/tasks/zeitwerk.rake
@@ -14,8 +14,8 @@ end
 report_not_checked = ->(not_checked) do
   puts
   puts <<~EOS
-    WARNING: The files in these directories cannot be checked because they
-    are not eager loaded:
+    WARNING: The following files will only be checked if you configure
+    them to be eager loaded:
   EOS
   puts
 


### PR DESCRIPTION
### Summary
The messages that are printed to the console when users run rails zeitwerk:check
can be a little confusing if they've generated a mailer, as the test files aren't
included by default, and a warning appears about this.

To address this issue the warning message has been improved so that it is clearer
that this behaviour is normal and it explicitly states that the user must configure
eager loading to silence these warnings. Fixes #38156