### PR TITLE
Output ActiveRecord log only when in the console:

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -57,10 +57,12 @@ module ActiveRecord
     console do |app|
       require "active_record/railties/console_sandbox" if app.sandbox?
       require "active_record/base"
-      unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
+      unless ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDERR, STDOUT)
+        logger = ActiveRecord::Base.logger
+        ActiveRecord::Base.logger = logger.dup
         console = ActiveSupport::Logger.new(STDERR)
         console.level = Rails.logger.level
-        Rails.logger.extend ActiveSupport::Logger.broadcast console
+        ActiveRecord::Base.logger.extend ActiveSupport::Logger.broadcast console
       end
       ActiveRecord::Base.verbose_query_logs = false
     end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -174,4 +174,11 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "puts Rails.env", "puts Rails.env\r\ntest"
     @primary.puts "quit"
   end
+
+  def test_logger_dont_output_on_stdout
+    spawn_console(nil)
+
+    write_prompt("Rails.logger.info('hello')", "\r\n=> 6")
+    write_prompt("ActiveRecord::Base.logger.info('hello')", "\r\nhello\r\n=> 6")
+  end
 end


### PR DESCRIPTION
Output ActiveRecord log only when in the console:

- ActiveRecord railtie modify the main Rails logger and will broadcast
  any logs to STDOUT.

  I think this behaviour is quite surprising and having log on STDOUT
  clutters the terminal.
  The original intention was to output ActiveRecord related logs
  to STDOUT, not all logs https://github.com/rails/rails/commit/b9bba555caa

  I'm restoring this behaviour in this PR which was removed in https://github.com/rails/rails/commit/983bf6d456d29bfb9c8b497991e65682ca4d1ce4

  Fix #38284

