### PR TITLE
Anchor generated plugin .gitgnore entries

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -1,19 +1,19 @@
-.bundle/
-log/*.log
-pkg/
+/.bundle/
+/log/*.log
+/pkg/
 <% if with_dummy_app? -%>
 <% if sqlite3? -%>
-<%= dummy_path %>/db/*.sqlite3
-<%= dummy_path %>/db/*.sqlite3-*
+/<%= dummy_path %>/db/*.sqlite3
+/<%= dummy_path %>/db/*.sqlite3-*
 <% end -%>
-<%= dummy_path %>/log/*.log
+/<%= dummy_path %>/log/*.log
 <% unless options[:skip_javascript] -%>
-<%= dummy_path %>/node_modules/
-<%= dummy_path %>/yarn-error.log
+/<%= dummy_path %>/node_modules/
+/<%= dummy_path %>/yarn-error.log
 <% end -%>
 <% unless skip_active_storage? -%>
-<%= dummy_path %>/storage/
+/<%= dummy_path %>/storage/
 <% end -%>
-<%= dummy_path %>/tmp/
+/<%= dummy_path %>/tmp/
 <% end -%>
 .byebug_history


### PR DESCRIPTION
This is a good practice to encourage to prevent inadvertent exclusions from version control.  This also matches [generated app .gitignore files](https://github.com/rails/rails/blob/a0569ff8c349f4f7673d76ca83efe6147b2be263/railties/lib/rails/generators/rails/app/templates/gitignore.tt).
