### PR TITLE
Remove unused event_object_subscriber method

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -104,10 +104,6 @@ module ActiveSupport
           wrap_all pattern, subscriber_class.new(pattern, listener)
         end
 
-        def self.event_object_subscriber(pattern, block)
-          wrap_all pattern, EventObject.new(pattern, block)
-        end
-
         def self.wrap_all(pattern, subscriber)
           unless pattern
             AllMessages.new(subscriber)


### PR DESCRIPTION
This was added in https://github.com/rails/rails/pull/33451, but was never used.