### PR TITLE
Fix `rails new --dev`

### DIFF
--- a/railties/lib/rails/commands/generate/generate_command.rb
+++ b/railties/lib/rails/commands/generate/generate_command.rb
@@ -21,7 +21,7 @@ module Rails
         require_application_and_environment!
         load_generators
 
-        ARGV.shift
+        ARGV.replace(args) # set up ARGV for third-party libraries
 
         Rails::Generators.invoke generator, args, behavior: :invoke, destination_root: Rails::Command.root
       end

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -12,10 +12,10 @@ module Rails
           formatted_rake_tasks.map(&:first)
         end
 
-        def perform(task, *)
+        def perform(task, args, config)
           require_rake
 
-          ARGV.unshift(task) # Prepend the task, so Rake knows how to run it.
+          ARGV.replace([task, *args]) # set up ARGV for Rake
 
           Rake.application.standard_exception_handling do
             Rake.application.init("rails")

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/string/strip"
 
 module Rails


### PR DESCRIPTION
Follow-up to #38429.

`Rails::Command.invoke` passes arguments through to the appropriate command class.  However, some command classes were ignoring those arguments, and instead relying on the contents of `ARGV`.  In particular, `RakeCommand` expected `ARGV` to contain the arguments necessary to the Rake task, and no other arguments.  This caused the `webpacker:install` task to fail when the `--dev` option from `rails new --dev` remained in `ARGV`.

This commit changes the relevant command classes to not rely on the previous contents of `ARGV`.  This commit also adds a missing `require` for use of `Kernel#silence_warnings`.

Fixes #38459.