### PR TITLE
Update examples's Migration versions to 6.0

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -140,7 +140,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
 
 * Database agnostic schema management with Migrations.
 
-    class AddSystemSettings < ActiveRecord::Migration[5.0]
+    class AddSystemSettings < ActiveRecord::Migration[6.0]
       def up
         create_table :system_settings do |t|
           t.string  :name

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1675,7 +1675,7 @@ module ActiveRecord
         # The join table should not have a primary key or a model associated with it. You must manually generate the
         # join table with a migration such as this:
         #
-        #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[5.0]
+        #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[6.0]
         #     def change
         #       create_join_table :developers, :projects
         #     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -242,7 +242,7 @@ module ActiveRecord
     # Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
     # is actually of this type:
     #
-    #   class SomeMigration < ActiveRecord::Migration[5.0]
+    #   class SomeMigration < ActiveRecord::Migration[6.0]
     #     def up
     #       create_table :foo do |t|
     #         puts t.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -19,7 +19,7 @@ module ActiveRecord
   # For example the following migration is not reversible.
   # Rolling back this migration will raise an ActiveRecord::IrreversibleMigration error.
   #
-  #   class IrreversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #   class IrreversibleMigrationExample < ActiveRecord::Migration[6.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -37,7 +37,7 @@ module ActiveRecord
   #
   # 1. Define <tt>#up</tt> and <tt>#down</tt> methods instead of <tt>#change</tt>:
   #
-  #  class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #  class ReversibleMigrationExample < ActiveRecord::Migration[6.0]
   #    def up
   #      create_table :distributors do |t|
   #        t.string :zipcode
@@ -62,7 +62,7 @@ module ActiveRecord
   #
   # 2. Use the #reversible method in <tt>#change</tt> method:
   #
-  #   class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #   class ReversibleMigrationExample < ActiveRecord::Migration[6.0]
   #     def change
   #       create_table :distributors do |t|
   #         t.string :zipcode
@@ -202,7 +202,7 @@ module ActiveRecord
   #
   # Example of a simple migration:
   #
-  #   class AddSsl < ActiveRecord::Migration[5.0]
+  #   class AddSsl < ActiveRecord::Migration[6.0]
   #     def up
   #       add_column :accounts, :ssl_enabled, :boolean, default: true
   #     end
@@ -222,7 +222,7 @@ module ActiveRecord
   #
   # Example of a more complex migration that also needs to initialize data:
   #
-  #   class AddSystemSettings < ActiveRecord::Migration[5.0]
+  #   class AddSystemSettings < ActiveRecord::Migration[6.0]
   #     def up
   #       create_table :system_settings do |t|
   #         t.string  :name
@@ -350,7 +350,7 @@ module ActiveRecord
   #   bin/rails generate migration add_fieldname_to_tablename fieldname:string
   #
   # This will generate the file <tt>timestamp_add_fieldname_to_tablename.rb</tt>, which will look like this:
-  #   class AddFieldnameToTablename < ActiveRecord::Migration[5.0]
+  #   class AddFieldnameToTablename < ActiveRecord::Migration[6.0]
   #     def change
   #       add_column :tablenames, :fieldname, :string
   #     end
@@ -381,7 +381,7 @@ module ActiveRecord
   #
   # Not all migrations change the schema. Some just fix the data:
   #
-  #   class RemoveEmptyTags < ActiveRecord::Migration[5.0]
+  #   class RemoveEmptyTags < ActiveRecord::Migration[6.0]
   #     def up
   #       Tag.all.each { |tag| tag.destroy if tag.pages.empty? }
   #     end
@@ -394,7 +394,7 @@ module ActiveRecord
   #
   # Others remove columns when they migrate up instead of down:
   #
-  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[5.0]
+  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[6.0]
   #     def up
   #       remove_column :items, :incomplete_items_count
   #       remove_column :items, :completed_items_count
@@ -408,7 +408,7 @@ module ActiveRecord
   #
   # And sometimes you need to do something in SQL not abstracted directly by migrations:
   #
-  #   class MakeJoinUnique < ActiveRecord::Migration[5.0]
+  #   class MakeJoinUnique < ActiveRecord::Migration[6.0]
   #     def up
   #       execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
   #     end
@@ -425,7 +425,7 @@ module ActiveRecord
   # <tt>Base#reset_column_information</tt> in order to ensure that the model has the
   # latest column data from after the new column was added. Example:
   #
-  #   class AddPeopleSalary < ActiveRecord::Migration[5.0]
+  #   class AddPeopleSalary < ActiveRecord::Migration[6.0]
   #     def up
   #       add_column :people, :salary, :integer
   #       Person.reset_column_information
@@ -483,7 +483,7 @@ module ActiveRecord
   # To define a reversible migration, define the +change+ method in your
   # migration like this:
   #
-  #   class TenderloveMigration < ActiveRecord::Migration[5.0]
+  #   class TenderloveMigration < ActiveRecord::Migration[6.0]
   #     def change
   #       create_table(:horses) do |t|
   #         t.column :content, :text
@@ -513,7 +513,7 @@ module ActiveRecord
   # can't execute inside a transaction though, and for these situations
   # you can turn the automatic transactions off.
   #
-  #   class ChangeEnum < ActiveRecord::Migration[5.0]
+  #   class ChangeEnum < ActiveRecord::Migration[6.0]
   #     disable_ddl_transaction!
   #
   #     def up
@@ -674,7 +674,7 @@ module ActiveRecord
     # and create the table 'apples' on the way up, and the reverse
     # on the way down.
     #
-    #   class FixTLMigration < ActiveRecord::Migration[5.0]
+    #   class FixTLMigration < ActiveRecord::Migration[6.0]
     #     def change
     #       revert do
     #         create_table(:horses) do |t|
@@ -693,7 +693,7 @@ module ActiveRecord
     #
     #   require_relative '20121212123456_tenderlove_migration'
     #
-    #   class FixupTLMigration < ActiveRecord::Migration[5.0]
+    #   class FixupTLMigration < ActiveRecord::Migration[6.0]
     #     def change
     #       revert TenderloveMigration
     #
@@ -744,7 +744,7 @@ module ActiveRecord
     # when the three columns 'first_name', 'last_name' and 'full_name' exist,
     # even when migrating down:
     #
-    #    class SplitNameMigration < ActiveRecord::Migration[5.0]
+    #    class SplitNameMigration < ActiveRecord::Migration[6.0]
     #      def change
     #        add_column :users, :first_name, :string
     #        add_column :users, :last_name, :string
@@ -772,7 +772,7 @@ module ActiveRecord
     # In the following example, the new column +published+ will be given
     # the value +true+ for all existing records.
     #
-    #    class AddPublishedToPosts < ActiveRecord::Migration[5.2]
+    #    class AddPublishedToPosts < ActiveRecord::Migration[6.0]
     #      def change
     #        add_column :posts, :published, :boolean, default: false
     #        up_only do

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -426,7 +426,7 @@ module ActiveRecord
       # when just after creating a table you want to populate it with some default
       # values, eg:
       #
-      #  class CreateJobLevels < ActiveRecord::Migration[5.0]
+      #  class CreateJobLevels < ActiveRecord::Migration[6.0]
       #    def up
       #      create_table :job_levels do |t|
       #        t.integer :id


### PR DESCRIPTION
Update the Migration versions to 6.0 in the commented examples in order to ensure consistency with the documentation and current Migration version.

### Summary

The commented examples Migration versions were updated from 5.0 or 5.2 to the latest 6.0. This change:

- [x]  Ensures consistency with the official documentation where all the Migration versions are updated to 6.0 as discussed here: #38297 and here: #38311.

- [x] Updates the official API document found [here](https://api.rubyonrails.org/classes/ActiveRecord/Migration.html).

### Other Information

Thank you, please let me know your comments.

Kind regards from Colombia,

[David Auza](https://github.com/davidauza-engineer)
