### PR TITLE
Use rails_command :inline option

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -9,7 +9,7 @@ module ActionText
       source_root File.expand_path("templates", __dir__)
 
       def install_javascript_dependencies
-        rails_command "app:update:bin"
+        rails_command "app:update:bin", inline: true
 
         say "Installing JavaScript dependencies", :green
         run "yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}",
@@ -49,7 +49,7 @@ module ActionText
       end
 
       def create_migrations
-        rails_command "railties:install:migrations FROM=active_storage,action_text"
+        rails_command "railties:install:migrations FROM=active_storage,action_text", inline: true
       end
 
       hook_for :test_framework

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -409,8 +409,10 @@ module Rails
 
       def run_webpack
         if webpack_install?
-          rails_command "webpacker:install"
-          rails_command "webpacker:install:#{options[:webpack]}" if options[:webpack] && options[:webpack] != "webpack"
+          rails_command "webpacker:install", inline: true
+          if options[:webpack] && options[:webpack] != "webpack"
+            rails_command "webpacker:install:#{options[:webpack]}", inline: true
+          end
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -316,7 +316,7 @@ module Rails
 
       def update_active_storage
         unless skip_active_storage?
-          rails_command "active_storage:update"
+          rails_command "active_storage:update", inline: true
         end
       end
       remove_task :update_active_storage


### PR DESCRIPTION
Follow-up to #37516.

---

Running locally (on a not-very-powerful machine), I saw the time for `railties/test/generators/app_generator_test.rb` reduced from ~260 seconds to ~232 seconds.  However, all that time came from a single call site (see my review comments below).

