### PR TITLE
Fix the environment.rb file path in the benchmark generator template

### DIFF
--- a/railties/lib/rails/generators/rails/benchmark/templates/benchmark.rb.tt
+++ b/railties/lib/rails/generators/rails/benchmark/templates/benchmark.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../config/environment"
+require_relative "../../config/environment"
 
 # Any benchmarking setup goes here...
 

--- a/railties/test/generators/benchmark_generator_test.rb
+++ b/railties/test/generators/benchmark_generator_test.rb
@@ -23,7 +23,7 @@ module Rails
           assert_equal <<~RUBY, content
             # frozen_string_literal: true
 
-            require_relative "../config/environment"
+            require_relative "../../config/environment"
 
             # Any benchmarking setup goes here...
 
@@ -56,7 +56,7 @@ module Rails
           assert_equal <<~RUBY, content
             # frozen_string_literal: true
 
-            require_relative "../config/environment"
+            require_relative "../../config/environment"
 
             # Any benchmarking setup goes here...
 


### PR DESCRIPTION
The environment.rb file path in the benchmark generator template is incorrect. So if we generate a benchmark file using benchmark generator and run it. It throws an error 

```
Traceback (most recent call last):
	1: from script/benchmarks/opt_compare.rb:3:in `<main>'
script/benchmarks/opt_compare.rb:3:in `require_relative': cannot load such file -- /path/to/rails_repo/script/config/environment (LoadError)
```

This PR fixes this path.