### PR TITLE
Count TypeScript files as JavaScript in `rails stats`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `rails stats` will now count TypeScript files toward JavaScript stats
+
+    *Joshua Cody*
+
 *   Run `git init` when generating plugins.
 
     Opt out with `--skip-git`.

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -38,7 +38,7 @@ class CodeStatistics #:nodoc:
       Hash[@pairs.map { |pair| [pair.first, calculate_directory_statistics(pair.last)] }]
     end
 
-    def calculate_directory_statistics(directory, pattern = /^(?!\.).*?\.(rb|js|coffee|rake)$/)
+    def calculate_directory_statistics(directory, pattern = /^(?!\.).*?\.(rb|js|ts|coffee|rake)$/)
       stats = CodeStatisticsCalculator.new
 
       Dir.foreach(directory) do |file_name|


### PR DESCRIPTION
### Summary

This simply counts files with a `ts` extension toward the "JavaScript" output in `rails stats`.

### Other Information

This seemed reasonable given TypeScript's growing popularity and CoffeeScript already being included here.