### PR TITLE
Fix load_additional_types handling of large OIDs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -637,7 +637,7 @@ module ActiveRecord
           SQL
 
           if oids
-            query += "WHERE t.oid::integer IN (%s)" % oids.join(", ")
+            query += "WHERE t.oid IN (%s)" % oids.join(", ")
           else
             query += initializer.query_conditions_for_initial_load
           end


### PR DESCRIPTION
### Summary

**Background:**
In Postgres, OIDs are *unsigned* 4 byte integers. Postgres allows
casting oids to integers so that you can have access to more operators;
however, doing this could lead to some issues if the oids are very large
as they might around to the negative number range.

From the [Postgres docs](https://www.postgresql.org/docs/12/datatype-oid.html):

> The oid type itself has few operations beyond comparison. It can be
> cast to integer, however, and then manipulated using the standard
> integer operators. (Beware of possible signed-versus-unsigned
> confusion if you do this.)

In most real-world databases this is never going to be a problem. In
order to reach the overflow, you have to have 2,147,483,648 objects in
your database (not rows, but relations, types, views, etc.). In extreme
cases though it is possible to reach that number and encounter some
buggy behavior.

**How does this show up:**
We have a model using a PostGIS `geography` column. When our OIDs are very large, ActiveRecord cannot find the corresponding pg_type and treats the column as a String:

```ruby
irb(main):001:0> MyModel.find(id).lonlat
unknown OID 2690647372: failed to recognize type of 'lonlat'. It will be treated as String.          
=> "[REDACTED]" 
```

I think this sort of illustrates the problem:

```sql
CREATE TABLE foooid (
  pk serial Primary Key,
  oid oid,
  name text
);

INSERT INTO foooid (oid, name) VALUES (2779325372, 'foo'), (30, 'bar');

SELECT * FROM foooid;
 pk |    oid     | name
----+------------+------
  1 | 2779325372 | foo
  2 |         30 | bar
(2 rows)

-- Original load_additional_types code
SELECT * FROM foooid WHERE oid::integer IN (2779325372);
 pk | oid | name
----+-----+------
(0 rows)

-- Don't cast oid to an integer to avoid the overflow
SELECT * FROM foooid WHERE oid IN (2779325372);
 pk |    oid     | name
----+------------+------
  1 | 2779325372 | foo
(1 row)

SELECT pk, oid, oid::integer, name FROM foooid;
 pk |    oid     |     oid     | name
----+------------+-------------+------
  1 | 2779325372 | -1515641924 | foo
  2 |         30 |          30 | bar
(2 rows)
```

As far as tests go. I'm not sure how to write a test for this, but the code in question already does have test coverage. I think it would be pretty hard (it could potentially require billiions of operations) to get a database into the required state for this to work. I have not looked into this though. It may be easier than that.