### PR TITLE
Fix: on accessing the parent record before creation with has_many_inv…

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -278,8 +278,8 @@ module ActiveRecord
         target
       end
 
-      def add_to_target(record, skip_callbacks = false, &block)
-        if association_scope.distinct_value
+      def add_to_target(record, skip_callbacks: false, replace: false, &block)
+        if replace || association_scope.distinct_value
           index = @target.index(record)
         end
         replace_on_target(record, index, skip_callbacks, &block)
@@ -292,7 +292,7 @@ module ActiveRecord
         when Array
           super
         else
-          add_to_target(record, true)
+          add_to_target(record, skip_callbacks: true, replace: true)
         end
       end
 

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -509,7 +509,7 @@ module ActiveRecord
               if target_record
                 existing_record = target_record
               else
-                association.add_to_target(existing_record, :skip_callbacks)
+                association.add_to_target(existing_record, skip_callbacks: true)
               end
 
               assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -650,6 +650,16 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.horrible_man }
   end
+
+  def test_building_has_many_parent_association_inverses_one_record
+    with_has_many_inversing do
+      interest = Interest.new
+      interest.build_man
+      assert_equal 1, interest.man.interests.size
+      interest.save!
+      assert_equal 1, interest.man.interests.size
+    end
+  end
 end
 
 class InversePolymorphicBelongsToTests < ActiveRecord::TestCase


### PR DESCRIPTION
…ersing adds two records to association

### Summary

When _has_many_inversing = true_ if you build a model linked through _belongs_to_ it gets added twice before saving it, there is a test case on the [linked issue](https://github.com/rails/rails/issues/38312)

