### PR TITLE
Add support to `connected_to` and `connects_to` for horizontal sharding

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,43 @@
+*   Add support for horizontal sharding to `connects_to` and `connected_to`.
+
+    Applications can now connect to multiple shards and switch between their shards in an application. Note that the shard swapping is still a manual process as this change does not include an API for automatic shard swapping.
+
+    Usage:
+
+    Given the following configuration:
+
+    ```yaml
+    # config/database.yml
+    production:
+      primary:
+        database: my_database
+      primary_shard_one:
+        database: my_database_shard_one
+    ```
+
+    Connect to multiple shards:
+
+    ```ruby
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+
+      connects_to shards: {
+        default: { writing: :primary },
+        shard_one: { writing: :primary_shard_one }
+      }
+    ```
+
+    Swap between shards in your controller / model code:
+
+    ```ruby
+    ActiveRecord::Base.connected_to(shard: :shard_one) do
+      # Read from shard one
+    end
+    ```
+
+    The horizontal sharding API also supports read replicas. See guides for more details.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
 *   Deprecate `spec_name` in favor of `name` on database configurations
 
     The accessors for `spec_name` on `configs_for` and `DatabaseConfig` are deprecated. Please use `name` instead.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1039,7 +1039,7 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(config, pool_key = :default)
+      def establish_connection(config, pool_key = ActiveRecord::Base.default_pool_key)
         pool_config = resolve_pool_config(config)
         db_config = pool_config.db_config
 
@@ -1100,16 +1100,19 @@ module ActiveRecord
       # active or defined connection: if it is the latter, it will be
       # opened and set as the active connection for the class it was defined
       # for (not necessarily the current class).
-      def retrieve_connection(spec_name) # :nodoc:
-        pool = retrieve_connection_pool(spec_name)
+      def retrieve_connection(spec_name, pool_key = ActiveRecord::Base.default_pool_key) # :nodoc:
+        pool = retrieve_connection_pool(spec_name, pool_key)
 
         unless pool
-          # multiple database application
-          if ActiveRecord::Base.connection_handler != ActiveRecord::Base.default_connection_handler
-            raise ConnectionNotEstablished, "No connection pool for '#{spec_name}' found for the '#{ActiveRecord::Base.current_role}' role."
+          if pool_key != ActiveRecord::Base.default_pool_key
+            message = "No connection pool for '#{spec_name}' found for the '#{pool_key}' shard."
+          elsif ActiveRecord::Base.connection_handler != ActiveRecord::Base.default_connection_handler
+            message = "No connection pool for '#{spec_name}' found for the '#{ActiveRecord::Base.current_role}' role."
           else
-            raise ConnectionNotEstablished, "No connection pool for '#{spec_name}' found."
+            message = "No connection pool for '#{spec_name}' found."
           end
+
+          raise ConnectionNotEstablished, message
         end
 
         pool.connection
@@ -1117,7 +1120,7 @@ module ActiveRecord
 
       # Returns true if a connection that's accessible to this class has
       # already been opened.
-      def connected?(spec_name, pool_key = :default)
+      def connected?(spec_name, pool_key = ActiveRecord::Base.default_pool_key)
         pool = retrieve_connection_pool(spec_name, pool_key)
         pool && pool.connected?
       end
@@ -1126,12 +1129,12 @@ module ActiveRecord
       # connection and the defined connection (if they exist). The result
       # can be used as an argument for #establish_connection, for easily
       # re-establishing the connection.
-      def remove_connection(owner, pool_key = :default)
+      def remove_connection(owner, pool_key = ActiveRecord::Base.default_pool_key)
         remove_connection_pool(owner, pool_key)&.configuration_hash
       end
       deprecate remove_connection: "Use #remove_connection_pool, which now returns a DatabaseConfig object instead of a Hash"
 
-      def remove_connection_pool(owner, pool_key = :default)
+      def remove_connection_pool(owner, pool_key = ActiveRecord::Base.default_pool_key)
         if pool_manager = get_pool_manager(owner)
           pool_config = pool_manager.remove_pool_config(pool_key)
 
@@ -1145,7 +1148,7 @@ module ActiveRecord
       # Retrieving the connection pool happens a lot, so we cache it in @owner_to_pool_manager.
       # This makes retrieving the connection pool O(1) once the process is warm.
       # When a connection is established or removed, we invalidate the cache.
-      def retrieve_connection_pool(owner, pool_key = :default)
+      def retrieve_connection_pool(owner, pool_key = ActiveRecord::Base.default_pool_key)
         pool_config = get_pool_manager(owner)&.get_pool_config(pool_key)
         pool_config&.pool
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -132,6 +132,8 @@ module ActiveRecord
 
       class_attribute :default_connection_handler, instance_writer: false
 
+      class_attribute :default_pool_key, instance_writer: false
+
       self.filter_attributes = []
 
       def self.connection_handler
@@ -142,7 +144,16 @@ module ActiveRecord
         Thread.current.thread_variable_set(:ar_connection_handler, handler)
       end
 
+      def self.current_pool_key
+        Thread.current.thread_variable_get(:ar_pool_key) || default_pool_key
+      end
+
+      def self.current_pool_key=(pool_key)
+        Thread.current.thread_variable_set(:ar_pool_key, pool_key)
+      end
+
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
+      self.default_pool_key = :default
     end
 
     module ClassMethods

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -215,14 +215,14 @@ module ActiveRecord
               ActiveRecord::Base.connected_to(database: :readonly, role: :writing) { }
             end
           end
-          assert_equal "connected_to can only accept a `database` or a `role` argument, but not both arguments.", error.message
+          assert_equal "`connected_to` cannot accept a `database` argument with any other arguments.", error.message
         end
 
         def test_switching_connections_without_database_and_role_raises
           error = assert_raises(ArgumentError) do
             ActiveRecord::Base.connected_to { }
           end
-          assert_equal "must provide a `database` or a `role`.", error.message
+          assert_equal "must provide a `shard` and/or `role`.", error.message
         end
 
         def test_switching_connections_with_database_symbol_uses_default_role
@@ -376,7 +376,7 @@ module ActiveRecord
 
         reading_handler = ActiveRecord::Base.connection_handlers[:reading]
 
-        reading = ActiveRecord::Base.with_handler(:reading) do
+        reading = ActiveRecord::Base.connected_to(role: :reading) do
           Person.connection_handler
         end
 
@@ -397,7 +397,7 @@ module ActiveRecord
           r << ActiveRecord::Base.connection_handler
         end
 
-        reading = ActiveRecord::Base.with_handler(:reading) do
+        reading = ActiveRecord::Base.connected_to(role: :reading) do
           enum.next
         end
 

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -1,0 +1,412 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/person"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionHandlersShardingDbTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
+      fixtures :people
+
+      def setup
+        @handlers = { writing: ConnectionHandler.new, reading: ConnectionHandler.new }
+        @rw_handler = @handlers[:writing]
+        @ro_handler = @handlers[:reading]
+        @owner_name = "ActiveRecord::Base"
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        @rw_pool = @handlers[:writing].establish_connection(db_config)
+        @ro_pool = @handlers[:reading].establish_connection(db_config)
+      end
+
+      def teardown
+        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+      end
+
+      unless in_memory_db?
+        def test_establish_connection_using_3_levels_config
+          previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+
+          config = {
+            "default_env" => {
+              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
+            }
+          }
+
+          @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+          ActiveRecord::Base.connects_to(shards: {
+            default: { writing: :primary },
+            shard_one: { writing: :primary_shard_one }
+          })
+
+          base_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
+          default_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
+
+          assert_equal base_pool, default_pool
+          assert_equal "db/primary.sqlite3", default_pool.db_config.database
+          assert_equal "primary", default_pool.db_config.spec_name
+
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "primary_shard_one", pool.db_config.spec_name
+        ensure
+          ActiveRecord::Base.configurations = @prev_configs
+          ActiveRecord::Base.establish_connection(:arunit)
+          ENV["RAILS_ENV"] = previous_env
+        end
+
+        def test_establish_connection_using_3_levels_config_with_shards_and_replica
+          previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+
+          config = {
+            "default_env" => {
+              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+            }
+          }
+
+          @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+          ActiveRecord::Base.connects_to(shards: {
+            default: { writing: :primary, reading: :primary_replica },
+            shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+          })
+
+          default_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
+          base_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
+          assert_equal base_writing_pool, default_writing_pool
+          assert_equal "db/primary.sqlite3", default_writing_pool.db_config.database
+          assert_equal "primary", default_writing_pool.db_config.spec_name
+
+          default_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :default)
+          base_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
+          assert_equal base_reading_pool, default_reading_pool
+          assert_equal "db/primary.sqlite3", default_reading_pool.db_config.database
+          assert_equal "primary_replica", default_reading_pool.db_config.spec_name
+
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "primary_shard_one", pool.db_config.spec_name
+
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "primary_shard_one_replica", pool.db_config.spec_name
+        ensure
+          ActiveRecord::Base.configurations = @prev_configs
+          ActiveRecord::Base.establish_connection(:arunit)
+          ENV["RAILS_ENV"] = previous_env
+        end
+
+        def test_switching_connections_via_handler
+          previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+
+          config = {
+            "default_env" => {
+              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+            }
+          }
+
+          @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+          ActiveRecord::Base.connects_to(shards: {
+            default: { writing: :primary, reading: :primary_replica },
+            shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+          })
+
+          ActiveRecord::Base.connected_to(role: :reading, shard: :default) do
+            @ro_handler = ActiveRecord::Base.connection_handler
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:reading]
+            assert_equal :reading, ActiveRecord::Base.current_role
+            assert ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
+            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          end
+
+          ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_not_equal @ro_handler, ActiveRecord::Base.connection_handler
+            assert_equal :writing, ActiveRecord::Base.current_role
+            assert ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+          end
+
+          ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
+            @ro_handler = ActiveRecord::Base.connection_handler
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:reading]
+            assert_equal :reading, ActiveRecord::Base.current_role
+            assert ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
+            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          end
+
+          ActiveRecord::Base.connected_to(role: :writing, shard: :shard_one) do
+            assert_equal ActiveRecord::Base.connection_handler, ActiveRecord::Base.connection_handlers[:writing]
+            assert_not_equal @ro_handler, ActiveRecord::Base.connection_handler
+            assert_equal :writing, ActiveRecord::Base.current_role
+            assert ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
+            assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
+            assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+          end
+        ensure
+          ActiveRecord::Base.configurations = @prev_configs
+          ActiveRecord::Base.establish_connection(:arunit)
+          ENV["RAILS_ENV"] = previous_env
+          FileUtils.rm_rf("db")
+        end
+
+        def test_retrieves_proper_connection_with_nested_connected_to
+          previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+
+          config = {
+            "default_env" => {
+              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+            }
+          }
+
+          @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+          ActiveRecord::Base.connects_to(shards: {
+            default: { writing: :primary, reading: :primary_replica },
+            shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+          })
+
+          ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
+            # Uses the correct connection
+            assert_equal "primary_shard_one_replica", ActiveRecord::Base.connection_pool.db_config.spec_name
+
+            # Uses the shard currently in use
+            ActiveRecord::Base.connected_to(role: :writing) do
+              assert_equal "primary_shard_one", ActiveRecord::Base.connection_pool.db_config.spec_name
+            end
+
+            # Allows overriding the shard as well
+            ActiveRecord::Base.connected_to(role: :reading, shard: :default) do
+              assert_equal "primary_replica", ActiveRecord::Base.connection_pool.db_config.spec_name
+            end
+
+            # Uses the current role
+            ActiveRecord::Base.connected_to(shard: :default) do
+              assert_equal "primary_replica", ActiveRecord::Base.connection_pool.db_config.spec_name
+            end
+
+            # Resets correctly
+            assert_equal "primary_shard_one_replica", ActiveRecord::Base.connection_pool.db_config.spec_name
+          end
+        ensure
+          ActiveRecord::Base.configurations = @prev_configs
+          ActiveRecord::Base.establish_connection(:arunit)
+          ENV["RAILS_ENV"] = previous_env
+          FileUtils.rm_rf("db")
+        end
+
+        def test_connected_to_raises_without_a_shard_or_role
+          error = assert_raises(ArgumentError) do
+            ActiveRecord::Base.connected_to { }
+          end
+          assert_equal "must provide a `shard` and/or `role`.", error.message
+        end
+
+        def test_connects_to_raises_with_a_shard_and_database_key
+          error = assert_raises(ArgumentError) do
+            ActiveRecord::Base.connects_to(database: { writing: :arunit }, shards: { shard_one: { writing: :arunit } })
+          end
+          assert_equal "connects_to can only accept a `database` or `shards` argument, but not both arguments.", error.message
+        end
+
+        def test_retrieve_connection_pool_with_invalid_shard
+          assert_not_nil @rw_handler.retrieve_connection_pool("ActiveRecord::Base")
+          assert_nil @rw_handler.retrieve_connection_pool("ActiveRecord::Base", :foo)
+
+          assert_not_nil @ro_handler.retrieve_connection_pool("ActiveRecord::Base")
+          assert_nil @ro_handler.retrieve_connection_pool("ActiveRecord::Base", :foo)
+        end
+
+        def test_calling_connected_to_on_a_non_existent_shard_raises
+          ActiveRecord::Base.connects_to(shards: {
+            default: { writing: :arunit, reading: :arunit }
+          })
+
+          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+            ActiveRecord::Base.connected_to(role: :reading, shard: :foo) do
+              Person.first
+            end
+          end
+
+          assert_equal "No connection pool for 'ActiveRecord::Base' found for the 'foo' shard.", error.message
+        end
+      end
+
+      class ShardConnectionTestModel < ActiveRecord::Base
+      end
+
+      class ShardConnectionTestModelB < ActiveRecord::Base
+      end
+
+      def test_same_shards_across_clusters
+        ShardConnectionTestModel.connects_to shards: { one: { writing: { database: ":memory:", adapter: "sqlite3" } } }
+        ShardConnectionTestModelB.connects_to shards: { one: { writing: { database: ":memory:", adapter: "sqlite3" } } }
+
+        ActiveRecord::Base.connected_to(shard: :one) do
+          ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+          ShardConnectionTestModel.create!(shard_key: "test_model_default")
+
+          ShardConnectionTestModelB.connection.execute("CREATE TABLE `shard_connection_test_model_bs` (shard_key VARCHAR (255))")
+          ShardConnectionTestModelB.create!(shard_key: "test_model_b_default")
+
+          assert_equal "test_model_default", ShardConnectionTestModel.where(shard_key: "test_model_default").first.shard_key
+          assert_equal "test_model_b_default", ShardConnectionTestModelB.where(shard_key: "test_model_b_default").first.shard_key
+        end
+      end
+
+      def test_sharding_separation
+        ShardConnectionTestModel.connects_to shards: {
+          default: { writing: { database: ":memory:", adapter: "sqlite3" } },
+          one: { writing: { database: ":memory:", adapter: "sqlite3" } }
+        }
+
+        [:default, :one].each do |shard_name|
+          ActiveRecord::Base.connected_to(shard: shard_name) do
+            ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+          end
+        end
+
+        # Create a record on :default
+        ShardConnectionTestModel.create!(shard_key: "foo")
+
+        # Make sure we can read it when explicitly connecting to :default
+        ActiveRecord::Base.connected_to(shard: :default) do
+          assert ShardConnectionTestModel.find_by_shard_key("foo")
+        end
+
+        # Switch to shard and make sure we can't read the record from :default
+        # Also add a new record on :one
+        ActiveRecord::Base.connected_to(shard: :one) do
+          assert_not ShardConnectionTestModel.find_by_shard_key("foo")
+          ShardConnectionTestModel.create!(shard_key: "bar")
+        end
+
+        # Make sure we can't read the record from :one but can read the record
+        # from :default
+        assert_not ShardConnectionTestModel.find_by_shard_key("bar")
+        assert ShardConnectionTestModel.find_by_shard_key("foo")
+      end
+
+      def test_swapping_shards_in_a_multi_threaded_environment
+        tf_default = Tempfile.open "shard_key_default"
+        tf_shard_one = Tempfile.open "shard_key_one"
+
+        ShardConnectionTestModel.connects_to shards: {
+          default: { writing: { database: tf_default.path, adapter: "sqlite3" } },
+          one: { writing: { database: tf_shard_one.path, adapter: "sqlite3" } }
+        }
+
+        [:default, :one].each do |shard_name|
+          ActiveRecord::Base.connected_to(shard: shard_name) do
+            ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+            ShardConnectionTestModel.connection.execute("INSERT INTO `shard_connection_test_models` VALUES ('shard_key_#{shard_name}')")
+          end
+        end
+
+        shard_one_latch = Concurrent::CountDownLatch.new
+        shard_default_latch = Concurrent::CountDownLatch.new
+
+        ShardConnectionTestModel.connection
+
+        thread = Thread.new do
+          ShardConnectionTestModel.connection
+
+          shard_default_latch.wait
+          assert_equal "shard_key_default", ShardConnectionTestModel.connection.select_value("SELECT shard_key from shard_connection_test_models")
+          shard_one_latch.count_down
+        end
+
+        ActiveRecord::Base.connected_to(shard: :one) do
+          shard_default_latch.count_down
+          assert_equal "shard_key_one", ShardConnectionTestModel.connection.select_value("SELECT shard_key from shard_connection_test_models")
+          shard_one_latch.wait
+        end
+
+        thread.join
+      ensure
+        tf_shard_one.close
+        tf_shard_one.unlink
+        tf_default.close
+        tf_default.unlink
+      end
+
+      def test_swapping_shards_and_roles_in_a_multi_threaded_environment
+        tf_default = Tempfile.open "shard_key_default"
+        tf_shard_one = Tempfile.open "shard_key_one"
+        tf_default_reading = Tempfile.open "shard_key_default_reading"
+        tf_shard_one_reading = Tempfile.open "shard_key_one_reading"
+
+        ShardConnectionTestModel.connects_to shards: {
+          default: { writing: { database: tf_default.path, adapter: "sqlite3" }, secondary: { database: tf_default_reading.path, adapter: "sqlite3" } },
+          one: { writing: { database: tf_shard_one.path, adapter: "sqlite3" }, secondary: { database: tf_shard_one_reading.path, adapter: "sqlite3" } }
+        }
+
+        [:default, :one].each do |shard_name|
+          ActiveRecord::Base.connected_to(shard: shard_name) do
+            ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+            ShardConnectionTestModel.connection.execute("INSERT INTO `shard_connection_test_models` VALUES ('shard_key_#{shard_name}')")
+          end
+
+          ActiveRecord::Base.connected_to(shard: shard_name, role: :secondary) do
+            ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+            ShardConnectionTestModel.connection.execute("INSERT INTO `shard_connection_test_models` VALUES ('shard_key_#{shard_name}_secondary')")
+          end
+        end
+
+        shard_one_latch = Concurrent::CountDownLatch.new
+        shard_default_latch = Concurrent::CountDownLatch.new
+
+        ShardConnectionTestModel.connection
+
+        thread = Thread.new do
+          ShardConnectionTestModel.connection
+
+          shard_default_latch.wait
+          assert_equal "shard_key_default", ShardConnectionTestModel.connection.select_value("SELECT shard_key from shard_connection_test_models")
+          shard_one_latch.count_down
+        end
+
+        ActiveRecord::Base.connected_to(shard: :one, role: :secondary) do
+          shard_default_latch.count_down
+          assert_equal "shard_key_one_secondary", ShardConnectionTestModel.connection.select_value("SELECT shard_key from shard_connection_test_models")
+          shard_one_latch.wait
+        end
+
+        thread.join
+      ensure
+        tf_shard_one.close
+        tf_shard_one.unlink
+        tf_default.close
+        tf_default.unlink
+        tf_shard_one_reading.close
+        tf_shard_one_reading.unlink
+        tf_default_reading.close
+        tf_default_reading.unlink
+      end
+    end
+  end
+end


### PR DESCRIPTION
Applications can now connect to multiple shards and switch between
their shards in an application. Note that the shard swapping is
still a manual process as this change does not include an API for
automatic shard swapping.

Usage:

Given the following configuration:

```yaml
production:
  primary:
    database: my_database
  primary_shard_one:
    database: my_database_shard_one

```

Connect to multiple shards:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  connects_to shards: {
    default: { writing: :primary },
    shard_one: { writing: :primary_shard_one }
  }
```

Swap between shards in your controller / model code:

```ruby
  ActiveRecord::Base.connected_to(shard: :shard_one) do
    # Read from shard one
  end
```

The horizontal sharding API also supports read replicas. See
guides for more details.

This PR also moves some no-doc'd methods into the private namespace as
they were unnecessarily public. We've updated some error messages and
documentation.

cc / @eileencodes @tenderlove @rafaelfranca @matthewd 