### PR TITLE
Add schema cache tests

### DIFF
--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -311,6 +311,25 @@ module ApplicationTests
         db_migrate_and_schema_cache_dump
       end
 
+      # Note that schema cache loader depends on the connection and
+      # does not work for all connections.
+      test "schema_cache is loaded on primary db in multi-db app" do
+        require "#{app_path}/config/environment"
+        db_migrate_and_schema_cache_dump
+
+        cache_size_a = lambda { rails("runner", "p ActiveRecord::Base.connection.schema_cache.size").strip }
+        cache_tables_a = lambda { rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')").strip }
+        cache_size_b = lambda { rails("runner", "p AnimalsBase.connection.schema_cache.size").strip }
+        cache_tables_b = lambda { rails("runner", "p AnimalsBase.connection.schema_cache.columns('dogs')").strip }
+
+        assert_equal "12", cache_size_a[]
+        assert_includes cache_tables_a[], "title", "expected cache_tables_a to include a title entry"
+
+        # Will be 0 because it's not loaded by the railtie
+        assert_equal "0", cache_size_b[]
+        assert_includes cache_tables_b[], "name", "expected cache_tables_b to include a name entry"
+      end
+
       test "db:schema:cache:clear works on all databases" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_cache_dump_and_schema_cache_clear


### PR DESCRIPTION
The schema cache tests test the following scenarios:

1) The default case works (single db, primary spec name (dev is default
to primary in 2-tier config), standard default schema cache filename)
2) Primary always wins over other entries
3) A custom schema cache filename works when set in the configuration
4) A custom schema cache filename works when set in the ENV

Cases that don't work:

1) A non-primary database entry picks up a namespaced schema cache file

This can't work currently because there's no way of knowing which cache
we actually want. In this railtie we can only load ActiveRecord::Base's
schema cache. If we grab the first config we risk loading a cache for
another connection because order is not guaranteed.

2) Multi-db schema caches

The reasons are similar to above. In addition we can't loop through the
configs, establish a connection, and load the cache because we don't
know what parent class to establish a connection to. In that case AR
Base will always get the cache and it would cause the last one to win
and therefore be loaded on the wrong connection.

The real fix for these issues is to get rid of the railtie entirely, but
for now we needed to set this back to what the behavior was before
recent changes but with the ability to pass a custom key.


Co-authored-by: Katrina Owen <kytrinyx@github.com>