### PR TITLE
Change all "can not"s to the correct "cannot"

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -19,7 +19,7 @@ module ActiveRecord
             end
           else
             # Custom preload scope is used and
-            # the association can not be marked as loaded
+            # the association cannot be marked as loaded
             # Loading into a Hash instead
             records_by_owner
           end

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -64,7 +64,7 @@ module ActiveSupport
     def transliterate(string, replacement = "?", locale: nil)
       string = string.dup if string.frozen?
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
-      raise ArgumentError, "Can not transliterate strings with #{string.encoding} encoding" unless ALLOWED_ENCODINGS_FOR_TRANSLITERATE.include?(string.encoding)
+      raise ArgumentError, "Cannot transliterate strings with #{string.encoding} encoding" unless ALLOWED_ENCODINGS_FOR_TRANSLITERATE.include?(string.encoding)
 
       input_encoding = string.encoding
 

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -88,7 +88,7 @@ class TransliterateTest < ActiveSupport::TestCase
       exception = assert_raises ArgumentError do
         ActiveSupport::Inflector.transliterate(string)
       end
-      assert_equal "Can not transliterate strings with #{encoding} encoding", exception.message
+      assert_equal "Cannot transliterate strings with #{encoding} encoding", exception.message
     end
   end
 


### PR DESCRIPTION
It's been 6 years since [the original](https://github.com/rails/rails/pull/13584), so we're overdue for a sequel.

The correct word is "cannot", one word, not "can not", two words.