### PR TITLE
generator controller: Prevent create the same actions

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -10,6 +10,10 @@ module Rails
 
       check_class_collision suffix: "Controller"
 
+      def actions
+        @actions.uniq
+      end
+
       def create_controller_files
         template "controller.rb", File.join("app/controllers", class_path, "#{file_name}_controller.rb")
       end

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -67,8 +67,8 @@ module Rails
         def run_generator(args = default_arguments, config = {})
           capture(:stdout) do
             args += ["--skip-bundle"] unless args.include? "--dev"
-            args |= ["--skip-bootsnap"] unless args.include? "--no-skip-bootsnap"
-            args |= ["--skip-webpack-install"] unless args.include? "--no-skip-webpack-install"
+            args += ["--skip-bootsnap"] unless args.include? "--no-skip-bootsnap"
+            args += ["--skip-webpack-install"] unless args.include? "--no-skip-webpack-install"
 
             generator_class.start(args, config.reverse_merge(destination_root: destination_root))
           end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -92,6 +92,22 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/admin/account"
   end
 
+  def test_actions_dont_repeated
+    run_generator ["account", "foo", "bar", "foo"]
+
+    assert_file "app/controllers/account_controller.rb" do |controller|
+      assert_equal controller.scan(/def foo\n  end$/).size,  1
+    end
+
+    assert_file "config/routes.rb" do |routes|
+      assert_equal routes.scan(/get 'account\/foo'$/).size,  1
+    end
+
+    assert_file "test/controllers/account_controller_test.rb" do |test_controller|
+      assert_equal test_controller.scan(/account_foo_url$/).size,  1
+    end
+  end
+
   def test_actions_are_turned_into_methods
     run_generator
 


### PR DESCRIPTION
This change prevent add the same routes and actions for test and controller

