### PR TITLE
Add the `filename` when building ERB:

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -19,7 +19,9 @@ module ActiveSupport
     end
 
     def parse(context: nil, **options)
-      yaml = context ? ERB.new(@content).result(context) : ERB.new(@content).result
+      erb = ERB.new(@content)
+      erb.filename = @content_path.to_s
+      yaml = context ? erb.result(context) : erb.result
       YAML.load(yaml, **options) || {}
     rescue Psych::SyntaxError => error
       raise "YAML syntax error occurred while parsing #{@content_path}. " \

--- a/activesupport/test/configuration_file_test.rb
+++ b/activesupport/test/configuration_file_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class ConfigurationFileTest < ActiveSupport::TestCase
+  test "backtrace contain the path to the yaml" do
+    Tempfile.create do |file|
+      file.write("wrong: <%= foo %>")
+      file.rewind
+
+      error = assert_raises do
+        ActiveSupport::ConfigurationFile.parse(file.path)
+      end
+
+      assert_match(file.path, error.backtrace.first)
+    end
+  end
+end


### PR DESCRIPTION
Add the `filename` when building ERB:

- If an error occurs when rendering ERB (other than a Psych's
  SyntaxError), it's impossible to know in which file the error
  occured.

  This commit fixes that

cc/ @kaspth @rafaelfranca @casperisfine