### PR TITLE
Reduce allocation in expand cache key

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -78,7 +78,7 @@ module ActiveSupport
       #
       # The +key+ argument can also respond to +cache_key+ or +to_param+.
       def expand_cache_key(key, namespace = nil)
-        expanded_cache_key = (namespace ? "#{namespace}/" : "").dup
+        expanded_cache_key = namespace ? +"#{namespace}/" : +""
 
         if prefix = ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]
           expanded_cache_key << "#{prefix}/"


### PR DESCRIPTION
### Summary

Reduce an extra allocation from expand_cache_key. The `dup` had been added to make the code compatible with `frozen_string_literal`. Please find a benchmark of memory and IPS below.

Additionally, I also explored a different implementation ("Alternative style"). I'm not sure if the format would be desired, but both the savings in allocations and the improvement in IPS are better in that implementation. Please let me know your thoughts about it.

#### Alternative style
```ruby
def expand_cache_key(key, namespace = nil)
  prefix = ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]

  if namespace && prefix
    "#{namespace}/#{prefix}/#{retrieve_cache_key(key)}"
  elsif namespace
    "#{namespace}/#{retrieve_cache_key(key)}"
  elsif prefix
    "#{prefix}/#{retrieve_cache_key(key)}"
  else
    retrieve_cache_key(key)
  end
end
```

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActiveSupport
  module Cache
    class << self
      def fast_expand_cache_key(key, namespace = nil)
        expanded_cache_key = namespace ? +"#{namespace}/" : +""

        if prefix = ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]
          expanded_cache_key << "#{prefix}/"
        end

        expanded_cache_key << retrieve_cache_key(key)
        expanded_cache_key
      end
    end
  end
end

SCENARIOS = {
  "No namespace"     => nil,
  "With namespace"   => "some_namespace",
  "With namespace and app version" => "app_version_namespace",
}

puts " MEMORY ".center(80, "*")

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  ENV["RAILS_APP_VERSION"] = "123123" if value == "app_version_namespace"

  Benchmark.memory do |x|
    x.report("expand_cache_key")      { ActiveSupport::Cache.expand_cache_key("some_key", value) }
    x.report("fast_expand_cache_key") { ActiveSupport::Cache.fast_expand_cache_key("some_key", value) }
    x.compare!
  end
end

puts " IPS ".center(80, "*")

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  ENV["RAILS_APP_VERSION"] = "123123" if value == "app_version_namespace"

  Benchmark.ips do |x|
    x.report("expand_cache_key")      { ActiveSupport::Cache.expand_cache_key("some_key", value) }
    x.report("fast_expand_cache_key") { ActiveSupport::Cache.fast_expand_cache_key("some_key", value) }
    x.compare!
  end
end
```
#### Results
```
************************************ MEMORY ************************************

================================= No namespace =================================

Calculating -------------------------------------
    expand_cache_key    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
fast_expand_cache_key
                        40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
    expand_cache_key:         40 allocated
fast_expand_cache_key:         40 allocated - same

================================ With namespace ================================

Calculating -------------------------------------
    expand_cache_key    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
fast_expand_cache_key
                        40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
fast_expand_cache_key:         40 allocated
    expand_cache_key:         80 allocated - 2.00x more

======================== With namespace and app version ========================

Calculating -------------------------------------
    expand_cache_key   208.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
fast_expand_cache_key
                       168.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)

Comparison:
fast_expand_cache_key:        168 allocated
    expand_cache_key:        208 allocated - 1.24x more
************************************* IPS **************************************

================================= No namespace =================================

Warming up --------------------------------------
    expand_cache_key    80.467k i/100ms
fast_expand_cache_key
                        88.450k i/100ms
Calculating -------------------------------------
    expand_cache_key    993.207k (± 2.7%) i/s -      4.989M in   5.026945s
fast_expand_cache_key
                          1.133M (± 3.5%) i/s -      5.661M in   5.001279s

Comparison:
fast_expand_cache_key:  1133374.3 i/s
    expand_cache_key:   993207.0 i/s - 1.14x  slower


================================ With namespace ================================

Warming up --------------------------------------
    expand_cache_key    68.268k i/100ms
fast_expand_cache_key
                        75.423k i/100ms
Calculating -------------------------------------
    expand_cache_key    798.816k (± 3.5%) i/s -      4.028M in   5.048077s
fast_expand_cache_key
                        885.889k (± 4.2%) i/s -      4.450M in   5.031918s

Comparison:
fast_expand_cache_key:   885888.8 i/s
    expand_cache_key:   798816.0 i/s - 1.11x  slower


======================== With namespace and app version ========================

Warming up --------------------------------------
    expand_cache_key    68.795k i/100ms
fast_expand_cache_key
                        74.627k i/100ms
Calculating -------------------------------------
    expand_cache_key    796.087k (± 3.2%) i/s -      3.990M in   5.017142s
fast_expand_cache_key
                        873.615k (± 4.4%) i/s -      4.403M in   5.049635s

Comparison:
fast_expand_cache_key:   873614.7 i/s
    expand_cache_key:   796086.8 i/s - 1.10x  slower
```