### PR TITLE
Memoize ActiveRecord::Relation#inspect

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Cache computation of `#inspect` on ActiveRecord relations.
+
+    *Felix Bünemann*
+
 *   Add support for PostgreSQL 11+ partitioned indexes when using `upsert_all`.
 
     *Sebastián Palma*

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1088,6 +1088,7 @@ module ActiveRecord
       def reset_scope # :nodoc:
         @offsets = {}
         @scope = nil
+        @inspect = nil
         self
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -638,6 +638,7 @@ module ActiveRecord
       unless loaded?
         @records = exec_queries(&block)
         @loaded = true
+        @inspect = nil
       end
 
       self
@@ -652,7 +653,7 @@ module ActiveRecord
     def reset
       @delegate_to_klass = false
       @_deprecated_scope_source = nil
-      @to_sql = @arel = @loaded = @should_eager_load = nil
+      @to_sql = @arel = @loaded = @should_eager_load = @inspect = nil
       @records = [].freeze
       @offsets = {}
       @take = nil
@@ -730,12 +731,14 @@ module ActiveRecord
     end
 
     def inspect
-      subject = loaded? ? records : self
-      entries = subject.take([limit_value, 11].compact.min).map!(&:inspect)
+      @inspect ||= begin
+        subject = loaded? ? records : self
+        entries = subject.take([limit_value, 11].compact.min).map!(&:inspect)
 
-      entries[10] = "..." if entries.size == 11
+        entries[10] = "..." if entries.size == 11
 
-      "#<#{self.class.name} [#{entries.join(', ')}]>"
+        "#<#{self.class.name} [#{entries.join(', ')}]>"
+      end
     end
 
     def empty_scope? # :nodoc:

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -187,6 +187,28 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_match(/message: "new developer added"/, andreas.audit_logs.inspect)
   end
 
+  def test_inspect_memoizes
+    posts = authors(:david).posts
+    assert_same posts.inspect, posts.inspect
+  end
+
+  def test_reset_invalidates_inspect_memoization
+    posts = authors(:david).posts
+    assert_not_same posts.inspect, posts.reset.inspect
+  end
+
+  def test_load_invalidates_inspect_memoization
+    posts = authors(:david).posts
+    assert_not_predicate posts, :loaded?
+    assert_not_same posts.inspect, posts.load.inspect
+  end
+
+  def test_reload_invalidates_inspect_memoization
+    posts = authors(:david).posts.load
+    assert_predicate posts, :loaded?
+    assert_not_same posts.inspect, posts.reload.inspect
+  end
+
   def test_save_on_parent_saves_children
     developer = Developer.create name: "Bryan", salary: 50_000
     assert_equal 1, developer.reload.audit_logs.size

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -602,6 +602,31 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal car.bulbs.includes(:car), car.bulbs, "AssociationRelation should be comparable with CollectionProxy"
   end
 
+  def test_inspect_memoization
+    car = Car.create!
+    car.bulbs.build
+    car.save
+
+    relation = Bulb.where(car_id: car.id)
+    collection_proxy = car.bulbs
+    association_relation = car.bulbs.includes(:car)
+
+    assert_match(/::Relation/, relation.inspect, "Relation should have class name in inspect")
+    assert_same relation.inspect, relation.inspect, "Relation should memoize inspect"
+    assert_not_same relation.inspect, relation.reset.inspect, "Relation reset should invalidate inspect"
+    assert_not_same relation.inspect, relation.load.inspect, "Relation load should invalidate inspect"
+
+    assert_match(/::CollectionProxy/, collection_proxy.inspect, "CollectionProxy should have class name in inspect")
+    assert_same collection_proxy.inspect, collection_proxy.inspect, "CollectionProxy should memoize inspect"
+    assert_not_same collection_proxy.inspect, collection_proxy.reset.inspect, "CollectionProxy reset should invalidate inspect"
+    assert_not_same collection_proxy.inspect, collection_proxy.load.inspect, "CollectionProxy load should invalidate inspect"
+
+    assert_match(/::AssociationRelation/, association_relation.inspect, "AssociationRelation should have class name in inspect")
+    assert_same association_relation.inspect, association_relation.inspect, "AssociationRelation should memoize inspect"
+    assert_not_same association_relation.inspect, association_relation.reset.inspect, "AssociationRelation reset should invalidate inspect"
+    assert_not_same association_relation.inspect, association_relation.load.inspect, "AssociationRelation load should invalidate inspect"
+  end
+
   def test_hashing
     assert_equal [ Topic.find(1) ], [ Topic.find(2).topic ] & [ Topic.find(1) ]
   end


### PR DESCRIPTION
### Summary

This adds memoization to `ActiveRecord::Relation#inspect`.

The following methods invalidate the cached `@inspect` text:

* `ActiveRecord::Relation#reset`
* `ActiveRecord::Relation#load` (unless already loaded)
* `ActiveRecord::Associations::CollectionProxy#reset_scope`

### Other Information

The memoization avoids excessive database queries when unloaded relations are inspected.

This commonly happens if there are lazy loaded relations assigned to instance variables in a controller and an exception occurs, causing many inspect calls per instance variable in the exception handlers.

Here are some metrics on how often controller instance variables are inspected when an exception occurs in development:

* 4x with the default middleware stack
* 7x with meta-request active
* 2 x 33x with better_errors active (and additional times when navigating the stack)

Another area were this helps is when working with IRB in the rails console, because every return statement is inspected automatically by IRB.