### PR TITLE
Handle literal SQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -216,6 +216,7 @@ module ActiveRecord
 
         def _quote(value)
           case value
+          when Arel::Nodes::SqlLiteral then value.to_s
           when String, Symbol, ActiveSupport::Multibyte::Chars
             "'#{quote_string(value.to_s)}'"
           when true       then quoted_true

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -12,6 +12,7 @@ module ActiveRecord
       register_handler(Base, BaseHandler.new(self))
       register_handler(Range, RangeHandler.new(self))
       register_handler(Relation, RelationHandler.new)
+      register_handler(Arel::Nodes::SqlLiteral, SqlLiteralHandler.new(self))
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
     end
@@ -141,6 +142,7 @@ require "active_record/relation/predicate_builder/base_handler"
 require "active_record/relation/predicate_builder/basic_object_handler"
 require "active_record/relation/predicate_builder/range_handler"
 require "active_record/relation/predicate_builder/relation_handler"
+require "active_record/relation/predicate_builder/sql_literal_handler"
 
 require "active_record/relation/predicate_builder/association_query_value"
 require "active_record/relation/predicate_builder/polymorphic_array_value"

--- a/activerecord/lib/active_record/relation/predicate_builder/sql_literal_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/sql_literal_handler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class SqlLiteralHandler # :nodoc:
+      def initialize(predicate_builder)
+        @predicate_builder = predicate_builder
+      end
+
+      def call(attribute, value)
+        attribute.in(value)
+      end
+
+      private
+        attr_reader :predicate_builder
+    end
+  end
+end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -142,6 +142,12 @@ module ActiveRecord
         end
       end
 
+      def test_quote_sql_literal
+        raw_sql = %{title like '"%something%"'}
+        literal = Arel.sql(raw_sql)
+        assert_equal raw_sql, @quoter.quote(literal)
+      end
+
       def test_quote_nil
         assert_equal "NULL", @quoter.quote(nil)
       end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -359,6 +359,14 @@ module ActiveRecord
       assert_equal 0, count
     end
 
+    def test_where_with_sql_literal
+      subquery = Arel.sql("select id from posts where title like 'Welcome%'")
+      count = Post.where(id: subquery).count
+      puts Post.where(id: subquery).to_sql
+
+      assert_equal 1, count
+    end
+
     def test_where_on_association_with_custom_primary_key
       author = authors(:david)
       essay = Essay.where(writer: author).first


### PR DESCRIPTION
See #38301 for discussion.

### Summary

When a SqlLiteral is passed instead of a String, the following patterns are now supported:

```ruby
complex_ids_sql = Arel.sql(QUERY)
where(project_id: complex_ids_sql)
where("project_id IN (?)", complex_ids_sql)
where("project_id IN (%s)", complex_ids_sql)
```

This is also mirrored in the `sanitize_sql` methods, so it is interpolated as a literal and not quoted:

```ruby
sanitize_sql(["id IN (?)", complex_ids_sql])
```