### PR TITLE
Update maintenance policy on security releases

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -54,7 +54,7 @@ and new versions in case of a security issue.
 
 These releases are created by taking the last released version, applying the
 security patches, and releasing. Those patches are then applied to the end of
-the x-y-stable branch. For example, a theoretical 1.2.3 security release would
+the x-y-stable branch. For example, a theoretical 1.2.2.1 security release would
 be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.


### PR DESCRIPTION
This update should reflect our current release behavior where we bump the fourth digit for security release. (For example,  6.0.2.1 instead of 6.0.2).

/cc @rafaelfranca as you're the release manager 🙇 