### PR TITLE
Use correct fallback in schema cache initializer

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -132,11 +132,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
               env_name: Rails.env,
               spec_name: "primary",
             )
-            next if db_config.nil?
 
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
-              db_config.spec_name,
-              schema_cache_path: db_config.schema_cache_path,
+              "primary",
+              schema_cache_path: db_config&.schema_cache_path,
             )
 
             if File.file?(filename)


### PR DESCRIPTION
### Summary

Instead of bailing when a `primary` db config is not found, attempt to load the default schema cache path.

### Other Information

Hopefully third time's a charm.

Originally, the schema cache initializer railtie was loading
the 'schema_cache.yml' file by hard-coding the path.

Since it's possible to override the schema cache path either by
providing an ENV variable, or by adding a configuration entry to
the database.yml config file, this means that we could potentially
end up not loading a cache that is configured to use a non-default
file.

The first attempt at fixing this (#38348) assumed that the
db config must contain a spec named 'primary'. This is not the case.
A second attempt at fixing this (#38383) bailed if no db config
was found.

This however, means that for an app without a db config named
'primary', we would not be attempting to load a schema cache
at all, even if they were using the default schema cache path.

Instead of bailing, here we go get the filename, passing a 'nil'
for the schema_cache_path, which will fall back to the default
path.
