### PR TITLE
Update "Eagerly Requiring Helpers" section in testing docs [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1443,7 +1443,7 @@ You may find it convenient to eagerly require helpers in `test_helper.rb` so you
 
 ```ruby
 # test/test_helper.rb
-Dir[Rails.root.join('lib', 'test', '**', '*.rb')].each { |file| require file }
+Dir[Rails.root.join('test', 'test_helpers', '**', '*.rb')].each { |file| require file }
 ```
 
 This has the downside of increasing the boot-up time, as opposed to manually requiring only the necessary files in your individual tests.


### PR DESCRIPTION
### Summary

This will change the path for requiring helper files in `test_helper.rb` to be consistent with previous examples in "Using Separate Files" section:

> #### Using Separate Files
> If you find your helpers are cluttering `test_helper.rb`, you can extract them into separate files.
> One good place to store them is `test/lib` or `test/test_helpers`.