### PR TITLE
scaffold_controller: Include the routes when create a generator Controller

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -15,6 +15,8 @@ module Rails
       class_option :api, type: :boolean,
                          desc: "Generates API controller"
 
+      class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def create_controller_files
@@ -24,6 +26,10 @@ module Rails
 
       hook_for :template_engine, as: :scaffold do |template_engine|
         invoke template_engine unless options.api?
+      end
+
+      hook_for :resource_route, required: true do |route|
+        invoke route unless options.skip_routes?
       end
 
       hook_for :test_framework, as: :scaffold

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -12,6 +12,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   arguments %w(User name:string age:integer)
 
+  setup :copy_routes
+
   def test_controller_skeleton_is_created
     run_generator
 
@@ -95,6 +97,22 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_match(/def message_params/, content)
       assert_match(/params\.require\(:message\)\.permit\(photos: \[\]\)/, content)
+    end
+  end
+
+  def test_controller_route_are_added
+    run_generator ["Message", "photos:attachments"]
+
+    assert_file "config/routes.rb" do |route|
+      assert_match(/resources :messages$/, route)
+    end
+  end
+
+  def test_controller_route_are_skipped
+    run_generator ["Message", "photos:attachments", "--skip-routes"]
+
+    assert_file "config/routes.rb" do |route|
+      assert_no_match(/resources :messages$/, route)
     end
   end
 


### PR DESCRIPTION
When is use a scaffold_controller add the routes as resources to the
`config/route.rb`

Also enable to use `--skip-routes` if doesn't want include the resources
into the config/routes.rb file.


