### PR TITLE
Copy argument in AttributeAssignment#attributes=

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -10,6 +10,8 @@ module ActiveRecord
       super(attributes.dup)
     end
 
+    alias attributes= assign_attributes
+
     private
       def _assign_attributes(attributes)
         multi_parameter_attributes  = {}

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -279,14 +279,16 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   test "hashes are not mangled" do
-    new_topic = { title: "New Topic" }
-    new_topic_values = { title: "AnotherTopic" }
+    new_topic = { title: "New Topic", content: { key: "First value" } }
+    new_topic_values = { title: "AnotherTopic", content: { key: "Second value" } }
 
     topic = Topic.new(new_topic)
     assert_equal new_topic[:title], topic.title
+    assert_equal new_topic[:content], topic.content
 
     topic.attributes = new_topic_values
     assert_equal new_topic_values[:title], topic.title
+    assert_equal new_topic_values[:content], topic.content
   end
 
   test "create through factory" do


### PR DESCRIPTION
Before https://github.com/rails/rails/pull/38401, `assign_attributes` and `attributes=` were both defined in Active Model and both made a copy of their argument. Now `assign_attributes` is overridden in Active Record and the copy happens there instead, but `attributes=` isn't overridden.

This meant that assigning nested or multi-parameters via `attributes=` would mutate the argument, which the copying was meant to prevent.