### PR TITLE
Cast `ConfigurationFile#content_path` to a string:

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -10,7 +10,7 @@ module ActiveSupport
     class FormatError < StandardError; end
 
     def initialize(content_path)
-      @content_path = content_path
+      @content_path = content_path.to_s
       @content = read content_path
     end
 

--- a/activesupport/test/configuration_file_test.rb
+++ b/activesupport/test/configuration_file_test.rb
@@ -15,4 +15,17 @@ class ConfigurationFileTest < ActiveSupport::TestCase
       assert_match file.path, error.backtrace.first
     end
   end
+
+  test "backtrace contains yaml path (when Pathname given)" do
+    Tempfile.create do |file|
+      file.write("wrong: <%= foo %>")
+      file.rewind
+
+      error = assert_raises do
+        ActiveSupport::ConfigurationFile.parse(Pathname(file.path))
+      end
+
+      assert_match file.path, error.backtrace.first
+    end
+  end
 end


### PR DESCRIPTION
Cast `ConfigurationFile#content_path` to a string:

- This is required when we assign the `ERB#filename` in case
  of a Pathname.
