### PR TITLE
Add config.action_view.image_loading

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -21,6 +21,8 @@ module ActionView
       include AssetUrlHelper
       include TagHelper
 
+      mattr_accessor :image_loading
+
       # Returns an HTML script tag for each of the +sources+ provided.
       #
       # Sources may be paths to JavaScript files. Relative paths are assumed to be relative
@@ -365,6 +367,9 @@ module ActionView
         end
 
         options[:width], options[:height] = extract_dimensions(options.delete(:size)) if options[:size]
+
+        options[:loading] ||= image_loading if image_loading
+
         tag("img", options)
       end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -10,6 +10,7 @@ module ActionView
     config.action_view.embed_authenticity_token_in_remote_forms = nil
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
+    config.action_view.image_loading = nil
 
     config.eager_load_namespaces << ActionView
 
@@ -35,6 +36,10 @@ module ActionView
       unless default_enforce_utf8.nil?
         ActionView::Helpers::FormTagHelper.default_enforce_utf8 = default_enforce_utf8
       end
+    end
+
+    config.after_initialize do |app|
+      ActionView::Helpers::AssetTagHelper.image_loading = app.config.action_view.delete(:image_loading)
     end
 
     config.after_initialize do |app|

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -569,6 +569,16 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal("Cannot pass a :size option with a :height or :width option", exception.message)
   end
 
+  def test_image_tag_loading_attribute_default_value
+    original_image_loading = ActionView::Helpers::AssetTagHelper.image_loading
+    ActionView::Helpers::AssetTagHelper.image_loading = "lazy"
+
+    assert_dom_equal %(<img src="" loading="lazy" />), image_tag("")
+    assert_dom_equal %(<img src="" loading="eager" />), image_tag("", loading: "eager")
+  ensure
+    ActionView::Helpers::AssetTagHelper.image_loading = original_image_loading
+  end
+
   def test_favicon_link_tag
     FaviconLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -706,6 +706,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.default_enforce_utf8` determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8. This defaults to `false`.
 
+* `config.action_view.image_loading` specifies a default value for the `loading` attribute of `<img>` tags rendered by the `image_tag` helper. For example, when set to `"lazy"`, `<img>` tags rendered by `image_tag` will include `loading="lazy"`, which [instructs the browser to wait until an image is near the viewport to load it](https://html.spec.whatwg.org/#lazy-loading-attributes). (This value can still be overridden per image by passing e.g. `loading: "eager"` to `image_tag`.) Defaults to `nil`.
+
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
 ### Configuring Action Mailbox

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2322,6 +2322,23 @@ module ApplicationTests
       assert_equal true, ActionView::Helpers::FormTagHelper.default_enforce_utf8
     end
 
+    test "ActionView::Helpers::AssetTagHelper.image_loading is nil by default" do
+      app "development"
+      assert_nil ActionView::Helpers::AssetTagHelper.image_loading
+    end
+
+    test "ActionView::Helpers::AssetTagHelper.image_loading can be configured via config.action_view.image_loading" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_view.image_loading = "lazy"
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal "lazy", ActionView::Helpers::AssetTagHelper.image_loading
+    end
+
     test "raises when unknown configuration option is set for ActiveJob" do
       add_to_config <<-RUBY
         config.active_job.unknown = "test"


### PR DESCRIPTION
Browser native support for lazy loading images is [now a part of the official HTML standard](https://github.com/whatwg/html/pull/3752).  To indicate to the browser that an image should be lazily loaded, add the `loading="lazy"` attribute to the `img` tag.  Or, in Rails parlance, add the `loading: "lazy"` option to the `image_tag` call.

This commit adds `Rails.application.config.action_view.image_loading` to configure the default value of the `image_tag` `:loading` option.  Thus by setting `config.action_view.image_loading = "lazy"`, an application can opt in to lazy loading images sitewide, without changing view code.

---

Currently only Chrome and Edge support `loading="lazy"` ([reference](https://caniuse.com/#feat=loading-lazy-attr)), but [Firefox 75 will support it](https://bugzilla.mozilla.org/show_bug.cgi?id=1542784), and [Safari will soon](https://bugs.webkit.org/show_bug.cgi?id=196698).

**TODO**
- [x] documentation
- [x] additional tests for the Railtie code
