### PR TITLE
Get rid of Ruby 2.7 keyword argument usage warnings

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -612,9 +612,9 @@ module ActionMailer
         payload[:perform_deliveries] = mail.perform_deliveries
       end
 
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, **kwargs)
         if action_methods.include?(method_name.to_s)
-          MessageDelivery.new(self, method_name, *args)
+          MessageDelivery.new(self, method_name, *args, **kwargs)
         else
           super
         end

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -20,8 +20,8 @@ module ActionMailer
       MSG
     end
 
-    def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
-      mailer.constantize.public_send(mail_method, *args).send(delivery_method)
+    def perform(mailer, mail_method, delivery_method, *args, **kwargs) #:nodoc:
+      mailer.constantize.public_send(mail_method, *args, **kwargs).send(delivery_method)
     end
     ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
 

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -108,9 +108,9 @@ module ActionMailer
       end
 
       private
-        def method_missing(method_name, *args)
+        def method_missing(method_name, *args, **kwargs)
           if @mailer.action_methods.include?(method_name.to_s)
-            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, *args)
+            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, *args, **kwargs)
           else
             super
           end
@@ -123,15 +123,15 @@ module ActionMailer
     end
 
     class DeliveryJob < ActionMailer::DeliveryJob # :nodoc:
-      def perform(mailer, mail_method, delivery_method, params, *args)
-        mailer.constantize.with(params).public_send(mail_method, *args).send(delivery_method)
+      def perform(mailer, mail_method, delivery_method, params, *args, **kwargs)
+        mailer.constantize.with(params).public_send(mail_method, *args, **kwargs).send(delivery_method)
       end
       ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
     end
 
     class MessageDelivery < ActionMailer::MessageDelivery # :nodoc:
-      def initialize(mailer_class, action, params, *args)
-        super(mailer_class, action, *args)
+      def initialize(mailer_class, action, params, *args, **kwargs)
+        super(mailer_class, action, *args, **kwargs)
         @params = params
       end
       ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -66,9 +66,9 @@ module AbstractController
 
         methods.each do |method|
           _helpers.class_eval <<-ruby_eval, file, line
-            def #{method}(*args, &blk)                     # def current_user(*args, &blk)
-              controller.send(%(#{method}), *args, &blk)   #   controller.send(:current_user, *args, &blk)
-            end                                            # end
+            def #{method}(*args, **kwargs, &blk)                     # def current_user(*args, **kwargs, &blk)
+              controller.send(%(#{method}), *args, **kwargs, &blk)   #   controller.send(:current_user, *args, **kwargs, &blk)
+            end                                                      # end
             ruby2_keywords(%(#{method})) if respond_to?(:ruby2_keywords, true)
           ruby_eval
         end

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -219,8 +219,8 @@ module ActionController
     class << self
       # Pushes the given Rack middleware and its arguments to the bottom of the
       # middleware stack.
-      def use(*args, &block)
-        middleware_stack.use(*args, &block)
+      def use(*args, **kwargs, &block)
+        middleware_stack.use(*args, **kwargs, &block)
       end
       ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
     end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -98,7 +98,7 @@ module ActionDispatch
       self.middlewares = other.middlewares.dup
     end
 
-    def insert(index, klass, *args, &block)
+    def insert(index, klass, *args, **kwargs, &block)
       index = assert_index(index, :before)
       middlewares.insert(index, Middleware.new(klass, *args, **kwargs, &block))
     end
@@ -106,15 +106,15 @@ module ActionDispatch
 
     alias_method :insert_before, :insert
 
-    def insert_after(index, *args, &block)
+    def insert_after(index, *args, **kwargs, &block)
       index = assert_index(index, :after)
-      insert(index + 1, *args, &block)
+      insert(index + 1, *args, **kwargs, &block)
     end
     ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
 
-    def swap(target, *args, &block)
+    def swap(target, *args, **kwargs, &block)
       index = assert_index(target, :before)
-      insert(index, *args, &block)
+      insert(index, *args, **kwargs, &block)
       middlewares.delete_at(index + 1)
     end
     ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -35,7 +35,11 @@ module ActionDispatch
       end
 
       def build(app)
-        klass.new(app, *args, **kwargs, &block)
+        if kwargs.empty?
+          klass.new(app, *args, &block)
+        else
+          klass.new(app, *args, **kwargs, &block)
+        end
       end
 
       def build_instrumented(app)

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -423,9 +423,9 @@ module ActionDispatch
       end
 
       # Delegate unhandled messages to the current session instance.
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         if integration_session.respond_to?(method)
-          integration_session.public_send(method, *args, &block).tap do
+          integration_session.public_send(method, *args, **kwargs, &block).tap do
             copy_session_variables!
           end
         else

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -394,7 +394,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       super
     end
 
-    def with_test_route_set(options = {})
+    def with_test_route_set(**options)
       with_routing do |set|
         set.draw do
           ActiveSupport::Deprecation.silence do
@@ -405,7 +405,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
         options = { key: SessionKey }.merge!(options)
 
         @app = self.class.build_app(set) do |middleware|
-          middleware.use ActionDispatch::Session::CookieStore, options
+          middleware.use ActionDispatch::Session::CookieStore, **options
           middleware.delete ActionDispatch::ShowExceptions
         end
 

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -2,18 +2,18 @@
 
 module ActiveJob
   class ConfiguredJob #:nodoc:
-    def initialize(job_class, options = {})
+    def initialize(job_class, **options)
       @options = options
       @job_class = job_class
     end
 
-    def perform_now(*args)
-      @job_class.new(*args).perform_now
+    def perform_now(*args, **kwargs)
+      @job_class.new(*args, **kwargs).perform_now
     end
     ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
-    def perform_later(*args)
-      @job_class.new(*args).enqueue @options
+    def perform_later(*args, **kwargs)
+      @job_class.new(*args, **kwargs).enqueue @options
     end
     ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
   end

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -8,12 +8,20 @@ module ActiveJob
     end
 
     def perform_now(*args, **kwargs)
-      @job_class.new(*args, **kwargs).perform_now
+      if kwargs.empty?
+        @job_class.new(*args).perform_now
+      else
+        @job_class.new(*args, **kwargs).perform_now
+      end
     end
     ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
     def perform_later(*args, **kwargs)
-      @job_class.new(*args, **kwargs).enqueue @options
+      if kwargs.empty?
+        @job_class.new(*args).enqueue @options
+      else
+        @job_class.new(*args, **kwargs).enqueue @options
+      end
     end
     ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
   end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -18,14 +18,14 @@ module ActiveJob
       #
       # Returns an instance of the job class queued with arguments available in
       # Job#arguments.
-      def perform_later(*args)
-        job_or_instantiate(*args).enqueue
+      def perform_later(*args, **kwargs)
+        job_or_instantiate(*args, **kwargs).enqueue
       end
       ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
 
       private
-        def job_or_instantiate(*args) # :doc:
-          args.first.is_a?(self) ? args.first : new(*args)
+        def job_or_instantiate(*args, **kwargs) # :doc:
+          args.first.is_a?(self) ? args.first : new(*args, **kwargs)
         end
         ruby2_keywords(:job_or_instantiate) if respond_to?(:ruby2_keywords, true)
     end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -25,7 +25,12 @@ module ActiveJob
 
       private
         def job_or_instantiate(*args, **kwargs) # :doc:
-          args.first.is_a?(self) ? args.first : new(*args, **kwargs)
+          return args.first if args.first.is_a?(self)
+          if kwargs.empty?
+            new(*args)
+          else
+            new(*args, **kwargs)
+          end
         end
         ruby2_keywords(:job_or_instantiate) if respond_to?(:ruby2_keywords, true)
     end

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -14,8 +14,8 @@ module ActiveJob
       #
       #   MyJob.perform_now("mike")
       #
-      def perform_now(*args)
-        job_or_instantiate(*args).perform_now
+      def perform_now(*args, **kwargs)
+        job_or_instantiate(*args, **kwargs).perform_now
       end
       ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -9,7 +9,7 @@ module ActiveModel
       end
 
       def register(type_name, klass = nil, **options, &block)
-        block ||= proc { |_, *args| klass.new(*args) }
+        block ||= proc { |_, *args, **kwargs| klass.new(*args, **kwargs) }
         block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
         registrations << registration_klass.new(type_name, block, **options)
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -633,7 +633,11 @@ module ActiveRecord
       end
 
       def method_missing(name, *args, **kwargs, &block) #:nodoc:
-        nearest_delegate.send(name, *args, **kwargs, &block)
+        if kwargs.empty?
+          nearest_delegate.send(name, *args, &block)
+        else
+          nearest_delegate.send(name, *args, **kwargs, &block)
+        end
       end
       ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -632,8 +632,8 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) #:nodoc:
-        nearest_delegate.send(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block) #:nodoc:
+        nearest_delegate.send(name, *args, **kwargs, &block)
       end
       ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -284,9 +284,9 @@ module ActiveRecord
         end
 
         # Forwards any missing method call to the \target.
-        def method_missing(method, *args, &block)
+        def method_missing(method, *args, **kwargs, &block)
           if delegate.respond_to?(method)
-            delegate.public_send(method, *args, &block)
+            delegate.public_send(method, *args, **kwargs, &block)
           else
             super
           end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -67,8 +67,8 @@ module ActiveRecord
               end
             RUBY
           else
-            define_method(method) do |*args, &block|
-              scoping { klass.public_send(method, *args, &block) }
+            define_method(method) do |*args, **kwargs, &block|
+              scoping { klass.public_send(method, *args, **kwargs, &block) }
             end
             ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
           end
@@ -101,10 +101,10 @@ module ActiveRecord
       end
 
       private
-        def method_missing(method, *args, &block)
+        def method_missing(method, *args, **kwargs, &block)
           if @klass.respond_to?(method)
             @klass.generate_relation_method(method)
-            scoping { @klass.public_send(method, *args, &block) }
+            scoping { @klass.public_send(method, *args, **kwargs, &block) }
           else
             super
           end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -104,7 +104,13 @@ module ActiveRecord
         def method_missing(method, *args, **kwargs, &block)
           if @klass.respond_to?(method)
             @klass.generate_relation_method(method)
-            scoping { @klass.public_send(method, *args, **kwargs, &block) }
+            scoping do
+              if kwargs.empty?
+                @klass.public_send(method, *args, &block)
+              else
+                @klass.public_send(method, *args, **kwargs, &block)
+              end
+            end
           else
             super
           end

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -185,8 +185,8 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
       end
     end
 
-    def method_missing(method_symbol, *arguments)
-      ActiveRecord::Base.connection.send(method_symbol, *arguments)
+    def method_missing(method_symbol, *arguments, **kwargs)
+      ActiveRecord::Base.connection.send(method_symbol, *arguments, **kwargs)
     end
     ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 end

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -12,7 +12,11 @@ module ActiveSupport
           yield self
         end
       elsif respond_to?(method_name)
-        public_send(method_name, *args, **kwargs, &b)
+        if kwargs.empty?
+          public_send(method_name, *args, &b)
+        else
+          public_send(method_name, *args, **kwargs, &b)
+        end
       end
     end
     ruby2_keywords(:try) if respond_to?(:ruby2_keywords, true)
@@ -25,7 +29,11 @@ module ActiveSupport
           yield self
         end
       else
-        public_send(method_name, *args, **kwargs, &b)
+        if kwargs.empty?
+          public_send(method_name, *args, &b)
+        else
+          public_send(method_name, *args, **kwargs, &b)
+        end
       end
     end
     ruby2_keywords(:try!) if respond_to?(:ruby2_keywords, true)

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -4,7 +4,7 @@ require "delegate"
 
 module ActiveSupport
   module Tryable #:nodoc:
-    def try(method_name = nil, *args, &b)
+    def try(method_name = nil, *args, **kwargs, &b)
       if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
@@ -12,12 +12,12 @@ module ActiveSupport
           yield self
         end
       elsif respond_to?(method_name)
-        public_send(method_name, *args, &b)
+        public_send(method_name, *args, **kwargs, &b)
       end
     end
     ruby2_keywords(:try) if respond_to?(:ruby2_keywords, true)
 
-    def try!(method_name = nil, *args, &b)
+    def try!(method_name = nil, *args, **kwargs, &b)
       if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
@@ -25,7 +25,7 @@ module ActiveSupport
           yield self
         end
       else
-        public_send(method_name, *args, &b)
+        public_send(method_name, *args, **kwargs, &b)
       end
     end
     ruby2_keywords(:try!) if respond_to?(:ruby2_keywords, true)

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -60,18 +60,18 @@ module ActiveSupport
           if target_module.method_defined?(method_name) || target_module.private_method_defined?(method_name)
             method = target_module.instance_method(method_name)
             target_module.module_eval do
-              redefine_method(method_name) do |*args, &block|
+              redefine_method(method_name) do |*args, **kwargs, &block|
                 deprecator.deprecation_warning(method_name, message)
-                method.bind(self).call(*args, &block)
+                method.bind(self).call(*args, **kwargs, &block)
               end
               ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
             end
           else
             mod ||= Module.new
             mod.module_eval do
-              define_method(method_name) do |*args, &block|
+              define_method(method_name) do |*args, **kwargs, &block|
                 deprecator.deprecation_warning(method_name, message)
-                super(*args, &block)
+                super(*args, **kwargs, &block)
               end
               ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
             end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -29,7 +29,7 @@ module Rails
 
           if rack_cache = load_rack_cache
             require "action_dispatch/http/rack_cache"
-            middleware.use ::Rack::Cache, rack_cache
+            middleware.use ::Rack::Cache, **rack_cache
           end
 
           if config.allow_concurrency == false
@@ -62,7 +62,7 @@ module Rails
             if config.force_ssl && config.ssl_options.fetch(:secure_cookies, true) && !config.session_options.key?(:secure)
               config.session_options[:secure] = true
             end
-            middleware.use config.session_store, config.session_options
+            middleware.use config.session_store, **config.session_options
             middleware.use ::ActionDispatch::Flash
           end
 

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -49,25 +49,25 @@ module Rails
         @delete_operations = delete_operations
       end
 
-      def insert_before(*args, &block)
-        @operations << -> middleware { middleware.send(__method__, *args, &block) }
+      def insert_before(*args, **kwargs, &block)
+        @operations << -> middleware { middleware.send(__method__, *args, **kwargs, &block) }
       end
       ruby2_keywords(:insert_before) if respond_to?(:ruby2_keywords, true)
 
       alias :insert :insert_before
 
-      def insert_after(*args, &block)
-        @operations << -> middleware { middleware.send(__method__, *args, &block) }
+      def insert_after(*args, **kwargs, &block)
+        @operations << -> middleware { middleware.send(__method__, *args, **kwargs, &block) }
       end
       ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
 
-      def swap(*args, &block)
-        @operations << -> middleware { middleware.send(__method__, *args, &block) }
+      def swap(*args, **kwargs, &block)
+        @operations << -> middleware { middleware.send(__method__, *args, **kwargs, &block) }
       end
       ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)
 
-      def use(*args, &block)
-        @operations << -> middleware { middleware.send(__method__, *args, &block) }
+      def use(*args, **kwargs, &block)
+        @operations << -> middleware { middleware.send(__method__, *args, **kwargs, &block) }
       end
       ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
@@ -85,8 +85,8 @@ module Rails
         @delete_operations << -> middleware { middleware.send(__method__, *args, &block) }
       end
 
-      def unshift(*args, &block)
-        @operations << -> middleware { middleware.send(__method__, *args, &block) }
+      def unshift(*args, **kwargs, &block)
+        @operations << -> middleware { middleware.send(__method__, *args, **kwargs, &block) }
       end
       ruby2_keywords(:unshift) if respond_to?(:ruby2_keywords, true)
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -187,7 +187,11 @@ module Rails
         # to the Railtie instance.
         def method_missing(name, *args, **kwargs, &block)
           if instance.respond_to?(name)
-            instance.public_send(name, *args, **kwargs, &block)
+            if kwargs.empty?
+              instance.public_send(name, *args, &block)
+            else
+              instance.public_send(name, *args, **kwargs, &block)
+            end
           else
             super
           end

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -185,9 +185,9 @@ module Rails
 
         # If the class method does not have a method, then send the method call
         # to the Railtie instance.
-        def method_missing(name, *args, &block)
+        def method_missing(name, *args, **kwargs, &block)
           if instance.respond_to?(name)
-            instance.public_send(name, *args, &block)
+            instance.public_send(name, *args, **kwargs, &block)
           else
             super
           end


### PR DESCRIPTION
### Summary

This fixes leftover warnings and attempts to get rid of `ruby2_keywords` where possible.
Example warning:
```
/home/travis/build/rspec/bundle/ruby/2.7.0/gems/actionpack-6.0.2.1/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/travis/build/rspec/bundle/ruby/2.7.0/gems/actionpack-6.0.2.1/lib/action_dispatch/middleware/static.rb:110: warning: The called method `initialize' is defined here
```

NOTE: no `ruby2_keywords` were harmed during the process.

### TODO

- [ ] rework `if kwargs.empty?` to macro-like method definition inside `if RUBY_VERSION < '3'`

### Other Information

Those commits were made before 6.0.2.1 was released, and are on `master`, but are not part of 6.0.2.1:

https://github.com/rails/rails/commit/6d68bb5f695414b1801c1c3952ef955a5b0b6c6a
https://github.com/rails/rails/commit/2c66870726ce0f644a14f369b2b1bae78bd366e8
https://github.com/rails/rails/commit/352560308bc13b881efd6d062134a9a67102b204
https://github.com/rails/rails/commit/a9ac7a8ab8fcf965080bad3eb01254c42a4c27a0
https://github.com/rails/rails/commit/e1e7fd6c445774815a83d9e4981772f6ab859643
https://github.com/rails/rails/commit/f42f2862bb6a05a39e410349ae6ec7e069442e15

Is it possible to include them in one of the upcoming releases?