### PR TITLE
Initialize Git when generating plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -161,6 +161,12 @@ task default: :test
         append_file gemfile_in_app_path, entry
       end
     end
+
+    def version_control
+      if  !options[:skip_git] && !options[:pretend]
+        run "git init", capture: options[:quiet], abort_on_failure: false
+      end
+    end
   end
 
   module Generators
@@ -203,6 +209,7 @@ task default: :test
         build(:license)
         build(:gitignore) unless options[:skip_git]
         build(:gemfile)   unless options[:skip_gemfile]
+        build(:version_control)
       end
 
       def create_app_files

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -64,7 +64,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generating_without_options
-    run_generator
+    output = run_generator
     assert_file "README.md", /Bukkits/
     assert_no_file "config/routes.rb"
     assert_no_file "app/assets/config/bukkits_manifest.js"
@@ -79,6 +79,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
     assert_file "bin/test"
     assert_no_file "bin/rails"
+    assert_match(/run  git init/, output)
   end
 
   def test_generating_in_full_mode_with_almost_of_all_skip_options


### PR DESCRIPTION
### Summary

When generating applications, it initializes Git repository since https://github.com/rails/rails/commit/8989a5057b6dc0e287a8b27ded31f08c5e56d0a7
However, it doesn't initialize Git when creating plugins.
Plugins are mostly libraries and are likely hosted on GitHub, so initializing Git for plugins makes sense.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

I'm not sure if this test is enough.
Also, I suspect now is the chance to put Git initialization to the common parent class.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
