### PR TITLE
Delete .ruby-version in generated plugin dummy app

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -127,6 +127,7 @@ task default: :test
 
     def test_dummy_clean
       inside dummy_path do
+        remove_file ".ruby-version"
         remove_file "db/seeds.rb"
         remove_file "Gemfile"
         remove_file "lib/tasks"

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -482,6 +482,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_unnecessary_files_are_not_generated_in_dummy_application
     run_generator
     assert_no_file "test/dummy/.gitignore"
+    assert_no_file "test/dummy/.ruby-version"
     assert_no_file "test/dummy/db/seeds.rb"
     assert_no_file "test/dummy/Gemfile"
     assert_no_file "test/dummy/public/robots.txt"


### PR DESCRIPTION
A `.ruby-version` file is not useful in a plugin dummy app because the plugin itself dictates the required Ruby version.  Indeed, the dummy app `.ruby-version` file might fall out of sync with whatever the plugin dictates, and thus result in unexpected "Could not find gem" errors when running commands from within the dummy app directory.
