### PR TITLE
Fix ActiveJob Test adapter not respecting retry attempts:

### DIFF
--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -41,7 +41,11 @@ module ActiveJob
 
       private
         def job_to_hash(job, extras = {})
-          { job: job.class, args: job.serialize.fetch("arguments"), queue: job.queue_name }.merge!(extras)
+          job.serialize.tap do |job_data|
+            job_data[:job] = job.class
+            job_data[:args] = job_data.fetch("arguments")
+            job_data[:queue] = job_data.fetch("queue_name")
+          end.merge(extras)
         end
 
         def perform_or_enqueue(perform, job, job_data)

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -674,10 +674,9 @@ module ActiveJob
       end
 
       def instantiate_job(payload)
-        args = ActiveJob::Arguments.deserialize(payload[:args])
-        job = payload[:job].new(*args)
+        job = payload[:job].deserialize(payload)
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
-        job.queue_name = payload[:queue]
+        job.send(:deserialize_arguments_if_needed)
         job
       end
 

--- a/activejob/test/jobs/raising_job.rb
+++ b/activejob/test/jobs/raising_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RaisingJob < ActiveJob::Base
+  MyError = Class.new(StandardError)
+
+  retry_on(MyError, attempts: 2)
+
+  def perform
+    raise MyError
+  end
+end


### PR DESCRIPTION
Fix ActiveJob Test adapter not respecting retry attempts:

- ### Problem

  Given the below example the test adapter will retry the job
  indefinitely:

  ```ruby
    class BuggyJob < ActiveJob::Base
      retry_on(Exception,  attempts: 2)

      def perform
        raise "error"
      end
    end

    BuggyJob.perform_later
    perform_enqueued_jobs
  ```

  The problem is that when the job get retried, the
  `exception_executions` variable is not serialized/deserialized,
  resulting in ActiveJob to not be able to determine how many time
  this job was retried.

  The solution in this PR is to deserialize the whole job in the test
  adapter, and reserialize it before retrying.

  Fix #38391

