### PR TITLE
Prepend class methods of prepended concerns

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -14,9 +14,10 @@
           prepend Imposter
         end
 
-    Concerning is also updated: `concerning :Imposter, prepend: true do`
+    Class methods are prepended to the base class, concerning is also 
+    updated: `concerning :Imposter, prepend: true do`.
 
-    *Jason Karns*
+    *Jason Karns, Elia Schito*
 
 *   Deprecate using `Range#include?` method to check the inclusion of a value
     in a date time range. It is recommended to use `Range#cover?` method

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -104,7 +104,7 @@ module ActiveSupport
   #
   # Just like `include`, concerns also support `prepend` with a corresponding
   # `prepended do` callback. `module ClassMethods` or `class_methods do` are
-  # still extended.
+  # prepended as well.
   #
   # `prepend` is also used for any dependencies.
   module Concern
@@ -145,7 +145,7 @@ module ActiveSupport
         return false if base < self
         @_dependencies.each { |dep| base.prepend(dep) }
         super
-        base.extend const_get(:ClassMethods) if const_defined?(:ClassMethods)
+        base.singleton_class.prepend const_get(:ClassMethods) if const_defined?(:ClassMethods)
         base.class_eval(&@_prepended_block) if instance_variable_defined?(:@_prepended_block)
       end
     end

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -194,4 +194,34 @@ class ConcernTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_prepended_and_included_methods
+    included = Module.new.extend(ActiveSupport::Concern)
+    prepended = Module.new.extend(ActiveSupport::Concern)
+
+    @klass.class_eval { def initialize; @foo = []; end }
+    included.module_eval { def foo; @foo << :included; end }
+    @klass.class_eval { def foo; super; @foo << :class; end }
+    prepended.module_eval { def foo; super; @foo << :prepended; end }
+
+    @klass.include included
+    @klass.prepend prepended
+
+    assert_equal @klass.new.foo, [:included, :class, :prepended]
+  end
+
+  def test_prepended_and_included_class_methods
+    included = Module.new.extend(ActiveSupport::Concern)
+    prepended = Module.new.extend(ActiveSupport::Concern)
+
+    @klass.class_eval { @foo = [] }
+    included.class_methods { def foo; @foo << :included; end }
+    @klass.class_eval { def self.foo; super; @foo << :class; end }
+    prepended.class_methods { def foo; super; @foo << :prepended; end }
+
+    @klass.include included
+    @klass.prepend prepended
+
+    assert_equal @klass.foo, [:included, :class, :prepended]
+  end
 end


### PR DESCRIPTION
### Summary

Fixes rails/rails#38439 by prepending class methods with `singleton_class.prepend ClassMethods` when prepending the concern.
