### PR TITLE
Remove redundant .gitignore entries

### DIFF
--- a/actionmailbox/.gitignore
+++ b/actionmailbox/.gitignore
@@ -1,5 +1,4 @@
 /test/dummy/db/*.sqlite3
-/test/dummy/db/*.sqlite3-journal
 /test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/tmp/

--- a/actiontext/.gitignore
+++ b/actiontext/.gitignore
@@ -1,5 +1,4 @@
 /test/dummy/db/*.sqlite3
-/test/dummy/db/*.sqlite3-journal
 /test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/public/packs-test

--- a/activestorage/.gitignore
+++ b/activestorage/.gitignore
@@ -1,6 +1,5 @@
 /src/
 /test/dummy/db/*.sqlite3
-/test/dummy/db/*.sqlite3-journal
 /test/dummy/db/*.sqlite3-*
 /test/dummy/log/*.log
 /test/dummy/tmp/

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -10,7 +10,6 @@
 <% if sqlite3? -%>
 # Ignore the default SQLite database.
 /db/*.sqlite3
-/db/*.sqlite3-journal
 /db/*.sqlite3-*
 
 <% end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -4,7 +4,6 @@ pkg/
 <% if with_dummy_app? -%>
 <% if sqlite3? -%>
 <%= dummy_path %>/db/*.sqlite3
-<%= dummy_path %>/db/*.sqlite3-journal
 <%= dummy_path %>/db/*.sqlite3-*
 <% end -%>
 <%= dummy_path %>/log/*.log


### PR DESCRIPTION
Follow-up to #37053.  The `*.sqlite3-*` .gitignore entries added in that commit subsume previous `*.sqlite3-journal` entries.
