### PR TITLE
Add tmp/ to generated plugin .gitignore

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -1,6 +1,7 @@
 /.bundle/
 /log/*.log
 /pkg/
+/tmp/
 <% if with_dummy_app? -%>
 <% if sqlite3? -%>
 /<%= dummy_path %>/db/*.sqlite3


### PR DESCRIPTION
The documentation for `Rails::Generators::TestCase` [suggests using `tmp/` as the destination directory](https://github.com/rails/rails/blob/39d3c9bcacb43b0a45bcf06aa5b98f6e54deeb24/railties/lib/rails/generators/test_case.rb#L19) when testing generators.  Many plugins test generators, so it makes sense to include `tmp/` in the default `.gitignore`.
