### PR TITLE
Introduce `#as_tags`, a generalisation of the class_names helper

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/as_tags"
 require "active_support/core_ext/string/output_safety"
 require "set"
 
@@ -94,7 +95,7 @@ module ActionView
         def tag_option(key, value, escape)
           case value
           when Array, Hash
-            value = TagHelper.build_tag_values(value) if key.to_s == "class"
+            value = value.as_tags if key.to_s == "class"
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
@@ -300,7 +301,7 @@ module ActionView
       #   class_names(nil, false, 123, "", "foo", { bar: true })
       #    # => "123 foo bar"
       def class_names(*args)
-        safe_join(build_tag_values(*args), " ")
+        safe_join(args.as_tags, " ")
       end
 
       # Returns a CDATA section with the given +content+. CDATA sections
@@ -333,26 +334,6 @@ module ActionView
       end
 
       private
-        def build_tag_values(*args)
-          tag_values = []
-
-          args.each do |tag_value|
-            case tag_value
-            when Hash
-              tag_value.each do |key, val|
-                tag_values << key.to_s if val && key.present?
-              end
-            when Array
-              tag_values.concat build_tag_values(*tag_value)
-            else
-              tag_values << tag_value.to_s if tag_value.present?
-            end
-          end
-
-          tag_values
-        end
-        module_function :build_tag_values
-
         def tag_builder
           @tag_builder ||= TagBuilder.new(self)
         end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Introduce `Object#as_tags`, as a generalisation of the `class_names`
+    view helper.
+
+    Converts data structures to an array of nonblank strings, useful for
+    generating tag-like lists with expressive optionality:
+
+    ```ruby
+    [
+      "shipment",
+      overdue: delivery_date.past?,
+      international: origin.country != destination.country,
+      priority: customer.vip?
+    ].as_tags
+    # => ["shipment", "overdue", "priority"]
+    ```
+
+    *Josh Goodall*
+
 *   Support `prepend` with `ActiveSupport::Concern`.
 
     Allows a module with `extend ActiveSupport::Concern` to be prepended.

--- a/activesupport/lib/active_support/core_ext/object/as_tags.rb
+++ b/activesupport/lib/active_support/core_ext/object/as_tags.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/blank"
+
+class Object
+  # +as_tags+ accumulates and returns a flat array of nonblank strings representing
+  # an object.
+  #
+  # When called on an +Enumerable+, each element has +as_tags+ called in turn. When
+  # called on a +Hash+, keys for truthy values will append their tags, leading to an
+  # expressive optionality.
+  #
+  # +nil+, +false+, and blank strings, will not append themselves to the accumulator.
+  #
+  # ==== Examples
+  #
+  #  [:red, nil, [false, "bold", 123]].as_tags
+  #  # => ["red", "bold", "123"]
+  #
+  #  {
+  #    overdue: delivery_date.past?,
+  #    international: origin.country != destination.country,
+  #    priority: customer.vip?
+  #  }.as_tags
+  #  # => ["overdue", "priority"]
+  #
+  # The {tag and class_names helpers}[rdoc-ref:ActionView::Helpers::TagHelper] are both implemented using +as_tags+:
+  #
+  #  tag.button "Resolve", class: [
+  #    "font-bold", "py-2", "px-4", "rounded",
+  #    %w(bg-red-500 text-white) => model.alert_state?,
+  #    %w(bg-blue-500 text-white) => model.normal_state?,
+  #    %w(opacity-50 cursor-not-allowed) => model.readonly?
+  #  ]
+  #  # => '<button class="font-bold py-2 px-4 rounded bg-red-500 text-white">Resolve</button>'
+  #
+  # ==== Extending
+  #
+  # Any object may implement +as_tags+.  This is ideally in terms of delegating +as_tags+ in
+  # turn to collaborators:
+  #
+  #  class Topic < ApplicationRecord
+  #    has_and_belongs_to_many :articles
+  #    delegate :as_tags, to: :name
+  #  end
+  #
+  #  class Article < ApplicationRecord
+  #    has_and_belongs_to_many :topics
+  #    delegate :as_tags, to: :tag_sources
+  #
+  #    private
+  #      def tag_sources
+  #        [model_name.singular, topics]
+  #      end
+  #  end
+  #
+  #  @article.as_tags # => ["article", "programming", "ruby", "rails"]
+  #
+  # You may also write the method directly, in which case be sure to respect the method
+  # signature and invocation style:
+  #
+  #  class WarningStyle
+  #    def as_tags(tags = [])
+  #      %w(red bold).as_tags(tags)
+  #    end
+  #  end
+  #
+  #  tag.p "Warning", class: [:alert, WarningStyle.new] # => '<p class="alert red bold">Warning</p>'
+  #
+  # The result of passing or instantiating an accumulator other than an +Array+,
+  # returning any object other than the accumulator array, or self-referential invocation,
+  # is undefined.
+  #
+  def as_tags(tags = [])
+    to_s.as_tags(tags)
+  end
+end
+
+class String
+  # Append +self+ to tags accumulator unless blank.
+  def as_tags(tags = [])
+    present? ? tags << self : tags
+  end
+end
+
+class FalseClass
+  # Returns the +tags+ accumulator unmodified.
+  def as_tags(tags = [])
+    tags
+  end
+end
+
+class NilClass
+  # Returns the +tags+ accumulator unmodified.
+  def as_tags(tags = [])
+    tags
+  end
+end
+
+class Hash
+  # Returns the +tags+ accumulator with tags appended for every key with a truthy value.
+  def as_tags(tags = [])
+    each_pair do |key, value|
+      key.as_tags(tags) if value
+    end
+    tags
+  end
+end
+
+module Enumerable
+  # Accumulate the result of calling +as_tags+ over each element.
+  def as_tags(tags = [])
+    each_with_object(tags, &:as_tags)
+  end
+end

--- a/activesupport/lib/active_support/core_ext/object/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/object/conversions.rb
@@ -2,5 +2,6 @@
 
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/to_query"
+require "active_support/core_ext/object/as_tags"
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/hash/conversions"

--- a/activesupport/test/core_ext/object/as_tags_test.rb
+++ b/activesupport/test/core_ext/object/as_tags_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/object/as_tags"
+
+class AsTagsTest < ActiveSupport::TestCase
+  def test_empty_string
+    assert_equal [], "".as_tags
+  end
+
+  def test_empty_array
+    assert_equal [], [].as_tags
+  end
+
+  def test_false
+    assert_equal [], false.as_tags
+  end
+
+  def test_nil
+    assert_equal [], nil.as_tags
+  end
+
+  def test_string
+    assert_equal ["bold"], "bold".as_tags
+  end
+
+  def test_symbol
+    assert_equal ["bold"], :bold.as_tags
+  end
+
+  def test_simple_array
+    assert_equal ["bold", "123", "red"], [:bold, false, nil, "", 123, "red"].as_tags
+  end
+
+  def test_simple_hash
+    assert_equal ["bold", "red"], { bold: true, green: false, red: true, false => true }.as_tags
+  end
+
+  def test_array_with_options_hash
+    assert_equal ["bold", "red"], [:bold, { red: true, green: false }].as_tags
+  end
+
+  def test_array_key
+    assert_equal ["bold", "red"], { ["bold", "red"] => true }.as_tags
+  end
+
+  def test_varied
+    is_good = false
+    is_emergency = true
+
+    assert_equal ["alert", "red", "bold", "flashing"], arguments_to_tags(
+      "alert",
+      "",
+      [false, nil],
+      green: is_good,
+      red: !is_good,
+      [:bold, "flashing"] => is_emergency
+    )
+  end
+
+  private
+    def arguments_to_tags(*args)
+      args.as_tags
+    end
+end


### PR DESCRIPTION
### Summary

I was stoked to see `class_names` from #37872 and #37918, and realised I had another use for exactly that structural behaviour, particularly treating the hash values as boolean selectors for keys used as tag-like values.  (My use case is specifically an export to an external system from a job, not a view-layer activity)

At the same time, the implementation of `class_names`, being a switch on classes, triggered my inner OO purist.

So here is the refactoring of conversion-to-tags as a more general behaviour, with the tag builder & class_names helper as clients.

### Example

This is an only-very-slightly fictional example from my own code:

```ruby
[
  "shipment",
  overdue: delivery_date.past?,
  international: origin.country != destination.country,
  priority: customer.vip?
].as_tags
# => ["shipment", "overdue", "priority"]
```

### Discussion

_How is this different to `["red", ("overdue" if delivery_date.past?)]`_ ?

For one thing, it avoids the nils. The intention is that the `as_tags` interface always produces a flat array of nonblank strings.

However, more helpfully, it also handles nested items, including nested arrays and hashes. This is super relevant for utility-first CSS frameworks such as TailwindCSS, where multiple classes are composed together:

```ruby
tag.button class: [
  "font-bold", "py-2", "px-4", "rounded",
  %w(bg-red-500 text-white) => model.alert_state?,
  %w(bg-blue-500 text-white) => model.normal_state?,
  %w(opacity-50 cursor-not-allowed) => model.readonly?
]
```

Any object implementing as_tags can participate in this protocol, allowing deeper compositional options for those then needing to DRY things up even further.

