### PR TITLE
Improve documentation for :foreign_key option in migrations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -894,6 +894,8 @@ module ActiveRecord
       #   See #add_index for usage of this option.
       # [<tt>:foreign_key</tt>]
       #   Add an appropriate foreign key constraint. Defaults to false.
+      #   If the association name doesn't correspond to the joined table name,
+      #   specify Hash with <tt>to_table:</tt> key points to that table name.
       # [<tt>:polymorphic</tt>]
       #   Whether an additional +_type+ column should be added. Defaults to false.
       # [<tt>:null</tt>]


### PR DESCRIPTION
### Summary

Improve documentation for `foreign_key` option of `#add_reference` method in migrations.

### Other information

A [backstory](https://railsguides.net/foreign-key-for-custom-table-name/).
