### PR TITLE
Use Mailgun Signing key instead of API Key

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Rails.application.credentials.action_mailbox.api_key` and `MAILGUN_INGRESS_API_KEY` in favor of `Rails.application.credentials.action_mailbox.signing_key` and `MAILGUN_INGRESS_SIGNING_KEY`.
+
+    *Matthijs Vos*
+    
 *   Allow easier creation of multi-part emails from the `create_inbound_email_from_mail` and `receive_inbound_email_from_mail` test helpers.
 
     *Michael Herold*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -6,7 +6,7 @@ module ActionMailbox
   # - +body-mime+: The full RFC 822 message
   # - +timestamp+: The current time according to Mailgun as the number of seconds passed since the UNIX epoch
   # - +token+: A randomly-generated, 50-character string
-  # - +signature+: A hexadecimal HMAC-SHA256 of the timestamp concatenated with the token, generated using the Mailgun API key
+  # - +signature+: A hexadecimal HMAC-SHA256 of the timestamp concatenated with the token, generated using the Mailgun Signing key
   #
   # Authenticates requests by validating their signatures.
   #
@@ -16,21 +16,21 @@ module ActionMailbox
   # - <tt>401 Unauthorized</tt> if the request's signature could not be validated, or if its timestamp is more than 2 minutes old
   # - <tt>404 Not Found</tt> if Action Mailbox is not configured to accept inbound emails from Mailgun
   # - <tt>422 Unprocessable Entity</tt> if the request is missing required parameters
-  # - <tt>500 Server Error</tt> if the Mailgun API key is missing, or one of the Active Record database,
+  # - <tt>500 Server Error</tt> if the Mailgun Signing key is missing, or one of the Active Record database,
   #   the Active Storage service, or the Active Job backend is misconfigured or unavailable
   #
   # == Usage
   #
-  # 1. Give Action Mailbox your {Mailgun API key}[https://help.mailgun.com/hc/en-us/articles/203380100-Where-can-I-find-my-API-key-and-SMTP-credentials-]
+  # 1. Give Action Mailbox your Mailgun Signing key (which you can find under Settings -> Security & Users -> API security in Mailgun)
   #    so it can authenticate requests to the Mailgun ingress.
   #
-  #    Use <tt>bin/rails credentials:edit</tt> to add your API key to your application's encrypted credentials under
-  #    +action_mailbox.mailgun_api_key+, where Action Mailbox will automatically find it:
+  #    Use <tt>bin/rails credentials:edit</tt> to add your Signing key to your application's encrypted credentials under
+  #    +action_mailbox.mailgun_signing_key+, where Action Mailbox will automatically find it:
   #
   #        action_mailbox:
-  #          mailgun_api_key: ...
+  #          mailgun_signing_key: ...
   #
-  #    Alternatively, provide your API key in the +MAILGUN_INGRESS_API_KEY+ environment variable.
+  #    Alternatively, provide your Signing key in the +MAILGUN_INGRESS_SIGNING_KEY+ environment variable.
   #
   # 2. Tell Action Mailbox to accept emails from Mailgun:
   #
@@ -64,14 +64,28 @@ module ActionMailbox
           ).authenticated?
         else
           raise ArgumentError, <<~MESSAGE.squish
-            Missing required Mailgun API key. Set action_mailbox.mailgun_api_key in your application's
-            encrypted credentials or provide the MAILGUN_INGRESS_API_KEY environment variable.
+            Missing required Mailgun Signing key. Set action_mailbox.mailgun_signing_key in your application's
+            encrypted credentials or provide the MAILGUN_INGRESS_SIGNING_KEY environment variable.
           MESSAGE
         end
       end
 
       def key
-        Rails.application.credentials.dig(:action_mailbox, :mailgun_api_key) || ENV["MAILGUN_INGRESS_API_KEY"]
+        if Rails.application.credentials.dig(:action_mailbox, :mailgun_api_key)
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Rails.application.credentials.action_mailbox.api_key is deprecated and will be ignored in Rails 6.2.
+            Use Rails.application.credentials.action_mailbox.signing_key instead.
+          MSG
+          Rails.application.credentials.dig(:action_mailbox, :mailgun_api_key)
+        elsif ENV["MAILGUN_INGRESS_API_KEY"]
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            The MAILGUN_INGRESS_API_KEY environment variable is deprecated and will be ignored in Rails 6.2.
+            Use MAILGUN_INGRESS_SIGNING_KEY instead.
+          MSG
+          ENV["MAILGUN_INGRESS_API_KEY"]
+        else
+          Rails.application.credentials.dig(:action_mailbox, :mailgun_signing_key) || ENV["MAILGUN_INGRESS_SIGNING_KEY"]
+        end
       end
 
       class Authenticator

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-ENV["MAILGUN_INGRESS_API_KEY"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
+ENV["MAILGUN_INGRESS_SIGNING_KEY"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
 
 class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDispatch::IntegrationTest
   setup { ActionMailbox.ingress = :mailgun }
@@ -53,7 +53,7 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_response :unauthorized
   end
 
-  test "raising when the configured Mailgun API key is nil" do
+  test "raising when the configured Mailgun Signing key is nil" do
     switch_key_to nil do
       assert_raises ArgumentError do
         travel_to "2018-10-09 15:15:00 EDT"
@@ -67,7 +67,7 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     end
   end
 
-  test "raising when the configured Mailgun API key is blank" do
+  test "raising when the configured Mailgun Signing key is blank" do
     switch_key_to "" do
       assert_raises ArgumentError do
         travel_to "2018-10-09 15:15:00 EDT"
@@ -83,9 +83,9 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
 
   private
     def switch_key_to(new_key)
-      previous_key, ENV["MAILGUN_INGRESS_API_KEY"] = ENV["MAILGUN_INGRESS_API_KEY"], new_key
+      previous_key, ENV["MAILGUN_INGRESS_SIGNING_KEY"] = ENV["MAILGUN_INGRESS_SIGNING_KEY"], new_key
       yield
     ensure
-      ENV["MAILGUN_INGRESS_API_KEY"] = previous_key
+      ENV["MAILGUN_INGRESS_SIGNING_KEY"] = previous_key
     end
 end

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -76,19 +76,19 @@ bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mailb
 ### Mailgun
 
 Give Action Mailbox your
-[Mailgun API key](https://help.mailgun.com/hc/en-us/articles/203380100-Where-can-I-find-my-API-key-and-SMTP-credentials)
+Mailgun Signing key (which you can find under Settings -> Security & Users -> API security in Mailgun)
 so it can authenticate requests to the Mailgun ingress.
 
-Use `bin/rails credentials:edit` to add your API key to your application's
-encrypted credentials under `action_mailbox.mailgun_api_key`,
+Use `bin/rails credentials:edit` to add your Signing key to your application's
+encrypted credentials under `action_mailbox.mailgun_signing_key`,
 where Action Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
-  mailgun_api_key: ...
+  mailgun_signing_key: ...
 ```
 
-Alternatively, provide your API key in the `MAILGUN_INGRESS_API_KEY` environment
+Alternatively, provide your Signing key in the `MAILGUN_INGRESS_SIGNING_KEY` environment
 variable.
 
 Tell Action Mailbox to accept emails from Mailgun:


### PR DESCRIPTION
### Summary
Mailgun needs the signing key instead of the API key for validating incoming mails. For this reason the naming has been changed. See also issue #38471

### Other Information
This introduces a deprecation of a credential key and an environment variable. I could not find what the normal workflow for deprecation is, so I have included a deprecation warning and left the version in which this will be removed open. Please let me know if I have to do something different for this.