### PR TITLE
Add method ActionCable::Channel#stream_or_reject_for to stream if record is present, otherwise reject the connection

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActionCable::Channel#stream_or_reject_for` to stream if record is present, otherwise reject the connection
+
+    *Atul Bhosale*
+
 *   Add `ActionCable::Channel#stop_stream_from` and `#stop_stream_for` to unsubscribe from a specific stream.
 
     *Zhang Kang*

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -124,6 +124,18 @@ module ActionCable
         end.clear
       end
 
+      # Calls stream_for if record is present, otherwise calls reject.
+      # This method is intended to be called when you're looking
+      # for a record based on a parameter, if its found it will start
+      # streaming. If the record is nil then it will reject the connection.
+      def stream_or_reject_for(record)
+        if record
+          stream_for record
+        else
+          reject
+        end
+      end
+
       private
         delegate :pubsub, to: :connection
 


### PR DESCRIPTION
### Summary
closes #38371

As mentioned on issue #38371 ActionCable::Channel#stream_or_reject_for can be use to stream if the record is present otherwise reject the connection.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
