### PR TITLE
Callbacks conditionals and Symbol#to_proc syntax

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -457,6 +457,8 @@ module ActiveSupport
               new(nil, :instance_exec, [:target, :block], filter)
             elsif filter.arity > 0
               new(nil, :instance_exec, [:target], filter)
+            elsif filter.arity == -1 && filter.to_s.match?(%r{(&:[a-zA-Z]\w+)})
+              new(nil, :instance_exec, [:target], filter)
             else
               new(nil, :instance_exec, [], filter)
             end

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -1193,4 +1193,19 @@ module CallbacksTest
       end
     end
   end
+
+  class ToProcConditionalTest < ActiveSupport::TestCase
+    class ToProcConditional < Record
+      before_save :skipped, if: Proc.new(&:skip?)
+
+      def skipped; end
+      def skip?; true; end
+    end
+
+    def test_to_proc_conditional
+      assert_nothing_raised do
+        ToProcConditional.new.run_callbacks(:save) { }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Callback creation checks arity to determine which kind of conditional to build. In the case of a normal block that accepts one argument, as in:

```
Proc.new { |record| record.errors }
```

you end up with arity 1. But in case you convert that into using Symbol#to_proc syntax, as in:

```
Proc.new(&:errors)
```

you end up with arity -1. This will fail with an error of no receiver given, because it thinks a block was passed to the callback. Effectively, these two should amount to the same thing, but because of the nature of the metaprogramming happening here, we end up with an error.

There are a couple of ways to determine whether or not a Proc is using this kind of syntax, but the easiest way it to just check Proc#to_s and match against a regex. Other options include:

* using the `source_location` method to determine the original place of the block creation and parsing the source using something from `RubyVM`
* calling the Proc with different numbers of arguments and rescuing to determine the correct number

The Proc#to_s feels like the simplest solution of these 3.