### PR TITLE
Remove validations from example components

### DIFF
--- a/actionpack/test/lib/test_component.rb
+++ b/actionpack/test/lib/test_component.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class TestComponent < ActionView::Base
-  include ActiveModel::Validations
-
-  validates :title, presence: true
   delegate :render, to: :view_context
 
   def initialize(title:)
@@ -13,7 +10,6 @@ class TestComponent < ActionView::Base
   def render_in(view_context)
     self.class.compile
     @view_context = view_context
-    validate!
     rendered_template
   end
 

--- a/actionview/test/lib/test_component.rb
+++ b/actionview/test/lib/test_component.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class TestComponent < ActionView::Base
-  include ActiveModel::Validations
-
-  validates :content, :title, presence: true
   delegate :render, to: :view_context
 
   def initialize(title:)
@@ -17,7 +14,6 @@ class TestComponent < ActionView::Base
     self.class.compile
     @view_context = view_context
     @content = view_context.capture(&block) if block_given?
-    validate!
     rendered_template
   end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -681,14 +681,6 @@ module RenderTestCases
       @view.render(TestComponent.new(title: "my title")) { "Hello, World!" }.strip
     )
   end
-
-  def test_render_component_with_validation_error
-    error = assert_raises(ActiveModel::ValidationError) do
-      @view.render(TestComponent.new(title: "my title")).strip
-    end
-
-    assert_match "Content can't be blank", error.message
-  end
 end
 
 class CachedViewRenderTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

We're moving away from using validations in our component framework, and feel that it's better to avoid prescribing their usage in these example classes, which exist to serve as example objects that are compatible with the `render_in` API.

### Other Information

These example classes were introduced in: 

https://github.com/rails/rails/pull/36388
https://github.com/rails/rails/pull/37919