### PR TITLE
Clarify passing an array as a cookie's domain

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -154,8 +154,10 @@ module ActionDispatch
   # * <tt>:domain</tt> - The domain for which this cookie applies so you can
   #   restrict to the domain level. If you use a schema like www.example.com
   #   and want to share session with user.example.com set <tt>:domain</tt>
-  #   to <tt>:all</tt>. Make sure to specify the <tt>:domain</tt> option with
-  #   <tt>:all</tt> or <tt>Array</tt> again when deleting cookies.
+  #   to <tt>:all</tt>. To support multiple domains, provide an array, and
+  #   the first domain matching <tt>request.host</tt> will be used. Make
+  #   sure to specify the <tt>:domain</tt> option with <tt>:all</tt> or
+  #   <tt>Array</tt> again when deleting cookies.
   #
   #     domain: nil  # Does not set cookie domain. (default)
   #     domain: :all # Allow the cookie for the top most level


### PR DESCRIPTION
### Summary

When working through an issue, I found myself a little confused stumbling upon some code like this:

```rb
cookies[...] = {
  # ...
  domain: %w(.site.io .site.com)
}
```

In my mind I was thinking "is this some weird part of the cookie spec? or is this Rails?" and the docs didn't offer much insight into how it works. Going back into the commit where that line was added, the folks who added it were confused until someone linked to the source.

I figured that clarifying this in the docs would be useful. Of course, people should know how cookies work before fiddling with them (unlike me), but since cookies are so sensitive, I think the docs should opt for being explicit about this.

Edit: I'm sorry I didn't add [ci skip]—I edited this file using GitHub, which didn't show me the PR template before creating the commit 😢 