### PR TITLE
Do not stringify attributes in assign_attributes

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -26,13 +26,12 @@ module ActiveModel
     #   cat.name # => 'Gorby'
     #   cat.status # => 'sleeping'
     def assign_attributes(new_attributes)
-      if !new_attributes.respond_to?(:stringify_keys)
+      unless new_attributes.respond_to?(:stringify_keys)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
       end
       return if new_attributes.empty?
 
-      attributes = new_attributes.stringify_keys
-      _assign_attributes(sanitize_for_mass_assignment(attributes))
+      _assign_attributes(sanitize_for_mass_assignment(new_attributes.dup))
     end
 
     alias attributes= assign_attributes
@@ -49,7 +48,7 @@ module ActiveModel
         if respond_to?(setter)
           public_send(setter, v)
         else
-          raise UnknownAttributeError.new(self, k)
+          raise UnknownAttributeError.new(self, k.to_s)
         end
       end
   end

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -31,7 +31,7 @@ module ActiveModel
       end
       return if new_attributes.empty?
 
-      _assign_attributes(sanitize_for_mass_assignment(new_attributes.dup))
+      _assign_attributes(sanitize_for_mass_assignment(new_attributes))
     end
 
     alias attributes= assign_attributes

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -26,7 +26,7 @@ module ActiveModel
     #   cat.name # => 'Gorby'
     #   cat.status # => 'sleeping'
     def assign_attributes(new_attributes)
-      unless new_attributes.respond_to?(:stringify_keys)
+      unless new_attributes.respond_to?(:each_pair)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
       end
       return if new_attributes.empty?

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -49,8 +49,8 @@ class AttributeAssignmentTest < ActiveModel::TestCase
       @parameters
     end
 
-    def stringify_keys
-      dup
+    def each_pair(&block)
+      @parameters.each_pair(&block)
     end
 
     def dup

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -6,22 +6,25 @@ module ActiveRecord
   module AttributeAssignment
     include ActiveModel::AttributeAssignment
 
+    def assign_attributes(attributes)
+      super(attributes.dup)
+    end
+
     private
       def _assign_attributes(attributes)
         multi_parameter_attributes  = {}
         nested_parameter_attributes = {}
-        new_attributes = attributes.dup
 
-        new_attributes.each do |k, v|
+        attributes.each do |k, v|
           key = k.to_s
 
           if key.include?("(")
-            multi_parameter_attributes[key] = new_attributes.delete(k)
+            multi_parameter_attributes[key] = attributes.delete(k)
           elsif v.is_a?(Hash)
-            nested_parameter_attributes[key] = new_attributes.delete(k)
+            nested_parameter_attributes[key] = attributes.delete(k)
           end
         end
-        super(new_attributes)
+        super(attributes)
 
         assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
         assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -10,17 +10,18 @@ module ActiveRecord
       def _assign_attributes(attributes)
         multi_parameter_attributes  = {}
         nested_parameter_attributes = {}
+        new_attributes = attributes.dup
 
-        attributes.each do |k, v|
+        new_attributes.each do |k, v|
           key = k.to_s
 
           if key.include?("(")
-            multi_parameter_attributes[key] = attributes.delete(k)
+            multi_parameter_attributes[key] = new_attributes.delete(k)
           elsif v.is_a?(Hash)
-            nested_parameter_attributes[key] = attributes.delete(k)
+            nested_parameter_attributes[key] = new_attributes.delete(k)
           end
         end
-        super(attributes)
+        super(new_attributes)
 
         assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
         assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -12,10 +12,12 @@ module ActiveRecord
         nested_parameter_attributes = {}
 
         attributes.each do |k, v|
-          if k.include?("(")
-            multi_parameter_attributes[k] = attributes.delete(k)
+          key = k.to_s
+
+          if key.include?("(")
+            multi_parameter_attributes[key] = attributes.delete(k)
           elsif v.is_a?(Hash)
-            nested_parameter_attributes[k] = attributes.delete(k)
+            nested_parameter_attributes[key] = attributes.delete(k)
           end
         end
         super(attributes)

--- a/activerecord/test/support/stubs/strong_parameters.rb
+++ b/activerecord/test/support/stubs/strong_parameters.rb
@@ -28,8 +28,8 @@ class ProtectedParams
   end
   alias to_unsafe_h to_h
 
-  def stringify_keys
-    dup
+  def each_pair(&block)
+    @parameters.each_pair(&block)
   end
 
   def dup


### PR DESCRIPTION
### Summary

This PR switches from stringifying attributes early on and invokes `to_s` whenever necessary within the processing loops.

I also took the opportunity to change `if !condition` to `unless condition`.

### Benchmark script
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
end

module ActiveModel
  module AttributeAssignment
    def fast_assign_attributes(new_attributes)
      if !new_attributes.respond_to?(:stringify_keys)
        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
      end
      return if new_attributes.empty?

      _fast_assign_attributes(sanitize_for_mass_assignment(new_attributes))
    end

    alias attributes= assign_attributes

    private
    def _fast_assign_attributes(attributes)
      attributes.each do |k, v|
        _fast_assign_attribute(k, v)
      end
    end

    def _fast_assign_attribute(k, v)
      setter = :"#{k}="
      if respond_to?(setter)
        public_send(setter, v)
      else
        raise UnknownAttributeError.new(self, k.to_s)
      end
    end
  end
end

module ActiveRecord
  module AttributeAssignment
    def _fast_assign_attributes(attributes)
      multi_parameter_attributes  = {}
      nested_parameter_attributes = {}

      attributes.each do |k, v|
        key = k.to_s

        if key.include?("(")
          multi_parameter_attributes[key] = attributes.delete(k)
        elsif v.is_a?(Hash)
          nested_parameter_attributes[key] = attributes.delete(k)
        end
      end
      super(attributes)

      assign_nested_parameter_attributes(nested_parameter_attributes) unless nested_parameter_attributes.empty?
      assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
    end
  end
end

class Post
  include ActiveModel::AttributeAssignment
  attr_accessor :title, :author, :published, :score, :tags, :content
end

post = Post.new
attributes = {
  title: "My post",
  author: "John",
  published: true,
  score: 500,
  tags: "Software development,Web development",
  content: "random text" * 100
}

action_controller_params = ActionController::Parameters.new(attributes)
action_controller_params.permit!

SCENARIOS = {
  "Simple hash" => attributes,
  "ActionController params" => action_controller_params
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("assign_attributes")      { post.assign_attributes(value) }
    x.report("fast_assign_attributes") { post.fast_assign_attributes(value) }
    x.compare!
  end
end
```
### Results
```
================================= Simple hash ==================================

Warming up --------------------------------------
   assign_attributes    26.067k i/100ms
fast_assign_attributes
                        36.034k i/100ms
Calculating -------------------------------------
   assign_attributes    280.621k (± 2.1%) i/s -      1.408M in   5.018190s
fast_assign_attributes
                        384.638k (± 3.8%) i/s -      1.946M in   5.067378s

Comparison:
fast_assign_attributes:   384637.9 i/s
   assign_attributes:   280620.9 i/s - 1.37x  slower


=========================== ActionController params ============================

Warming up --------------------------------------
   assign_attributes     5.406k i/100ms
fast_assign_attributes
                         7.209k i/100ms
Calculating -------------------------------------
   assign_attributes     59.000k (± 7.5%) i/s -    297.330k in   5.069136s
fast_assign_attributes
                         78.789k (± 8.0%) i/s -    396.495k in   5.063842s

Comparison:
fast_assign_attributes:    78788.7 i/s
   assign_attributes:    59000.3 i/s - 1.34x  slower
```