### PR TITLE
Fix grammar and diction of NOR conditions warning message

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -51,7 +51,7 @@ module ActiveRecord
         if not_behaves_as_nor?(opts)
           ActiveSupport::Deprecation.warn(<<~MSG.squish)
             NOT conditions will no longer behave as NOR in Rails 6.1.
-            To continue using NOR conditions, NOT each conditions manually
+            To continue using NOR conditions, NOT each condition individually
             (`#{
               opts.flat_map { |key, value|
                 if value.is_a?(Hash) && value.size > 1

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -167,7 +167,7 @@ module ActiveRecord
 
       message = <<~MSG.squish
         NOT conditions will no longer behave as NOR in Rails 6.1.
-        To continue using NOR conditions, NOT each conditions manually
+        To continue using NOR conditions, NOT each condition individually
         (`.where.not(:estimate_of_type => ...).where.not(:estimate_of_id => ...)`).
       MSG
       actual = assert_deprecated(message) do
@@ -188,7 +188,7 @@ module ActiveRecord
 
       message = <<~MSG.squish
         NOT conditions will no longer behave as NOR in Rails 6.1.
-        To continue using NOR conditions, NOT each conditions manually
+        To continue using NOR conditions, NOT each condition individually
         (`.where.not(:price_estimates => { :price => ... }).where.not(:price_estimates => { :currency => ... })`).
       MSG
       assert_deprecated(message) do


### PR DESCRIPTION
The previous warning message read:

> To continue using NOR conditions, NOT each conditions manually

I believe this contains a grammatical error (the second use of “conditions” should be singular). Also, the word “manually” is not quite right. I believe “individually” is a better word choice, so I changed the message to read:

> To continue using NOR conditions, NOT each condition individually

I hope this change makes the warning clearer.

I also updated the tests to ensure that they pass.