### PR TITLE
Fix wrong spec asserting headers maintain original definition

### DIFF
--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -222,7 +222,7 @@ class SecureCookiesTest < SSLTest
   end
 
   def test_keeps_original_headers_behavior
-    get headers: { "Connection" => %w[close] }
+    get headers: { "Connection" => "close" }
     assert_equal "close", response.headers["Connection"]
   end
 end


### PR DESCRIPTION
This was introduced in https://github.com/rails/rails/pull/20559 but was wrongly asserting %w[close] to match "close" as the header value

Changes from https://github.com/rack/rack/commit/d2e608e8d54b76ec7e52bb7c6508c5a5259c934e returns headers as is which makes this break.