### PR TITLE
Improve i18n reloader to only reload once

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -62,8 +62,6 @@ module I18n
       reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do
         I18n.load_path.keep_if { |p| File.exist?(p) }
         I18n.load_path |= reloadable_paths.flat_map(&:existent)
-
-        I18n.reload!
       end
 
       app.reloaders << reloader


### PR DESCRIPTION
### Summary

Assigning to `I18n.load_path` will also trigger a reload. Prior to this change, the code would reload i18n twice when there is an assignment to `I18n.load_path`.

### Other Information

https://github.com/ruby-i18n/i18n/blob/eac7a9e6bb481c3c325fb030b9f57534da66da09/lib/i18n.rb#L67-L70

https://github.com/ruby-i18n/i18n/blob/master/lib/i18n/config.rb#L132-L136
