### PR TITLE
Expose Marshal as a legit SchemaCache serialization strategy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -129,6 +129,12 @@ module ActiveRecord
         @indexes.delete name
       end
 
+      def dump_to(filename)
+        clear!
+        connection.data_sources.each { |table| add(table) }
+        open(filename, "wb") { |f| f.write(YAML.dump(self)) }
+      end
+
       def marshal_dump
         # if we get current version during initialization, it happens stack over flow.
         @version = connection.migration_context.current_version

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -3,6 +3,12 @@
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCache
+      def self.load_from(filename)
+        return unless File.file?(filename)
+
+        YAML.load(File.read(filename))
+      end
+
       attr_reader :version
       attr_accessor :connection
 

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -6,7 +6,8 @@ module ActiveRecord
       def self.load_from(filename)
         return unless File.file?(filename)
 
-        YAML.load(File.read(filename))
+        file = File.read(filename)
+        filename.end_with?(".dump") ? Marshal.load(file) : YAML.load(file)
       end
 
       attr_reader :version
@@ -138,7 +139,13 @@ module ActiveRecord
       def dump_to(filename)
         clear!
         connection.data_sources.each { |table| add(table) }
-        open(filename, "wb") { |f| f.write(YAML.dump(self)) }
+        open(filename, "wb") { |f|
+          if filename.end_with?(".dump")
+            f.write(Marshal.dump(self))
+          else
+            f.write(YAML.dump(self))
+          end
+        }
       end
 
       def marshal_dump

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -132,24 +132,23 @@ To keep using the current cache store, you can turn off cache versioning entirel
               env_name: Rails.env,
               spec_name: "primary",
             )
-
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
               "primary",
               schema_cache_path: db_config&.schema_cache_path,
             )
 
-            if File.file?(filename)
-              current_version = ActiveRecord::Migrator.current_version
+            cache = ActiveRecord::ConnectionAdapters::SchemaCache.load_from(filename)
+            next if cache.nil?
 
-              next if current_version.nil?
+            current_version = ActiveRecord::Migrator.current_version
+            next if current_version.nil?
 
-              cache = YAML.load(File.read(filename))
-              if cache.version == current_version
-                connection_pool.schema_cache = cache.dup
-              else
-                warn "Ignoring db/schema_cache.yml because it has expired. The current schema version is #{current_version}, but the one in the cache is #{cache.version}."
-              end
+            if cache.version != current_version
+              warn "Ignoring #{filename} because it has expired. The current schema version is #{current_version}, but the one in the cache is #{cache.version}."
+              next
             end
+
+            connection_pool.set_schema_cache(cache.dup)
           end
         end
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -449,9 +449,7 @@ module ActiveRecord
       # ==== Examples:
       #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, "tmp/schema_dump.yaml")
       def dump_schema_cache(conn, filename)
-        conn.schema_cache.clear!
-        conn.data_sources.each { |table| conn.schema_cache.add(table) }
-        open(filename, "wb") { |f| f.write(YAML.dump(conn.schema_cache)) }
+        conn.schema_cache.dump_to(filename)
       end
 
       def clear_schema_cache(filename)


### PR DESCRIPTION
### Summary

This lets people choose between `Marshal` and `YAML` as a serialization strategy, but defining the schema dump path filename for each database connection, either with the suffix `.dump` (for Marshal) or `.yml` (for YAML).

The default behavior is still YAML.

### Other Information

The Marshal behavior was replaced with YAML in 2016, and then in 2019 an attempt was made to remove it. It was put back the next day. In https://github.com/rails/rails/pull/38347 I suggested deprecating it, since it seemed like the intention was to be able to remove it, though I had not found any issues/PRs discussing it.

@tenderlove suggested that instead of removing it, we should make it configurable.

Here I've pushed the load and dump behavior into the schema class itself, in order to group the serialization logic somewhat.
