### PR TITLE
Include parallelize :threads option in template when fork not available

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -535,7 +535,7 @@ class ActiveSupport::TestCase
 end
 ```
 
-Rails applications generated from JRuby will automatically include the `with: :threads` option.
+Rails applications generated from JRuby or TruffleRuby will automatically include the `with: :threads` option.
 
 The number of workers passed to `parallelize` determines the number of threads the tests will use. You may
 want to parallelize your local test suite differently from your CI, so an environment variable is provided

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -4,10 +4,10 @@ require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-<% if defined?(JRUBY_VERSION) || Gem.win_platform? -%>
-  parallelize(workers: :number_of_processors, with: :threads)
-<%- else -%>
+<% if Process.respond_to?(:fork) && !Gem.win_platform? -%>
   parallelize(workers: :number_of_processors)
+<%- else -%>
+  parallelize(workers: :number_of_processors, with: :threads)
 <% end -%>
 
 <% unless options[:skip_active_record] -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -862,7 +862,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_spring_no_fork
     jruby_skip "spring doesn't run on JRuby"
-    assert_called_with(Process, :respond_to?, [[:fork], [:fork], [:fork]], returns: false) do
+    assert_called_with(Process, :respond_to?, [[:fork], [:fork], [:fork], [:fork]], returns: false) do
       run_generator
 
       assert_no_gem "spring"


### PR DESCRIPTION
### Summary
This PR updates the test template to use the `parallelize` `:threads` options when an app is generated with a Ruby implementation that does not support fork.

Also, the documentation was updated to reflect this change.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
