### PR TITLE
Deobfuscate Rake version error in generated plugin

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,8 +1,4 @@
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+require 'bundler/setup'
 
 require 'rdoc/task'
 


### PR DESCRIPTION
If the plugin or one of its dependencies requires a version of Rake that is different than the version executing the Rakefile, `require 'bundler/setup'` will raise a LoadError with a helpful error message like: "You have already activated rake 13.0.1, but your Gemfile requires rake 12.3.3. Prepending `bundle exec` to your command may solve this."

If that LoadError is swallowed, another LoadError will eventually be raised with a less helpful / more confusing error message like: "cannot load such file -- rake".
