### PR TITLE
`OID` type should accept a value range of unsigned integers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/oid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/oid.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Oid < Type::Integer # :nodoc:
+        class Oid < Type::UnsignedInteger # :nodoc:
           def type
             :oid
           end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -55,7 +55,7 @@ class PostgresqlDataTypeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_update_oid
-    new_value = 567890
+    new_value = 2147483648
     @first_oid.obj_id = new_value
     assert @first_oid.save
     assert @first_oid.reload


### PR DESCRIPTION
Related #38425.