### PR TITLE
Add a fallback database config when loading schema cache

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -128,10 +128,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.delete(:use_schema_cache_dump)
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
-            db_config = ActiveRecord::Base.configurations.configs_for(
+            configs = ActiveRecord::Base.configurations.configs_for(
               env_name: Rails.env,
-              spec_name: "primary",
             )
+            db_config = configs.find { |config| config.spec_name == "primary" } || configs.first
+
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
               db_config.spec_name,
               schema_cache_path: db_config.schema_cache_path,

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -128,10 +128,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.delete(:use_schema_cache_dump)
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
-            configs = ActiveRecord::Base.configurations.configs_for(
+            db_config = ActiveRecord::Base.configurations.configs_for(
               env_name: Rails.env,
+              spec_name: "primary",
             )
-            db_config = configs.find { |config| config.spec_name == "primary" } || configs.first
+            next if db_config.nil?
 
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
               db_config.spec_name,


### PR DESCRIPTION
### Summary

The schema cache defaults to loading the 'primary' database config.
However, if an app doesn't have a db config with a spec name of
'primary' the filename lookup will blow up.

This adds a fallback for this case.

### Other Information

The filename for the schema cache used to be hard-coded, but Rails allows people to override the default path. In https://github.com/rails/rails/pull/38348 I made a change to take overrides into account, but failed to account for apps without a database config containing a spec named `primary`.

It turns out, at GitHub we don't have a database named `primary`, so even though we don't rely on this active record initializer, it blows up for us.