### PR TITLE
Improve the output log for route action with many lines:

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -259,7 +259,14 @@ module Rails
           "namespace :#{ns} do\n#{indent(code, 2)}\nend"
         end
 
-        log :route, routing_code
+        log_msg = routing_code
+        if log_msg.lines.size > 1
+          tmp = [log_msg.lines.first]
+          tmp << optimize_indentation(log_msg.lines.to_a[1..-1].join, 14)
+          log_msg = tmp.join
+        end
+
+        log :route, log_msg
         sentinel = /\.routes\.draw do\s*\n/m
 
         in_root do

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -500,6 +500,38 @@ class ActionsTest < Rails::Generators::TestCase
     assert_routes route_commands
   end
 
+  test "route should indent routing code in the log output" do
+    run_generator
+    route_commands = ["get 'foo'", "get 'bar'", "get 'baz'"]
+    action_result = action :route, route_commands.join("\n")
+    assert_log_routes = <<-ROUTING_LOG
+       route  get 'foo'
+              get 'bar'
+              get 'baz'
+    ROUTING_LOG
+    assert_equal(action_result, assert_log_routes)
+  end
+
+  test "route should indent routing code with one line in the log output" do
+    run_generator
+    route_commands = "get 'foo'"
+    action_result = action :route, route_commands
+    assert_log_routes = "       route  get 'foo'\n"
+    assert_equal(action_result, assert_log_routes)
+  end
+
+  test "route should indent routing code with namespace in the log output" do
+    run_generator
+    action_result = action :route,  "get 'foo'\nget 'bar'", namespace: :baz
+    assert_log_routes = <<-ROUTING_LOG
+       route  namespace :baz do
+                get 'foo'
+                get 'bar'
+              end
+    ROUTING_LOG
+    assert_equal(action_result, assert_log_routes)
+  end
+
   test "route should be idempotent" do
     run_generator
     route_command = "root 'welcome#index'"


### PR DESCRIPTION
### Sumary
This change add indent the lines to improve the read in route section in the console log.

### Output before this change

```

$ rails g controller myspace/other index show
      create  app/controllers/myspace/other_controller.rb
       route  namespace :myspace do
  get 'other/index'
  get 'other/show'
end
      invoke  erb
       exist    app/views/myspace/other
   identical    app/views/myspace/other/index.html.erb
   identical    app/views/myspace/other/show.html.erb
      invoke  test_unit
      create    test/controllers/myspace/other_controller_test.rb
      invoke  helper
      create    app/helpers/myspace/other_helper.rb
      invoke    test_unit
      invoke  assets
      invoke    scss
   identical      app/assets/stylesheets/myspace/other.scss
```

### After this change
```
$ rails g controller myspace/other index show
      create  app/controllers/myspace/other_controller.rb
       route  namespace :myspace do
                get 'other/index'
                get 'other/show'
              end
      invoke  erb
      create    app/views/myspace/other
      create    app/views/myspace/other/index.html.erb
      create    app/views/myspace/other/show.html.erb
      invoke  test_unit
      create    test/controllers/myspace/other_controller_test.rb
      invoke  helper
      create    app/helpers/myspace/other_helper.rb
      invoke    test_unit
      invoke  assets
      invoke    scss
      create      app/assets/stylesheets/myspace/other.scss
```