### PR TITLE
Fix ConfigurationFile check for non-breaking space

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -32,7 +32,7 @@ module ActiveSupport
         require "erb"
 
         File.read(content_path).tap do |content|
-          if content.match?(/\U+A0/)
+          if content.include?("\u00A0")
             warn "File contains invisible non-breaking spaces, you may want to remove those"
           end
         end


### PR DESCRIPTION
The regular expression used to check for non-breaking spaces is invalid, but [prints a warning](https://buildkite.com/rails/rails/builds/67015#dcbb4da1-375e-4122-8797-638923e73dbc/1019-1025) (`"Unknown escape \U is ignored: /\U+A0/"`) instead of raising an error.

This commit fixes the check (and the warning).
